### PR TITLE
feat: hardening — test discovery cache, prompt truncation, SecurityCodeScan

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Version>0.10.0</Version>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,5 +22,6 @@
     <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />
   </ItemGroup>
 </Project>

--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -195,7 +195,7 @@ public static class RoslynPrompts
 
                     **Source Code:**
                     ```csharp
-                    {sourceText}
+                    {TruncateSourceLines(sourceText, 500)}
                     ```
 
                     Review the code for:
@@ -229,13 +229,13 @@ public static class RoslynPrompts
         try
         {
             var graph = workspace.GetProjectGraph(workspaceId);
-            var graphJson = JsonSerializer.Serialize(graph, JsonOptions);
+            var graphJson = SerializeTruncatedList(graph.Projects, 50, JsonOptions);
 
             var namespaceDeps = await dependencyAnalysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
-            var namespaceDepsJson = JsonSerializer.Serialize(namespaceDeps, JsonOptions);
+            var namespaceDepsJson = SerializeTruncatedList(namespaceDeps.Edges, 100, JsonOptions);
 
             var nugetDeps = await dependencyAnalysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
-            var nugetDepsJson = JsonSerializer.Serialize(nugetDeps, JsonOptions);
+            var nugetDepsJson = SerializeTruncatedList(nugetDeps.Packages, 50, JsonOptions);
 
             return
             [
@@ -716,7 +716,12 @@ public static class RoslynPrompts
         try
         {
             var discovered = await testDiscoveryService.DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
-            var discoveredJson = JsonSerializer.Serialize(discovered, JsonOptions);
+            var totalTests = discovered.TestProjects.Sum(p => p.Tests.Count);
+            var truncatedProjects = discovered.TestProjects.Select(p =>
+                new Core.Models.TestProjectDto(p.ProjectName, p.ProjectFilePath, p.Tests.Take(200 / Math.Max(1, discovered.TestProjects.Count)).ToList())).ToList();
+            var discoveredJson = JsonSerializer.Serialize(new Core.Models.TestDiscoveryDto(truncatedProjects), JsonOptions);
+            if (totalTests > 200)
+                discoveredJson += $"\n[Showing ~200 of {totalTests} test cases]";
 
             return
             [
@@ -871,7 +876,7 @@ public static class RoslynPrompts
             var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, ct).ConfigureAwait(false);
             if (result is null) return [CreatePromptMessage("No symbol found at the specified location.")];
 
-            var resultJson = JsonSerializer.Serialize(result, JsonOptions);
+            var resultJson = SerializeTruncatedList(result.Consumers, 50, JsonOptions);
 
             return
             [
@@ -904,6 +909,24 @@ public static class RoslynPrompts
         {
             return [CreateErrorMessage("consumer_impact", ex)];
         }
+    }
+
+    // ── Truncation Helpers ──
+
+    private static string TruncateSourceLines(string source, int maxLines)
+    {
+        var lines = source.Split('\n');
+        if (lines.Length <= maxLines) return source;
+        return string.Join('\n', lines.Take(maxLines)) + $"\n// ... [{lines.Length - maxLines} more lines truncated]";
+    }
+
+    private static string SerializeTruncatedList<T>(IReadOnlyList<T> items, int max, JsonSerializerOptions options)
+    {
+        if (items.Count <= max)
+            return JsonSerializer.Serialize(items, options);
+
+        var json = JsonSerializer.Serialize(items.Take(max).ToList(), options);
+        return json + $"\n[Showing {max} of {items.Count} items]";
     }
 
     // ── Helpers ──

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -14,6 +14,7 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
     private readonly IWorkspaceManager _workspaceManager;
     private readonly ILogger<TestDiscoveryService> _logger;
     private readonly ValidationServiceOptions _options;
+    private readonly ConcurrentDictionary<string, (int Version, TestDiscoveryDto Result)> _cache = new();
 
     public TestDiscoveryService(
         IWorkspaceManager workspaceManager,
@@ -27,6 +28,10 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
 
     public async Task<TestDiscoveryDto> DiscoverTestsAsync(string workspaceId, CancellationToken ct)
     {
+        var currentVersion = _workspaceManager.GetCurrentVersion(workspaceId);
+        if (_cache.TryGetValue(workspaceId, out var cached) && cached.Version == currentVersion)
+            return cached.Result;
+
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
         var testProjectNames = _workspaceManager.GetStatus(workspaceId).Projects
             .Where(project => project.IsTestProject)
@@ -74,7 +79,9 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             discoveredProjects.Add(new TestProjectDto(project.Name, project.FilePath ?? project.Name, tests));
         }
 
-        return new TestDiscoveryDto(discoveredProjects);
+        var result = new TestDiscoveryDto(discoveredProjects);
+        _cache[workspaceId] = (currentVersion, result);
+        return result;
     }
 
     public async Task<IReadOnlyList<TestCaseDto>> FindRelatedTestsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
@@ -137,15 +137,15 @@ public class SecurityDiagnosticIntegrationTests : TestBase
     }
 
     [TestMethod]
-    public async Task AnalyzerStatus_Reports_Missing_SecurityCodeScan()
+    public async Task AnalyzerStatus_Reports_SecurityCodeScan_Present()
     {
         var status = await SecurityService.GetAnalyzerStatusAsync(
             WorkspaceId, CancellationToken.None);
 
-        // SampleSolution doesn't reference SecurityCodeScan, so it should be missing
-        Assert.IsFalse(status.SecurityCodeScanPresent);
-        Assert.IsTrue(status.MissingRecommendedPackages.Count > 0,
-            "Should recommend SecurityCodeScan when not present");
+        // SecurityCodeScan.VS2019 is installed via Directory.Build.props
+        Assert.IsTrue(status.SecurityCodeScanPresent);
+        Assert.AreEqual(0, status.MissingRecommendedPackages.Count,
+            "No recommended packages should be missing");
     }
 
     // ── Catalog Tests ──


### PR DESCRIPTION
## Summary

- **PERF-02**: Cache test discovery results per workspace version using a `ConcurrentDictionary` keyed by workspaceId with version comparison. Benefits `DiscoverTestsAsync` and its 3 downstream callers.
- **API-04**: Truncate unbounded data in 4 high-risk prompt templates: `review_file` (500 lines), `analyze_dependencies` (50 projects, 100 namespace edges, 50 packages), `review_test_coverage` (200 test cases), `consumer_impact` (50 consumers).
- **REL-13**: Install `SecurityCodeScan.VS2019` 5.6.7 globally via `Directory.Build.props` with `PrivateAssets=all`. Zero new warnings. Update test to assert analyzer present.

## Test plan

- [x] All 98 tests pass
- [x] `verify-release.ps1` passes (build + test + publish)
- [ ] Manual: verify `security_analyzer_status` reports `SecurityCodeScanPresent: true`
- [ ] Manual: verify consecutive `test_discover` calls are instant (cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)