### PR TITLE
Define production release contract and harden local host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Verify release build
+        shell: pwsh
+        run: ./eng/verify-release.ps1 -Configuration Release
+
+      - name: Audit packages for known vulnerabilities
+        shell: pwsh
+        run: dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive
+
+      - name: Upload published host artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-stdio-publish
+          path: artifacts/publish/host-stdio
+
+      - name: Upload release manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-manifests
+          path: artifacts/manifests

--- a/README.md
+++ b/README.md
@@ -78,61 +78,65 @@ Then use the published executable:
 }
 ```
 
-## Tool Surface (v2)
+For a reproducible release build and publish verification:
 
-### Workspace Tools
+```powershell
+./eng/verify-release.ps1
+```
 
-| Tool | Description |
-|------|-------------|
-| `workspace_load` | Load a `.sln`, `.slnx`, or `.csproj` file and return a `workspaceId` session handle |
-| `workspace_reload` | Reload a specific workspace session by `workspaceId` |
-| `workspace_status` | Get loaded path, project/document counts, snapshot metadata, and workspace/load diagnostics for a `workspaceId` |
-| `project_graph` | Get project dependency edges plus test/output/framework metadata for every loaded project |
-| `source_generated_documents` | List generated `.g.cs` artifacts for a workspace or a single project |
+## Canonical Docs
 
-### Validation Tools
+- `docs/product-contract.md` defines the supported product shape and support tiers.
+- `docs/parity-gap-matrix.md` records release-critical parity decisions and remaining gaps.
+- `docs/release-policy.md` defines the compatibility, deprecation, CI, and release gate policy.
+- `docs/roadmap.md` records the explicit strategic decisions for transport, live-workspace parity, and large-solution performance.
+- `roslyn://server/catalog` is the canonical machine-readable surface contract exposed by the running server.
 
-| Tool | Description |
-|------|-------------|
-| `build_workspace` | Run `dotnet build` for the loaded workspace and return structured diagnostics plus stdout/stderr |
-| `build_project` | Run `dotnet build` for a single project in the loaded workspace |
-| `test_discover` | Discover test methods in test projects using the loaded Roslyn workspace |
-| `test_run` | Run `dotnet test` for the workspace or a specific test project and return structured results |
-| `test_related` | Find likely related tests for a symbol by matching names/types against discovered tests |
+## Supported Surface
 
-### Semantic Read Tools
+The server exposes a larger surface than earlier versions of the README documented. Support is now split into stable and experimental tiers.
 
-| Tool | Description |
-|------|-------------|
-| `symbol_search` | Search symbols by name with optional kind/project/namespace filters |
-| `symbol_info` | Get detailed info for a symbol by file:line:column or fully qualified metadata name |
-| `go_to_definition` | Find definition locations by source position or stable symbol handle |
-| `find_references` | Find all references across the solution by source position or stable symbol handle |
-| `find_implementations` | Find implementations of interfaces/abstract members by source position or stable symbol handle |
-| `find_overrides` | Find overriding members for a virtual, abstract, or interface member |
-| `find_base_members` | Find base or implemented members for an override or implementation |
-| `member_hierarchy` | Summarize a member's base chain and known overrides |
-| `document_symbols` | Get hierarchical symbol tree for a file in a specific workspace session |
-| `symbol_signature_help` | Get a symbol's display signature, parameters, return type, and documentation |
-| `symbol_relationships` | Get a combined view of definitions, references, implementations, base members, and overrides |
-| `project_diagnostics` | Get workspace/load, compiler, and analyzer diagnostics with severity filtering |
-| `type_hierarchy` | Get base types, derived types, and interfaces by source position or stable symbol handle |
-| `callers_callees` | Find direct callers and callees of a method by source position or stable symbol handle |
-| `impact_analysis` | Analyze impact of changing a symbol by source position or stable symbol handle |
+### Stable Tool Families
 
-### Preview-First Refactoring Tools
+- workspace session management and inspection
+- source text and generated-document reads
+- semantic symbol navigation, relationships, references, completions, and type-usage tooling
+- diagnostics, impact analysis, and related semantic analysis tools
+- build/test discovery, execution, and related-test lookup
+- preview/apply refactoring workflows
+- `server_info`
 
-| Tool | Description |
-|------|-------------|
-| `rename_preview` | Preview a rename by source position or stable symbol handle with unified diffs |
-| `rename_apply` | Apply a previewed rename (rejects stale tokens) |
-| `organize_usings_preview` | Preview removing/sorting usings |
-| `organize_usings_apply` | Apply organize usings |
-| `format_document_preview` | Preview formatting changes |
-| `format_document_apply` | Apply formatting |
-| `diagnostic_details` | Get detailed metadata plus curated fix options for a specific diagnostic occurrence |
-| `code_fix_preview` | Preview a curated code fix for a supported diagnostic occurrence |
-| `code_fix_apply` | Apply a previewed code fix (rejects stale tokens) |
+### Experimental Tool Families
+
+- advanced-analysis tools
+- direct text-edit tools
+- syntax-tree inspection
+- generic Roslyn code actions
+- coverage collection
+
+### Stable Resources
+
+- `server_catalog`
+- `workspaces`
+- `workspace_status`
+- `workspace_projects`
+- `workspace_diagnostics`
+- `source_file`
+
+### Experimental Prompts
+
+- `explain_error`
+- `suggest_refactoring`
+- `review_file`
+- `analyze_dependencies`
+- `debug_test_failure`
+
+### Product Boundaries
+
+- The current production target is the local stdio host on a developer workstation.
+- Workspace state comes from `MSBuildWorkspace` and on-disk files, not unsaved editor buffers.
+- HTTP/SSE hosting is intentionally deferred to a future host project.
+- Live IDE parity requires a separate editor-backed integration path and is not implied by the current host.
 
 ## Architecture
 
@@ -187,3 +191,5 @@ The integration suite covers:
 - separated workspace/load, compiler, and analyzer diagnostics
 - preview/apply behavior for rename, organize-usings, formatting, and curated code fixes on isolated sample-solution copies
 - stale preview rejection when a workspace session changes after preview creation
+- wrapper/integration coverage for server catalog, resources, prompts, syntax, completions, direct edits, multi-file edits, code-action contracts, and coverage response shape
+- hardening coverage for workspace-load validation, workspace-count limits, related-test scan bounds, and command timeout enforcement

--- a/docs/parity-gap-matrix.md
+++ b/docs/parity-gap-matrix.md
@@ -1,0 +1,33 @@
+# Parity And Gap Matrix
+
+## Comparison Summary
+
+| Comparison area | Current position | Release decision |
+|---|---|---|
+| Standalone Roslyn MCP servers | Competitive or ahead on semantic navigation, preview/apply refactoring, and build/test workflows | Ship now after hardening and contract cleanup |
+| Visual Studio-backed Roslyn servers | Behind on unsaved buffers, live diagnostics, and IDE fidelity | Document as an explicit product boundary, not a hidden gap |
+| MCP production best practices | Stronger now on contract discoverability, support tiers, and local operational limits; still local-first only | Ship as local stdio with remote hosting deferred to a second host |
+| AI coding agent needs | Strong stable path for workspace/session management, semantic navigation, diagnostics, validation, and bounded mutation | Keep stable contract narrow and machine-readable; leave opportunistic features experimental |
+
+## Must-Have Before Release
+
+- explicit stable vs experimental surface
+- machine-readable contract via `server_catalog`
+- wrapper/integration tests for previously under-tested tool families
+- workspace/session limits and failed-load cleanup
+- bounded related-test scans and command timeouts
+- canonical CI and publish verification path
+- documented compatibility, deprecation, and release policy
+
+## Post-Release Roadmap
+
+- second host for HTTP/SSE with auth, policy, and observability
+- editor-backed or Visual Studio-backed live workspace integration for unsaved-buffer parity
+- large-solution indexing and cache strategy
+- selective promotion of experimental surfaces to stable once they have stronger operational evidence
+
+## Out Of Scope For This Release
+
+- claiming parity with live IDE state while still using `MSBuildWorkspace`
+- treating prompts as part of the compatibility-guaranteed API surface
+- exposing remote deployment guidance before a dedicated remote host exists

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -1,0 +1,54 @@
+# Product Contract
+
+`roslyn-mcp` ships as a local-first MCP server for developer workstations. The canonical machine-readable contract is the `server_catalog` resource at `roslyn://server/catalog`.
+
+## Stable Surface
+
+Stable support is for the local stdio host only. Stable entries follow the compatibility and deprecation rules in `docs/release-policy.md`.
+
+Supported stable tool families:
+
+- `server_info`
+- workspace session management and inspection
+- source text and source-generated document reads
+- semantic symbol navigation and relationship tools
+- diagnostics and impact-analysis tools
+- build/test discovery and execution tools
+- preview/apply refactoring tools
+
+Stable resources:
+
+- `server_catalog`
+- `workspaces`
+- `workspace_status`
+- `workspace_projects`
+- `workspace_diagnostics`
+- `source_file`
+
+## Experimental Surface
+
+Experimental entries are intentionally discoverable but may evolve faster before a second transport or editor-backed host exists.
+
+Current experimental families:
+
+- advanced-analysis tools
+- direct text-edit tools
+- syntax-tree inspection
+- generic Roslyn code actions
+- coverage collection
+- all prompts
+
+## Product Boundaries
+
+- The production target is the local stdio host on a developer workstation.
+- Workspace state comes from `MSBuildWorkspace` and on-disk files, not unsaved editor buffers.
+- HTTP/SSE hosting is a future host tier, not part of the current stable contract.
+- Visual Studio or editor-backed live-workspace parity is a separate integration path, not a promise of the current host.
+- Destructive operations remain bounded to explicit edit requests or preview/apply flows.
+
+## Agent Guidance
+
+- Load a workspace first and keep using the returned `workspaceId`.
+- Prefer stable tools for navigation, diagnostics, validation, and preview-first refactoring flows.
+- Treat experimental tools as opt-in accelerators rather than required dependencies.
+- Read `server_info` and `server_catalog` at session start when you need to adapt automatically to support tiers.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,45 @@
+# Release Policy
+
+## Production-Ready Definition
+
+A release is production-ready when all of the following are true:
+
+- the stable contract in `docs/product-contract.md` matches `roslyn://server/catalog`
+- `dotnet build RoslynMcp.slnx --nologo` succeeds
+- `dotnet test RoslynMcp.slnx --nologo` succeeds
+- `eng/verify-release.ps1` succeeds and writes publish hashes
+- CI passes on the protected branch
+- dependency audit output has been reviewed for vulnerable packages
+
+## Compatibility Policy
+
+- Stable tools/resources keep backward-compatible request and response shapes within a release line.
+- Experimental entries may change faster and can be promoted, renamed, or removed in a future minor release.
+- Preview/apply token semantics are stable only within one running server instance and workspace version.
+
+## Versioning And Deprecation
+
+- Use semantic versioning for the published host artifact.
+- Adding stable tools/resources/prompts is a minor-version change.
+- Breaking a stable request/response contract is a major-version change.
+- Experimental-surface changes must still be called out in release notes.
+- Deprecate stable entries for at least one minor release before removal.
+
+## Release Checklist
+
+1. Run `eng/verify-release.ps1`.
+2. Review the generated publish hash manifest under `artifacts/manifests/`.
+3. Review dependency audit output from CI.
+4. Confirm `server_info` and `server_catalog` reflect the intended support tiers.
+5. Publish the host executable built from `src/Company.RoslynMcp.Host.Stdio`.
+
+## CI Gate
+
+CI must run on every pull request and on `main`:
+
+- restore
+- build
+- test
+- publish host executable
+- upload publish artifacts and hash manifest
+- run `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,57 @@
+# Strategic Roadmap Decisions
+
+## Release 1 Decision
+
+Optimize the product for local stdio deployment on developer workstations.
+
+That means:
+
+- the stable contract is defined around the current stdio host
+- destructive operations stay bounded and local
+- remote hosting requirements do not block the first production release
+
+## Unsaved Buffer And Live Workspace Parity
+
+Decision: do not claim parity with Visual Studio-backed servers in the current host.
+
+Reason:
+
+- `MSBuildWorkspace` is sourced from on-disk state
+- unsaved editor buffers and live IDE diagnostics require a different integration path
+
+Future direction:
+
+- add a separate editor-backed or Visual Studio-backed host if live parity becomes a product requirement
+
+## HTTP/SSE Hosting
+
+Decision: defer to a second host project.
+
+Reason:
+
+- remote deployment needs auth, authorization, observability, policy enforcement, and tenancy boundaries
+- mixing those concerns into the current local-first host would slow the release and blur the support story
+
+Future direction:
+
+- keep `Core` and `Roslyn` transport-agnostic
+- build an HTTP/SSE host only when the operational requirements are approved and staffed
+
+## Large-Solution Performance Strategy
+
+Decision: ship bounded local behavior now, then add indexing/caching later if real users need it.
+
+Release-1 strategy:
+
+- per-workspace execution gating
+- bounded command output
+- bounded related-test scans
+- bounded generated-document discovery
+- workspace-count cap
+
+Post-release candidates:
+
+- persistent symbol/index cache
+- incremental background indexing
+- opt-in warmup for enterprise solutions
+- separate performance profile for remote hosting

--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$Configuration = "Release",
+    [string]$OutputRoot = "artifacts"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$solutionPath = Join-Path $repoRoot "RoslynMcp.slnx"
+$hostProject = Join-Path $repoRoot "src\Company.RoslynMcp.Host.Stdio\Company.RoslynMcp.Host.Stdio.csproj"
+$publishDir = Join-Path $repoRoot "$OutputRoot\publish\host-stdio"
+$manifestDir = Join-Path $repoRoot "$OutputRoot\manifests"
+$hashManifestPath = Join-Path $manifestDir "host-stdio-sha256.txt"
+
+New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
+New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+dotnet restore $solutionPath --nologo
+dotnet build $solutionPath -c $Configuration --no-restore --nologo
+dotnet test $solutionPath -c $Configuration --no-build --nologo
+dotnet publish $hostProject -c $Configuration --no-build -o $publishDir
+
+$hashLines = Get-ChildItem -Path $publishDir -File -Recurse |
+    Sort-Object FullName |
+    ForEach-Object {
+        $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        $relativePath = Resolve-Path -Relative $_.FullName
+        "$hash  $relativePath"
+    }
+
+Set-Content -Path $hashManifestPath -Value $hashLines
+
+Write-Host "Publish directory: $publishDir"
+Write-Host "Hash manifest: $hashManifestPath"

--- a/src/Company.RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -1,0 +1,168 @@
+namespace Company.RoslynMcp.Host.Stdio.Catalog;
+
+public static class ServerSurfaceCatalog
+{
+    public const string CatalogVersion = "2026.03";
+
+    public static IReadOnlyList<SurfaceEntry> Tools { get; } =
+    [
+        Tool("server_info", "server", "stable", true, false, "Inspect server capabilities, versions, and support tiers."),
+
+        Tool("workspace_load", "workspace", "stable", false, false, "Load a solution or project into a named Roslyn workspace session."),
+        Tool("workspace_reload", "workspace", "stable", false, false, "Reload an existing workspace session from disk."),
+        Tool("workspace_close", "workspace", "stable", false, true, "Close a loaded workspace session and release resources."),
+        Tool("workspace_list", "workspace", "stable", true, false, "List active workspace sessions."),
+        Tool("workspace_status", "workspace", "stable", true, false, "Inspect status, diagnostics, and stale-state information for a workspace."),
+        Tool("project_graph", "workspace", "stable", true, false, "Inspect project and dependency structure."),
+        Tool("source_generated_documents", "workspace", "stable", true, false, "List source-generated documents for a workspace or project."),
+        Tool("get_source_text", "workspace", "stable", true, false, "Read source text as Roslyn currently sees it in the loaded workspace."),
+
+        Tool("symbol_search", "symbols", "stable", true, false, "Search symbols by name across the workspace."),
+        Tool("symbol_info", "symbols", "stable", true, false, "Inspect the symbol at a source location."),
+        Tool("go_to_definition", "symbols", "stable", true, false, "Navigate to the symbol definition."),
+        Tool("find_references", "symbols", "stable", true, false, "Find references to a symbol."),
+        Tool("find_implementations", "symbols", "stable", true, false, "Find implementations of an interface or abstract member."),
+        Tool("document_symbols", "symbols", "stable", true, false, "List declared symbols in a document."),
+        Tool("find_overrides", "symbols", "stable", true, false, "Find overrides of a virtual or abstract member."),
+        Tool("find_base_members", "symbols", "stable", true, false, "Find base or implemented members."),
+        Tool("member_hierarchy", "symbols", "stable", true, false, "Summarize base and override relationships for a member."),
+        Tool("symbol_signature_help", "symbols", "stable", true, false, "Return symbol signature and documentation."),
+        Tool("symbol_relationships", "symbols", "stable", true, false, "Combine definition, reference, base, and implementation relationships."),
+        Tool("find_references_bulk", "symbols", "stable", true, false, "Resolve references for multiple symbols in one request."),
+        Tool("find_property_writes", "symbols", "stable", true, false, "Find property write sites and classify object-initializer writes."),
+        Tool("enclosing_symbol", "symbols", "stable", true, false, "Return the enclosing symbol for a source position."),
+        Tool("goto_type_definition", "symbols", "stable", true, false, "Navigate from a symbol usage to its type definition."),
+        Tool("get_completions", "symbols", "stable", true, false, "Return IntelliSense-style completion items at a position."),
+
+        Tool("project_diagnostics", "analysis", "stable", true, false, "Return compiler diagnostics for a workspace."),
+        Tool("diagnostic_details", "analysis", "stable", true, false, "Inspect one diagnostic occurrence in detail."),
+        Tool("type_hierarchy", "analysis", "stable", true, false, "Inspect type inheritance and interface relationships."),
+        Tool("callers_callees", "analysis", "stable", true, false, "Find direct callers and callees for a method."),
+        Tool("impact_analysis", "analysis", "stable", true, false, "Estimate the impact of changing a symbol."),
+        Tool("find_type_mutations", "analysis", "stable", true, false, "Identify mutating members of a type and who calls them."),
+        Tool("find_type_usages", "analysis", "stable", true, false, "Classify usages of a type across the solution."),
+
+        Tool("build_workspace", "validation", "stable", false, false, "Run dotnet build for the loaded workspace."),
+        Tool("build_project", "validation", "stable", false, false, "Run dotnet build for a selected project."),
+        Tool("test_discover", "validation", "stable", true, false, "Discover tests in the loaded workspace."),
+        Tool("test_run", "validation", "stable", false, false, "Run dotnet test for the workspace or a selected project."),
+        Tool("test_related", "validation", "stable", true, false, "Find tests related to a symbol."),
+        Tool("test_related_files", "validation", "stable", true, false, "Find tests related to a set of changed files."),
+
+        Tool("rename_preview", "refactoring", "stable", true, false, "Preview a rename refactoring."),
+        Tool("rename_apply", "refactoring", "stable", false, true, "Apply a previously previewed rename refactoring."),
+        Tool("organize_usings_preview", "refactoring", "stable", true, false, "Preview using-directive cleanup."),
+        Tool("organize_usings_apply", "refactoring", "stable", false, true, "Apply a previously previewed organize-usings operation."),
+        Tool("format_document_preview", "refactoring", "stable", true, false, "Preview document formatting."),
+        Tool("format_document_apply", "refactoring", "stable", false, true, "Apply a previously previewed document format operation."),
+        Tool("code_fix_preview", "refactoring", "stable", true, false, "Preview a curated diagnostic code fix."),
+        Tool("code_fix_apply", "refactoring", "stable", false, true, "Apply a previously previewed curated code fix."),
+
+        Tool("find_unused_symbols", "advanced-analysis", "experimental", true, false, "Find likely unused symbols."),
+        Tool("get_di_registrations", "advanced-analysis", "experimental", true, false, "Inspect DI registration patterns in source."),
+        Tool("get_complexity_metrics", "advanced-analysis", "experimental", true, false, "Compute cyclomatic complexity and related metrics."),
+        Tool("find_reflection_usages", "advanced-analysis", "experimental", true, false, "Find reflection-heavy call sites."),
+        Tool("get_namespace_dependencies", "advanced-analysis", "experimental", true, false, "Build namespace dependency graphs."),
+        Tool("get_nuget_dependencies", "advanced-analysis", "experimental", true, false, "Inspect NuGet package references and versions."),
+        Tool("semantic_search", "advanced-analysis", "experimental", true, false, "Run semantic search over symbols and declarations."),
+
+        Tool("apply_text_edit", "editing", "experimental", false, true, "Apply direct text edits to a single file."),
+        Tool("apply_multi_file_edit", "editing", "experimental", false, true, "Apply direct text edits to multiple files."),
+        Tool("test_coverage", "validation", "experimental", false, false, "Run coverage collection for test execution."),
+        Tool("get_syntax_tree", "syntax", "experimental", true, false, "Return a structured syntax tree for a document or range."),
+        Tool("get_code_actions", "code-actions", "experimental", true, false, "List Roslyn code fixes and refactorings at a location."),
+        Tool("preview_code_action", "code-actions", "experimental", true, false, "Preview a Roslyn code action before applying it."),
+        Tool("apply_code_action", "code-actions", "experimental", false, true, "Apply a previously previewed Roslyn code action.")
+    ];
+
+    public static IReadOnlyList<SurfaceEntry> Resources { get; } =
+    [
+        Resource("server_catalog", "server", "stable", true, false, "Machine-readable support policy and surface inventory.", "roslyn://server/catalog"),
+        Resource("workspaces", "workspace", "stable", true, false, "List active workspace sessions.", "roslyn://workspaces"),
+        Resource("workspace_status", "workspace", "stable", true, false, "Inspect workspace status and diagnostics.", "roslyn://workspace/{workspaceId}/status"),
+        Resource("workspace_projects", "workspace", "stable", true, false, "Read project graph metadata for a workspace.", "roslyn://workspace/{workspaceId}/projects"),
+        Resource("workspace_diagnostics", "analysis", "stable", true, false, "Read all compiler diagnostics for a workspace.", "roslyn://workspace/{workspaceId}/diagnostics"),
+        Resource("source_file", "workspace", "stable", true, false, "Read a source file from the loaded workspace.", "roslyn://workspace/{workspaceId}/file/{filePath}")
+    ];
+
+    public static IReadOnlyList<SurfaceEntry> Prompts { get; } =
+    [
+        Prompt("explain_error", "prompts", "experimental", true, false, "Generate a prompt for explaining a compiler diagnostic."),
+        Prompt("suggest_refactoring", "prompts", "experimental", true, false, "Generate a prompt for refactoring suggestions."),
+        Prompt("review_file", "prompts", "experimental", true, false, "Generate a prompt for file review."),
+        Prompt("analyze_dependencies", "prompts", "experimental", true, false, "Generate a prompt for architecture and dependency analysis."),
+        Prompt("debug_test_failure", "prompts", "experimental", true, false, "Generate a prompt for debugging a failing test.")
+    ];
+
+    public static SurfaceSummary GetSummary()
+    {
+        return new SurfaceSummary(
+            CatalogVersion,
+            CountByTier(Tools, "stable"),
+            CountByTier(Tools, "experimental"),
+            CountByTier(Resources, "stable"),
+            CountByTier(Resources, "experimental"),
+            CountByTier(Prompts, "stable"),
+            CountByTier(Prompts, "experimental"));
+    }
+
+    public static ServerCatalogDto CreateDocument()
+    {
+        return new ServerCatalogDto(
+            CatalogVersion,
+            ProductShape: "local-first",
+            SupportPolicy: "Stable entries are covered by release documentation and compatibility expectations for the local stdio host. Experimental entries may evolve faster and can change with less notice before a remote host exists.",
+            ProductBoundaries:
+            [
+                "The production target is the local stdio server running on a developer workstation.",
+                "Workspace state comes from MSBuildWorkspace and on-disk files, not unsaved editor buffers.",
+                "Future HTTP/SSE hosting is intentionally a separate operational tier and not part of the current stable contract.",
+                "Write-capable tools require an already loaded workspace and are intentionally bounded by preview/apply or explicit edit requests."
+            ],
+            Tools,
+            Resources,
+            Prompts,
+            Summary: GetSummary());
+    }
+
+    private static int CountByTier(IReadOnlyList<SurfaceEntry> entries, string tier) =>
+        entries.Count(entry => string.Equals(entry.SupportTier, tier, StringComparison.Ordinal));
+
+    private static SurfaceEntry Tool(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
+        new("tool", name, category, supportTier, readOnly, destructive, summary, null);
+
+    private static SurfaceEntry Resource(string name, string category, string supportTier, bool readOnly, bool destructive, string summary, string uriTemplate) =>
+        new("resource", name, category, supportTier, readOnly, destructive, summary, uriTemplate);
+
+    private static SurfaceEntry Prompt(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
+        new("prompt", name, category, supportTier, readOnly, destructive, summary, null);
+}
+
+public sealed record SurfaceEntry(
+    string Kind,
+    string Name,
+    string Category,
+    string SupportTier,
+    bool ReadOnly,
+    bool Destructive,
+    string Summary,
+    string? UriTemplate);
+
+public sealed record SurfaceSummary(
+    string CatalogVersion,
+    int StableTools,
+    int ExperimentalTools,
+    int StableResources,
+    int ExperimentalResources,
+    int StablePrompts,
+    int ExperimentalPrompts);
+
+public sealed record ServerCatalogDto(
+    string CatalogVersion,
+    string ProductShape,
+    string SupportPolicy,
+    IReadOnlyList<string> ProductBoundaries,
+    IReadOnlyList<SurfaceEntry> Tools,
+    IReadOnlyList<SurfaceEntry> Resources,
+    IReadOnlyList<SurfaceEntry> Prompts,
+    SurfaceSummary Summary);

--- a/src/Company.RoslynMcp.Host.Stdio/Resources/ServerResources.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Resources/ServerResources.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Company.RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Host.Stdio.Resources;
+
+[McpServerResourceType]
+public static class ServerResources
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerResource(UriTemplate = "roslyn://server/catalog", Name = "server_catalog", MimeType = "application/json")]
+    [Description("Machine-readable catalog of tools, resources, prompts, support tiers, and product boundaries.")]
+    public static string GetServerCatalog()
+    {
+        return JsonSerializer.Serialize(ServerSurfaceCatalog.CreateDocument(), JsonOptions);
+    }
+}

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
+using Company.RoslynMcp.Host.Stdio.Catalog;
 using Company.RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 
@@ -26,10 +27,36 @@ public static class ServerTools
             {
                 server = "roslyn-mcp",
                 version,
+                productShape = "local-first",
                 runtime = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
                 os = System.Runtime.InteropServices.RuntimeInformation.OSDescription,
                 roslynVersion = typeof(Microsoft.CodeAnalysis.SyntaxNode).Assembly.GetName().Version?.ToString() ?? "unknown",
                 workspaceCount = workspace.ListWorkspaces().Count,
+                catalogVersion = ServerSurfaceCatalog.CatalogVersion,
+                surface = new
+                {
+                    tools = new
+                    {
+                        stable = ServerSurfaceCatalog.GetSummary().StableTools,
+                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalTools
+                    },
+                    resources = new
+                    {
+                        stable = ServerSurfaceCatalog.GetSummary().StableResources,
+                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalResources
+                    },
+                    prompts = new
+                    {
+                        stable = ServerSurfaceCatalog.GetSummary().StablePrompts,
+                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalPrompts
+                    }
+                },
+                productBoundaries = new[]
+                {
+                    "Stable support targets the local stdio host on a developer workstation.",
+                    "Workspace state comes from on-disk MSBuildWorkspace snapshots rather than unsaved editor buffers.",
+                    "Remote HTTP/SSE hosting is not part of the current stable release contract."
+                },
                 capabilities = new
                 {
                     tools = true,

--- a/src/Company.RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/Company.RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -28,6 +28,10 @@ internal static class ToolErrorHandler
         {
             throw new McpToolException($"Invalid operation: {ex.Message}", ex);
         }
+        catch (TimeoutException ex)
+        {
+            throw new McpToolException($"Timed out: {ex.Message}", ex);
+        }
         catch (McpToolException)
         {
             throw; // Already wrapped

--- a/src/Company.RoslynMcp.Roslyn/Services/FileWatcherService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/FileWatcherService.cs
@@ -27,10 +27,10 @@ public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFi
         var entry = new WatcherEntry(watcher);
         _watchers[workspaceId] = entry;
 
-        watcher.Changed += (_, _) => entry.MarkStale();
-        watcher.Created += (_, _) => entry.MarkStale();
-        watcher.Deleted += (_, _) => entry.MarkStale();
-        watcher.Renamed += (_, _) => entry.MarkStale();
+        watcher.Changed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Created += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Deleted += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Renamed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
 
         logger.LogInformation("Started file watcher for workspace {WorkspaceId} at {Directory}", workspaceId, directory);
     }
@@ -64,6 +64,23 @@ public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFi
             kvp.Value.Dispose();
         }
         _watchers.Clear();
+    }
+
+    private static void MarkStaleIfRelevant(WatcherEntry entry, string fullPath)
+    {
+        if (ShouldIgnorePath(fullPath))
+        {
+            return;
+        }
+
+        entry.MarkStale();
+    }
+
+    private static bool ShouldIgnorePath(string fullPath)
+    {
+        return fullPath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) ||
+               fullPath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) ||
+               fullPath.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class WatcherEntry(FileSystemWatcher watcher) : IDisposable

--- a/src/Company.RoslynMcp.Roslyn/Services/ValidationService.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/ValidationService.cs
@@ -17,15 +17,18 @@ public sealed class ValidationService : IValidationService, IDisposable
     private readonly IWorkspaceManager _workspaceManager;
     private readonly IDotnetCommandRunner _commandRunner;
     private readonly ILogger<ValidationService> _logger;
+    private readonly ValidationServiceOptions _options;
 
     public ValidationService(
         IWorkspaceManager workspaceManager,
         IDotnetCommandRunner commandRunner,
-        ILogger<ValidationService> logger)
+        ILogger<ValidationService> logger,
+        ValidationServiceOptions? options = null)
     {
         _workspaceManager = workspaceManager;
         _commandRunner = commandRunner;
         _logger = logger;
+        _options = options ?? new ValidationServiceOptions();
         var globalLimit = Math.Clamp(Environment.ProcessorCount / 4, 1, 4);
         _globalCommandGate = new SemaphoreSlim(globalLimit, globalLimit);
     }
@@ -34,7 +37,12 @@ public sealed class ValidationService : IValidationService, IDisposable
     {
         var status = _workspaceManager.GetStatus(workspaceId);
         var targetPath = status.LoadedPath ?? throw new InvalidOperationException($"Workspace '{workspaceId}' is not loaded.");
-        var execution = await RunDotnetCommandAsync(workspaceId, targetPath, ["build", targetPath, "--nologo"], ct).ConfigureAwait(false);
+        var execution = await RunDotnetCommandAsync(
+            workspaceId,
+            targetPath,
+            ["build", targetPath, "--nologo"],
+            _options.BuildTimeout,
+            ct).ConfigureAwait(false);
         var diagnostics = DotnetOutputParser.ParseBuildDiagnostics($"{execution.StdOut}{Environment.NewLine}{execution.StdErr}");
 
         return new BuildResultDto(
@@ -47,7 +55,12 @@ public sealed class ValidationService : IValidationService, IDisposable
     public async Task<BuildResultDto> BuildProjectAsync(string workspaceId, string projectName, CancellationToken ct)
     {
         var project = ResolveProject(workspaceId, projectName);
-        var execution = await RunDotnetCommandAsync(workspaceId, project.FilePath, ["build", project.FilePath, "--nologo"], ct).ConfigureAwait(false);
+        var execution = await RunDotnetCommandAsync(
+            workspaceId,
+            project.FilePath,
+            ["build", project.FilePath, "--nologo"],
+            _options.BuildTimeout,
+            ct).ConfigureAwait(false);
         var diagnostics = DotnetOutputParser.ParseBuildDiagnostics($"{execution.StdOut}{Environment.NewLine}{execution.StdErr}");
 
         return new BuildResultDto(
@@ -170,7 +183,12 @@ public sealed class ValidationService : IValidationService, IDisposable
                 arguments.Add(filter);
             }
 
-            var execution = await RunDotnetCommandAsync(workspaceId, targetPath, arguments, ct).ConfigureAwait(false);
+            var execution = await RunDotnetCommandAsync(
+                workspaceId,
+                targetPath,
+                arguments,
+                _options.TestTimeout,
+                ct).ConfigureAwait(false);
             return DotnetOutputParser.ParseTestRun(execution, trxPath);
         }
         finally
@@ -185,6 +203,13 @@ public sealed class ValidationService : IValidationService, IDisposable
     public async Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(
         string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct)
     {
+        if (filePaths.Count > _options.MaxRelatedFiles)
+        {
+            throw new ArgumentException(
+                $"A maximum of {_options.MaxRelatedFiles} files may be analyzed at once for related tests.",
+                nameof(filePaths));
+        }
+
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
         var discovery = await DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
         var allTests = discovery.TestProjects
@@ -274,6 +299,7 @@ public sealed class ValidationService : IValidationService, IDisposable
         string workspaceId,
         string targetPath,
         IReadOnlyList<string> arguments,
+        TimeSpan timeout,
         CancellationToken ct)
     {
         var workspaceGate = _workspaceCommandGates.GetOrAdd(workspaceId, static _ => new SemaphoreSlim(1, 1));
@@ -286,7 +312,19 @@ public sealed class ValidationService : IValidationService, IDisposable
             try
             {
                 var workingDirectory = GetWorkingDirectory(targetPath);
-                var execution = await _commandRunner.RunAsync(workingDirectory, targetPath, arguments, ct).ConfigureAwait(false);
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(timeout);
+
+                CommandExecutionDto execution;
+                try
+                {
+                    execution = await _commandRunner.RunAsync(workingDirectory, targetPath, arguments, timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"The command 'dotnet {string.Join(" ", arguments)}' exceeded the timeout of {timeout.TotalMinutes:F1} minute(s).");
+                }
 
                 _logger.LogInformation(
                     "Executed dotnet command for {TargetPath}: {Arguments} (ExitCode={ExitCode})",

--- a/src/Company.RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
@@ -1,0 +1,10 @@
+namespace Company.RoslynMcp.Roslyn.Services;
+
+public sealed class ValidationServiceOptions
+{
+    public TimeSpan BuildTimeout { get; init; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan TestTimeout { get; init; } = TimeSpan.FromMinutes(10);
+
+    public int MaxRelatedFiles { get; init; } = 25;
+}

--- a/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -14,23 +14,49 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     private readonly ILogger<WorkspaceManager> _logger;
     private readonly IPreviewStore _previewStore;
     private readonly IFileWatcherService _fileWatcher;
+    private readonly WorkspaceManagerOptions _options;
     private readonly ConcurrentDictionary<string, WorkspaceSession> _sessions = new(StringComparer.Ordinal);
 
-    public WorkspaceManager(ILogger<WorkspaceManager> logger, IPreviewStore previewStore, IFileWatcherService fileWatcher)
+    public WorkspaceManager(
+        ILogger<WorkspaceManager> logger,
+        IPreviewStore previewStore,
+        IFileWatcherService fileWatcher,
+        WorkspaceManagerOptions? options = null)
     {
         _logger = logger;
         _previewStore = previewStore;
         _fileWatcher = fileWatcher;
+        _options = options ?? new WorkspaceManagerOptions();
     }
 
     public async Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct)
     {
+        var fullPath = ValidateWorkspacePath(path);
+        if (_sessions.Count >= _options.MaxConcurrentWorkspaces)
+        {
+            throw new InvalidOperationException(
+                $"The server is already tracking {_sessions.Count} workspaces. Close an existing workspace before loading another.");
+        }
+
         var workspaceId = Guid.NewGuid().ToString("N");
         var session = new WorkspaceSession(workspaceId);
-        _sessions[workspaceId] = session;
-        await LoadIntoSessionAsync(session, path, ct).ConfigureAwait(false);
-        _fileWatcher.Watch(workspaceId, session.LoadedPath!);
-        return BuildStatus(session);
+
+        try
+        {
+            await LoadIntoSessionAsync(session, fullPath, ct).ConfigureAwait(false);
+            if (!_sessions.TryAdd(workspaceId, session))
+            {
+                throw new InvalidOperationException($"Workspace '{workspaceId}' already exists.");
+            }
+
+            _fileWatcher.Watch(workspaceId, session.LoadedPath!);
+            return BuildStatus(session);
+        }
+        catch
+        {
+            session.Dispose();
+            throw;
+        }
     }
 
     public async Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct)
@@ -93,13 +119,22 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         foreach (var project in solution.Projects.Where(project =>
                      projectName is null || string.Equals(project.Name, projectName, StringComparison.OrdinalIgnoreCase)))
         {
+            if (results.Count >= _options.MaxSourceGeneratedDocuments)
+            {
+                break;
+            }
+
             var generatedDocuments = await project.GetSourceGeneratedDocumentsAsync(ct).ConfigureAwait(false);
             var projectResults = generatedDocuments.Select(document => new GeneratedDocumentDto(
                 ProjectName: project.Name,
                 HintName: document.Name,
-                FilePath: document.FilePath ?? document.Name)).ToList();
+                FilePath: document.FilePath ?? document.Name))
+                .Take(_options.MaxSourceGeneratedDocuments - results.Count)
+                .ToList();
 
-            if (projectResults.Count == 0 && !string.IsNullOrWhiteSpace(project.FilePath))
+            if (projectResults.Count == 0 &&
+                results.Count < _options.MaxSourceGeneratedDocuments &&
+                !string.IsNullOrWhiteSpace(project.FilePath))
             {
                 var projectDirectory = Path.GetDirectoryName(project.FilePath);
                 if (!string.IsNullOrWhiteSpace(projectDirectory))
@@ -108,6 +143,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                     if (Directory.Exists(objDirectory))
                     {
                         projectResults.AddRange(Directory.EnumerateFiles(objDirectory, "*.g.cs", SearchOption.AllDirectories)
+                            .Take(_options.MaxSourceGeneratedDocuments - results.Count)
                             .Select(filePath => new GeneratedDocumentDto(
                                 ProjectName: project.Name,
                                 HintName: Path.GetFileName(filePath),
@@ -177,6 +213,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         {
             session.Dispose();
         }
+        _sessions.Clear();
     }
 
     private async Task LoadIntoSessionAsync(WorkspaceSession session, string path, CancellationToken ct)
@@ -188,6 +225,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             session.Workspace = MSBuildWorkspace.Create();
             session.WorkspaceDiagnostics = new ConcurrentQueue<DiagnosticDto>();
             session.ProjectStatuses = ImmutableArray<ProjectStatusDto>.Empty;
+            var fullPath = path;
 
             session.Workspace.RegisterWorkspaceFailedHandler(args =>
             {
@@ -208,8 +246,6 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                     session.WorkspaceId,
                     args.Diagnostic.Message);
             });
-
-            var fullPath = Path.GetFullPath(path);
 
             if (fullPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
                 fullPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
@@ -287,6 +323,29 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         }
 
         throw new KeyNotFoundException($"Workspace '{workspaceId}' was not found.");
+    }
+
+    private static string ValidateWorkspacePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("A workspace path is required.", nameof(path));
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Workspace path was not found: {fullPath}", fullPath);
+        }
+
+        if (!fullPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) &&
+            !fullPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) &&
+            !fullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Path must end with .sln, .slnx, or .csproj: {path}");
+        }
+
+        return fullPath;
     }
 
     private static IReadOnlyList<string> GetTargetFrameworks(string? projectFilePath)

--- a/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManagerOptions.cs
+++ b/src/Company.RoslynMcp.Roslyn/Services/WorkspaceManagerOptions.cs
@@ -1,0 +1,8 @@
+namespace Company.RoslynMcp.Roslyn.Services;
+
+public sealed class WorkspaceManagerOptions
+{
+    public int MaxConcurrentWorkspaces { get; init; } = 8;
+
+    public int MaxSourceGeneratedDocuments { get; init; } = 500;
+}

--- a/tests/Company.RoslynMcp.Tests/Company.RoslynMcp.Tests.csproj
+++ b/tests/Company.RoslynMcp.Tests/Company.RoslynMcp.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Company.RoslynMcp.Core\Company.RoslynMcp.Core.csproj" />
+    <ProjectReference Include="..\..\src\Company.RoslynMcp.Host.Stdio\Company.RoslynMcp.Host.Stdio.csproj" />
     <ProjectReference Include="..\..\src\Company.RoslynMcp.Roslyn\Company.RoslynMcp.Roslyn.csproj" />
   </ItemGroup>
 

--- a/tests/Company.RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/Company.RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -1,0 +1,285 @@
+using System.Text.Json;
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Host.Stdio.Prompts;
+using Company.RoslynMcp.Host.Stdio.Resources;
+using Company.RoslynMcp.Host.Stdio.Tools;
+using ModelContextProtocol.Protocol;
+
+namespace Company.RoslynMcp.Tests;
+
+[TestClass]
+public sealed class ExpandedSurfaceIntegrationTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task GetCompletions_Returns_Service_Members()
+    {
+        var programFile = FindDocumentPath("Program.cs");
+        var json = await SymbolTools.GetCompletions(
+            WorkspaceExecutionGate,
+            CompletionService,
+            WorkspaceId,
+            programFile,
+            line: 6,
+            column: 9,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var items = doc.RootElement.GetProperty("Items");
+        Assert.IsTrue(items.GetArrayLength() > 0, "Expected completion items.");
+        Assert.IsTrue(items.EnumerateArray().Any(item => item.GetProperty("DisplayText").GetString() == "MakeThemSpeak"));
+    }
+
+    [TestMethod]
+    public async Task GetSyntaxTree_Returns_Hierarchy_Json()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var json = await SyntaxTools.GetSyntaxTree(
+            WorkspaceExecutionGate,
+            SyntaxService,
+            WorkspaceId,
+            filePath,
+            startLine: null,
+            endLine: null,
+            maxDepth: 2,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("CompilationUnit", doc.RootElement.GetProperty("Kind").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("Children").GetArrayLength() > 0);
+    }
+
+    [TestMethod]
+    public async Task AdvancedAnalysisTools_Return_Expected_Results()
+    {
+        var namespaceJson = await AdvancedAnalysisTools.GetNamespaceDependencies(
+            WorkspaceExecutionGate,
+            AdvancedAnalysisService,
+            WorkspaceId,
+            project: "SampleLib",
+            CancellationToken.None);
+        using var namespaceDoc = JsonDocument.Parse(namespaceJson);
+        Assert.IsTrue(namespaceDoc.RootElement.GetProperty("Nodes").GetArrayLength() > 0);
+
+        var complexityJson = await AdvancedAnalysisTools.GetComplexityMetrics(
+            WorkspaceExecutionGate,
+            AdvancedAnalysisService,
+            WorkspaceId,
+            filePath: null,
+            project: "SampleLib",
+            minComplexity: 1,
+            limit: 20,
+            CancellationToken.None);
+        using var complexityDoc = JsonDocument.Parse(complexityJson);
+        Assert.IsTrue(complexityDoc.RootElement.GetProperty("metrics").GetArrayLength() > 0);
+    }
+
+    [TestMethod]
+    public void Resources_Return_Machine_Readable_Contracts()
+    {
+        using var catalogDoc = JsonDocument.Parse(ServerResources.GetServerCatalog());
+        Assert.AreEqual("local-first", catalogDoc.RootElement.GetProperty("ProductShape").GetString());
+        Assert.IsTrue(catalogDoc.RootElement.GetProperty("Tools").GetArrayLength() > 0);
+
+        using var workspacesDoc = JsonDocument.Parse(WorkspaceResources.GetWorkspaces(WorkspaceManager));
+        Assert.IsTrue(workspacesDoc.RootElement.GetProperty("count").GetInt32() >= 1);
+    }
+
+    [TestMethod]
+    public async Task Prompts_Return_Actionable_Context()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var reviewMessages = (await RoslynPrompts.ReviewFile(
+            WorkspaceManager,
+            SymbolService,
+            DiagnosticService,
+            WorkspaceId,
+            filePath,
+            CancellationToken.None)).ToList();
+
+        Assert.AreEqual(1, reviewMessages.Count);
+        var reviewText = GetPromptText(reviewMessages[0]);
+        StringAssert.Contains(reviewText, "AnimalService.cs");
+        StringAssert.Contains(reviewText, "Perform a thorough code review");
+
+        var dependencyMessages = (await RoslynPrompts.AnalyzeDependencies(
+            WorkspaceManager,
+            AdvancedAnalysisService,
+            WorkspaceId,
+            CancellationToken.None)).ToList();
+        Assert.AreEqual(1, dependencyMessages.Count);
+        StringAssert.Contains(GetPromptText(dependencyMessages[0]), "Project Dependency Graph");
+    }
+
+    [TestMethod]
+    public async Task CodeActionTools_Return_Structured_Results()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var actionsJson = await CodeActionTools.GetCodeActions(
+            WorkspaceExecutionGate,
+            CodeActionService,
+            WorkspaceId,
+            filePath,
+            startLine: 1,
+            startColumn: 1,
+            endLine: null,
+            endColumn: null,
+            CancellationToken.None);
+
+        using var actionsDoc = JsonDocument.Parse(actionsJson);
+        Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("count", out _));
+        Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("actions", out _));
+    }
+
+    [TestMethod]
+    public async Task PreviewCodeAction_Serializes_Service_Response()
+    {
+        var previewJson = await CodeActionTools.PreviewCodeAction(
+            WorkspaceExecutionGate,
+            new FakeCodeActionService(),
+            WorkspaceId,
+            filePath: "C:\\temp\\Example.cs",
+            startLine: 1,
+            startColumn: 1,
+            actionIndex: 0,
+            endLine: null,
+            endColumn: null,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(previewJson);
+        Assert.AreEqual("preview-token", doc.RootElement.GetProperty("PreviewToken").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("Changes").GetArrayLength() == 1);
+    }
+
+    [TestMethod]
+    public async Task EditTools_And_MultiFileEdit_Apply_Changes_On_Workspace_Copy()
+    {
+        var workspacePath = CreateSampleSolutionCopy();
+        var tempRoot = Path.GetDirectoryName(workspacePath)!;
+        var tempWorkspaceId = await LoadWorkspaceCopyAsync(workspacePath);
+
+        try
+        {
+            var programFile = FindDocumentPath(tempWorkspaceId, "Program.cs");
+            var singleEditJson = await EditTools.ApplyTextEdit(
+                WorkspaceExecutionGate,
+                EditService,
+                tempWorkspaceId,
+                programFile,
+                [new TextEditDto(1, 1, 1, 1, "// edited\n")],
+                CancellationToken.None);
+
+            using var singleEditDoc = JsonDocument.Parse(singleEditJson);
+            Assert.IsTrue(singleEditDoc.RootElement.GetProperty("EditsApplied").GetInt32() == 1);
+            StringAssert.Contains(await File.ReadAllTextAsync(programFile), "// edited");
+
+            var animalFile = FindDocumentPath(tempWorkspaceId, "AnimalService.cs");
+            var multiEditJson = await MultiFileEditTools.ApplyMultiFileEdit(
+                WorkspaceExecutionGate,
+                EditService,
+                tempWorkspaceId,
+                [
+                    new FileEditsDto(programFile, [new TextEditDto(2, 1, 2, 1, "// second edit\n")]),
+                    new FileEditsDto(animalFile, [new TextEditDto(1, 1, 1, 1, "// animal edit\n")])
+                ],
+                CancellationToken.None);
+
+            using var multiEditDoc = JsonDocument.Parse(multiEditJson);
+            Assert.IsTrue(multiEditDoc.RootElement.GetProperty("FilesModified").GetInt32() == 2);
+            StringAssert.Contains(await File.ReadAllTextAsync(animalFile), "// animal edit");
+        }
+        finally
+        {
+            WorkspaceManager.Close(tempWorkspaceId);
+            DeleteDirectoryIfExists(tempRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task TestCoverageTool_Returns_Structured_Response()
+    {
+        var json = await TestCoverageTools.RunTestCoverage(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            DotnetCommandRunner,
+            WorkspaceId,
+            projectName: "SampleLib.Tests",
+            progress: null,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("Success", out _));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("Error", out _));
+    }
+
+    private static string FindDocumentPath(string name) => FindDocumentPath(WorkspaceId, name);
+
+    private static string FindDocumentPath(string workspaceId, string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(workspaceId);
+        var path = solution.Projects
+            .SelectMany(project => project.Documents)
+            .FirstOrDefault(document => string.Equals(document.Name, name, StringComparison.Ordinal))?.FilePath;
+
+        return path ?? throw new AssertFailedException($"Document '{name}' was not found.");
+    }
+
+    private static string GetPromptText(PromptMessage message)
+    {
+        return (message.Content as TextContentBlock)?.Text
+            ?? throw new AssertFailedException("Prompt content was not a text block.");
+    }
+
+    private static async Task<string> LoadWorkspaceCopyAsync(string workspacePath)
+    {
+        var status = await WorkspaceManager.LoadAsync(workspacePath, CancellationToken.None);
+        return status.WorkspaceId;
+    }
+
+    private sealed class FakeCodeActionService : Company.RoslynMcp.Core.Services.ICodeActionService
+    {
+        public Task<IReadOnlyList<CodeActionDto>> GetCodeActionsAsync(
+            string workspaceId,
+            string filePath,
+            int startLine,
+            int startColumn,
+            int? endLine,
+            int? endColumn,
+            CancellationToken ct)
+        {
+            return Task.FromResult<IReadOnlyList<CodeActionDto>>([new CodeActionDto(0, "Demo action", "Refactor", "demo")]);
+        }
+
+        public Task<RefactoringPreviewDto> PreviewCodeActionAsync(
+            string workspaceId,
+            string filePath,
+            int startLine,
+            int startColumn,
+            int? endLine,
+            int? endColumn,
+            int actionIndex,
+            CancellationToken ct)
+        {
+            return Task.FromResult(new RefactoringPreviewDto(
+                "preview-token",
+                "Demo preview",
+                [new FileChangeDto(filePath, "--- before\n+++ after")],
+                null));
+        }
+    }
+}

--- a/tests/Company.RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/Company.RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -1,0 +1,132 @@
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Core.Services;
+using Company.RoslynMcp.Roslyn.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Company.RoslynMcp.Tests;
+
+[TestClass]
+public sealed class HardeningBehaviorTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task WorkspaceLoad_InvalidPath_DoesNotLeakSession()
+    {
+        var beforeCount = WorkspaceManager.ListWorkspaces().Count;
+        var missingPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.slnx");
+
+        await Assert.ThrowsExceptionAsync<FileNotFoundException>(() =>
+            WorkspaceManager.LoadAsync(missingPath, CancellationToken.None));
+
+        Assert.AreEqual(beforeCount, WorkspaceManager.ListWorkspaces().Count);
+    }
+
+    [TestMethod]
+    public async Task WorkspaceManager_RejectsLoadsPastConfiguredLimit()
+    {
+        using var manager = new WorkspaceManager(
+            NullLogger<WorkspaceManager>.Instance,
+            new PreviewStore(),
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 1 });
+
+        var firstPath = CreateSampleSolutionCopy();
+        var secondPath = CreateSampleSolutionCopy();
+
+        try
+        {
+            await manager.LoadAsync(firstPath, CancellationToken.None);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                manager.LoadAsync(secondPath, CancellationToken.None));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(Path.GetDirectoryName(firstPath)!);
+            DeleteDirectoryIfExists(Path.GetDirectoryName(secondPath)!);
+        }
+    }
+
+    [TestMethod]
+    public async Task FindRelatedTestsForFiles_RejectsTooManyFilePaths()
+    {
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        var excessivePaths = Enumerable.Range(0, 26)
+            .Select(index => Path.Combine(Path.GetTempPath(), $"File{index}.cs"))
+            .ToArray();
+
+        try
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                ValidationService.FindRelatedTestsForFilesAsync(status.WorkspaceId, excessivePaths, 100, CancellationToken.None));
+        }
+        finally
+        {
+            WorkspaceManager.Close(status.WorkspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ValidationService_TimesOutLongRunningCommands()
+    {
+        var service = new ValidationService(
+            new FakeWorkspaceManager(),
+            new HangingDotnetCommandRunner(),
+            NullLogger<ValidationService>.Instance,
+            new ValidationServiceOptions
+            {
+                BuildTimeout = TimeSpan.FromMilliseconds(50),
+                TestTimeout = TimeSpan.FromMilliseconds(50),
+                MaxRelatedFiles = 25
+            });
+
+        await Assert.ThrowsExceptionAsync<TimeoutException>(() =>
+            service.BuildWorkspaceAsync("workspace-1", CancellationToken.None));
+    }
+
+    private sealed class HangingDotnetCommandRunner : IDotnetCommandRunner
+    {
+        public async Task<CommandExecutionDto> RunAsync(
+            string workingDirectory,
+            string targetPath,
+            IReadOnlyList<string> arguments,
+            CancellationToken ct)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            throw new InvalidOperationException("The delay should have been cancelled.");
+        }
+    }
+
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+        public WorkspaceStatusDto GetStatus(string workspaceId) =>
+            new(
+                WorkspaceId: workspaceId,
+                LoadedPath: "C:\\repo\\Sample.slnx",
+                WorkspaceVersion: 1,
+                SnapshotToken: "snapshot",
+                LoadedAtUtc: DateTimeOffset.UtcNow,
+                ProjectCount: 0,
+                DocumentCount: 0,
+                Projects: [],
+                IsLoaded: true,
+                IsStale: false,
+                WorkspaceDiagnostics: []);
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}

--- a/tests/Company.RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/Company.RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using System.Text.Json;
+using Company.RoslynMcp.Core.Models;
+using Company.RoslynMcp.Core.Services;
+using Company.RoslynMcp.Host.Stdio.Catalog;
+using Company.RoslynMcp.Host.Stdio.Tools;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+
+namespace Company.RoslynMcp.Tests;
+
+[TestClass]
+public sealed class SurfaceCatalogTests
+{
+    [TestMethod]
+    public void ServerSurfaceCatalog_CoversAllRegisteredToolsResourcesAndPrompts()
+    {
+        var assembly = typeof(ServerTools).Assembly;
+
+        CollectionAssert.AreEquivalent(
+            GetRegisteredNames<McpServerToolAttribute>(assembly),
+            ServerSurfaceCatalog.Tools.Select(entry => entry.Name).ToArray());
+
+        CollectionAssert.AreEquivalent(
+            GetRegisteredNames<McpServerResourceAttribute>(assembly),
+            ServerSurfaceCatalog.Resources.Select(entry => entry.Name).ToArray());
+
+        CollectionAssert.AreEquivalent(
+            GetRegisteredNames<McpServerPromptAttribute>(assembly),
+            ServerSurfaceCatalog.Prompts.Select(entry => entry.Name).ToArray());
+    }
+
+    [TestMethod]
+    public async Task ServerInfo_IncludesSurfaceSupportSummary()
+    {
+        var json = await ServerTools.GetServerInfo(new FakeWorkspaceManager());
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.IsTrue(doc.RootElement.TryGetProperty("surface", out var surface));
+        Assert.IsTrue(surface.TryGetProperty("tools", out var tools));
+        Assert.IsTrue(tools.TryGetProperty("stable", out var stableTools));
+        Assert.IsTrue(stableTools.GetInt32() > 0);
+        Assert.IsTrue(tools.TryGetProperty("experimental", out _));
+    }
+
+    private static string[] GetRegisteredNames<TAttribute>(Assembly assembly)
+        where TAttribute : Attribute
+    {
+        return assembly.GetTypes()
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            .Select(method => method.GetCustomAttribute<TAttribute>())
+            .OfType<TAttribute>()
+            .Select(GetName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string GetName<TAttribute>(TAttribute attribute)
+        where TAttribute : Attribute
+    {
+        return attribute switch
+        {
+            McpServerToolAttribute tool => tool.Name ?? throw new InvalidOperationException("Tool name is required."),
+            McpServerResourceAttribute resource => resource.Name ?? throw new InvalidOperationException("Resource name is required."),
+            McpServerPromptAttribute prompt => prompt.Name ?? throw new InvalidOperationException("Prompt name is required."),
+            _ => throw new InvalidOperationException($"Unsupported attribute type: {typeof(TAttribute).Name}")
+        };
+    }
+
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}

--- a/tests/Company.RoslynMcp.Tests/TestBase.cs
+++ b/tests/Company.RoslynMcp.Tests/TestBase.cs
@@ -17,6 +17,13 @@ public abstract class TestBase
     protected static DiagnosticService DiagnosticService { get; private set; } = null!;
     protected static RefactoringService RefactoringService { get; private set; } = null!;
     protected static ValidationService ValidationService { get; private set; } = null!;
+    protected static CompletionService CompletionService { get; private set; } = null!;
+    protected static CodeActionService CodeActionService { get; private set; } = null!;
+    protected static AdvancedAnalysisService AdvancedAnalysisService { get; private set; } = null!;
+    protected static EditService EditService { get; private set; } = null!;
+    protected static SyntaxService SyntaxService { get; private set; } = null!;
+    protected static WorkspaceExecutionGate WorkspaceExecutionGate { get; private set; } = null!;
+    protected static DotnetCommandRunner DotnetCommandRunner { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -34,6 +41,8 @@ public abstract class TestBase
         }
 
         PreviewStore = new PreviewStore();
+        WorkspaceExecutionGate = new WorkspaceExecutionGate();
+        DotnetCommandRunner = new DotnetCommandRunner();
         WorkspaceManager = new WorkspaceManager(
             NullLogger<WorkspaceManager>.Instance,
             PreviewStore,
@@ -50,8 +59,22 @@ public abstract class TestBase
             NullLogger<RefactoringService>.Instance);
         ValidationService = new ValidationService(
             WorkspaceManager,
-            new DotnetCommandRunner(),
+            DotnetCommandRunner,
             NullLogger<ValidationService>.Instance);
+        CompletionService = new CompletionService(
+            WorkspaceManager,
+            NullLogger<CompletionService>.Instance);
+        CodeActionService = new CodeActionService(
+            WorkspaceManager,
+            PreviewStore,
+            NullLogger<CodeActionService>.Instance);
+        AdvancedAnalysisService = new AdvancedAnalysisService(
+            WorkspaceManager,
+            NullLogger<AdvancedAnalysisService>.Instance);
+        EditService = new EditService(
+            WorkspaceManager,
+            NullLogger<EditService>.Instance);
+        SyntaxService = new SyntaxService(WorkspaceManager);
 
         RepositoryRootPath = FindRepositoryRoot();
         SampleSolutionPath = FindFixturePath("SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");


### PR DESCRIPTION
## Summary
- add a canonical machine-readable server catalog plus stable and experimental product-contract docs for the local stdio release
- expand wrapper-level integration coverage across the previously under-tested MCP surface, including resources, prompts, syntax, code actions, edits, and hardening behavior
- harden local workspace and validation execution with bounded workspace counts, failed-load cleanup, command timeouts, bounded related-test scans, release verification, and CI governance

## Test plan
- [x] `dotnet build RoslynMcp.slnx --nologo`
- [x] `dotnet test RoslynMcp.slnx --nologo`
- [x] `./eng/verify-release.ps1`
- [x] `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`
