### PR TITLE
feat: add security diagnostic surface and agent awareness improvements

### DIFF
--- a/ai_docs/prompts/add-security-diagnostic-surface.prompt.md
+++ b/ai_docs/prompts/add-security-diagnostic-surface.prompt.md
@@ -1,0 +1,175 @@
+# Add Security Diagnostic Surface To Roslyn MCP Server
+
+## Context
+
+This Roslyn MCP server already exposes `project_diagnostics` and `diagnostic_details` tools that surface compiler diagnostics, analyzer diagnostics, and workspace diagnostics via `CompilationWithAnalyzers`. Any Roslyn-based `DiagnosticAnalyzer` referenced by a project's NuGet packages is automatically picked up.
+
+However, there is no purpose-built surface for **security-focused diagnostics** — an AI agent must call `project_diagnostics`, parse all results, and manually filter for security-relevant IDs. There is also no mechanism to ensure security analyzer packages are present in target projects, and no curated mapping of which diagnostic IDs represent security concerns.
+
+## Objective
+
+Add a security diagnostic surface that enables an AI coding agent to:
+
+1. Check whether a workspace has security analyzers installed
+2. Run security-focused analysis and get only security-relevant results
+3. Understand what each security finding means and how to fix it
+4. Get actionable fix suggestions for common security issues
+
+## What Already Exists (Do Not Duplicate)
+
+- `IDiagnosticService` / `DiagnosticService` — runs `Compilation.GetDiagnostics()` and `CompilationWithAnalyzers.GetAnalyzerDiagnosticsAsync()` with filtering by project, file, and severity
+- `project_diagnostics` tool — exposes the above via MCP
+- `diagnostic_details` tool — returns diagnostic description, help link, and available code fixes
+- `code_fix_preview` / `code_fix_apply` — previews and applies Roslyn code fixes for diagnostics
+- The existing analyzer pipeline picks up any `DiagnosticAnalyzer` from project NuGet package references automatically
+
+## Scope Of Work
+
+### 1. Security Diagnostic ID Registry
+
+Create a static registry that maps known security-relevant diagnostic IDs to categories. This is a curated lookup table, not a new analyzer. It should cover at minimum:
+
+**Microsoft.CodeAnalysis.NetAnalyzers (ships with .NET SDK):**
+- `CA2100` — SQL injection
+- `CA2109` — Review visible event handlers
+- `CA2119` — Seal methods that satisfy private interfaces
+- `CA2153` — Avoid handling corrupted state exceptions
+- `CA2300`–`CA2330` — Insecure deserialization (BinaryFormatter, JavaScriptSerializer, etc.)
+- `CA3001` — SQL injection
+- `CA3002` — XSS
+- `CA3003` — File path injection
+- `CA3004` — Information disclosure
+- `CA3005` — LDAP injection
+- `CA3006` — Process command injection
+- `CA3007` — Open redirect
+- `CA3008` — XPath injection
+- `CA3009` — XML injection
+- `CA3010` — XAML injection
+- `CA3011` — DLL injection
+- `CA3012` — Regex injection
+- `CA3061` — Do not add schema by URL
+- `CA3075` — Insecure DTD processing
+- `CA3076` — Insecure XSLT script processing
+- `CA3077` — Insecure processing in API design
+- `CA3147` — Mark verb handlers with ValidateAntiForgeryToken
+- `CA5350` — Weak cryptographic algorithm (SHA1)
+- `CA5351` — Broken cryptographic algorithm (DES, TripleDES)
+- `CA5358`–`CA5404` — Various crypto, TLS, and certificate validation issues
+
+**SecurityCodeScan (if referenced as NuGet package):**
+- `SCS0001` — Command injection
+- `SCS0002` — SQL injection (LINQ)
+- `SCS0003` — XPath injection
+- `SCS0005` — Weak random
+- `SCS0006` — Weak hash
+- `SCS0007` — XML external entity (XXE)
+- `SCS0008` — Cookie without HttpOnly
+- `SCS0009` — Cookie without Secure
+- `SCS0010`–`SCS0039` — CSRF, open redirect, LDAP injection, hardcoded password, certificate validation, etc.
+
+Each entry should carry: diagnostic ID, short name, OWASP category (e.g., "A03:2021 Injection"), severity, and a one-line description.
+
+### 2. New Tool: `security_diagnostics`
+
+Add a new MCP tool that filters the existing diagnostic pipeline to return only security-relevant results.
+
+**Behavior:**
+- Calls the existing `IDiagnosticService.GetDiagnosticsAsync()` (do NOT reimplement the diagnostic pipeline)
+- Filters results against the security diagnostic ID registry
+- Enriches each result with: OWASP category, security severity (critical/high/medium/low), and a fix hint
+- Accepts the same `workspaceId`, `project`, and `file` filters as `project_diagnostics`
+
+**Response DTO:**
+
+```csharp
+public sealed record SecurityDiagnosticsResultDto(
+    IReadOnlyList<SecurityDiagnosticDto> Findings,
+    SecurityAnalyzerStatusDto AnalyzerStatus,
+    int TotalFindings,
+    int CriticalCount,
+    int HighCount,
+    int MediumCount,
+    int LowCount);
+
+public sealed record SecurityDiagnosticDto(
+    string DiagnosticId,         // e.g., "CA3001"
+    string Message,
+    string SecurityCategory,     // e.g., "Injection"
+    string OwaspCategory,        // e.g., "A03:2021 Injection"
+    string SecuritySeverity,     // "Critical", "High", "Medium", "Low"
+    string? FilePath,
+    int? StartLine,
+    int? StartColumn,
+    string? FixHint,             // Short actionable fix description
+    string? HelpLinkUri);
+
+public sealed record SecurityAnalyzerStatusDto(
+    bool NetAnalyzersPresent,           // SDK analyzers always present
+    bool SecurityCodeScanPresent,       // NuGet package detected
+    IReadOnlyList<string> MissingRecommendedPackages);
+```
+
+### 3. New Tool: `security_analyzer_status`
+
+A lightweight tool that checks whether security analyzer packages are referenced in the workspace without running a full diagnostic pass.
+
+**Behavior:**
+- Iterates `project.AnalyzerReferences` for each project in the workspace
+- Checks for known security analyzer assembly names (e.g., `SecurityCodeScan`, `Microsoft.CodeAnalysis.NetAnalyzers`)
+- Returns which analyzers are present and which recommended packages are missing
+- Suggests NuGet package additions if security coverage is incomplete
+
+### 4. New Prompt: `security_review`
+
+Add an MCP prompt (in `Prompts/RoslynPrompts.cs`) that generates a structured security review prompt for an AI agent. The prompt should:
+
+- Instruct the agent to call `security_analyzer_status` first to verify coverage
+- Then call `security_diagnostics` to get findings
+- Guide the agent through triaging findings by severity
+- Suggest using `code_fix_preview` / `code_fix_apply` for findings that have Roslyn code fixes
+- Flag findings that require manual review (no automated fix available)
+
+## Implementation Constraints
+
+- **Do not reimplement the diagnostic pipeline.** The existing `DiagnosticService` already handles compilation, analyzer execution, and diagnostic collection. The new tools filter and enrich those results.
+- **Do not add custom DiagnosticAnalyzer implementations.** The security coverage comes from existing NuGet analyzer packages. This feature surfaces and enriches their output, it does not replace them.
+- **Follow the existing tool registration pattern.** Use `[McpServerTool]` attributes, inject services via method parameters, use `ToolErrorHandler.ExecuteAsync()`, and return JSON.
+- **Follow the existing service pattern.** Add `ISecurityDiagnosticService` in `Core/Services/`, implement in `Roslyn/Services/`, register in `ServiceCollectionExtensions`.
+- **Follow the existing DTO pattern.** All new types go in `Core/Models/`. No raw Roslyn types in DTOs.
+- **The security ID registry should be a static class**, not configuration-driven. It is a curated security knowledge base that ships with the server. It can be extended over time but does not need runtime configuration.
+- **Mark new tools as stable** (`ReadOnly = true, Destructive = false, Idempotent = true`) — they are read-only analysis tools.
+
+## Testing
+
+Add integration tests in `tests/RoslynMcp.Tests/` following the existing test patterns:
+
+- `SecurityDiagnosticIntegrationTests.cs`
+  - Load a workspace with known security issues (e.g., `string.Format` in SQL query construction)
+  - Verify `security_diagnostics` returns the expected finding with correct OWASP category
+  - Verify `security_analyzer_status` correctly detects present/missing analyzer packages
+  - Verify filtering by project and file works
+  - Verify the response contains zero findings for a clean project
+
+Create a small test fixture project under `tests/fixtures/SecurityTestProject/` with intentional security anti-patterns for the tests to detect.
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `src/RoslynMcp.Core/Models/SecurityDiagnosticDto.cs` | Security diagnostic DTOs |
+| `src/RoslynMcp.Core/Services/ISecurityDiagnosticService.cs` | Service interface |
+| `src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs` | Service implementation |
+| `src/RoslynMcp.Roslyn/Services/SecurityDiagnosticRegistry.cs` | Static ID → category mapping |
+| `src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs` | MCP tool definitions |
+| `src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs` | Add `security_review` prompt |
+| `src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs` | Register new service |
+| `tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs` | Integration tests |
+| `tests/fixtures/SecurityTestProject/` | Test fixture with security anti-patterns |
+
+## Success Criteria
+
+1. An AI agent can call `security_analyzer_status` to check if a workspace has adequate security analyzer coverage
+2. An AI agent can call `security_diagnostics` to get only security-relevant findings with OWASP categorization and fix hints
+3. The tools work with any .NET project without requiring the project to add special configuration — SDK analyzers are always available
+4. The `security_review` prompt guides an agent through a complete security review workflow using the existing code fix tools
+5. All new tools follow the server's established patterns for registration, error handling, concurrency, and serialization

--- a/src/RoslynMcp.Core/Models/SecurityDiagnosticDto.cs
+++ b/src/RoslynMcp.Core/Models/SecurityDiagnosticDto.cs
@@ -1,0 +1,56 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents a single security-relevant diagnostic finding enriched with OWASP categorization.
+/// </summary>
+/// <param name="DiagnosticId">The diagnostic identifier (e.g., <c>CA3001</c>).</param>
+/// <param name="Message">The compiler/analyzer diagnostic message.</param>
+/// <param name="SecurityCategory">Security category (e.g., "Injection", "Cryptography").</param>
+/// <param name="OwaspCategory">OWASP Top 10 category (e.g., "A03:2021 Injection").</param>
+/// <param name="SecuritySeverity">Security severity: Critical, High, Medium, or Low.</param>
+/// <param name="FilePath">Absolute path to the source file, or <see langword="null"/> if not file-specific.</param>
+/// <param name="StartLine">1-based start line, or <see langword="null"/> if not available.</param>
+/// <param name="StartColumn">1-based start column, or <see langword="null"/> if not available.</param>
+/// <param name="FixHint">Short actionable fix description, or <see langword="null"/>.</param>
+/// <param name="HelpLinkUri">Link to documentation for this diagnostic, or <see langword="null"/>.</param>
+public sealed record SecurityDiagnosticDto(
+    string DiagnosticId,
+    string Message,
+    string SecurityCategory,
+    string OwaspCategory,
+    string SecuritySeverity,
+    string? FilePath,
+    int? StartLine,
+    int? StartColumn,
+    string? FixHint,
+    string? HelpLinkUri);
+
+/// <summary>
+/// Result of a security diagnostic scan, containing findings and analyzer status.
+/// </summary>
+/// <param name="Findings">The security-relevant diagnostic findings.</param>
+/// <param name="AnalyzerStatus">Status of security analyzer packages in the workspace.</param>
+/// <param name="TotalFindings">Total number of security findings.</param>
+/// <param name="CriticalCount">Count of Critical severity findings.</param>
+/// <param name="HighCount">Count of High severity findings.</param>
+/// <param name="MediumCount">Count of Medium severity findings.</param>
+/// <param name="LowCount">Count of Low severity findings.</param>
+public sealed record SecurityDiagnosticsResultDto(
+    IReadOnlyList<SecurityDiagnosticDto> Findings,
+    SecurityAnalyzerStatusDto AnalyzerStatus,
+    int TotalFindings,
+    int CriticalCount,
+    int HighCount,
+    int MediumCount,
+    int LowCount);
+
+/// <summary>
+/// Status of security analyzer packages detected in the workspace.
+/// </summary>
+/// <param name="NetAnalyzersPresent">Whether .NET SDK analyzers are present (always true for SDK-style .NET 5+ projects).</param>
+/// <param name="SecurityCodeScanPresent">Whether the SecurityCodeScan NuGet package is referenced.</param>
+/// <param name="MissingRecommendedPackages">Recommended security analyzer packages that are not currently referenced.</param>
+public sealed record SecurityAnalyzerStatusDto(
+    bool NetAnalyzersPresent,
+    bool SecurityCodeScanPresent,
+    IReadOnlyList<string> MissingRecommendedPackages);

--- a/src/RoslynMcp.Core/Services/ISecurityDiagnosticService.cs
+++ b/src/RoslynMcp.Core/Services/ISecurityDiagnosticService.cs
@@ -1,0 +1,28 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides security-focused diagnostic analysis by filtering and enriching the existing
+/// diagnostic pipeline with OWASP categorization and fix hints.
+/// </summary>
+public interface ISecurityDiagnosticService
+{
+    /// <summary>
+    /// Returns only security-relevant diagnostics from the workspace, enriched with
+    /// OWASP categories, severity classifications, and fix hints.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="projectFilter">Restricts results to the named project, or <see langword="null"/> for all projects.</param>
+    /// <param name="fileFilter">Restricts results to a specific file path, or <see langword="null"/> for all files.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<SecurityDiagnosticsResultDto> GetSecurityDiagnosticsAsync(
+        string workspaceId, string? projectFilter, string? fileFilter, CancellationToken ct);
+
+    /// <summary>
+    /// Checks whether security analyzer packages are present in the workspace without running diagnostics.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<SecurityAnalyzerStatusDto> GetAnalyzerStatusAsync(string workspaceId, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -19,7 +19,7 @@ public static class ServerSurfaceCatalog
         Tool("workspace_status", "workspace", "stable", true, false, "Inspect status, diagnostics, and stale-state information for a workspace."),
         Tool("project_graph", "workspace", "stable", true, false, "Inspect project and dependency structure."),
         Tool("source_generated_documents", "workspace", "stable", true, false, "List source-generated documents for a workspace or project."),
-        Tool("get_source_text", "workspace", "stable", true, false, "Read source text as Roslyn currently sees it in the loaded workspace."),
+        Tool("get_source_text", "workspace", "stable", true, false, "Read source text as the Roslyn workspace currently sees it (may differ from disk if workspace hasn't been reloaded)."),
 
         Tool("symbol_search", "symbols", "stable", true, false, "Search symbols by name across the workspace."),
         Tool("symbol_info", "symbols", "stable", true, false, "Inspect the symbol at a source location."),
@@ -106,7 +106,10 @@ public static class ServerSurfaceCatalog
         Tool("get_syntax_tree", "syntax", "experimental", true, false, "Return a structured syntax tree for a document or range."),
         Tool("get_code_actions", "code-actions", "experimental", true, false, "List Roslyn code fixes and refactorings at a location."),
         Tool("preview_code_action", "code-actions", "experimental", true, false, "Preview a Roslyn code action before applying it."),
-        Tool("apply_code_action", "code-actions", "experimental", false, true, "Apply a previously previewed Roslyn code action.")
+        Tool("apply_code_action", "code-actions", "experimental", false, true, "Apply a previously previewed Roslyn code action."),
+
+        Tool("security_diagnostics", "security", "stable", true, false, "Return security-relevant diagnostics with OWASP categorization and fix hints."),
+        Tool("security_analyzer_status", "security", "stable", true, false, "Check which security analyzer packages are present and recommend missing ones.")
     ];
 
     public static IReadOnlyList<SurfaceEntry> Resources { get; } =
@@ -129,7 +132,12 @@ public static class ServerSurfaceCatalog
         Prompt("refactor_and_validate", "prompts", "experimental", true, false, "Generate a prompt for preview-first refactoring and validation."),
         Prompt("fix_all_diagnostics", "prompts", "experimental", true, false, "Generate a prompt for batched diagnostic cleanup."),
         Prompt("guided_package_migration", "prompts", "experimental", true, false, "Generate a prompt for package migration across affected projects."),
-        Prompt("guided_extract_interface", "prompts", "experimental", true, false, "Generate a prompt for interface extraction and consumer updates.")
+        Prompt("guided_extract_interface", "prompts", "experimental", true, false, "Generate a prompt for interface extraction and consumer updates."),
+        Prompt("security_review", "prompts", "experimental", true, false, "Generate a prompt for comprehensive security review using security diagnostic tools."),
+        Prompt("discover_capabilities", "prompts", "experimental", true, false, "Generate a prompt to discover relevant server tools and workflows for a task category."),
+        Prompt("dead_code_audit", "prompts", "experimental", true, false, "Generate a prompt for dead code audit using unused symbol detection and removal."),
+        Prompt("review_test_coverage", "prompts", "experimental", true, false, "Generate a prompt for test coverage review and gap identification."),
+        Prompt("review_complexity", "prompts", "experimental", true, false, "Generate a prompt for complexity review and refactoring opportunities.")
     ];
 
     public static SurfaceSummary GetSummary()
@@ -143,6 +151,19 @@ public static class ServerSurfaceCatalog
             CountByTier(Prompts, "stable"),
             CountByTier(Prompts, "experimental"));
     }
+
+    public static IReadOnlyList<WorkflowHint> WorkflowHints { get; } =
+    [
+        new("Preview/Apply", ["rename_preview", "rename_apply"], "Most write operations use a two-step pattern: call *_preview to inspect the diff, then *_apply with the preview token."),
+        new("Diagnostic Fix", ["project_diagnostics", "diagnostic_details", "code_fix_preview", "code_fix_apply"], "Identify diagnostics, inspect details, preview a fix, then apply it."),
+        new("Code Action", ["get_code_actions", "preview_code_action", "apply_code_action"], "List available Roslyn refactorings/fixes at a location, preview, then apply."),
+        new("Security Audit", ["security_analyzer_status", "security_diagnostics", "diagnostic_details", "code_fix_preview", "code_fix_apply"], "Check analyzer coverage, get security findings, then fix them."),
+        new("Build and Test", ["build_workspace", "test_run"], "Validate compilation then run tests after any code change."),
+        new("Change Validation", ["test_related_files", "test_run"], "Find tests related to changed files, then run them."),
+        new("Dead Code Cleanup", ["find_unused_symbols", "remove_dead_code_preview", "remove_dead_code_apply", "build_workspace"], "Find unused symbols, preview removal, apply, then verify build."),
+        new("Package Migration", ["migrate_package_preview", "apply_composite_preview", "build_workspace"], "Preview migrating a package across projects, apply, then verify."),
+        new("Coverage Analysis", ["test_discover", "test_coverage", "scaffold_test_preview", "scaffold_test_apply"], "Discover tests, run coverage, scaffold new tests for gaps.")
+    ];
 
     public static ServerCatalogDto CreateDocument()
     {
@@ -160,6 +181,7 @@ public static class ServerSurfaceCatalog
             Tools,
             Resources,
             Prompts,
+            WorkflowHints,
             Summary: GetSummary());
     }
 
@@ -220,4 +242,16 @@ public sealed record ServerCatalogDto(
     IReadOnlyList<SurfaceEntry> Tools,
     IReadOnlyList<SurfaceEntry> Resources,
     IReadOnlyList<SurfaceEntry> Prompts,
+    IReadOnlyList<WorkflowHint> WorkflowHints,
     SurfaceSummary Summary);
+
+/// <summary>
+/// Describes a common tool workflow — a sequence of tools that work together.
+/// </summary>
+/// <param name="Name">Human-readable workflow name (e.g., "Diagnostic Fix").</param>
+/// <param name="ToolSequence">Ordered list of tool names in the typical execution flow.</param>
+/// <param name="Description">Short description of when and how to use this workflow.</param>
+public sealed record WorkflowHint(
+    string Name,
+    IReadOnlyList<string> ToolSequence,
+    string Description);

--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -9,6 +10,8 @@ namespace RoslynMcp.Host.Stdio.Prompts;
 [McpServerPromptType]
 public static class RoslynPrompts
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
     [McpServerPrompt(Name = "explain_error")]
     [Description("Generate a prompt to explain a compiler diagnostic error and suggest fixes")]
     public static async Task<IEnumerable<PromptMessage>> ExplainError(
@@ -21,59 +24,65 @@ public static class RoslynPrompts
         [Description("1-based column number")] int column,
         CancellationToken ct = default)
     {
-        var details = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
-        var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-
-        // Extract surrounding lines for context
-        var contextLines = "";
-        if (sourceText is not null)
+        try
         {
-            var lines = sourceText.Split('\n');
-            var startLine = Math.Max(0, line - 6);
-            var endLine = Math.Min(lines.Length - 1, line + 4);
-            contextLines = string.Join('\n', lines[startLine..endLine].Select((l, i) =>
-            {
-                var lineNum = startLine + i + 1;
-                var marker = lineNum == line ? " >>> " : "     ";
-                return $"{marker}{lineNum,4}: {l.TrimEnd('\r')}";
-            }));
-        }
+            var details = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
+            var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
 
-        var detailsJson = JsonSerializer.Serialize(details, new JsonSerializerOptions { WriteIndented = true });
-
-        return
-        [
-            new PromptMessage
+            var contextLines = "";
+            if (sourceText is not null)
             {
-                Role = Role.User,
-                Content = new TextContentBlock
+                var lines = sourceText.Split('\n');
+                var startLine = Math.Max(0, line - 6);
+                var endLine = Math.Min(lines.Length - 1, line + 4);
+                contextLines = string.Join('\n', lines[startLine..endLine].Select((l, i) =>
                 {
-                    Text = $"""
-                        Explain the following C# compiler diagnostic and suggest how to fix it.
-
-                        **Diagnostic:** {diagnosticId}
-                        **File:** {filePath}
-                        **Line:** {line}, **Column:** {column}
-
-                        **Diagnostic Details:**
-                        ```json
-                        {detailsJson}
-                        ```
-
-                        **Source Context:**
-                        ```csharp
-                        {contextLines}
-                        ```
-
-                        Please:
-                        1. Explain what this diagnostic means in plain language
-                        2. Explain why it occurs in this context
-                        3. Suggest one or more fixes with code examples
-                        4. Note any potential side effects of each fix
-                        """
-                }
+                    var lineNum = startLine + i + 1;
+                    var marker = lineNum == line ? " >>> " : "     ";
+                    return $"{marker}{lineNum,4}: {l.TrimEnd('\r')}";
+                }));
             }
-        ];
+
+            var detailsJson = JsonSerializer.Serialize(details, JsonOptions);
+
+            return
+            [
+                new PromptMessage
+                {
+                    Role = Role.User,
+                    Content = new TextContentBlock
+                    {
+                        Text = $"""
+                            Explain the following C# compiler diagnostic and suggest how to fix it.
+
+                            **Diagnostic:** {diagnosticId}
+                            **File:** {filePath}
+                            **Line:** {line}, **Column:** {column}
+
+                            **Diagnostic Details:**
+                            ```json
+                            {detailsJson}
+                            ```
+
+                            **Source Context:**
+                            ```csharp
+                            {contextLines}
+                            ```
+
+                            Please:
+                            1. Explain what this diagnostic means in plain language
+                            2. Explain why it occurs in this context
+                            3. Suggest one or more fixes with code examples
+                            4. Note any potential side effects of each fix
+                            """
+                    }
+                }
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("explain_error", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "suggest_refactoring")]
@@ -87,62 +96,62 @@ public static class RoslynPrompts
         [Description("Optional: end line to focus on")] int? endLine = null,
         CancellationToken ct = default)
     {
-        var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        if (sourceText is null)
-            return [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = $"File not found in workspace: {filePath}" } }];
-
-        var symbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        var symbolsSummary = JsonSerializer.Serialize(symbols, new JsonSerializerOptions { WriteIndented = true });
-
-        string codeSection;
-        if (startLine.HasValue && endLine.HasValue)
+        try
         {
-            var lines = sourceText.Split('\n');
-            var start = Math.Max(0, startLine.Value - 1);
-            var end = Math.Min(lines.Length, endLine.Value);
-            codeSection = string.Join('\n', lines[start..end].Select((l, i) => $"{start + i + 1,4}: {l.TrimEnd('\r')}"));
-        }
-        else
-        {
-            codeSection = sourceText;
-        }
+            var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            if (sourceText is null)
+                return [CreatePromptMessage($"File not found in workspace: {filePath}")];
 
-        return
-        [
-            new PromptMessage
+            var symbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonOptions);
+
+            string codeSection;
+            if (startLine.HasValue && endLine.HasValue)
             {
-                Role = Role.User,
-                Content = new TextContentBlock
-                {
-                    Text = $"""
-                        Analyze the following C# code and suggest refactorings to improve its quality, readability, and maintainability.
-
-                        **File:** {filePath}
-
-                        **Document Symbols:**
-                        ```json
-                        {symbolsSummary}
-                        ```
-
-                        **Code:**
-                        ```csharp
-                        {codeSection}
-                        ```
-
-                        Please suggest refactorings considering:
-                        1. SOLID principles violations
-                        2. Code duplication opportunities
-                        3. Method extraction candidates
-                        4. Naming improvements
-                        5. Pattern usage (e.g., Strategy, Factory, Builder)
-                        6. Performance improvements
-                        7. C# idiom improvements (pattern matching, LINQ, etc.)
-
-                        For each suggestion, provide the specific code change and explain the benefit.
-                        """
-                }
+                var lines = sourceText.Split('\n');
+                var start = Math.Max(0, startLine.Value - 1);
+                var end = Math.Min(lines.Length, endLine.Value);
+                codeSection = string.Join('\n', lines[start..end].Select((l, i) => $"{start + i + 1,4}: {l.TrimEnd('\r')}"));
             }
-        ];
+            else
+            {
+                codeSection = sourceText;
+            }
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Analyze the following C# code and suggest refactorings to improve its quality, readability, and maintainability.
+
+                    **File:** {filePath}
+
+                    **Document Symbols:**
+                    ```json
+                    {symbolsSummary}
+                    ```
+
+                    **Code:**
+                    ```csharp
+                    {codeSection}
+                    ```
+
+                    Please suggest refactorings considering:
+                    1. SOLID principles violations
+                    2. Code duplication opportunities
+                    3. Method extraction candidates
+                    4. Naming improvements
+                    5. Pattern usage (e.g., Strategy, Factory, Builder)
+                    6. Performance improvements
+                    7. C# idiom improvements (pattern matching, LINQ, etc.)
+
+                    For each suggestion, provide the specific code change and explain the benefit.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("suggest_refactoring", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "review_file")]
@@ -155,58 +164,58 @@ public static class RoslynPrompts
         [Description("Absolute path to the source file")] string filePath,
         CancellationToken ct = default)
     {
-        var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        if (sourceText is null)
-            return [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = $"File not found in workspace: {filePath}" } }];
+        try
+        {
+            var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            if (sourceText is null)
+                return [CreatePromptMessage($"File not found in workspace: {filePath}")];
 
-        var symbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, filePath, null, ct).ConfigureAwait(false);
+            var symbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, filePath, null, ct).ConfigureAwait(false);
 
-        var symbolsSummary = JsonSerializer.Serialize(symbols, new JsonSerializerOptions { WriteIndented = true });
-        var diagnosticsSummary = JsonSerializer.Serialize(diagnostics, new JsonSerializerOptions { WriteIndented = true });
+            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonOptions);
+            var diagnosticsSummary = JsonSerializer.Serialize(diagnostics, JsonOptions);
 
-        return
-        [
-            new PromptMessage
-            {
-                Role = Role.User,
-                Content = new TextContentBlock
-                {
-                    Text = $"""
-                        Perform a thorough code review of the following C# source file.
+            return
+            [
+                CreatePromptMessage($"""
+                    Perform a thorough code review of the following C# source file.
 
-                        **File:** {filePath}
+                    **File:** {filePath}
 
-                        **Document Symbols:**
-                        ```json
-                        {symbolsSummary}
-                        ```
+                    **Document Symbols:**
+                    ```json
+                    {symbolsSummary}
+                    ```
 
-                        **Current Diagnostics:**
-                        ```json
-                        {diagnosticsSummary}
-                        ```
+                    **Current Diagnostics:**
+                    ```json
+                    {diagnosticsSummary}
+                    ```
 
-                        **Source Code:**
-                        ```csharp
-                        {sourceText}
-                        ```
+                    **Source Code:**
+                    ```csharp
+                    {sourceText}
+                    ```
 
-                        Review the code for:
-                        1. **Correctness**: Logic errors, edge cases, null handling
-                        2. **Security**: Injection risks, input validation, sensitive data exposure
-                        3. **Performance**: Unnecessary allocations, N+1 queries, missing async/await
-                        4. **Thread Safety**: Race conditions, shared mutable state
-                        5. **Design**: SOLID violations, coupling issues, missing abstractions
-                        6. **Maintainability**: Readability, naming, documentation gaps
-                        7. **Error Handling**: Missing try/catch, swallowed exceptions
-                        8. **Testing**: Testability concerns, missing validation
+                    Review the code for:
+                    1. **Correctness**: Logic errors, edge cases, null handling
+                    2. **Security**: Injection risks, input validation, sensitive data exposure
+                    3. **Performance**: Unnecessary allocations, N+1 queries, missing async/await
+                    4. **Thread Safety**: Race conditions, shared mutable state
+                    5. **Design**: SOLID violations, coupling issues, missing abstractions
+                    6. **Maintainability**: Readability, naming, documentation gaps
+                    7. **Error Handling**: Missing try/catch, swallowed exceptions
+                    8. **Testing**: Testability concerns, missing validation
 
-                        For each issue found, specify the line number, severity (critical/major/minor/suggestion), and proposed fix.
-                        """
-                }
-            }
-        ];
+                    For each issue found, specify the line number, severity (critical/major/minor/suggestion), and proposed fix.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("review_file", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "analyze_dependencies")]
@@ -217,51 +226,51 @@ public static class RoslynPrompts
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default)
     {
-        var graph = workspace.GetProjectGraph(workspaceId);
-        var graphJson = JsonSerializer.Serialize(graph, new JsonSerializerOptions { WriteIndented = true });
+        try
+        {
+            var graph = workspace.GetProjectGraph(workspaceId);
+            var graphJson = JsonSerializer.Serialize(graph, JsonOptions);
 
-        var namespaceDeps = await analysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
-        var namespaceDepsJson = JsonSerializer.Serialize(namespaceDeps, new JsonSerializerOptions { WriteIndented = true });
+            var namespaceDeps = await analysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
+            var namespaceDepsJson = JsonSerializer.Serialize(namespaceDeps, JsonOptions);
 
-        var nugetDeps = await analysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
-        var nugetDepsJson = JsonSerializer.Serialize(nugetDeps, new JsonSerializerOptions { WriteIndented = true });
+            var nugetDeps = await analysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
+            var nugetDepsJson = JsonSerializer.Serialize(nugetDeps, JsonOptions);
 
-        return
-        [
-            new PromptMessage
-            {
-                Role = Role.User,
-                Content = new TextContentBlock
-                {
-                    Text = $"""
-                        Analyze the architecture and dependency structure of this .NET solution.
+            return
+            [
+                CreatePromptMessage($"""
+                    Analyze the architecture and dependency structure of this .NET solution.
 
-                        **Project Dependency Graph:**
-                        ```json
-                        {graphJson}
-                        ```
+                    **Project Dependency Graph:**
+                    ```json
+                    {graphJson}
+                    ```
 
-                        **Namespace Dependencies:**
-                        ```json
-                        {namespaceDepsJson}
-                        ```
+                    **Namespace Dependencies:**
+                    ```json
+                    {namespaceDepsJson}
+                    ```
 
-                        **NuGet Dependencies:**
-                        ```json
-                        {nugetDepsJson}
-                        ```
+                    **NuGet Dependencies:**
+                    ```json
+                    {nugetDepsJson}
+                    ```
 
-                        Please analyze:
-                        1. **Architecture**: Identify the layering strategy and assess if it follows clean architecture / onion architecture principles
-                        2. **Circular Dependencies**: Flag any circular namespace or project dependencies and suggest how to break them
-                        3. **Coupling**: Identify tightly coupled components and suggest decoupling strategies
-                        4. **NuGet Health**: Flag outdated, redundant, or conflicting package versions
-                        5. **Dependency Direction**: Verify that dependencies flow in the correct direction (e.g., UI → Domain, not Domain → UI)
-                        6. **Modularity**: Suggest opportunities to extract shared libraries or consolidate projects
-                        """
-                }
-            }
-        ];
+                    Please analyze:
+                    1. **Architecture**: Identify the layering strategy and assess if it follows clean architecture / onion architecture principles
+                    2. **Circular Dependencies**: Flag any circular namespace or project dependencies and suggest how to break them
+                    3. **Coupling**: Identify tightly coupled components and suggest decoupling strategies
+                    4. **NuGet Health**: Flag outdated, redundant, or conflicting package versions
+                    5. **Dependency Direction**: Verify that dependencies flow in the correct direction (e.g., UI → Domain, not Domain → UI)
+                    6. **Modularity**: Suggest opportunities to extract shared libraries or consolidate projects
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("analyze_dependencies", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "debug_test_failure")]
@@ -273,44 +282,44 @@ public static class RoslynPrompts
         [Description("Optional: test filter expression to narrow which tests to run")] string? filter = null,
         CancellationToken ct = default)
     {
-        var testResult = await validationService.RunTestsAsync(workspaceId, projectName, filter, ct).ConfigureAwait(false);
-        var testResultJson = JsonSerializer.Serialize(testResult, new JsonSerializerOptions { WriteIndented = true });
+        try
+        {
+            var testResult = await validationService.RunTestsAsync(workspaceId, projectName, filter, ct).ConfigureAwait(false);
+            var testResultJson = JsonSerializer.Serialize(testResult, JsonOptions);
 
-        var failureSummary = testResult.Failures.Count > 0
-            ? string.Join("\n", testResult.Failures.Select((f, i) =>
-                $"  {i + 1}. **{f.DisplayName}**\n     Message: {f.Message}\n     Stack: {f.StackTrace ?? "N/A"}"))
-            : "No failures detected.";
+            var failureSummary = testResult.Failures.Count > 0
+                ? string.Join("\n", testResult.Failures.Select((f, i) =>
+                    $"  {i + 1}. **{f.DisplayName}**\n     Message: {f.Message}\n     Stack: {f.StackTrace ?? "N/A"}"))
+                : "No failures detected.";
 
-        return
-        [
-            new PromptMessage
-            {
-                Role = Role.User,
-                Content = new TextContentBlock
-                {
-                    Text = $"""
-                        Diagnose the following test failure(s) and suggest fixes.
+            return
+            [
+                CreatePromptMessage($"""
+                    Diagnose the following test failure(s) and suggest fixes.
 
-                        **Test Summary:** {testResult.Total} total, {testResult.Passed} passed, {testResult.Failed} failed, {testResult.Skipped} skipped
+                    **Test Summary:** {testResult.Total} total, {testResult.Passed} passed, {testResult.Failed} failed, {testResult.Skipped} skipped
 
-                        **Test Results (full):**
-                        ```json
-                        {testResultJson}
-                        ```
+                    **Test Results (full):**
+                    ```json
+                    {testResultJson}
+                    ```
 
-                        **Failure Details:**
-                        {failureSummary}
+                    **Failure Details:**
+                    {failureSummary}
 
-                        Please:
-                        1. Identify the root cause of each failing test
-                        2. Determine if the failure is in the test itself or the code under test
-                        3. Suggest specific code changes to fix the failure
-                        4. If the test expectation is wrong, explain why and suggest the correct assertion
-                        5. Note any test isolation issues (shared state, timing, external dependencies)
-                        """
-                }
-            }
-        ];
+                    Please:
+                    1. Identify the root cause of each failing test
+                    2. Determine if the failure is in the test itself or the code under test
+                    3. Suggest specific code changes to fix the failure
+                    4. If the test expectation is wrong, explain why and suggest the correct assertion
+                    5. Note any test isolation issues (shared state, timing, external dependencies)
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("debug_test_failure", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "refactor_and_validate")]
@@ -327,46 +336,53 @@ public static class RoslynPrompts
         [Description("Optional: 1-based end column number for a selection range")] int? endColumn = null,
         CancellationToken ct = default)
     {
-        var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        if (sourceText is null)
+        try
         {
-            return [CreatePromptMessage($"File not found in workspace: {filePath}")];
+            var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            if (sourceText is null)
+            {
+                return [CreatePromptMessage($"File not found in workspace: {filePath}")];
+            }
+
+            var codeActions = await codeActionService.GetCodeActionsAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, ct).ConfigureAwait(false);
+            var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, filePath, null, ct).ConfigureAwait(false);
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Plan and execute a focused refactoring for the selected C# code using the server's preview/apply workflow.
+
+                    **File:** {filePath}
+                    **Selection:** {startLine}:{startColumn}{FormatRangeSuffix(endLine, endColumn)}
+
+                    **Source Context:**
+                    ```csharp
+                    {FormatSourceContext(sourceText, startLine, endLine)}
+                    ```
+
+                    **Available Code Actions:**
+                    {SummarizeCodeActions(codeActions)}
+
+                    **Current Diagnostics In File:**
+                    {SummarizeDiagnostics(diagnostics)}
+
+                    Use this workflow:
+                    1. Call `get_code_actions` for the same span and select the best action index from the list above.
+                    2. Call `preview_code_action` with that action index and inspect the returned diff carefully.
+                    3. If the diff is acceptable, call `apply_code_action` with the preview token.
+                    4. If no appropriate code action exists, fall back to `rename_preview`, `organize_usings_preview`, `format_document_preview`, `apply_text_edit`, or `apply_multi_file_edit` as needed.
+                    5. After applying changes, call `build_project` for the owning project if obvious from the path; otherwise call `build_workspace`.
+                    6. If tests are likely impacted, call `test_related_files` or `test_run` and confirm whether any failures were introduced.
+                    7. Finish by calling `project_diagnostics` or `diagnostic_details` to confirm the targeted issue was reduced or resolved.
+
+                    Prefer minimal diffs and explain why you chose the selected code action over the alternatives.
+                    """)
+            ];
         }
-
-        var codeActions = await codeActionService.GetCodeActionsAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, ct).ConfigureAwait(false);
-        var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, filePath, null, ct).ConfigureAwait(false);
-
-        return
-        [
-            CreatePromptMessage($"""
-                Plan and execute a focused refactoring for the selected C# code using the server's preview/apply workflow.
-
-                **File:** {filePath}
-                **Selection:** {startLine}:{startColumn}{FormatRangeSuffix(endLine, endColumn)}
-
-                **Source Context:**
-                ```csharp
-                {FormatSourceContext(sourceText, startLine, endLine)}
-                ```
-
-                **Available Code Actions:**
-                {SummarizeCodeActions(codeActions)}
-
-                **Current Diagnostics In File:**
-                {SummarizeDiagnostics(diagnostics)}
-
-                Use this workflow:
-                1. Call `get_code_actions` for the same span and select the best action index from the list above.
-                2. Call `preview_code_action` with that action index and inspect the returned diff carefully.
-                3. If the diff is acceptable, call `apply_code_action` with the preview token.
-                4. If no appropriate code action exists, fall back to `rename_preview`, `organize_usings_preview`, `format_document_preview`, `apply_text_edit`, or `apply_multi_file_edit` as needed.
-                5. After applying changes, call `build_project` for the owning project if obvious from the path; otherwise call `build_workspace`.
-                6. If tests are likely impacted, call `test_related_files` or `test_run` and confirm whether any failures were introduced.
-                7. Finish by calling `project_diagnostics` or `diagnostic_details` to confirm the targeted issue was reduced or resolved.
-
-                Prefer minimal diffs and explain why you chose the selected code action over the alternatives.
-                """)
-        ];
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("refactor_and_validate", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "fix_all_diagnostics")]
@@ -378,38 +394,45 @@ public static class RoslynPrompts
         [Description("Optional: severity filter such as error, warning, or info")] string? severityFilter = null,
         CancellationToken ct = default)
     {
-        var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, projectName, null, severityFilter, ct).ConfigureAwait(false);
-        var groupedDiagnostics = diagnostics.CompilerDiagnostics
-            .Concat(diagnostics.AnalyzerDiagnostics)
-            .GroupBy(diagnostic => diagnostic.Id, StringComparer.OrdinalIgnoreCase)
-            .OrderByDescending(group => group.Count())
-            .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
-            .Take(12)
-            .Select(group => $"- {group.Key}: {group.Count()} occurrence(s)")
-            .ToArray();
+        try
+        {
+            var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, projectName, null, severityFilter, ct).ConfigureAwait(false);
+            var groupedDiagnostics = diagnostics.CompilerDiagnostics
+                .Concat(diagnostics.AnalyzerDiagnostics)
+                .GroupBy(diagnostic => diagnostic.Id, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .Take(12)
+                .Select(group => $"- {group.Key}: {group.Count()} occurrence(s)")
+                .ToArray();
 
-        return
-        [
-            CreatePromptMessage($"""
-                Clean up diagnostics in this workspace using a preview-first loop.
+            return
+            [
+                CreatePromptMessage($"""
+                    Clean up diagnostics in this workspace using a preview-first loop.
 
-                **Project Filter:** {projectName ?? "(entire workspace)"}
-                **Severity Filter:** {severityFilter ?? "(all severities)"}
+                    **Project Filter:** {projectName ?? "(entire workspace)"}
+                    **Severity Filter:** {severityFilter ?? "(all severities)"}
 
-                **Diagnostic Summary:**
-                {FormatBulletList(groupedDiagnostics, "No compiler or analyzer diagnostics matched the filter.")}
+                    **Diagnostic Summary:**
+                    {FormatBulletList(groupedDiagnostics, "No compiler or analyzer diagnostics matched the filter.")}
 
-                Use this workflow:
-                1. Start with the highest-volume or highest-severity diagnostic group.
-                2. For one representative occurrence, call `diagnostic_details` to inspect curated fix metadata.
-                3. If a curated fix exists, call `code_fix_preview`, review the diff, then `code_fix_apply`.
-                4. If no curated fix exists, use `get_code_actions` and `preview_code_action` at the relevant span, or fall back to text-edit tools.
-                5. After each applied batch, call `build_project` or `build_workspace` and verify the count for that diagnostic ID decreases.
-                6. Repeat until the remaining diagnostics require manual design changes rather than mechanical fixes.
+                    Use this workflow:
+                    1. Start with the highest-volume or highest-severity diagnostic group.
+                    2. For one representative occurrence, call `diagnostic_details` to inspect curated fix metadata.
+                    3. If a curated fix exists, call `code_fix_preview`, review the diff, then `code_fix_apply`.
+                    4. If no curated fix exists, use `get_code_actions` and `preview_code_action` at the relevant span, or fall back to text-edit tools.
+                    5. After each applied batch, call `build_project` or `build_workspace` and verify the count for that diagnostic ID decreases.
+                    6. Repeat until the remaining diagnostics require manual design changes rather than mechanical fixes.
 
-                Keep changes batched by diagnostic ID so validation remains attributable.
-                """)
-        ];
+                    Keep changes batched by diagnostic ID so validation remains attributable.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("fix_all_diagnostics", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "guided_package_migration")]
@@ -422,31 +445,38 @@ public static class RoslynPrompts
         [Description("Replacement package version")] string newVersion,
         CancellationToken ct = default)
     {
-        var dependencyResult = await analysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
-        var matchingProjects = dependencyResult.Projects
-            .Where(project => project.PackageReferences.Any(reference => string.Equals(reference.PackageId, oldPackageId, StringComparison.OrdinalIgnoreCase)))
-            .Select(project => $"- {project.ProjectName}: {string.Join(", ", project.PackageReferences.Where(reference => string.Equals(reference.PackageId, oldPackageId, StringComparison.OrdinalIgnoreCase)).Select(reference => reference.Version))}")
-            .ToArray();
+        try
+        {
+            var dependencyResult = await analysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
+            var matchingProjects = dependencyResult.Projects
+                .Where(project => project.PackageReferences.Any(reference => string.Equals(reference.PackageId, oldPackageId, StringComparison.OrdinalIgnoreCase)))
+                .Select(project => $"- {project.ProjectName}: {string.Join(", ", project.PackageReferences.Where(reference => string.Equals(reference.PackageId, oldPackageId, StringComparison.OrdinalIgnoreCase)).Select(reference => reference.Version))}")
+                .ToArray();
 
-        return
-        [
-            CreatePromptMessage($"""
-                Migrate this solution from `{oldPackageId}` to `{newPackageId}` version `{newVersion}` using preview/apply tools.
+            return
+            [
+                CreatePromptMessage($"""
+                    Migrate this solution from `{oldPackageId}` to `{newPackageId}` version `{newVersion}` using preview/apply tools.
 
-                **Projects Currently Using {oldPackageId}:**
-                {FormatBulletList(matchingProjects, $"No projects currently reference {oldPackageId}.")}
+                    **Projects Currently Using {oldPackageId}:**
+                    {FormatBulletList(matchingProjects, $"No projects currently reference {oldPackageId}.")}
 
-                Use this workflow:
-                        1. Prefer a single call to `migrate_package_preview` and inspect the combined diff across all affected project files.
-                        2. If the preview looks correct, call `apply_composite_preview`.
-                        3. If you need more granular control, fall back to `remove_package_reference_preview`, `add_package_reference_preview`, and `add_central_package_version_preview` per project.
-                        4. After project-file changes, call `build_workspace` and inspect resulting diagnostics.
-                        5. For any API or namespace incompatibilities, use `symbol_search`, `find_references`, `get_code_actions`, `preview_code_action`, or text-edit tools to adapt consumers.
-                        6. Finish with `test_run` or `test_related_files` for impacted areas.
+                    Use this workflow:
+                            1. Prefer a single call to `migrate_package_preview` and inspect the combined diff across all affected project files.
+                            2. If the preview looks correct, call `apply_composite_preview`.
+                            3. If you need more granular control, fall back to `remove_package_reference_preview`, `add_package_reference_preview`, and `add_central_package_version_preview` per project.
+                            4. After project-file changes, call `build_workspace` and inspect resulting diagnostics.
+                            5. For any API or namespace incompatibilities, use `symbol_search`, `find_references`, `get_code_actions`, `preview_code_action`, or text-edit tools to adapt consumers.
+                            6. Finish with `test_run` or `test_related_files` for impacted areas.
 
-                Prefer migrating all project references first, then fixing source-level API fallout in a second pass.
-                """)
-        ];
+                    Prefer migrating all project references first, then fixing source-level API fallout in a second pass.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("guided_package_migration", ex)];
+        }
     }
 
     [McpServerPrompt(Name = "guided_extract_interface")]
@@ -460,46 +490,319 @@ public static class RoslynPrompts
         [Description("Optional: target project for the extracted interface")] string? targetProjectName = null,
         CancellationToken ct = default)
     {
-        var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        if (sourceText is null)
+        try
         {
-            return [CreatePromptMessage($"File not found in workspace: {filePath}")];
+            var sourceText = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            if (sourceText is null)
+            {
+                return [CreatePromptMessage($"File not found in workspace: {filePath}")];
+            }
+
+            var documentSymbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
+            var projectGraph = workspace.GetProjectGraph(workspaceId);
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Extract an interface from `{typeName}` and update downstream consumers using preview-first operations.
+
+                    **File:** {filePath}
+                    **Target Project:** {targetProjectName ?? "(same project unless the architecture suggests otherwise)"}
+
+                    **Document Symbols:**
+                    ```json
+                    {JsonSerializer.Serialize(documentSymbols, JsonOptions)}
+                    ```
+
+                    **Project Graph:**
+                    ```json
+                    {JsonSerializer.Serialize(projectGraph, JsonOptions)}
+                    ```
+
+                    Use this workflow:
+                    1. Locate the declaration span for `{typeName}` from the document-symbol output.
+                            2. Prefer `extract_and_wire_interface_preview` if you want one orchestration preview that also updates DI registrations.
+                            3. If you only need interface extraction, call `extract_interface_preview`, review the diff, then apply it with `rename_apply`.
+                            4. If no suitable dedicated flow exists, fall back to `get_code_actions`, `preview_code_action`, or manual scaffolding with `scaffold_type_preview`.
+                            5. If the interface should live in another project, ensure the necessary project reference exists in the preview before applying.
+                            6. Call `find_references` for `{typeName}` and update consumer type annotations or constructor parameters where interface-based dependencies are more appropriate.
+                            7. Finish with `build_workspace`, then `test_related` or `test_run` for the affected components.
+
+                    Prefer preserving the concrete type while introducing the interface incrementally unless a broader dependency inversion is explicitly required.
+                    """)
+            ];
         }
-
-        var documentSymbols = await symbolService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-        var projectGraph = workspace.GetProjectGraph(workspaceId);
-
-        return
-        [
-            CreatePromptMessage($"""
-                Extract an interface from `{typeName}` and update downstream consumers using preview-first operations.
-
-                **File:** {filePath}
-                **Target Project:** {targetProjectName ?? "(same project unless the architecture suggests otherwise)"}
-
-                **Document Symbols:**
-                ```json
-                {JsonSerializer.Serialize(documentSymbols, new JsonSerializerOptions { WriteIndented = true })}
-                ```
-
-                **Project Graph:**
-                ```json
-                {JsonSerializer.Serialize(projectGraph, new JsonSerializerOptions { WriteIndented = true })}
-                ```
-
-                Use this workflow:
-                1. Locate the declaration span for `{typeName}` from the document-symbol output.
-                        2. Prefer `extract_and_wire_interface_preview` if you want one orchestration preview that also updates DI registrations.
-                        3. If you only need interface extraction, call `extract_interface_preview`, review the diff, then apply it with `rename_apply`.
-                        4. If no suitable dedicated flow exists, fall back to `get_code_actions`, `preview_code_action`, or manual scaffolding with `scaffold_type_preview`.
-                        5. If the interface should live in another project, ensure the necessary project reference exists in the preview before applying.
-                        6. Call `find_references` for `{typeName}` and update consumer type annotations or constructor parameters where interface-based dependencies are more appropriate.
-                        7. Finish with `build_workspace`, then `test_related` or `test_run` for the affected components.
-
-                Prefer preserving the concrete type while introducing the interface incrementally unless a broader dependency inversion is explicitly required.
-                """)
-        ];
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("guided_extract_interface", ex)];
+        }
     }
+
+    // ── New prompts: Security and Agent Awareness ──
+
+    [McpServerPrompt(Name = "security_review")]
+    [Description("Generate a prompt that guides a comprehensive security review using security diagnostic tools and code fix workflows.")]
+    public static async Task<IEnumerable<PromptMessage>> SecurityReview(
+        ISecurityDiagnosticService securityService,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Optional: filter by project name")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var status = await securityService.GetAnalyzerStatusAsync(workspaceId, ct).ConfigureAwait(false);
+            var findings = await securityService.GetSecurityDiagnosticsAsync(workspaceId, projectName, null, ct).ConfigureAwait(false);
+
+            var statusSummary = new List<string>();
+            statusSummary.Add($"- .NET SDK Analyzers: {(status.NetAnalyzersPresent ? "Present" : "Not detected")}");
+            statusSummary.Add($"- SecurityCodeScan: {(status.SecurityCodeScanPresent ? "Present" : "Not installed")}");
+            if (status.MissingRecommendedPackages.Count > 0)
+            {
+                statusSummary.Add($"- Recommended packages to add: {string.Join(", ", status.MissingRecommendedPackages)}");
+            }
+
+            var findingsSummary = findings.Findings.Take(20).Select(f =>
+                $"- [{f.SecuritySeverity}] {f.DiagnosticId} ({f.OwaspCategory}): {f.Message} at {f.FilePath}:{f.StartLine}").ToArray();
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Perform a comprehensive security review of this .NET workspace.
+
+                    **Project Filter:** {projectName ?? "(entire workspace)"}
+
+                    **Analyzer Coverage:**
+                    {string.Join('\n', statusSummary)}
+
+                    **Security Findings Summary:** {findings.TotalFindings} total ({findings.CriticalCount} critical, {findings.HighCount} high, {findings.MediumCount} medium, {findings.LowCount} low)
+
+                    **Findings:**
+                    {FormatBulletList(findingsSummary, "No security findings detected.")}
+
+                    Use this workflow:
+                    1. Review the analyzer coverage above. If recommended packages are missing, consider using `add_package_reference_preview` to add them, then `workspace_reload` to pick up new analyzers.
+                    2. Triage findings by severity — address Critical and High findings first.
+                    3. For each finding, call `diagnostic_details` with the diagnostic ID, file, line, and column to get detailed fix information.
+                    4. If a Roslyn code fix is available, use `code_fix_preview` to inspect the proposed change, then `code_fix_apply` to apply it.
+                    5. If no automated fix is available, use `get_code_actions` at the finding location, or apply manual fixes via `apply_text_edit` or `apply_multi_file_edit`.
+                    6. After fixing a batch of findings, call `build_workspace` to verify the fixes compile.
+                    7. Re-run `security_diagnostics` to confirm the finding count has decreased.
+                    8. Flag any findings that require architectural changes or manual review rather than mechanical fixes.
+
+                    Prioritize fixes that eliminate injection vulnerabilities and insecure deserialization patterns.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("security_review", ex)];
+        }
+    }
+
+    [McpServerPrompt(Name = "discover_capabilities")]
+    [Description("Generate a prompt that helps an agent discover relevant server tools and workflows for a given task category.")]
+    public static Task<IEnumerable<PromptMessage>> DiscoverCapabilities(
+        [Description("Task category: refactoring, analysis, security, testing, editing, navigation, project-mutation, scaffolding, or all")] string category)
+    {
+        try
+        {
+            var allTools = ServerSurfaceCatalog.Tools;
+            var allPrompts = ServerSurfaceCatalog.Prompts;
+
+            var normalizedCategory = category.Trim().ToLowerInvariant();
+            var filteredTools = normalizedCategory == "all"
+                ? allTools
+                : allTools.Where(t => MatchesCategory(t.Category, normalizedCategory)).ToList();
+
+            var toolList = filteredTools.Select(t =>
+                $"- `{t.Name}` [{t.SupportTier}] {(t.Destructive ? "(destructive) " : "")}{(t.ReadOnly ? "(read-only) " : "")}— {t.Summary}").ToArray();
+
+            var relevantPrompts = normalizedCategory == "all"
+                ? allPrompts
+                : allPrompts.Where(p => MatchesPromptCategory(p.Name, normalizedCategory)).ToList();
+
+            var promptList = relevantPrompts.Select(p =>
+                $"- `{p.Name}` — {p.Summary}").ToArray();
+
+            var workflows = GetWorkflowsForCategory(normalizedCategory);
+
+            IEnumerable<PromptMessage> result =
+            [
+                CreatePromptMessage($"""
+                    Here are the server capabilities relevant to **{category}**:
+
+                    **Tools ({filteredTools.Count}):**
+                    {FormatBulletList(toolList, "No tools match this category.")}
+
+                    **Guided Prompts ({relevantPrompts.Count}):**
+                    {FormatBulletList(promptList, "No prompts match this category.")}
+
+                    **Common Workflows:**
+                    {workflows}
+
+                    **Key Patterns:**
+                    - **Preview/Apply**: Most write operations use a two-step preview-then-apply pattern. Call the `*_preview` tool first, inspect the diff, then call the corresponding `*_apply` tool with the preview token.
+                    - **Validation**: After any code change, call `build_workspace` or `build_project` to verify compilation, then `test_run` or `test_related_files` if tests may be affected.
+                    - **Workspace Gate**: All tools require a `workspaceId` from `workspace_load`. The workspace serializes concurrent requests.
+
+                    Use the `server_catalog` resource at `roslyn://server/catalog` for the complete machine-readable inventory.
+                    """)
+            ];
+
+            return Task.FromResult(result);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return Task.FromResult<IEnumerable<PromptMessage>>([CreateErrorMessage("discover_capabilities", ex)]);
+        }
+    }
+
+    [McpServerPrompt(Name = "dead_code_audit")]
+    [Description("Generate a prompt that guides a dead code audit using unused symbol detection and removal tools.")]
+    public static async Task<IEnumerable<PromptMessage>> DeadCodeAudit(
+        IAdvancedAnalysisService analysisService,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Optional: filter by project name")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var unused = await analysisService.FindUnusedSymbolsAsync(workspaceId, projectName, includePublic: false, limit: 50, ct).ConfigureAwait(false);
+            var unusedSummary = unused.Take(20).Select(u =>
+                $"- `{u.SymbolName}` ({u.SymbolKind}) in {u.FilePath}:{u.Line} — {u.ContainingType ?? "top-level"}").ToArray();
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Perform a dead code audit for this workspace.
+
+                    **Project Filter:** {projectName ?? "(entire workspace)"}
+                    **Unused Symbols Found:** {unused.Count}
+
+                    **Sample Unused Symbols (first 20):**
+                    {FormatBulletList(unusedSummary, "No unused symbols detected.")}
+
+                    Use this workflow:
+                    1. Review the unused symbols above. Consider whether each is truly unused or accessed via reflection, serialization, or external entry points.
+                    2. For symbols that are safe to remove, call `remove_dead_code_preview` with the symbol handles to preview the removal.
+                    3. Inspect the preview diff — check that no other code is affected.
+                    4. If the preview looks correct, call `remove_dead_code_apply` with the preview token.
+                    5. After removal, call `build_workspace` to verify compilation succeeds.
+                    6. Run `test_run` to confirm no tests break.
+                    7. If more unused symbols remain, repeat the process with `find_unused_symbols`.
+
+                    Be cautious with:
+                    - Public API types that may be used by external consumers
+                    - Types used via reflection (`find_reflection_usages` can help identify these)
+                    - Event handlers and interface implementations that appear unused but are wired at runtime
+                    - Serialization targets that are only instantiated during deserialization
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("dead_code_audit", ex)];
+        }
+    }
+
+    [McpServerPrompt(Name = "review_test_coverage")]
+    [Description("Generate a prompt that guides a test coverage review using test discovery, execution, and coverage tools.")]
+    public static async Task<IEnumerable<PromptMessage>> ReviewTestCoverage(
+        IValidationService validationService,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Optional: specific test project name")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var discovered = await validationService.DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
+            var discoveredJson = JsonSerializer.Serialize(discovered, JsonOptions);
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Review test coverage for this workspace and identify gaps.
+
+                    **Project Filter:** {projectName ?? "(all test projects)"}
+
+                    **Discovered Tests:**
+                    ```json
+                    {discoveredJson}
+                    ```
+
+                    Use this workflow:
+                    1. Review the discovered tests above to understand current test coverage areas.
+                    2. Call `test_coverage` to run tests with code coverage collection (requires coverlet.collector).
+                    3. Analyze the coverage report to identify uncovered source files and methods.
+                    4. For each uncovered area, use `document_symbols` and `symbol_info` to understand the code structure.
+                    5. Use `scaffold_test_preview` to generate test stubs for uncovered types.
+                    6. After scaffolding, call `scaffold_test_apply` to create the test files.
+                    7. Use `test_run` to verify the new tests compile and run (they will initially fail or be skipped).
+                    8. Prioritize coverage for:
+                       - Public API surface (high-impact if broken)
+                       - Complex methods (use `get_complexity_metrics` to identify high-complexity code)
+                       - Security-sensitive code (use `security_diagnostics` to identify these areas)
+                       - Recently changed code (high risk of regression)
+
+                    Focus on meaningful coverage that validates behavior, not just line coverage.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("review_test_coverage", ex)];
+        }
+    }
+
+    [McpServerPrompt(Name = "review_complexity")]
+    [Description("Generate a prompt that guides a complexity review to identify and address high-complexity code.")]
+    public static async Task<IEnumerable<PromptMessage>> ReviewComplexity(
+        IAdvancedAnalysisService analysisService,
+        [Description("The workspace session identifier")] string workspaceId,
+        [Description("Optional: filter by project name")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var metrics = await analysisService.GetComplexityMetricsAsync(workspaceId, filePath: null, projectFilter: projectName, minComplexity: 5, limit: 50, ct).ConfigureAwait(false);
+            var metricsJson = JsonSerializer.Serialize(metrics, JsonOptions);
+
+            return
+            [
+                CreatePromptMessage($"""
+                    Review code complexity for this workspace and identify refactoring opportunities.
+
+                    **Project Filter:** {projectName ?? "(entire workspace)"}
+
+                    **Complexity Metrics:**
+                    ```json
+                    {metricsJson}
+                    ```
+
+                    Use this workflow:
+                    1. Identify methods with cyclomatic complexity > 10 — these are prime refactoring candidates.
+                    2. Identify methods with nesting depth > 4 — consider guard clauses or early returns.
+                    3. Identify methods with parameter count > 5 — consider parameter objects or builder patterns.
+                    4. For each hotspot, call `get_code_actions` at the method declaration to see if Roslyn offers automated refactorings.
+                    5. If automated refactorings are available, use `preview_code_action` and `apply_code_action`.
+                    6. For manual refactoring:
+                       - Use `callers_callees` to understand the method's call graph before changing its signature.
+                       - Use `find_references` to identify all callers that would need updating.
+                       - Use `impact_analysis` to estimate the blast radius of changes.
+                    7. After refactoring, call `build_workspace` to verify compilation.
+                    8. Call `test_related` or `test_related_files` to find and run affected tests.
+
+                    Prioritize methods that are both high-complexity AND high-reference-count, as these have the most impact on maintainability.
+                    """)
+            ];
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return [CreateErrorMessage("review_complexity", ex)];
+        }
+    }
+
+    // ── Helpers ──
 
     private static PromptMessage CreatePromptMessage(string text)
     {
@@ -509,6 +812,18 @@ public static class RoslynPrompts
             Content = new TextContentBlock
             {
                 Text = text
+            }
+        };
+    }
+
+    private static PromptMessage CreateErrorMessage(string promptName, Exception ex)
+    {
+        return new PromptMessage
+        {
+            Role = Role.User,
+            Content = new TextContentBlock
+            {
+                Text = $"The `{promptName}` prompt failed to gather context: {ex.Message}\n\nPlease verify the workspace is loaded and the parameters are correct, then try again."
             }
         };
     }
@@ -557,4 +872,85 @@ public static class RoslynPrompts
     {
         return lines.Count == 0 ? emptyMessage : string.Join('\n', lines);
     }
+
+    private static bool MatchesCategory(string toolCategory, string searchCategory) =>
+        searchCategory switch
+        {
+            "refactoring" => toolCategory is "refactoring" or "code-actions" or "cross-project-refactoring" or "orchestration",
+            "analysis" => toolCategory is "analysis" or "advanced-analysis",
+            "security" => toolCategory is "security",
+            "testing" => toolCategory is "validation",
+            "editing" => toolCategory is "editing" or "file-operations",
+            "navigation" => toolCategory is "symbols",
+            "project-mutation" => toolCategory is "project-mutation",
+            "scaffolding" => toolCategory is "scaffolding" or "dead-code",
+            _ => true
+        };
+
+    private static bool MatchesPromptCategory(string promptName, string searchCategory) =>
+        searchCategory switch
+        {
+            "refactoring" => promptName is "suggest_refactoring" or "refactor_and_validate" or "guided_extract_interface",
+            "analysis" => promptName is "analyze_dependencies" or "review_complexity",
+            "security" => promptName is "security_review" or "review_file",
+            "testing" => promptName is "debug_test_failure" or "review_test_coverage",
+            "editing" => promptName is "fix_all_diagnostics",
+            "navigation" => false,
+            "project-mutation" => promptName is "guided_package_migration",
+            "scaffolding" => promptName is "dead_code_audit",
+            _ => true
+        };
+
+    private static string GetWorkflowsForCategory(string category) =>
+        category switch
+        {
+            "refactoring" => """
+                - **Code Action Flow**: `get_code_actions` → `preview_code_action` → `apply_code_action` → `build_workspace`
+                - **Rename Flow**: `rename_preview` → `rename_apply` → `build_workspace` → `test_run`
+                - **Curated Fix Flow**: `diagnostic_details` → `code_fix_preview` → `code_fix_apply` → `build_workspace`
+                - **Extract Interface**: `extract_and_wire_interface_preview` → `apply_composite_preview` → `build_workspace`
+                """,
+            "analysis" => """
+                - **Diagnostic Analysis**: `project_diagnostics` → `diagnostic_details` → `code_fix_preview`
+                - **Architecture Review**: `project_graph` + `get_namespace_dependencies` + `get_nuget_dependencies`
+                - **Complexity Review**: `get_complexity_metrics` → identify hotspots → `get_code_actions`
+                - **Impact Assessment**: `impact_analysis` → `find_references` → `callers_callees`
+                """,
+            "security" => """
+                - **Security Audit**: `security_analyzer_status` → `security_diagnostics` → `diagnostic_details` → `code_fix_preview` → `code_fix_apply`
+                - **Security Coverage**: `security_analyzer_status` → `add_package_reference_preview` (add SecurityCodeScan) → `workspace_reload`
+                """,
+            "testing" => """
+                - **Test Discovery**: `test_discover` → `test_run` → `debug_test_failure` (if failures)
+                - **Coverage Analysis**: `test_coverage` → identify gaps → `scaffold_test_preview` → `scaffold_test_apply`
+                - **Change Validation**: `test_related_files` → `test_run` (filtered)
+                """,
+            "editing" => """
+                - **Single File Edit**: `apply_text_edit` → `build_project`
+                - **Multi-File Edit**: `apply_multi_file_edit` → `build_workspace`
+                - **File Operations**: `create_file_preview` → `create_file_apply`, `move_file_preview` → `move_file_apply`
+                """,
+            "navigation" => """
+                - **Symbol Exploration**: `symbol_search` → `symbol_info` → `go_to_definition`
+                - **Reference Tracing**: `find_references` → `find_implementations` → `callers_callees`
+                - **Hierarchy Navigation**: `type_hierarchy` → `find_overrides` → `find_base_members`
+                - **Context Discovery**: `enclosing_symbol` → `symbol_relationships`
+                """,
+            "project-mutation" => """
+                - **Add Package**: `add_package_reference_preview` → `apply_project_mutation` → `workspace_reload` → `build_workspace`
+                - **Package Migration**: `migrate_package_preview` → `apply_composite_preview` → `build_workspace`
+                - **Central Versioning**: `add_central_package_version_preview` → `apply_project_mutation`
+                """,
+            "scaffolding" => """
+                - **New Type**: `scaffold_type_preview` → `scaffold_type_apply` → `build_project`
+                - **New Test**: `scaffold_test_preview` → `scaffold_test_apply` → `test_run`
+                - **Dead Code Cleanup**: `find_unused_symbols` → `remove_dead_code_preview` → `remove_dead_code_apply` → `build_workspace`
+                """,
+            _ => """
+                - **Preview/Apply Pattern**: Most write tools follow `*_preview` → inspect diff → `*_apply` → validate
+                - **Validation**: `build_workspace` or `build_project` after any code change, then `test_run` if tests may be affected
+                - **Diagnostics Flow**: `project_diagnostics` → `diagnostic_details` → `code_fix_preview` → `code_fix_apply`
+                - **Security Flow**: `security_analyzer_status` → `security_diagnostics` → triage → fix
+                """
+        };
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class SecurityTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    [McpServerTool(Name = "security_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get security-relevant diagnostics with OWASP categorization, severity classification, and fix hints. Filters the existing diagnostic pipeline to return only security findings.")]
+    public static Task<string> GetSecurityDiagnostics(
+        IWorkspaceExecutionGate gate,
+        ISecurityDiagnosticService securityService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name")] string? project = null,
+        [Description("Optional: filter by file path")] string? file = null,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var results = await securityService.GetSecurityDiagnosticsAsync(workspaceId, project, file, c);
+                return JsonSerializer.Serialize(results, JsonOptions);
+            }, ct));
+    }
+
+    [McpServerTool(Name = "security_analyzer_status", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Check whether security analyzer packages are present in the workspace. Returns which analyzers are installed and recommends missing packages for improved security coverage.")]
+    public static Task<string> GetSecurityAnalyzerStatus(
+        IWorkspaceExecutionGate gate,
+        ISecurityDiagnosticService securityService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await securityService.GetAnalyzerStatusAsync(workspaceId, c);
+                return JsonSerializer.Serialize(result, JsonOptions);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeadCodeService, DeadCodeService>();
         services.AddSingleton<ISyntaxService, SyntaxService>();
         services.AddSingleton<IFileWatcherService, FileWatcherService>();
+        services.AddSingleton<ISecurityDiagnosticService, SecurityDiagnosticService>();
         return services;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticRegistry.cs
+++ b/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticRegistry.cs
@@ -1,0 +1,326 @@
+using System.Collections.Frozen;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Static, curated registry mapping known security-relevant diagnostic IDs to categories,
+/// OWASP classifications, severity levels, and fix hints. This is a lookup table, not an analyzer.
+/// </summary>
+public static class SecurityDiagnosticRegistry
+{
+    /// <summary>
+    /// Returns <see langword="true"/> if the diagnostic ID is recognized as security-relevant.
+    /// </summary>
+    public static bool IsSecurityDiagnostic(string diagnosticId) =>
+        Entries.ContainsKey(diagnosticId);
+
+    /// <summary>
+    /// Returns the security info for a diagnostic ID, or <see langword="null"/> if not recognized.
+    /// </summary>
+    public static SecurityDiagnosticInfo? GetSecurityInfo(string diagnosticId) =>
+        Entries.GetValueOrDefault(diagnosticId);
+
+    /// <summary>
+    /// Returns all registered security diagnostic entries.
+    /// </summary>
+    public static IReadOnlyDictionary<string, SecurityDiagnosticInfo> All => Entries;
+
+    private static readonly FrozenDictionary<string, SecurityDiagnosticInfo> Entries =
+        BuildRegistry().ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, SecurityDiagnosticInfo> BuildRegistry()
+    {
+        var map = new Dictionary<string, SecurityDiagnosticInfo>(StringComparer.OrdinalIgnoreCase);
+
+        // ── Microsoft.CodeAnalysis.NetAnalyzers (ships with .NET SDK) ──
+
+        Add(map, "CA2100", "SQL Injection (Review)", "Injection", "A03:2021 Injection", "High",
+            "Review SQL command text for user input. Use parameterized queries.");
+        Add(map, "CA2109", "Review Visible Event Handlers", "Access Control", "A01:2021 Broken Access Control", "Medium",
+            "Ensure event handlers are not unintentionally public.");
+        Add(map, "CA2119", "Seal Private Interface Methods", "Access Control", "A01:2021 Broken Access Control", "Medium",
+            "Seal methods satisfying private interfaces to prevent external override.");
+        Add(map, "CA2153", "Corrupted State Exceptions", "Error Handling", "A09:2021 Security Logging and Monitoring Failures", "High",
+            "Do not catch corrupted state exceptions. Let the process terminate.");
+
+        // Insecure deserialization (CA2300-CA2330)
+        Add(map, "CA2300", "Insecure Deserializer – BinaryFormatter", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not use BinaryFormatter. Use System.Text.Json or a safe alternative.");
+        Add(map, "CA2301", "BinaryFormatter Without Binder", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not call BinaryFormatter.Deserialize without a binder.");
+        Add(map, "CA2302", "BinaryFormatter Binder Not Set Before Deserialize", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Ensure BinaryFormatter.Binder is set before calling Deserialize.");
+        Add(map, "CA2305", "Insecure Deserializer – LosFormatter", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not use LosFormatter for deserialization.");
+        Add(map, "CA2310", "Insecure Deserializer – NetDataContractSerializer", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not use NetDataContractSerializer. Use a safe alternative.");
+        Add(map, "CA2311", "NetDataContractSerializer Without Binder", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not deserialize without setting Binder first.");
+        Add(map, "CA2312", "NetDataContractSerializer Binder Not Set", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Ensure Binder is set before calling Deserialize.");
+        Add(map, "CA2315", "Insecure Deserializer – ObjectStateFormatter", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not use ObjectStateFormatter for deserialization.");
+        Add(map, "CA2321", "JavaScriptSerializer With SimpleTypeResolver", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Do not use JavaScriptSerializer with SimpleTypeResolver.");
+        Add(map, "CA2322", "JavaScriptSerializer Initialized With SimpleTypeResolver", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver.");
+        Add(map, "CA2326", "TypeNameHandling Not None", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Do not use TypeNameHandling values other than None.");
+        Add(map, "CA2327", "Insecure JsonSerializerSettings", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Do not use insecure JsonSerializerSettings.");
+        Add(map, "CA2328", "Insecure JsonSerializerSettings Possible", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Ensure JsonSerializerSettings are configured securely.");
+        Add(map, "CA2329", "JsonSerializer With Insecure Settings", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Do not use JsonSerializer with insecure settings.");
+        Add(map, "CA2330", "JsonSerializer With Insecure Settings Possible", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Ensure JsonSerializer configuration is secure.");
+
+        // Taint-flow analyzers (CA3001-CA3012)
+        Add(map, "CA3001", "SQL Injection", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized queries or stored procedures instead of string concatenation.");
+        Add(map, "CA3002", "Cross-Site Scripting (XSS)", "Injection", "A03:2021 Injection", "High",
+            "Encode output before rendering. Use HtmlEncoder or framework-provided encoding.");
+        Add(map, "CA3003", "File Path Injection", "Injection", "A03:2021 Injection", "High",
+            "Validate and sanitize file paths. Use Path.GetFullPath with allow-list validation.");
+        Add(map, "CA3004", "Information Disclosure", "Information Disclosure", "A01:2021 Broken Access Control", "Medium",
+            "Do not expose sensitive information in error messages or responses.");
+        Add(map, "CA3005", "LDAP Injection", "Injection", "A03:2021 Injection", "High",
+            "Validate and escape LDAP filter inputs.");
+        Add(map, "CA3006", "Process Command Injection", "Injection", "A03:2021 Injection", "Critical",
+            "Do not pass user input directly to Process.Start. Use allow-lists.");
+        Add(map, "CA3007", "Open Redirect", "Redirect", "A01:2021 Broken Access Control", "Medium",
+            "Validate redirect URLs against an allow-list of trusted destinations.");
+        Add(map, "CA3008", "XPath Injection", "Injection", "A03:2021 Injection", "High",
+            "Use parameterized XPath queries or validate inputs.");
+        Add(map, "CA3009", "XML Injection", "Injection", "A03:2021 Injection", "High",
+            "Validate XML input and use secure XML writers.");
+        Add(map, "CA3010", "XAML Injection", "Injection", "A03:2021 Injection", "High",
+            "Do not load XAML from untrusted sources.");
+        Add(map, "CA3011", "DLL Injection", "Injection", "A03:2021 Injection", "Critical",
+            "Do not load assemblies from user-controlled paths.");
+        Add(map, "CA3012", "Regex Injection", "Injection", "A03:2021 Injection", "Medium",
+            "Validate regex patterns from user input. Set timeout on Regex.");
+
+        // XML and schema processing
+        Add(map, "CA3061", "Schema By URL", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Do not add schema by URL. Use local schema files.");
+        Add(map, "CA3075", "Insecure DTD Processing", "XML Processing", "A05:2021 Security Misconfiguration", "High",
+            "Set DtdProcessing to Prohibit or configure secure XmlReaderSettings.");
+        Add(map, "CA3076", "Insecure XSLT Script Processing", "XML Processing", "A05:2021 Security Misconfiguration", "High",
+            "Disable script execution in XsltSettings.");
+        Add(map, "CA3077", "Insecure Processing In API Design", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Review API design for insecure XML processing defaults.");
+
+        // Web security
+        Add(map, "CA3147", "Missing ValidateAntiForgeryToken", "CSRF", "A01:2021 Broken Access Control", "High",
+            "Add [ValidateAntiForgeryToken] attribute to POST/PUT/DELETE action methods.");
+
+        // Cryptography
+        Add(map, "CA5350", "Weak Cryptographic Algorithm (SHA1)", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use SHA256 or SHA512 instead of SHA1.");
+        Add(map, "CA5351", "Broken Cryptographic Algorithm (DES/TripleDES)", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use AES instead of DES or TripleDES.");
+
+        // CA5358-CA5404: Various crypto, TLS, and certificate validation
+        Add(map, "CA5358", "Unsafe Cipher Mode", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not use ECB or other unsafe cipher modes. Use CBC or GCM.");
+        Add(map, "CA5359", "Do Not Disable Certificate Validation", "Cryptography", "A02:2021 Cryptographic Failures", "Critical",
+            "Do not set ServerCertificateValidationCallback to always return true.");
+        Add(map, "CA5360", "Do Not Call Dangerous Methods In Deserialization", "Deserialization", "A08:2021 Software and Data Integrity Failures", "High",
+            "Do not call dangerous methods during deserialization.");
+        Add(map, "CA5361", "Do Not Disable SChannel Strong Crypto", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not disable strong cryptography for SChannel.");
+        Add(map, "CA5362", "Potential Reference Cycle In Deserialized Object Graph", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Medium",
+            "Review deserialized object graphs for reference cycles.");
+        Add(map, "CA5363", "Do Not Disable Request Validation", "Input Validation", "A03:2021 Injection", "High",
+            "Do not disable ASP.NET request validation.");
+        Add(map, "CA5364", "Do Not Use Deprecated Security Protocols", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use TLS 1.2 or later. Do not use SSL3, TLS 1.0, or TLS 1.1.");
+        Add(map, "CA5365", "Do Not Disable HTTP Header Checking", "Input Validation", "A03:2021 Injection", "Medium",
+            "Do not disable HTTP header checking.");
+        Add(map, "CA5366", "Use XmlReader For DataSet Read Xml", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Use XmlReader when calling DataSet.ReadXml.");
+        Add(map, "CA5367", "Do Not Serialize Types With Pointer Fields", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Medium",
+            "Do not serialize types containing pointer fields.");
+        Add(map, "CA5368", "Set ViewStateUserKey", "CSRF", "A01:2021 Broken Access Control", "Medium",
+            "Set ViewStateUserKey in Page_Init to prevent CSRF attacks.");
+        Add(map, "CA5369", "Use XmlReader For Deserialize", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Use XmlReader when calling XmlSerializer.Deserialize.");
+        Add(map, "CA5370", "Use XmlReader For Validating Reader", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Use XmlReader for XmlValidatingReader.");
+        Add(map, "CA5371", "Use XmlReader For Schema Read", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Use XmlReader when calling XmlSchema.Read.");
+        Add(map, "CA5372", "Use XmlReader For XPathDocument", "XML Processing", "A05:2021 Security Misconfiguration", "Medium",
+            "Use XmlReader when constructing XPathDocument.");
+        Add(map, "CA5373", "Do Not Use Obsolete Key Derivation Function", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use Rfc2898DeriveBytes with SHA256 or higher.");
+        Add(map, "CA5374", "Do Not Use XslTransform", "XML Processing", "A05:2021 Security Misconfiguration", "High",
+            "Use XslCompiledTransform instead of XslTransform.");
+        Add(map, "CA5375", "Do Not Use Account Shared Access Signature", "Access Control", "A01:2021 Broken Access Control", "Medium",
+            "Use service SAS or user delegation SAS instead of account SAS.");
+        Add(map, "CA5376", "Use SharedAccessProtocol HttpsOnly", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Set SharedAccessProtocol to HttpsOnly.");
+        Add(map, "CA5377", "Use Container Level Access Policy", "Access Control", "A01:2021 Broken Access Control", "Medium",
+            "Use container-level access policies for SAS tokens.");
+        Add(map, "CA5378", "Do Not Disable ServicePointManager SecurityProtocols", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not set SecurityProtocol to insecure values.");
+        Add(map, "CA5379", "Do Not Use Weak Key Derivation Function Algorithm", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use a strong hash algorithm for key derivation (SHA256+).");
+        Add(map, "CA5380", "Do Not Add Certificates To Root Store", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not programmatically add certificates to the root store.");
+        Add(map, "CA5381", "Do Not Install Certificates To Root Store", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not install certificates into the trusted root store.");
+        Add(map, "CA5382", "Use Secure Cookies In ASP.NET Core", "Cookie Security", "A05:2021 Security Misconfiguration", "Medium",
+            "Set CookieOptions.Secure to true.");
+        Add(map, "CA5383", "Ensure Use Of Secure Cookies In ASP.NET Core", "Cookie Security", "A05:2021 Security Misconfiguration", "Medium",
+            "Ensure cookies are sent only over HTTPS.");
+        Add(map, "CA5384", "Do Not Use Digital Signature Algorithm (DSA)", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use RSA or ECDSA instead of DSA.");
+        Add(map, "CA5385", "Use RSA With Sufficient Key Size", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use RSA keys of at least 2048 bits.");
+        Add(map, "CA5386", "Avoid Hardcoding SecurityProtocolType Value", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Do not hardcode SecurityProtocolType. Let the OS choose the default.");
+        Add(map, "CA5387", "Do Not Use Weak Key Derivation Function With Insufficient Iteration Count", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use at least 100,000 iterations for PBKDF2.");
+        Add(map, "CA5388", "Ensure Sufficient Iteration Count When Using Weak Key Derivation Function", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Ensure PBKDF2 iteration count is at least 100,000.");
+        Add(map, "CA5389", "Do Not Add Archive Item Path To Target File System Path", "Injection", "A03:2021 Injection", "High",
+            "Validate archive entry paths to prevent zip-slip attacks.");
+        Add(map, "CA5390", "Do Not Hard-Code Encryption Key", "Cryptography", "A02:2021 Cryptographic Failures", "Critical",
+            "Do not hardcode encryption keys. Use secure key storage.");
+        Add(map, "CA5391", "Use Antiforgery Tokens In ASP.NET Core MVC Controllers", "CSRF", "A01:2021 Broken Access Control", "High",
+            "Use [AutoValidateAntiforgeryToken] or [ValidateAntiForgeryToken] attributes.");
+        Add(map, "CA5392", "Use DefaultDllImportSearchPaths For P/Invokes", "Injection", "A03:2021 Injection", "Medium",
+            "Specify DefaultDllImportSearchPaths to prevent DLL search-order hijacking.");
+        Add(map, "CA5393", "Do Not Use Unsafe DllImportSearchPath Value", "Injection", "A03:2021 Injection", "Medium",
+            "Do not use DllImportSearchPath values that include user-writable directories.");
+        Add(map, "CA5394", "Do Not Use Insecure Randomness", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use RandomNumberGenerator instead of System.Random for security-sensitive values.");
+        Add(map, "CA5395", "Miss HttpVerb Attribute For Action Methods", "CSRF", "A01:2021 Broken Access Control", "Medium",
+            "Add explicit [HttpGet], [HttpPost], etc. attributes to action methods.");
+        Add(map, "CA5396", "Set HttpOnly To True For HttpCookie", "Cookie Security", "A05:2021 Security Misconfiguration", "Medium",
+            "Set HttpOnly = true on cookies to prevent XSS-based cookie theft.");
+        Add(map, "CA5397", "Do Not Use Deprecated SslProtocols Values", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use SslProtocols.Tls12 or SslProtocols.Tls13.");
+        Add(map, "CA5398", "Avoid Hardcoded SslProtocols Values", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Avoid hardcoding SslProtocols values. Use SslProtocols.None to let the OS choose.");
+        Add(map, "CA5399", "Definitely Disable HttpClient Certificate Revocation List Check", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Enable certificate revocation list checking.");
+        Add(map, "CA5400", "Ensure HttpClient Certificate Revocation List Check Not Disabled", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Ensure certificate revocation list checking is enabled.");
+        Add(map, "CA5401", "Do Not Use CreateEncryptor With Non-Default IV", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use a cryptographically random IV, not a hardcoded one.");
+        Add(map, "CA5402", "Use CreateEncryptor With Default IV", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use the default IV generation rather than providing a custom one.");
+        Add(map, "CA5403", "Do Not Hard-Code Certificate", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Do not embed certificates in source code. Use certificate stores.");
+        Add(map, "CA5404", "Do Not Disable Token Validation Checks", "Authentication", "A07:2021 Identification and Authentication Failures", "Critical",
+            "Do not disable JWT token validation checks.");
+
+        // ── SecurityCodeScan (NuGet package) ──
+
+        Add(map, "SCS0001", "Command Injection", "Injection", "A03:2021 Injection", "Critical",
+            "Do not pass user input to Process.Start. Use allow-lists and parameterization.");
+        Add(map, "SCS0002", "SQL Injection (LINQ)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized queries or LINQ methods instead of string concatenation in SQL.");
+        Add(map, "SCS0003", "XPath Injection", "Injection", "A03:2021 Injection", "High",
+            "Use parameterized XPath or validate user inputs before building queries.");
+        Add(map, "SCS0005", "Weak Random Number Generator", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use RandomNumberGenerator instead of System.Random for security-sensitive values.");
+        Add(map, "SCS0006", "Weak Hashing Function", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Use SHA-256 or stronger. Avoid MD5 and SHA-1 for security purposes.");
+        Add(map, "SCS0007", "XML External Entity (XXE)", "XML Processing", "A05:2021 Security Misconfiguration", "High",
+            "Disable external entity resolution in XML parsers.");
+        Add(map, "SCS0008", "Cookie Without HttpOnly", "Cookie Security", "A05:2021 Security Misconfiguration", "Medium",
+            "Set HttpOnly = true to prevent JavaScript access to cookies.");
+        Add(map, "SCS0009", "Cookie Without Secure Flag", "Cookie Security", "A05:2021 Security Misconfiguration", "Medium",
+            "Set Secure = true so cookies are only sent over HTTPS.");
+        Add(map, "SCS0010", "Weak Cipher Algorithm", "Cryptography", "A02:2021 Cryptographic Failures", "High",
+            "Use AES with an appropriate mode (CBC/GCM). Avoid DES and RC2.");
+        Add(map, "SCS0011", "Unsafe CSRF Configuration", "CSRF", "A01:2021 Broken Access Control", "High",
+            "Ensure anti-forgery tokens are validated on state-changing requests.");
+        Add(map, "SCS0012", "Controller Without Authorization", "Access Control", "A01:2021 Broken Access Control", "High",
+            "Add [Authorize] attribute to controllers or actions that require authentication.");
+        Add(map, "SCS0013", "Potential Usage Of Weak Cipher Mode", "Cryptography", "A02:2021 Cryptographic Failures", "Medium",
+            "Avoid ECB mode. Use CBC or GCM.");
+        Add(map, "SCS0014", "SQL Injection (Entity Framework)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized queries or LINQ instead of raw SQL with string concatenation.");
+        Add(map, "SCS0015", "Hardcoded Password", "Credentials", "A07:2021 Identification and Authentication Failures", "Critical",
+            "Move passwords to secure configuration or a secrets manager.");
+        Add(map, "SCS0016", "CSRF Token Validation Missing", "CSRF", "A01:2021 Broken Access Control", "High",
+            "Add [ValidateAntiForgeryToken] to state-changing actions.");
+        Add(map, "SCS0017", "Request Validation Disabled", "Input Validation", "A03:2021 Injection", "High",
+            "Do not disable ASP.NET request validation.");
+        Add(map, "SCS0018", "Path Traversal", "Injection", "A03:2021 Injection", "High",
+            "Validate file paths and canonicalize before use. Reject path traversal sequences.");
+        Add(map, "SCS0019", "OutputCache Conflict", "Information Disclosure", "A01:2021 Broken Access Control", "Medium",
+            "Do not use OutputCache on actions that require authorization.");
+        Add(map, "SCS0020", "ORM Injection (NHibernate)", "Injection", "A03:2021 Injection", "High",
+            "Use parameterized queries with NHibernate instead of string concatenation.");
+        Add(map, "SCS0021", "Request Validation Disabled (MVC)", "Input Validation", "A03:2021 Injection", "High",
+            "Do not use [ValidateInput(false)] on controller actions.");
+        Add(map, "SCS0022", "Event Validation Disabled", "Input Validation", "A03:2021 Injection", "Medium",
+            "Do not disable event validation in Web Forms.");
+        Add(map, "SCS0023", "View State Not Encrypted", "Information Disclosure", "A02:2021 Cryptographic Failures", "Medium",
+            "Enable ViewState encryption to protect against tampering.");
+        Add(map, "SCS0024", "View State MAC Disabled", "Information Disclosure", "A02:2021 Cryptographic Failures", "High",
+            "Enable ViewState MAC validation.");
+        Add(map, "SCS0025", "SQL Injection (OleDb)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized OleDbCommand instead of string concatenation.");
+        Add(map, "SCS0026", "SQL Injection (ODBC)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized OdbcCommand instead of string concatenation.");
+        Add(map, "SCS0027", "Open Redirect", "Redirect", "A01:2021 Broken Access Control", "Medium",
+            "Validate redirect URLs. Use Url.IsLocalUrl or an allow-list.");
+        Add(map, "SCS0028", "Insecure Deserialization (TypeNameHandling)", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Do not use TypeNameHandling.All or Auto. Use TypeNameHandling.None.");
+        Add(map, "SCS0029", "Cross-Site Scripting (XSS)", "Injection", "A03:2021 Injection", "High",
+            "Encode output. Use @Html.Encode or framework-provided encoding.");
+        Add(map, "SCS0030", "Request Validation Disabled (Attribute)", "Input Validation", "A03:2021 Injection", "High",
+            "Do not disable request validation via attributes.");
+        Add(map, "SCS0031", "LDAP Injection", "Injection", "A03:2021 Injection", "High",
+            "Validate and escape LDAP distinguished name and search filter inputs.");
+        Add(map, "SCS0032", "LDAP Injection (Path)", "Injection", "A03:2021 Injection", "High",
+            "Validate LDAP paths before use.");
+        Add(map, "SCS0033", "LDAP Injection (Filter)", "Injection", "A03:2021 Injection", "High",
+            "Encode special characters in LDAP filter inputs.");
+        Add(map, "SCS0034", "Password Complexity (ASP.NET Identity)", "Authentication", "A07:2021 Identification and Authentication Failures", "Medium",
+            "Configure minimum password complexity requirements.");
+        Add(map, "SCS0035", "SQL Injection (Entity Framework Core)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized queries with EF Core. Avoid FromSqlRaw with string concatenation.");
+        Add(map, "SCS0036", "SQL Injection (EnterpriseLibrary)", "Injection", "A03:2021 Injection", "Critical",
+            "Use parameterized queries with Enterprise Library Data Access.");
+        Add(map, "SCS0037", "Insecure Deserialization (Various)", "Deserialization", "A08:2021 Software and Data Integrity Failures", "Critical",
+            "Avoid insecure deserialization. Validate types before deserializing.");
+        Add(map, "SCS0038", "Path Traversal (Cookie)", "Injection", "A03:2021 Injection", "High",
+            "Do not use cookie values in file paths without validation.");
+        Add(map, "SCS0039", "Certificate Validation Disabled", "Cryptography", "A02:2021 Cryptographic Failures", "Critical",
+            "Do not disable certificate validation. Always validate server certificates.");
+
+        return map;
+    }
+
+    private static void Add(
+        Dictionary<string, SecurityDiagnosticInfo> map,
+        string id, string shortName, string category, string owaspCategory,
+        string severity, string fixHint)
+    {
+        map[id] = new SecurityDiagnosticInfo(id, shortName, category, owaspCategory, severity, fixHint);
+    }
+}
+
+/// <summary>
+/// Metadata for a single security-relevant diagnostic ID.
+/// </summary>
+/// <param name="DiagnosticId">The diagnostic identifier (e.g., <c>CA3001</c>).</param>
+/// <param name="ShortName">Human-readable short name (e.g., "SQL Injection").</param>
+/// <param name="SecurityCategory">Security category (e.g., "Injection", "Cryptography").</param>
+/// <param name="OwaspCategory">OWASP Top 10 category (e.g., "A03:2021 Injection").</param>
+/// <param name="SecuritySeverity">Severity level: Critical, High, Medium, or Low.</param>
+/// <param name="FixHint">Short actionable fix description.</param>
+public sealed record SecurityDiagnosticInfo(
+    string DiagnosticId,
+    string ShortName,
+    string SecurityCategory,
+    string OwaspCategory,
+    string SecuritySeverity,
+    string FixHint);

--- a/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
@@ -1,0 +1,186 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Filters and enriches the existing diagnostic pipeline with security-focused metadata.
+/// Does not reimplement diagnostic collection — delegates to <see cref="IDiagnosticService"/>.
+/// </summary>
+public sealed class SecurityDiagnosticService : ISecurityDiagnosticService
+{
+    private readonly IDiagnosticService _diagnosticService;
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<SecurityDiagnosticService> _logger;
+
+    /// <summary>
+    /// Recommended security analyzer NuGet packages beyond what the SDK provides.
+    /// </summary>
+    private static readonly string[] RecommendedPackages =
+    [
+        "SecurityCodeScan.VS2019"
+    ];
+
+    /// <summary>
+    /// Known assembly name prefixes that indicate a security analyzer.
+    /// </summary>
+    private static readonly string[] SecurityCodeScanAssemblyPrefixes =
+    [
+        "SecurityCodeScan"
+    ];
+
+    private static readonly string[] NetAnalyzerAssemblyPrefixes =
+    [
+        "Microsoft.CodeAnalysis.NetAnalyzers",
+        "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
+        "Microsoft.CodeQuality.Analyzers",
+        "Microsoft.NetCore.Analyzers",
+        "Microsoft.NetFramework.Analyzers"
+    ];
+
+    public SecurityDiagnosticService(
+        IDiagnosticService diagnosticService,
+        IWorkspaceManager workspace,
+        ILogger<SecurityDiagnosticService> logger)
+    {
+        _diagnosticService = diagnosticService;
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<SecurityDiagnosticsResultDto> GetSecurityDiagnosticsAsync(
+        string workspaceId, string? projectFilter, string? fileFilter, CancellationToken ct)
+    {
+        var diagnostics = await _diagnosticService.GetDiagnosticsAsync(workspaceId, projectFilter, fileFilter, null, ct)
+            .ConfigureAwait(false);
+
+        var findings = new List<SecurityDiagnosticDto>();
+
+        foreach (var diag in diagnostics.CompilerDiagnostics.Concat(diagnostics.AnalyzerDiagnostics))
+        {
+            var info = SecurityDiagnosticRegistry.GetSecurityInfo(diag.Id);
+            if (info is null)
+            {
+                continue;
+            }
+
+            findings.Add(new SecurityDiagnosticDto(
+                DiagnosticId: diag.Id,
+                Message: diag.Message,
+                SecurityCategory: info.SecurityCategory,
+                OwaspCategory: info.OwaspCategory,
+                SecuritySeverity: info.SecuritySeverity,
+                FilePath: diag.FilePath,
+                StartLine: diag.StartLine,
+                StartColumn: diag.StartColumn,
+                FixHint: info.FixHint,
+                HelpLinkUri: BuildHelpLink(diag.Id)));
+        }
+
+        // Sort by severity (Critical first) then by file path
+        findings.Sort((a, b) =>
+        {
+            var severityOrder = GetSeverityOrder(a.SecuritySeverity).CompareTo(GetSeverityOrder(b.SecuritySeverity));
+            if (severityOrder != 0) return severityOrder;
+            return string.Compare(a.FilePath, b.FilePath, StringComparison.OrdinalIgnoreCase);
+        });
+
+        var analyzerStatus = await GetAnalyzerStatusAsync(workspaceId, ct).ConfigureAwait(false);
+
+        return new SecurityDiagnosticsResultDto(
+            Findings: findings,
+            AnalyzerStatus: analyzerStatus,
+            TotalFindings: findings.Count,
+            CriticalCount: findings.Count(f => f.SecuritySeverity == "Critical"),
+            HighCount: findings.Count(f => f.SecuritySeverity == "High"),
+            MediumCount: findings.Count(f => f.SecuritySeverity == "Medium"),
+            LowCount: findings.Count(f => f.SecuritySeverity == "Low"));
+    }
+
+    public Task<SecurityAnalyzerStatusDto> GetAnalyzerStatusAsync(string workspaceId, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        var netAnalyzersPresent = false;
+        var securityCodeScanPresent = false;
+
+        foreach (var project in solution.Projects)
+        {
+            foreach (var analyzerRef in project.AnalyzerReferences)
+            {
+                var displayName = analyzerRef.Display ?? string.Empty;
+
+                if (!netAnalyzersPresent && MatchesAnyPrefix(displayName, NetAnalyzerAssemblyPrefixes))
+                {
+                    netAnalyzersPresent = true;
+                }
+
+                if (!securityCodeScanPresent && MatchesAnyPrefix(displayName, SecurityCodeScanAssemblyPrefixes))
+                {
+                    securityCodeScanPresent = true;
+                }
+
+                if (netAnalyzersPresent && securityCodeScanPresent)
+                {
+                    break;
+                }
+            }
+
+            if (netAnalyzersPresent && securityCodeScanPresent)
+            {
+                break;
+            }
+        }
+
+        var missingPackages = new List<string>();
+        if (!securityCodeScanPresent)
+        {
+            missingPackages.AddRange(RecommendedPackages);
+        }
+
+        var result = new SecurityAnalyzerStatusDto(
+            NetAnalyzersPresent: netAnalyzersPresent,
+            SecurityCodeScanPresent: securityCodeScanPresent,
+            MissingRecommendedPackages: missingPackages);
+
+        return Task.FromResult(result);
+    }
+
+    private static bool MatchesAnyPrefix(string value, string[] prefixes)
+    {
+        foreach (var prefix in prefixes)
+        {
+            if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int GetSeverityOrder(string severity) =>
+        severity switch
+        {
+            "Critical" => 0,
+            "High" => 1,
+            "Medium" => 2,
+            "Low" => 3,
+            _ => 4
+        };
+
+    private static string BuildHelpLink(string diagnosticId)
+    {
+        if (diagnosticId.StartsWith("CA", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/{diagnosticId.ToLowerInvariant()}";
+        }
+
+        if (diagnosticId.StartsWith("SCS", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"https://security-code-scan.github.io/#{diagnosticId}";
+        }
+
+        return $"https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/{diagnosticId.ToLowerInvariant()}";
+    }
+}

--- a/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
@@ -1,0 +1,216 @@
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Roslyn.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public class SecurityDiagnosticIntegrationTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+    private static SecurityDiagnosticService SecurityService { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+        SecurityService = new SecurityDiagnosticService(
+            DiagnosticService,
+            WorkspaceManager,
+            NullLogger<SecurityDiagnosticService>.Instance);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    // ── Registry Tests ──
+
+    [TestMethod]
+    public void Registry_Recognizes_Known_CA_Diagnostics()
+    {
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CA3001"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CA2100"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CA5350"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CA5404"));
+    }
+
+    [TestMethod]
+    public void Registry_Recognizes_Known_SCS_Diagnostics()
+    {
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("SCS0001"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("SCS0002"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("SCS0039"));
+    }
+
+    [TestMethod]
+    public void Registry_Does_Not_Recognize_Non_Security_Diagnostic()
+    {
+        Assert.IsFalse(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CS8019"));
+        Assert.IsFalse(SecurityDiagnosticRegistry.IsSecurityDiagnostic("CS0101"));
+        Assert.IsFalse(SecurityDiagnosticRegistry.IsSecurityDiagnostic("UNKNOWN"));
+    }
+
+    [TestMethod]
+    public void Registry_Is_Case_Insensitive()
+    {
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("ca3001"));
+        Assert.IsTrue(SecurityDiagnosticRegistry.IsSecurityDiagnostic("scs0001"));
+    }
+
+    [TestMethod]
+    public void Registry_GetSecurityInfo_Returns_Correct_Metadata()
+    {
+        var info = SecurityDiagnosticRegistry.GetSecurityInfo("CA3001");
+        Assert.IsNotNull(info);
+        Assert.AreEqual("CA3001", info.DiagnosticId);
+        Assert.AreEqual("SQL Injection", info.ShortName);
+        Assert.AreEqual("Injection", info.SecurityCategory);
+        Assert.AreEqual("A03:2021 Injection", info.OwaspCategory);
+        Assert.AreEqual("Critical", info.SecuritySeverity);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(info.FixHint));
+    }
+
+    [TestMethod]
+    public void Registry_GetSecurityInfo_Returns_Null_For_Unknown()
+    {
+        var info = SecurityDiagnosticRegistry.GetSecurityInfo("CS8019");
+        Assert.IsNull(info);
+    }
+
+    [TestMethod]
+    public void Registry_Contains_Expected_Entry_Count()
+    {
+        // At minimum, we should have entries for the CA and SCS ranges documented in the prompt
+        Assert.IsTrue(SecurityDiagnosticRegistry.All.Count >= 80,
+            $"Expected at least 80 registry entries, got {SecurityDiagnosticRegistry.All.Count}");
+    }
+
+    // ── Service Tests ──
+
+    [TestMethod]
+    public async Task SecurityDiagnostics_Returns_Zero_Findings_For_Clean_Project()
+    {
+        var result = await SecurityService.GetSecurityDiagnosticsAsync(
+            WorkspaceId, null, null, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Findings);
+        Assert.IsNotNull(result.AnalyzerStatus);
+        Assert.AreEqual(result.Findings.Count, result.TotalFindings);
+        Assert.AreEqual(result.CriticalCount + result.HighCount + result.MediumCount + result.LowCount,
+            result.TotalFindings);
+    }
+
+    [TestMethod]
+    public async Task SecurityDiagnostics_Respects_Project_Filter()
+    {
+        var result = await SecurityService.GetSecurityDiagnosticsAsync(
+            WorkspaceId, "SampleLib", null, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        // All findings (if any) should be from SampleLib
+        foreach (var finding in result.Findings)
+        {
+            Assert.IsNotNull(finding.DiagnosticId);
+            Assert.IsNotNull(finding.SecurityCategory);
+            Assert.IsNotNull(finding.OwaspCategory);
+            Assert.IsNotNull(finding.SecuritySeverity);
+        }
+    }
+
+    [TestMethod]
+    public async Task AnalyzerStatus_Returns_Valid_Status()
+    {
+        var status = await SecurityService.GetAnalyzerStatusAsync(
+            WorkspaceId, CancellationToken.None);
+
+        Assert.IsNotNull(status);
+        Assert.IsNotNull(status.MissingRecommendedPackages);
+        // SDK-style .NET 5+ projects should have net analyzers
+        // (may vary by environment, so we just check the status is populated)
+    }
+
+    [TestMethod]
+    public async Task AnalyzerStatus_Reports_Missing_SecurityCodeScan()
+    {
+        var status = await SecurityService.GetAnalyzerStatusAsync(
+            WorkspaceId, CancellationToken.None);
+
+        // SampleSolution doesn't reference SecurityCodeScan, so it should be missing
+        Assert.IsFalse(status.SecurityCodeScanPresent);
+        Assert.IsTrue(status.MissingRecommendedPackages.Count > 0,
+            "Should recommend SecurityCodeScan when not present");
+    }
+
+    // ── Catalog Tests ──
+
+    [TestMethod]
+    public void Catalog_Contains_Security_Tools()
+    {
+        var tools = ServerSurfaceCatalog.Tools;
+        Assert.IsTrue(tools.Any(t => t.Name == "security_diagnostics"),
+            "security_diagnostics tool not found in catalog");
+        Assert.IsTrue(tools.Any(t => t.Name == "security_analyzer_status"),
+            "security_analyzer_status tool not found in catalog");
+    }
+
+    [TestMethod]
+    public void Catalog_Contains_New_Prompts()
+    {
+        var prompts = ServerSurfaceCatalog.Prompts;
+        Assert.IsTrue(prompts.Any(p => p.Name == "security_review"),
+            "security_review prompt not found in catalog");
+        Assert.IsTrue(prompts.Any(p => p.Name == "discover_capabilities"),
+            "discover_capabilities prompt not found in catalog");
+        Assert.IsTrue(prompts.Any(p => p.Name == "dead_code_audit"),
+            "dead_code_audit prompt not found in catalog");
+        Assert.IsTrue(prompts.Any(p => p.Name == "review_test_coverage"),
+            "review_test_coverage prompt not found in catalog");
+        Assert.IsTrue(prompts.Any(p => p.Name == "review_complexity"),
+            "review_complexity prompt not found in catalog");
+    }
+
+    [TestMethod]
+    public void Catalog_Contains_Workflow_Hints()
+    {
+        var hints = ServerSurfaceCatalog.WorkflowHints;
+        Assert.IsTrue(hints.Count >= 5, $"Expected at least 5 workflow hints, got {hints.Count}");
+        Assert.IsTrue(hints.Any(h => h.Name == "Security Audit"),
+            "Security Audit workflow hint not found");
+        Assert.IsTrue(hints.Any(h => h.Name == "Preview/Apply"),
+            "Preview/Apply workflow hint not found");
+    }
+
+    [TestMethod]
+    public void Catalog_Security_Tools_Are_Marked_Stable_And_ReadOnly()
+    {
+        var securityTools = ServerSurfaceCatalog.Tools
+            .Where(t => t.Category == "security")
+            .ToList();
+
+        Assert.AreEqual(2, securityTools.Count);
+        foreach (var tool in securityTools)
+        {
+            Assert.AreEqual("stable", tool.SupportTier,
+                $"Security tool {tool.Name} should be stable");
+            Assert.IsTrue(tool.ReadOnly,
+                $"Security tool {tool.Name} should be read-only");
+            Assert.IsFalse(tool.Destructive,
+                $"Security tool {tool.Name} should not be destructive");
+        }
+    }
+
+    [TestMethod]
+    public void Catalog_Document_Includes_WorkflowHints()
+    {
+        var doc = ServerSurfaceCatalog.CreateDocument();
+        Assert.IsNotNull(doc.WorkflowHints);
+        Assert.IsTrue(doc.WorkflowHints.Count > 0);
+    }
+}


### PR DESCRIPTION
## Summary

- **Security diagnostic surface**: New `security_diagnostics` and `security_analyzer_status` tools that filter the existing diagnostic pipeline for security-relevant findings, enriched with OWASP categorization, severity levels, and fix hints. Backed by a static registry of 90+ CA/SCS diagnostic IDs.
- **Agent awareness prompts**: 5 new guided workflow prompts (`security_review`, `discover_capabilities`, `dead_code_audit`, `review_test_coverage`, `review_complexity`) that help agents discover and use server tools effectively.
- **Workflow hints in catalog**: `ServerCatalogDto` now includes a `WorkflowHints` section mapping 9 common tool sequences (preview/apply, diagnostic fix, security audit, etc.).
- **ERR-03 fix**: All 14 prompt methods now wrapped in try/catch returning structured error messages instead of raw exceptions.

## Test plan

- [x] Build succeeds in Debug and Release (0 warnings, 0 errors)
- [x] All 98 tests pass (16 new security diagnostic tests + 82 existing)
- [x] AI docs verification passes
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)