### PR TITLE
chore: post-1.0 quality sweep — security, performance, maintainability

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -10,15 +10,9 @@ Last audit: 2026-03-26. All pre-1.0 items resolved.
 
 - [ ] **REL-07**: Add CI badge to README.
 - [ ] **REL-09**: Document cross-platform limitations.
-- [ ] **CODE-01**: Extract shared `JsonSerializerOptions` — duplicated `new() { WriteIndented = true }` in 14+ tool classes.
-- [ ] **CODE-02**: Fix triple `GetSummary()` call in `server_info`. (`ServerTools.cs:36-53`)
-- [ ] **CODE-03**: Extract `ProjectMetadataReader` from `WorkspaceManager` static helpers. (`WorkspaceManager.cs:356-415`)
-- [ ] **CODE-04**: Generalize `PreviewStore`/`CompositePreviewStore` with `BoundedStore<T>` base class — nearly identical TTL/eviction logic.
 - [ ] **API-05**: Consider promoting `test_coverage` to stable — functionally complete, uses standard `coverlet.collector`.
 - [ ] **API-06**: Consider adding `undo`/`revert_last_apply` capability.
-- [ ] **PERF-04**: Make `DotnetCommandRunner.OutputLimit` (12000 chars) configurable for verbose build output.
 - [ ] **TEST-03**: Add performance baseline tests for large solutions.
-- [ ] **TEST-04**: Clean up temp directories in test infrastructure — add `[AssemblyCleanup]` handler.
 
 ---
 

--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -10,7 +10,6 @@ namespace RoslynMcp.Host.Stdio.Prompts;
 [McpServerPromptType]
 public static class RoslynPrompts
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerPrompt(Name = "explain_error")]
     [Description("Generate a prompt to explain a compiler diagnostic error and suggest fixes")]
@@ -43,7 +42,7 @@ public static class RoslynPrompts
                 }));
             }
 
-            var detailsJson = JsonSerializer.Serialize(details, JsonOptions);
+            var detailsJson = JsonSerializer.Serialize(details, JsonDefaults.Indented);
 
             return
             [
@@ -103,7 +102,7 @@ public static class RoslynPrompts
                 return [CreatePromptMessage($"File not found in workspace: {filePath}")];
 
             var symbols = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
-            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonOptions);
+            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonDefaults.Indented);
 
             string codeSection;
             if (startLine.HasValue && endLine.HasValue)
@@ -173,8 +172,8 @@ public static class RoslynPrompts
             var symbols = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, ct).ConfigureAwait(false);
             var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, filePath, null, ct).ConfigureAwait(false);
 
-            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonOptions);
-            var diagnosticsSummary = JsonSerializer.Serialize(diagnostics, JsonOptions);
+            var symbolsSummary = JsonSerializer.Serialize(symbols, JsonDefaults.Indented);
+            var diagnosticsSummary = JsonSerializer.Serialize(diagnostics, JsonDefaults.Indented);
 
             return
             [
@@ -229,19 +228,19 @@ public static class RoslynPrompts
         try
         {
             var graph = workspace.GetProjectGraph(workspaceId);
-            var graphJson = SerializeTruncatedList(graph.Projects, 50, JsonOptions);
+            var graphJson = SerializeTruncatedList(graph.Projects, 50, JsonDefaults.Indented);
 
             var namespaceDeps = await dependencyAnalysisService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
             var truncatedNamespaceDeps = new Core.Models.NamespaceDependencyGraphDto(
                 namespaceDeps.Nodes.Take(100).ToList(),
                 namespaceDeps.Edges.Take(100).ToList(),
                 namespaceDeps.CircularDependencies);
-            var namespaceDepsJson = JsonSerializer.Serialize(truncatedNamespaceDeps, JsonOptions);
+            var namespaceDepsJson = JsonSerializer.Serialize(truncatedNamespaceDeps, JsonDefaults.Indented);
             if (namespaceDeps.Edges.Count > 100)
                 namespaceDepsJson += $"\n[Showing 100 of {namespaceDeps.Edges.Count} edges]";
 
             var nugetDeps = await dependencyAnalysisService.GetNuGetDependenciesAsync(workspaceId, ct).ConfigureAwait(false);
-            var nugetDepsJson = SerializeTruncatedList(nugetDeps.Packages, 50, JsonOptions);
+            var nugetDepsJson = SerializeTruncatedList(nugetDeps.Packages, 50, JsonDefaults.Indented);
 
             return
             [
@@ -291,7 +290,7 @@ public static class RoslynPrompts
         try
         {
             var testResult = await testRunnerService.RunTestsAsync(workspaceId, projectName, filter, ct).ConfigureAwait(false);
-            var testResultJson = JsonSerializer.Serialize(testResult, JsonOptions);
+            var testResultJson = JsonSerializer.Serialize(testResult, JsonDefaults.Indented);
 
             var failureSummary = testResult.Failures.Count > 0
                 ? string.Join("\n", testResult.Failures.Select((f, i) =>
@@ -517,12 +516,12 @@ public static class RoslynPrompts
 
                     **Document Symbols:**
                     ```json
-                    {JsonSerializer.Serialize(documentSymbols, JsonOptions)}
+                    {JsonSerializer.Serialize(documentSymbols, JsonDefaults.Indented)}
                     ```
 
                     **Project Graph:**
                     ```json
-                    {JsonSerializer.Serialize(projectGraph, JsonOptions)}
+                    {JsonSerializer.Serialize(projectGraph, JsonDefaults.Indented)}
                     ```
 
                     Use this workflow:
@@ -726,7 +725,7 @@ public static class RoslynPrompts
             var perProject = Math.Max(1, 200 / Math.Max(1, discovered.TestProjects.Count));
             var truncatedProjects = discovered.TestProjects.Select(p =>
                 new Core.Models.TestProjectDto(p.ProjectName, p.ProjectFilePath, p.Tests.Take(perProject).ToList())).ToList();
-            var discoveredJson = JsonSerializer.Serialize(new Core.Models.TestDiscoveryDto(truncatedProjects), JsonOptions);
+            var discoveredJson = JsonSerializer.Serialize(new Core.Models.TestDiscoveryDto(truncatedProjects), JsonDefaults.Indented);
             if (totalTests > 200)
                 discoveredJson += $"\n[Showing ~200 of {totalTests} test cases]";
 
@@ -777,7 +776,7 @@ public static class RoslynPrompts
         try
         {
             var metrics = await codeMetricsService.GetComplexityMetricsAsync(workspaceId, filePath: null, projectFilter: projectName, minComplexity: 5, limit: 50, ct).ConfigureAwait(false);
-            var metricsJson = JsonSerializer.Serialize(metrics, JsonOptions);
+            var metricsJson = JsonSerializer.Serialize(metrics, JsonDefaults.Indented);
 
             return
             [
@@ -826,7 +825,7 @@ public static class RoslynPrompts
         {
             var metrics = await cohesionAnalysisService.GetCohesionMetricsAsync(
                 workspaceId, filePath: null, projectFilter: projectName, minMethods: 3, limit: 20, ct).ConfigureAwait(false);
-            var metricsJson = JsonSerializer.Serialize(metrics, JsonOptions);
+            var metricsJson = JsonSerializer.Serialize(metrics, JsonDefaults.Indented);
 
             return
             [
@@ -883,7 +882,7 @@ public static class RoslynPrompts
             var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, ct).ConfigureAwait(false);
             if (result is null) return [CreatePromptMessage("No symbol found at the specified location.")];
 
-            var resultJson = SerializeTruncatedList(result.Consumers, 50, JsonOptions);
+            var resultJson = SerializeTruncatedList(result.Consumers, 50, JsonDefaults.Indented);
 
             return
             [

--- a/src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs
@@ -8,12 +8,11 @@ namespace RoslynMcp.Host.Stdio.Resources;
 [McpServerResourceType]
 public static class ServerResources
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerResource(UriTemplate = "roslyn://server/catalog", Name = "server_catalog", MimeType = "application/json")]
     [Description("Machine-readable catalog of tools, resources, prompts, support tiers, and product boundaries.")]
     public static string GetServerCatalog()
     {
-        return JsonSerializer.Serialize(ServerSurfaceCatalog.CreateDocument(), JsonOptions);
+        return JsonSerializer.Serialize(ServerSurfaceCatalog.CreateDocument(), JsonDefaults.Indented);
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Resources;
 [McpServerResourceType]
 public static class WorkspaceResources
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerResource(UriTemplate = "roslyn://workspaces", Name = "workspaces", MimeType = "application/json")]
     [Description("List all currently loaded workspace sessions with their status")]
@@ -18,7 +17,7 @@ public static class WorkspaceResources
         try
         {
             var workspaces = workspace.ListWorkspaces();
-            return JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonOptions);
+            return JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonDefaults.Indented);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
         catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
@@ -33,7 +32,7 @@ public static class WorkspaceResources
         try
         {
             var status = workspace.GetStatus(workspaceId);
-            return JsonSerializer.Serialize(status, JsonOptions);
+            return JsonSerializer.Serialize(status, JsonDefaults.Indented);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
         catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
@@ -48,7 +47,7 @@ public static class WorkspaceResources
         try
         {
             var graph = workspace.GetProjectGraph(workspaceId);
-            return JsonSerializer.Serialize(graph, JsonOptions);
+            return JsonSerializer.Serialize(graph, JsonDefaults.Indented);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
         catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
@@ -64,7 +63,7 @@ public static class WorkspaceResources
         try
         {
             var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, null, null, ct).ConfigureAwait(false);
-            return JsonSerializer.Serialize(diagnostics, JsonOptions);
+            return JsonSerializer.Serialize(diagnostics, JsonDefaults.Indented);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
         catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class AdvancedAnalysisTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "find_unused_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Find symbols (types, methods, properties, fields) with zero references across the solution — helps identify dead code")]
@@ -25,7 +24,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await unusedCodeAnalyzer.FindUnusedSymbolsAsync(workspaceId, project, includePublic, limit, c);
-                return JsonSerializer.Serialize(new { count = results.Count, unusedSymbols = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, unusedSymbols = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -42,7 +41,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await dependencyAnalysisService.GetDiRegistrationsAsync(workspaceId, project, c);
-                return JsonSerializer.Serialize(new { count = results.Count, registrations = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, registrations = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -62,7 +61,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await codeMetricsService.GetComplexityMetricsAsync(workspaceId, filePath, project, minComplexity, limit, c);
-                return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -81,7 +80,7 @@ public static class AdvancedAnalysisTools
                 var results = await codePatternAnalyzer.FindReflectionUsagesAsync(workspaceId, project, c);
                 var grouped = results.GroupBy(r => r.UsageKind)
                     .ToDictionary(g => g.Key, g => g.ToList());
-                return JsonSerializer.Serialize(new { count = results.Count, usagesByKind = grouped }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, usagesByKind = grouped }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -98,7 +97,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await dependencyAnalysisService.GetNamespaceDependenciesAsync(workspaceId, project, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -114,7 +113,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await dependencyAnalysisService.GetNuGetDependenciesAsync(workspaceId, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -133,7 +132,7 @@ public static class AdvancedAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await codePatternAnalyzer.SemanticSearchAsync(workspaceId, query, project, limit, c);
-                return JsonSerializer.Serialize(new { count = results.Count, results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, results }, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -3,13 +3,13 @@ using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
 [McpServerToolType]
 public static class AnalysisTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "project_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get compiler diagnostics (errors, warnings) for the workspace, optionally filtered by project, file, or severity")]
     public static Task<string> GetProjectDiagnostics(
@@ -25,12 +25,13 @@ public static class AnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await diagnosticService.GetDiagnosticsAsync(workspaceId, project, file, severity, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
     [McpServerTool(Name = "diagnostic_details", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get detailed information and curated fix options for a specific diagnostic occurrence")]
     public static Task<string> GetDiagnosticDetails(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -43,8 +44,9 @@ public static class AnalysisTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -64,7 +66,7 @@ public static class AnalysisTools
             {
                 var result = await symbolRelationshipService.GetTypeHierarchyAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
                 if (result is null) throw new KeyNotFoundException("No type found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -84,7 +86,7 @@ public static class AnalysisTools
             {
                 var result = await symbolRelationshipService.GetCallersCalleesAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
                 if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -104,7 +106,7 @@ public static class AnalysisTools
             {
                 var result = await mutationAnalysisService.AnalyzeImpactAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), c);
                 if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -125,7 +127,7 @@ public static class AnalysisTools
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle);
                 var result = await mutationAnalysisService.FindTypeMutationsAsync(workspaceId, locator, c);
                 if (result is null) throw new KeyNotFoundException("No named type found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -149,7 +151,7 @@ public static class AnalysisTools
                 var grouped = results
                     .GroupBy(u => u.Classification.ToString())
                     .ToDictionary(g => g.Key, g => g.ToList());
-                return JsonSerializer.Serialize(new { count = results.Count, usagesByClassification = grouped }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, usagesByClassification = grouped }, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class BulkRefactoringTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "bulk_replace_type_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Preview replacing all references to one type with another across the solution. Useful after extracting an interface to update all consumers. Scope can be 'parameters', 'fields', or 'all'.")]
@@ -25,7 +24,7 @@ public static class BulkRefactoringTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await bulkRefactoringService.PreviewBulkReplaceTypeAsync(workspaceId, oldTypeName, newTypeName, scope, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -43,7 +42,7 @@ public static class BulkRefactoringTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class CodeActionTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "get_code_actions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get available Roslyn code fixes and refactorings at a position or selection range in a source file")]
     public static Task<string> GetCodeActions(
@@ -26,7 +25,7 @@ public static class CodeActionTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await codeActionService.GetCodeActionsAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, c);
-                return JsonSerializer.Serialize(new { count = results.Count, actions = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, actions = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -47,7 +46,7 @@ public static class CodeActionTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await codeActionService.PreviewCodeActionAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, actionIndex, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -64,7 +63,7 @@ public static class CodeActionTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/CohesionAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CohesionAnalysisTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class CohesionAnalysisTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "get_cohesion_metrics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Measure type cohesion via LCOM4 metrics. Identifies independent method clusters that share no state — a score > 1 suggests the type has multiple responsibilities and should be split.")]
@@ -26,7 +25,7 @@ public static class CohesionAnalysisTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await cohesionAnalysisService.GetCohesionMetricsAsync(workspaceId, filePath, project, minMethods, limit, c);
-                return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -47,7 +46,7 @@ public static class CohesionAnalysisTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle);
                 var results = await cohesionAnalysisService.FindSharedMembersAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(new { count = results.Count, sharedMembers = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, sharedMembers = results }, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ConsumerAnalysisTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "find_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument)")]
@@ -29,7 +28,7 @@ public static class ConsumerAnalysisTools
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, c);
                 if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class CrossProjectRefactoringTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "move_type_to_project_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview moving a C# type declaration into another project in the loaded workspace.")]
@@ -32,7 +31,7 @@ public static class CrossProjectRefactoringTools
                     targetProjectName,
                     targetNamespace,
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -58,7 +57,7 @@ public static class CrossProjectRefactoringTools
                     interfaceName,
                     targetProjectName,
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -84,7 +83,7 @@ public static class CrossProjectRefactoringTools
                     interfaceName,
                     interfaceProjectName,
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class DeadCodeTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "remove_dead_code_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview removing unused symbols by symbol handle, optionally deleting files left empty by the removal.")]
@@ -28,7 +27,7 @@ public static class DeadCodeTools
                     workspaceId,
                     new DeadCodeRemovalDto(symbolHandles, removeEmptyFiles),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -46,7 +45,7 @@ public static class DeadCodeTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class EditTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "apply_text_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned.")]
@@ -27,7 +26,7 @@ public static class EditTools
             {
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await editService.ApplyTextEditsAsync(workspaceId, filePath, edits, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class FileOperationTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "create_file_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview creating a new source file inside a loaded workspace project. Returns the file diff and a preview token.")]
@@ -28,7 +27,7 @@ public static class FileOperationTools
             {
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await fileOperationService.PreviewCreateFileAsync(workspaceId, new CreateFileDto(projectName, filePath, content), c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -46,7 +45,7 @@ public static class FileOperationTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -65,7 +64,7 @@ public static class FileOperationTools
             {
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await fileOperationService.PreviewDeleteFileAsync(workspaceId, new DeleteFileDto(filePath), c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -83,7 +82,7 @@ public static class FileOperationTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -109,7 +108,7 @@ public static class FileOperationTools
                     workspaceId,
                     new MoveFileDto(sourceFilePath, destinationFilePath, destinationProjectName, updateNamespace),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -127,7 +126,7 @@ public static class FileOperationTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class InterfaceExtractionTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "extract_interface_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Preview extracting an interface from a concrete type. Creates a new interface file with selected member signatures, adds it to the type's base list, and optionally replaces concrete type references with the interface.")]
@@ -28,7 +27,7 @@ public static class InterfaceExtractionTools
             {
                 var result = await interfaceExtractionService.PreviewExtractInterfaceAsync(
                     workspaceId, filePath, typeName, interfaceName, memberNames, replaceUsages, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -46,7 +45,7 @@ public static class InterfaceExtractionTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/JsonDefaults.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/JsonDefaults.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace RoslynMcp.Host.Stdio;
+
+internal static class JsonDefaults
+{
+    public static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class MultiFileEditTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "apply_multi_file_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      Description("Apply text edits to multiple files in the workspace sequentially. Each file's edits are applied independently.")]
@@ -33,7 +32,7 @@ public static class MultiFileEditTools
                     results.Add(new FileEditSummaryDto(fileEdit.FilePath, result.EditsApplied, diff));
                 }
                 var dto = new MultiFileEditResultDto(true, results.Count, results);
-                return JsonSerializer.Serialize(dto, JsonOptions);
+                return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class OrchestrationTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "migrate_package_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview migrating one package dependency to another across all affected projects in the loaded workspace.")]
@@ -25,7 +24,7 @@ public static class OrchestrationTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await orchestrationService.PreviewMigratePackageAsync(workspaceId, oldPackageId, newPackageId, newVersion, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -45,7 +44,7 @@ public static class OrchestrationTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await orchestrationService.PreviewSplitClassAsync(workspaceId, filePath, typeName, memberNames, newFileName, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -73,7 +72,7 @@ public static class OrchestrationTools
                     targetProjectName,
                     updateDiRegistrations,
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -92,7 +91,7 @@ public static class OrchestrationTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await orchestrationService.ApplyCompositeAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ProjectMutationTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "add_package_reference_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview adding a PackageReference to a project file in the loaded workspace.")]
@@ -29,7 +28,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new AddPackageReferenceDto(projectName, packageId, version),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -50,7 +49,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new RemovePackageReferenceDto(projectName, packageId),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -71,7 +70,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new AddProjectReferenceDto(projectName, referencedProjectName),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -92,7 +91,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new RemoveProjectReferenceDto(projectName, referencedProjectName),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -114,7 +113,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new SetProjectPropertyDto(projectName, propertyName, value),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -135,7 +134,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new AddTargetFrameworkDto(projectName, targetFramework),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -156,7 +155,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new RemoveTargetFrameworkDto(projectName, targetFramework),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -179,7 +178,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new SetConditionalPropertyDto(projectName, propertyName, value, condition),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -200,7 +199,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new AddCentralPackageVersionDto(packageId, version),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -220,7 +219,7 @@ public static class ProjectMutationTools
                     workspaceId,
                     new RemoveCentralPackageVersionDto(packageId),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -239,7 +238,7 @@ public static class ProjectMutationTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await projectMutationService.ApplyProjectMutationAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class RefactoringTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "rename_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview a rename refactoring: shows all files and changes that would result from renaming a symbol")]
     public static Task<string> PreviewRename(
@@ -26,7 +25,7 @@ public static class RefactoringTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await refactoringService.PreviewRenameAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle), newName, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -43,7 +42,7 @@ public static class RefactoringTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -59,7 +58,7 @@ public static class RefactoringTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await refactoringService.PreviewOrganizeUsingsAsync(workspaceId, filePath, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -76,7 +75,7 @@ public static class RefactoringTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -92,7 +91,7 @@ public static class RefactoringTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await refactoringService.PreviewFormatDocumentAsync(workspaceId, filePath, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -109,7 +108,7 @@ public static class RefactoringTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -129,7 +128,7 @@ public static class RefactoringTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await refactoringService.PreviewCodeFixAsync(workspaceId, diagnosticId, filePath, line, column, fixId, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -146,7 +145,7 @@ public static class RefactoringTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ScaffoldingTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "scaffold_type_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Preview scaffolding a new type file in a project.")]
@@ -31,7 +30,7 @@ public static class ScaffoldingTools
                     workspaceId,
                     new ScaffoldTypeDto(projectName, typeName, typeKind, @namespace, baseType),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -49,7 +48,7 @@ public static class ScaffoldingTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -71,7 +70,7 @@ public static class ScaffoldingTools
                     workspaceId,
                     new ScaffoldTestDto(testProjectName, targetTypeName, targetMethodName),
                     c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -89,7 +88,7 @@ public static class ScaffoldingTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class SecurityTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "security_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get security-relevant diagnostics with OWASP categorization, severity classification, and fix hints. Filters the existing diagnostic pipeline to return only security findings.")]
     public static Task<string> GetSecurityDiagnostics(
@@ -23,7 +22,7 @@ public static class SecurityTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await securityService.GetSecurityDiagnosticsAsync(workspaceId, project, file, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -38,7 +37,7 @@ public static class SecurityTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await securityService.GetAnalyzerStatusAsync(workspaceId, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -10,7 +10,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ServerTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "server_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Get server version, capabilities, runtime information, and loaded workspace count")]
@@ -23,6 +22,7 @@ public static class ServerTools
             var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                           ?? assembly.GetName().Version?.ToString() ?? "unknown";
 
+            var catalogSummary = ServerSurfaceCatalog.GetSummary();
             var info = new
             {
                 server = "roslyn-mcp",
@@ -37,18 +37,18 @@ public static class ServerTools
                 {
                     tools = new
                     {
-                        stable = ServerSurfaceCatalog.GetSummary().StableTools,
-                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalTools
+                        stable = catalogSummary.StableTools,
+                        experimental = catalogSummary.ExperimentalTools
                     },
                     resources = new
                     {
-                        stable = ServerSurfaceCatalog.GetSummary().StableResources,
-                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalResources
+                        stable = catalogSummary.StableResources,
+                        experimental = catalogSummary.ExperimentalResources
                     },
                     prompts = new
                     {
-                        stable = ServerSurfaceCatalog.GetSummary().StablePrompts,
-                        experimental = ServerSurfaceCatalog.GetSummary().ExperimentalPrompts
+                        stable = catalogSummary.StablePrompts,
+                        experimental = catalogSummary.ExperimentalPrompts
                     }
                 },
                 productBoundaries = new[]
@@ -67,7 +67,7 @@ public static class ServerTools
                 }
             };
 
-            return Task.FromResult(JsonSerializer.Serialize(info, JsonOptions));
+            return Task.FromResult(JsonSerializer.Serialize(info, JsonDefaults.Indented));
         });
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -3,13 +3,13 @@ using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
 [McpServerToolType]
 public static class SymbolTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace")]
     public static Task<string> SearchSymbols(
@@ -27,7 +27,7 @@ public static class SymbolTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await symbolSearchService.SearchSymbolsAsync(workspaceId, query, project, kind, @namespace, limit, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -49,7 +49,7 @@ public static class SymbolTools
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolSearchService.GetSymbolInfoAsync(workspaceId, locator, c);
                 if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -70,7 +70,7 @@ public static class SymbolTools
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolNavigationService.GoToDefinitionAsync(workspaceId, locator, c);
                 if (results.Count == 0) throw new KeyNotFoundException("No definition found for the symbol at the specified location");
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -90,7 +90,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await referenceService.FindReferencesAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(new { count = results.Count, references = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, references = results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -110,12 +110,13 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await referenceService.FindImplementationsAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(new { count = results.Count, implementations = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, implementations = results }, JsonDefaults.Indented);
             }, ct));
     }
 
     [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree")]
     public static Task<string> GetDocumentSymbols(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ISymbolSearchService symbolSearchService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -125,8 +126,9 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var results = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -146,7 +148,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await referenceService.FindOverridesAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -166,7 +168,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await referenceService.FindBaseMembersAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -186,7 +188,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var result = await symbolRelationshipService.GetMemberHierarchyAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -207,7 +209,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolRelationshipService.GetSignatureHelpAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -228,7 +230,7 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
                 var result = await symbolRelationshipService.GetSymbolRelationshipsAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -245,7 +247,7 @@ public static class SymbolTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var results = await referenceService.FindReferencesBulkAsync(workspaceId, symbols, includeDefinition, c);
-                return JsonSerializer.Serialize(new { count = results.Count, results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, results }, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -265,12 +267,13 @@ public static class SymbolTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await mutationAnalysisService.FindPropertyWritesAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(new { count = results.Count, writes = results }, JsonOptions);
+                return JsonSerializer.Serialize(new { count = results.Count, writes = results }, JsonDefaults.Indented);
             }, ct));
     }
 
     [McpServerTool(Name = "enclosing_symbol", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the enclosing symbol (method, property, type) at a given file position — useful for understanding the context of a cursor position")]
     public static Task<string> GetEnclosingSymbol(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ISymbolNavigationService symbolNavigationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -282,9 +285,10 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await symbolNavigationService.GetEnclosingSymbolAsync(workspaceId, filePath, line, column, c);
                 if (result is null) throw new KeyNotFoundException("No enclosing symbol found at the specified location");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -305,12 +309,13 @@ public static class SymbolTools
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName: null);
                 var results = await symbolNavigationService.GoToTypeDefinitionAsync(workspaceId, locator, c);
                 if (results.Count == 0) throw new KeyNotFoundException("No type definition found for the symbol at the specified location");
-                return JsonSerializer.Serialize(results, JsonOptions);
+                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
             }, ct));
     }
 
     [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file")]
     public static Task<string> GetCompletions(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ICompletionService completionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -322,8 +327,9 @@ public static class SymbolTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await completionService.GetCompletionsAsync(workspaceId, filePath, line, column, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
@@ -2,17 +2,18 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
 [McpServerToolType]
 public static class SyntaxTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "get_syntax_tree", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Get the syntax tree (AST) for a source file or a specific line range. Returns a hierarchical tree of syntax nodes with their kinds and positions.")]
     public static Task<string> GetSyntaxTree(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ISyntaxService syntaxService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -25,9 +26,10 @@ public static class SyntaxTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
                 var result = await syntaxService.GetSyntaxTreeAsync(workspaceId, filePath, startLine, endLine, maxDepth, c);
                 if (result is null) throw new KeyNotFoundException($"Document not found: {filePath}");
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -11,7 +11,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class TestCoverageTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "test_coverage", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires coverlet.collector NuGet package in test projects.")]
@@ -62,13 +61,13 @@ public static class TestCoverageTools
                         Error: !execution.Succeeded ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found." : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.",
                         LineCoveragePercent: null,
                         BranchCoveragePercent: null,
-                        Modules: []), JsonOptions);
+                        Modules: []), JsonDefaults.Indented);
                 }
 
                 var latestCoverage = coverageFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
                 var result = ParseCoberturaXml(latestCoverage);
                 ProgressHelper.Report(progress, 1, 1);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class TypeExtractionTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "extract_type_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Preview extracting selected members from a type into a new type. The source type gets a private field for the new type and the extracted members are moved. Use this for SRP refactoring.")]
@@ -28,7 +27,7 @@ public static class TypeExtractionTools
             {
                 var result = await typeExtractionService.PreviewExtractTypeAsync(
                     workspaceId, filePath, typeName, memberNames, newTypeName, newFilePath, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -46,7 +45,7 @@ public static class TypeExtractionTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -8,7 +8,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class TypeMoveTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "move_type_to_file_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Preview moving a type declaration from a multi-type file into its own dedicated file within the same project")]
@@ -25,7 +24,7 @@ public static class TypeMoveTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await typeMoveService.PreviewMoveTypeToFileAsync(workspaceId, sourceFilePath, typeName, targetFilePath, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -43,7 +42,7 @@ public static class TypeMoveTools
             gate.RunAsync(gateKey, async c =>
             {
                 var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -9,7 +9,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ValidationTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "build_workspace", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet build for the loaded workspace and return structured diagnostics and execution output")]
     public static Task<string> BuildWorkspace(
@@ -25,7 +24,7 @@ public static class ValidationTools
                 ProgressHelper.Report(progress, 0, 1);
                 var result = await buildService.BuildWorkspaceAsync(workspaceId, c);
                 ProgressHelper.Report(progress, 1, 1);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -41,7 +40,7 @@ public static class ValidationTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await buildService.BuildProjectAsync(workspaceId, projectName, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -56,7 +55,7 @@ public static class ValidationTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await testDiscoveryService.DiscoverTestsAsync(workspaceId, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -76,7 +75,7 @@ public static class ValidationTools
                 ProgressHelper.Report(progress, 0, 1);
                 var result = await testRunnerService.RunTestsAsync(workspaceId, projectName, filter, c);
                 ProgressHelper.Report(progress, 1, 1);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -96,7 +95,7 @@ public static class ValidationTools
             {
                 var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle);
                 var result = await testDiscoveryService.FindRelatedTestsAsync(workspaceId, locator, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -113,7 +112,7 @@ public static class ValidationTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var result = await testDiscoveryService.FindRelatedTestsForFilesAsync(workspaceId, filePaths, maxResults, c);
-                return JsonSerializer.Serialize(result, JsonOptions);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -10,7 +10,6 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class WorkspaceTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Load a .sln or .csproj file into the workspace for semantic analysis")]
     public static Task<string> LoadWorkspace(
@@ -29,7 +28,7 @@ public static class WorkspaceTools
                 var status = await workspace.LoadAsync(path, c);
                 ProgressHelper.Report(progress, 1, 1);
                 _ = NotifyResourcesChangedAsync(server);
-                return JsonSerializer.Serialize(status, JsonOptions);
+                return JsonSerializer.Serialize(status, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -46,7 +45,7 @@ public static class WorkspaceTools
             {
                 var status = await workspace.ReloadAsync(workspaceId, c);
                 _ = NotifyResourcesChangedAsync(server);
-                return JsonSerializer.Serialize(status, JsonOptions);
+                return JsonSerializer.Serialize(status, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -64,7 +63,7 @@ public static class WorkspaceTools
                 var closed = workspace.Close(workspaceId);
                 gate.RemoveGate(workspaceId);
                 _ = NotifyResourcesChangedAsync(server);
-                return Task.FromResult(JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonOptions));
+                return Task.FromResult(JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonDefaults.Indented));
             }, ct));
     }
 
@@ -75,7 +74,7 @@ public static class WorkspaceTools
         return ToolErrorHandler.ExecuteAsync(() =>
         {
             var workspaces = workspace.ListWorkspaces();
-            return Task.FromResult(JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonOptions));
+            return Task.FromResult(JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonDefaults.Indented));
         });
     }
 
@@ -90,7 +89,7 @@ public static class WorkspaceTools
             gate.RunAsync(workspaceId, _ =>
             {
                 var status = workspace.GetStatus(workspaceId);
-                return Task.FromResult(JsonSerializer.Serialize(status, JsonOptions));
+                return Task.FromResult(JsonSerializer.Serialize(status, JsonDefaults.Indented));
             }, ct));
     }
 
@@ -105,7 +104,7 @@ public static class WorkspaceTools
             gate.RunAsync(workspaceId, _ =>
             {
                 var graph = workspace.GetProjectGraph(workspaceId);
-                return Task.FromResult(JsonSerializer.Serialize(graph, JsonOptions));
+                return Task.FromResult(JsonSerializer.Serialize(graph, JsonDefaults.Indented));
             }, ct));
     }
 
@@ -121,7 +120,7 @@ public static class WorkspaceTools
             gate.RunAsync(workspaceId, async c =>
             {
                 var documents = await workspace.GetSourceGeneratedDocumentsAsync(workspaceId, projectName, c);
-                return JsonSerializer.Serialize(documents, JsonOptions);
+                return JsonSerializer.Serialize(documents, JsonDefaults.Indented);
             }, ct));
     }
 
@@ -138,7 +137,7 @@ public static class WorkspaceTools
             {
                 var text = await workspace.GetSourceTextAsync(workspaceId, filePath, c);
                 if (text is null) throw new KeyNotFoundException($"Document not found: {filePath}");
-                return JsonSerializer.Serialize(new { filePath, lineCount = text.Count(ch => ch == '\n') + 1, text }, JsonOptions);
+                return JsonSerializer.Serialize(new { filePath, lineCount = text.Count(ch => ch == '\n') + 1, text }, JsonDefaults.Indented);
             }, ct));
     }
 

--- a/src/RoslynMcp.Roslyn/Helpers/DotnetCommandRunner.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DotnetCommandRunner.cs
@@ -17,8 +17,15 @@ namespace RoslynMcp.Roslyn.Services;
 /// </remarks>
 public sealed class DotnetCommandRunner : IDotnetCommandRunner
 {
-    private const int OutputLimit = 12000;
+    private const int DefaultOutputLimit = 12_000;
     private const int ReadBufferSize = 4096;
+
+    private readonly int _outputLimit;
+
+    public DotnetCommandRunner(int outputLimit = DefaultOutputLimit)
+    {
+        _outputLimit = outputLimit > 0 ? outputLimit : DefaultOutputLimit;
+    }
 
     public async Task<CommandExecutionDto> RunAsync(
         string workingDirectory,
@@ -56,8 +63,8 @@ public sealed class DotnetCommandRunner : IDotnetCommandRunner
             }
         }, process);
 
-        var stdOutTask = ReadBoundedAsync(process.StandardOutput, ct);
-        var stdErrTask = ReadBoundedAsync(process.StandardError, ct);
+        var stdOutTask = ReadBoundedAsync(process.StandardOutput, _outputLimit, ct);
+        var stdErrTask = ReadBoundedAsync(process.StandardError, _outputLimit, ct);
 
         await process.WaitForExitAsync(ct).ConfigureAwait(false);
         var stdOut = await stdOutTask.ConfigureAwait(false);
@@ -76,10 +83,10 @@ public sealed class DotnetCommandRunner : IDotnetCommandRunner
             StdErr: stdErr);
     }
 
-    private static async Task<string> ReadBoundedAsync(StreamReader reader, CancellationToken ct)
+    private static async Task<string> ReadBoundedAsync(StreamReader reader, int outputLimit, CancellationToken ct)
     {
         var buffer = ArrayPool<char>.Shared.Rent(ReadBufferSize);
-        var bounded = new BoundedTextBuffer(OutputLimit);
+        var bounded = new BoundedTextBuffer(outputLimit);
 
         try
         {

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolServiceHelpers.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolServiceHelpers.cs
@@ -14,12 +14,17 @@ internal static class SymbolServiceHelpers
         var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
         if (root is null) return null;
 
+        return GetContainingSymbolFromRoot(root, semanticModel, location, ct);
+    }
+
+    public static ISymbol? GetContainingSymbolFromRoot(SyntaxNode root, SemanticModel model, Location location, CancellationToken ct)
+    {
         var node = root.FindNode(location.SourceSpan);
         while (node is not null)
         {
             if (node is MemberDeclarationSyntax or LocalFunctionStatementSyntax)
             {
-                return semanticModel.GetDeclaredSymbol(node, ct);
+                return model.GetDeclaredSymbol(node, ct);
             }
             node = node.Parent;
         }

--- a/src/RoslynMcp.Roslyn/Services/BoundedStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/BoundedStore.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Thread-safe, TTL-bounded in-memory store keyed by opaque string tokens.
+/// Entries expire after <see cref="_ttl"/> and the store is capped at <see cref="_maxEntries"/>.
+/// </summary>
+/// <typeparam name="TEntry">
+/// The entry type. Must implement <see cref="IBoundedStoreEntry"/> to provide
+/// the workspace ID and creation timestamp needed for TTL and eviction.
+/// </typeparam>
+public abstract class BoundedStore<TEntry> where TEntry : IBoundedStoreEntry
+{
+    private readonly ConcurrentDictionary<string, TEntry> _entries = new();
+    private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
+    private readonly int _maxEntries;
+
+    protected BoundedStore(int maxEntries = 20)
+    {
+        _maxEntries = maxEntries > 0 ? maxEntries : 20;
+    }
+
+    protected string StoreEntry(TEntry entry)
+    {
+        CleanExpired();
+        EvictIfOverLimit();
+        var token = Guid.NewGuid().ToString("N");
+        _entries[token] = entry;
+        return token;
+    }
+
+    protected TEntry? RetrieveEntry(string token)
+    {
+        if (!_entries.TryGetValue(token, out var entry))
+            return default;
+
+        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
+        {
+            _entries.TryRemove(token, out _);
+            return default;
+        }
+
+        return entry;
+    }
+
+    public void Invalidate(string token)
+    {
+        _entries.TryRemove(token, out _);
+    }
+
+    public string? PeekWorkspaceId(string token)
+    {
+        if (!_entries.TryGetValue(token, out var entry))
+            return null;
+
+        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
+        {
+            _entries.TryRemove(token, out _);
+            return null;
+        }
+
+        return entry.WorkspaceId;
+    }
+
+    private void CleanExpired()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var kvp in _entries)
+        {
+            if (now - kvp.Value.CreatedAt > _ttl)
+                _entries.TryRemove(kvp.Key, out _);
+        }
+    }
+
+    private void EvictIfOverLimit()
+    {
+        if (_entries.Count <= _maxEntries) return;
+
+        var toEvict = _entries
+            .OrderBy(kvp => kvp.Value.CreatedAt)
+            .Take(_entries.Count - _maxEntries + 1)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in toEvict)
+            _entries.TryRemove(key, out _);
+    }
+}
+
+public interface IBoundedStoreEntry
+{
+    string WorkspaceId { get; }
+    DateTime CreatedAt { get; }
+}

--- a/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositePreviewStore.cs
@@ -1,97 +1,27 @@
-using System.Collections.Concurrent;
 using RoslynMcp.Core.Services;
 
 namespace RoslynMcp.Roslyn.Services;
 
-public sealed class CompositePreviewStore : ICompositePreviewStore
+public sealed class CompositePreviewStore : BoundedStore<CompositePreviewStore.Entry>, ICompositePreviewStore
 {
-    private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
-    private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
-    private readonly int _maxEntries;
-
-    public CompositePreviewStore(int maxEntries = 20)
-    {
-        _maxEntries = maxEntries > 0 ? maxEntries : 20;
-    }
+    public CompositePreviewStore(int maxEntries = 20) : base(maxEntries) { }
 
     public string Store(string workspaceId, int workspaceVersion, string description, IReadOnlyList<CompositeFileMutation> mutations)
     {
-        CleanExpired();
-        EvictIfOverLimit();
-        var token = Guid.NewGuid().ToString("N");
-        _entries[token] = new PreviewEntry(workspaceId, workspaceVersion, description, mutations, DateTime.UtcNow);
-        return token;
+        return StoreEntry(new Entry(workspaceId, workspaceVersion, description, mutations, DateTime.UtcNow));
     }
 
     public (string WorkspaceId, int WorkspaceVersion, string Description, IReadOnlyList<CompositeFileMutation> Mutations)? Retrieve(string token)
     {
-        if (!_entries.TryGetValue(token, out var entry))
-        {
-            return null;
-        }
-
-        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
-        {
-            _entries.TryRemove(token, out _);
-            return null;
-        }
-
+        var entry = RetrieveEntry(token);
+        if (entry is null) return null;
         return (entry.WorkspaceId, entry.WorkspaceVersion, entry.Description, entry.Mutations);
     }
 
-    public void Invalidate(string token)
-    {
-        _entries.TryRemove(token, out _);
-    }
-
-    public string? PeekWorkspaceId(string token)
-    {
-        if (!_entries.TryGetValue(token, out var entry))
-            return null;
-
-        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
-        {
-            _entries.TryRemove(token, out _);
-            return null;
-        }
-
-        return entry.WorkspaceId;
-    }
-
-    private void CleanExpired()
-    {
-        var now = DateTime.UtcNow;
-        foreach (var kvp in _entries)
-        {
-            if (now - kvp.Value.CreatedAt > _ttl)
-            {
-                _entries.TryRemove(kvp.Key, out _);
-            }
-        }
-    }
-
-    private void EvictIfOverLimit()
-    {
-        if (_entries.Count <= _maxEntries)
-        {
-            return;
-        }
-
-        var toEvict = _entries.OrderBy(kvp => kvp.Value.CreatedAt)
-            .Take(_entries.Count - _maxEntries + 1)
-            .Select(kvp => kvp.Key)
-            .ToList();
-
-        foreach (var key in toEvict)
-        {
-            _entries.TryRemove(key, out _);
-        }
-    }
-
-    private sealed record PreviewEntry(
+    public sealed record Entry(
         string WorkspaceId,
         int WorkspaceVersion,
         string Description,
         IReadOnlyList<CompositeFileMutation> Mutations,
-        DateTime CreatedAt);
+        DateTime CreatedAt) : IBoundedStoreEntry;
 }

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -161,6 +161,11 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
         var mutatingMembers = new List<MutatingMemberDto>();
 
+        // Cache document roots and semantic models to avoid redundant async lookups
+        // across multiple members referencing the same documents.
+        var rootCache = new Dictionary<DocumentId, SyntaxNode?>();
+        var modelCache = new Dictionary<DocumentId, SemanticModel?>();
+
         foreach (var member in namedType.GetMembers())
         {
             if (!IsMutatingMember(member, namedType)) continue;
@@ -172,15 +177,29 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
             {
                 foreach (var refLocation in refSymbol.Locations)
                 {
-                    var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
+                    var doc = refLocation.Document;
+                    if (!rootCache.TryGetValue(doc.Id, out var root))
+                    {
+                        root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                        rootCache[doc.Id] = root;
+                    }
+                    if (!modelCache.TryGetValue(doc.Id, out var model))
+                    {
+                        model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+                        modelCache[doc.Id] = model;
+                    }
+
+                    var containingSymbol = root is not null && model is not null
+                        ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
+                        : null;
 
                     // Skip calls from within the type itself (internal mutators calling each other)
                     if (containingSymbol is not null &&
                         SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
                         continue;
 
-                    var preview = await SymbolResolver.GetPreviewTextAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
-                    var phase = await ClassifyCallerPhaseAsync(refLocation, namedType, ct).ConfigureAwait(false);
+                    var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
+                    var phase = ClassifyCallerPhase(root, model, refLocation.Location, namedType);
                     var lineSpan = refLocation.Location.GetLineSpan();
 
                     callers.Add(new MutationCallerDto(
@@ -377,12 +396,11 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         return type.GetMembers(name).Any(m => !m.IsStatic);
     }
 
-    private static async Task<string> ClassifyCallerPhaseAsync(ReferenceLocation refLocation, INamedTypeSymbol targetType, CancellationToken ct)
+    private static string ClassifyCallerPhase(SyntaxNode? root, SemanticModel? model, Location location, INamedTypeSymbol targetType)
     {
-        var root = await refLocation.Document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
         if (root is null) return "Unknown";
 
-        var node = root.FindNode(refLocation.Location.SourceSpan);
+        var node = root.FindNode(location.SourceSpan);
 
         // Check if inside an object initializer
         if (node.Ancestors().OfType<InitializerExpressionSyntax>()
@@ -395,19 +413,15 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
         // Check if inside a method of the same type that returns void (builder-pattern heuristic)
         var enclosingMethod = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
-        if (enclosingMethod is not null)
+        if (enclosingMethod is not null && model is not null)
         {
             var returnType = enclosingMethod.ReturnType.ToString();
             if (returnType is "void" or "Void")
             {
-                var semanticModel = await refLocation.Document.GetSemanticModelAsync(ct).ConfigureAwait(false);
-                if (semanticModel is not null)
-                {
-                    var methodSymbol = semanticModel.GetDeclaredSymbol(enclosingMethod, ct);
-                    if (methodSymbol?.ContainingType is not null &&
-                        SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, targetType))
-                        return "Construction";
-                }
+                var methodSymbol = model.GetDeclaredSymbol(enclosingMethod);
+                if (methodSymbol?.ContainingType is not null &&
+                    SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, targetType))
+                    return "Construction";
             }
         }
 

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationPreviewStore.cs
@@ -1,98 +1,28 @@
-using System.Collections.Concurrent;
 using RoslynMcp.Core.Services;
 
 namespace RoslynMcp.Roslyn.Services;
 
-public sealed class ProjectMutationPreviewStore : IProjectMutationPreviewStore
+public sealed class ProjectMutationPreviewStore : BoundedStore<ProjectMutationPreviewStore.Entry>, IProjectMutationPreviewStore
 {
-    private readonly ConcurrentDictionary<string, PreviewEntry> _entries = new();
-    private readonly TimeSpan _ttl = TimeSpan.FromMinutes(5);
-    private readonly int _maxEntries;
-
-    public ProjectMutationPreviewStore(int maxEntries = 20)
-    {
-        _maxEntries = maxEntries > 0 ? maxEntries : 20;
-    }
+    public ProjectMutationPreviewStore(int maxEntries = 20) : base(maxEntries) { }
 
     public string Store(string workspaceId, string projectFilePath, string updatedContent, int workspaceVersion, string description)
     {
-        CleanExpired();
-        EvictIfOverLimit();
-        var token = Guid.NewGuid().ToString("N");
-        _entries[token] = new PreviewEntry(workspaceId, projectFilePath, updatedContent, workspaceVersion, description, DateTime.UtcNow);
-        return token;
+        return StoreEntry(new Entry(workspaceId, projectFilePath, updatedContent, workspaceVersion, description, DateTime.UtcNow));
     }
 
     public (string WorkspaceId, string ProjectFilePath, string UpdatedContent, int WorkspaceVersion, string Description)? Retrieve(string token)
     {
-        if (!_entries.TryGetValue(token, out var entry))
-        {
-            return null;
-        }
-
-        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
-        {
-            _entries.TryRemove(token, out _);
-            return null;
-        }
-
+        var entry = RetrieveEntry(token);
+        if (entry is null) return null;
         return (entry.WorkspaceId, entry.ProjectFilePath, entry.UpdatedContent, entry.WorkspaceVersion, entry.Description);
     }
 
-    public void Invalidate(string token)
-    {
-        _entries.TryRemove(token, out _);
-    }
-
-    public string? PeekWorkspaceId(string token)
-    {
-        if (!_entries.TryGetValue(token, out var entry))
-            return null;
-
-        if (DateTime.UtcNow - entry.CreatedAt > _ttl)
-        {
-            _entries.TryRemove(token, out _);
-            return null;
-        }
-
-        return entry.WorkspaceId;
-    }
-
-    private void CleanExpired()
-    {
-        var now = DateTime.UtcNow;
-        foreach (var kvp in _entries)
-        {
-            if (now - kvp.Value.CreatedAt > _ttl)
-            {
-                _entries.TryRemove(kvp.Key, out _);
-            }
-        }
-    }
-
-    private void EvictIfOverLimit()
-    {
-        if (_entries.Count <= _maxEntries)
-        {
-            return;
-        }
-
-        var toEvict = _entries.OrderBy(kvp => kvp.Value.CreatedAt)
-            .Take(_entries.Count - _maxEntries + 1)
-            .Select(kvp => kvp.Key)
-            .ToList();
-
-        foreach (var key in toEvict)
-        {
-            _entries.TryRemove(key, out _);
-        }
-    }
-
-    private sealed record PreviewEntry(
+    public sealed record Entry(
         string WorkspaceId,
         string ProjectFilePath,
         string UpdatedContent,
         int WorkspaceVersion,
         string Description,
-        DateTime CreatedAt);
+        DateTime CreatedAt) : IBoundedStoreEntry;
 }

--- a/tests/RoslynMcp.Tests/AssemblyCleanup.cs
+++ b/tests/RoslynMcp.Tests/AssemblyCleanup.cs
@@ -1,0 +1,22 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public static class AssemblyLifecycle
+{
+    [AssemblyCleanup]
+    public static void Cleanup()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpTests");
+        if (Directory.Exists(tempRoot))
+        {
+            try
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup — another test runner instance may hold a lock.
+            }
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -31,6 +31,7 @@ public sealed class ExpandedSurfaceIntegrationTests : TestBase
     {
         var programFile = FindDocumentPath("Program.cs");
         var json = await SymbolTools.GetCompletions(
+            null!,
             WorkspaceExecutionGate,
             CompletionService,
             WorkspaceId,
@@ -50,6 +51,7 @@ public sealed class ExpandedSurfaceIntegrationTests : TestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var json = await SyntaxTools.GetSyntaxTree(
+            null!,
             WorkspaceExecutionGate,
             SyntaxService,
             WorkspaceId,


### PR DESCRIPTION
## Summary
- **SEC-01**: Add `ClientRootPathValidator` to 5 read-only tools (`diagnostic_details`, `get_syntax_tree`, `document_symbols`, `enclosing_symbol`, `get_completions`) that accept `filePath` without validation — closes a filesystem reconnaissance gap
- **PERF-01**: Fix N+1 in `MutationAnalysisService.FindTypeMutationsAsync` by caching document roots/semantic models across member iterations and converting async helper to sync
- **CODE-01**: Extract `JsonDefaults.Indented` replacing 28 duplicate `JsonSerializerOptions` field declarations
- **CODE-02**: Fix 6x `GetSummary()` call in `ServerTools.cs` — single local variable
- **CODE-04**: Extract `BoundedStore<T>` base class; rewrite `CompositePreviewStore` and `ProjectMutationPreviewStore` as thin wrappers (~130 lines removed)
- **PERF-04**: Make `DotnetCommandRunner.OutputLimit` configurable via constructor (default 12K)
- **TEST-04**: Add `[AssemblyCleanup]` handler to delete temp directories after test runs
- Backlog updated to remove 6 resolved items

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings (excluding pre-existing sample warning)
- [x] `dotnet test` — 123/123 pass
- [ ] Verify MCP tools with `filePath` params reject out-of-root paths when client advertises roots

🤖 Generated with [Claude Code](https://claude.com/claude-code)