### PR TITLE
fix: find_unused_symbols false positives for extension methods and implicit-conversion overloads

### DIFF
--- a/samples/SampleSolution/SampleApp/Program.cs
+++ b/samples/SampleSolution/SampleApp/Program.cs
@@ -8,6 +8,15 @@ service.MakeThemSpeak(animals);
 var count = service.CountAnimals(animals);
 Console.WriteLine($"Total animals: {count}");
 
+// Calls extension method via obj.Method() syntax (reduced extension method)
+var description = animals.First().Describe();
+Console.WriteLine(description);
+
+// Calls CountAnimals(IEnumerable<IAnimal>) via implicit conversion from IAnimal[] -> IEnumerable<IAnimal>
+IAnimal[] animalArray = animals.ToArray();
+var arrayCount = service.CountAnimals(animalArray);
+Console.WriteLine($"Array count: {arrayCount}");
+
 var shapes = new List<Shape>
 {
     new Circle(5.0),

--- a/samples/SampleSolution/SampleLib/AnimalExtensions.cs
+++ b/samples/SampleSolution/SampleLib/AnimalExtensions.cs
@@ -1,0 +1,9 @@
+namespace SampleLib;
+
+public static class AnimalExtensions
+{
+    public static string Describe(this IAnimal animal)
+    {
+        return $"{animal.Name}: {animal.Speak()}";
+    }
+}

--- a/samples/SampleSolution/SampleLib/AnimalService.cs
+++ b/samples/SampleSolution/SampleLib/AnimalService.cs
@@ -26,4 +26,14 @@ public class AnimalService
     {
         return animals.Count;
     }
+
+    public int CountAnimals(IEnumerable<IAnimal> animals)
+    {
+        var count = 0;
+        foreach (var _ in animals)
+        {
+            count++;
+        }
+        return count;
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -76,8 +76,25 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                     // Skip entry points
                     if (symbol is IMethodSymbol { Name: "Main" } && symbol.IsStatic) continue;
 
+                    // Skip static classes that contain extension methods — they are
+                    // accessed implicitly through their members, not by direct reference.
+                    if (symbol is INamedTypeSymbol { IsStatic: true } staticType &&
+                        staticType.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsExtensionMethod))
+                        continue;
+
                     var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
                     var refCount = refs.Sum(r => r.Locations.Count());
+
+                    // Fallback: cross-compilation re-resolution for symbols prone to
+                    // identity mismatches (extension methods, overloaded methods resolved
+                    // via implicit conversion). The project-local symbol from
+                    // GetDeclaredSymbol may not match the reduced/converted form that
+                    // callers bind to in other compilations.
+                    if (refCount == 0 && NeedsCrossCompilationCheck(symbol))
+                    {
+                        refCount = await CountCrossCompilationReferencesAsync(
+                            symbol, project, solution, ct).ConfigureAwait(false);
+                    }
 
                     if (refCount == 0)
                     {
@@ -99,5 +116,107 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Determines whether a symbol is susceptible to cross-compilation identity
+    /// mismatches that cause <see cref="SymbolFinder.FindReferencesAsync"/> to miss
+    /// references when the symbol comes from the declaring project's compilation.
+    /// </summary>
+    private static bool NeedsCrossCompilationCheck(ISymbol symbol)
+    {
+        if (symbol is IMethodSymbol method)
+        {
+            // Extension methods: call sites bind to ReducedExtensionMethod which
+            // may not map back to the original definition across compilations.
+            if (method.IsExtensionMethod)
+                return true;
+
+            // Overloaded methods: when callers resolve via implicit conversion
+            // (e.g. List<T> → IEnumerable<T>), the bound symbol in the caller's
+            // compilation may have a different identity than the declaring symbol.
+            if (method.ContainingType is not null &&
+                method.ContainingType.GetMembers(method.Name)
+                    .OfType<IMethodSymbol>()
+                    .Count(m => m.MethodKind == MethodKind.Ordinary) > 1)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Re-resolves a symbol through dependent projects' compilations and checks for
+    /// references from each. Returns the total reference count found, or 0 if none.
+    /// </summary>
+    private static async Task<int> CountCrossCompilationReferencesAsync(
+        ISymbol symbol, Project declaringProject, Solution solution, CancellationToken ct)
+    {
+        var containingType = symbol.ContainingType;
+        if (containingType is null) return 0;
+
+        var metadataName = containingType.ToDisplayString();
+
+        foreach (var project in solution.Projects)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            // Skip the declaring project — we already checked it.
+            if (project.Id == declaringProject.Id) continue;
+
+            // Only check projects that could reference the declaring project.
+            if (!project.ProjectReferences.Any(r => r.ProjectId == declaringProject.Id))
+                continue;
+
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            var resolvedType = compilation.GetTypeByMetadataName(metadataName);
+            if (resolvedType is null) continue;
+
+            // Find the equivalent member in this compilation's type.
+            var resolvedMember = FindMatchingMember(resolvedType, symbol);
+            if (resolvedMember is null) continue;
+
+            var refs = await SymbolFinder.FindReferencesAsync(resolvedMember, solution, ct).ConfigureAwait(false);
+            var count = refs.Sum(r => r.Locations.Count());
+            if (count > 0) return count;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Finds a member in <paramref name="type"/> that matches <paramref name="original"/>
+    /// by name, kind, and parameter signature.
+    /// </summary>
+    private static ISymbol? FindMatchingMember(INamedTypeSymbol type, ISymbol original)
+    {
+        var candidates = type.GetMembers(original.Name);
+
+        if (original is not IMethodSymbol originalMethod)
+            return candidates.FirstOrDefault(c => c.Kind == original.Kind);
+
+        foreach (var candidate in candidates.OfType<IMethodSymbol>())
+        {
+            if (candidate.Parameters.Length != originalMethod.Parameters.Length)
+                continue;
+
+            var match = true;
+            for (var i = 0; i < candidate.Parameters.Length; i++)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(
+                        candidate.Parameters[i].Type.OriginalDefinition,
+                        originalMethod.Parameters[i].Type.OriginalDefinition))
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match) return candidate;
+        }
+
+        return null;
     }
 }

--- a/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
@@ -55,4 +55,38 @@ public sealed class DeadCodeIntegrationTests : TestBase
             DeleteDirectoryIfExists(copiedRoot);
         }
     }
+
+    [TestMethod]
+    public async Task Extension_Method_With_Callers_Not_Reported_As_Unused()
+    {
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        var workspaceId = status.WorkspaceId;
+
+        var unusedSymbols = await UnusedCodeAnalyzer.FindUnusedSymbolsAsync(
+            workspaceId, "SampleLib", includePublic: true, limit: 200, CancellationToken.None);
+
+        var unusedNames = unusedSymbols.Select(s => s.SymbolName).ToHashSet();
+
+        Assert.IsFalse(unusedNames.Contains("Describe"),
+            "Extension method 'Describe' should not be reported as unused — it is called from SampleApp via obj.Describe() syntax.");
+        Assert.IsFalse(unusedNames.Contains("AnimalExtensions"),
+            "Static class 'AnimalExtensions' should not be reported as unused — its extension method is called from SampleApp.");
+    }
+
+    [TestMethod]
+    public async Task Implicit_Conversion_Overload_With_Callers_Not_Reported_As_Unused()
+    {
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        var workspaceId = status.WorkspaceId;
+
+        var unusedSymbols = await UnusedCodeAnalyzer.FindUnusedSymbolsAsync(
+            workspaceId, "SampleLib", includePublic: true, limit: 200, CancellationToken.None);
+
+        // The IEnumerable<IAnimal> overload of CountAnimals is called from SampleApp
+        // with an IAnimal[] argument (implicit conversion). It should not be reported as unused.
+        var unusedCountAnimals = unusedSymbols.Where(s => s.SymbolName == "CountAnimals").ToList();
+
+        Assert.AreEqual(0, unusedCountAnimals.Count,
+            $"CountAnimals overload(s) should not be reported as unused. Found: {string.Join(", ", unusedCountAnimals.Select(s => $"{s.ContainingType}.{s.SymbolName}"))}");
+    }
 }


### PR DESCRIPTION
## Summary
- **Cross-compilation fallback**: When `FindReferencesAsync` returns 0 for an extension method or overloaded method, re-resolve the symbol through dependent projects' compilations and retry. This handles the identity mismatch between project-local `GetDeclaredSymbol` symbols and the reduced/converted forms callers bind to in other compilations.
- **Extension class exclusion**: Static classes containing extension methods are skipped (they're accessed implicitly through their members, not by direct reference).
- **Regression tests**: Two new integration tests covering both bug scenarios, plus sample fixtures (`AnimalExtensions.cs`, `CountAnimals(IEnumerable<IAnimal>)` overload).

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 123/123 pass (121 existing + 2 new)
- [ ] Load a workspace with extension methods via MCP and verify `find_unused_symbols` no longer reports them

🤖 Generated with [Claude Code](https://claude.com/claude-code)