### PR TITLE
fix: address Codex review notes from PRs #18 and #19

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -232,7 +232,13 @@ public static class RoslynPrompts
             var graphJson = SerializeTruncatedList(graph.Projects, 50, JsonOptions);
 
             var namespaceDeps = await dependencyAnalysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
-            var namespaceDepsJson = SerializeTruncatedList(namespaceDeps.Edges, 100, JsonOptions);
+            var truncatedNamespaceDeps = new Core.Models.NamespaceDependencyGraphDto(
+                namespaceDeps.Nodes.Take(100).ToList(),
+                namespaceDeps.Edges.Take(100).ToList(),
+                namespaceDeps.CircularDependencies);
+            var namespaceDepsJson = JsonSerializer.Serialize(truncatedNamespaceDeps, JsonOptions);
+            if (namespaceDeps.Edges.Count > 100)
+                namespaceDepsJson += $"\n[Showing 100 of {namespaceDeps.Edges.Count} edges]";
 
             var nugetDeps = await dependencyAnalysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
             var nugetDepsJson = SerializeTruncatedList(nugetDeps.Packages, 50, JsonOptions);
@@ -717,8 +723,9 @@ public static class RoslynPrompts
         {
             var discovered = await testDiscoveryService.DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
             var totalTests = discovered.TestProjects.Sum(p => p.Tests.Count);
+            var perProject = Math.Max(1, 200 / Math.Max(1, discovered.TestProjects.Count));
             var truncatedProjects = discovered.TestProjects.Select(p =>
-                new Core.Models.TestProjectDto(p.ProjectName, p.ProjectFilePath, p.Tests.Take(200 / Math.Max(1, discovered.TestProjects.Count)).ToList())).ToList();
+                new Core.Models.TestProjectDto(p.ProjectName, p.ProjectFilePath, p.Tests.Take(perProject).ToList())).ToList();
             var discoveredJson = JsonSerializer.Serialize(new Core.Models.TestDiscoveryDto(truncatedProjects), JsonOptions);
             if (totalTests > 200)
                 discoveredJson += $"\n[Showing ~200 of {totalTests} test cases]";

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -55,6 +55,7 @@ public sealed class CohesionAnalysisTests : TestBase
             WorkspaceId, doc.FilePath, null, 1, 50, CancellationToken.None);
 
         Assert.IsNotNull(result);
+        Assert.IsTrue(result.Count > 0, "Expected at least one metric from filtered file");
         Assert.IsTrue(result.All(m =>
             m.FilePath?.Contains("AnimalService.cs") == true),
             "All results should be from the filtered file");


### PR DESCRIPTION
## Summary

Resolves 3 Codex code review findings from PRs #18 and #19:

- **PR #18 — test truncation floor**: `200 / projectCount` evaluated to `0` when >200 projects, producing `Take(0)` for every project. Fixed with `Math.Max(1, ...)` on the per-project limit.
- **PR #18 — circular dependencies dropped**: `analyze_dependencies` was serializing only `namespaceDeps.Edges`, dropping the `CircularDependencies` collection. Now serializes the full `NamespaceDependencyGraphDto` with truncated Nodes/Edges while preserving all circular dependency data.
- **PR #19 — vacuous All() assertion**: `CohesionAnalysisTests.GetCohesionMetrics_WithFilePath_FiltersByFile` used `All()` on a potentially empty list. Added `Assert.IsTrue(result.Count > 0)` before the `All` check.

## Test plan

- [x] All 121 tests pass
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)