### PR TITLE
feat: Production hardening - error handling, stale detection, executi…

### DIFF
--- a/src/Company.RoslynMcp.Core/Models/FileEditsDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/FileEditsDto.cs
@@ -1,0 +1,3 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record FileEditsDto(string FilePath, TextEditDto[] Edits);

--- a/src/Company.RoslynMcp.Core/Models/MultiFileEditResultDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/MultiFileEditResultDto.cs
@@ -1,0 +1,11 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record MultiFileEditResultDto(
+    bool Success,
+    int FilesModified,
+    IReadOnlyList<FileEditSummaryDto> Files);
+
+public sealed record FileEditSummaryDto(
+    string FilePath,
+    int EditsApplied,
+    string? Diff);

--- a/src/Company.RoslynMcp.Core/Models/SyntaxNodeDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/SyntaxNodeDto.cs
@@ -1,0 +1,10 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record SyntaxNodeDto(
+    string Kind,
+    string? Text,
+    int StartLine,
+    int StartColumn,
+    int EndLine,
+    int EndColumn,
+    IReadOnlyList<SyntaxNodeDto>? Children);

--- a/src/Company.RoslynMcp.Core/Models/TestCoverageDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/TestCoverageDto.cs
@@ -1,0 +1,21 @@
+namespace Company.RoslynMcp.Core.Models;
+
+public sealed record TestCoverageResultDto(
+    bool Success,
+    string? Error,
+    double? LineCoveragePercent,
+    double? BranchCoveragePercent,
+    IReadOnlyList<ModuleCoverageDto> Modules);
+
+public sealed record ModuleCoverageDto(
+    string ModuleName,
+    double LineCoveragePercent,
+    int LinesCovered,
+    int LinesTotal,
+    IReadOnlyList<ClassCoverageDto>? Classes);
+
+public sealed record ClassCoverageDto(
+    string ClassName,
+    double LineCoveragePercent,
+    int LinesCovered,
+    int LinesTotal);

--- a/src/Company.RoslynMcp.Core/Models/WorkspaceStatusDto.cs
+++ b/src/Company.RoslynMcp.Core/Models/WorkspaceStatusDto.cs
@@ -10,6 +10,7 @@ public sealed record WorkspaceStatusDto(
     int DocumentCount,
     IReadOnlyList<ProjectStatusDto> Projects,
     bool IsLoaded,
+    bool IsStale,
     IReadOnlyList<DiagnosticDto> WorkspaceDiagnostics);
 
 public sealed record ProjectStatusDto(

--- a/src/Company.RoslynMcp.Core/Services/IFileWatcherService.cs
+++ b/src/Company.RoslynMcp.Core/Services/IFileWatcherService.cs
@@ -1,0 +1,20 @@
+namespace Company.RoslynMcp.Core.Services;
+
+/// <summary>
+/// Watches the file system for changes in loaded workspace directories
+/// and tracks which workspaces have become stale.
+/// </summary>
+public interface IFileWatcherService : IDisposable
+{
+    /// <summary>Start watching for changes in the directory containing the loaded workspace.</summary>
+    void Watch(string workspaceId, string workspacePath);
+
+    /// <summary>Stop watching a workspace.</summary>
+    void Unwatch(string workspaceId);
+
+    /// <summary>Check if a workspace has pending file changes since last load/reload.</summary>
+    bool IsStale(string workspaceId);
+
+    /// <summary>Clear the stale flag (called after reload).</summary>
+    void ClearStale(string workspaceId);
+}

--- a/src/Company.RoslynMcp.Core/Services/ISyntaxService.cs
+++ b/src/Company.RoslynMcp.Core/Services/ISyntaxService.cs
@@ -1,0 +1,8 @@
+using Company.RoslynMcp.Core.Models;
+
+namespace Company.RoslynMcp.Core.Services;
+
+public interface ISyntaxService
+{
+    Task<SyntaxNodeDto?> GetSyntaxTreeAsync(string workspaceId, string filePath, int? startLine, int? endLine, int maxDepth, CancellationToken ct);
+}

--- a/src/Company.RoslynMcp.Core/Services/PreviewStore.cs
+++ b/src/Company.RoslynMcp.Core/Services/PreviewStore.cs
@@ -8,9 +8,12 @@ public sealed class PreviewStore : IPreviewStore
     private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
     private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
 
+    private const int MaxEntries = 50;
+
     public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
     {
         CleanExpired();
+        EvictIfOverLimit();
         var token = Guid.NewGuid().ToString("N");
         _entries[token] = new PreviewEntry(workspaceId, modifiedSolution, workspaceVersion, description, DateTime.UtcNow);
         return token;
@@ -59,6 +62,22 @@ public sealed class PreviewStore : IPreviewStore
         {
             if (now - kvp.Value.CreatedAt > _ttl)
                 _entries.TryRemove(kvp.Key, out _);
+        }
+    }
+
+    private void EvictIfOverLimit()
+    {
+        if (_entries.Count <= MaxEntries) return;
+
+        var toEvict = _entries
+            .OrderBy(kvp => kvp.Value.CreatedAt)
+            .Take(_entries.Count - MaxEntries + 1)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in toEvict)
+        {
+            _entries.TryRemove(key, out _);
         }
     }
 

--- a/src/Company.RoslynMcp.Host.Stdio/Program.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Program.cs
@@ -1,7 +1,9 @@
+using Company.RoslynMcp.Host.Stdio;
 using Company.RoslynMcp.Roslyn;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
 
 // MUST be called before any Microsoft.Build types are loaded
 MsBuildInitializer.EnsureInitialized();
@@ -12,12 +14,43 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
 
+// Register the MCP logging bridge that forwards log events to the client
+var mcpLoggingProvider = new McpLoggingProvider();
+builder.Logging.AddProvider(mcpLoggingProvider);
+
 builder.Services.AddRoslynServices();
 builder.Services
-    .AddMcpServer()
+    .AddMcpServer(options =>
+    {
+        options.ServerInfo = new()
+        {
+            Name = "roslyn-mcp",
+            Title = "Roslyn MCP Server",
+            Version = typeof(Company.RoslynMcp.Host.Stdio.McpLoggingProvider).Assembly.GetName().Version?.ToString() ?? "1.0.0",
+        };
+    })
     .WithStdioServerTransport()
     .WithToolsFromAssembly()
     .WithResourcesFromAssembly()
     .WithPromptsFromAssembly();
 
-await builder.Build().RunAsync();
+var host = builder.Build();
+
+// Wire the MCP logging bridge to the server instance
+var server = host.Services.GetRequiredService<McpServer>();
+mcpLoggingProvider.SetServer(server);
+
+// Register graceful shutdown to dispose all workspaces
+var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+lifetime.ApplicationStopping.Register(() =>
+{
+    var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Shutdown");
+    logger.LogInformation("Shutting down — disposing all workspace sessions");
+    var workspaceManager = host.Services.GetRequiredService<Company.RoslynMcp.Core.Services.IWorkspaceManager>();
+    if (workspaceManager is IDisposable disposable)
+    {
+        disposable.Dispose();
+    }
+});
+
+await host.RunAsync();

--- a/src/Company.RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -208,4 +208,108 @@ public static class RoslynPrompts
             }
         ];
     }
+
+    [McpServerPrompt(Name = "analyze_dependencies")]
+    [Description("Generate a prompt to analyze architecture and dependency structure of a workspace")]
+    public static async Task<IEnumerable<PromptMessage>> AnalyzeDependencies(
+        IWorkspaceManager workspace,
+        IAdvancedAnalysisService analysisService,
+        [Description("The workspace session identifier")] string workspaceId,
+        CancellationToken ct = default)
+    {
+        var graph = workspace.GetProjectGraph(workspaceId);
+        var graphJson = JsonSerializer.Serialize(graph, new JsonSerializerOptions { WriteIndented = true });
+
+        var namespaceDeps = await analysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
+        var namespaceDepsJson = JsonSerializer.Serialize(namespaceDeps, new JsonSerializerOptions { WriteIndented = true });
+
+        var nugetDeps = await analysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
+        var nugetDepsJson = JsonSerializer.Serialize(nugetDeps, new JsonSerializerOptions { WriteIndented = true });
+
+        return
+        [
+            new PromptMessage
+            {
+                Role = Role.User,
+                Content = new TextContentBlock
+                {
+                    Text = $"""
+                        Analyze the architecture and dependency structure of this .NET solution.
+
+                        **Project Dependency Graph:**
+                        ```json
+                        {graphJson}
+                        ```
+
+                        **Namespace Dependencies:**
+                        ```json
+                        {namespaceDepsJson}
+                        ```
+
+                        **NuGet Dependencies:**
+                        ```json
+                        {nugetDepsJson}
+                        ```
+
+                        Please analyze:
+                        1. **Architecture**: Identify the layering strategy and assess if it follows clean architecture / onion architecture principles
+                        2. **Circular Dependencies**: Flag any circular namespace or project dependencies and suggest how to break them
+                        3. **Coupling**: Identify tightly coupled components and suggest decoupling strategies
+                        4. **NuGet Health**: Flag outdated, redundant, or conflicting package versions
+                        5. **Dependency Direction**: Verify that dependencies flow in the correct direction (e.g., UI → Domain, not Domain → UI)
+                        6. **Modularity**: Suggest opportunities to extract shared libraries or consolidate projects
+                        """
+                }
+            }
+        ];
+    }
+
+    [McpServerPrompt(Name = "debug_test_failure")]
+    [Description("Generate a prompt to diagnose test failures by running tests and analyzing the output")]
+    public static async Task<IEnumerable<PromptMessage>> DebugTestFailure(
+        IValidationService validationService,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Optional: specific test project name")] string? projectName = null,
+        [Description("Optional: test filter expression to narrow which tests to run")] string? filter = null,
+        CancellationToken ct = default)
+    {
+        var testResult = await validationService.RunTestsAsync(workspaceId, projectName, filter, ct).ConfigureAwait(false);
+        var testResultJson = JsonSerializer.Serialize(testResult, new JsonSerializerOptions { WriteIndented = true });
+
+        var failureSummary = testResult.Failures.Count > 0
+            ? string.Join("\n", testResult.Failures.Select((f, i) =>
+                $"  {i + 1}. **{f.DisplayName}**\n     Message: {f.Message}\n     Stack: {f.StackTrace ?? "N/A"}"))
+            : "No failures detected.";
+
+        return
+        [
+            new PromptMessage
+            {
+                Role = Role.User,
+                Content = new TextContentBlock
+                {
+                    Text = $"""
+                        Diagnose the following test failure(s) and suggest fixes.
+
+                        **Test Summary:** {testResult.Total} total, {testResult.Passed} passed, {testResult.Failed} failed, {testResult.Skipped} skipped
+
+                        **Test Results (full):**
+                        ```json
+                        {testResultJson}
+                        ```
+
+                        **Failure Details:**
+                        {failureSummary}
+
+                        Please:
+                        1. Identify the root cause of each failing test
+                        2. Determine if the failure is in the test itself or the code under test
+                        3. Suggest specific code changes to fix the failure
+                        4. If the test expectation is wrong, explain why and suggest the correct assertion
+                        5. Note any test isolation issues (shared state, timing, external dependencies)
+                        """
+                }
+            }
+        ];
+    }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -37,4 +37,27 @@ public static class WorkspaceResources
         var graph = workspace.GetProjectGraph(workspaceId);
         return JsonSerializer.Serialize(graph, JsonOptions);
     }
+
+    [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/diagnostics", Name = "workspace_diagnostics", MimeType = "application/json")]
+    [Description("Get all compiler diagnostics for a loaded workspace")]
+    public static async Task<string> GetDiagnostics(
+        IDiagnosticService diagnosticService,
+        [Description("The workspace session identifier")] string workspaceId,
+        CancellationToken ct = default)
+    {
+        var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, null, null, ct).ConfigureAwait(false);
+        return JsonSerializer.Serialize(diagnostics, JsonOptions);
+    }
+
+    [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}", Name = "source_file", MimeType = "text/x-csharp")]
+    [Description("Read the source text of a file in the loaded workspace")]
+    public static async Task<string> GetSourceFile(
+        IWorkspaceManager workspace,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Absolute path to the source file (URL-encoded)")] string filePath,
+        CancellationToken ct = default)
+    {
+        var text = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+        return text ?? $"Document not found: {filePath}";
+    }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -62,8 +62,8 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var result = await symbolService.GetTypeHierarchyAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
-                if (result is null) return """{"error": "No type found at the specified location"}""";
+                var result = await symbolService.GetTypeHierarchyAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
+                if (result is null) throw new KeyNotFoundException("No type found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -82,8 +82,8 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var result = await symbolService.GetCallersCalleesAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
-                if (result is null) return """{"error": "No symbol found at the specified location"}""";
+                var result = await symbolService.GetCallersCalleesAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
+                if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -102,8 +102,8 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var result = await symbolService.AnalyzeImpactAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), c);
-                if (result is null) return """{"error": "No symbol found at the specified location"}""";
+                var result = await symbolService.AnalyzeImpactAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
+                if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -122,9 +122,9 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle);
                 var result = await symbolService.FindTypeMutationsAsync(workspaceId, locator, c);
-                if (result is null) return """{"error": "No named type found at the specified location"}""";
+                if (result is null) throw new KeyNotFoundException("No named type found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -144,35 +144,12 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocatorWithMetadata(filePath, line, column, symbolHandle, metadataName);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var results = await symbolService.FindTypeUsagesAsync(workspaceId, locator, c);
                 var grouped = results
                     .GroupBy(u => u.Classification.ToString())
                     .ToDictionary(g => g.Key, g => g.ToList());
                 return JsonSerializer.Serialize(new { count = results.Count, usagesByClassification = grouped }, JsonOptions);
             }, ct));
-    }
-
-    private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)
-        => CreateLocatorWithMetadata(filePath, line, column, symbolHandle, null);
-
-    private static SymbolLocator CreateLocatorWithMetadata(string? filePath, int? line, int? column, string? symbolHandle, string? metadataName)
-    {
-        if (!string.IsNullOrWhiteSpace(symbolHandle))
-        {
-            return SymbolLocator.ByHandle(symbolHandle);
-        }
-
-        if (!string.IsNullOrWhiteSpace(metadataName))
-        {
-            return SymbolLocator.ByMetadataName(metadataName);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
-        {
-            return SymbolLocator.BySource(filePath, line.Value, column.Value);
-        }
-
-        throw new ArgumentException("Provide either filePath/line/column, symbolHandle, or metadataName.");
     }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class MultiFileEditTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerTool(Name = "apply_multi_file_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
+     Description("Apply text edits to multiple files in the workspace sequentially. Each file's edits are applied independently.")]
+    public static Task<string> ApplyMultiFileEdit(
+        IWorkspaceExecutionGate gate,
+        IEditService editService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Array of file edits. Each has filePath (string) and edits (array of TextEditDto with startLine, startColumn, endLine, endColumn, newText)")] FileEditsDto[] fileEdits,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var results = new List<FileEditSummaryDto>();
+                foreach (var fileEdit in fileEdits)
+                {
+                    var result = await editService.ApplyTextEditsAsync(workspaceId, fileEdit.FilePath, fileEdit.Edits, c);
+                    var diff = result.Changes.Count > 0 ? string.Join("\n", result.Changes.Select(ch => ch.UnifiedDiff)) : null;
+                    results.Add(new FileEditSummaryDto(fileEdit.FilePath, result.EditsApplied, diff));
+                }
+                var dto = new MultiFileEditResultDto(true, results.Count, results);
+                return JsonSerializer.Serialize(dto, JsonOptions);
+            }, ct));
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Text.Json;
-using Company.RoslynMcp.Core.Models;
 using Company.RoslynMcp.Core.Services;
 using Company.RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
@@ -27,7 +26,7 @@ public static class RefactoringTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var result = await refactoringService.PreviewRenameAsync(workspaceId, CreateLocator(filePath, line, column, symbolHandle), newName, c);
+                var result = await refactoringService.PreviewRenameAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), newName, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -142,20 +141,5 @@ public static class RefactoringTools
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
-    }
-
-    private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)
-    {
-        if (!string.IsNullOrWhiteSpace(symbolHandle))
-        {
-            return SymbolLocator.ByHandle(symbolHandle);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
-        {
-            return SymbolLocator.BySource(filePath, line.Value, column.Value);
-        }
-
-        throw new ArgumentException("Provide either filePath/line/column or symbolHandle.");
     }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Text.Json;
+using Company.RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class ServerTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerTool(Name = "server_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Get server version, capabilities, runtime information, and loaded workspace count")]
+    public static Task<string> GetServerInfo(
+        IWorkspaceManager workspace)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+        {
+            var assembly = typeof(ServerTools).Assembly;
+            var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                          ?? assembly.GetName().Version?.ToString() ?? "unknown";
+
+            var info = new
+            {
+                server = "roslyn-mcp",
+                version,
+                runtime = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+                os = System.Runtime.InteropServices.RuntimeInformation.OSDescription,
+                roslynVersion = typeof(Microsoft.CodeAnalysis.SyntaxNode).Assembly.GetName().Version?.ToString() ?? "unknown",
+                workspaceCount = workspace.ListWorkspaces().Count,
+                capabilities = new
+                {
+                    tools = true,
+                    resources = true,
+                    prompts = true,
+                    logging = true,
+                    progress = true
+                }
+            };
+
+            return Task.FromResult(JsonSerializer.Serialize(info, JsonOptions));
+        });
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs
@@ -1,0 +1,25 @@
+using Company.RoslynMcp.Core.Models;
+
+namespace Company.RoslynMcp.Host.Stdio.Tools;
+
+internal static class SymbolLocatorFactory
+{
+    public static SymbolLocator Create(
+        string? filePath = null,
+        int? line = null,
+        int? column = null,
+        string? symbolHandle = null,
+        string? metadataName = null)
+    {
+        if (!string.IsNullOrWhiteSpace(symbolHandle))
+            return SymbolLocator.ByHandle(symbolHandle);
+
+        if (!string.IsNullOrWhiteSpace(metadataName))
+            return SymbolLocator.ByMetadataName(metadataName);
+
+        if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
+            return SymbolLocator.BySource(filePath, line.Value, column.Value);
+
+        throw new ArgumentException("Provide either filePath/line/column, symbolHandle, or metadataName.");
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -46,9 +46,9 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolService.GetSymbolInfoAsync(workspaceId, locator, c);
-                if (result is null) return """{"error": "No symbol found at the specified location"}""";
+                if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -67,9 +67,9 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.GoToDefinitionAsync(workspaceId, locator, c);
-                if (results.Count == 0) return """{"error": "No definition found for the symbol at the specified location"}""";
+                if (results.Count == 0) throw new KeyNotFoundException("No definition found for the symbol at the specified location");
                 return JsonSerializer.Serialize(results, JsonOptions);
             }, ct));
     }
@@ -88,7 +88,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.FindReferencesAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(new { count = results.Count, references = results }, JsonOptions);
             }, ct));
@@ -108,7 +108,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.FindImplementationsAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(new { count = results.Count, implementations = results }, JsonOptions);
             }, ct));
@@ -144,7 +144,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.FindOverridesAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(results, JsonOptions);
             }, ct));
@@ -164,7 +164,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.FindBaseMembersAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(results, JsonOptions);
             }, ct));
@@ -184,7 +184,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var result = await symbolService.GetMemberHierarchyAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
@@ -205,7 +205,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolService.GetSignatureHelpAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
@@ -226,7 +226,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolService.GetSymbolRelationshipsAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
@@ -263,7 +263,7 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.FindPropertyWritesAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(new { count = results.Count, writes = results }, JsonOptions);
             }, ct));
@@ -283,7 +283,7 @@ public static class SymbolTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await symbolService.GetEnclosingSymbolAsync(workspaceId, filePath, line, column, c);
-                if (result is null) return """{"error": "No enclosing symbol found at the specified location"}""";
+                if (result is null) throw new KeyNotFoundException("No enclosing symbol found at the specified location");
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
     }
@@ -302,9 +302,9 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle, metadataName: null);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolService.GoToTypeDefinitionAsync(workspaceId, locator, c);
-                if (results.Count == 0) return """{"error": "No type definition found for the symbol at the specified location"}""";
+                if (results.Count == 0) throw new KeyNotFoundException("No type definition found for the symbol at the specified location");
                 return JsonSerializer.Serialize(results, JsonOptions);
             }, ct));
     }
@@ -327,29 +327,4 @@ public static class SymbolTools
             }, ct));
     }
 
-    private static SymbolLocator CreateLocator(
-        string? filePath,
-        int? line,
-        int? column,
-        string? symbolHandle,
-        string? metadataName)
-    {
-        if (!string.IsNullOrWhiteSpace(symbolHandle))
-        {
-            return SymbolLocator.ByHandle(symbolHandle);
-        }
-
-        if (!string.IsNullOrWhiteSpace(metadataName))
-        {
-            return SymbolLocator.ByMetadataName(metadataName);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
-        {
-            return SymbolLocator.BySource(filePath, line.Value, column.Value);
-        }
-
-        throw new ArgumentException(
-            "Provide either filePath/line/column, symbolHandle, or metadataName.");
-    }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Company.RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class SyntaxTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerTool(Name = "get_syntax_tree", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Get the syntax tree (AST) for a source file or a specific line range. Returns a hierarchical tree of syntax nodes with their kinds and positions.")]
+    public static Task<string> GetSyntaxTree(
+        IWorkspaceExecutionGate gate,
+        ISyntaxService syntaxService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("Optional: start line (1-based) to limit the tree to a specific range")] int? startLine = null,
+        [Description("Optional: end line (1-based) to limit the tree to a specific range")] int? endLine = null,
+        [Description("Maximum depth of the syntax tree to return (default: 3)")] int maxDepth = 3,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await syntaxService.GetSyntaxTreeAsync(workspaceId, filePath, startLine, endLine, maxDepth, c);
+                if (result is null) throw new KeyNotFoundException($"Document not found: {filePath}");
+                return JsonSerializer.Serialize(result, JsonOptions);
+            }, ct));
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Xml.Linq;
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Core.Services;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class TestCoverageTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerTool(Name = "test_coverage", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
+     Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires coverlet.collector NuGet package in test projects.")]
+    public static Task<string> RunTestCoverage(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceManager workspace,
+        IDotnetCommandRunner commandRunner,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: specific test project name")] string? projectName = null,
+        IProgress<ProgressNotificationValue>? progress = null,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                ProgressHelper.Report(progress, 0, 1);
+                var status = workspace.GetStatus(workspaceId);
+                var loadedPath = status.LoadedPath ?? throw new InvalidOperationException("Workspace has no loaded path.");
+
+                var coverageDir = Path.Combine(Path.GetTempPath(), "roslyn-mcp-coverage", Guid.NewGuid().ToString("N"));
+                var targetPath = projectName is not null
+                    ? status.Projects.FirstOrDefault(p => string.Equals(p.Name, projectName, StringComparison.OrdinalIgnoreCase))?.FilePath ?? loadedPath
+                    : loadedPath;
+
+                var arguments = new List<string>
+                {
+                    "test",
+                    targetPath,
+                    "--collect",
+                    "XPlat Code Coverage",
+                    "--results-directory",
+                    coverageDir
+                };
+
+                var execution = await commandRunner.RunAsync(Path.GetDirectoryName(loadedPath)!, targetPath, arguments, c).ConfigureAwait(false);
+                ProgressHelper.Report(progress, 0.8f, 1);
+
+                // Find the coverage XML file
+                var coverageFiles = Directory.Exists(coverageDir)
+                    ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
+                    : [];
+
+                if (coverageFiles.Length == 0)
+                {
+                    ProgressHelper.Report(progress, 1, 1);
+                    return JsonSerializer.Serialize(new TestCoverageResultDto(
+                        Success: execution.Succeeded,
+                        Error: !execution.Succeeded ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found." : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.",
+                        LineCoveragePercent: null,
+                        BranchCoveragePercent: null,
+                        Modules: []), JsonOptions);
+                }
+
+                var latestCoverage = coverageFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
+                var result = ParseCoberturaXml(latestCoverage);
+                ProgressHelper.Report(progress, 1, 1);
+                return JsonSerializer.Serialize(result, JsonOptions);
+            }, ct));
+    }
+
+    private static TestCoverageResultDto ParseCoberturaXml(string path)
+    {
+        var doc = XDocument.Load(path);
+        var coverage = doc.Root!;
+        var lineRate = double.TryParse(coverage.Attribute("line-rate")?.Value, out var lr) ? lr * 100 : (double?)null;
+        var branchRate = double.TryParse(coverage.Attribute("branch-rate")?.Value, out var br) ? br * 100 : (double?)null;
+
+        var modules = new List<ModuleCoverageDto>();
+        foreach (var package in coverage.Descendants("package"))
+        {
+            var moduleName = package.Attribute("name")?.Value ?? "unknown";
+            var moduleLineRate = double.TryParse(package.Attribute("line-rate")?.Value, out var mlr) ? mlr * 100 : 0.0;
+
+            var classes = new List<ClassCoverageDto>();
+            foreach (var cls in package.Descendants("class"))
+            {
+                var className = cls.Attribute("name")?.Value ?? "unknown";
+                var clsLineRate = double.TryParse(cls.Attribute("line-rate")?.Value, out var clr) ? clr * 100 : 0.0;
+                var lines = cls.Descendants("line").ToList();
+                var linesCovered = lines.Count(l => int.TryParse(l.Attribute("hits")?.Value, out var h) && h > 0);
+                classes.Add(new ClassCoverageDto(className, Math.Round(clsLineRate, 1), linesCovered, lines.Count));
+            }
+
+            var totalLines = classes.Sum(c => c.LinesTotal);
+            var totalCovered = classes.Sum(c => c.LinesCovered);
+            modules.Add(new ModuleCoverageDto(moduleName, Math.Round(moduleLineRate, 1), totalCovered, totalLines, classes));
+        }
+
+        return new TestCoverageResultDto(
+            Success: true,
+            Error: null,
+            LineCoveragePercent: lineRate.HasValue ? Math.Round(lineRate.Value, 1) : null,
+            BranchCoveragePercent: branchRate.HasValue ? Math.Round(branchRate.Value, 1) : null,
+            Modules: modules);
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -1,14 +1,10 @@
-using System.Text.Json;
-
 namespace Company.RoslynMcp.Host.Stdio.Tools;
 
 internal static class ToolErrorHandler
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
-
     /// <summary>
-    /// Wraps a tool action with structured error handling. Returns JSON error responses
-    /// instead of propagating raw exceptions through the MCP transport.
+    /// Wraps a tool action with structured error handling. Rethrows exceptions with clean messages
+    /// so the MCP SDK sets isError=true on the tool result.
     /// </summary>
     public static async Task<string> ExecuteAsync(Func<Task<string>> action)
     {
@@ -18,23 +14,32 @@ internal static class ToolErrorHandler
         }
         catch (OperationCanceledException)
         {
-            return JsonSerializer.Serialize(new { error = "Operation was cancelled." }, JsonOptions);
+            throw; // Let MCP SDK handle cancellation
         }
         catch (KeyNotFoundException ex)
         {
-            return JsonSerializer.Serialize(new { error = ex.Message, errorType = "NotFound" }, JsonOptions);
+            throw new McpToolException($"Not found: {ex.Message}", ex);
         }
         catch (ArgumentException ex)
         {
-            return JsonSerializer.Serialize(new { error = ex.Message, errorType = "InvalidArgument" }, JsonOptions);
+            throw new McpToolException($"Invalid argument: {ex.Message}", ex);
         }
         catch (InvalidOperationException ex)
         {
-            return JsonSerializer.Serialize(new { error = ex.Message, errorType = "InvalidOperation" }, JsonOptions);
+            throw new McpToolException($"Invalid operation: {ex.Message}", ex);
+        }
+        catch (McpToolException)
+        {
+            throw; // Already wrapped
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { error = ex.Message, errorType = "InternalError" }, JsonOptions);
+            throw new McpToolException($"Internal error: {ex.Message}", ex);
         }
     }
 }
+
+/// <summary>
+/// Exception type for tool errors. The MCP SDK will catch this and set isError=true on the result.
+/// </summary>
+public sealed class McpToolException(string message, Exception? inner = null) : Exception(message, inner);

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Text.Json;
-using Company.RoslynMcp.Core.Models;
 using Company.RoslynMcp.Core.Services;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
@@ -95,7 +94,7 @@ public static class ValidationTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
-                var locator = CreateLocator(filePath, line, column, symbolHandle);
+                var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle);
                 var result = await validationService.FindRelatedTestsAsync(workspaceId, locator, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
@@ -116,20 +115,5 @@ public static class ValidationTools
                 var result = await validationService.FindRelatedTestsForFilesAsync(workspaceId, filePaths, maxResults, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
-    }
-
-    private static SymbolLocator CreateLocator(string? filePath, int? line, int? column, string? symbolHandle)
-    {
-        if (!string.IsNullOrWhiteSpace(symbolHandle))
-        {
-            return SymbolLocator.ByHandle(symbolHandle);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filePath) && line.HasValue && column.HasValue)
-        {
-            return SymbolLocator.BySource(filePath, line.Value, column.Value);
-        }
-
-        throw new ArgumentException("Provide either filePath/line/column or symbolHandle.");
     }
 }

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Company.RoslynMcp.Core.Services;
 using Company.RoslynMcp.Roslyn.Services;
 using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
 namespace Company.RoslynMcp.Host.Stdio.Tools;
@@ -14,6 +15,7 @@ public static class WorkspaceTools
 
     [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Load a .sln or .csproj file into the workspace for semantic analysis")]
     public static Task<string> LoadWorkspace(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("Absolute path to a .sln or .csproj file")] string path,
@@ -24,14 +26,17 @@ public static class WorkspaceTools
             gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
             {
                 ProgressHelper.Report(progress, 0, 1);
+                await ValidatePathAgainstRootsAsync(server, path, c).ConfigureAwait(false);
                 var status = await workspace.LoadAsync(path, c);
                 ProgressHelper.Report(progress, 1, 1);
+                _ = NotifyResourcesChangedAsync(server);
                 return JsonSerializer.Serialize(status, JsonOptions);
             }, ct));
     }
 
     [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes")]
     public static Task<string> ReloadWorkspace(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -41,25 +46,28 @@ public static class WorkspaceTools
             gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
             {
                 var status = await workspace.ReloadAsync(workspaceId, c);
+                _ = NotifyResourcesChangedAsync(server);
                 return JsonSerializer.Serialize(status, JsonOptions);
             }, ct));
     }
 
     [McpServerTool(Name = "workspace_close", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false), Description("Close and dispose a loaded workspace session, freeing all resources")]
     public static Task<string> CloseWorkspace(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, _ =>
+            gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, c =>
             {
                 var closed = workspace.Close(workspaceId);
                 if (gate is WorkspaceExecutionGate concreteGate)
                 {
                     concreteGate.RemoveGate(workspaceId);
                 }
+                _ = NotifyResourcesChangedAsync(server);
                 return Task.FromResult(JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonOptions));
             }, ct));
     }
@@ -133,8 +141,61 @@ public static class WorkspaceTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var text = await workspace.GetSourceTextAsync(workspaceId, filePath, c);
-                if (text is null) return JsonSerializer.Serialize(new { error = $"Document not found: {filePath}" }, JsonOptions);
+                if (text is null) throw new KeyNotFoundException($"Document not found: {filePath}");
                 return JsonSerializer.Serialize(new { filePath, lineCount = text.Count(ch => ch == '\n') + 1, text }, JsonOptions);
             }, ct));
+    }
+
+    /// <summary>
+    /// Fire-and-forget notification to clients that the resource list has changed.
+    /// </summary>
+    private static async Task NotifyResourcesChangedAsync(McpServer server)
+    {
+        try
+        {
+            await server.SendNotificationAsync(NotificationMethods.ResourceListChangedNotification).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Notification failure should not affect the tool result
+        }
+    }
+
+    /// <summary>
+    /// If the client advertises roots, validate that the requested path falls under an allowed root.
+    /// If the client doesn't support roots, this is a no-op.
+    /// </summary>
+    private static async Task ValidatePathAgainstRootsAsync(McpServer server, string path, CancellationToken ct)
+    {
+        try
+        {
+            if (server.ClientCapabilities?.Roots is null) return;
+
+            var rootsResult = await server.RequestRootsAsync(new ListRootsRequestParams(), ct).ConfigureAwait(false);
+            if (rootsResult.Roots.Count == 0) return;
+
+            var fullPath = Path.GetFullPath(path);
+            foreach (var root in rootsResult.Roots)
+            {
+                if (root.Uri.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+                {
+                    var rootPath = new Uri(root.Uri).LocalPath;
+                    if (fullPath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+                        return;
+                }
+            }
+
+            throw new ArgumentException(
+                $"Path '{path}' is not under any client-sanctioned root. " +
+                $"Allowed roots: {string.Join(", ", rootsResult.Roots.Select(r => r.Uri))}");
+        }
+        catch (ArgumentException)
+        {
+            throw;
+        }
+        catch
+        {
+            // If roots request fails (e.g., client doesn't actually support it), allow the operation
+        }
     }
 }

--- a/src/Company.RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/Company.RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -20,6 +20,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICodeActionService, CodeActionService>();
         services.AddSingleton<IAdvancedAnalysisService, AdvancedAnalysisService>();
         services.AddSingleton<IEditService, EditService>();
+        services.AddSingleton<ISyntaxService, SyntaxService>();
+        services.AddSingleton<IFileWatcherService, FileWatcherService>();
         return services;
     }
 }

--- a/src/Company.RoslynMcp.Roslyn/Services/FileWatcherService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/FileWatcherService.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+using Company.RoslynMcp.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Company.RoslynMcp.Roslyn.Services;
+
+public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFileWatcherService
+{
+    private readonly ConcurrentDictionary<string, WatcherEntry> _watchers = new(StringComparer.Ordinal);
+
+    public void Watch(string workspaceId, string workspacePath)
+    {
+        Unwatch(workspaceId);
+
+        var directory = Path.GetDirectoryName(workspacePath);
+        if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+            return;
+
+        var watcher = new FileSystemWatcher(directory)
+        {
+            Filter = "*.cs",
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
+            EnableRaisingEvents = true
+        };
+
+        var entry = new WatcherEntry(watcher);
+        _watchers[workspaceId] = entry;
+
+        watcher.Changed += (_, _) => entry.MarkStale();
+        watcher.Created += (_, _) => entry.MarkStale();
+        watcher.Deleted += (_, _) => entry.MarkStale();
+        watcher.Renamed += (_, _) => entry.MarkStale();
+
+        logger.LogInformation("Started file watcher for workspace {WorkspaceId} at {Directory}", workspaceId, directory);
+    }
+
+    public void Unwatch(string workspaceId)
+    {
+        if (_watchers.TryRemove(workspaceId, out var entry))
+        {
+            entry.Dispose();
+            logger.LogInformation("Stopped file watcher for workspace {WorkspaceId}", workspaceId);
+        }
+    }
+
+    public bool IsStale(string workspaceId)
+    {
+        return _watchers.TryGetValue(workspaceId, out var entry) && entry.IsStale;
+    }
+
+    public void ClearStale(string workspaceId)
+    {
+        if (_watchers.TryGetValue(workspaceId, out var entry))
+        {
+            entry.ClearStale();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var kvp in _watchers)
+        {
+            kvp.Value.Dispose();
+        }
+        _watchers.Clear();
+    }
+
+    private sealed class WatcherEntry(FileSystemWatcher watcher) : IDisposable
+    {
+        private volatile bool _isStale;
+
+        public bool IsStale => _isStale;
+
+        public void MarkStale() => _isStale = true;
+
+        public void ClearStale() => _isStale = false;
+
+        public void Dispose() => watcher.Dispose();
+    }
+}

--- a/src/Company.RoslynMcp.Roslyn/Services/SyntaxService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/SyntaxService.cs
@@ -1,0 +1,54 @@
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Core.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Company.RoslynMcp.Roslyn.Services;
+
+public sealed class SyntaxService(IWorkspaceManager workspace) : ISyntaxService
+{
+    public async Task<SyntaxNodeDto?> GetSyntaxTreeAsync(string workspaceId, string filePath, int? startLine, int? endLine, int maxDepth, CancellationToken ct)
+    {
+        var solution = workspace.GetCurrentSolution(workspaceId);
+        var document = Helpers.SymbolResolver.FindDocument(solution, filePath);
+        if (document is null) return null;
+
+        var tree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
+        if (tree is null) return null;
+
+        var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+        var text = await document.GetTextAsync(ct).ConfigureAwait(false);
+
+        SyntaxNode targetNode = root;
+        if (startLine.HasValue && endLine.HasValue)
+        {
+            var startPosition = text.Lines[Math.Max(0, startLine.Value - 1)].Start;
+            var endPosition = text.Lines[Math.Min(text.Lines.Count - 1, endLine.Value - 1)].End;
+            var span = TextSpan.FromBounds(startPosition, endPosition);
+            targetNode = root.FindNode(span, findInsideTrivia: false, getInnermostNodeForTie: false);
+        }
+
+        return BuildNode(targetNode, text, 0, maxDepth);
+    }
+
+    private static SyntaxNodeDto BuildNode(SyntaxNode node, SourceText text, int depth, int maxDepth)
+    {
+        var lineSpan = node.GetLocation().GetLineSpan();
+        var children = depth < maxDepth
+            ? node.ChildNodes().Select(c => BuildNode(c, text, depth + 1, maxDepth)).ToList()
+            : null;
+
+        var nodeText = (children is null || children.Count == 0) ? node.ToString() : null;
+        if (nodeText is not null && nodeText.Length > 500)
+            nodeText = string.Concat(nodeText.AsSpan(0, 500), "\u2026");
+
+        return new SyntaxNodeDto(
+            Kind: node.GetType().Name.Replace("Syntax", ""),
+            Text: nodeText,
+            StartLine: lineSpan.StartLinePosition.Line + 1,
+            StartColumn: lineSpan.StartLinePosition.Character + 1,
+            EndLine: lineSpan.EndLinePosition.Line + 1,
+            EndColumn: lineSpan.EndLinePosition.Character + 1,
+            Children: children);
+    }
+}

--- a/src/Company.RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -9,7 +9,14 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     /// <summary>Gate for refactoring apply operations (no workspaceId in parameters).</summary>
     public const string ApplyGateKey = "__apply__";
 
+    /// <summary>Default per-request timeout (2 minutes).</summary>
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>Global concurrency limit across all workspaces.</summary>
+    private static readonly int MaxGlobalConcurrency = Math.Max(2, Environment.ProcessorCount);
+
     private readonly SemaphoreSlim _loadGate = new(1, 1);
+    private readonly SemaphoreSlim _globalThrottle = new(MaxGlobalConcurrency, MaxGlobalConcurrency);
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _workspaceGates = new(StringComparer.Ordinal);
 
     public async Task<T> RunAsync<T>(string? gateKey, Func<CancellationToken, Task<T>> action, CancellationToken ct)
@@ -17,14 +24,27 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
         var key = string.IsNullOrWhiteSpace(gateKey) ? LoadGateKey : gateKey;
         var gate = key == LoadGateKey ? _loadGate : _workspaceGates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
 
-        await gate.WaitAsync(ct).ConfigureAwait(false);
+        // Apply per-request timeout and global concurrency throttle
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(DefaultTimeout);
+        var linked = timeoutCts.Token;
+
+        await _globalThrottle.WaitAsync(linked).ConfigureAwait(false);
         try
         {
-            return await action(ct).ConfigureAwait(false);
+            await gate.WaitAsync(linked).ConfigureAwait(false);
+            try
+            {
+                return await action(linked).ConfigureAwait(false);
+            }
+            finally
+            {
+                gate.Release();
+            }
         }
         finally
         {
-            gate.Release();
+            _globalThrottle.Release();
         }
     }
 
@@ -42,6 +62,7 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     public void Dispose()
     {
         _loadGate.Dispose();
+        _globalThrottle.Dispose();
         foreach (var kvp in _workspaceGates)
         {
             kvp.Value.Dispose();

--- a/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -13,12 +13,14 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 {
     private readonly ILogger<WorkspaceManager> _logger;
     private readonly IPreviewStore _previewStore;
+    private readonly IFileWatcherService _fileWatcher;
     private readonly ConcurrentDictionary<string, WorkspaceSession> _sessions = new(StringComparer.Ordinal);
 
-    public WorkspaceManager(ILogger<WorkspaceManager> logger, IPreviewStore previewStore)
+    public WorkspaceManager(ILogger<WorkspaceManager> logger, IPreviewStore previewStore, IFileWatcherService fileWatcher)
     {
         _logger = logger;
         _previewStore = previewStore;
+        _fileWatcher = fileWatcher;
     }
 
     public async Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct)
@@ -27,6 +29,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         var session = new WorkspaceSession(workspaceId);
         _sessions[workspaceId] = session;
         await LoadIntoSessionAsync(session, path, ct).ConfigureAwait(false);
+        _fileWatcher.Watch(workspaceId, session.LoadedPath!);
         return BuildStatus(session);
     }
 
@@ -36,6 +39,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         await LoadIntoSessionAsync(session, session.LoadedPath ?? throw new InvalidOperationException(
             $"Workspace '{workspaceId}' is not loaded."),
             ct).ConfigureAwait(false);
+        _fileWatcher.ClearStale(workspaceId);
         return BuildStatus(session);
     }
 
@@ -46,6 +50,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             return false;
         }
 
+        _fileWatcher.Unwatch(workspaceId);
         _previewStore.InvalidateAll(workspaceId);
         session.Dispose();
         _logger.LogInformation("Closed workspace {WorkspaceId}", workspaceId);
@@ -167,6 +172,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 
     public void Dispose()
     {
+        _fileWatcher.Dispose();
         foreach (var session in _sessions.Values)
         {
             session.Dispose();
@@ -239,6 +245,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 
     private WorkspaceStatusDto BuildStatus(WorkspaceSession session)
     {
+        var isStale = _fileWatcher.IsStale(session.WorkspaceId);
+
         if (session.Workspace is null || session.LoadedPath is null)
         {
             return new WorkspaceStatusDto(
@@ -251,6 +259,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 DocumentCount: 0,
                 Projects: [],
                 IsLoaded: false,
+                IsStale: isStale,
                 WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray());
         }
 
@@ -266,6 +275,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             DocumentCount: projects.Sum(project => project.DocumentCount),
             Projects: projects,
             IsLoaded: true,
+            IsStale: isStale,
             WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray());
     }
 

--- a/tests/Company.RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/Company.RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -113,6 +113,7 @@ public class PerformanceBehaviorTests : TestBase
                         OutputType: "Library")
                 ],
                 IsLoaded: true,
+                IsStale: false,
                 WorkspaceDiagnostics: []);
 
         public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();

--- a/tests/Company.RoslynMcp.Tests/TestBase.cs
+++ b/tests/Company.RoslynMcp.Tests/TestBase.cs
@@ -36,7 +36,8 @@ public abstract class TestBase
         PreviewStore = new PreviewStore();
         WorkspaceManager = new WorkspaceManager(
             NullLogger<WorkspaceManager>.Instance,
-            PreviewStore);
+            PreviewStore,
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance));
         SymbolService = new SymbolService(
             WorkspaceManager,
             NullLogger<SymbolService>.Instance);


### PR DESCRIPTION
…on safety, new tools

Breaking changes before production release:
- ToolErrorHandler now throws McpToolException for proper MCP isError=true instead of returning JSON error strings as successful responses
- All tool "not found" cases throw KeyNotFoundException instead of returning JSON errors, ensuring clients see errors as errors

Production hardening:
- WorkspaceExecutionGate: 2-minute per-request timeout + global concurrency throttle (ProcessorCount) to prevent resource exhaustion
- PreviewStore: LRU eviction with max 50 entries and 5-minute TTL
- FileWatcherService: detects file changes and marks workspaces stale
- WorkspaceStatusDto gains IsStale flag from file watcher state

New tools and services:
- server_info: runtime/version/capability introspection
- get_syntax_tree: depth-limited syntax tree exploration
- apply_multi_file_edit: sequential multi-file text edits (honest about non-atomicity)
- test_coverage: XPlat Code Coverage via dotnet test
- SyntaxService + ISyntaxService for syntax tree queries

Code quality:
- SymbolLocatorFactory consolidates 4 duplicate CreateLocator methods
- WorkspaceTools validates paths against MCP roots and sends resource-list-changed notifications
- Program.cs adds McpLoggingProvider, ServerInfo, graceful shutdown hook
- 2 new resources (diagnostics, file source) and 2 new prompts (analyze_dependencies, debug_test_failure)

All 47 tests pass, 0 warnings, 0 errors.