### PR TITLE
feat: backlog sweep, undo capability, test expansion, MCP compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Roslyn-Backed MCP Server
 
+[![CI](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/workflows/ci.yml)
+
 A production-usable MCP (Model Context Protocol) server that provides semantic C# analysis capabilities powered by Roslyn, without requiring Visual Studio. Designed for AI coding agents to semantically navigate, analyze, and refactor real C# solutions.
 
 ## AI Session Fast Start
@@ -41,6 +43,16 @@ dotnet run --project src/RoslynMcp.Host.Stdio
 ```bash
 dotnet test RoslynMcp.slnx
 ```
+
+## Cross-Platform Notes
+
+The server runs on Windows, macOS, and Linux wherever the .NET 10 SDK is available. Known platform-specific behavior:
+
+- **Path separators**: The server normalizes paths internally but MCP clients should send OS-native paths (backslashes on Windows, forward slashes elsewhere).
+- **MSBuild locator**: Uses `Microsoft.Build.Locator` to find the SDK. On Linux/macOS, ensure the SDK is on `PATH` or set `DOTNET_ROOT`.
+- **Symlink resolution**: `ClientRootPathValidator` resolves symlinks and junctions before path comparison. Behavior varies by filesystem — NTFS junctions on Windows, symlinks on Unix.
+- **Process management**: `dotnet build` and `dotnet test` child processes use `Process.Kill(entireProcessTree: true)` on cancellation, which requires `SIGKILL` support on Unix (available on all modern distributions).
+- **File watchers**: `FileSystemWatcher` reliability varies by OS and filesystem. NFS and some container-mounted volumes may not emit change events.
 
 ## Security Considerations
 
@@ -158,6 +170,24 @@ Example:
   }
 }
 ```
+
+## Privacy Policy
+
+This MCP server runs entirely on your local machine and does not collect, transmit, or store any telemetry, analytics, or personal data.
+
+- **Data processed**: The server reads `.sln`, `.csproj`, and `.cs` files from workspaces you explicitly load. All analysis happens in-process using Roslyn.
+- **Network access**: The server makes no outbound network requests. `dotnet build` and `dotnet test` child processes may download NuGet packages as part of normal .NET SDK behavior.
+- **Data retention**: Workspace state exists only in memory for the duration of the server process. Preview stores expire entries after 5 minutes. No data is persisted to disk beyond what `dotnet build`/`dotnet test` produce.
+- **Logging**: Diagnostic logs are emitted via MCP's logging notification channel to the connected client. No logs are written to disk or sent to external services.
+- **Third-party sharing**: No data is shared with Anthropic, any third party, or any external service.
+
+For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/issues](https://github.com/darylmcd/Roslyn-Backed-MCP/issues).
+
+## Support
+
+- **Bug reports and feature requests**: [GitHub Issues](https://github.com/darylmcd/Roslyn-Backed-MCP/issues)
+- **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+- **Security vulnerabilities**: See [SECURITY.md](SECURITY.md) for the disclosure policy.
 
 ## Canonical Docs
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,17 +2,13 @@
 
 Canonical location for unfinished work items. Prioritized for 1.0 release.
 
-Last audit: 2026-03-26. All pre-1.0 items resolved.
+Last audit: 2026-03-27. All post-1.0 items resolved.
 
 ---
 
 ## Post-1.0
 
-- [ ] **REL-07**: Add CI badge to README.
-- [ ] **REL-09**: Document cross-platform limitations.
-- [ ] **API-05**: Consider promoting `test_coverage` to stable — functionally complete, uses standard `coverlet.collector`.
-- [ ] **API-06**: Consider adding `undo`/`revert_last_apply` capability.
-- [ ] **TEST-03**: Add performance baseline tests for large solutions.
+- [ ] **REL-10**: Create 512x512 PNG icon for MCP directory listing and manifest. Required by the [Anthropic MCP submission guide](https://support.claude.com/en/articles/12922832-local-mcp-server-submission-guide).
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,49 @@
+{
+  "manifest_version": "0.3",
+  "name": "roslyn-mcp",
+  "version": "1.0.0",
+  "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
+  "author": {
+    "name": "darylmcd",
+    "url": "https://github.com/darylmcd/Roslyn-Backed-MCP"
+  },
+  "server": {
+    "type": "binary",
+    "entry_point": "RoslynMcp.Host.Stdio",
+    "mcp_config": {
+      "command": "roslynmcp",
+      "args": [],
+      "env": {}
+    }
+  },
+  "compatibility": {
+    "platforms": ["win32", "darwin", "linux"]
+  },
+  "tools": [
+    { "name": "workspace_load", "description": "Load a .sln or .csproj file into the workspace for semantic analysis" },
+    { "name": "symbol_search", "description": "Search for symbols by name pattern across the loaded workspace" },
+    { "name": "find_references", "description": "Find all references to a symbol across the entire solution" },
+    { "name": "go_to_definition", "description": "Find the definition location of a symbol" },
+    { "name": "project_diagnostics", "description": "Get compiler diagnostics for the workspace" },
+    { "name": "rename_preview", "description": "Preview a rename refactoring" },
+    { "name": "build_workspace", "description": "Run dotnet build for the loaded workspace" },
+    { "name": "test_run", "description": "Run dotnet test for the workspace or a selected project" }
+  ],
+  "user_config": {
+    "ROSLYNMCP_MAX_WORKSPACES": {
+      "type": "number",
+      "description": "Maximum concurrent workspace sessions",
+      "default": 8
+    },
+    "ROSLYNMCP_BUILD_TIMEOUT_SECONDS": {
+      "type": "number",
+      "description": "Build operation timeout in seconds",
+      "default": 300
+    },
+    "ROSLYNMCP_TEST_TIMEOUT_SECONDS": {
+      "type": "number",
+      "description": "Test run timeout in seconds",
+      "default": 600
+    }
+  }
+}

--- a/src/RoslynMcp.Core/Services/IUndoService.cs
+++ b/src/RoslynMcp.Core/Services/IUndoService.cs
@@ -1,0 +1,45 @@
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Records pre-apply workspace state so that the most recent apply operation
+/// can be reverted. Only the last operation per workspace is retained.
+/// </summary>
+public interface IUndoService
+{
+    /// <summary>
+    /// Captures the current solution state before an apply operation.
+    /// Call this immediately before mutating the workspace.
+    /// </summary>
+    /// <param name="workspaceId">The workspace being mutated.</param>
+    /// <param name="description">Human-readable description of the operation being applied.</param>
+    /// <param name="preApplySolution">The solution snapshot before mutation.</param>
+    void CaptureBeforeApply(string workspaceId, string description, object preApplySolution);
+
+    /// <summary>
+    /// Returns metadata about the last undoable operation for the given workspace,
+    /// or <see langword="null"/> if nothing is undoable.
+    /// </summary>
+    UndoEntry? GetLastOperation(string workspaceId);
+
+    /// <summary>
+    /// Reverts the most recent apply operation for the given workspace.
+    /// Returns <see langword="true"/> if the revert succeeded.
+    /// </summary>
+    bool Revert(string workspaceId, IWorkspaceManager workspace);
+
+    /// <summary>
+    /// Clears undo history for a workspace (e.g., on workspace close).
+    /// </summary>
+    void Clear(string workspaceId);
+}
+
+/// <summary>
+/// Metadata about an undoable operation.
+/// </summary>
+/// <param name="WorkspaceId">The workspace the operation was applied to.</param>
+/// <param name="Description">Human-readable description of the operation.</param>
+/// <param name="AppliedAtUtc">When the operation was applied.</param>
+public sealed record UndoEntry(
+    string WorkspaceId,
+    string Description,
+    DateTime AppliedAtUtc);

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -102,7 +102,7 @@ public static class ServerSurfaceCatalog
         Tool("split_class_preview", "orchestration", "experimental", true, false, "Preview splitting a class into a new partial file."),
         Tool("extract_and_wire_interface_preview", "orchestration", "experimental", true, false, "Preview extracting an interface and updating DI registrations."),
         Tool("apply_composite_preview", "orchestration", "experimental", false, true, "Apply a previously previewed orchestration operation."),
-        Tool("test_coverage", "validation", "experimental", false, false, "Run coverage collection for test execution."),
+        Tool("test_coverage", "validation", "stable", false, false, "Run coverage collection for test execution."),
         Tool("get_syntax_tree", "syntax", "experimental", true, false, "Return a structured syntax tree for a document or range."),
         Tool("get_code_actions", "code-actions", "experimental", true, false, "List Roslyn code fixes and refactorings at a location."),
         Tool("preview_code_action", "code-actions", "experimental", true, false, "Preview a Roslyn code action before applying it."),
@@ -122,7 +122,9 @@ public static class ServerSurfaceCatalog
         Tool("bulk_replace_type_preview", "refactoring", "experimental", true, false, "Preview replacing all references to one type with another across the solution. Scope can be 'parameters', 'fields', or 'all'. Useful after extracting an interface."),
         Tool("bulk_replace_type_apply", "refactoring", "experimental", false, true, "Apply a previewed bulk type replacement. Updates all matching type references and adds using directives where needed."),
         Tool("extract_type_preview", "refactoring", "experimental", true, false, "Preview extracting selected members from a type into a new type. Adds a private field and constructor parameter for composition. Use get_cohesion_metrics and find_shared_members to plan the extraction."),
-        Tool("extract_type_apply", "refactoring", "experimental", false, true, "Apply a previewed type extraction. Moves members to the new type file and wires composition in the source type.")
+        Tool("extract_type_apply", "refactoring", "experimental", false, true, "Apply a previewed type extraction. Moves members to the new type file and wires composition in the source type."),
+
+        Tool("revert_last_apply", "undo", "experimental", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace.")
     ];
 
     public static IReadOnlyList<SurfaceEntry> Resources { get; } =

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class UndoTools
+{
+    [McpServerTool(Name = "revert_last_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
+     Description("Revert the most recent apply operation for a workspace, restoring the previous solution state. Only Roslyn solution-level changes (renames, code fixes, format, organize usings) can be reverted. Disk-direct operations (file create/delete/move, project mutations, composite orchestrations) are not revertible.")]
+    public static Task<string> RevertLastApply(
+        IWorkspaceExecutionGate gate,
+        IUndoService undoService,
+        IWorkspaceManager workspace,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, _ =>
+            {
+                var entry = undoService.GetLastOperation(workspaceId);
+                if (entry is null)
+                    throw new InvalidOperationException("No undoable operation found for this workspace.");
+
+                var success = undoService.Revert(workspaceId, workspace);
+                if (!success)
+                    throw new InvalidOperationException("Failed to revert — the workspace state may have changed since the operation was applied.");
+
+                var result = new
+                {
+                    success = true,
+                    revertedOperation = entry.Description,
+                    appliedAtUtc = entry.AppliedAtUtc
+                };
+                return Task.FromResult(JsonSerializer.Serialize(result, JsonDefaults.Indented));
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Roslyn/Helpers/DiffGenerator.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DiffGenerator.cs
@@ -36,45 +36,9 @@ public static class DiffGenerator
                 continue;
             }
 
-            int contextStart = Math.Max(0, i - 3);
-            int chunkEnd = i;
-
-            while (chunkEnd < lines.Count)
-            {
-                if (lines[chunkEnd].Type != ChangeType.Unchanged)
-                {
-                    chunkEnd++;
-                    continue;
-                }
-
-                int nextChange = chunkEnd;
-                while (nextChange < lines.Count && lines[nextChange].Type == ChangeType.Unchanged)
-                    nextChange++;
-
-                if (nextChange < lines.Count && nextChange - chunkEnd <= 6)
-                {
-                    chunkEnd = nextChange + 1;
-                    continue;
-                }
-
-                break;
-            }
-
-            int contextEnd = Math.Min(lines.Count, chunkEnd + 3);
-
-            int oldLine = 1, newLine = 1;
-            for (int j = 0; j < contextStart; j++)
-            {
-                if (lines[j].Type != ChangeType.Inserted) oldLine++;
-                if (lines[j].Type != ChangeType.Deleted) newLine++;
-            }
-
-            int oldCount = 0, newCount = 0;
-            for (int j = contextStart; j < contextEnd; j++)
-            {
-                if (lines[j].Type != ChangeType.Inserted) oldCount++;
-                if (lines[j].Type != ChangeType.Deleted) newCount++;
-            }
+            var (contextStart, contextEnd) = FindHunkBounds(lines, i);
+            var (oldLine, newLine) = ComputeLineNumbers(lines, contextStart);
+            var (oldCount, newCount) = CountHunkLines(lines, contextStart, contextEnd);
 
             sb.AppendLine($"@@ -{oldLine},{oldCount} +{newLine},{newCount} @@");
 
@@ -93,5 +57,68 @@ public static class DiffGenerator
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Finds the context-padded start and end indices for a diff hunk beginning at
+    /// <paramref name="changeStart"/>, merging adjacent hunks within 6-line proximity.
+    /// </summary>
+    private static (int ContextStart, int ContextEnd) FindHunkBounds(IList<DiffPiece> lines, int changeStart)
+    {
+        int contextStart = Math.Max(0, changeStart - 3);
+        int chunkEnd = changeStart;
+
+        while (chunkEnd < lines.Count)
+        {
+            if (lines[chunkEnd].Type != ChangeType.Unchanged)
+            {
+                chunkEnd++;
+                continue;
+            }
+
+            int nextChange = chunkEnd;
+            while (nextChange < lines.Count && lines[nextChange].Type == ChangeType.Unchanged)
+                nextChange++;
+
+            if (nextChange < lines.Count && nextChange - chunkEnd <= 6)
+            {
+                chunkEnd = nextChange + 1;
+                continue;
+            }
+
+            break;
+        }
+
+        int contextEnd = Math.Min(lines.Count, chunkEnd + 3);
+        return (contextStart, contextEnd);
+    }
+
+    /// <summary>
+    /// Computes the 1-based old/new line numbers at <paramref name="contextStart"/> by
+    /// counting non-inserted (old) and non-deleted (new) lines before it.
+    /// </summary>
+    private static (int OldLine, int NewLine) ComputeLineNumbers(IList<DiffPiece> lines, int contextStart)
+    {
+        int oldLine = 1, newLine = 1;
+        for (int j = 0; j < contextStart; j++)
+        {
+            if (lines[j].Type != ChangeType.Inserted) oldLine++;
+            if (lines[j].Type != ChangeType.Deleted) newLine++;
+        }
+        return (oldLine, newLine);
+    }
+
+    /// <summary>
+    /// Counts old-side and new-side lines within the hunk range.
+    /// </summary>
+    private static (int OldCount, int NewCount) CountHunkLines(IList<DiffPiece> lines, int start, int end)
+    {
+        int oldCount = 0, newCount = 0;
+        for (int j = start; j < end; j++)
+        {
+            if (lines[j].Type != ChangeType.Inserted) oldCount++;
+            if (lines[j].Type != ChangeType.Deleted) newCount++;
+        }
+        return (oldCount, newCount);
     }
 }

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -67,6 +67,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IInterfaceExtractionService, InterfaceExtractionService>();
         services.AddSingleton<IBulkRefactoringService, BulkRefactoringService>();
         services.AddSingleton<ITypeExtractionService, TypeExtractionService>();
+        services.AddSingleton<IUndoService, UndoService>();
         return services;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -15,12 +15,14 @@ public sealed class RefactoringService : IRefactoringService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly IUndoService? _undoService;
     private readonly ILogger<RefactoringService> _logger;
 
-    public RefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<RefactoringService> logger)
+    public RefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<RefactoringService> logger, IUndoService? undoService = null)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _undoService = undoService;
         _logger = logger;
     }
 
@@ -63,6 +65,7 @@ public sealed class RefactoringService : IRefactoringService
         }
 
         var currentSolution = _workspace.GetCurrentSolution(workspaceId);
+        _undoService?.CaptureBeforeApply(workspaceId, description, currentSolution);
         var solutionChanges = modifiedSolution.GetChanges(currentSolution);
         var hasDocumentSetChanges = solutionChanges.GetProjectChanges()
             .Any(projectChange => projectChange.GetAddedDocuments().Any() || projectChange.GetRemovedDocuments().Any());

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using RoslynMcp.Core.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Retains the last pre-apply solution snapshot per workspace so that it can
+/// be restored via <see cref="Revert"/>.
+/// </summary>
+public sealed class UndoService : IUndoService
+{
+    private readonly ConcurrentDictionary<string, UndoSnapshot> _snapshots = new(StringComparer.Ordinal);
+
+    public void CaptureBeforeApply(string workspaceId, string description, object preApplySolution)
+    {
+        if (preApplySolution is not Solution solution)
+            throw new ArgumentException("preApplySolution must be a Roslyn Solution.", nameof(preApplySolution));
+
+        _snapshots[workspaceId] = new UndoSnapshot(workspaceId, description, solution, DateTime.UtcNow);
+    }
+
+    public UndoEntry? GetLastOperation(string workspaceId)
+    {
+        if (!_snapshots.TryGetValue(workspaceId, out var snapshot))
+            return null;
+
+        return new UndoEntry(snapshot.WorkspaceId, snapshot.Description, snapshot.AppliedAtUtc);
+    }
+
+    public bool Revert(string workspaceId, IWorkspaceManager workspace)
+    {
+        if (!_snapshots.TryRemove(workspaceId, out var snapshot))
+            return false;
+
+        // MSBuildWorkspace.TryApplyChanges only accepts solutions derived from its
+        // current solution. We rebuild the target state by replacing document texts
+        // in the workspace's current solution with the pre-apply snapshot texts.
+        var currentSolution = workspace.GetCurrentSolution(workspaceId);
+        var targetSolution = currentSolution;
+
+        foreach (var projectChange in snapshot.PreApplySolution.GetChanges(currentSolution).GetProjectChanges())
+        {
+            foreach (var docId in projectChange.GetChangedDocuments())
+            {
+                var oldDoc = snapshot.PreApplySolution.GetDocument(docId);
+                if (oldDoc is null) continue;
+
+                var oldText = oldDoc.GetTextAsync().GetAwaiter().GetResult();
+                targetSolution = targetSolution.WithDocumentText(docId, oldText);
+            }
+        }
+
+        return workspace.TryApplyChanges(workspaceId, targetSolution);
+    }
+
+    public void Clear(string workspaceId)
+    {
+        _snapshots.TryRemove(workspaceId, out _);
+    }
+
+    private sealed record UndoSnapshot(
+        string WorkspaceId,
+        string Description,
+        Solution PreApplySolution,
+        DateTime AppliedAtUtc);
+}

--- a/tests/RoslynMcp.Tests/PerformanceBaselineTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBaselineTests.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Performance baseline tests that establish upper bounds for key operations.
+/// These are not micro-benchmarks — they verify that operations complete within
+/// a generous wall-clock budget to catch severe regressions.
+/// </summary>
+[TestClass]
+public sealed class PerformanceBaselineTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task SymbolSearch_Completes_Within_Budget()
+    {
+        var sw = Stopwatch.StartNew();
+        var results = await SymbolSearchService.SearchSymbolsAsync(
+            WorkspaceId, "Animal", null, null, null, 50, CancellationToken.None);
+        sw.Stop();
+
+        Assert.IsTrue(results.Count > 0, "Expected results");
+        Assert.IsTrue(sw.ElapsedMilliseconds < 10_000,
+            $"Symbol search took {sw.ElapsedMilliseconds}ms — expected < 10s");
+    }
+
+    [TestMethod]
+    public async Task FindReferences_Completes_Within_Budget()
+    {
+        var sw = Stopwatch.StartNew();
+        var results = await ReferenceService.FindReferencesAsync(
+            WorkspaceId,
+            SymbolLocator.ByMetadataName("SampleLib.IAnimal"),
+            CancellationToken.None);
+        sw.Stop();
+
+        Assert.IsTrue(results.Count > 0, "Expected references");
+        Assert.IsTrue(sw.ElapsedMilliseconds < 10_000,
+            $"Find references took {sw.ElapsedMilliseconds}ms — expected < 10s");
+    }
+
+    [TestMethod]
+    public async Task ComplexityMetrics_Completes_Within_Budget()
+    {
+        var sw = Stopwatch.StartNew();
+        var results = await CodeMetricsService.GetComplexityMetricsAsync(
+            WorkspaceId, null, null, null, 100, CancellationToken.None);
+        sw.Stop();
+
+        Assert.IsTrue(results.Count > 0, "Expected metrics");
+        Assert.IsTrue(sw.ElapsedMilliseconds < 15_000,
+            $"Complexity metrics took {sw.ElapsedMilliseconds}ms — expected < 15s");
+    }
+
+    [TestMethod]
+    public async Task UnusedSymbolScan_Completes_Within_Budget()
+    {
+        var sw = Stopwatch.StartNew();
+        var results = await UnusedCodeAnalyzer.FindUnusedSymbolsAsync(
+            WorkspaceId, null, includePublic: true, limit: 50, CancellationToken.None);
+        sw.Stop();
+
+        Assert.IsTrue(sw.ElapsedMilliseconds < 30_000,
+            $"Unused symbol scan took {sw.ElapsedMilliseconds}ms — expected < 30s");
+    }
+
+    [TestMethod]
+    public async Task WorkspaceLoad_Completes_Within_Budget()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            sw.Stop();
+
+            Assert.IsTrue(sw.ElapsedMilliseconds < 30_000,
+                $"Workspace load took {sw.ElapsedMilliseconds}ms — expected < 30s");
+
+            WorkspaceManager.Close(status.WorkspaceId);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
@@ -1,0 +1,199 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public class ServiceCoverageTests : TestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    private static string FindDocumentPath(string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        return solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == name).FilePath!;
+    }
+
+    // ── SymbolSearchService ──────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SearchSymbols_Finds_Dog_Class()
+    {
+        var results = await SymbolSearchService.SearchSymbolsAsync(
+            WorkspaceId, "Dog", null, null, null, 10, CancellationToken.None);
+
+        Assert.IsTrue(results.Any(s => s.Name == "Dog"),
+            "Expected at least one result with Name == 'Dog'");
+    }
+
+    [TestMethod]
+    public async Task GetSymbolInfo_Returns_Details_For_AnimalService()
+    {
+        var result = await SymbolSearchService.GetSymbolInfoAsync(
+            WorkspaceId,
+            SymbolLocator.ByMetadataName("SampleLib.AnimalService"),
+            CancellationToken.None);
+
+        Assert.IsNotNull(result, "SymbolInfo should not be null for AnimalService");
+        Assert.AreEqual("AnimalService", result.Name);
+    }
+
+    [TestMethod]
+    public async Task GetDocumentSymbols_Returns_Members_For_Dog()
+    {
+        var dogPath = FindDocumentPath("Dog.cs");
+
+        var symbols = await SymbolSearchService.GetDocumentSymbolsAsync(
+            WorkspaceId, dogPath, CancellationToken.None);
+
+        Assert.IsTrue(symbols.Count > 0,
+            "Expected at least one symbol in Dog.cs");
+    }
+
+    // ── SymbolNavigationService ──────────────────────────────────────
+
+    [TestMethod]
+    public async Task GoToDefinition_Finds_IAnimal()
+    {
+        var definitions = await SymbolNavigationService.GoToDefinitionAsync(
+            WorkspaceId,
+            SymbolLocator.ByMetadataName("SampleLib.IAnimal"),
+            CancellationToken.None);
+
+        Assert.IsTrue(definitions.Count >= 1,
+            $"Expected at least 1 definition location for IAnimal, got {definitions.Count}");
+    }
+
+    [TestMethod]
+    public async Task GoToTypeDefinition_Navigates_From_Variable()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 18: "foreach (var animal in animals)" — position on 'animal' should navigate to IAnimal
+        var results = await SymbolNavigationService.GoToTypeDefinitionAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(animalServicePath, 18, 22),
+            CancellationToken.None);
+
+        Assert.IsTrue(results.Count > 0,
+            "Expected at least one type definition result for the 'animal' variable");
+    }
+
+    [TestMethod]
+    public async Task GetEnclosingSymbol_Returns_Method()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 18 is inside MakeThemSpeak method body
+        var result = await SymbolNavigationService.GetEnclosingSymbolAsync(
+            WorkspaceId, animalServicePath, 18, 10, CancellationToken.None);
+
+        Assert.IsNotNull(result, "Enclosing symbol should not be null");
+        Assert.IsTrue(result.Name.Contains("MakeThemSpeak"),
+            $"Expected enclosing symbol to contain 'MakeThemSpeak', got '{result.Name}'");
+    }
+
+    // ── SymbolRelationshipService ────────────────────────────────────
+
+    [TestMethod]
+    public async Task GetTypeHierarchy_Shows_Shape_Hierarchy()
+    {
+        var hierarchy = await SymbolRelationshipService.GetTypeHierarchyAsync(
+            WorkspaceId,
+            SymbolLocator.ByMetadataName("SampleLib.Hierarchy.Shape"),
+            CancellationToken.None);
+
+        Assert.IsNotNull(hierarchy, "Type hierarchy should not be null for Shape");
+        Assert.IsNotNull(hierarchy.DerivedTypes, "Shape should have derived types");
+
+        var derivedNames = hierarchy.DerivedTypes.Select(d => d.TypeName).ToList();
+        Assert.IsTrue(derivedNames.Any(n => n.Contains("Circle")),
+            "Circle should be a derived type of Shape");
+        Assert.IsTrue(derivedNames.Any(n => n.Contains("Rectangle")),
+            "Rectangle should be a derived type of Shape");
+    }
+
+    [TestMethod]
+    public async Task GetSignatureHelp_Returns_Method_Signature()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 16 column 17 is MakeThemSpeak declaration
+        var result = await SymbolRelationshipService.GetSignatureHelpAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(animalServicePath, 16, 17),
+            CancellationToken.None);
+
+        Assert.IsNotNull(result, "Signature help should not be null for MakeThemSpeak");
+    }
+
+    [TestMethod]
+    public async Task GetCallersCallees_Finds_Speak_Callers()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 16 column 17 is MakeThemSpeak declaration
+        var result = await SymbolRelationshipService.GetCallersCalleesAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(animalServicePath, 16, 17),
+            CancellationToken.None);
+
+        Assert.IsNotNull(result, "CallerCallee result should not be null");
+        Assert.IsTrue(result.Callers.Count > 0 || result.Callees.Count > 0,
+            "MakeThemSpeak should have callers or callees");
+    }
+
+    // ── CompletionService ────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task GetCompletions_Returns_Items_At_Valid_Position()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 20 column 30 is inside method body where completions are available
+        var result = await CompletionService.GetCompletionsAsync(
+            WorkspaceId, animalServicePath, 20, 30, CancellationToken.None);
+
+        Assert.IsTrue(result.Items.Count > 0,
+            "Expected completion items at a valid position in AnimalService.cs");
+    }
+
+    // ── TestDiscoveryService ─────────────────────────────────────────
+
+    [TestMethod]
+    public async Task DiscoverTests_Finds_Sample_Tests()
+    {
+        var result = await TestDiscoveryService.DiscoverTestsAsync(
+            WorkspaceId, CancellationToken.None);
+
+        Assert.IsTrue(result.TestProjects.Count > 0,
+            "Expected at least one test project to be discovered in the sample solution");
+    }
+
+    // ── TestRunnerService ────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task RunTests_Executes_SampleLib_Tests()
+    {
+        var result = await TestRunnerService.RunTestsAsync(
+            WorkspaceId, "SampleLib.Tests", null, CancellationToken.None);
+
+        Assert.IsNotNull(result,
+            "Test run result should not be null for SampleLib.Tests");
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -44,6 +44,7 @@ public abstract class TestBase
     protected static ConsumerAnalysisService ConsumerAnalysisService { get; private set; } = null!;
     protected static TypeExtractionService TypeExtractionService { get; private set; } = null!;
     protected static TypeMoveService TypeMoveService { get; private set; } = null!;
+    protected static UndoService UndoService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -86,10 +87,12 @@ public abstract class TestBase
         DiagnosticService = new DiagnosticService(
             WorkspaceManager,
             NullLogger<DiagnosticService>.Instance);
+        UndoService = new UndoService();
         RefactoringService = new RefactoringService(
             WorkspaceManager,
             PreviewStore,
-            NullLogger<RefactoringService>.Instance);
+            NullLogger<RefactoringService>.Instance,
+            UndoService);
         BuildService = new BuildService(
             WorkspaceManager,
             DotnetCommandRunner,

--- a/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
@@ -1,0 +1,87 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class UndoIntegrationTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        InitializeServices();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task Revert_Last_Apply_Restores_Previous_State()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+
+        try
+        {
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            var workspaceId = status.WorkspaceId;
+
+            // Find the Dog.Speak method and preview a rename
+            var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+            var original = await SymbolSearchService.GetSymbolInfoAsync(workspaceId, locator, CancellationToken.None);
+            Assert.IsNotNull(original);
+
+            // Preview rename of IAnimal → ICreature
+            var preview = await RefactoringService.PreviewRenameAsync(
+                workspaceId,
+                locator,
+                "ICreature",
+                CancellationToken.None);
+            Assert.IsNotNull(preview.PreviewToken);
+
+            // Apply the rename
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(
+                preview.PreviewToken, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+            // Verify the rename took effect
+            var renamedSymbol = await SymbolSearchService.GetSymbolInfoAsync(
+                workspaceId, SymbolLocator.ByMetadataName("SampleLib.ICreature"), CancellationToken.None);
+            Assert.IsNotNull(renamedSymbol, "ICreature should exist after rename");
+
+            // Verify undo entry exists
+            var undoEntry = UndoService.GetLastOperation(workspaceId);
+            Assert.IsNotNull(undoEntry, "Undo entry should exist after apply");
+            StringAssert.Contains(undoEntry.Description, "Rename");
+
+            // Revert
+            var reverted = UndoService.Revert(workspaceId, WorkspaceManager);
+            Assert.IsTrue(reverted, "Revert should succeed");
+
+            // Verify original name is back
+            var restored = await SymbolSearchService.GetSymbolInfoAsync(
+                workspaceId, SymbolLocator.ByMetadataName("SampleLib.IAnimal"), CancellationToken.None);
+            Assert.IsNotNull(restored, "IAnimal should exist after revert");
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public void Revert_Without_Prior_Apply_Returns_False()
+    {
+        var result = UndoService.Revert("nonexistent-workspace", WorkspaceManager);
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void GetLastOperation_Returns_Null_Without_Apply()
+    {
+        var entry = UndoService.GetLastOperation("nonexistent-workspace");
+        Assert.IsNull(entry);
+    }
+}


### PR DESCRIPTION
## Summary
- **REL-07**: CI badge added to README
- **REL-09**: Cross-platform limitations documented (path separators, MSBuild locator, symlinks, process management, file watchers)
- **API-05**: `test_coverage` promoted from experimental to stable
- **API-06**: New `revert_last_apply` tool — `IUndoService`/`UndoService` captures pre-apply solution state; rebuilds reverse changes from workspace's current solution for MSBuildWorkspace compatibility
- **TEST-03**: 5 performance baseline tests with wall-clock budgets
- **Test coverage**: 12 new integration tests across 6 previously untested services (SymbolSearch, SymbolNavigation, SymbolRelationship, Completion, TestDiscovery, TestRunner) + 3 undo tests
- **DiffGenerator**: Decomposed from CC=19 to ~8
- **MCP compliance**: Privacy Policy and Support sections in README; `manifest.json` (v0.3) with binary server type, tools, user_config, cross-platform compat
- **Backlog**: All items resolved except REL-10 (icon — needs graphic design)

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 143/143 pass (was 123)
- [ ] Verify `revert_last_apply` tool via MCP client after a rename apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)