### PR TITLE
fix: revert ClientRootPathValidator to fail-open on roots lookup failure

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
@@ -11,8 +11,9 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// </summary>
 /// <remarks>
 /// If the client does not advertise roots capability, or if the roots list is empty,
-/// the path is allowed unconditionally. If the roots request itself fails, validation
-/// is denied (fail-closed) to prevent accidental security bypass.
+/// the path is allowed unconditionally. If the roots request itself fails (e.g. the
+/// client advertises the capability but doesn't fully support it), the path is allowed
+/// (fail-open) to avoid blocking legitimate workspace loads.
 /// Symlinks and junctions are resolved before comparison to prevent traversal attacks.
 /// </remarks>
 internal static class ClientRootPathValidator
@@ -26,7 +27,6 @@ internal static class ClientRootPathValidator
     /// <param name="ct">Cancellation token.</param>
     /// <param name="logger">Optional logger for diagnostics.</param>
     /// <exception cref="System.ArgumentException">Thrown when the path falls outside all client-sanctioned roots.</exception>
-    /// <exception cref="System.InvalidOperationException">Thrown when the roots lookup fails (fail-closed).</exception>
     public static async Task ValidatePathAgainstRootsAsync(
         McpServer server, string path, CancellationToken ct, ILogger? logger = null)
     {
@@ -74,10 +74,10 @@ internal static class ClientRootPathValidator
         }
         catch (Exception ex)
         {
-            logger?.LogWarning(ex, "Roots lookup failed for path '{Path}' — denying access (fail-closed)", path);
-            throw new InvalidOperationException(
-                "Unable to validate path against client roots — roots lookup failed. " +
-                "Denying access as a precaution.", ex);
+            // Roots lookup can fail when the client advertises the capability but
+            // doesn't fully support it (common with Claude Code and other clients).
+            // Fail-open here so workspace loads aren't blocked by infrastructure errors.
+            logger?.LogWarning(ex, "Roots lookup failed for path '{Path}' — allowing access (fail-open)", path);
         }
     }
 


### PR DESCRIPTION
## Summary
- The P0 audit (5b676ee) changed `ClientRootPathValidator` from fail-open to fail-closed when `RequestRootsAsync` throws
- This breaks `workspace_load` for clients like Claude Code that advertise the `roots` capability but don't fully support it
- Reverts to fail-open for infrastructure errors while keeping fail-closed for actual path validation violations (`ArgumentException`)

## Test plan
- [x] Verified `workspace_load` succeeds after the fix (loaded 6 projects, 227 documents)
- [ ] Run full test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)