### PR TITLE
feat: hardening & configuration (CFG-01, PERF-03, CON-02, REL-06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,33 @@ For a reproducible release build and publish verification:
 ./eng/verify-release.ps1
 ```
 
+## Configuration
+
+The server reads optional environment variables at startup. When set, these override the built-in defaults.
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `ROSLYNMCP_MAX_WORKSPACES` | `8` | Maximum concurrent workspace sessions |
+| `ROSLYNMCP_BUILD_TIMEOUT_SECONDS` | `300` | Build operation timeout (seconds) |
+| `ROSLYNMCP_TEST_TIMEOUT_SECONDS` | `600` | Test run timeout (seconds) |
+| `ROSLYNMCP_PREVIEW_MAX_ENTRIES` | `20` | Maximum preview store entries per store |
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "roslyn-mcp": {
+      "command": "roslynmcp",
+      "env": {
+        "ROSLYNMCP_MAX_WORKSPACES": "4",
+        "ROSLYNMCP_BUILD_TIMEOUT_SECONDS": "120"
+      }
+    }
+  }
+}
+```
+
 ## Canonical Docs
 
 - `AGENTS.md` is the canonical bootstrap entry point for AI agents.

--- a/src/RoslynMcp.Core/Services/ICompositePreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/ICompositePreviewStore.cs
@@ -34,6 +34,12 @@ public interface ICompositePreviewStore
     /// </summary>
     /// <param name="workspaceId">The workspace to clear, or <see langword="null"/> to clear all workspaces.</param>
     void InvalidateAll(string? workspaceId = null);
+
+    /// <summary>
+    /// Returns the workspace identifier associated with a preview token without consuming the entry,
+    /// or <see langword="null"/> if the token is expired or not found.
+    /// </summary>
+    string? PeekWorkspaceId(string token);
 }
 
 /// <summary>

--- a/src/RoslynMcp.Core/Services/IPreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/IPreviewStore.cs
@@ -36,4 +36,10 @@ public interface IPreviewStore
     /// </summary>
     /// <param name="workspaceId">The workspace to clear, or <see langword="null"/> to clear all workspaces.</param>
     void InvalidateAll(string? workspaceId = null);
+
+    /// <summary>
+    /// Returns the workspace identifier associated with a preview token without consuming the entry,
+    /// or <see langword="null"/> if the token is expired or not found.
+    /// </summary>
+    string? PeekWorkspaceId(string token);
 }

--- a/src/RoslynMcp.Core/Services/IProjectMutationPreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/IProjectMutationPreviewStore.cs
@@ -35,4 +35,10 @@ public interface IProjectMutationPreviewStore
     /// </summary>
     /// <param name="workspaceId">The workspace to clear, or <see langword="null"/> to clear all workspaces.</param>
     void InvalidateAll(string? workspaceId = null);
+
+    /// <summary>
+    /// Returns the workspace identifier associated with a preview token without consuming the entry,
+    /// or <see langword="null"/> if the token is expired or not found.
+    /// </summary>
+    string? PeekWorkspaceId(string token);
 }

--- a/src/RoslynMcp.Core/Services/PreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/PreviewStore.cs
@@ -5,15 +5,19 @@ namespace RoslynMcp.Core.Services;
 
 /// <summary>
 /// Thread-safe, TTL-bounded in-memory store for pending Roslyn solution previews.
-/// Entries expire after 5 minutes. The store is capped at 50 entries; oldest entries are
-/// evicted when the limit is reached.
+/// Entries expire after 5 minutes. The store is capped at <see cref="_maxEntries"/> entries;
+/// oldest entries are evicted when the limit is reached.
 /// </summary>
 public sealed class PreviewStore : IPreviewStore
 {
     private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
     private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
+    private readonly int _maxEntries;
 
-    private const int MaxEntries = 50;
+    public PreviewStore(int maxEntries = 20)
+    {
+        _maxEntries = maxEntries > 0 ? maxEntries : 20;
+    }
 
     public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
     {
@@ -60,6 +64,20 @@ public sealed class PreviewStore : IPreviewStore
         }
     }
 
+    public string? PeekWorkspaceId(string token)
+    {
+        if (!_entries.TryGetValue(token, out var entry))
+            return null;
+
+        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
+        {
+            _entries.TryRemove(token, out _);
+            return null;
+        }
+
+        return entry.WorkspaceId;
+    }
+
     private void CleanExpired()
     {
         var now = DateTime.UtcNow;
@@ -72,11 +90,11 @@ public sealed class PreviewStore : IPreviewStore
 
     private void EvictIfOverLimit()
     {
-        if (_entries.Count <= MaxEntries) return;
+        if (_entries.Count <= _maxEntries) return;
 
         var toEvict = _entries
             .OrderBy(kvp => kvp.Value.CreatedAt)
-            .Take(_entries.Count - MaxEntries + 1)
+            .Take(_entries.Count - _maxEntries + 1)
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Host.Stdio;
 using RoslynMcp.Roslyn;
+using RoslynMcp.Roslyn.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,11 @@ builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogL
 // Register the MCP logging bridge that forwards log events to the client
 var mcpLoggingProvider = new McpLoggingProvider();
 builder.Logging.AddProvider(mcpLoggingProvider);
+
+// Bind options from environment variables (hardcoded defaults used when env vars are absent)
+builder.Services.AddSingleton(BindWorkspaceManagerOptions());
+builder.Services.AddSingleton(BindValidationServiceOptions());
+builder.Services.AddSingleton(BindPreviewStoreOptions());
 
 builder.Services.AddRoslynServices();
 builder.Services
@@ -54,3 +60,33 @@ lifetime.ApplicationStopping.Register(() =>
 });
 
 await host.RunAsync();
+
+static WorkspaceManagerOptions BindWorkspaceManagerOptions()
+{
+    var opts = new WorkspaceManagerOptions();
+    if (int.TryParse(Environment.GetEnvironmentVariable("ROSLYNMCP_MAX_WORKSPACES"), out var maxWs) && maxWs > 0)
+        opts = new WorkspaceManagerOptions { MaxConcurrentWorkspaces = maxWs, MaxSourceGeneratedDocuments = opts.MaxSourceGeneratedDocuments };
+    return opts;
+}
+
+static ValidationServiceOptions BindValidationServiceOptions()
+{
+    var opts = new ValidationServiceOptions();
+    var buildSec = Environment.GetEnvironmentVariable("ROSLYNMCP_BUILD_TIMEOUT_SECONDS");
+    var testSec = Environment.GetEnvironmentVariable("ROSLYNMCP_TEST_TIMEOUT_SECONDS");
+
+    if (int.TryParse(buildSec, out var bs) && bs > 0)
+        opts = new ValidationServiceOptions { BuildTimeout = TimeSpan.FromSeconds(bs), TestTimeout = opts.TestTimeout, MaxRelatedFiles = opts.MaxRelatedFiles };
+    if (int.TryParse(testSec, out var ts) && ts > 0)
+        opts = new ValidationServiceOptions { BuildTimeout = opts.BuildTimeout, TestTimeout = TimeSpan.FromSeconds(ts), MaxRelatedFiles = opts.MaxRelatedFiles };
+
+    return opts;
+}
+
+static PreviewStoreOptions BindPreviewStoreOptions()
+{
+    var opts = new PreviewStoreOptions();
+    if (int.TryParse(Environment.GetEnvironmentVariable("ROSLYNMCP_PREVIEW_MAX_ENTRIES"), out var max) && max > 0)
+        opts = new PreviewStoreOptions { MaxEntries = max };
+    return opts;
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
@@ -35,11 +35,13 @@ public static class BulkRefactoringTools
     public static Task<string> ApplyBulkReplaceType(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by bulk_replace_type_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
@@ -56,11 +56,13 @@ public static class CodeActionTools
     public static Task<string> ApplyCodeAction(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by preview_code_action")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
@@ -38,11 +38,13 @@ public static class DeadCodeTools
     public static Task<string> ApplyRemoveDeadCode(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by remove_dead_code_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
@@ -38,11 +38,13 @@ public static class FileOperationTools
     public static Task<string> ApplyCreateFile(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by create_file_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -73,11 +75,13 @@ public static class FileOperationTools
     public static Task<string> ApplyDeleteFile(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by delete_file_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -115,11 +119,13 @@ public static class FileOperationTools
     public static Task<string> ApplyMoveFile(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by move_file_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -38,11 +38,13 @@ public static class InterfaceExtractionTools
     public static Task<string> ApplyExtractInterface(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by extract_interface_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
@@ -83,11 +83,14 @@ public static class OrchestrationTools
     public static Task<string> ApplyCompositePreview(
         IWorkspaceExecutionGate gate,
         IOrchestrationService orchestrationService,
+        ICompositePreviewStore compositePreviewStore,
         [Description("The preview token returned by an orchestration preview tool")] string previewToken,
         CancellationToken ct = default)
     {
+        var wsId = compositePreviewStore.PeekWorkspaceId(previewToken);
+        var gateKey = wsId != null ? $"__apply__:{wsId}" : "__apply__";
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await orchestrationService.ApplyCompositeAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
@@ -230,11 +230,14 @@ public static class ProjectMutationTools
     public static Task<string> ApplyProjectMutation(
         IWorkspaceExecutionGate gate,
         IProjectMutationService projectMutationService,
+        IProjectMutationPreviewStore projectMutationPreviewStore,
         [Description("The preview token returned by one of the project mutation preview tools")] string previewToken,
         CancellationToken ct = default)
     {
+        var wsId = projectMutationPreviewStore.PeekWorkspaceId(previewToken);
+        var gateKey = wsId != null ? $"__apply__:{wsId}" : "__apply__";
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await projectMutationService.ApplyProjectMutationAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -35,11 +35,13 @@ public static class RefactoringTools
     public static Task<string> ApplyRename(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by rename_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -66,11 +68,13 @@ public static class RefactoringTools
     public static Task<string> ApplyOrganizeUsings(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by organize_usings_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -97,11 +101,13 @@ public static class RefactoringTools
     public static Task<string> ApplyFormatDocument(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by format_document_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -132,14 +138,22 @@ public static class RefactoringTools
     public static Task<string> ApplyCodeFix(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by code_fix_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);
             }, ct));
+    }
+
+    internal static string ApplyGateKeyFor(IPreviewStore store, string token)
+    {
+        var wsId = store.PeekWorkspaceId(token);
+        return wsId != null ? $"__apply__:{wsId}" : "__apply__";
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -41,11 +41,13 @@ public static class ScaffoldingTools
     public static Task<string> ApplyScaffoldType(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by scaffold_type_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);
@@ -79,11 +81,13 @@ public static class ScaffoldingTools
     public static Task<string> ApplyScaffoldTest(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by scaffold_test_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -38,11 +38,13 @@ public static class TypeExtractionTools
     public static Task<string> ApplyExtractType(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by extract_type_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -35,11 +35,13 @@ public static class TypeMoveTools
     public static Task<string> ApplyMoveTypeToFile(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
+        IPreviewStore previewStore,
         [Description("The preview token returned by move_type_to_file_preview")] string previewToken,
         CancellationToken ct = default)
     {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.ApplyGateKey, async c =>
+            gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
                 return JsonSerializer.Serialize(result, JsonOptions);

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -19,9 +19,21 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IWorkspaceExecutionGate, WorkspaceExecutionGate>();
         services.AddSingleton<IDotnetCommandRunner, DotnetCommandRunner>();
-        services.AddSingleton<IPreviewStore, PreviewStore>();
-        services.AddSingleton<IProjectMutationPreviewStore, ProjectMutationPreviewStore>();
-        services.AddSingleton<ICompositePreviewStore, CompositePreviewStore>();
+        services.AddSingleton<IPreviewStore>(sp =>
+        {
+            var opts = sp.GetService<PreviewStoreOptions>() ?? new PreviewStoreOptions();
+            return new PreviewStore(opts.MaxEntries);
+        });
+        services.AddSingleton<IProjectMutationPreviewStore>(sp =>
+        {
+            var opts = sp.GetService<PreviewStoreOptions>() ?? new PreviewStoreOptions();
+            return new ProjectMutationPreviewStore(opts.MaxEntries);
+        });
+        services.AddSingleton<ICompositePreviewStore>(sp =>
+        {
+            var opts = sp.GetService<PreviewStoreOptions>() ?? new PreviewStoreOptions();
+            return new CompositePreviewStore(opts.MaxEntries);
+        });
         services.AddSingleton<IWorkspaceManager, WorkspaceManager>();
         services.AddSingleton<ISymbolNavigationService, SymbolNavigationService>();
         services.AddSingleton<ISymbolSearchService, SymbolSearchService>();

--- a/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
@@ -7,8 +7,12 @@ public sealed class CompositePreviewStore : ICompositePreviewStore
 {
     private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
     private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
+    private readonly int _maxEntries;
 
-    private const int MaxEntries = 50;
+    public CompositePreviewStore(int maxEntries = 20)
+    {
+        _maxEntries = maxEntries > 0 ? maxEntries : 20;
+    }
 
     public string Store(string workspaceId, int workspaceVersion, string description, IReadOnlyList<CompositeFileMutation> mutations)
     {
@@ -57,6 +61,20 @@ public sealed class CompositePreviewStore : ICompositePreviewStore
         }
     }
 
+    public string? PeekWorkspaceId(string token)
+    {
+        if (!_entries.TryGetValue(token, out var entry))
+            return null;
+
+        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
+        {
+            _entries.TryRemove(token, out _);
+            return null;
+        }
+
+        return entry.WorkspaceId;
+    }
+
     private void CleanExpired()
     {
         var now = DateTime.UtcNow;
@@ -71,13 +89,13 @@ public sealed class CompositePreviewStore : ICompositePreviewStore
 
     private void EvictIfOverLimit()
     {
-        if (_entries.Count <= MaxEntries)
+        if (_entries.Count <= _maxEntries)
         {
             return;
         }
 
         var toEvict = _entries.OrderBy(kvp => kvp.Value.CreatedAt)
-            .Take(_entries.Count - MaxEntries + 1)
+            .Take(_entries.Count - _maxEntries + 1)
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/src/RoslynMcp.Roslyn/Services/FileWatcherService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FileWatcherService.cs
@@ -16,21 +16,19 @@ public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFi
         if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
             return;
 
-        var watcher = new FileSystemWatcher(directory)
-        {
-            Filter = "*.cs",
-            IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
-            EnableRaisingEvents = true
-        };
-
-        var entry = new WatcherEntry(watcher);
+        var entry = new WatcherEntry();
         _watchers[workspaceId] = entry;
 
-        watcher.Changed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
-        watcher.Created += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
-        watcher.Deleted += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
-        watcher.Renamed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        // Watch .cs source files
+        var csWatcher = CreateWatcher(directory, "*.cs", entry);
+        entry.AddWatcher(csWatcher);
+
+        // Watch project/solution files so project-level changes also mark the workspace stale
+        foreach (var filter in new[] { "*.csproj", "*.props", "*.targets", "*.sln", "*.slnx" })
+        {
+            var projWatcher = CreateWatcher(directory, filter, entry);
+            entry.AddWatcher(projWatcher);
+        }
 
         logger.LogInformation("Started file watcher for workspace {WorkspaceId} at {Directory}", workspaceId, directory);
     }
@@ -66,6 +64,24 @@ public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFi
         _watchers.Clear();
     }
 
+    private static FileSystemWatcher CreateWatcher(string directory, string filter, WatcherEntry entry)
+    {
+        var watcher = new FileSystemWatcher(directory)
+        {
+            Filter = filter,
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
+            EnableRaisingEvents = true
+        };
+
+        watcher.Changed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Created += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Deleted += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+        watcher.Renamed += (_, args) => MarkStaleIfRelevant(entry, args.FullPath);
+
+        return watcher;
+    }
+
     private static void MarkStaleIfRelevant(WatcherEntry entry, string fullPath)
     {
         if (ShouldIgnorePath(fullPath))
@@ -83,16 +99,23 @@ public sealed class FileWatcherService(ILogger<FileWatcherService> logger) : IFi
                fullPath.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
     }
 
-    private sealed class WatcherEntry(FileSystemWatcher watcher) : IDisposable
+    private sealed class WatcherEntry : IDisposable
     {
         private volatile bool _isStale;
+        private readonly List<FileSystemWatcher> _watchers = [];
 
         public bool IsStale => _isStale;
+
+        public void AddWatcher(FileSystemWatcher watcher) => _watchers.Add(watcher);
 
         public void MarkStale() => _isStale = true;
 
         public void ClearStale() => _isStale = false;
 
-        public void Dispose() => watcher.Dispose();
+        public void Dispose()
+        {
+            foreach (var w in _watchers)
+                w.Dispose();
+        }
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/PreviewStoreOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/PreviewStoreOptions.cs
@@ -1,0 +1,13 @@
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Configuration options for preview store entry limits.
+/// </summary>
+public sealed class PreviewStoreOptions
+{
+    /// <summary>
+    /// Gets the maximum number of preview entries allowed per store.
+    /// Defaults to 20.
+    /// </summary>
+    public int MaxEntries { get; init; } = 20;
+}

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
@@ -7,8 +7,12 @@ public sealed class ProjectMutationPreviewStore : IProjectMutationPreviewStore
 {
     private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
     private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
+    private readonly int _maxEntries;
 
-    private const int MaxEntries = 50;
+    public ProjectMutationPreviewStore(int maxEntries = 20)
+    {
+        _maxEntries = maxEntries > 0 ? maxEntries : 20;
+    }
 
     public string Store(string workspaceId, string projectFilePath, string updatedContent, int workspaceVersion, string description)
     {
@@ -57,6 +61,20 @@ public sealed class ProjectMutationPreviewStore : IProjectMutationPreviewStore
         }
     }
 
+    public string? PeekWorkspaceId(string token)
+    {
+        if (!_entries.TryGetValue(token, out var entry))
+            return null;
+
+        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
+        {
+            _entries.TryRemove(token, out _);
+            return null;
+        }
+
+        return entry.WorkspaceId;
+    }
+
     private void CleanExpired()
     {
         var now = DateTime.UtcNow;
@@ -71,13 +89,13 @@ public sealed class ProjectMutationPreviewStore : IProjectMutationPreviewStore
 
     private void EvictIfOverLimit()
     {
-        if (_entries.Count <= MaxEntries)
+        if (_entries.Count <= _maxEntries)
         {
             return;
         }
 
         var toEvict = _entries.OrderBy(kvp => kvp.Value.CreatedAt)
-            .Take(_entries.Count - MaxEntries + 1)
+            .Take(_entries.Count - _maxEntries + 1)
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -18,8 +18,6 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposable
 {
     public const string LoadGateKey = "__load__";
-    /// <summary>Gate for refactoring apply operations (no workspaceId in parameters).</summary>
-    public const string ApplyGateKey = "__apply__";
 
     /// <summary>Default per-request timeout (2 minutes).</summary>
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);


### PR DESCRIPTION
## Summary

- **CFG-01**: Wire options classes to env var overrides (`ROSLYNMCP_MAX_WORKSPACES`, `ROSLYNMCP_BUILD_TIMEOUT_SECONDS`, `ROSLYNMCP_TEST_TIMEOUT_SECONDS`, `ROSLYNMCP_PREVIEW_MAX_ENTRIES`). Documented in README Configuration section.
- **PERF-03**: Lower default preview store cap from 50 to 20 entries across all three stores. Make configurable via `PreviewStoreOptions` / env var.
- **CON-02**: Replace global `ApplyGateKey` with per-workspace apply gates (`__apply__:{workspaceId}`). Add `PeekWorkspaceId` to all preview store interfaces. Update all 13 apply tool methods.
- **REL-06**: Expand `FileWatcherService` to watch `*.csproj`, `*.props`, `*.targets`, `*.sln`, `*.slnx` in addition to `*.cs`.

## Test plan

- [x] All 98 tests pass
- [x] `verify-release.ps1` passes (build, test, publish, hash)
- [ ] Manual: set `ROSLYNMCP_MAX_WORKSPACES=2` and verify workspace limit enforced
- [ ] Manual: verify project file changes trigger workspace stale flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)