### PR TITLE
feat: Roslyn MCP enhancements and per-workspace execution gating

### DIFF
--- a/Roslyn-MCP-Enhancement-Prompt.md
+++ b/Roslyn-MCP-Enhancement-Prompt.md
@@ -1,0 +1,398 @@
+# Roslyn MCP Server Enhancement Prompt
+
+**Generated:** 2026-03-15
+**Server Repo:** `C:\code-repo\roslyn-backed-mcp`
+**Consumer Repo:** `C:\Code-Repo\DotNet-Network-Documentation`
+**Motivation:** Gaps identified while planning execution of `Codebase-Refactoring-Prompt.md` — a 6-phase refactoring of a ~41,300 LOC .NET 10 codebase across 7 projects
+
+---
+
+## Context for the Implementing Agent
+
+You are enhancing a custom Roslyn-backed MCP server. The server provides semantic C# analysis tools to AI coding agents in Cursor. It is a .NET 10 application using Roslyn workspaces, the ModelContextProtocol SDK (1.1.0), and Microsoft.CodeAnalysis 5.3.0.
+
+### Server Architecture (read-only — do not restructure)
+
+```
+C:\code-repo\roslyn-backed-mcp\
+├── RoslynMcp.slnx
+├── src/
+│   ├── Company.RoslynMcp.Host.Stdio/     # Entry point + MCP tool classes
+│   │   ├── Program.cs                     # Generic host, stdio transport, WithToolsFromAssembly()
+│   │   └── Tools/
+│   │       ├── WorkspaceTools.cs          # workspace_load, workspace_reload, workspace_status, project_graph, source_generated_documents
+│   │       ├── SymbolTools.cs             # symbol_search, symbol_info, go_to_definition, find_references, find_implementations, document_symbols, find_overrides, find_base_members, member_hierarchy, symbol_signature_help, symbol_relationships
+│   │       ├── AnalysisTools.cs           # project_diagnostics, diagnostic_details, type_hierarchy, callers_callees, impact_analysis
+│   │       ├── RefactoringTools.cs        # rename_preview/apply, organize_usings_preview/apply, format_document_preview/apply, code_fix_preview/apply
+│   │       └── ValidationTools.cs         # build_workspace, build_project, test_discover, test_run, test_related
+│   ├── Company.RoslynMcp.Core/            # DTOs, service interfaces, PreviewStore
+│   │   ├── Services/
+│   │   │   ├── IWorkspaceManager.cs
+│   │   │   ├── ISymbolService.cs
+│   │   │   ├── IDiagnosticService.cs
+│   │   │   ├── IRefactoringService.cs
+│   │   │   ├── IValidationService.cs
+│   │   │   ├── IDotnetCommandRunner.cs
+│   │   │   └── IPreviewStore.cs + PreviewStore.cs
+│   │   └── Models/                        # ~25 DTO records (SymbolDto, LocationDto, ImpactAnalysisDto, etc.)
+│   └── Company.RoslynMcp.Roslyn/          # Roslyn service implementations
+│       ├── Services/
+│       │   ├── WorkspaceManager.cs
+│       │   ├── SymbolService.cs
+│       │   ├── DiagnosticService.cs
+│       │   ├── RefactoringService.cs
+│       │   └── ValidationService.cs
+│       └── Helpers/
+│           ├── DotnetCommandRunner.cs
+│           ├── DotnetOutputParser.cs
+│           ├── SymbolMapper.cs
+│           ├── SymbolResolver.cs
+│           ├── SymbolHandleSerializer.cs
+│           └── DiffGenerator.cs
+└── tests/
+    └── Company.RoslynMcp.Tests/
+```
+
+### Tool Registration Pattern
+
+Tools are static classes with `[McpServerToolType]` containing static methods with `[McpServerTool(Name = "...")]`. Service interfaces are injected as method parameters. The host calls `WithToolsFromAssembly()` to discover them.
+
+### Existing Capabilities (34 tools)
+
+The server already provides strong coverage in these areas:
+- **Workspace management:** load, reload, status, project graph, source-generated documents
+- **Symbol discovery:** search, info, definition, document symbols, signature help
+- **Relationship analysis:** references, implementations, overrides, base members, callers/callees, type hierarchy, member hierarchy, symbol relationships, impact analysis
+- **Diagnostics:** project diagnostics with filtering, diagnostic details with curated fix options
+- **Code transformations:** rename, format document, organize usings, code fix — all with preview/apply pattern
+- **Validation:** build workspace/project, test discover, test run, test related
+
+---
+
+## What the Refactoring Needs and What's Missing
+
+The consuming repo's refactoring prompt describes 6 phases. During analysis of how the Roslyn MCP would support each phase, the following gaps were identified. Each gap is a scenario where an agent would need to fall back to error-prone text search or manual inspection because the current MCP tools don't provide the semantic information needed.
+
+---
+
+## Enhancement 1: Property Accessor Query Tool
+
+### The gap
+
+**Phase 1 (Record Type Immutability)** requires converting ~200 mutable properties (`{ get; set; }`) across 20+ record classes to `{ get; init; }`. The agent needs to answer: "Which properties on `InterfaceRecord` have a `set` accessor?" and "Which call sites assign to those properties after construction?"
+
+The current `symbol_search` and `symbol_info` tools return `SymbolDto` which includes `Modifiers` (a list of strings like `"public"`, `"static"`) but does **not** include property accessor information (get/set/init). The agent also can't distinguish between a reference that *reads* a property vs. one that *writes* to it.
+
+`find_references` returns `LocationDto` (file, line, column) but doesn't classify whether each reference is a read, write, or definition — so the agent cannot filter for "only the sites that assign to `InterfaceRecord.Port`" without reading every referenced line of code and parsing it manually.
+
+### Proposed tool: `find_property_writes`
+
+Find all locations where a property is assigned to (written), excluding reads and the initial declaration/initializer.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| workspaceId | string | Yes | Workspace session identifier |
+| filePath | string? | No | Source file containing the property |
+| line | int? | No | 1-based line of the property |
+| column | int? | No | 1-based column of the property |
+| symbolHandle | string? | No | Symbol handle for the property |
+
+**Returns:** A list of write-site locations, each annotated with:
+- The location (file, line, column)
+- Whether the write is in an object initializer (safe for `init`) or a post-construction assignment (breaks `init`)
+- The containing method/type for context
+
+### Supporting change: Enrich `SymbolDto` for properties
+
+Add optional fields to `SymbolDto`:
+- `HasGetter` (bool?)
+- `HasSetter` (bool?)
+- `SetterAccessibility` (string? — e.g. `"public"`, `"private"`, `"init"`)
+
+This lets the agent query property accessor details from any tool that returns `SymbolDto` without a separate call.
+
+### Implementation notes
+
+- Roslyn's `IPropertySymbol` exposes `GetMethod`, `SetMethod`, and the set method's `IsInitOnly` property — these are the backing APIs
+- Roslyn's `SymbolFinder.FindReferencesAsync` returns `ReferencedSymbol` which has `Locations` — each `ReferenceLocation` has `IsWrittenTo` — use this to classify read vs. write
+- Object-initializer writes can be distinguished from post-construction assignments by checking if the write location is inside an `ObjectInitializerExpression` syntax node
+
+### Affected files
+
+- `ISymbolService.cs` — add `FindPropertyWritesAsync` method
+- `SymbolService.cs` — implement using `SymbolFinder` + `IsWrittenTo` + syntax-node classification
+- `SymbolTools.cs` — add `find_property_writes` MCP tool
+- `SymbolDto.cs` — add `HasGetter`, `HasSetter`, `SetterAccessibility` fields
+- `SymbolMapper.cs` — map `IPropertySymbol` accessor info to the new DTO fields
+
+---
+
+## Enhancement 2: Bulk Symbol Query Tool
+
+### The gap
+
+**Phase 1** needs to inspect all 20+ record types in a single file (`DeviceRecords.cs`, 392 lines) to understand their property accessor patterns. **Phase 3** needs to trace ~617 occurrences of `Dictionary<string, object?>` across 67 files to understand usage patterns. Currently, the agent must call `symbol_search` or `find_references` one symbol at a time. For 20+ types with 10-15 properties each, that's 200-300 sequential MCP calls.
+
+### Proposed tool: `find_references_bulk`
+
+Find references for multiple symbols in a single call.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| workspaceId | string | Yes | Workspace session identifier |
+| symbols | array | Yes | Array of `SymbolLocator` objects (max 50) |
+| includeDefinition | bool | No | Include the definition location in results (default: false) |
+
+**Returns:** A map from each symbol handle/name to its list of reference locations. Symbols that can't be resolved are reported with an error message rather than failing the whole batch.
+
+### Implementation notes
+
+- This is primarily a performance/batching optimization — no new Roslyn APIs needed beyond what `find_references` already uses
+- Process symbols in parallel using `Task.WhenAll` with a bounded concurrency (e.g. 4-8 concurrent resolution tasks) to avoid starving the Roslyn workspace
+- Return results keyed by the input symbol's handle or name for easy correlation
+
+### Affected files
+
+- `ISymbolService.cs` — add `FindReferencesBulkAsync` method
+- `SymbolService.cs` — implement with parallel resolution and aggregation
+- `SymbolTools.cs` — add `find_references_bulk` MCP tool
+- Consider a new `BulkReferenceResultDto.cs` for the return shape
+
+---
+
+## Enhancement 3: Type Usage Pattern Analysis
+
+### The gap
+
+**Phase 3 (Eliminate Dictionary Pipeline)** requires understanding *how* `Dictionary<string, object?>` is used at each of its 617 occurrences — is it a method return type, a parameter type, a local variable, a property type, a generic argument? The agent needs to classify usage patterns to plan the migration strategy (e.g., "all 45 occurrences in `CommandDispatcher` are method return types → change the return type" vs. "these 12 in `BuildSteps` are parameter types → change the parameter type").
+
+The current `find_references` only returns locations. The agent would need to read every file and analyze the surrounding syntax manually to classify usage patterns.
+
+### Proposed tool: `find_type_usages`
+
+Find all usages of a type across the solution, classified by how the type is used.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| workspaceId | string | Yes | Workspace session identifier |
+| filePath | string? | No | Source file containing the type |
+| line | int? | No | 1-based line of the type |
+| column | int? | No | 1-based column of the type |
+| symbolHandle | string? | No | Symbol handle for the type |
+| metadataName | string? | No | Fully qualified type name (e.g., `System.Collections.Generic.Dictionary<string, object?>`) |
+
+**Returns:** Usages grouped by classification:
+- `MethodReturnType` — methods that return this type
+- `MethodParameter` — methods that accept this type as a parameter
+- `PropertyType` — properties of this type
+- `LocalVariable` — local variable declarations of this type
+- `FieldType` — fields of this type
+- `GenericArgument` — used as a generic type argument in another type
+- `BaseType` — used as a base type or interface
+- `Cast` — cast expressions or `as` expressions
+- `TypeCheck` — `is` patterns
+- `ObjectCreation` — `new` expressions creating this type
+- `Other` — anything not classified above
+
+Each usage includes: file, line, column, containing symbol, classification, and a short context snippet (the line of code).
+
+### Implementation notes
+
+- After resolving the type symbol, use `SymbolFinder.FindReferencesAsync` to get all reference locations
+- For each reference location, walk up the syntax tree from the reference node to classify its role:
+  - Parent is `ReturnTypeSyntax` → `MethodReturnType`
+  - Parent is `ParameterSyntax` → `MethodParameter`
+  - Parent is `PropertyDeclarationSyntax` type clause → `PropertyType`
+  - Parent is `VariableDeclarationSyntax` → `LocalVariable` or `FieldType` depending on context
+  - etc.
+- For constructed generic types like `Dictionary<string, object?>`, the agent may pass the fully qualified constructed name via `metadataName` — the implementation should handle open and closed generic type matching
+
+### Affected files
+
+- `ISymbolService.cs` — add `FindTypeUsagesAsync` method
+- `SymbolService.cs` — implement with reference finding + syntax classification
+- `SymbolTools.cs` or `AnalysisTools.cs` — add `find_type_usages` MCP tool
+- New DTO: `TypeUsageDto.cs` and `TypeUsageClassification` enum in `Models/`
+
+---
+
+## Enhancement 4: Classify Reference Reads vs. Writes
+
+### The gap
+
+This is a smaller, more general version of Enhancement 1 that benefits multiple phases. The current `find_references` tool returns raw `LocationDto` without indicating whether each reference is a read, write, definition, or other classification. This forces the agent to read surrounding code for *every* reference to understand usage intent.
+
+The refactoring prompt has multiple phases where read/write classification matters:
+- **Phase 1:** Identifying post-construction property assignments
+- **Phase 3:** Understanding whether dict accesses are reads (`.GetStr()` calls) or writes (`.Add()`, `dict["key"] = value`)
+- **Phase 5:** Understanding whether `ProjectedDeviceRow` fields are read by the sheet builders or mutated
+
+### Proposed change: Enrich `find_references` output
+
+Add a `Classification` field to reference locations returned by `find_references`. This is not a new tool — it enriches the existing one.
+
+**New field on each reference location:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| classification | string | One of: `Definition`, `Read`, `Write`, `ReadWrite`, `NameOf`, `Attribute`, `Other` |
+
+### Implementation notes
+
+- Roslyn's `ReferenceLocation` already exposes:
+  - `IsDefinition`
+  - `IsWrittenTo` (available via `FindReferencesAsync` with appropriate options)
+- These properties directly map to the proposed classifications
+- Compute `ReadWrite` when both `IsWrittenTo` is true and the expression is also read (e.g. `x += 1`)
+- Check for `nameof()` and attribute usages via syntax node inspection
+
+### Affected files
+
+- `LocationDto.cs` — add optional `Classification` field (string?)
+- `SymbolService.cs` — update `FindReferencesAsync` to pass `FindReferencesSearchOptions` that request write classification, and populate the new field
+- `SymbolMapper.cs` — map `ReferenceLocation` flags to classification string
+
+---
+
+## Enhancement 5: Mutation Analysis for a Type
+
+### The gap
+
+**Phase 1** requires understanding whether `Device` objects are mutated after initial construction. The `Device` class has 30+ public settable properties and several mutator methods (`SetMgmtIp()`, `SetArea()`, etc.). The refactoring prompt asks: "Which of these are called during construction/building vs. after the device is 'complete'?"
+
+The agent can use `callers_callees` on each mutator method individually, but there's no tool to ask the composite question: "Show me all mutation paths into this type — every method that modifies its state, and every call site that invokes those methods."
+
+### Proposed tool: `find_type_mutations`
+
+Given a type, find all methods/properties that mutate its state, and all external call sites that trigger those mutations.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| workspaceId | string | Yes | Workspace session identifier |
+| filePath | string? | No | Source file containing the type |
+| line | int? | No | 1-based line of the type |
+| column | int? | No | 1-based column of the type |
+| symbolHandle | string? | No | Symbol handle for the type |
+
+**Returns:**
+- List of **mutating members** on the type: methods with `set` property calls, methods that modify fields, methods that modify collection properties (`.Add()`, `.Clear()`, etc.)
+- For each mutating member: list of **external callers** (file, line, containing method, containing type)
+- A summary grouping callers by phase (constructor/init vs. post-construction) where possible — specifically, calls from within object initializers, constructors, or builder-pattern methods vs. calls from arbitrary consumer code
+
+### Implementation notes
+
+- Resolve the type symbol, enumerate all members
+- For properties: check if `SetMethod` exists and is externally accessible
+- For methods: use simple heuristic — methods that assign to `this.` fields/properties are mutating (walk the method body syntax tree for assignment expressions targeting instance members)
+- For each mutating member, run `FindReferencesAsync` to find external callers
+- Classify callers by context: is the caller inside a constructor, object initializer, or a "builder" method (method on the same type that returns `void`) vs. external consumer code
+- This tool is inherently expensive — document it as a heavy analysis tool, not suitable for rapid iteration
+
+### Affected files
+
+- `ISymbolService.cs` or a new `IAnalysisService.cs` — add `FindTypeMutationsAsync`
+- `SymbolService.cs` or new `AnalysisService.cs` — implement
+- `AnalysisTools.cs` — add `find_type_mutations` MCP tool
+- New DTOs: `TypeMutationDto.cs`, `MutatingMemberDto.cs` in `Models/`
+
+---
+
+## Enhancement 6: Filtered Test Execution
+
+### The gap
+
+The refactoring prompt specifies running targeted tests after each incremental change (e.g., "after migrating each parser, run its tests"). The current `test_run` tool accepts a `filter` parameter (dotnet test filter expression), but there's no tool to discover which tests are related to a *set* of changed files.
+
+`test_related` takes a single symbol. When the agent changes 5 files in Phase 1, it would need to call `test_related` 5+ times (once per changed type), then deduplicate and construct a combined filter expression. A more natural workflow would be: "given these changed files, which tests should I run?"
+
+### Proposed tool: `test_related_files`
+
+Given a list of changed file paths, find all related tests.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| workspaceId | string | Yes | Workspace session identifier |
+| filePaths | string[] | Yes | Array of absolute paths to changed source files |
+| maxResults | int | No | Maximum number of test cases to return (default: 100) |
+
+**Returns:** Deduplicated list of related test cases, each with:
+- Test method name
+- Test class name
+- Test project
+- File path and line
+- Which of the input files triggered the relationship
+
+### Implementation notes
+
+- For each input file, call `GetDocumentSymbolsAsync` to find declared types, then `FindRelatedTestsAsync` for each type
+- Deduplicate across files and sort by relevance
+- Also include a combined `dotnet test --filter` expression the agent can pass directly to `test_run` — this saves the agent from constructing filter syntax manually
+
+### Affected files
+
+- `IValidationService.cs` — add `FindRelatedTestsForFilesAsync`
+- `ValidationService.cs` — implement with per-file symbol discovery + test relation + dedup
+- `ValidationTools.cs` — add `test_related_files` MCP tool
+
+---
+
+## Priority Order
+
+| # | Enhancement | Impact on Refactoring | Complexity |
+|---|------------|----------------------|------------|
+| 4 | Classify reference reads vs. writes | HIGH — enriches existing tool, benefits Phases 1, 3, 5 | LOW — uses existing Roslyn API (`IsWrittenTo`) |
+| 1 | Property accessor query / `SymbolDto` enrichment | HIGH — critical for Phase 1 (200 properties) | MEDIUM — new tool + DTO enrichment |
+| 3 | Type usage pattern analysis | HIGH — critical for Phase 3 (617 occurrences) | MEDIUM — syntax tree classification |
+| 6 | Filtered test execution by changed files | MEDIUM — quality-of-life for every phase | LOW — composition of existing functionality |
+| 2 | Bulk symbol query | MEDIUM — performance for Phases 1, 3 | LOW — parallel wrapper around existing code |
+| 5 | Mutation analysis for a type | MEDIUM — valuable for Phase 1 Device class | HIGH — composite analysis, expensive |
+
+**Recommendation:** Implement enhancements 4, 1, and 3 first. These close the biggest gaps for Phases 1 and 3. Enhancement 6 is a nice-to-have that improves workflow for every phase. Enhancement 2 is a performance optimization. Enhancement 5 is the most complex and can be deferred — the agent can approximate mutation analysis by combining `callers_callees` with `find_property_writes` (Enhancement 1) after those are available.
+
+---
+
+## Session-Start Requirements for the Implementing Agent
+
+Before making changes, read these files in the server repo (`C:\code-repo\roslyn-backed-mcp`):
+
+1. `README.md` — project overview and conventions
+2. `src/Company.RoslynMcp.Core/Services/ISymbolService.cs` — primary service interface to extend
+3. `src/Company.RoslynMcp.Roslyn/Services/SymbolService.cs` — primary implementation to extend
+4. `src/Company.RoslynMcp.Host.Stdio/Tools/SymbolTools.cs` — tool registration pattern
+5. `src/Company.RoslynMcp.Core/Models/SymbolDto.cs` — DTO to enrich
+6. `src/Company.RoslynMcp.Core/Models/LocationDto.cs` — DTO to enrich
+7. `src/Company.RoslynMcp.Roslyn/Helpers/SymbolMapper.cs` — mapping logic to extend
+8. `src/Company.RoslynMcp.Roslyn/Helpers/SymbolResolver.cs` — symbol resolution pattern
+9. `tests/Company.RoslynMcp.Tests/` — test patterns and conventions
+
+## Constraints
+
+- Preserve all 34 existing tools and their current behavior
+- Follow the existing preview/apply pattern for any new tools that modify files
+- New analysis-only tools do not need preview/apply — they are read-only
+- Use the existing `SymbolLocator` pattern for symbol identification parameters
+- Add tests for new tools using the existing test conventions and sample solutions
+- Update tool JSON descriptors after adding new tools (or document how they are auto-generated)
+- After changes, republish the server executable to `publish/` and verify it still loads in Cursor
+
+## Verification
+
+After implementation:
+1. Build the solution: `dotnet build` with no errors or new warnings
+2. Run the test suite: `dotnet test`
+3. Load the consumer solution (`NetworkDocumentation.sln`) via `workspace_load` and verify the new tools work against real data:
+   - `find_property_writes` on `InterfaceRecord.Port` should return write sites
+   - `find_type_usages` on `Dictionary<string, object?>` should classify usages
+   - `find_references` with classification on a well-known symbol should show read/write/definition
+   - `test_related_files` for `DeviceRecords.cs` should find `DeviceRoundTripTests`
+4. Republish: `dotnet publish` to update the executable in `publish/`

--- a/src/Company.RoslynMcp.Core/Models/BulkReferenceResultDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/BulkReferenceResultDto.cs
@@ -1,0 +1,15 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record BulkSymbolLocator(
+    string? SymbolHandle,
+    string? MetadataName,
+    string? FilePath,
+    int? Line,
+    int? Column);
+
+public sealed record BulkReferenceResultDto(
+    string Key,
+    string? ResolvedSymbol,
+    int ReferenceCount,
+    IReadOnlyList<LocationDto> References,
+    string? Error);

--- a/src/Company.RoslynMcp.Core/Models/PropertyWriteDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/PropertyWriteDto.cs
@@ -1,6 +1,6 @@
 namespace Company.RoslynMcp.Core.Models;
 
-public sealed record LocationDto(
+public sealed record PropertyWriteDto(
     string FilePath,
     int StartLine,
     int StartColumn,
@@ -8,4 +8,4 @@ public sealed record LocationDto(
     int EndColumn,
     string? ContainingMember,
     string? PreviewText,
-    string? Classification = null);
+    bool IsObjectInitializer);

--- a/src/Company.RoslynMcp.Core/Models/RelatedTestsForFilesDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/RelatedTestsForFilesDto.cs
@@ -1,0 +1,13 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record RelatedTestCaseDto(
+    string DisplayName,
+    string FullyQualifiedName,
+    string ProjectName,
+    string? FilePath,
+    int? Line,
+    IReadOnlyList<string> TriggeredByFiles);
+
+public sealed record RelatedTestsForFilesDto(
+    IReadOnlyList<RelatedTestCaseDto> Tests,
+    string DotnetTestFilter);

--- a/src/Company.RoslynMcp.Core/Models/SymbolDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/SymbolDto.cs
@@ -18,4 +18,7 @@ public sealed record SymbolDto(
     IReadOnlyList<string>? Modifiers,
     IReadOnlyList<string>? BaseTypes,
     IReadOnlyList<string>? Interfaces,
-    string? Documentation);
+    string? Documentation,
+    bool? HasGetter = null,
+    bool? HasSetter = null,
+    string? SetterAccessibility = null);

--- a/src/Company.RoslynMcp.Core/Models/TypeMutationDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/TypeMutationDto.cs
@@ -1,0 +1,22 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record MutatingMemberDto(
+    string Name,
+    string FullyQualifiedName,
+    string Kind,
+    string? FilePath,
+    int? Line,
+    IReadOnlyList<MutationCallerDto> ExternalCallers);
+
+public sealed record MutationCallerDto(
+    string FilePath,
+    int StartLine,
+    int StartColumn,
+    string? ContainingMember,
+    string? PreviewText,
+    string CallerPhase);
+
+public sealed record TypeMutationDto(
+    SymbolDto Type,
+    IReadOnlyList<MutatingMemberDto> MutatingMembers,
+    string Summary);

--- a/src/Company.RoslynMcp.Core/Models/TypeUsageDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/TypeUsageDto.cs
@@ -1,0 +1,26 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public enum TypeUsageClassification
+{
+    MethodReturnType,
+    MethodParameter,
+    PropertyType,
+    LocalVariable,
+    FieldType,
+    GenericArgument,
+    BaseType,
+    Cast,
+    TypeCheck,
+    ObjectCreation,
+    Other
+}
+
+public sealed record TypeUsageDto(
+    string FilePath,
+    int StartLine,
+    int StartColumn,
+    int EndLine,
+    int EndColumn,
+    string? ContainingMember,
+    string? PreviewText,
+    TypeUsageClassification Classification);

--- a/src/Company.RoslynMcp.Core/Services/ISymbolService.cs
+++ b/src/Company.RoslynMcp.Core/Services/ISymbolService.cs
@@ -32,4 +32,13 @@ public interface ISymbolService
     Task<SignatureHelpDto?> GetSignatureHelpAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
 
     Task<SymbolRelationshipsDto?> GetSymbolRelationshipsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    Task<IReadOnlyList<PropertyWriteDto>> FindPropertyWritesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    Task<IReadOnlyList<TypeUsageDto>> FindTypeUsagesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    Task<IReadOnlyList<BulkReferenceResultDto>> FindReferencesBulkAsync(
+        string workspaceId, IReadOnlyList<BulkSymbolLocator> symbols, bool includeDefinition, CancellationToken ct);
+
+    Task<TypeMutationDto?> FindTypeMutationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
 }

--- a/src/Company.RoslynMcp.Core/Services/IValidationService.cs
+++ b/src/Company.RoslynMcp.Core/Services/IValidationService.cs
@@ -13,4 +13,6 @@ public interface IValidationService
     Task<IReadOnlyList<TestCaseDto>> FindRelatedTestsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
 
     Task<TestRunResultDto> RunTestsAsync(string workspaceId, string? projectName, string? filter, CancellationToken ct);
+
+    Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct);
 }

--- a/src/Company.RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
+++ b/src/Company.RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
@@ -1,0 +1,16 @@
+namespace Company.RoslynMcp.Core.Services;
+
+/// <summary>
+/// Serializes execution per workspace so that multiple concurrent callers (e.g. subagents)
+/// do not corrupt Roslyn state. One operation per workspace at a time; different workspaces can run in parallel.
+/// Use the load gate for workspace_load and workspace_reload.
+/// </summary>
+public interface IWorkspaceExecutionGate
+{
+/// <summary>
+/// Run an async action while holding the gate for the given key.
+/// Use the load gate key (e.g. "__load__") for workspace_load and workspace_reload.
+/// Use the workspace session id for all other tools that take a workspaceId.
+/// </summary>
+    Task<T> RunAsync<T>(string? gateKey, Func<CancellationToken, Task<T>> action, CancellationToken ct);
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -13,6 +13,7 @@ public static class AnalysisTools
 
     [McpServerTool(Name = "project_diagnostics"), Description("Get compiler diagnostics (errors, warnings) for the workspace, optionally filtered by project, file, or severity")]
     public static async Task<string> GetProjectDiagnostics(
+        IWorkspaceExecutionGate gate,
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name")] string? project = null,
@@ -20,12 +21,16 @@ public static class AnalysisTools
         [Description("Optional: minimum severity filter (Error, Warning, Info, Hidden)")] string? severity = null,
         CancellationToken ct = default)
     {
-        var results = await diagnosticService.GetDiagnosticsAsync(workspaceId, project, file, severity, ct);
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var results = await diagnosticService.GetDiagnosticsAsync(workspaceId, project, file, severity, c);
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "diagnostic_details"), Description("Get detailed information and curated fix options for a specific diagnostic occurrence")]
     public static async Task<string> GetDiagnosticDetails(
+        IWorkspaceExecutionGate gate,
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Diagnostic identifier, e.g. CS8019")] string diagnosticId,
@@ -34,12 +39,16 @@ public static class AnalysisTools
         [Description("1-based column number")] int column,
         CancellationToken ct = default)
     {
-        var result = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "type_hierarchy"), Description("Get the type hierarchy (base types, derived types, implemented interfaces) for a type at the given position")]
     public static async Task<string> GetTypeHierarchy(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -48,16 +57,17 @@ public static class AnalysisTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var result = await symbolService.GetTypeHierarchyAsync(
-            workspaceId,
-            CreateLocator(filePath, line, column, symbolHandle),
-            ct);
-        if (result is null) return """{"error": "No type found at the specified location"}""";
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await symbolService.GetTypeHierarchyAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
+            if (result is null) return """{"error": "No type found at the specified location"}""";
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "callers_callees"), Description("Find direct callers and callees of a method at the given position")]
     public static async Task<string> GetCallersCallees(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -66,16 +76,17 @@ public static class AnalysisTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var result = await symbolService.GetCallersCalleesAsync(
-            workspaceId,
-            CreateLocator(filePath, line, column, symbolHandle),
-            ct);
-        if (result is null) return """{"error": "No symbol found at the specified location"}""";
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await symbolService.GetCallersCalleesAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
+            if (result is null) return """{"error": "No symbol found at the specified location"}""";
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "impact_analysis"), Description("Analyze the impact of changing a symbol: find all references, affected declarations, and affected projects")]
     public static async Task<string> AnalyzeImpact(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -84,19 +95,70 @@ public static class AnalysisTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var result = await symbolService.AnalyzeImpactAsync(
-            workspaceId,
-            CreateLocator(filePath, line, column, symbolHandle),
-            ct);
-        if (result is null) return """{"error": "No symbol found at the specified location"}""";
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await symbolService.AnalyzeImpactAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
+            if (result is null) return """{"error": "No symbol found at the specified location"}""";
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "find_type_mutations"), Description("Heavy analysis: find all mutating members of a type (settable properties, methods that write instance state) and their external callers, classified as construction-phase vs post-construction callers")]
+    public static async Task<string> FindTypeMutations(
+        IWorkspaceExecutionGate gate,
+        ISymbolService symbolService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: absolute path to the source file containing the type")] string? filePath = null,
+        [Description("Optional: 1-based line number")] int? line = null,
+        [Description("Optional: 1-based column number")] int? column = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        CancellationToken ct = default)
+    {
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle);
+            var result = await symbolService.FindTypeMutationsAsync(workspaceId, locator, c);
+            if (result is null) return """{"error": "No named type found at the specified location"}""";
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "find_type_usages"), Description("Find all usages of a type across the solution, classified by role: MethodReturnType, MethodParameter, PropertyType, LocalVariable, FieldType, GenericArgument, BaseType, Cast, TypeCheck, ObjectCreation, or Other")]
+    public static async Task<string> FindTypeUsages(
+        IWorkspaceExecutionGate gate,
+        ISymbolService symbolService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: absolute path to the source file containing the type")] string? filePath = null,
+        [Description("Optional: 1-based line number")] int? line = null,
+        [Description("Optional: 1-based column number")] int? column = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        [Description("Optional: fully qualified metadata name, e.g. System.Collections.Generic.Dictionary`2")] string? metadataName = null,
+        CancellationToken ct = default)
+    {
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocatorWithMetadata(filePath, line, column, symbolHandle, metadataName);
+            var results = await symbolService.FindTypeUsagesAsync(workspaceId, locator, c);
+            var grouped = results
+                .GroupBy(u => u.Classification.ToString())
+                .ToDictionary(g => g.Key, g => g.ToList());
+            return JsonSerializer.Serialize(new { count = results.Count, usagesByClassification = grouped }, JsonOptions);
+        }, ct);
     }
 
     private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)
+        => CreateLocatorWithMetadata(filePath, line, column, symbolHandle, null);
+
+    private static SymbolLocator CreateLocatorWithMetadata(string? filePath, int? line, int? column, string? symbolHandle, string? metadataName)
     {
         if (!string.IsNullOrWhiteSpace(symbolHandle))
         {
             return SymbolLocator.ByHandle(symbolHandle);
+        }
+
+        if (!string.IsNullOrWhiteSpace(metadataName))
+        {
+            return SymbolLocator.ByMetadataName(metadataName);
         }
 
         if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
@@ -104,6 +166,6 @@ public static class AnalysisTools
             return SymbolLocator.BySource(filePath, line.Value, column.Value);
         }
 
-        throw new ArgumentException("Provide either filePath/line/column or symbolHandle.");
+        throw new ArgumentException("Provide either filePath/line/column, symbolHandle, or metadataName.");
     }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using Company.RoslynMcp.Core.Models;
 using Company.RoslynMcp.Core.Services;
+using Company.RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace Company.RoslynMcp.Host.Stdio.Tools;
@@ -13,6 +14,7 @@ public static class RefactoringTools
 
     [McpServerTool(Name = "rename_preview"), Description("Preview a rename refactoring: shows all files and changes that would result from renaming a symbol")]
     public static async Task<string> PreviewRename(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("The new name for the symbol")] string newName,
@@ -22,68 +24,88 @@ public static class RefactoringTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.PreviewRenameAsync(
-            workspaceId,
-            CreateLocator(filePath, line, column, symbolHandle),
-            newName,
-            ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await refactoringService.PreviewRenameAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), newName, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "rename_apply"), Description("Apply a previously previewed rename refactoring using its preview token. Rejects stale tokens if the workspace has changed.")]
     public static async Task<string> ApplyRename(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The preview token returned by rename_preview")] string previewToken,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.ApplyRefactoringAsync(previewToken, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+        {
+            var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "organize_usings_preview"), Description("Preview organizing using directives in a file: removes unused usings and sorts them")]
     public static async Task<string> PreviewOrganizeUsings(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Absolute path to the source file")] string filePath,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.PreviewOrganizeUsingsAsync(workspaceId, filePath, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await refactoringService.PreviewOrganizeUsingsAsync(workspaceId, filePath, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "organize_usings_apply"), Description("Apply a previously previewed organize usings operation using its preview token")]
     public static async Task<string> ApplyOrganizeUsings(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The preview token returned by organize_usings_preview")] string previewToken,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.ApplyRefactoringAsync(previewToken, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+        {
+            var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "format_document_preview"), Description("Preview formatting a document: applies standard C# formatting rules")]
     public static async Task<string> PreviewFormatDocument(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Absolute path to the source file")] string filePath,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.PreviewFormatDocumentAsync(workspaceId, filePath, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await refactoringService.PreviewFormatDocumentAsync(workspaceId, filePath, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "format_document_apply"), Description("Apply a previously previewed format document operation using its preview token")]
     public static async Task<string> ApplyFormatDocument(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The preview token returned by format_document_preview")] string previewToken,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.ApplyRefactoringAsync(previewToken, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+        {
+            var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "code_fix_preview"), Description("Preview a curated code fix for a specific diagnostic occurrence")]
     public static async Task<string> PreviewCodeFix(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Diagnostic identifier, e.g. CS8019")] string diagnosticId,
@@ -93,18 +115,25 @@ public static class RefactoringTools
         [Description("Optional: curated fix identifier from diagnostic_details")] string? fixId = null,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.PreviewCodeFixAsync(workspaceId, diagnosticId, filePath, line, column, fixId, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await refactoringService.PreviewCodeFixAsync(workspaceId, diagnosticId, filePath, line, column, fixId, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "code_fix_apply"), Description("Apply a previously previewed code fix using its preview token")]
     public static async Task<string> ApplyCodeFix(
+        IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         [Description("The preview token returned by code_fix_preview")] string previewToken,
         CancellationToken ct = default)
     {
-        var result = await refactoringService.ApplyRefactoringAsync(previewToken, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+        {
+            var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -13,6 +13,7 @@ public static class SymbolTools
 
     [McpServerTool(Name = "symbol_search"), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace")]
     public static async Task<string> SearchSymbols(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Search query pattern (supports partial matching)")] string query,
@@ -22,12 +23,16 @@ public static class SymbolTools
         [Description("Maximum number of results to return (default: 20)")] int limit = 20,
         CancellationToken ct = default)
     {
-        var results = await symbolService.SearchSymbolsAsync(workspaceId, query, project, kind, @namespace, limit, ct);
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var results = await symbolService.SearchSymbolsAsync(workspaceId, query, project, kind, @namespace, limit, c);
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "symbol_info"), Description("Get detailed information about a symbol at a specific file location")]
     public static async Task<string> GetSymbolInfo(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -37,14 +42,18 @@ public static class SymbolTools
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
-        var result = await symbolService.GetSymbolInfoAsync(workspaceId, locator, ct);
-        if (result is null) return """{"error": "No symbol found at the specified location"}""";
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+            var result = await symbolService.GetSymbolInfoAsync(workspaceId, locator, c);
+            if (result is null) return """{"error": "No symbol found at the specified location"}""";
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "go_to_definition"), Description("Find the definition location(s) of a symbol at the given position")]
     public static async Task<string> GoToDefinition(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -53,14 +62,18 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var results = await symbolService.GoToDefinitionAsync(workspaceId, locator, ct);
-        if (results.Count == 0) return """{"error": "No definition found for the symbol at the specified location"}""";
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.GoToDefinitionAsync(workspaceId, locator, c);
+            if (results.Count == 0) return """{"error": "No definition found for the symbol at the specified location"}""";
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "find_references"), Description("Find all references to a symbol at the given position across the entire solution")]
     public static async Task<string> FindReferences(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -69,13 +82,17 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var results = await symbolService.FindReferencesAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(new { count = results.Count, references = results }, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.FindReferencesAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(new { count = results.Count, references = results }, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "find_implementations"), Description("Find all implementations of an interface or abstract member at the given position")]
     public static async Task<string> FindImplementations(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -84,24 +101,32 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var results = await symbolService.FindImplementationsAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(new { count = results.Count, implementations = results }, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.FindImplementationsAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(new { count = results.Count, implementations = results }, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "document_symbols"), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree")]
     public static async Task<string> GetDocumentSymbols(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Absolute path to the source file")] string filePath,
         CancellationToken ct = default)
     {
-        var results = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct);
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var results = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, c);
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "find_overrides"), Description("Find overriding members for a virtual, abstract, or interface member")]
     public static async Task<string> FindOverrides(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -110,13 +135,17 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var results = await symbolService.FindOverridesAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.FindOverridesAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "find_base_members"), Description("Find base or implemented members for an override or implementation")]
     public static async Task<string> FindBaseMembers(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -125,13 +154,17 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var results = await symbolService.FindBaseMembersAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(results, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.FindBaseMembersAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(results, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "member_hierarchy"), Description("Get a summary of base members and overrides for a symbol")]
     public static async Task<string> GetMemberHierarchy(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -140,13 +173,17 @@ public static class SymbolTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
-        var result = await symbolService.GetMemberHierarchyAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var result = await symbolService.GetMemberHierarchyAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "symbol_signature_help"), Description("Get display signature, parameters, return type, and documentation for a symbol")]
     public static async Task<string> GetSignatureHelp(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -156,13 +193,17 @@ public static class SymbolTools
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
-        var result = await symbolService.GetSignatureHelpAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+            var result = await symbolService.GetSignatureHelpAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "symbol_relationships"), Description("Get a combined summary of definitions, references, implementations, base members, and overrides")]
     public static async Task<string> GetSymbolRelationships(
+        IWorkspaceExecutionGate gate,
         ISymbolService symbolService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -172,9 +213,47 @@ public static class SymbolTools
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
-        var result = await symbolService.GetSymbolRelationshipsAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+            var result = await symbolService.GetSymbolRelationshipsAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "find_references_bulk"), Description("Find references for multiple symbols in a single call (max 50). Returns a list of results keyed by symbol handle, metadata name, or file:line:column")]
+    public static async Task<string> FindReferencesBulk(
+        IWorkspaceExecutionGate gate,
+        ISymbolService symbolService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Array of symbol locators (max 50). Each object may have symbolHandle, metadataName, or filePath/line/column")] BulkSymbolLocator[] symbols,
+        [Description("Include the definition location in each result (default: false)")] bool includeDefinition = false,
+        CancellationToken ct = default)
+    {
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var results = await symbolService.FindReferencesBulkAsync(workspaceId, symbols, includeDefinition, c);
+            return JsonSerializer.Serialize(new { count = results.Count, results }, JsonOptions);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "find_property_writes"), Description("Find all locations where a property is assigned to (written), classified as object-initializer writes (safe for init) or post-construction assignments")]
+    public static async Task<string> FindPropertyWrites(
+        IWorkspaceExecutionGate gate,
+        ISymbolService symbolService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: absolute path to the source file containing the property")] string? filePath = null,
+        [Description("Optional: 1-based line number")] int? line = null,
+        [Description("Optional: 1-based column number")] int? column = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        CancellationToken ct = default)
+    {
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+            var results = await symbolService.FindPropertyWritesAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(new { count = results.Count, writes = results }, JsonOptions);
+        }, ct);
     }
 
     private static SymbolLocator CreateLocator(

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -13,49 +13,66 @@ public static class ValidationTools
 
     [McpServerTool(Name = "build_workspace"), Description("Run dotnet build for the loaded workspace and return structured diagnostics and execution output")]
     public static async Task<string> BuildWorkspace(
+        IWorkspaceExecutionGate gate,
         IValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         CancellationToken ct = default)
     {
-        var result = await validationService.BuildWorkspaceAsync(workspaceId, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await validationService.BuildWorkspaceAsync(workspaceId, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "build_project"), Description("Run dotnet build for a specific project in the loaded workspace and return structured diagnostics and execution output")]
     public static async Task<string> BuildProject(
+        IWorkspaceExecutionGate gate,
         IValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Project name or project file path within the loaded workspace")] string projectName,
         CancellationToken ct = default)
     {
-        var result = await validationService.BuildProjectAsync(workspaceId, projectName, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await validationService.BuildProjectAsync(workspaceId, projectName, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "test_discover"), Description("Discover tests from test projects in the loaded workspace")]
     public static async Task<string> DiscoverTests(
+        IWorkspaceExecutionGate gate,
         IValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         CancellationToken ct = default)
     {
-        var result = await validationService.DiscoverTestsAsync(workspaceId, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await validationService.DiscoverTestsAsync(workspaceId, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "test_run"), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results")]
     public static async Task<string> RunTests(
+        IWorkspaceExecutionGate gate,
         IValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: specific test project name or file path")] string? projectName = null,
         [Description("Optional: dotnet test filter expression")] string? filter = null,
         CancellationToken ct = default)
     {
-        var result = await validationService.RunTestsAsync(workspaceId, projectName, filter, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await validationService.RunTestsAsync(workspaceId, projectName, filter, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "test_related"), Description("Find likely related tests for a symbol by source location or symbol handle")]
     public static async Task<string> FindRelatedTests(
+        IWorkspaceExecutionGate gate,
         IValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -64,9 +81,28 @@ public static class ValidationTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         CancellationToken ct = default)
     {
-        var locator = CreateLocator(filePath, line, column, symbolHandle);
-        var result = await validationService.FindRelatedTestsAsync(workspaceId, locator, ct);
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var locator = CreateLocator(filePath, line, column, symbolHandle);
+            var result = await validationService.FindRelatedTestsAsync(workspaceId, locator, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "test_related_files"), Description("Given a list of changed source file paths, find all related tests across the solution and return a combined dotnet test filter expression")]
+    public static async Task<string> FindRelatedTestsForFiles(
+        IWorkspaceExecutionGate gate,
+        IValidationService validationService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Array of absolute paths to changed source files")] string[] filePaths,
+        [Description("Maximum number of test cases to return (default: 100)")] int maxResults = 100,
+        CancellationToken ct = default)
+    {
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var result = await validationService.FindRelatedTestsForFilesAsync(workspaceId, filePaths, maxResults, c);
+            return JsonSerializer.Serialize(result, JsonOptions);
+        }, ct);
     }
 
     private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using Company.RoslynMcp.Core.Services;
+using Company.RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace Company.RoslynMcp.Host.Stdio.Tools;
@@ -12,50 +13,72 @@ public static class WorkspaceTools
 
     [McpServerTool(Name = "workspace_load"), Description("Load a .sln or .csproj file into the workspace for semantic analysis")]
     public static async Task<string> LoadWorkspace(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("Absolute path to a .sln or .csproj file")] string path,
         CancellationToken ct)
     {
-        var status = await workspace.LoadAsync(path, ct);
-        return JsonSerializer.Serialize(status, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
+        {
+            var status = await workspace.LoadAsync(path, c);
+            return JsonSerializer.Serialize(status, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "workspace_reload"), Description("Reload the currently loaded workspace to pick up file changes")]
     public static async Task<string> ReloadWorkspace(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         CancellationToken ct)
     {
-        var status = await workspace.ReloadAsync(workspaceId, ct);
-        return JsonSerializer.Serialize(status, JsonOptions);
+        return await gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
+        {
+            var status = await workspace.ReloadAsync(workspaceId, c);
+            return JsonSerializer.Serialize(status, JsonOptions);
+        }, ct);
     }
 
     [McpServerTool(Name = "workspace_status"), Description("Get the current status of the loaded workspace including projects and diagnostics")]
-    public static string GetWorkspaceStatus(
+    public static async Task<string> GetWorkspaceStatus(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId)
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        CancellationToken ct = default)
     {
-        var status = workspace.GetStatus(workspaceId);
-        return JsonSerializer.Serialize(status, JsonOptions);
+        return await gate.RunAsync(workspaceId, _ =>
+        {
+            var status = workspace.GetStatus(workspaceId);
+            return Task.FromResult(JsonSerializer.Serialize(status, JsonOptions));
+        }, ct);
     }
 
     [McpServerTool(Name = "project_graph"), Description("Get the project dependency graph and project metadata for a loaded workspace")]
-    public static string GetProjectGraph(
+    public static async Task<string> GetProjectGraph(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId)
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        CancellationToken ct = default)
     {
-        var graph = workspace.GetProjectGraph(workspaceId);
-        return JsonSerializer.Serialize(graph, JsonOptions);
+        return await gate.RunAsync(workspaceId, _ =>
+        {
+            var graph = workspace.GetProjectGraph(workspaceId);
+            return Task.FromResult(JsonSerializer.Serialize(graph, JsonOptions));
+        }, ct);
     }
 
     [McpServerTool(Name = "source_generated_documents"), Description("List source-generated documents for a workspace or specific project")]
     public static async Task<string> GetSourceGeneratedDocuments(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name")] string? projectName = null,
         CancellationToken ct = default)
     {
-        var documents = await workspace.GetSourceGeneratedDocumentsAsync(workspaceId, projectName, ct);
-        return JsonSerializer.Serialize(documents, JsonOptions);
+        return await gate.RunAsync(workspaceId, async c =>
+        {
+            var documents = await workspace.GetSourceGeneratedDocumentsAsync(workspaceId, projectName, c);
+            return JsonSerializer.Serialize(documents, JsonOptions);
+        }, ct);
     }
 }

--- a/src/Company.RoslynMcp.Roslyn/Helpers/SymbolMapper.cs
+++ b/src/Company.RoslynMcp.Roslyn/Helpers/SymbolMapper.cs
@@ -1,5 +1,8 @@
 using Company.RoslynMcp.Core.Models;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
 
 namespace Company.RoslynMcp.Roslyn.Helpers;
 
@@ -44,6 +47,28 @@ public static class SymbolMapper
                 : null;
         }
 
+        bool? hasGetter = null;
+        bool? hasSetter = null;
+        string? setterAccessibility = null;
+        if (symbol is IPropertySymbol prop)
+        {
+            hasGetter = prop.GetMethod is not null;
+            hasSetter = prop.SetMethod is not null;
+            if (prop.SetMethod is not null)
+            {
+                setterAccessibility = prop.SetMethod.IsInitOnly ? "init" : prop.SetMethod.DeclaredAccessibility switch
+                {
+                    Accessibility.Public => "public",
+                    Accessibility.Private => "private",
+                    Accessibility.Protected => "protected",
+                    Accessibility.Internal => "internal",
+                    Accessibility.ProtectedOrInternal => "protected internal",
+                    Accessibility.ProtectedAndInternal => "private protected",
+                    _ => "unknown"
+                };
+            }
+        }
+
         return new SymbolDto(
             Name: symbol.Name,
             FullyQualifiedName: symbol.ToDisplayString(),
@@ -64,10 +89,13 @@ public static class SymbolMapper
             Modifiers: modifiers.Count > 0 ? modifiers : null,
             BaseTypes: baseTypes,
             Interfaces: interfaces,
-            Documentation: symbol.GetDocumentationCommentXml());
+            Documentation: symbol.GetDocumentationCommentXml(),
+            HasGetter: hasGetter,
+            HasSetter: hasSetter,
+            SetterAccessibility: setterAccessibility);
     }
 
-    public static LocationDto ToLocationDto(Location location, ISymbol? containingSymbol = null, string? previewText = null)
+    public static LocationDto ToLocationDto(Location location, ISymbol? containingSymbol = null, string? previewText = null, string? classification = null)
     {
         var lineSpan = location.GetLineSpan();
         return new LocationDto(
@@ -77,7 +105,65 @@ public static class SymbolMapper
             EndLine: lineSpan.EndLinePosition.Line + 1,
             EndColumn: lineSpan.EndLinePosition.Character + 1,
             ContainingMember: containingSymbol?.ToDisplayString(),
-            PreviewText: previewText);
+            PreviewText: previewText,
+            Classification: classification);
+    }
+
+    public static string ClassifyReferenceLocation(ReferenceLocation refLocation)
+    {
+        if (refLocation.IsImplicit)
+            return "Other";
+
+        var syntaxNode = refLocation.Location.SourceTree is not null
+            ? refLocation.Location.SourceTree
+                .GetRoot()
+                .FindNode(refLocation.Location.SourceSpan)
+            : null;
+
+        if (syntaxNode is null)
+            return "Read";
+
+        // Check for nameof — InvocationExpressionSyntax with "nameof" as the expression
+        if (syntaxNode.Ancestors().OfType<InvocationExpressionSyntax>()
+            .Any(inv => inv.Expression is IdentifierNameSyntax id && id.Identifier.Text == "nameof"))
+            return "NameOf";
+
+        if (syntaxNode.Ancestors().OfType<AttributeSyntax>().Any())
+            return "Attribute";
+
+        // Check if this node is the left-hand side of an assignment
+        if (syntaxNode.Parent is AssignmentExpressionSyntax assignment && assignment.Left == syntaxNode)
+            return "Write";
+
+        if (syntaxNode.Parent is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Parent is AssignmentExpressionSyntax memberAssignment &&
+            memberAssignment.Left == memberAccess)
+            return "Write";
+
+        // Prefix/postfix increment or decrement counts as ReadWrite
+        if (syntaxNode.Parent is PrefixUnaryExpressionSyntax prefix &&
+            (prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+            return "ReadWrite";
+
+        if (syntaxNode.Parent is PostfixUnaryExpressionSyntax postfix &&
+            (postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression)))
+            return "ReadWrite";
+
+        // Compound assignment (+=, -=, etc.) is also ReadWrite
+        if (syntaxNode.Parent is AssignmentExpressionSyntax compoundAssignment &&
+            compoundAssignment.Left == syntaxNode &&
+            (compoundAssignment.IsKind(SyntaxKind.AddAssignmentExpression) ||
+             compoundAssignment.IsKind(SyntaxKind.SubtractAssignmentExpression) ||
+             compoundAssignment.IsKind(SyntaxKind.MultiplyAssignmentExpression) ||
+             compoundAssignment.IsKind(SyntaxKind.DivideAssignmentExpression)))
+            return "ReadWrite";
+
+        // ref or out argument
+        if (syntaxNode.Parent is ArgumentSyntax arg &&
+            (arg.RefKindKeyword.IsKind(SyntaxKind.RefKeyword) || arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)))
+            return "Write";
+
+        return "Read";
     }
 
     public static DiagnosticDto ToDiagnosticDto(Diagnostic diagnostic)

--- a/src/Company.RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/Company.RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddRoslynServices(this IServiceCollection services)
     {
+        services.AddSingleton<IWorkspaceExecutionGate, WorkspaceExecutionGate>();
         services.AddSingleton<IDotnetCommandRunner, DotnetCommandRunner>();
         services.AddSingleton<IPreviewStore, PreviewStore>();
         services.AddSingleton<IWorkspaceManager, WorkspaceManager>();

--- a/src/Company.RoslynMcp.Roslyn/Services/SymbolService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/SymbolService.cs
@@ -117,7 +117,8 @@ public sealed class SymbolService : ISymbolService
                 var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct);
 
                 var containingSymbol = await GetContainingSymbolAsync(doc, refLocation.Location, ct);
-                results.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview));
+                var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
+                results.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
             }
         }
 
@@ -404,6 +405,429 @@ public sealed class SymbolService : ISymbolService
             Implementations: await implementationsTask,
             BaseMembers: await baseMembersTask,
             Overrides: await overridesTask);
+    }
+
+    public async Task<IReadOnlyList<PropertyWriteDto>> FindPropertyWritesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct);
+        if (symbol is not IPropertySymbol property) return [];
+
+        var references = await SymbolFinder.FindReferencesAsync(property, solution, ct);
+        var results = new List<PropertyWriteDto>();
+
+        foreach (var refSymbol in references)
+        {
+            foreach (var refLocation in refSymbol.Locations)
+            {
+                var doc = refLocation.Document;
+                var root = await doc.GetSyntaxRootAsync(ct);
+                if (root is null) continue;
+
+                var refNode = root.FindNode(refLocation.Location.SourceSpan);
+
+                // Determine if this reference is a write (left side of assignment, out/ref arg, or in an initializer)
+                var isWrite = IsWriteReference(refNode);
+                if (!isWrite) continue;
+
+                var isObjectInitializer = refNode.Ancestors()
+                    .Any(static a => a is InitializerExpressionSyntax init &&
+                        init.Kind() == SyntaxKind.ObjectInitializerExpression);
+
+                var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct);
+                var containingSymbol = await GetContainingSymbolAsync(doc, refLocation.Location, ct);
+                var lineSpan = refLocation.Location.GetLineSpan();
+
+                results.Add(new PropertyWriteDto(
+                    FilePath: lineSpan.Path,
+                    StartLine: lineSpan.StartLinePosition.Line + 1,
+                    StartColumn: lineSpan.StartLinePosition.Character + 1,
+                    EndLine: lineSpan.EndLinePosition.Line + 1,
+                    EndColumn: lineSpan.EndLinePosition.Character + 1,
+                    ContainingMember: containingSymbol?.ToDisplayString(),
+                    PreviewText: preview,
+                    IsObjectInitializer: isObjectInitializer));
+            }
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<TypeUsageDto>> FindTypeUsagesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct);
+        if (symbol is null) return [];
+
+        var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct);
+        var results = new List<TypeUsageDto>();
+
+        foreach (var refSymbol in references)
+        {
+            foreach (var refLocation in refSymbol.Locations)
+            {
+                var doc = refLocation.Document;
+                var root = await doc.GetSyntaxRootAsync(ct);
+                if (root is null) continue;
+
+                var refNode = root.FindNode(refLocation.Location.SourceSpan);
+                var classification = ClassifyTypeUsage(refNode);
+
+                var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct);
+                var containingSymbol = await GetContainingSymbolAsync(doc, refLocation.Location, ct);
+                var lineSpan = refLocation.Location.GetLineSpan();
+
+                results.Add(new TypeUsageDto(
+                    FilePath: lineSpan.Path,
+                    StartLine: lineSpan.StartLinePosition.Line + 1,
+                    StartColumn: lineSpan.StartLinePosition.Character + 1,
+                    EndLine: lineSpan.EndLinePosition.Line + 1,
+                    EndColumn: lineSpan.EndLinePosition.Character + 1,
+                    ContainingMember: containingSymbol?.ToDisplayString(),
+                    PreviewText: preview,
+                    Classification: classification));
+            }
+        }
+
+        return results;
+    }
+
+    private static TypeUsageClassification ClassifyTypeUsage(SyntaxNode refNode)
+    {
+        var parent = refNode.Parent;
+        if (parent is null) return TypeUsageClassification.Other;
+
+        // Walk up past qualified names, generic names, etc.
+        var typeNode = refNode;
+        while (parent is QualifiedNameSyntax or AliasQualifiedNameSyntax or NullableTypeSyntax or ArrayTypeSyntax)
+        {
+            typeNode = parent;
+            parent = parent.Parent;
+            if (parent is null) return TypeUsageClassification.Other;
+        }
+
+        // Handle generic type arguments (e.g., List<T>)
+        if (parent is TypeArgumentListSyntax)
+            return TypeUsageClassification.GenericArgument;
+
+        // Method return type
+        if (parent is MethodDeclarationSyntax methodDecl && methodDecl.ReturnType == typeNode)
+            return TypeUsageClassification.MethodReturnType;
+
+        // Local function return type
+        if (parent is LocalFunctionStatementSyntax localFunc && localFunc.ReturnType == typeNode)
+            return TypeUsageClassification.MethodReturnType;
+
+        // Method parameter
+        if (parent is ParameterSyntax param)
+        {
+            if (param.Type == typeNode)
+                return TypeUsageClassification.MethodParameter;
+        }
+
+        // Property type
+        if (parent is PropertyDeclarationSyntax propDecl && propDecl.Type == typeNode)
+            return TypeUsageClassification.PropertyType;
+
+        // Variable declaration — field or local
+        if (parent is VariableDeclarationSyntax varDecl && varDecl.Type == typeNode)
+        {
+            var grandparent = varDecl.Parent;
+            return grandparent is FieldDeclarationSyntax
+                ? TypeUsageClassification.FieldType
+                : TypeUsageClassification.LocalVariable;
+        }
+
+        // Base list (base class or interface)
+        if (parent is SimpleBaseTypeSyntax || parent is BaseListSyntax)
+            return TypeUsageClassification.BaseType;
+
+        // Cast expression: (T)expr or expr as T
+        if (parent is CastExpressionSyntax castExpr && castExpr.Type == typeNode)
+            return TypeUsageClassification.Cast;
+        if (parent is BinaryExpressionSyntax binaryAs &&
+            binaryAs.IsKind(SyntaxKind.AsExpression) &&
+            binaryAs.Right == typeNode)
+            return TypeUsageClassification.Cast;
+
+        // Is-pattern / type check
+        if (parent is IsPatternExpressionSyntax)
+            return TypeUsageClassification.TypeCheck;
+        if (parent is BinaryExpressionSyntax binaryIs &&
+            binaryIs.IsKind(SyntaxKind.IsExpression))
+            return TypeUsageClassification.TypeCheck;
+        if (parent is TypePatternSyntax || parent is DeclarationPatternSyntax)
+            return TypeUsageClassification.TypeCheck;
+
+        // Object creation: new T()
+        if (parent is ObjectCreationExpressionSyntax objCreate && objCreate.Type == typeNode)
+            return TypeUsageClassification.ObjectCreation;
+        if (parent is ImplicitObjectCreationExpressionSyntax)
+            return TypeUsageClassification.ObjectCreation;
+
+        return TypeUsageClassification.Other;
+    }
+
+    public async Task<IReadOnlyList<BulkReferenceResultDto>> FindReferencesBulkAsync(
+        string workspaceId, IReadOnlyList<BulkSymbolLocator> symbols, bool includeDefinition, CancellationToken ct)
+    {
+        if (symbols.Count > 50)
+            throw new ArgumentException("Maximum of 50 symbols per bulk request.");
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var semaphore = new SemaphoreSlim(6, 6);
+
+        async Task<BulkReferenceResultDto> ProcessOneAsync(BulkSymbolLocator bulk, int index)
+        {
+            var key = bulk.SymbolHandle ?? bulk.MetadataName
+                ?? (bulk.FilePath is not null && bulk.Line.HasValue && bulk.Column.HasValue
+                    ? $"{bulk.FilePath}:{bulk.Line}:{bulk.Column}"
+                    : $"symbol[{index}]");
+
+            await semaphore.WaitAsync(ct);
+            try
+            {
+                var locator = ToSymbolLocator(bulk);
+                var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct);
+                if (symbol is null)
+                    return new BulkReferenceResultDto(key, null, 0, [], "Symbol could not be resolved.");
+
+                var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct);
+                var locations = new List<LocationDto>();
+
+                if (includeDefinition)
+                {
+                    foreach (var loc in symbol.Locations.Where(l => l.IsInSource))
+                    {
+                        var doc = solution.GetDocument(loc.SourceTree!);
+                        var preview = doc is not null ? await SymbolResolver.GetPreviewTextAsync(doc, loc, ct) : null;
+                        locations.Add(SymbolMapper.ToLocationDto(loc, symbol, preview, "Definition"));
+                    }
+                }
+
+                foreach (var refSymbol in references)
+                {
+                    foreach (var refLocation in refSymbol.Locations)
+                    {
+                        var doc = refLocation.Document;
+                        var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct);
+                        var containingSymbol = await GetContainingSymbolAsync(doc, refLocation.Location, ct);
+                        var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
+                        locations.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
+                    }
+                }
+
+                return new BulkReferenceResultDto(key, symbol.ToDisplayString(), locations.Count, locations, null);
+            }
+            catch (Exception ex)
+            {
+                return new BulkReferenceResultDto(key, null, 0, [], ex.Message);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        var tasks = symbols.Select((s, i) => ProcessOneAsync(s, i)).ToList();
+        var results = await Task.WhenAll(tasks);
+        return results;
+    }
+
+    public async Task<TypeMutationDto?> FindTypeMutationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct);
+        if (symbol is not INamedTypeSymbol namedType) return null;
+
+        var mutatingMembers = new List<MutatingMemberDto>();
+
+        foreach (var member in namedType.GetMembers())
+        {
+            if (!IsMutatingMember(member, namedType)) continue;
+
+            var callers = new List<MutationCallerDto>();
+            var references = await SymbolFinder.FindReferencesAsync(member, solution, ct);
+
+            foreach (var refSymbol in references)
+            {
+                foreach (var refLocation in refSymbol.Locations)
+                {
+                    var containingSymbol = await GetContainingSymbolAsync(refLocation.Document, refLocation.Location, ct);
+
+                    // Skip calls from within the type itself (internal mutators calling each other)
+                    if (containingSymbol is not null &&
+                        SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
+                        continue;
+
+                    var preview = await SymbolResolver.GetPreviewTextAsync(refLocation.Document, refLocation.Location, ct);
+                    var phase = await ClassifyCallerPhaseAsync(refLocation, namedType, ct);
+                    var lineSpan = refLocation.Location.GetLineSpan();
+
+                    callers.Add(new MutationCallerDto(
+                        FilePath: lineSpan.Path,
+                        StartLine: lineSpan.StartLinePosition.Line + 1,
+                        StartColumn: lineSpan.StartLinePosition.Character + 1,
+                        ContainingMember: containingSymbol?.ToDisplayString(),
+                        PreviewText: preview,
+                        CallerPhase: phase));
+                }
+            }
+
+            var memberLoc = member.Locations.FirstOrDefault(l => l.IsInSource);
+            mutatingMembers.Add(new MutatingMemberDto(
+                Name: member.Name,
+                FullyQualifiedName: member.ToDisplayString(),
+                Kind: member.Kind.ToString(),
+                FilePath: memberLoc?.GetLineSpan().Path,
+                Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
+                ExternalCallers: callers));
+        }
+
+        var summary = $"Type '{namedType.Name}' has {mutatingMembers.Count} mutating member(s) " +
+                      $"with {mutatingMembers.Sum(m => m.ExternalCallers.Count)} external caller(s).";
+
+        return new TypeMutationDto(
+            Type: SymbolMapper.ToDto(namedType, solution),
+            MutatingMembers: mutatingMembers,
+            Summary: summary);
+    }
+
+    private static bool IsMutatingMember(ISymbol member, INamedTypeSymbol containingType)
+    {
+        if (member.IsStatic) return false;
+        if (member.DeclaredAccessibility == Accessibility.Private) return false;
+
+        // Settable properties
+        if (member is IPropertySymbol prop && prop.SetMethod is not null &&
+            !prop.SetMethod.IsInitOnly && prop.SetMethod.DeclaredAccessibility != Accessibility.Private)
+            return true;
+
+        // Methods that write to instance fields/properties (simple heuristic: check method body)
+        if (member is IMethodSymbol method &&
+            method.MethodKind is MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation)
+        {
+            var location = method.Locations.FirstOrDefault(l => l.IsInSource);
+            if (location?.SourceTree is null) return false;
+
+            var root = location.SourceTree.GetRoot();
+            var methodNode = root.FindNode(location.SourceSpan);
+
+            var hasInstanceAssignment = methodNode.DescendantNodes()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a =>
+                {
+                    var left = a.Left;
+                    if (left is MemberAccessExpressionSyntax memberAccess)
+                    {
+                        return memberAccess.Expression is ThisExpressionSyntax ||
+                               (memberAccess.Expression is IdentifierNameSyntax && IsInstanceMember(memberAccess.Name.Identifier.Text, containingType));
+                    }
+                    if (left is IdentifierNameSyntax ident)
+                    {
+                        return IsInstanceMember(ident.Identifier.Text, containingType);
+                    }
+                    return false;
+                });
+
+            if (hasInstanceAssignment) return true;
+
+            // Methods that call mutating collection methods (.Add, .Remove, .Clear) on instance members
+            var hasMutatingCollectionCall = methodNode.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(inv =>
+                {
+                    if (inv.Expression is MemberAccessExpressionSyntax access)
+                    {
+                        var methodName = access.Name.Identifier.Text;
+                        return methodName is "Add" or "Remove" or "Clear" or "Insert" or "RemoveAt" or "AddRange" or "RemoveAll";
+                    }
+                    return false;
+                });
+
+            return hasMutatingCollectionCall;
+        }
+
+        return false;
+    }
+
+    private static bool IsInstanceMember(string name, INamedTypeSymbol type)
+    {
+        return type.GetMembers(name).Any(m => !m.IsStatic);
+    }
+
+    private static async Task<string> ClassifyCallerPhaseAsync(ReferenceLocation refLocation, INamedTypeSymbol targetType, CancellationToken ct)
+    {
+        var root = await refLocation.Document.GetSyntaxRootAsync(ct);
+        if (root is null) return "Unknown";
+
+        var node = root.FindNode(refLocation.Location.SourceSpan);
+
+        // Check if inside an object initializer
+        if (node.Ancestors().OfType<InitializerExpressionSyntax>()
+            .Any(e => e.Kind() == SyntaxKind.ObjectInitializerExpression))
+            return "Construction";
+
+        // Check if inside a constructor
+        if (node.Ancestors().OfType<ConstructorDeclarationSyntax>().Any())
+            return "Construction";
+
+        // Check if inside a method of the same type that returns void (builder-pattern heuristic)
+        var enclosingMethod = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+        if (enclosingMethod is not null)
+        {
+            var returnType = enclosingMethod.ReturnType.ToString();
+            if (returnType is "void" or "Void")
+            {
+                var semanticModel = await refLocation.Document.GetSemanticModelAsync(ct);
+                if (semanticModel is not null)
+                {
+                    var methodSymbol = semanticModel.GetDeclaredSymbol(enclosingMethod, ct);
+                    if (methodSymbol?.ContainingType is not null &&
+                        SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, targetType))
+                        return "Construction";
+                }
+            }
+        }
+
+        return "PostConstruction";
+    }
+
+    private static SymbolLocator ToSymbolLocator(BulkSymbolLocator bulk)
+    {
+        if (!string.IsNullOrWhiteSpace(bulk.SymbolHandle))
+            return SymbolLocator.ByHandle(bulk.SymbolHandle);
+        if (!string.IsNullOrWhiteSpace(bulk.MetadataName))
+            return SymbolLocator.ByMetadataName(bulk.MetadataName);
+        if (!string.IsNullOrWhiteSpace(bulk.FilePath) && bulk.Line.HasValue && bulk.Column.HasValue)
+            return SymbolLocator.BySource(bulk.FilePath, bulk.Line.Value, bulk.Column.Value);
+        throw new ArgumentException("BulkSymbolLocator requires symbolHandle, metadataName, or filePath/line/column.");
+    }
+
+    private static bool IsWriteReference(SyntaxNode refNode)
+    {
+        // Object initializer member assignment: { Prop = value }
+        if (refNode.Parent is AssignmentExpressionSyntax assignInInit &&
+            assignInInit.Left == refNode &&
+            assignInInit.Parent is InitializerExpressionSyntax)
+            return true;
+
+        // Regular assignment: target = value
+        if (refNode.Parent is AssignmentExpressionSyntax directAssign && directAssign.Left == refNode)
+            return true;
+
+        // MemberAccess on left of assignment: obj.Prop = value
+        if (refNode.Parent is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Parent is AssignmentExpressionSyntax memberAssign &&
+            memberAssign.Left == memberAccess)
+            return true;
+
+        // out or ref argument
+        if (refNode.Parent is ArgumentSyntax arg &&
+            (arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword) || arg.RefKindKeyword.IsKind(SyntaxKind.RefKeyword)))
+            return true;
+
+        return false;
     }
 
     private static bool MatchesKind(ISymbol symbol, string kindFilter)

--- a/src/Company.RoslynMcp.Roslyn/Services/ValidationService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/ValidationService.cs
@@ -1,6 +1,8 @@
 using Company.RoslynMcp.Core.Models;
 using Company.RoslynMcp.Core.Services;
 using Company.RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
@@ -178,6 +180,94 @@ public sealed class ValidationService : IValidationService
                 Directory.Delete(resultsDirectory, recursive: true);
             }
         }
+    }
+
+    public async Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(
+        string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct)
+    {
+        var solution = _workspaceManager.GetCurrentSolution(workspaceId);
+        var discovery = await DiscoverTestsAsync(workspaceId, ct);
+        var allTests = discovery.TestProjects
+            .SelectMany(p => p.Tests.Select(t => (Project: p.ProjectName, Test: t)))
+            .ToList();
+
+        var testToTriggers = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var filePath in filePaths)
+        {
+            var document = _workspaceManager.GetCurrentSolution(workspaceId)
+                .Projects
+                .SelectMany(p => p.Documents)
+                .FirstOrDefault(d => d.FilePath is not null &&
+                    string.Equals(Path.GetFullPath(d.FilePath), Path.GetFullPath(filePath), StringComparison.OrdinalIgnoreCase));
+
+            if (document is null) continue;
+
+            var root = await document.GetSyntaxRootAsync(ct);
+            if (root is null) continue;
+
+            var searchTerms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // Collect type names declared in the file from syntax (no semantic model needed)
+            var typeDeclarations = root.DescendantNodes().OfType<TypeDeclarationSyntax>();
+            foreach (var typeDecl in typeDeclarations)
+            {
+                searchTerms.Add(typeDecl.Identifier.Text);
+            }
+
+            // Also use the file name as a search term
+            searchTerms.Add(Path.GetFileNameWithoutExtension(filePath));
+
+            foreach (var (projectName, test) in allTests)
+            {
+                if (!searchTerms.Any(term =>
+                    test.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                    test.FullyQualifiedName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                    (test.FilePath?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)))
+                    continue;
+
+                var key = test.FullyQualifiedName;
+                if (!testToTriggers.TryGetValue(key, out var triggers))
+                {
+                    triggers = new List<string>();
+                    testToTriggers[key] = triggers;
+                }
+                triggers.Add(filePath);
+            }
+        }
+
+        var projectLookup = discovery.TestProjects
+            .SelectMany(p => p.Tests.Select(t => (t.FullyQualifiedName, p.ProjectName)))
+            .ToDictionary(x => x.FullyQualifiedName, x => x.ProjectName, StringComparer.Ordinal);
+
+        var testCaseLookup = discovery.TestProjects
+            .SelectMany(p => p.Tests)
+            .ToDictionary(t => t.FullyQualifiedName, StringComparer.Ordinal);
+
+        var results = testToTriggers
+            .Take(maxResults)
+            .Select(kv =>
+            {
+                var test = testCaseLookup.TryGetValue(kv.Key, out var t) ? t : null;
+                var projectName = projectLookup.TryGetValue(kv.Key, out var pn) ? pn : string.Empty;
+                return new RelatedTestCaseDto(
+                    DisplayName: test?.DisplayName ?? kv.Key,
+                    FullyQualifiedName: kv.Key,
+                    ProjectName: projectName,
+                    FilePath: test?.FilePath,
+                    Line: test?.Line,
+                    TriggeredByFiles: kv.Value.Distinct().ToList());
+            })
+            .ToList();
+
+        var filterParts = results
+            .Select(t => t.FullyQualifiedName)
+            .Distinct()
+            .Select(fqn => $"FullyQualifiedName~{fqn}")
+            .ToList();
+        var dotnetFilter = filterParts.Count > 0 ? string.Join("|", filterParts) : string.Empty;
+
+        return new RelatedTestsForFilesDto(results, dotnetFilter);
     }
 
     private async Task<CommandExecutionDto> RunDotnetCommandAsync(

--- a/src/Company.RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using Company.RoslynMcp.Core.Services;
+
+namespace Company.RoslynMcp.Roslyn.Services;
+
+public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate
+{
+    public const string LoadGateKey = "__load__";
+    /// <summary>Gate for refactoring apply operations (no workspaceId in parameters).</summary>
+    public const string ApplyGateKey = "__apply__";
+
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _workspaceGates = new(StringComparer.Ordinal);
+
+    public async Task<T> RunAsync<T>(string? gateKey, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+    {
+        var key = string.IsNullOrWhiteSpace(gateKey) ? LoadGateKey : gateKey;
+        var gate = key == LoadGateKey ? _loadGate : _workspaceGates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await action(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements all 6 enhancements from \Roslyn-MCP-Enhancement-Prompt.md\ and adds per-workspace execution gating so multiple subagents can call the server safely in a single session.

## New tools
- **find_property_writes** – property write sites, classified as object-initializer vs post-construction
- **find_references_bulk** – references for up to 50 symbols in one call
- **find_type_usages** – type usages classified (MethodReturnType, MethodParameter, PropertyType, etc.)
- **find_type_mutations** – mutating members and external callers (construction vs post-construction)
- **test_related_files** – related tests for changed files + combined dotnet test filter

## Enrichments
- **SymbolDto**: \HasGetter\, \HasSetter\, \SetterAccessibility\ for properties
- **find_references**: each reference has \Classification\ (Read, Write, ReadWrite, NameOf, Attribute, Other)

## Concurrency
- **Per-workspace execution gate**: one operation per workspace at a time; different workspaces run in parallel. Prevents Roslyn corruption when multiple subagents call the same server.
- Load/reload and refactoring apply use dedicated gates.

## Verification
- \dotnet build\ – 0 errors, 0 warnings
- \dotnet test\ – 47 tests passed

Made with [Cursor](https://cursor.com)