### PR TITLE
feat: test coverage expansion — 23 new tests for edge cases and untested services

### DIFF
--- a/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
+++ b/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
@@ -1,0 +1,46 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class BulkRefactoringTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task BulkReplaceType_Preview_ReturnsChanges()
+    {
+        var result = await BulkRefactoringService.PreviewBulkReplaceTypeAsync(
+            WorkspaceId, "IAnimal", "Shape", null, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.PreviewToken));
+    }
+
+    [TestMethod]
+    public async Task BulkReplaceType_NonExistentType_ThrowsInvalidOperation()
+    {
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            BulkRefactoringService.PreviewBulkReplaceTypeAsync(
+                WorkspaceId, "NonExistentType123", "Shape", null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task BulkReplaceType_InvalidScope_ThrowsArgument()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            BulkRefactoringService.PreviewBulkReplaceTypeAsync(
+                WorkspaceId, "IAnimal", "Shape", "invalid_scope", CancellationToken.None));
+    }
+}

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -1,0 +1,62 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class CohesionAnalysisTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task GetCohesionMetrics_ReturnsMetrics()
+    {
+        var result = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            WorkspaceId, null, null, 2, 50, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Count > 0, "Expected at least one type with cohesion metrics");
+
+        var first = result[0];
+        Assert.IsFalse(string.IsNullOrWhiteSpace(first.TypeName));
+        Assert.IsTrue(first.Lcom4Score >= 1, "LCOM4 score should be at least 1");
+    }
+
+    [TestMethod]
+    public async Task FindSharedMembers_RunsWithoutError()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService");
+        var result = await CohesionAnalysisService.FindSharedMembersAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public async Task GetCohesionMetrics_WithFilePath_FiltersByFile()
+    {
+        var doc = WorkspaceManager.GetCurrentSolution(WorkspaceId)
+            .Projects.SelectMany(p => p.Documents)
+            .FirstOrDefault(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+
+        Assert.IsNotNull(doc?.FilePath, "AnimalService.cs not found in workspace");
+
+        var result = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            WorkspaceId, doc.FilePath, null, 1, 50, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.All(m =>
+            m.FilePath?.Contains("AnimalService.cs") == true),
+            "All results should be from the filtered file");
+    }
+}

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -1,0 +1,58 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class ConsumerAnalysisTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task FindConsumers_IAnimal_ReturnsConsumingTypes()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Consumers.Count >= 3,
+            $"Expected at least 3 consumers of IAnimal (Dog, Cat, AnimalService), got {result.Consumers.Count}");
+
+        var consumerNames = result.Consumers.Select(c => c.TypeName).ToList();
+        CollectionAssert.Contains(consumerNames, "Dog");
+        CollectionAssert.Contains(consumerNames, "Cat");
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_NonExistentSymbol_ReturnsNull()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.NonExistentType");
+        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_Shape_ReturnsRectangleAsConsumer()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.Hierarchy.Shape");
+        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Consumers.Count >= 1,
+            $"Expected at least 1 consumer of Shape, got {result.Consumers.Count}");
+
+        var rectangle = result.Consumers.FirstOrDefault(c => c.TypeName == "Rectangle");
+        Assert.IsNotNull(rectangle, "Rectangle should consume Shape");
+        CollectionAssert.Contains(rectangle.DependencyKinds.ToList(), "BaseType");
+    }
+}

--- a/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
+++ b/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
@@ -1,0 +1,101 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class NegativeEdgeCaseTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public void InvalidWorkspaceId_ThrowsKeyNotFoundException()
+    {
+        Assert.ThrowsException<KeyNotFoundException>(() =>
+            WorkspaceManager.GetStatus("nonexistent-workspace-id"));
+    }
+
+    [TestMethod]
+    public async Task MalformedSymbolHandle_InvalidBase64_ReturnsGracefully()
+    {
+        var locator = SymbolLocator.ByHandle("not-valid-base64!!!");
+        var result = await SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public async Task MalformedSymbolHandle_ValidBase64InvalidJson_ReturnsGracefully()
+    {
+        var handle = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("this is not json"));
+        var locator = SymbolLocator.ByHandle(handle);
+        var result = await SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public void SymbolLocator_NoFields_ThrowsArgumentException()
+    {
+        var locator = new SymbolLocator(null, null, null, null, null);
+        Assert.ThrowsException<ArgumentException>(() => locator.Validate());
+    }
+
+    [TestMethod]
+    public async Task SourceLocation_NonExistentFile_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.BySource(@"C:\nonexistent\file.cs", 1, 1);
+        var result = await SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public async Task NegativeLineColumn_ThrowsArgumentOutOfRange()
+    {
+        var status = WorkspaceManager.GetStatus(WorkspaceId);
+        var project = status.Projects.First(p => !p.IsTestProject);
+        var doc = WorkspaceManager.GetCurrentSolution(WorkspaceId)
+            .Projects.First(p => p.Name == project.Name)
+            .Documents.First(d => d.FilePath?.EndsWith(".cs") == true);
+
+        var locator = SymbolLocator.BySource(doc.FilePath!, -1, -1);
+        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+            SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task EmptySearchQuery_HandledGracefully()
+    {
+        var result = await SymbolSearchService.SearchSymbolsAsync(
+            WorkspaceId, "", null, null, null, 20, CancellationToken.None);
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public async Task PreCancelledToken_ThrowsOperationCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        try
+        {
+            await SymbolSearchService.SearchSymbolsAsync(WorkspaceId, "Dog", null, null, null, 20, cts.Token);
+            Assert.Fail("Expected OperationCanceledException or TaskCanceledException");
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — TaskCanceledException is a subclass of OperationCanceledException
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -39,6 +39,11 @@ public abstract class TestBase
     protected static SyntaxService SyntaxService { get; private set; } = null!;
     protected static WorkspaceExecutionGate WorkspaceExecutionGate { get; private set; } = null!;
     protected static DotnetCommandRunner DotnetCommandRunner { get; private set; } = null!;
+    protected static BulkRefactoringService BulkRefactoringService { get; private set; } = null!;
+    protected static CohesionAnalysisService CohesionAnalysisService { get; private set; } = null!;
+    protected static ConsumerAnalysisService ConsumerAnalysisService { get; private set; } = null!;
+    protected static TypeExtractionService TypeExtractionService { get; private set; } = null!;
+    protected static TypeMoveService TypeMoveService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -142,6 +147,24 @@ public abstract class TestBase
             WorkspaceManager,
             PreviewStore);
         SyntaxService = new SyntaxService(WorkspaceManager);
+        BulkRefactoringService = new BulkRefactoringService(
+            WorkspaceManager,
+            PreviewStore,
+            NullLogger<BulkRefactoringService>.Instance);
+        CohesionAnalysisService = new CohesionAnalysisService(
+            WorkspaceManager,
+            NullLogger<CohesionAnalysisService>.Instance);
+        ConsumerAnalysisService = new ConsumerAnalysisService(
+            WorkspaceManager,
+            NullLogger<ConsumerAnalysisService>.Instance);
+        TypeExtractionService = new TypeExtractionService(
+            WorkspaceManager,
+            PreviewStore,
+            NullLogger<TypeExtractionService>.Instance);
+        TypeMoveService = new TypeMoveService(
+            WorkspaceManager,
+            PreviewStore,
+            NullLogger<TypeMoveService>.Instance);
 
         RepositoryRootPath = FindRepositoryRoot();
         SampleSolutionPath = FindFixturePath("SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -1,0 +1,99 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class TypeExtractionTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task ExtractType_FromAnimalService_CreatesPreview()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, doc.FilePath!, "AnimalService", ["CountAnimals"], "AnimalCounter", null, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(result.PreviewToken));
+            Assert.IsTrue(result.Description?.Contains("AnimalCounter") == true,
+                $"Description should mention AnimalCounter, got: {result.Description}");
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_EmptyMemberList_ThrowsArgument()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, doc.FilePath!, "AnimalService", [], "NewType", null, CancellationToken.None));
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_NonExistentType_ThrowsInvalidOperation()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, doc.FilePath!, "NonExistentType", ["Foo"], "NewType", null, CancellationToken.None));
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    private static void CleanupTempDirectory(string path)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (dir != null && Directory.Exists(dir))
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -1,0 +1,102 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class TypeMoveTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task MoveType_FromMultiTypeFile_CreatesPreview()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            // Add a second class to Cat.cs so it becomes a multi-type file
+            var catDir = Path.GetDirectoryName(copyPath)!;
+            var catFile = Path.Combine(catDir, "SampleLib", "Cat.cs");
+            File.AppendAllText(catFile, "\npublic class Kitten : IAnimal\n{\n    public string Name => \"Kitten\";\n    public string Speak() => \"Mew\";\n}\n");
+
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+            var result = await TypeMoveService.PreviewMoveTypeToFileAsync(
+                wsId, doc.FilePath!, "Kitten", null, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(result.PreviewToken));
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task MoveType_SingleTypeFile_ThrowsInvalidOperation()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("Dog.cs") == true);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                TypeMoveService.PreviewMoveTypeToFileAsync(
+                    wsId, doc.FilePath!, "Dog", null, CancellationToken.None));
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task MoveType_NonExistentType_ThrowsInvalidOperation()
+    {
+        var copyPath = CreateSampleSolutionCopy();
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copyPath, CancellationToken.None);
+            var wsId = status.WorkspaceId;
+
+            var doc = WorkspaceManager.GetCurrentSolution(wsId)
+                .Projects.SelectMany(p => p.Documents)
+                .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                TypeMoveService.PreviewMoveTypeToFileAsync(
+                    wsId, doc.FilePath!, "NonExistentType", null, CancellationToken.None));
+
+            WorkspaceManager.Close(wsId);
+        }
+        finally
+        {
+            CleanupTempDirectory(copyPath);
+        }
+    }
+
+    private static void CleanupTempDirectory(string path)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (dir != null && Directory.Exists(dir))
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **TEST-01**: 8 negative/edge-case tests covering invalid workspace IDs, malformed symbol handles, empty SymbolLocator validation, non-existent file paths, negative line/column values, empty search queries, and pre-cancelled cancellation tokens.
- **TEST-02**: 15 dedicated tests for 5 previously untested services: `BulkRefactoringService`, `CohesionAnalysisService`, `ConsumerAnalysisService`, `TypeExtractionService`, `TypeMoveService`.

Test count: 98 → 121 (+23 new tests).

## Test plan

- [x] All 121 tests pass
- [x] `verify-release.ps1` passes (build + test + publish)
- [x] All new test classes follow existing TestBase patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)