### PR TITLE
feat: documentation & test infrastructure (DOC-01, TEST-05)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,5 +21,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/RoslynMcp.Core/Services/IBuildService.cs
+++ b/src/RoslynMcp.Core/Services/IBuildService.cs
@@ -2,6 +2,9 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Builds a workspace or individual project and returns structured compiler diagnostics.
+/// </summary>
 public interface IBuildService
 {
     Task<BuildResultDto> BuildWorkspaceAsync(string workspaceId, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/ICodeMetricsService.cs
+++ b/src/RoslynMcp.Core/Services/ICodeMetricsService.cs
@@ -2,6 +2,9 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Calculates cyclomatic complexity, lines of code, nesting depth, and parameter count for methods in a workspace.
+/// </summary>
 public interface ICodeMetricsService
 {
     Task<IReadOnlyList<ComplexityMetricsDto>> GetComplexityMetricsAsync(

--- a/src/RoslynMcp.Core/Services/ICodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Core/Services/ICodePatternAnalyzer.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Performs semantic search across a workspace using natural language queries and detects
+/// reflection API usage patterns.
+/// </summary>
 public interface ICodePatternAnalyzer
 {
     Task<IReadOnlyList<ReflectionUsageDto>> FindReflectionUsagesAsync(

--- a/src/RoslynMcp.Core/Services/IDependencyAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/IDependencyAnalysisService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Analyzes NuGet package references, project dependency graphs, namespace dependencies,
+/// and dependency injection registrations across a loaded workspace.
+/// </summary>
 public interface IDependencyAnalysisService
 {
     Task<NamespaceDependencyGraphDto> GetNamespaceDependenciesAsync(

--- a/src/RoslynMcp.Core/Services/IMutationAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/IMutationAnalysisService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Finds mutable members of a type, classifies property writes, analyzes type usages by role,
+/// and performs impact analysis for a symbol.
+/// </summary>
 public interface IMutationAnalysisService
 {
     Task<ImpactAnalysisDto?> AnalyzeImpactAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/IReferenceService.cs
+++ b/src/RoslynMcp.Core/Services/IReferenceService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Finds all references, implementations, overrides, and base members for a symbol across
+/// a solution, with classified usage locations and bulk lookup support.
+/// </summary>
 public interface IReferenceService
 {
     Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/ISymbolNavigationService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolNavigationService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Navigates to symbol definitions and type definitions, and resolves the enclosing symbol
+/// at a given source position.
+/// </summary>
 public interface ISymbolNavigationService
 {
     Task<IReadOnlyList<LocationDto>> GoToDefinitionAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/ISymbolRelationshipService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolRelationshipService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Provides combined summaries of type hierarchy, member hierarchy, symbol relationships,
+/// signature help, and caller/callee analysis for a symbol.
+/// </summary>
 public interface ISymbolRelationshipService
 {
     Task<TypeHierarchyDto?> GetTypeHierarchyAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Searches for symbols by name pattern across a loaded workspace, retrieves detailed symbol
+/// information, and lists document-level symbol declarations.
+/// </summary>
 public interface ISymbolSearchService
 {
     Task<IReadOnlyList<SymbolDto>> SearchSymbolsAsync(

--- a/src/RoslynMcp.Core/Services/ITestDiscoveryService.cs
+++ b/src/RoslynMcp.Core/Services/ITestDiscoveryService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Discovers test methods in test projects and finds tests related to a given symbol or
+/// set of changed source files using heuristic name matching.
+/// </summary>
 public interface ITestDiscoveryService
 {
     Task<TestDiscoveryDto> DiscoverTestsAsync(string workspaceId, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/ITestRunnerService.cs
+++ b/src/RoslynMcp.Core/Services/ITestRunnerService.cs
@@ -2,6 +2,10 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Executes <c>dotnet test</c> against a loaded workspace or specific test project and returns
+/// structured pass/fail results.
+/// </summary>
 public interface ITestRunnerService
 {
     Task<TestRunResultDto> RunTestsAsync(string workspaceId, string? projectName, string? filter, CancellationToken ct);

--- a/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
@@ -2,6 +2,9 @@ using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
 
+/// <summary>
+/// Finds symbols with zero references across a solution to identify dead code candidates.
+/// </summary>
 public interface IUnusedCodeAnalyzer
 {
     Task<IReadOnlyList<UnusedSymbolDto>> FindUnusedSymbolsAsync(

--- a/tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj
+++ b/tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- **DOC-01**: Add XML doc summary comments to 12 undocumented service interfaces in `RoslynMcp.Core/Services`: `IBuildService`, `ICodeMetricsService`, `ICodePatternAnalyzer`, `IDependencyAnalysisService`, `IMutationAnalysisService`, `IReferenceService`, `ISymbolNavigationService`, `ISymbolRelationshipService`, `ISymbolSearchService`, `ITestDiscoveryService`, `ITestRunnerService`, `IUnusedCodeAnalyzer`. (3 interfaces were already documented.)
- **TEST-05**: Install `coverlet.collector` NuGet package. Baseline coverage established: **50.3% line rate, 34.0% branch rate** (4,796/9,528 lines, 1,295/3,811 branches). No hard coverage gate yet — this establishes the metric for future enforcement.

## Test plan

- [x] All 98 tests pass
- [x] `verify-release.ps1` passes (build, test, publish, hash)
- [x] Coverage XML generates via `dotnet test --collect:"XPlat Code Coverage"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)