### PR TITLE
refactor: fix layer boundary, dead code, and complexity hotspots

### DIFF
--- a/src/RoslynMcp.Core/Services/ICompositePreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/ICompositePreviewStore.cs
@@ -30,12 +30,6 @@ public interface ICompositePreviewStore
     void Invalidate(string token);
 
     /// <summary>
-    /// Removes all entries, optionally scoped to a specific workspace.
-    /// </summary>
-    /// <param name="workspaceId">The workspace to clear, or <see langword="null"/> to clear all workspaces.</param>
-    void InvalidateAll(string? workspaceId = null);
-
-    /// <summary>
     /// Returns the workspace identifier associated with a preview token without consuming the entry,
     /// or <see langword="null"/> if the token is expired or not found.
     /// </summary>

--- a/src/RoslynMcp.Core/Services/IProjectMutationPreviewStore.cs
+++ b/src/RoslynMcp.Core/Services/IProjectMutationPreviewStore.cs
@@ -31,12 +31,6 @@ public interface IProjectMutationPreviewStore
     void Invalidate(string token);
 
     /// <summary>
-    /// Removes all entries, optionally scoped to a specific workspace.
-    /// </summary>
-    /// <param name="workspaceId">The workspace to clear, or <see langword="null"/> to clear all workspaces.</param>
-    void InvalidateAll(string? workspaceId = null);
-
-    /// <summary>
     /// Returns the workspace identifier associated with a preview token without consuming the entry,
     /// or <see langword="null"/> if the token is expired or not found.
     /// </summary>

--- a/src/RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
@@ -7,10 +7,20 @@ namespace RoslynMcp.Core.Services;
 /// </summary>
 public interface IWorkspaceExecutionGate
 {
-/// <summary>
-/// Run an async action while holding the gate for the given key.
-/// Use the load gate key (e.g. "__load__") for workspace_load and workspace_reload.
-/// Use the workspace session id for all other tools that take a workspaceId.
-/// </summary>
+    /// <summary>
+    /// The well-known gate key used for workspace_load and workspace_reload operations.
+    /// </summary>
+    const string LoadGateKey = "__load__";
+
+    /// <summary>
+    /// Run an async action while holding the gate for the given key.
+    /// Use <see cref="LoadGateKey"/> for workspace_load and workspace_reload.
+    /// Use the workspace session id for all other tools that take a workspaceId.
+    /// </summary>
     Task<T> RunAsync<T>(string? gateKey, Func<CancellationToken, Task<T>> action, CancellationToken ct);
+
+    /// <summary>
+    /// Remove and dispose the gate for a workspace that is being closed.
+    /// </summary>
+    void RemoveGate(string workspaceId);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Core.Models;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -23,7 +22,7 @@ public static class WorkspaceTools
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
+            gate.RunAsync(IWorkspaceExecutionGate.LoadGateKey, async c =>
             {
                 ProgressHelper.Report(progress, 0, 1);
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, path, c).ConfigureAwait(false);
@@ -43,7 +42,7 @@ public static class WorkspaceTools
         CancellationToken ct)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, async c =>
+            gate.RunAsync(IWorkspaceExecutionGate.LoadGateKey, async c =>
             {
                 var status = await workspace.ReloadAsync(workspaceId, c);
                 _ = NotifyResourcesChangedAsync(server);
@@ -60,13 +59,10 @@ public static class WorkspaceTools
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(WorkspaceExecutionGate.LoadGateKey, c =>
+            gate.RunAsync(IWorkspaceExecutionGate.LoadGateKey, c =>
             {
                 var closed = workspace.Close(workspaceId);
-                if (gate is WorkspaceExecutionGate concreteGate)
-                {
-                    concreteGate.RemoveGate(workspaceId);
-                }
+                gate.RemoveGate(workspaceId);
                 _ = NotifyResourcesChangedAsync(server);
                 return Task.FromResult(JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonOptions));
             }, ct));

--- a/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
@@ -53,49 +53,11 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
         {
             if (ct.IsCancellationRequested) break;
 
-            var doc = newSolution.GetDocument(docGroup.Key);
-            if (doc is null) continue;
-
-            var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-            if (root is null) continue;
-
-            var nodesToReplace = new Dictionary<SyntaxNode, SyntaxNode>();
-
-            foreach (var refLocation in docGroup)
-            {
-                var node = root.FindNode(refLocation.Location.SourceSpan);
-                if (node is not (IdentifierNameSyntax or GenericNameSyntax or QualifiedNameSyntax)) continue;
-
-                if (!ShouldReplace(node, normalizedScope)) continue;
-
-                // Create replacement node
-                var newNode = SyntaxFactory.IdentifierName(GetSimpleName(newTypeName))
-                    .WithTriviaFrom(node);
-                nodesToReplace[node] = newNode;
-            }
-
-            if (nodesToReplace.Count > 0)
-            {
-                root = root.ReplaceNodes(nodesToReplace.Keys, (original, _) =>
-                    nodesToReplace.TryGetValue(original, out var replacement) ? replacement : original);
-
-                // Add using directive for new type's namespace if needed
-                if (root is CompilationUnitSyntax compilationUnit)
-                {
-                    var newTypeNs = newTypeSymbol.ContainingNamespace?.ToDisplayString();
-                    if (!string.IsNullOrWhiteSpace(newTypeNs) &&
-                        !compilationUnit.Usings.Any(u => u.Name?.ToString() == newTypeNs))
-                    {
-                        var newUsing = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(newTypeNs))
-                            .NormalizeWhitespace()
-                            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
-                        root = compilationUnit.AddUsings(newUsing);
-                    }
-                }
-
-                newSolution = newSolution.WithDocumentSyntaxRoot(doc.Id, root);
-                replacementCount += nodesToReplace.Count;
-            }
+            var (updatedSolution, count) = await ReplaceReferencesInDocumentAsync(
+                newSolution, docGroup.Key, docGroup, newTypeName, newTypeSymbol, normalizedScope, ct)
+                .ConfigureAwait(false);
+            newSolution = updatedSolution;
+            replacementCount += count;
         }
 
         if (replacementCount == 0)
@@ -109,6 +71,53 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
         var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description);
 
         return new RefactoringPreviewDto(token, description, changes, null);
+    }
+
+    private static async Task<(Solution Solution, int Count)> ReplaceReferencesInDocumentAsync(
+        Solution solution, DocumentId docId, IEnumerable<ReferenceLocation> locations,
+        string newTypeName, INamedTypeSymbol newTypeSymbol, string scope, CancellationToken ct)
+    {
+        var doc = solution.GetDocument(docId);
+        if (doc is null) return (solution, 0);
+
+        var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+        if (root is null) return (solution, 0);
+
+        var nodesToReplace = new Dictionary<SyntaxNode, SyntaxNode>();
+
+        foreach (var refLocation in locations)
+        {
+            var node = root.FindNode(refLocation.Location.SourceSpan);
+            if (node is not (IdentifierNameSyntax or GenericNameSyntax or QualifiedNameSyntax)) continue;
+            if (!ShouldReplace(node, scope)) continue;
+
+            var newNode = SyntaxFactory.IdentifierName(GetSimpleName(newTypeName))
+                .WithTriviaFrom(node);
+            nodesToReplace[node] = newNode;
+        }
+
+        if (nodesToReplace.Count == 0) return (solution, 0);
+
+        root = root.ReplaceNodes(nodesToReplace.Keys, (original, _) =>
+            nodesToReplace.TryGetValue(original, out var replacement) ? replacement : original);
+
+        root = EnsureUsingDirective(root, newTypeSymbol.ContainingNamespace?.ToDisplayString());
+
+        return (solution.WithDocumentSyntaxRoot(docId, root), nodesToReplace.Count);
+    }
+
+    private static SyntaxNode EnsureUsingDirective(SyntaxNode root, string? namespaceName)
+    {
+        if (string.IsNullOrWhiteSpace(namespaceName) || root is not CompilationUnitSyntax compilationUnit)
+            return root;
+
+        if (compilationUnit.Usings.Any(u => u.Name?.ToString() == namespaceName))
+            return root;
+
+        var newUsing = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .NormalizeWhitespace()
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+        return compilationUnit.AddUsings(newUsing);
     }
 
     private static bool ShouldReplace(SyntaxNode node, string scope)

--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -40,71 +40,83 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
                 var semanticModel = compilation.GetSemanticModel(tree);
                 var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
 
-                var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
-                foreach (var invocation in invocations)
-                {
-                    var symbolInfo = semanticModel.GetSymbolInfo(invocation, ct);
-                    if (symbolInfo.Symbol is not IMethodSymbol method) continue;
-
-                    var containingNs = method.ContainingType?.ContainingNamespace?.ToDisplayString() ?? "";
-                    var containingTypeName = method.ContainingType?.Name ?? "";
-
-                    var usageKind = (containingNs, containingTypeName, method.Name) switch
-                    {
-                        ("System", "Type", "GetType") => "Type.GetType",
-                        ("System", "Activator", "CreateInstance") => "Activator.CreateInstance",
-                        ("System.Reflection", "Assembly", "GetType") => "Assembly.GetType",
-                        ("System.Reflection", "Assembly", "Load") => "Assembly.Load",
-                        ("System.Reflection", "Assembly", "LoadFrom") => "Assembly.LoadFrom",
-                        ("System.Reflection", _, "Invoke") => "Reflection.Invoke",
-                        ("System.Reflection", "PropertyInfo", "GetValue") => "PropertyInfo.GetValue",
-                        ("System.Reflection", "PropertyInfo", "SetValue") => "PropertyInfo.SetValue",
-                        ("System.Reflection", "FieldInfo", "GetValue") => "FieldInfo.GetValue",
-                        ("System.Reflection", "FieldInfo", "SetValue") => "FieldInfo.SetValue",
-                        (_, "Type", "GetMethod" or "GetProperty" or "GetField" or "GetMember" or "GetMethods"
-                            or "GetProperties" or "GetFields" or "GetMembers") => $"Type.{method.Name}",
-                        _ => null
-                    };
-
-                    if (usageKind is null) continue;
-
-                    var lineSpan = invocation.GetLocation().GetLineSpan();
-                    var containingMethod = GetContainingMethodName(invocation, semanticModel, ct);
-                    var typeArg = method.TypeArguments.Length > 0
-                        ? method.TypeArguments[0].ToDisplayString()
-                        : null;
-
-                    results.Add(new ReflectionUsageDto(
-                        usageKind,
-                        method.ToDisplayString(),
-                        lineSpan.Path,
-                        lineSpan.StartLinePosition.Line + 1,
-                        lineSpan.StartLinePosition.Character + 1,
-                        containingMethod,
-                        typeArg));
-                }
-
-                // Also check for typeof() expressions
-                var typeofExprs = root.DescendantNodes().OfType<TypeOfExpressionSyntax>();
-                foreach (var typeofExpr in typeofExprs)
-                {
-                    var typeInfo = semanticModel.GetTypeInfo(typeofExpr.Type, ct);
-                    var lineSpan = typeofExpr.GetLocation().GetLineSpan();
-                    var containingMethod = GetContainingMethodName(typeofExpr, semanticModel, ct);
-
-                    results.Add(new ReflectionUsageDto(
-                        "typeof",
-                        "typeof()",
-                        lineSpan.Path,
-                        lineSpan.StartLinePosition.Line + 1,
-                        lineSpan.StartLinePosition.Character + 1,
-                        containingMethod,
-                        typeInfo.Type?.ToDisplayString()));
-                }
+                CollectReflectionInvocations(root, semanticModel, results, ct);
+                CollectTypeofUsages(root, semanticModel, results, ct);
             }
         }
 
         return results;
+    }
+
+    private static void CollectReflectionInvocations(
+        SyntaxNode root, SemanticModel semanticModel, List<ReflectionUsageDto> results, CancellationToken ct)
+    {
+        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(invocation, ct);
+            if (symbolInfo.Symbol is not IMethodSymbol method) continue;
+
+            var usageKind = ClassifyReflectionUsage(method);
+            if (usageKind is null) continue;
+
+            var lineSpan = invocation.GetLocation().GetLineSpan();
+            var containingMethod = GetContainingMethodName(invocation, semanticModel, ct);
+            var typeArg = method.TypeArguments.Length > 0
+                ? method.TypeArguments[0].ToDisplayString()
+                : null;
+
+            results.Add(new ReflectionUsageDto(
+                usageKind,
+                method.ToDisplayString(),
+                lineSpan.Path,
+                lineSpan.StartLinePosition.Line + 1,
+                lineSpan.StartLinePosition.Character + 1,
+                containingMethod,
+                typeArg));
+        }
+    }
+
+    private static string? ClassifyReflectionUsage(IMethodSymbol method)
+    {
+        var containingNs = method.ContainingType?.ContainingNamespace?.ToDisplayString() ?? "";
+        var containingTypeName = method.ContainingType?.Name ?? "";
+
+        return (containingNs, containingTypeName, method.Name) switch
+        {
+            ("System", "Type", "GetType") => "Type.GetType",
+            ("System", "Activator", "CreateInstance") => "Activator.CreateInstance",
+            ("System.Reflection", "Assembly", "GetType") => "Assembly.GetType",
+            ("System.Reflection", "Assembly", "Load") => "Assembly.Load",
+            ("System.Reflection", "Assembly", "LoadFrom") => "Assembly.LoadFrom",
+            ("System.Reflection", _, "Invoke") => "Reflection.Invoke",
+            ("System.Reflection", "PropertyInfo", "GetValue") => "PropertyInfo.GetValue",
+            ("System.Reflection", "PropertyInfo", "SetValue") => "PropertyInfo.SetValue",
+            ("System.Reflection", "FieldInfo", "GetValue") => "FieldInfo.GetValue",
+            ("System.Reflection", "FieldInfo", "SetValue") => "FieldInfo.SetValue",
+            (_, "Type", "GetMethod" or "GetProperty" or "GetField" or "GetMember" or "GetMethods"
+                or "GetProperties" or "GetFields" or "GetMembers") => $"Type.{method.Name}",
+            _ => null
+        };
+    }
+
+    private static void CollectTypeofUsages(
+        SyntaxNode root, SemanticModel semanticModel, List<ReflectionUsageDto> results, CancellationToken ct)
+    {
+        foreach (var typeofExpr in root.DescendantNodes().OfType<TypeOfExpressionSyntax>())
+        {
+            var typeInfo = semanticModel.GetTypeInfo(typeofExpr.Type, ct);
+            var lineSpan = typeofExpr.GetLocation().GetLineSpan();
+            var containingMethod = GetContainingMethodName(typeofExpr, semanticModel, ct);
+
+            results.Add(new ReflectionUsageDto(
+                "typeof",
+                "typeof()",
+                lineSpan.Path,
+                lineSpan.StartLinePosition.Line + 1,
+                lineSpan.StartLinePosition.Character + 1,
+                containingMethod,
+                typeInfo.Type?.ToDisplayString()));
+        }
     }
 
     public async Task<IReadOnlyList<SemanticSearchResultDto>> SemanticSearchAsync(

--- a/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
@@ -44,23 +44,6 @@ public sealed class CompositePreviewStore : ICompositePreviewStore
         _entries.TryRemove(token, out _);
     }
 
-    public void InvalidateAll(string? workspaceId = null)
-    {
-        if (workspaceId is null)
-        {
-            _entries.Clear();
-            return;
-        }
-
-        foreach (var kvp in _entries)
-        {
-            if (string.Equals(kvp.Value.WorkspaceId, workspaceId, StringComparison.Ordinal))
-            {
-                _entries.TryRemove(kvp.Key, out _);
-            }
-        }
-    }
-
     public string? PeekWorkspaceId(string token)
     {
         if (!_entries.TryGetValue(token, out var entry))

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
@@ -44,23 +44,6 @@ public sealed class ProjectMutationPreviewStore : IProjectMutationPreviewStore
         _entries.TryRemove(token, out _);
     }
 
-    public void InvalidateAll(string? workspaceId = null)
-    {
-        if (workspaceId is null)
-        {
-            _entries.Clear();
-            return;
-        }
-
-        foreach (var kvp in _entries)
-        {
-            if (string.Equals(kvp.Value.WorkspaceId, workspaceId, StringComparison.Ordinal))
-            {
-                _entries.TryRemove(kvp.Key, out _);
-            }
-        }
-    }
-
     public string? PeekWorkspaceId(string token)
     {
         if (!_entries.TryGetValue(token, out var entry))

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -8,7 +8,7 @@ namespace RoslynMcp.Roslyn.Services;
 /// (e.g., multiple MCP sub-agents) cannot corrupt shared Roslyn state.
 /// </summary>
 /// <remarks>
-/// A dedicated load gate (<see cref="LoadGateKey"/>) is used for <c>workspace_load</c> and
+/// A dedicated load gate (<see cref="IWorkspaceExecutionGate.LoadGateKey"/>) is used for <c>workspace_load</c> and
 /// <c>workspace_reload</c> operations because those operations replace the entire session state.
 /// All other operations run under a per-workspace gate keyed by the workspace session identifier.
 /// A global concurrency throttle bounds the total number of simultaneous operations across all
@@ -17,8 +17,6 @@ namespace RoslynMcp.Roslyn.Services;
 /// </remarks>
 public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposable
 {
-    public const string LoadGateKey = "__load__";
-
     /// <summary>Default per-request timeout (2 minutes).</summary>
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
 
@@ -31,8 +29,8 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
 
     public async Task<T> RunAsync<T>(string? gateKey, Func<CancellationToken, Task<T>> action, CancellationToken ct)
     {
-        var key = string.IsNullOrWhiteSpace(gateKey) ? LoadGateKey : gateKey;
-        var gate = key == LoadGateKey ? _loadGate : _workspaceGates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+        var key = string.IsNullOrWhiteSpace(gateKey) ? IWorkspaceExecutionGate.LoadGateKey : gateKey;
+        var gate = key == IWorkspaceExecutionGate.LoadGateKey ? _loadGate : _workspaceGates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
 
         // Apply per-request timeout and global concurrency throttle
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);


### PR DESCRIPTION
## Summary
- **Layer boundary fix**: Moved `LoadGateKey` constant and `RemoveGate()` method from concrete `WorkspaceExecutionGate` to the `IWorkspaceExecutionGate` interface, eliminating the only real Host→Roslyn layer violation. Removed 12 unnecessary `using RoslynMcp.Roslyn.Services` directives from Host.Stdio.Tools.
- **Dead code removal**: Removed unused `InvalidateAll` from `ICompositePreviewStore` and `IProjectMutationPreviewStore` (interfaces + implementations).
- **Complexity reduction**: Decomposed `FindReflectionUsagesAsync` (CC 25→~8) and `PreviewBulkReplaceTypeAsync` (CC 18→~8) by extracting focused helper methods.

## Test plan
- [x] `dotnet build` — 0 errors, 0 new warnings
- [x] `dotnet test` — 121/121 tests pass
- [ ] Verify MCP tools still function correctly via integration testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)