### PR TITLE
docs: tighten canonical AI docs and validation

### DIFF
--- a/.cursor/rules/operational-essentials.md
+++ b/.cursor/rules/operational-essentials.md
@@ -9,12 +9,8 @@ Compact reminder layer aligned with `ai_docs/workflow.md`.
 
 ## Merge-Ready Handoff
 
-- Sync with base branch when branch protection requires it.
-- Resolve conflicts and ensure required checks pass before merge request.
-
-## Validation
-
-- Follow `CI_POLICY.md` for required build/test/release validation.
+- Follow `CI_POLICY.md` before merge handoff.
+- Sync with base branch if repository settings require it.
 
 ## Ownership
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Validate AI docs
+        shell: pwsh
+        run: ./eng/verify-ai-docs.ps1
+
       - name: Verify release build
         shell: pwsh
         run: ./eng/verify-release.ps1 -Configuration Release

--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -1,32 +1,27 @@
 # CI Policy
 
-This document is the single canonical source for validation and merge-gating expectations.
+This document is the single canonical source for validation requirements and merge-gating expectations.
 
-## Required Validation For Merge-Ready Handoff
+## Repository Evidence
 
-1. Build: `dotnet build RoslynMcp.slnx --nologo`
-2. Test: `dotnet test RoslynMcp.slnx --nologo`
-3. If release-impacting files changed, run: `./eng/verify-release.ps1`
+- `.github/workflows/ci.yml` runs on pull requests, pushes to `main`, and manual dispatch.
+- CI currently runs `./eng/verify-ai-docs.ps1`.
+- CI currently runs `./eng/verify-release.ps1 -Configuration Release`.
+- CI currently runs `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`.
 
-## Change-Class Expectations
+## Local Validation
 
-- Docs-only changes:
-  - Ensure markdown links/paths are valid.
-  - Ensure no stale references remain after renames/moves.
-- Product-code changes:
-  - Complete build and tests locally before handoff.
-  - Resolve new diagnostics introduced by the change.
-- Surface/contract changes:
-  - Update docs and tests in the same branch.
+- For AI-doc changes, run `./eng/verify-ai-docs.ps1`.
+- For release-impacting or code changes, run `./eng/verify-release.ps1`.
+- `eng/verify-release.ps1` performs restore, build, test, publish, and hash-manifest generation.
 
-## Merge Gating
+## Merge Gating Expectations
 
-- Respect repository branch protection and required checks.
-- Branch must be synchronized with base branch before merge-ready handoff when required by protection rules.
-- Do not bypass failing required checks.
+- Treat the documented CI workflow as the required merge gate.
+- Do not declare work merge-ready while required CI is failing.
+- If branch synchronization is required by repository protection settings, synchronize before merge.
 
-## Canonical Ownership
+## Ownership
 
-- Git and PR workflow details live in `ai_docs/workflow.md`.
-- Runtime/tool behavior details live in `ai_docs/runtime.md`.
-- This file remains the sole merge-gating and validation policy source.
+- Branch, worktree, and pull-request workflow belongs to `ai_docs/workflow.md`.
+- Runtime assumptions and execution constraints belong to `ai_docs/runtime.md`.

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -17,6 +17,7 @@ This directory is the canonical AI-facing documentation tree.
 - `runtime.md`: canonical runtime assumptions and execution context.
 - `backlog.md`: only place for unfinished work items.
 - `architecture.md`: compact system architecture and boundaries.
+- `../CI_POLICY.md`: canonical validation and merge-gating policy.
 
 ## Domain Entry Points
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,11 +2,7 @@
 
 This is the only canonical location for unfinished AI-facing documentation tasks.
 
-## Open Items
-
-- Evaluate whether `docs/parity-gap-matrix.md` should remain active product documentation or move to `ai_docs/archive/` with a compact current-state summary in `ai_docs/references/`.
-- Evaluate whether `docs/roadmap.md` should be split into current-state commitments vs historical planning notes, with historical planning moved to `ai_docs/archive/`.
-- Add a markdown lint config and CI docs-check target if maintainers want stricter link/style enforcement for docs-only changes.
+No open items.
 
 ## Backlog Rules
 

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -12,7 +12,8 @@ This document is the canonical runtime and execution-context reference for AI ag
 
 - .NET SDK baseline: see `../README.md` and `global.json`.
 - Primary v1 operating system target: Windows.
-- Build/test entry points:
+- Main local validation entry point: `./eng/verify-release.ps1`
+- Fast manual commands also used in repo docs:
   - `dotnet build RoslynMcp.slnx --nologo`
   - `dotnet test RoslynMcp.slnx --nologo`
 
@@ -20,7 +21,6 @@ This document is the canonical runtime and execution-context reference for AI ag
 
 - `stdout` is reserved for MCP protocol traffic.
 - Operational logging should go to `stderr`.
-- Prefer stable MCP surface first; use experimental surface intentionally and explicitly.
 
 ## Session And Mutation Safety
 

--- a/ai_docs/workflow.md
+++ b/ai_docs/workflow.md
@@ -1,48 +1,35 @@
 # Workflow
 
-This is the canonical git and pull request workflow policy for this repository.
+This document is the single owner for branch, worktree, pull-request, and merge-ready handoff workflow.
 
-## Branching Rules
+## Branching
 
-- For production-code changes, create a task branch before editing.
-- For documentation-only changes, use a branch unless explicit maintainer policy permits direct edits.
-- Keep branch names scoped to one concern.
+- Use a task branch for write work.
+- Keep one branch per concern.
 
 ## Concurrent Write Isolation
 
 - If another write-capable session is active or likely, use a dedicated git worktree.
-- Prefer one worktree per active branch to prevent cross-task contamination.
-- Do not run concurrent edits against the same branch in multiple worktrees.
+- Do not run concurrent write sessions against the same branch.
 
-## Development Loop
+## Pull Requests
 
-1. Create/switch to the task branch.
-2. Implement changes.
-3. Run required validation from `../CI_POLICY.md`.
-4. Update docs/tests for behavior or surface changes.
-5. Re-run validation if code changed after fixes.
+- Use a pull request for merge-ready handoff.
+- Keep the pull request scoped to one concern.
 
 ## Merge-Ready Handoff
 
-- Ensure branch is synchronized with base branch when required by branch protection.
-- Resolve merge conflicts before requesting merge.
-- Confirm required status checks are green.
-- Keep handoff notes concise and factual.
-
-## Pull Request Behavior
-
-- Use one focused PR per concern.
-- Link related issue/work item when available.
-- Avoid mixing unrelated refactors with functional changes.
+- Run the required validation from `../CI_POLICY.md`.
+- Resolve merge conflicts before merge handoff.
+- If repository settings require the branch to be up to date with base, sync it before merge.
 
 ## Post-Merge Cleanup
 
-- Delete merged task branches according to repository policy.
-- Clean up temporary worktrees after branch deletion.
-- Start follow-up work on a new branch, not a recycled closed/merged branch.
+- Delete merged task branches.
+- Remove temporary worktrees created for the task.
+- Start follow-up work on a new branch.
 
-## Ownership Boundaries
+## Ownership
 
-- Validation and merge gating policy belongs to `../CI_POLICY.md`.
-- Runtime assumptions and execution context belong to `runtime.md`.
-- This file owns git/worktree/branch/PR workflow guidance.
+- Validation and merge gating belong to `../CI_POLICY.md`.
+- Runtime constraints belong to `runtime.md`.

--- a/eng/verify-ai-docs.ps1
+++ b/eng/verify-ai-docs.ps1
@@ -1,0 +1,65 @@
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+
+$stalePatterns = @(
+    'agent_session_instructions.md',
+    'editor_notes.md',
+    'open_and_deferred_items.md',
+    'ai_docs/tmp',
+    'ai_docs/quickstart.md'
+)
+
+$staleSearchExtensions = @('*.md', '*.ps1', '*.yml', '*.yaml', '*.json')
+$contentFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Include $staleSearchExtensions |
+    Where-Object { $_.FullName -ne $PSCommandPath }
+$markdownFiles = Get-ChildItem -Path $RepoRoot -Recurse -File -Filter *.md
+
+$issues = New-Object System.Collections.Generic.List[string]
+
+foreach ($pattern in $stalePatterns) {
+    $matches = Select-String -Path $contentFiles.FullName -Pattern $pattern -SimpleMatch
+    foreach ($match in $matches) {
+        $issues.Add("Stale reference: $($match.Path):$($match.LineNumber) -> $pattern")
+    }
+}
+
+foreach ($file in $markdownFiles) {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    $matches = [regex]::Matches($content, '\[[^\]]+\]\(([^)]+)\)')
+
+    foreach ($match in $matches) {
+        $target = $match.Groups[1].Value.Trim()
+
+        if ($target -match '^(https?:|mailto:|#)') {
+            continue
+        }
+
+        $pathPart = $target.Split('#')[0].Split('?')[0] -replace '%20', ' '
+        if ([string]::IsNullOrWhiteSpace($pathPart)) {
+            continue
+        }
+
+        if ($pathPart -match '^[a-zA-Z]:\\') {
+            if (-not (Test-Path -LiteralPath $pathPart)) {
+                $issues.Add("Broken absolute link: $($file.FullName) -> $target")
+            }
+
+            continue
+        }
+
+        $resolved = Join-Path -Path $file.DirectoryName -ChildPath $pathPart
+        if (-not (Test-Path -LiteralPath $resolved)) {
+            $issues.Add("Broken relative link: $($file.FullName) -> $target")
+        }
+    }
+}
+
+if ($issues.Count -gt 0) {
+    $issues | Sort-Object -Unique | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host "AI docs validation passed."


### PR DESCRIPTION
## Summary
- tighten canonical AI-doc policy ownership and reduce over-assertive wording
- add repository-backed AI-doc validation script and wire it into CI
- clear backlog to explicit no-open-items state after verification
- keep bootstrap and reminder docs aligned with canonical owners

## Validation
- ran ./eng/verify-ai-docs.ps1
- checked diagnostics on changed files
- reviewed canonical ownership boundaries across bootstrap, CI, workflow, runtime, backlog, and reminder docs