### PR TITLE
docs: align AI bootstrap and canonical docs structure

### DIFF
--- a/.cursor/rules/operational-essentials.md
+++ b/.cursor/rules/operational-essentials.md
@@ -1,0 +1,23 @@
+# Operational Essentials
+
+Compact reminder layer aligned with `ai_docs/workflow.md`.
+
+## Branching And Isolation
+
+- Use a task branch before production-code edits.
+- Use a dedicated worktree when concurrent write-capable sessions are active or likely.
+
+## Merge-Ready Handoff
+
+- Sync with base branch when branch protection requires it.
+- Resolve conflicts and ensure required checks pass before merge request.
+
+## Validation
+
+- Follow `CI_POLICY.md` for required build/test/release validation.
+
+## Ownership
+
+- Canonical git/worktree/PR policy: `ai_docs/workflow.md`
+- Canonical validation and merge gating: `CI_POLICY.md`
+- Canonical runtime context: `ai_docs/runtime.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# Copilot Instructions
+
+Use this file as a thin bootstrap only.
+
+Canonical references:
+
+1. `AGENTS.md`
+2. `CI_POLICY.md`
+3. `ai_docs/README.md`
+4. `ai_docs/workflow.md`
+5. `ai_docs/runtime.md`
+6. `ai_docs/backlog.md`
+7. `.cursor/rules/operational-essentials.md`
+
+Policy ownership:
+- Branch/worktree/PR behavior: `ai_docs/workflow.md`
+- Validation and merge gating: `CI_POLICY.md`
+- Runtime assumptions and execution context: `ai_docs/runtime.md`
+
+Do not duplicate policy here. Link to canonical files instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,97 +1,25 @@
-# AGENTS Guide
+# AGENTS Bootstrap
 
-This file is the fast-start operating guide for AI coding agents working in this repository.
+Use this file as the stable AI bootstrap entry point for this repository.
 
-## 30-Second Startup Checklist
+Read these canonical files in order:
 
-1. Read `README.md` and this file.
-2. Load workspace and capture `workspaceId`.
-3. Read `server_info` and `roslyn://server/catalog`.
-4. Prefer stable tools/resources first.
-5. Use preview/apply for mutations, then validate with build/tests.
+1. `CI_POLICY.md`
+2. `ai_docs/README.md`
+3. `ai_docs/workflow.md`
+4. `ai_docs/runtime.md`
+5. `ai_docs/backlog.md`
+6. `.github/copilot-instructions.md`
+7. `.cursor/rules/operational-essentials.md`
+8. `CLAUDE.md`
 
-## One-Screen Decision Matrix
+Policy ownership:
 
-| If you need to... | Start here | Primary location |
-|---|---|---|
-| understand support tiers and boundaries | `docs/product-contract.md` | `docs/` |
-| confirm release and compatibility gates | `docs/release-policy.md` | `docs/`, `eng/verify-release.ps1` |
-| navigate or analyze C# code semantically | stable symbol/diagnostic tools | `src/Company.RoslynMcp.Roslyn/` |
-| change host wrapper/catalog/prompt wiring | MCP tool/resource/prompt wrappers | `src/Company.RoslynMcp.Host.Stdio/` |
-| change DTOs or cross-layer contracts | boundary models/interfaces | `src/Company.RoslynMcp.Core/` |
-| perform multi-file/project mutation safely | preview-first experimental tools | `src/Company.RoslynMcp.Roslyn/`, `tests/Company.RoslynMcp.Tests/` |
-| validate behavior/regressions | integration and hardening tests | `tests/Company.RoslynMcp.Tests/` |
+- Git, branch, worktree, and PR behavior: `ai_docs/workflow.md`
+- Validation and merge gating: `CI_POLICY.md`
+- Runtime assumptions and execution context: `ai_docs/runtime.md`
+- Unfinished work tracking: `ai_docs/backlog.md`
 
-## 1) Start Here In Every Session
+Deep historical context from prior versions of this file is preserved in:
 
-1. Read `README.md` for product shape and support tiers.
-2. Read `docs/product-contract.md` for stable vs experimental guarantees.
-3. Read `docs/release-policy.md` before making release-impacting changes.
-4. Read `docs/parity-gap-matrix.md` and `docs/roadmap.md` for non-goals and deferred scope.
-5. Use the command and file maps below to choose the minimal safe path.
-
-## 2) Repository Map
-
-- `src/Company.RoslynMcp.Host.Stdio/`: MCP host process, tool wrappers, catalog/resource/prompt wiring, startup and logging.
-- `src/Company.RoslynMcp.Core/`: contract DTOs, shared abstractions, preview-store contracts, cross-layer models.
-- `src/Company.RoslynMcp.Roslyn/`: Roslyn-backed workspace, diagnostics, symbols, refactorings, analysis, and execution services.
-- `tests/Company.RoslynMcp.Tests/`: integration and behavior tests for stable and experimental surfaces.
-- `samples/`: sample solutions used by integration tests and behavior validation.
-- `eng/verify-release.ps1`: release verification and publish/hash checks.
-- `publish/`: publish output and BuildHost runtime assets.
-- `docs/`: contract, policy, parity, and roadmap decisions.
-
-## 3) End-To-End Project Flow
-
-1. Load workspace session:
-   - Call workspace-load tool and capture `workspaceId`.
-2. Explore and assess:
-   - Prefer stable semantic/navigation/diagnostic tools first.
-3. Plan edits:
-   - Use preview-first refactoring and bounded mutation flows.
-4. Apply changes:
-   - Apply preview token only if workspace version is unchanged.
-5. Validate:
-   - Run build/test tools through MCP or `dotnet test RoslynMcp.slnx`.
-6. Re-check diagnostics:
-   - Confirm no new compiler/analyzer regressions.
-7. Finalize:
-   - Update docs/tests for any surface or behavior change.
-
-## 4) Stable-First Decision Rule
-
-- Default to stable tools/resources whenever they satisfy the task.
-- Use experimental tools only when they materially reduce risk or effort.
-- If experimental behavior is used, document it in the PR/release notes.
-
-## 5) Build, Test, Release Commands
-
-- Build: `dotnet build RoslynMcp.slnx --nologo`
-- Test: `dotnet test RoslynMcp.slnx --nologo`
-- Run host: `dotnet run --project src/Company.RoslynMcp.Host.Stdio`
-- Verify release: `./eng/verify-release.ps1`
-
-## 6) Where To Change What
-
-- Add or update MCP tool wrappers/catalog entries:
-  - `src/Company.RoslynMcp.Host.Stdio/`
-- Change DTO contract or cross-layer model behavior:
-  - `src/Company.RoslynMcp.Core/`
-- Implement Roslyn semantic/refactoring logic:
-  - `src/Company.RoslynMcp.Roslyn/`
-- Validate behavior and guard regressions:
-  - `tests/Company.RoslynMcp.Tests/`
-
-## 7) Common Pitfalls
-
-- Do not assume unsaved editor buffer parity; this host uses on-disk state via `MSBuildWorkspace`.
-- Do not bypass preview/apply for destructive refactoring flows.
-- Do not treat prompts as compatibility-stable API surface.
-- Do not broaden stable contracts without updating product contract and release policy docs.
-
-## 8) Definition Of Done For Agent Changes
-
-- Code builds and relevant tests pass.
-- Surface changes are reflected in catalog and docs.
-- Stable/experimental tiering remains consistent.
-- Non-goals and boundaries remain explicit.
+- `ai_docs/archive/legacy-agents-guide.md`

--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -1,0 +1,32 @@
+# CI Policy
+
+This document is the single canonical source for validation and merge-gating expectations.
+
+## Required Validation For Merge-Ready Handoff
+
+1. Build: `dotnet build RoslynMcp.slnx --nologo`
+2. Test: `dotnet test RoslynMcp.slnx --nologo`
+3. If release-impacting files changed, run: `./eng/verify-release.ps1`
+
+## Change-Class Expectations
+
+- Docs-only changes:
+  - Ensure markdown links/paths are valid.
+  - Ensure no stale references remain after renames/moves.
+- Product-code changes:
+  - Complete build and tests locally before handoff.
+  - Resolve new diagnostics introduced by the change.
+- Surface/contract changes:
+  - Update docs and tests in the same branch.
+
+## Merge Gating
+
+- Respect repository branch protection and required checks.
+- Branch must be synchronized with base branch before merge-ready handoff when required by protection rules.
+- Do not bypass failing required checks.
+
+## Canonical Ownership
+
+- Git and PR workflow details live in `ai_docs/workflow.md`.
+- Runtime/tool behavior details live in `ai_docs/runtime.md`.
+- This file remains the sole merge-gating and validation policy source.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Claude Bootstrap
+
+This file is a bootstrap index for Claude-family agents in this repository.
+
+Read these canonical files in order:
+
+1. `AGENTS.md`
+2. `CI_POLICY.md`
+3. `ai_docs/README.md`
+4. `ai_docs/workflow.md`
+5. `ai_docs/runtime.md`
+6. `ai_docs/backlog.md`
+7. `.github/copilot-instructions.md`
+8. `.cursor/rules/operational-essentials.md`
+
+Notes:
+- `ai_docs/workflow.md` is the canonical git/branch/worktree/PR policy.
+- `CI_POLICY.md` is the canonical validation and merge-gating policy.
+- `ai_docs/runtime.md` is the canonical runtime and execution-context guidance.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ A production-usable MCP (Model Context Protocol) server that provides semantic C
 For the shortest safe path in new agent sessions:
 
 1. Read `AGENTS.md` first.
-2. Read `docs/product-contract.md` for stable vs experimental expectations.
-3. Use `server_info` and `roslyn://server/catalog` to verify runtime surface.
-4. Follow preview/apply and validation loops before finalizing edits.
+2. Read `CI_POLICY.md` for validation and merge-gating expectations.
+3. Read `ai_docs/README.md`, then `ai_docs/workflow.md` and `ai_docs/runtime.md`.
+4. Use `server_info` and `roslyn://server/catalog` to verify runtime surface.
 
 ### 30-Second AI Quick Path
 
 1. Load workspace and keep `workspaceId`.
-2. Use stable tools/resources first.
-3. Use preview/apply for any mutation.
-4. Run build/test + diagnostics before completion.
-5. Use the one-screen matrix in `AGENTS.md` to route implementation quickly.
+2. Follow `ai_docs/workflow.md` for branch/worktree/PR behavior.
+3. Follow `CI_POLICY.md` for validation and merge handoff.
+4. Use stable tools/resources first and preview/apply for mutations.
 
 ## Quick Start
 
@@ -103,11 +102,15 @@ For a reproducible release build and publish verification:
 
 ## Canonical Docs
 
-- `AGENTS.md` is the canonical AI operator playbook for repo map, flow, and command defaults.
-- `docs/product-contract.md` defines the supported product shape and support tiers.
-- `docs/parity-gap-matrix.md` records release-critical parity decisions and remaining gaps.
-- `docs/release-policy.md` defines the compatibility, deprecation, CI, and release gate policy.
-- `docs/roadmap.md` records the explicit strategic decisions for transport, live-workspace parity, and large-solution performance.
+- `AGENTS.md` is the canonical bootstrap entry point for AI agents.
+- `CLAUDE.md` is the Claude bootstrap mirror.
+- `.github/copilot-instructions.md` is a thin bootstrap file for Copilot.
+- `CI_POLICY.md` is the canonical validation and merge-gating policy.
+- `ai_docs/README.md` is the canonical AI-doc routing index.
+- `ai_docs/workflow.md` is the canonical git/branch/worktree/PR workflow policy.
+- `ai_docs/runtime.md` is the canonical runtime and execution-context reference.
+- `ai_docs/backlog.md` is the canonical unfinished-work list.
+- `.cursor/rules/operational-essentials.md` is a compact reminder layer aligned with `ai_docs/workflow.md`.
 - `roslyn://server/catalog` is the canonical machine-readable surface contract exposed by the running server.
 
 ## Project Map

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -1,0 +1,41 @@
+# AI Docs Index
+
+This directory is the canonical AI-facing documentation tree.
+
+## Bootstrap Read Order
+
+1. `../AGENTS.md`
+2. `../CI_POLICY.md`
+3. `workflow.md`
+4. `runtime.md`
+5. `backlog.md`
+6. `../.cursor/rules/operational-essentials.md`
+
+## Active Current-State Docs
+
+- `workflow.md`: canonical git/branch/worktree/PR workflow guidance.
+- `runtime.md`: canonical runtime assumptions and execution context.
+- `backlog.md`: only place for unfinished work items.
+- `architecture.md`: compact system architecture and boundaries.
+
+## Domain Entry Points
+
+- `domains/host-stdio/reference.md`
+- `domains/core-contracts/reference.md`
+- `domains/roslyn-services/reference.md`
+
+## Stable Deep References
+
+- `references/testing.md`
+- `references/tooling/dotnet.md`
+- `references/tooling/mcp-clients.md`
+
+## Repeatable Procedures
+
+- `procedures/doc-migration-checklist.md`
+
+## Archive
+
+- `archive/README.md`
+
+Archive contains deep audits, historical investigations, and point-in-time analysis that should not stay in the active reading path.

--- a/ai_docs/architecture.md
+++ b/ai_docs/architecture.md
@@ -1,0 +1,24 @@
+# Architecture
+
+## Layering
+
+- `src/Company.RoslynMcp.Host.Stdio/`: MCP host wrapper and registration surface.
+- `src/Company.RoslynMcp.Core/`: DTO contracts and cross-layer abstractions.
+- `src/Company.RoslynMcp.Roslyn/`: Roslyn-backed workspace and semantic/refactoring services.
+- `tests/Company.RoslynMcp.Tests/`: integration and behavior validation.
+
+## Key Boundaries
+
+- Keep transport-specific concerns in host layer.
+- Keep public service boundaries DTO-based (no raw Roslyn types crossing boundaries).
+- Keep mutation flows preview-first and workspace-version aware.
+
+## Safety Invariants
+
+- Prefer stable tool/resource surface by default.
+- Validate with build/tests before merge-ready handoff.
+- Update docs/tests when behavior or surface contracts change.
+
+## Deep Material
+
+Historical rationale and superseded investigations belong in `archive/`.

--- a/ai_docs/archive/README.md
+++ b/ai_docs/archive/README.md
@@ -1,0 +1,10 @@
+# Archive
+
+This folder stores non-active AI-facing material:
+
+- deep audits
+- historical investigations
+- point-in-time analyses
+- superseded guidance retained for debugging or provenance
+
+Archive content is intentionally outside the active bootstrap reading path.

--- a/ai_docs/archive/legacy-agents-guide.md
+++ b/ai_docs/archive/legacy-agents-guide.md
@@ -1,0 +1,103 @@
+# Legacy AGENTS Guide (Archived)
+
+Source: previous root `AGENTS.md` before canonical bootstrap migration.
+
+---
+
+# AGENTS Guide
+
+This file is the fast-start operating guide for AI coding agents working in this repository.
+
+## 30-Second Startup Checklist
+
+1. Read `README.md` and this file.
+2. Load workspace and capture `workspaceId`.
+3. Read `server_info` and `roslyn://server/catalog`.
+4. Prefer stable tools/resources first.
+5. Use preview/apply for mutations, then validate with build/tests.
+
+## One-Screen Decision Matrix
+
+| If you need to... | Start here | Primary location |
+|---|---|---|
+| understand support tiers and boundaries | `docs/product-contract.md` | `docs/` |
+| confirm release and compatibility gates | `docs/release-policy.md` | `docs/`, `eng/verify-release.ps1` |
+| navigate or analyze C# code semantically | stable symbol/diagnostic tools | `src/Company.RoslynMcp.Roslyn/` |
+| change host wrapper/catalog/prompt wiring | MCP tool/resource/prompt wrappers | `src/Company.RoslynMcp.Host.Stdio/` |
+| change DTOs or cross-layer contracts | boundary models/interfaces | `src/Company.RoslynMcp.Core/` |
+| perform multi-file/project mutation safely | preview-first experimental tools | `src/Company.RoslynMcp.Roslyn/`, `tests/Company.RoslynMcp.Tests/` |
+| validate behavior/regressions | integration and hardening tests | `tests/Company.RoslynMcp.Tests/` |
+
+## 1) Start Here In Every Session
+
+1. Read `README.md` for product shape and support tiers.
+2. Read `docs/product-contract.md` for stable vs experimental guarantees.
+3. Read `docs/release-policy.md` before making release-impacting changes.
+4. Read `docs/parity-gap-matrix.md` and `docs/roadmap.md` for non-goals and deferred scope.
+5. Use the command and file maps below to choose the minimal safe path.
+
+## 2) Repository Map
+
+- `src/Company.RoslynMcp.Host.Stdio/`: MCP host process, tool wrappers, catalog/resource/prompt wiring, startup and logging.
+- `src/Company.RoslynMcp.Core/`: contract DTOs, shared abstractions, preview-store contracts, cross-layer models.
+- `src/Company.RoslynMcp.Roslyn/`: Roslyn-backed workspace, diagnostics, symbols, refactorings, analysis, and execution services.
+- `tests/Company.RoslynMcp.Tests/`: integration and behavior tests for stable and experimental surfaces.
+- `samples/`: sample solutions used by integration tests and behavior validation.
+- `eng/verify-release.ps1`: release verification and publish/hash checks.
+- `publish/`: publish output and BuildHost runtime assets.
+- `docs/`: contract, policy, parity, and roadmap decisions.
+
+## 3) End-To-End Project Flow
+
+1. Load workspace session:
+   - Call workspace-load tool and capture `workspaceId`.
+2. Explore and assess:
+   - Prefer stable semantic/navigation/diagnostic tools first.
+3. Plan edits:
+   - Use preview-first refactoring and bounded mutation flows.
+4. Apply changes:
+   - Apply preview token only if workspace version is unchanged.
+5. Validate:
+   - Run build/test tools through MCP or `dotnet test RoslynMcp.slnx`.
+6. Re-check diagnostics:
+   - Confirm no new compiler/analyzer regressions.
+7. Finalize:
+   - Update docs/tests for any surface or behavior change.
+
+## 4) Stable-First Decision Rule
+
+- Default to stable tools/resources whenever they satisfy the task.
+- Use experimental tools only when they materially reduce risk or effort.
+- If experimental behavior is used, document it in the PR/release notes.
+
+## 5) Build, Test, Release Commands
+
+- Build: `dotnet build RoslynMcp.slnx --nologo`
+- Test: `dotnet test RoslynMcp.slnx --nologo`
+- Run host: `dotnet run --project src/Company.RoslynMcp.Host.Stdio`
+- Verify release: `./eng/verify-release.ps1`
+
+## 6) Where To Change What
+
+- Add or update MCP tool wrappers/catalog entries:
+  - `src/Company.RoslynMcp.Host.Stdio/`
+- Change DTO contract or cross-layer model behavior:
+  - `src/Company.RoslynMcp.Core/`
+- Implement Roslyn semantic/refactoring logic:
+  - `src/Company.RoslynMcp.Roslyn/`
+- Validate behavior and guard regressions:
+  - `tests/Company.RoslynMcp.Tests/`
+
+## 7) Common Pitfalls
+
+- Do not assume unsaved editor buffer parity; this host uses on-disk state via `MSBuildWorkspace`.
+- Do not bypass preview/apply for destructive refactoring flows.
+- Do not treat prompts as compatibility-stable API surface.
+- Do not broaden stable contracts without updating product contract and release policy docs.
+
+## 8) Definition Of Done For Agent Changes
+
+- Code builds and relevant tests pass.
+- Surface changes are reflected in catalog and docs.
+- Stable/experimental tiering remains consistent.
+- Non-goals and boundaries remain explicit.

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -1,0 +1,15 @@
+# Backlog
+
+This is the only canonical location for unfinished AI-facing documentation tasks.
+
+## Open Items
+
+- Evaluate whether `docs/parity-gap-matrix.md` should remain active product documentation or move to `ai_docs/archive/` with a compact current-state summary in `ai_docs/references/`.
+- Evaluate whether `docs/roadmap.md` should be split into current-state commitments vs historical planning notes, with historical planning moved to `ai_docs/archive/`.
+- Add a markdown lint config and CI docs-check target if maintainers want stricter link/style enforcement for docs-only changes.
+
+## Backlog Rules
+
+- Keep only incomplete items here.
+- Remove completed items after verification.
+- Do not store session logs, handoff notes, or temporary plans in this file.

--- a/ai_docs/domains/core-contracts/reference.md
+++ b/ai_docs/domains/core-contracts/reference.md
@@ -1,0 +1,21 @@
+# Core Contracts Domain Reference
+
+## Scope
+
+This domain covers DTOs, shared abstractions, and cross-layer contract boundaries.
+
+## Primary Location
+
+- `src/Company.RoslynMcp.Core/`
+
+## Typical Changes
+
+- Add or evolve request/response DTOs.
+- Adjust service abstraction contracts.
+- Refine preview-store and shared boundary models.
+
+## Validation Focus
+
+- Backward/forward compatibility impact reviewed for stable surface.
+- Host and Roslyn layers compile against updated contracts.
+- Integration tests validate contract behavior where applicable.

--- a/ai_docs/domains/host-stdio/reference.md
+++ b/ai_docs/domains/host-stdio/reference.md
@@ -1,0 +1,21 @@
+# Host Stdio Domain Reference
+
+## Scope
+
+This domain covers MCP host startup, tool/resource/prompt wiring, and protocol-safe logging.
+
+## Primary Location
+
+- `src/Company.RoslynMcp.Host.Stdio/`
+
+## Typical Changes
+
+- Register or adjust tool wrappers.
+- Update catalog/resource/prompt wiring.
+- Adjust host startup and dependency wiring.
+
+## Validation Focus
+
+- Surface catalog remains coherent.
+- Wrapper behavior remains consistent with service contracts.
+- Integration tests covering exposed surface continue to pass.

--- a/ai_docs/domains/roslyn-services/reference.md
+++ b/ai_docs/domains/roslyn-services/reference.md
@@ -1,0 +1,21 @@
+# Roslyn Services Domain Reference
+
+## Scope
+
+This domain covers workspace loading, diagnostics, semantic navigation, and refactoring behavior.
+
+## Primary Location
+
+- `src/Company.RoslynMcp.Roslyn/`
+
+## Typical Changes
+
+- Update analysis/refactoring implementations.
+- Adjust workspace/session behavior.
+- Improve diagnostics or semantic data extraction.
+
+## Validation Focus
+
+- Build and tests pass for sample solutions.
+- Preview/apply flows remain safe and deterministic.
+- No regressions in semantic navigation and diagnostics surfaces.

--- a/ai_docs/procedures/doc-migration-checklist.md
+++ b/ai_docs/procedures/doc-migration-checklist.md
@@ -1,0 +1,14 @@
+# Documentation Migration Checklist
+
+Use this for structural AI-doc migrations.
+
+## Checklist
+
+1. Audit existing files and policy ownership.
+2. Establish canonical bootstrap files.
+3. Move/rename docs into canonical current-state locations.
+4. Archive historical/audit/session artifacts under `ai_docs/archive/`.
+5. Update links and references across repo.
+6. Scan for stale filenames/paths.
+7. Validate markdown links/paths.
+8. Confirm no policy conflicts between bootstrap/workflow/CI/runtime/reminder docs.

--- a/ai_docs/references/testing.md
+++ b/ai_docs/references/testing.md
@@ -1,0 +1,20 @@
+# Testing Reference
+
+## Primary Command
+
+- `dotnet test RoslynMcp.slnx --nologo`
+
+## Build + Test Baseline
+
+1. `dotnet build RoslynMcp.slnx --nologo`
+2. `dotnet test RoslynMcp.slnx --nologo`
+
+## Test Project
+
+- `tests/Company.RoslynMcp.Tests/`
+
+## Guidance
+
+- Prefer integration coverage for end-to-end workspace and tool behavior.
+- For docs-only changes, run lightweight link/reference checks at minimum.
+- For contract/surface changes, include or update tests in the same branch.

--- a/ai_docs/references/tooling/dotnet.md
+++ b/ai_docs/references/tooling/dotnet.md
@@ -1,0 +1,13 @@
+# Dotnet Tooling Reference
+
+## Core Commands
+
+- Build: `dotnet build RoslynMcp.slnx --nologo`
+- Test: `dotnet test RoslynMcp.slnx --nologo`
+- Run host: `dotnet run --project src/Company.RoslynMcp.Host.Stdio`
+- Verify release: `./eng/verify-release.ps1`
+
+## Notes
+
+- Prefer solution-level build/test for merge-ready handoff unless intentionally scoping validation.
+- Use `--nologo` in automation-oriented command examples for cleaner logs.

--- a/ai_docs/references/tooling/mcp-clients.md
+++ b/ai_docs/references/tooling/mcp-clients.md
@@ -1,0 +1,14 @@
+# MCP Client Tooling Reference
+
+## Cursor
+
+Configure `.cursor/mcp.json` to launch the host project or published executable.
+
+## Claude Code
+
+Configure MCP settings with the same command/args model used by Cursor.
+
+## Operational Guidance
+
+- Prefer published executable for lower startup overhead when repeatedly launching.
+- Keep command paths machine-local and avoid committing personal absolute paths.

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -1,0 +1,35 @@
+# Runtime
+
+This document is the canonical runtime and execution-context reference for AI agents and maintainers.
+
+## Execution Context
+
+- Primary runtime target: local stdio host process.
+- Workspace model: `MSBuildWorkspace` over on-disk files.
+- Unsaved editor buffers are not authoritative for semantic operations.
+
+## Platform And Tooling
+
+- .NET SDK baseline: see `../README.md` and `global.json`.
+- Primary v1 operating system target: Windows.
+- Build/test entry points:
+  - `dotnet build RoslynMcp.slnx --nologo`
+  - `dotnet test RoslynMcp.slnx --nologo`
+
+## MCP Runtime Notes
+
+- `stdout` is reserved for MCP protocol traffic.
+- Operational logging should go to `stderr`.
+- Prefer stable MCP surface first; use experimental surface intentionally and explicitly.
+
+## Session And Mutation Safety
+
+- Maintain and pass `workspaceId` for workspace-scoped operations.
+- Use preview/apply flows for destructive or broad changes.
+- Reject or regenerate previews if workspace version changed.
+
+## Policy Ownership
+
+- Git/worktree/PR behavior: `workflow.md`
+- Validation and merge gating: `../CI_POLICY.md`
+- Backlog of unfinished work: `backlog.md`

--- a/ai_docs/workflow.md
+++ b/ai_docs/workflow.md
@@ -1,0 +1,48 @@
+# Workflow
+
+This is the canonical git and pull request workflow policy for this repository.
+
+## Branching Rules
+
+- For production-code changes, create a task branch before editing.
+- For documentation-only changes, use a branch unless explicit maintainer policy permits direct edits.
+- Keep branch names scoped to one concern.
+
+## Concurrent Write Isolation
+
+- If another write-capable session is active or likely, use a dedicated git worktree.
+- Prefer one worktree per active branch to prevent cross-task contamination.
+- Do not run concurrent edits against the same branch in multiple worktrees.
+
+## Development Loop
+
+1. Create/switch to the task branch.
+2. Implement changes.
+3. Run required validation from `../CI_POLICY.md`.
+4. Update docs/tests for behavior or surface changes.
+5. Re-run validation if code changed after fixes.
+
+## Merge-Ready Handoff
+
+- Ensure branch is synchronized with base branch when required by branch protection.
+- Resolve merge conflicts before requesting merge.
+- Confirm required status checks are green.
+- Keep handoff notes concise and factual.
+
+## Pull Request Behavior
+
+- Use one focused PR per concern.
+- Link related issue/work item when available.
+- Avoid mixing unrelated refactors with functional changes.
+
+## Post-Merge Cleanup
+
+- Delete merged task branches according to repository policy.
+- Clean up temporary worktrees after branch deletion.
+- Start follow-up work on a new branch, not a recycled closed/merged branch.
+
+## Ownership Boundaries
+
+- Validation and merge gating policy belongs to `../CI_POLICY.md`.
+- Runtime assumptions and execution context belong to `runtime.md`.
+- This file owns git/worktree/branch/PR workflow guidance.


### PR DESCRIPTION
## Summary
- align repository AI-facing documentation with canonical bootstrap model
- add canonical files: AGENTS/CLAUDE bootstrap routing, CI policy, ai_docs workflow/runtime/backlog/index
- add domain references, stable references, procedures, and archive index
- archive previous deep AGENTS guide as legacy reference
- update README canonical doc routing and AI fast-start pointers

## Validation
- stale reference scan for old canonical names
- markdown local link/path validation
- diagnostics checks on changed markdown files