### PR TITLE
feat: add 13 new experimental tools from Roslyn gap analysis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
     <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />
   </ItemGroup>
 </Project>

--- a/ai_docs/roslyn-gap-analysis.md
+++ b/ai_docs/roslyn-gap-analysis.md
@@ -1,0 +1,232 @@
+# Roslyn SDK Gap Analysis vs. MCP Server v1.1.0
+
+> Generated: 2026-03-28 | Server: v1.1.0 (Roslyn 5.3.0.0, .NET 10.0.5)
+> 104 tools currently implemented (49 stable + 55 experimental)
+
+---
+
+## Currently Implemented (Summary)
+
+| Category | Count | Examples |
+|---|---|---|
+| Workspace Management | 6 | load, close, reload, status, list, server_info |
+| Navigation & Symbols | 9 | go_to_definition, symbol_info, symbol_search, semantic_search |
+| References & Calls | 7 | find_references, find_implementations, callers_callees |
+| Diagnostics & Analysis | 5 | project_diagnostics, security_diagnostics, get_completions |
+| Code Actions & Fixes | 5 | get_code_actions, preview/apply_code_action, code_fix_preview/apply |
+| Rename & Format | 4 | rename_preview/apply, format_document_preview/apply |
+| Organize Usings | 2 | organize_usings_preview/apply |
+| Interface Extraction | 5 | extract_interface (same-project, cross-project, DI wiring) |
+| Type Extraction & Split | 5 | extract_type, split_class, move_type_to_file |
+| Type/File Moving | 4 | move_type_to_project, move_file |
+| Bulk Refactoring | 2 | bulk_replace_type_preview/apply |
+| Dead Code | 4 | find_unused_symbols, remove_dead_code, find_type_usages |
+| Code Metrics | 4 | complexity_metrics, cohesion_metrics, find_shared_members, find_type_mutations |
+| Consumer & Dependency | 5 | find_consumers, find_property_writes, namespace_deps, nuget_deps, DI registrations |
+| Syntax & Source | 2 | get_syntax_tree, get_source_text |
+| Editing & Files | 8 | apply_text_edit, multi_file_edit, create/delete_file, impact_analysis |
+| Project Mutation | 11 | add/remove package/project refs, target frameworks, properties, migrate_package |
+| Build & Test | 7 | build_workspace/project, test_run/discover/related/coverage |
+| Scaffolding | 4 | scaffold_type, scaffold_test |
+| Project Graph | 2 | project_graph, source_generated_documents |
+| Undo | 1 | revert_last_apply |
+
+---
+
+## Roslyn Capabilities NOT Exposed (43 Gaps)
+
+### A. Compiler / Emit APIs
+
+| # | Capability | Description |
+|---|---|---|
+| 1 | **In-Memory Compilation (Compilation.Emit)** | Compile C# to IL/assemblies in-memory without shelling out to `dotnet build`. Enables fast compilability checks, snippet validation, and assembly production without MSBuild overhead. |
+| 2 | **Pure Compiler Diagnostics (Compilation.GetDiagnostics)** | Get compiler diagnostics without a full MSBuild build. Faster and lighter when only type-checking is needed. |
+| 3 | **Incremental Compilation / What-If Analysis** | Replace a syntax tree in a Compilation and check if it still compiles. Enables "would this change break anything?" without a rebuild. |
+
+### B. Scripting APIs
+
+| # | Capability | Description |
+|---|---|---|
+| 4 | **C# Script Evaluation (CSharpScript.EvaluateAsync)** | REPL-style evaluation of C# expressions/scripts at runtime. Enables interactive prototyping, expression testing, and dynamic code execution. |
+| 5 | **Script Compilation & Delegate Creation** | Pre-compile scripts for repeated execution. Enables user-defined analysis rules or custom refactoring logic expressed as C#. |
+
+### C. Data Flow & Control Flow Analysis
+
+| # | Capability | Description |
+|---|---|---|
+| 6 | **DataFlowAnalysis (SemanticModel.AnalyzeDataFlow)** | Analyze variable flow through a code region: reads, writes, captures, always-assigned. Enables deep lifetime analysis, side-effect detection, and dependency understanding. |
+| 7 | **ControlFlowAnalysis (SemanticModel.AnalyzeControlFlow)** | Analyze entry/exit points, reachability, and branching within code regions. Enables unreachable-code detection and path validation. |
+
+### D. Classification
+
+| # | Capability | Description |
+|---|---|---|
+| 8 | **Semantic Classification (Classifier.GetClassifiedSpans)** | Semantically-aware token classification (distinguishing type names from variables, keywords from identifiers). Richer than syntax-only highlighting. |
+
+### E. Syntax Transformation APIs
+
+| # | Capability | Description |
+|---|---|---|
+| 9 | **Programmatic Syntax Rewriting (CSharpSyntaxRewriter)** | Pattern-based AST rewriting. Enables custom automated transformations (e.g., convert `var` to explicit types, apply naming conventions systematically). |
+| 10 | **SyntaxGenerator (Microsoft.CodeAnalysis.Editing)** | Language-agnostic code generation API. Enables generating boilerplate (DTOs, builders, mappers) from specifications without string templating. |
+| 11 | **SyntaxFactory Direct Access** | Fine-grained syntax node construction with precise control over trivia and whitespace. |
+
+### F. Semantic Model Deep Queries
+
+| # | Capability | Description |
+|---|---|---|
+| 12 | **Expression-Level Type Queries** | Query inferred type of any expression, resolved overload, or implicit conversion -- not just at declaration positions. |
+| 13 | **GetConstantValue** | Extract compile-time constant values. Enables constant propagation analysis and magic number detection. |
+| 14 | **Alias & Preprocessor Resolution** | Resolve `using` aliases and `#if` preprocessor symbols. Enables understanding conditional compilation. |
+| 15 | **LookupSymbols / LookupNamespacesAndTypes** | Query all symbols visible at a scope position. More complete than completions for full scope analysis. |
+
+### G. Operations API
+
+| # | Capability | Description |
+|---|---|---|
+| 16 | **IOperation Tree** | Language-agnostic intermediate representation of code behavior (assignments, invocations, loops). Enables behavioral pattern matching at a higher abstraction than syntax trees. |
+
+### H. Analyzer Infrastructure
+
+| # | Capability | Description |
+|---|---|---|
+| 17 | **Dynamic Analyzer Loading** | Load and run third-party Roslyn analyzers (StyleCop, SonarAnalyzer, custom) against the workspace dynamically. |
+| 18 | **Suppression & Severity Management** | Programmatic management of pragma suppressions, SuppressMessage attributes, and severity overrides (.editorconfig / rulesets). |
+| 19 | **Analyzer Performance Profiling** | Expose analyzer execution time data to identify slow analyzers degrading builds. |
+
+### I. Source Generators (Extended)
+
+| # | Capability | Description |
+|---|---|---|
+| 20 | **Generator Debugging / Inspection** | Inspect registered generators, their execution diagnostics, and test generators in isolation. |
+| 21 | **Incremental Generator Pipeline Inspection** | Inspect pipeline stages (init, source-provided, post-init) to understand why a generator fires or doesn't. |
+
+### J. Workspace / Solution Manipulation (Extended)
+
+| # | Capability | Description |
+|---|---|---|
+| 22 | **Solution-Level Transformations** | Create new projects within a solution, duplicate projects, or perform arbitrary solution-level mutations beyond the current project mutation tools. |
+| 23 | **AdhocWorkspace / Snippet Analysis** | Create ephemeral workspaces for analyzing code snippets without loading a full solution. Enables diff review, paste analysis, and snippet validation. |
+| 24 | **Workspace Change Events / Streaming** | Expose real-time workspace change notifications (file added/removed/changed) as a streaming tool for reactive workflows. |
+
+### K. Code Fixes & Refactoring (Extended)
+
+| # | Capability | Description |
+|---|---|---|
+| 25 | **List All Analyzers & Rules** | Enumerate all loaded analyzers and their diagnostic IDs. Enables understanding analysis coverage. |
+| 26 | **Batch Code Fix (FixAllProvider)** | Apply a code fix to ALL instances of a diagnostic across the solution in one operation (e.g., remove all unused usings everywhere). |
+| 27 | **Extract Method** | Built-in Roslyn refactoring to extract selected code into a new method. A fundamental refactoring not individually exposed. |
+| 28 | **Extract Local Variable / Introduce Variable** | Extract a subexpression into a named local variable. |
+| 29 | **Inline Method / Inline Variable** | Replace a method call or variable with its body/value inline. |
+| 30 | **Encapsulate Field** | Convert a public field to a property with getter/setter. |
+
+### L. Formatting & Style
+
+| # | Capability | Description |
+|---|---|---|
+| 31 | **Range Formatting** | Format only a selected range within a document instead of the entire file. More efficient and less disruptive. |
+| 32 | **Formatting Options Query/Set** | Get/set formatting rules (indentation, brace style, spacing) programmatically. |
+| 33 | **.editorconfig Read/Write** | Programmatic access to .editorconfig settings and their effect on the workspace. Query active style rules and modify them. |
+
+### M. LSP Features Not Individually Exposed
+
+| # | Capability | Description |
+|---|---|---|
+| 34 | **Document Highlights (read/write classification)** | Highlight all occurrences in a document with read vs. write distinction. Partially covered by find_references but without in-file read/write classification. |
+| 35 | **Selection Range (smart expand/shrink)** | Semantic selection expansion: expression -> statement -> block -> method -> class. |
+| 36 | **Folding Ranges** | Collapsible code regions (imports, methods, classes, #region). |
+| 37 | **Inlay Hints** | Inline type annotations and parameter names at call sites for readability. |
+| 38 | **Document Links** | Extract navigable URLs and file references from comments and strings. |
+
+### N. Code Metrics (Extended)
+
+| # | Capability | Description |
+|---|---|---|
+| 39 | **Maintainability Index** | Composite metric of cyclomatic complexity, LOC, and Halstead volume. Standard quality dashboard metric. |
+| 40 | **Class Coupling** | Count unique types referenced by a class. Identifies overly coupled types. |
+
+### O. MSBuild Integration (Extended)
+
+| # | Capability | Description |
+|---|---|---|
+| 41 | **MSBuild Property/Item Evaluation** | Query resolved MSBuild properties and items (intermediate paths, resolved assets, conditional values). |
+| 42 | **Build Target Listing & Execution** | List and invoke specific MSBuild targets (Publish, Pack, Clean, custom targets) beyond Build/Test. |
+| 43 | **Project SDK Detection & Metadata** | Query SDK type, implicit imports, and global usings for a project. |
+
+---
+
+## Top 10 Recommended for Next Implementation
+
+Ranked by: (1) unique value Roslyn provides over shell tools, (2) agent workflow impact, (3) implementation feasibility, (4) user demand signal.
+
+### 1. Batch Code Fix -- FixAllProvider (Gap #26)
+**Priority: CRITICAL**
+- **Why:** This is the single highest-leverage missing capability. Agents frequently need to clean up entire solutions (remove unused usings, apply nullable annotations, fix naming conventions). Today each diagnostic must be fixed one at a time. A "fix all in solution" tool would turn an O(n) workflow into O(1).
+- **Roslyn API:** `FixAllProvider`, `FixAllContext`, `BatchFixAllProvider`
+- **Effort:** Medium -- requires wiring into the existing code-fix infrastructure with scope options (document / project / solution).
+
+### 2. DataFlowAnalysis (Gap #6)
+**Priority: HIGH**
+- **Why:** Understanding how data flows through code is essential for safe refactoring. Agents need to know which variables are read, written, captured by closures, or always assigned before they can safely extract methods, inline variables, or move code. No shell tool provides this -- it's pure Roslyn semantic model capability.
+- **Roslyn API:** `SemanticModel.AnalyzeDataFlow(statementRange)`
+- **Effort:** Medium -- the API is straightforward; the tool design (input region specification) needs care.
+
+### 3. ControlFlowAnalysis (Gap #7)
+**Priority: HIGH**
+- **Why:** Complements DataFlowAnalysis. Detecting unreachable code, validating all paths return, and understanding branching is critical for code quality analysis. Pairs naturally with complexity_metrics.
+- **Roslyn API:** `SemanticModel.AnalyzeControlFlow(statementRange)`
+- **Effort:** Low -- very similar shape to DataFlowAnalysis; can ship as a pair.
+
+### 4. C# Script Evaluation (Gap #4)
+**Priority: HIGH**
+- **Why:** Enables agents to test expressions, prototype logic, and validate code interactively without creating files or running full builds. Unique capability that transforms how agents can interact with C# -- no other tool provides this.
+- **Roslyn API:** `Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScript.EvaluateAsync`
+- **Effort:** Medium -- needs sandboxing and security considerations, but the API is clean.
+
+### 5. AdhocWorkspace / Snippet Analysis (Gap #23)
+**Priority: HIGH**
+- **Why:** Agents often need to analyze code fragments (from chat, diffs, or clipboard) without loading a full solution. An ephemeral workspace for quick type-checking, symbol resolution, or syntax validation of snippets would be enormously useful.
+- **Roslyn API:** `AdhocWorkspace`, `Document.WithText()`, `Compilation.GetDiagnostics()`
+- **Effort:** Medium -- standalone workspace management is well-documented.
+
+### 6. Range Formatting (Gap #31)
+**Priority: MEDIUM-HIGH**
+- **Why:** After edits or code generation, agents typically need to format only the changed region, not the entire file. Full-document formatting creates noisy diffs. Range formatting is a standard LSP feature that's missing.
+- **Roslyn API:** `Formatter.FormatAsync(document, spanToFormat)`
+- **Effort:** Low -- small extension of the existing format_document tool.
+
+### 7. .editorconfig Read/Write (Gap #33)
+**Priority: MEDIUM-HIGH**
+- **Why:** .editorconfig drives formatting, naming conventions, and analyzer severity. Agents need to understand the active style rules and sometimes modify them (e.g., enable nullable, change indentation). Currently opaque.
+- **Roslyn API:** `AnalyzerConfigDocument`, `AnalyzerConfigOptions`
+- **Effort:** Medium -- needs file parsing and option resolution chain understanding.
+
+### 8. In-Memory Compilation (Gap #1)
+**Priority: MEDIUM-HIGH**
+- **Why:** The current `build_workspace`/`build_project` tools shell out to `dotnet build`, which is slow and heavyweight. Roslyn's `Compilation.Emit` can validate compilability in-memory in milliseconds. Perfect for rapid feedback loops during code generation.
+- **Roslyn API:** `Compilation.Emit(Stream)`, `Compilation.GetDiagnostics()`
+- **Effort:** Medium -- the API is simple but needs careful integration with the MSBuildWorkspace snapshot.
+
+### 9. IOperation Tree (Gap #16)
+**Priority: MEDIUM**
+- **Why:** IOperation provides a language-agnostic, normalized view of code behavior. Enables writing analysis tools that reason about what code *does* rather than how it's *written*. Valuable for custom pattern detection (e.g., "find all methods that catch and swallow exceptions" or "find SQL string concatenation").
+- **Roslyn API:** `SemanticModel.GetOperation(syntaxNode)`
+- **Effort:** Medium -- the tree is rich; the challenge is useful serialization and query design.
+
+### 10. List All Analyzers & Rules (Gap #25)
+**Priority: MEDIUM**
+- **Why:** Before fixing diagnostics or managing suppressions, agents need to know what analyzers are loaded and what rules they provide. This is a discovery/transparency tool that makes the existing diagnostic tools more useful.
+- **Roslyn API:** `Compilation.Analyzers`, `DiagnosticAnalyzer.SupportedDiagnostics`
+- **Effort:** Low -- enumeration of already-loaded analyzer state.
+
+---
+
+## Honorable Mentions (Next 5)
+
+| Rank | Gap | Rationale |
+|---|---|---|
+| 11 | Custom Syntax Rewriter (#9) | Powerful but hard to expose safely through a tool interface |
+| 12 | Suppression Management (#18) | Natural follow-on to "List Analyzers" |
+| 13 | Maintainability Index (#39) | Natural extension of existing metrics tools |
+| 14 | Dynamic Analyzer Loading (#17) | High value but complex security/isolation story |
+| 15 | Incremental Compilation (#3) | Powerful but overlaps with in-memory compilation |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {
     "name": "darylmcd",

--- a/src/RoslynMcp.Core/Models/AnalyzerInfoDto.cs
+++ b/src/RoslynMcp.Core/Models/AnalyzerInfoDto.cs
@@ -1,0 +1,19 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Describes a loaded analyzer assembly and its supported diagnostic rules.
+/// </summary>
+public sealed record AnalyzerInfoDto(
+    string AssemblyName,
+    IReadOnlyList<AnalyzerRuleDto> Rules);
+
+/// <summary>
+/// Describes a single diagnostic rule supported by an analyzer.
+/// </summary>
+public sealed record AnalyzerRuleDto(
+    string Id,
+    string Title,
+    string Category,
+    string DefaultSeverity,
+    bool IsEnabledByDefault,
+    string? HelpLinkUri);

--- a/src/RoslynMcp.Core/Models/CompileCheckDto.cs
+++ b/src/RoslynMcp.Core/Models/CompileCheckDto.cs
@@ -1,0 +1,11 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the result of an in-memory compilation check without invoking dotnet build.
+/// </summary>
+public sealed record CompileCheckDto(
+    bool Success,
+    int ErrorCount,
+    int WarningCount,
+    IReadOnlyList<DiagnosticDto> Diagnostics,
+    long ElapsedMs);

--- a/src/RoslynMcp.Core/Models/ControlFlowAnalysisDto.cs
+++ b/src/RoslynMcp.Core/Models/ControlFlowAnalysisDto.cs
@@ -1,0 +1,20 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the result of analyzing control flow through a code region.
+/// </summary>
+public sealed record ControlFlowAnalysisDto(
+    bool Succeeded,
+    bool StartPointIsReachable,
+    bool EndPointIsReachable,
+    IReadOnlyList<string> EntryPoints,
+    IReadOnlyList<string> ExitPoints,
+    IReadOnlyList<ReturnStatementDto> ReturnStatements);
+
+/// <summary>
+/// Describes a return statement found during control flow analysis.
+/// </summary>
+public sealed record ReturnStatementDto(
+    int Line,
+    int Column,
+    string? ExpressionText);

--- a/src/RoslynMcp.Core/Models/DataFlowAnalysisDto.cs
+++ b/src/RoslynMcp.Core/Models/DataFlowAnalysisDto.cs
@@ -1,0 +1,18 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the result of analyzing data flow through a code region.
+/// </summary>
+public sealed record DataFlowAnalysisDto(
+    bool Succeeded,
+    IReadOnlyList<string> VariablesDeclared,
+    IReadOnlyList<string> DataFlowsIn,
+    IReadOnlyList<string> DataFlowsOut,
+    IReadOnlyList<string> AlwaysAssigned,
+    IReadOnlyList<string> ReadInside,
+    IReadOnlyList<string> WrittenInside,
+    IReadOnlyList<string> ReadOutside,
+    IReadOnlyList<string> WrittenOutside,
+    IReadOnlyList<string> Captured,
+    IReadOnlyList<string> CapturedInside,
+    IReadOnlyList<string> UnsafeAddressTaken);

--- a/src/RoslynMcp.Core/Models/EditorConfigDto.cs
+++ b/src/RoslynMcp.Core/Models/EditorConfigDto.cs
@@ -1,0 +1,17 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the effective .editorconfig options for a source file.
+/// </summary>
+public sealed record EditorConfigOptionsDto(
+    string FilePath,
+    string? ApplicableEditorConfigPath,
+    IReadOnlyList<EditorConfigEntryDto> Options);
+
+/// <summary>
+/// A single key-value pair from the effective .editorconfig options.
+/// </summary>
+public sealed record EditorConfigEntryDto(
+    string Key,
+    string Value,
+    string? Source);

--- a/src/RoslynMcp.Core/Models/FixAllPreviewDto.cs
+++ b/src/RoslynMcp.Core/Models/FixAllPreviewDto.cs
@@ -1,0 +1,11 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents a preview of applying a code fix to all instances of a diagnostic across a scope.
+/// </summary>
+public sealed record FixAllPreviewDto(
+    string PreviewToken,
+    string DiagnosticId,
+    string Scope,
+    int FixedCount,
+    IReadOnlyList<FileChangeDto> Changes);

--- a/src/RoslynMcp.Core/Models/OperationNodeDto.cs
+++ b/src/RoslynMcp.Core/Models/OperationNodeDto.cs
@@ -1,0 +1,14 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents a node in the Roslyn IOperation tree — a language-agnostic intermediate
+/// representation of code behavior (assignments, invocations, loops, etc.).
+/// </summary>
+public sealed record OperationNodeDto(
+    string Kind,
+    string? Type,
+    string? ConstantValue,
+    string? Syntax,
+    int Line,
+    int Column,
+    IReadOnlyList<OperationNodeDto>? Children);

--- a/src/RoslynMcp.Core/Models/ScriptEvaluationDto.cs
+++ b/src/RoslynMcp.Core/Models/ScriptEvaluationDto.cs
@@ -1,0 +1,12 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the result of evaluating a C# script expression or code block.
+/// </summary>
+public sealed record ScriptEvaluationDto(
+    bool Success,
+    string? ResultType,
+    string? ResultValue,
+    string? Error,
+    IReadOnlyList<DiagnosticDto>? CompilationErrors,
+    long ElapsedMs);

--- a/src/RoslynMcp.Core/Models/SnippetAnalysisDto.cs
+++ b/src/RoslynMcp.Core/Models/SnippetAnalysisDto.cs
@@ -1,0 +1,11 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents the result of analyzing a C# code snippet in an ephemeral workspace.
+/// </summary>
+public sealed record SnippetAnalysisDto(
+    bool IsValid,
+    int ErrorCount,
+    int WarningCount,
+    IReadOnlyList<DiagnosticDto> Diagnostics,
+    IReadOnlyList<string>? DeclaredSymbols);

--- a/src/RoslynMcp.Core/Services/IAnalyzerInfoService.cs
+++ b/src/RoslynMcp.Core/Services/IAnalyzerInfoService.cs
@@ -1,0 +1,15 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Enumerates all loaded Roslyn analyzers and their supported diagnostic rules for a workspace.
+/// </summary>
+public interface IAnalyzerInfoService
+{
+    /// <summary>
+    /// Lists all loaded analyzer assemblies and their supported diagnostic descriptors.
+    /// </summary>
+    Task<IReadOnlyList<AnalyzerInfoDto>> ListAnalyzersAsync(
+        string workspaceId, string? projectFilter, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/ICompileCheckService.cs
+++ b/src/RoslynMcp.Core/Services/ICompileCheckService.cs
@@ -1,0 +1,17 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides in-memory compilation checking using the Roslyn Compilation API,
+/// without shelling out to dotnet build.
+/// </summary>
+public interface ICompileCheckService
+{
+    /// <summary>
+    /// Performs an in-memory compilation check for the specified project or all projects in the workspace.
+    /// Returns compiler diagnostics (errors/warnings) without producing binaries on disk.
+    /// </summary>
+    Task<CompileCheckDto> CheckAsync(
+        string workspaceId, string? projectFilter, bool emitValidation, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/IEditorConfigService.cs
+++ b/src/RoslynMcp.Core/Services/IEditorConfigService.cs
@@ -1,0 +1,14 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides read and write access to .editorconfig settings affecting the workspace.
+/// </summary>
+public interface IEditorConfigService
+{
+    /// <summary>
+    /// Gets the effective .editorconfig options for the specified source file.
+    /// </summary>
+    Task<EditorConfigOptionsDto> GetOptionsAsync(string workspaceId, string filePath, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/IFixAllService.cs
+++ b/src/RoslynMcp.Core/Services/IFixAllService.cs
@@ -1,0 +1,23 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides batch code fix operations using Roslyn's FixAllProvider to apply a fix
+/// to all instances of a diagnostic across a document, project, or solution.
+/// </summary>
+public interface IFixAllService
+{
+    /// <summary>
+    /// Previews applying a code fix to all occurrences of the specified diagnostic across the given scope.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="diagnosticId">The diagnostic identifier to fix (e.g., CS8019).</param>
+    /// <param name="scope">The scope: "document", "project", or "solution".</param>
+    /// <param name="filePath">Required when scope is "document": the absolute path to the file.</param>
+    /// <param name="projectName">Optional: filter to a specific project when scope is "project".</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<FixAllPreviewDto> PreviewFixAllAsync(
+        string workspaceId, string diagnosticId, string scope,
+        string? filePath, string? projectName, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/IFlowAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/IFlowAnalysisService.cs
@@ -1,0 +1,23 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides data flow and control flow analysis for code regions using the Roslyn semantic model.
+/// </summary>
+public interface IFlowAnalysisService
+{
+    /// <summary>
+    /// Analyzes how variables flow through the statement range defined by <paramref name="startLine"/>
+    /// to <paramref name="endLine"/>: which are read, written, captured, always assigned, etc.
+    /// </summary>
+    Task<DataFlowAnalysisDto> AnalyzeDataFlowAsync(
+        string workspaceId, string filePath, int startLine, int endLine, CancellationToken ct);
+
+    /// <summary>
+    /// Analyzes control flow through the statement range defined by <paramref name="startLine"/>
+    /// to <paramref name="endLine"/>: entry/exit points, reachability, and return statements.
+    /// </summary>
+    Task<ControlFlowAnalysisDto> AnalyzeControlFlowAsync(
+        string workspaceId, string filePath, int startLine, int endLine, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/IOperationService.cs
+++ b/src/RoslynMcp.Core/Services/IOperationService.cs
@@ -1,0 +1,15 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides access to the Roslyn IOperation tree for behavioral analysis of code.
+/// </summary>
+public interface IOperationService
+{
+    /// <summary>
+    /// Gets the IOperation tree for the syntax node at the given source position.
+    /// </summary>
+    Task<OperationNodeDto?> GetOperationsAsync(
+        string workspaceId, string filePath, int line, int column, int maxDepth, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/IRefactoringService.cs
+++ b/src/RoslynMcp.Core/Services/IRefactoringService.cs
@@ -41,6 +41,19 @@ public interface IRefactoringService
     Task<RefactoringPreviewDto> PreviewFormatDocumentAsync(string workspaceId, string filePath, CancellationToken ct);
 
     /// <summary>
+    /// Previews applying the default Roslyn formatting rules to a specific range within a file.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="filePath">The absolute path to the source file.</param>
+    /// <param name="startLine">The 1-based start line of the range to format.</param>
+    /// <param name="startColumn">The 1-based start column of the range to format.</param>
+    /// <param name="endLine">The 1-based end line of the range to format.</param>
+    /// <param name="endColumn">The 1-based end column of the range to format.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<RefactoringPreviewDto> PreviewFormatRangeAsync(
+        string workspaceId, string filePath, int startLine, int startColumn, int endLine, int endColumn, CancellationToken ct);
+
+    /// <summary>
     /// Previews applying a curated code fix for the specified diagnostic.
     /// </summary>
     /// <param name="workspaceId">The workspace session identifier.</param>

--- a/src/RoslynMcp.Core/Services/IScriptingService.cs
+++ b/src/RoslynMcp.Core/Services/IScriptingService.cs
@@ -1,0 +1,18 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides C# script evaluation using the Roslyn Scripting API for interactive
+/// expression testing and prototyping.
+/// </summary>
+public interface IScriptingService
+{
+    /// <summary>
+    /// Evaluates a C# script expression or code block and returns the result.
+    /// </summary>
+    /// <param name="code">The C# code to evaluate.</param>
+    /// <param name="imports">Optional additional namespace imports.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ScriptEvaluationDto> EvaluateAsync(string code, string[]? imports, CancellationToken ct);
+}

--- a/src/RoslynMcp.Core/Services/ISnippetAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/ISnippetAnalysisService.cs
@@ -1,0 +1,19 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Provides code analysis for standalone C# snippets using an ephemeral AdhocWorkspace,
+/// without requiring a loaded solution.
+/// </summary>
+public interface ISnippetAnalysisService
+{
+    /// <summary>
+    /// Analyzes a C# code snippet for compilation errors and declared symbols.
+    /// </summary>
+    /// <param name="code">The C# code to analyze.</param>
+    /// <param name="usings">Optional additional using directives.</param>
+    /// <param name="kind">The snippet kind: "expression", "statements", "members", or "program" (default).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<SnippetAnalysisDto> AnalyzeAsync(string code, string[]? usings, string kind, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -124,7 +124,20 @@ public static class ServerSurfaceCatalog
         Tool("extract_type_preview", "refactoring", "experimental", true, false, "Preview extracting selected members from a type into a new type. Adds a private field and constructor parameter for composition. Use get_cohesion_metrics and find_shared_members to plan the extraction."),
         Tool("extract_type_apply", "refactoring", "experimental", false, true, "Apply a previewed type extraction. Moves members to the new type file and wires composition in the source type."),
 
-        Tool("revert_last_apply", "undo", "experimental", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace.")
+        Tool("revert_last_apply", "undo", "experimental", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace."),
+
+        Tool("analyze_data_flow", "advanced-analysis", "experimental", true, false, "Analyze variable flow through a code region: reads, writes, captures, always-assigned."),
+        Tool("analyze_control_flow", "advanced-analysis", "experimental", true, false, "Analyze control flow: entry/exit points, reachability, return statements."),
+        Tool("compile_check", "validation", "experimental", true, false, "Fast in-memory compilation check without invoking dotnet build."),
+        Tool("list_analyzers", "analysis", "experimental", true, false, "List all loaded analyzers and their diagnostic rules."),
+        Tool("fix_all_preview", "refactoring", "experimental", true, false, "Preview fixing ALL instances of a diagnostic across a scope."),
+        Tool("fix_all_apply", "refactoring", "experimental", false, true, "Apply a previously previewed fix-all operation."),
+        Tool("get_operations", "advanced-analysis", "experimental", true, false, "Get the IOperation tree for behavioral analysis at a source position."),
+        Tool("format_range_preview", "refactoring", "experimental", true, false, "Preview formatting a specific range within a document."),
+        Tool("format_range_apply", "refactoring", "experimental", false, true, "Apply a previously previewed range format operation."),
+        Tool("analyze_snippet", "analysis", "experimental", true, false, "Analyze a C# code snippet in an ephemeral workspace without loading a solution."),
+        Tool("evaluate_csharp", "scripting", "experimental", true, false, "Evaluate a C# expression or script interactively via the Roslyn Scripting API."),
+        Tool("get_editorconfig_options", "configuration", "experimental", true, false, "Get effective .editorconfig options for a source file.")
     ];
 
     public static IReadOnlyList<SurfaceEntry> Resources { get; } =
@@ -183,7 +196,10 @@ public static class ServerSurfaceCatalog
         new("SRP Analysis & Type Extraction", ["get_cohesion_metrics", "find_shared_members", "extract_type_preview", "extract_type_apply", "build_workspace"], "Identify types with multiple responsibilities via LCOM4 metrics, find shared private members that complicate extraction, preview and apply the extraction, then verify the build."),
         new("Consumer Impact Analysis", ["find_consumers", "find_references_bulk", "impact_analysis"], "Find all types that depend on a type or interface, understand dependency kinds (constructor, field, parameter, base type), then assess change impact."),
         new("Interface Extraction & Migration", ["extract_interface_preview", "extract_interface_apply", "bulk_replace_type_preview", "bulk_replace_type_apply", "build_workspace"], "Extract an interface from a concrete type, then bulk-replace all parameter/field references to use the interface instead. Verify with build."),
-        new("Type Organization", ["move_type_to_file_preview", "move_type_to_file_apply", "build_workspace"], "Move types from multi-type files into their own dedicated files for better code organization.")
+        new("Type Organization", ["move_type_to_file_preview", "move_type_to_file_apply", "build_workspace"], "Move types from multi-type files into their own dedicated files for better code organization."),
+        new("Batch Diagnostic Fix", ["list_analyzers", "project_diagnostics", "fix_all_preview", "fix_all_apply", "build_workspace"], "List available analyzers and rules, identify diagnostics, batch-fix all occurrences across the solution, then verify the build."),
+        new("Flow Analysis for Refactoring", ["analyze_data_flow", "analyze_control_flow", "extract_type_preview", "extract_type_apply"], "Analyze data and control flow to understand variable dependencies and reachability before extracting code into new types or methods."),
+        new("Quick Validation", ["compile_check", "analyze_snippet", "evaluate_csharp"], "Use in-memory compilation, snippet analysis, or script evaluation for rapid feedback without full builds.")
     ];
 
     public static ServerCatalogDto CreateDocument()

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class AnalyzerInfoTools
+{
+    [McpServerTool(Name = "list_analyzers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("List all loaded Roslyn analyzers and their supported diagnostic rules. Use to understand what analysis coverage exists and which diagnostic IDs are available for code_fix_preview or fix_all_preview.")]
+    public static Task<string> ListAnalyzers(
+        IWorkspaceExecutionGate gate,
+        IAnalyzerInfoService analyzerInfoService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name")] string? project = null,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var results = await analyzerInfoService.ListAnalyzersAsync(workspaceId, project, c);
+                var totalRules = results.Sum(a => a.Rules.Count);
+                return JsonSerializer.Serialize(new { analyzerCount = results.Count, totalRules, analyzers = results }, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class CompileCheckTools
+{
+    [McpServerTool(Name = "compile_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation.")]
+    public static Task<string> CompileCheck(
+        IWorkspaceExecutionGate gate,
+        ICompileCheckService compileCheckService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name")] string? project = null,
+        [Description("When true, performs full emit validation (catches more issues like missing references at emit time). Default: false (faster, uses GetDiagnostics only).")] bool emitValidation = false,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await compileCheckService.CheckAsync(workspaceId, project, emitValidation, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class EditorConfigTools
+{
+    [McpServerTool(Name = "get_editorconfig_options", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Get the effective .editorconfig options for a source file — returns the active code style rules, formatting settings, and naming conventions that Roslyn applies to the file.")]
+    public static Task<string> GetEditorConfigOptions(
+        IWorkspaceExecutionGate gate,
+        IEditorConfigService editorConfigService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file to inspect")] string filePath,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await editorConfigService.GetOptionsAsync(workspaceId, filePath, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class FixAllTools
+{
+    [McpServerTool(Name = "fix_all_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
+     Description("Preview applying a code fix to ALL instances of a diagnostic across a scope (document, project, or solution). Dramatically faster than fixing diagnostics one at a time. Use list_analyzers or project_diagnostics to find diagnostic IDs.")]
+    public static Task<string> PreviewFixAll(
+        IWorkspaceExecutionGate gate,
+        IFixAllService fixAllService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Diagnostic identifier to fix everywhere, e.g. CS8019, IDE0005")] string diagnosticId,
+        [Description("Scope of the fix: 'document', 'project', or 'solution'")] string scope,
+        [Description("Required when scope is 'document': absolute path to the source file")] string? filePath = null,
+        [Description("Optional: project name when scope is 'project'")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await fixAllService.PreviewFixAllAsync(workspaceId, diagnosticId, scope, filePath, projectName, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+
+    [McpServerTool(Name = "fix_all_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
+     Description("Apply a previously previewed fix-all operation using its preview token")]
+    public static Task<string> ApplyFixAll(
+        IWorkspaceExecutionGate gate,
+        IRefactoringService refactoringService,
+        IPreviewStore previewStore,
+        [Description("The preview token returned by fix_all_preview")] string previewToken,
+        CancellationToken ct = default)
+    {
+        var gateKey = RefactoringTools.ApplyGateKeyFor(previewStore, previewToken);
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(gateKey, async c =>
+            {
+                var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class FlowAnalysisTools
+{
+    [McpServerTool(Name = "analyze_data_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Analyze how variables flow through a code region: which are read, written, captured by lambdas, always assigned, etc. Use to understand data dependencies before refactoring.")]
+    public static Task<string> AnalyzeDataFlow(
+        IWorkspaceExecutionGate gate,
+        IFlowAnalysisService flowAnalysisService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based start line of the code region to analyze")] int startLine,
+        [Description("1-based end line of the code region to analyze")] int endLine,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await flowAnalysisService.AnalyzeDataFlowAsync(workspaceId, filePath, startLine, endLine, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+
+    [McpServerTool(Name = "analyze_control_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. Use to detect unreachable code and validate all code paths.")]
+    public static Task<string> AnalyzeControlFlow(
+        IWorkspaceExecutionGate gate,
+        IFlowAnalysisService flowAnalysisService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based start line of the code region to analyze")] int startLine,
+        [Description("1-based end line of the code region to analyze")] int endLine,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await flowAnalysisService.AnalyzeControlFlowAsync(workspaceId, filePath, startLine, endLine, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class OperationTools
+{
+    [McpServerTool(Name = "get_operations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Get the IOperation tree (language-agnostic behavioral representation) for a syntax node. Returns operation kinds like Invocation, Assignment, Loop, etc. Use for behavioral pattern matching at a higher abstraction than syntax trees.")]
+    public static Task<string> GetOperations(
+        IWorkspaceExecutionGate gate,
+        IOperationService operationService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based line number")] int line,
+        [Description("1-based column number")] int column,
+        [Description("Maximum depth of the operation tree to return (default: 3)")] int maxDepth = 3,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await operationService.GetOperationsAsync(workspaceId, filePath, line, column, maxDepth, c);
+                if (result is null)
+                    return JsonSerializer.Serialize(new { message = "No IOperation found at the specified position." }, JsonDefaults.Indented);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -149,6 +149,45 @@ public static class RefactoringTools
             }, ct));
     }
 
+    [McpServerTool(Name = "format_range_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
+     Description("Preview formatting a specific range within a document — more efficient than full-document formatting and produces smaller diffs")]
+    public static Task<string> PreviewFormatRange(
+        IWorkspaceExecutionGate gate,
+        IRefactoringService refactoringService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based start line of the range to format")] int startLine,
+        [Description("1-based start column of the range to format")] int startColumn,
+        [Description("1-based end line of the range to format")] int endLine,
+        [Description("1-based end column of the range to format")] int endColumn,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(workspaceId, async c =>
+            {
+                var result = await refactoringService.PreviewFormatRangeAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+
+    [McpServerTool(Name = "format_range_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
+     Description("Apply a previously previewed range format operation using its preview token")]
+    public static Task<string> ApplyFormatRange(
+        IWorkspaceExecutionGate gate,
+        IRefactoringService refactoringService,
+        IPreviewStore previewStore,
+        [Description("The preview token returned by format_range_preview")] string previewToken,
+        CancellationToken ct = default)
+    {
+        var gateKey = ApplyGateKeyFor(previewStore, previewToken);
+        return ToolErrorHandler.ExecuteAsync(() =>
+            gate.RunAsync(gateKey, async c =>
+            {
+                var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+
     internal static string ApplyGateKeyFor(IPreviewStore store, string token)
     {
         var wsId = store.PeekWorkspaceId(token);

--- a/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class ScriptingTools
+{
+    [McpServerTool(Name = "evaluate_csharp", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Evaluate a C# expression or script interactively using the Roslyn Scripting API. Returns the result value and type. Use for quick expression testing, prototyping, and validating logic without creating files or running builds.")]
+    public static Task<string> EvaluateCSharp(
+        IScriptingService scriptingService,
+        [Description("The C# code to evaluate (expression, statement, or multi-line script)")] string code,
+        [Description("Optional: additional namespace imports, e.g. [\"System.IO\", \"System.Net.Http\"]")] string[]? imports = null,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(async () =>
+        {
+            var result = await scriptingService.EvaluateAsync(code, imports, ct);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        });
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class SnippetAnalysisTools
+{
+    [McpServerTool(Name = "analyze_snippet", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     Description("Analyze a C# code snippet for compilation errors and declared symbols without loading a full solution. Uses an ephemeral workspace for quick validation of code fragments, diffs, or pasted code.")]
+    public static Task<string> AnalyzeSnippet(
+        ISnippetAnalysisService snippetAnalysisService,
+        [Description("The C# code to analyze")] string code,
+        [Description("Optional: additional using directives as an array, e.g. [\"System.IO\", \"System.Net.Http\"]")] string[]? usings = null,
+        [Description("The snippet kind: 'expression' (single expression), 'statements' (method body), 'members' (class members), or 'program' (full compilation unit, default)")] string kind = "program",
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync(async () =>
+        {
+            var result = await snippetAnalysisService.AnalyzeAsync(code, usings, kind, ct);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        });
+    }
+}

--- a/src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj
+++ b/src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="DiffPlex" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
   </ItemGroup>
 
   <!-- MSBuildLocator requires MSBuild packages to exclude runtime assets -->

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -72,6 +72,14 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBulkRefactoringService, BulkRefactoringService>();
         services.AddSingleton<ITypeExtractionService, TypeExtractionService>();
         services.AddSingleton<IUndoService, UndoService>();
+        services.AddSingleton<IFlowAnalysisService, FlowAnalysisService>();
+        services.AddSingleton<ICompileCheckService, CompileCheckService>();
+        services.AddSingleton<IAnalyzerInfoService, AnalyzerInfoService>();
+        services.AddSingleton<IFixAllService, FixAllService>();
+        services.AddSingleton<IOperationService, OperationService>();
+        services.AddSingleton<ISnippetAnalysisService, SnippetAnalysisService>();
+        services.AddSingleton<IScriptingService, ScriptingService>();
+        services.AddSingleton<IEditorConfigService, EditorConfigService>();
         return services;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/AnalyzerInfoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/AnalyzerInfoService.cs
@@ -1,0 +1,90 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class AnalyzerInfoService : IAnalyzerInfoService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<AnalyzerInfoService> _logger;
+
+    public AnalyzerInfoService(IWorkspaceManager workspace, ILogger<AnalyzerInfoService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<AnalyzerInfoDto>> ListAnalyzersAsync(
+        string workspaceId, string? projectFilter, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter);
+
+        // Collect all unique analyzers across projects
+        var analyzersByAssembly = new Dictionary<string, List<AnalyzerRuleDto>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            // Get analyzer references from the project
+            foreach (var analyzerRef in project.AnalyzerReferences)
+            {
+                var assemblyName = analyzerRef.Display ?? analyzerRef.FullPath ?? "Unknown";
+
+                if (analyzersByAssembly.ContainsKey(assemblyName))
+                    continue; // Already processed this assembly
+
+                var rules = new List<AnalyzerRuleDto>();
+
+                try
+                {
+                    var analyzers = analyzerRef.GetAnalyzers(compilation.Language);
+                    foreach (var analyzer in analyzers)
+                    {
+                        foreach (var descriptor in analyzer.SupportedDiagnostics)
+                        {
+                            rules.Add(new AnalyzerRuleDto(
+                                Id: descriptor.Id,
+                                Title: descriptor.Title.ToString(),
+                                Category: descriptor.Category,
+                                DefaultSeverity: descriptor.DefaultSeverity.ToString(),
+                                IsEnabledByDefault: descriptor.IsEnabledByDefault,
+                                HelpLinkUri: descriptor.HelpLinkUri));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load analyzers from {Assembly}", assemblyName);
+                    rules.Add(new AnalyzerRuleDto(
+                        Id: "LOAD_ERROR",
+                        Title: $"Failed to load: {ex.Message}",
+                        Category: "Error",
+                        DefaultSeverity: "Error",
+                        IsEnabledByDefault: false,
+                        HelpLinkUri: null));
+                }
+
+                analyzersByAssembly[assemblyName] = rules;
+            }
+        }
+
+        return analyzersByAssembly
+            .Select(kvp => new AnalyzerInfoDto(
+                AssemblyName: kvp.Key,
+                Rules: kvp.Value
+                    .DistinctBy(r => r.Id)
+                    .OrderBy(r => r.Id)
+                    .ToList()))
+            .OrderBy(a => a.AssemblyName)
+            .ToList();
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class CompileCheckService : ICompileCheckService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<CompileCheckService> _logger;
+
+    public CompileCheckService(IWorkspaceManager workspace, ILogger<CompileCheckService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<CompileCheckDto> CheckAsync(
+        string workspaceId, string? projectFilter, bool emitValidation, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter);
+        var allDiagnostics = new List<DiagnosticDto>();
+        int errorCount = 0;
+        int warningCount = 0;
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            IEnumerable<Diagnostic> diagnostics;
+
+            if (emitValidation)
+            {
+                // Full emit validation catches more issues (e.g., missing references at emit time)
+                using var stream = new MemoryStream();
+                var emitResult = compilation.Emit(stream, cancellationToken: ct);
+                diagnostics = emitResult.Diagnostics;
+            }
+            else
+            {
+                diagnostics = compilation.GetDiagnostics(ct);
+            }
+
+            foreach (var diag in diagnostics)
+            {
+                if (diag.Severity == DiagnosticSeverity.Hidden) continue;
+
+                if (diag.Severity == DiagnosticSeverity.Error) errorCount++;
+                else if (diag.Severity == DiagnosticSeverity.Warning) warningCount++;
+
+                var lineSpan = diag.Location.GetMappedLineSpan();
+                allDiagnostics.Add(new DiagnosticDto(
+                    Id: diag.Id,
+                    Message: diag.GetMessage(),
+                    Severity: diag.Severity.ToString(),
+                    Category: diag.Descriptor.Category,
+                    FilePath: lineSpan.Path,
+                    StartLine: lineSpan.IsValid ? lineSpan.StartLinePosition.Line + 1 : null,
+                    StartColumn: lineSpan.IsValid ? lineSpan.StartLinePosition.Character + 1 : null,
+                    EndLine: lineSpan.IsValid ? lineSpan.EndLinePosition.Line + 1 : null,
+                    EndColumn: lineSpan.IsValid ? lineSpan.EndLinePosition.Character + 1 : null));
+            }
+        }
+
+        sw.Stop();
+        return new CompileCheckDto(
+            Success: errorCount == 0,
+            ErrorCount: errorCount,
+            WarningCount: warningCount,
+            Diagnostics: allDiagnostics,
+            ElapsedMs: sw.ElapsedMilliseconds);
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -1,0 +1,197 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class EditorConfigService : IEditorConfigService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<EditorConfigService> _logger;
+
+    public EditorConfigService(IWorkspaceManager workspace, ILogger<EditorConfigService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<EditorConfigOptionsDto> GetOptionsAsync(
+        string workspaceId, string filePath, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var document = SymbolResolver.FindDocument(solution, filePath)
+            ?? throw new FileNotFoundException($"Document not found in workspace: {filePath}");
+
+        var tree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not get syntax tree.");
+
+        var options = new List<EditorConfigEntryDto>();
+
+        // Get analyzer config options from the workspace's analyzer config documents
+        var project = document.Project;
+        var analyzerOptions = project.AnalyzerOptions;
+
+        // Get options from the AnalyzerConfigOptionsProvider
+        var optionsProvider = analyzerOptions.AnalyzerConfigOptionsProvider;
+        var treeOptions = optionsProvider.GetOptions(tree);
+
+        // Extract all known keys
+        foreach (var key in GetKnownOptionKeys())
+        {
+            if (treeOptions.TryGetValue(key, out var value))
+            {
+                options.Add(new EditorConfigEntryDto(key, value, "editorconfig"));
+            }
+        }
+
+        // Find the applicable .editorconfig path
+        var editorconfigPath = FindEditorconfigPath(document.FilePath ?? filePath);
+
+        return new EditorConfigOptionsDto(
+            FilePath: filePath,
+            ApplicableEditorConfigPath: editorconfigPath,
+            Options: options.OrderBy(o => o.Key).ToList());
+    }
+
+    private static string? FindEditorconfigPath(string filePath)
+    {
+        var dir = Path.GetDirectoryName(filePath);
+        while (dir is not null)
+        {
+            var editorconfigPath = Path.Combine(dir, ".editorconfig");
+            if (File.Exists(editorconfigPath))
+                return editorconfigPath;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> GetKnownOptionKeys()
+    {
+        // Common .editorconfig keys that Roslyn respects
+        return
+        [
+            // Core editor settings
+            "indent_style",
+            "indent_size",
+            "tab_width",
+            "end_of_line",
+            "charset",
+            "trim_trailing_whitespace",
+            "insert_final_newline",
+            "max_line_length",
+
+            // .NET code style
+            "dotnet_sort_system_directives_first",
+            "dotnet_separate_import_directive_groups",
+            "dotnet_style_qualification_for_field",
+            "dotnet_style_qualification_for_property",
+            "dotnet_style_qualification_for_method",
+            "dotnet_style_qualification_for_event",
+            "dotnet_style_predefined_type_for_locals_parameters_members",
+            "dotnet_style_predefined_type_for_member_access",
+            "dotnet_style_require_accessibility_modifiers",
+            "dotnet_style_readonly_field",
+            "dotnet_style_parentheses_in_arithmetic_binary_operators",
+            "dotnet_style_parentheses_in_relational_binary_operators",
+            "dotnet_style_parentheses_in_other_binary_operators",
+            "dotnet_style_parentheses_in_other_operators",
+            "dotnet_style_object_initializer",
+            "dotnet_style_collection_initializer",
+            "dotnet_style_prefer_auto_properties",
+            "dotnet_style_explicit_tuple_names",
+            "dotnet_style_prefer_inferred_tuple_names",
+            "dotnet_style_prefer_inferred_anonymous_type_member_names",
+            "dotnet_style_prefer_conditional_expression_over_assignment",
+            "dotnet_style_prefer_conditional_expression_over_return",
+            "dotnet_style_prefer_compound_assignment",
+            "dotnet_style_prefer_simplified_interpolation",
+            "dotnet_style_prefer_simplified_boolean_expressions",
+            "dotnet_style_namespace_match_folder",
+            "dotnet_style_coalesce_expression",
+            "dotnet_style_null_propagation",
+            "dotnet_style_prefer_is_null_check_over_reference_equality_method",
+
+            // C# code style
+            "csharp_style_var_for_built_in_types",
+            "csharp_style_var_when_type_is_apparent",
+            "csharp_style_var_elsewhere",
+            "csharp_style_expression_bodied_methods",
+            "csharp_style_expression_bodied_constructors",
+            "csharp_style_expression_bodied_operators",
+            "csharp_style_expression_bodied_properties",
+            "csharp_style_expression_bodied_indexers",
+            "csharp_style_expression_bodied_accessors",
+            "csharp_style_expression_bodied_lambdas",
+            "csharp_style_expression_bodied_local_functions",
+            "csharp_style_pattern_matching_over_is_with_cast_check",
+            "csharp_style_pattern_matching_over_as_with_null_check",
+            "csharp_style_prefer_switch_expression",
+            "csharp_style_prefer_pattern_matching",
+            "csharp_style_prefer_not_pattern",
+            "csharp_style_inlined_variable_declaration",
+            "csharp_prefer_simple_default_expression",
+            "csharp_style_prefer_local_over_anonymous_function",
+            "csharp_style_deconstructed_variable_declaration",
+            "csharp_style_prefer_index_operator",
+            "csharp_style_prefer_range_operator",
+            "csharp_style_implicit_object_creation_when_type_is_apparent",
+            "csharp_style_prefer_tuple_swap",
+            "csharp_style_unused_value_expression_statement_preference",
+            "csharp_style_unused_value_assignment_preference",
+            "csharp_prefer_static_local_function",
+            "csharp_style_prefer_readonly_struct",
+            "csharp_style_prefer_readonly_struct_member",
+            "csharp_style_namespace_declarations",
+            "csharp_style_prefer_null_check_over_type_check",
+            "csharp_style_prefer_primary_constructors",
+            "csharp_style_prefer_top_level_statements",
+            "csharp_style_prefer_method_group_conversion",
+            "csharp_using_directive_placement",
+
+            // C# formatting
+            "csharp_new_line_before_open_brace",
+            "csharp_new_line_before_else",
+            "csharp_new_line_before_catch",
+            "csharp_new_line_before_finally",
+            "csharp_new_line_before_members_in_object_initializers",
+            "csharp_new_line_before_members_in_anonymous_types",
+            "csharp_new_line_between_query_expression_clauses",
+            "csharp_indent_case_contents",
+            "csharp_indent_switch_labels",
+            "csharp_indent_labels",
+            "csharp_indent_block_contents",
+            "csharp_indent_braces",
+            "csharp_indent_case_contents_when_block",
+            "csharp_space_after_cast",
+            "csharp_space_after_keywords_in_control_flow_statements",
+            "csharp_space_between_parentheses",
+            "csharp_space_before_colon_in_inheritance_clause",
+            "csharp_space_after_colon_in_inheritance_clause",
+            "csharp_space_around_binary_operators",
+            "csharp_space_between_method_declaration_parameter_list_parentheses",
+            "csharp_space_between_method_declaration_empty_parameter_list_parentheses",
+            "csharp_space_between_method_declaration_name_and_open_parenthesis",
+            "csharp_space_between_method_call_parameter_list_parentheses",
+            "csharp_space_between_method_call_empty_parameter_list_parentheses",
+            "csharp_space_between_method_call_name_and_opening_parenthesis",
+            "csharp_preserve_single_line_statements",
+            "csharp_preserve_single_line_blocks",
+
+            // Naming conventions
+            "dotnet_naming_rule.interface_should_begin_with_i.severity",
+            "dotnet_naming_rule.types_should_be_pascal_case.severity",
+            "dotnet_naming_rule.non_field_members_should_be_pascal_case.severity",
+
+            // Analyzer severity
+            "dotnet_diagnostic.severity",
+            "dotnet_analyzer_diagnostic.severity",
+
+            // Nullable
+            "dotnet_nullable",
+        ];
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -1,0 +1,260 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using System.Collections.Immutable;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class FixAllService : IFixAllService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly IPreviewStore _previewStore;
+    private readonly ILogger<FixAllService> _logger;
+    private readonly Lazy<ImmutableArray<CodeFixProvider>> _codeFixProviders;
+
+    public FixAllService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<FixAllService> logger)
+    {
+        _workspace = workspace;
+        _previewStore = previewStore;
+        _logger = logger;
+        _codeFixProviders = new Lazy<ImmutableArray<CodeFixProvider>>(LoadCodeFixProviders);
+    }
+
+    public async Task<FixAllPreviewDto> PreviewFixAllAsync(
+        string workspaceId, string diagnosticId, string scope,
+        string? filePath, string? projectName, CancellationToken ct)
+    {
+        var fixAllScope = ParseScope(scope);
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        // Find a provider that can fix this diagnostic
+        var provider = _codeFixProviders.Value
+            .FirstOrDefault(p => p.FixableDiagnosticIds.Contains(diagnosticId))
+            ?? throw new InvalidOperationException(
+                $"No code fix provider found for diagnostic '{diagnosticId}'. " +
+                "Use list_analyzers to see available diagnostic IDs.");
+
+        var fixAllProvider = provider.GetFixAllProvider()
+            ?? throw new InvalidOperationException(
+                $"The code fix provider for '{diagnosticId}' does not support FixAll operations.");
+
+        // Determine target document and project
+        Document? targetDocument = null;
+        Project? targetProject = null;
+
+        if (fixAllScope == FixAllScope.Document)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentException("filePath is required when scope is 'document'.");
+
+            targetDocument = SymbolResolver.FindDocument(solution, filePath)
+                ?? throw new FileNotFoundException($"Document not found: {filePath}");
+            targetProject = targetDocument.Project;
+        }
+        else if (fixAllScope == FixAllScope.Project)
+        {
+            var projects = ProjectFilterHelper.FilterProjects(solution, projectName);
+            targetProject = projects.FirstOrDefault()
+                ?? throw new InvalidOperationException($"Project not found: {projectName}");
+
+            // Need a document for the context; use the first one
+            targetDocument = targetProject.Documents.FirstOrDefault()
+                ?? throw new InvalidOperationException("Project has no documents.");
+        }
+        else // Solution
+        {
+            targetProject = solution.Projects.FirstOrDefault()
+                ?? throw new InvalidOperationException("Solution has no projects.");
+            targetDocument = targetProject.Documents.FirstOrDefault()
+                ?? throw new InvalidOperationException("Solution has no documents.");
+        }
+
+        // Collect all diagnostics matching the ID across the scope
+        var diagnosticsMap = await CollectDiagnosticsAsync(
+            solution, diagnosticId, fixAllScope, targetDocument, targetProject, ct).ConfigureAwait(false);
+
+        var totalDiagCount = diagnosticsMap.Values.Sum(d => d.Length);
+        if (totalDiagCount == 0)
+        {
+            return new FixAllPreviewDto(
+                PreviewToken: "",
+                DiagnosticId: diagnosticId,
+                Scope: scope,
+                FixedCount: 0,
+                Changes: []);
+        }
+
+        // Use the FixAllProvider to compute the fix
+        var fixAllContext = new FixAllContext(
+            document: targetDocument,
+            codeFixProvider: provider,
+            scope: fixAllScope,
+            codeActionEquivalenceKey: provider.GetType().Name + "." + diagnosticId,
+            diagnosticIds: [diagnosticId],
+            fixAllDiagnosticProvider: new DiagnosticMapProvider(diagnosticsMap),
+            cancellationToken: ct);
+
+        var fixAllAction = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
+        if (fixAllAction is null)
+        {
+            return new FixAllPreviewDto(
+                PreviewToken: "",
+                DiagnosticId: diagnosticId,
+                Scope: scope,
+                FixedCount: 0,
+                Changes: []);
+        }
+
+        var operations = await fixAllAction.GetOperationsAsync(ct).ConfigureAwait(false);
+        var applyOp = operations.OfType<ApplyChangesOperation>().FirstOrDefault()
+            ?? throw new InvalidOperationException("FixAll action did not produce workspace changes.");
+
+        var newSolution = applyOp.ChangedSolution;
+        var changes = await ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
+        var description = $"Fix all '{diagnosticId}' ({scope}): {totalDiagCount} occurrences";
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description);
+
+        return new FixAllPreviewDto(
+            PreviewToken: token,
+            DiagnosticId: diagnosticId,
+            Scope: scope,
+            FixedCount: totalDiagCount,
+            Changes: changes);
+    }
+
+    private static FixAllScope ParseScope(string scope) => scope.ToLowerInvariant() switch
+    {
+        "document" => FixAllScope.Document,
+        "project" => FixAllScope.Project,
+        "solution" => FixAllScope.Solution,
+        _ => throw new ArgumentException($"Invalid scope '{scope}'. Must be 'document', 'project', or 'solution'.")
+    };
+
+    private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> CollectDiagnosticsAsync(
+        Solution solution, string diagnosticId, FixAllScope scope,
+        Document targetDocument, Project targetProject, CancellationToken ct)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
+
+        IEnumerable<Project> projects = scope == FixAllScope.Solution
+            ? solution.Projects
+            : [targetProject];
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            var allDiagnostics = compilation.GetDiagnostics(ct)
+                .Where(d => d.Id == diagnosticId && d.Location.IsInSource);
+
+            var byTree = allDiagnostics.GroupBy(d => d.Location.SourceTree);
+
+            foreach (var group in byTree)
+            {
+                if (group.Key is null) continue;
+
+                var doc = project.GetDocument(group.Key);
+                if (doc is null) continue;
+
+                if (scope == FixAllScope.Document && doc.Id != targetDocument.Id)
+                    continue;
+
+                builder[doc] = group.ToImmutableArray();
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static async Task<IReadOnlyList<FileChangeDto>> ComputeChangesAsync(
+        Solution oldSolution, Solution newSolution, CancellationToken ct)
+    {
+        var changes = new List<FileChangeDto>();
+        var solutionChanges = newSolution.GetChanges(oldSolution);
+
+        foreach (var projectChange in solutionChanges.GetProjectChanges())
+        {
+            foreach (var docId in projectChange.GetChangedDocuments())
+            {
+                var oldDoc = oldSolution.GetDocument(docId);
+                var newDoc = newSolution.GetDocument(docId);
+                if (oldDoc is null || newDoc is null) continue;
+
+                var oldText = (await oldDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+                var newText = (await newDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+
+                if (oldText == newText) continue;
+
+                var path = oldDoc.FilePath ?? oldDoc.Name;
+                var diff = DiffGenerator.GenerateUnifiedDiff(oldText, newText, path);
+                changes.Add(new FileChangeDto(path, diff));
+            }
+        }
+
+        return changes;
+    }
+
+    private ImmutableArray<CodeFixProvider> LoadCodeFixProviders()
+    {
+        try
+        {
+            var featuresAssembly = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions).Assembly;
+            var providers = featuresAssembly.GetTypes()
+                .Where(t => !t.IsAbstract && typeof(CodeFixProvider).IsAssignableFrom(t))
+                .Select(t =>
+                {
+                    try { return (CodeFixProvider?)Activator.CreateInstance(t); }
+                    catch { return null; }
+                })
+                .Where(p => p is not null)
+                .Cast<CodeFixProvider>()
+                .ToImmutableArray();
+
+            _logger.LogInformation("FixAllService loaded {Count} code fix providers", providers.Length);
+            return providers;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load code fix providers for FixAll");
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Provides pre-computed diagnostics to the FixAllContext.
+    /// </summary>
+    private sealed class DiagnosticMapProvider : FixAllContext.DiagnosticProvider
+    {
+        private readonly ImmutableDictionary<Document, ImmutableArray<Diagnostic>> _map;
+
+        public DiagnosticMapProvider(ImmutableDictionary<Document, ImmutableArray<Diagnostic>> map) => _map = map;
+
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken ct)
+        {
+            var result = _map
+                .Where(kvp => kvp.Key.Project.Id == project.Id)
+                .SelectMany(kvp => kvp.Value);
+            return Task.FromResult(result);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken ct)
+        {
+            if (_map.TryGetValue(document, out var diagnostics))
+                return Task.FromResult<IEnumerable<Diagnostic>>(diagnostics);
+            return Task.FromResult<IEnumerable<Diagnostic>>([]);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken ct)
+        {
+            // Project-level diagnostics (not tied to a document)
+            return Task.FromResult<IEnumerable<Diagnostic>>([]);
+        }
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
@@ -1,0 +1,133 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class FlowAnalysisService : IFlowAnalysisService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<FlowAnalysisService> _logger;
+
+    public FlowAnalysisService(IWorkspaceManager workspace, ILogger<FlowAnalysisService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<DataFlowAnalysisDto> AnalyzeDataFlowAsync(
+        string workspaceId, string filePath, int startLine, int endLine, CancellationToken ct)
+    {
+        var (firstStatement, lastStatement, semanticModel) = await ResolveStatementRangeAsync(
+            workspaceId, filePath, startLine, endLine, ct).ConfigureAwait(false);
+
+        var result = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
+
+        return new DataFlowAnalysisDto(
+            Succeeded: result.Succeeded,
+            VariablesDeclared: SymbolNames(result.VariablesDeclared),
+            DataFlowsIn: SymbolNames(result.DataFlowsIn),
+            DataFlowsOut: SymbolNames(result.DataFlowsOut),
+            AlwaysAssigned: SymbolNames(result.AlwaysAssigned),
+            ReadInside: SymbolNames(result.ReadInside),
+            WrittenInside: SymbolNames(result.WrittenInside),
+            ReadOutside: SymbolNames(result.ReadOutside),
+            WrittenOutside: SymbolNames(result.WrittenOutside),
+            Captured: SymbolNames(result.Captured),
+            CapturedInside: SymbolNames(result.CapturedInside),
+            UnsafeAddressTaken: SymbolNames(result.UnsafeAddressTaken));
+    }
+
+    public async Task<ControlFlowAnalysisDto> AnalyzeControlFlowAsync(
+        string workspaceId, string filePath, int startLine, int endLine, CancellationToken ct)
+    {
+        var (firstStatement, lastStatement, semanticModel) = await ResolveStatementRangeAsync(
+            workspaceId, filePath, startLine, endLine, ct).ConfigureAwait(false);
+
+        var result = semanticModel.AnalyzeControlFlow(firstStatement, lastStatement);
+
+        var entryPoints = result.EntryPoints
+            .Select(n => FormatSyntaxLocation(n))
+            .ToList();
+
+        var exitPoints = result.ExitPoints
+            .Select(n => FormatSyntaxLocation(n))
+            .ToList();
+
+        var returnStatements = result.ReturnStatements
+            .Select(n =>
+            {
+                var lineSpan = n.GetLocation().GetLineSpan();
+                var expressionText = n is ReturnStatementSyntax rs ? rs.Expression?.ToString() : n.ToString();
+                return new ReturnStatementDto(
+                    lineSpan.StartLinePosition.Line + 1,
+                    lineSpan.StartLinePosition.Character + 1,
+                    expressionText);
+            })
+            .ToList();
+
+        return new ControlFlowAnalysisDto(
+            Succeeded: result.Succeeded,
+            StartPointIsReachable: result.StartPointIsReachable,
+            EndPointIsReachable: result.EndPointIsReachable,
+            EntryPoints: entryPoints,
+            ExitPoints: exitPoints,
+            ReturnStatements: returnStatements);
+    }
+
+    private async Task<(SyntaxNode First, SyntaxNode Last, SemanticModel Model)> ResolveStatementRangeAsync(
+        string workspaceId, string filePath, int startLine, int endLine, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var normalizedPath = Path.GetFullPath(filePath);
+
+        var document = solution.Projects
+            .SelectMany(p => p.Documents)
+            .FirstOrDefault(d => d.FilePath is not null &&
+                Path.GetFullPath(d.FilePath).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+            ?? throw new FileNotFoundException($"Document not found in workspace: {filePath}");
+
+        var tree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not get syntax tree.");
+        var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not get semantic model.");
+        var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+        // Convert 1-based lines to 0-based
+        int startLine0 = startLine - 1;
+        int endLine0 = endLine - 1;
+
+        // Find all statements that overlap the requested line range
+        var statements = root.DescendantNodes()
+            .Where(n => n is StatementSyntax && !(n is BlockSyntax))
+            .Where(n =>
+            {
+                var lineSpan = n.GetLocation().GetLineSpan();
+                return lineSpan.StartLinePosition.Line >= startLine0 &&
+                       lineSpan.StartLinePosition.Line <= endLine0;
+            })
+            .OrderBy(n => n.SpanStart)
+            .ToList();
+
+        if (statements.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No statements found in the line range {startLine}-{endLine}. " +
+                "Ensure the range contains executable statements (not just declarations or braces).");
+        }
+
+        return (statements.First(), statements.Last(), semanticModel);
+    }
+
+    private static IReadOnlyList<string> SymbolNames(
+        System.Collections.Immutable.ImmutableArray<ISymbol> symbols) =>
+        symbols.Select(s => s.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)).ToList();
+
+    private static string FormatSyntaxLocation(SyntaxNode node)
+    {
+        var lineSpan = node.GetLocation().GetLineSpan();
+        return $"Line {lineSpan.StartLinePosition.Line + 1}: {node.ToString().Trim()}";
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/OperationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/OperationService.cs
@@ -1,0 +1,88 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class OperationService : IOperationService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<OperationService> _logger;
+
+    public OperationService(IWorkspaceManager workspace, ILogger<OperationService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<OperationNodeDto?> GetOperationsAsync(
+        string workspaceId, string filePath, int line, int column, int maxDepth, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var document = SymbolResolver.FindDocument(solution, filePath)
+            ?? throw new FileNotFoundException($"Document not found in workspace: {filePath}");
+
+        var tree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not get syntax tree.");
+        var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Could not get semantic model.");
+        var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+        // Convert 1-based to 0-based and find the position
+        var text = await document.GetTextAsync(ct).ConfigureAwait(false);
+        var position = text.Lines[line - 1].Start + (column - 1);
+
+        // Find the most specific node at this position
+        var node = root.FindNode(new Microsoft.CodeAnalysis.Text.TextSpan(position, 0));
+        if (node is null) return null;
+
+        // Walk up to find a node that has an IOperation
+        IOperation? operation = null;
+        var current = node;
+        while (current is not null)
+        {
+            operation = semanticModel.GetOperation(current, ct);
+            if (operation is not null) break;
+            current = current.Parent;
+        }
+
+        if (operation is null) return null;
+
+        return MapOperation(operation, maxDepth, 0);
+    }
+
+    private static OperationNodeDto MapOperation(IOperation operation, int maxDepth, int currentDepth)
+    {
+        var lineSpan = operation.Syntax.GetLocation().GetLineSpan();
+        var syntaxText = operation.Syntax.ToString();
+
+        // Truncate long syntax text
+        if (syntaxText.Length > 120)
+            syntaxText = syntaxText[..117] + "...";
+
+        IReadOnlyList<OperationNodeDto>? children = null;
+
+        if (currentDepth < maxDepth)
+        {
+            var childOps = operation.ChildOperations.ToList();
+            if (childOps.Count > 0)
+            {
+                children = childOps
+                    .Select(child => MapOperation(child, maxDepth, currentDepth + 1))
+                    .ToList();
+            }
+        }
+
+        return new OperationNodeDto(
+            Kind: operation.Kind.ToString(),
+            Type: operation.Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+            ConstantValue: operation.ConstantValue.HasValue ? operation.ConstantValue.Value?.ToString() : null,
+            Syntax: syntaxText,
+            Line: lineSpan.StartLinePosition.Line + 1,
+            Column: lineSpan.StartLinePosition.Character + 1,
+            Children: children);
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -159,6 +159,29 @@ public sealed class RefactoringService : IRefactoringService
         return new RefactoringPreviewDto(token, description, changes, null);
     }
 
+    public async Task<RefactoringPreviewDto> PreviewFormatRangeAsync(
+        string workspaceId, string filePath, int startLine, int startColumn, int endLine, int endColumn, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var document = SymbolResolver.FindDocument(solution, filePath);
+        if (document is null)
+            throw new InvalidOperationException($"Document not found: {filePath}");
+
+        var text = await document.GetTextAsync(ct).ConfigureAwait(false);
+        var startPosition = text.Lines[startLine - 1].Start + (startColumn - 1);
+        var endPosition = text.Lines[endLine - 1].Start + (endColumn - 1);
+        var span = Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(startPosition, endPosition);
+
+        var formattedDoc = await Formatter.FormatAsync(document, span, cancellationToken: ct).ConfigureAwait(false);
+        var newSolution = formattedDoc.Project.Solution;
+
+        var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
+        var description = $"Format range in '{Path.GetFileName(filePath)}' (lines {startLine}-{endLine})";
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description);
+
+        return new RefactoringPreviewDto(token, description, changes, null);
+    }
+
     public async Task<RefactoringPreviewDto> PreviewCodeFixAsync(
         string workspaceId,
         string diagnosticId,

--- a/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class ScriptingService : IScriptingService
+{
+    private readonly ILogger<ScriptingService> _logger;
+
+    private static readonly string[] DefaultImports =
+    [
+        "System",
+        "System.Collections.Generic",
+        "System.Linq",
+        "System.Text",
+        "System.Text.RegularExpressions",
+        "System.Threading.Tasks",
+        "System.IO"
+    ];
+
+    private static readonly int TimeoutSeconds =
+        int.TryParse(Environment.GetEnvironmentVariable("ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS"), out var t) ? t : 10;
+
+    public ScriptingService(ILogger<ScriptingService> logger) => _logger = logger;
+
+    public async Task<ScriptEvaluationDto> EvaluateAsync(string code, string[]? imports, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+
+        var allImports = DefaultImports.Concat(imports ?? []).Distinct().ToArray();
+
+        var options = ScriptOptions.Default
+            .WithImports(allImports)
+            .WithReferences(
+                typeof(object).Assembly,
+                typeof(Enumerable).Assembly,
+                typeof(System.Text.RegularExpressions.Regex).Assembly)
+            .WithEmitDebugInformation(false);
+
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(TimeoutSeconds));
+
+            var result = await CSharpScript.EvaluateAsync<object?>(
+                code, options, cancellationToken: timeoutCts.Token).ConfigureAwait(false);
+
+            sw.Stop();
+            return new ScriptEvaluationDto(
+                Success: true,
+                ResultType: result?.GetType().FullName,
+                ResultValue: FormatResult(result),
+                Error: null,
+                CompilationErrors: null,
+                ElapsedMs: sw.ElapsedMilliseconds);
+        }
+        catch (CompilationErrorException ex)
+        {
+            sw.Stop();
+            var compilationErrors = ex.Diagnostics
+                .Where(d => d.Severity != DiagnosticSeverity.Hidden)
+                .Select(d =>
+                {
+                    var lineSpan = d.Location.GetMappedLineSpan();
+                    return new DiagnosticDto(
+                        Id: d.Id,
+                        Message: d.GetMessage(),
+                        Severity: d.Severity.ToString(),
+                        Category: d.Descriptor.Category,
+                        FilePath: null,
+                        StartLine: lineSpan.IsValid ? lineSpan.StartLinePosition.Line + 1 : null,
+                        StartColumn: lineSpan.IsValid ? lineSpan.StartLinePosition.Character + 1 : null,
+                        EndLine: lineSpan.IsValid ? lineSpan.EndLinePosition.Line + 1 : null,
+                        EndColumn: lineSpan.IsValid ? lineSpan.EndLinePosition.Character + 1 : null);
+                })
+                .ToList();
+
+            return new ScriptEvaluationDto(
+                Success: false,
+                ResultType: null,
+                ResultValue: null,
+                Error: ex.Message,
+                CompilationErrors: compilationErrors,
+                ElapsedMs: sw.ElapsedMilliseconds);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            sw.Stop();
+            return new ScriptEvaluationDto(
+                Success: false,
+                ResultType: null,
+                ResultValue: null,
+                Error: $"Script execution timed out after {TimeoutSeconds} seconds. Set ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS to increase.",
+                CompilationErrors: null,
+                ElapsedMs: sw.ElapsedMilliseconds);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            sw.Stop();
+            return new ScriptEvaluationDto(
+                Success: false,
+                ResultType: null,
+                ResultValue: null,
+                Error: $"Runtime error: {ex.GetType().Name}: {ex.Message}",
+                CompilationErrors: null,
+                ElapsedMs: sw.ElapsedMilliseconds);
+        }
+    }
+
+    private static string? FormatResult(object? result)
+    {
+        if (result is null) return "null";
+
+        var str = result.ToString();
+        if (str is not null && str.Length > 4096)
+            str = str[..4093] + "...";
+
+        return str;
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/SnippetAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SnippetAnalysisService.cs
@@ -1,0 +1,130 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging;
+using System.Collections.Immutable;
+
+namespace RoslynMcp.Roslyn.Services;
+
+public sealed class SnippetAnalysisService : ISnippetAnalysisService
+{
+    private readonly ILogger<SnippetAnalysisService> _logger;
+
+    private static readonly string[] DefaultUsings =
+    [
+        "System",
+        "System.Collections.Generic",
+        "System.Linq",
+        "System.Text",
+        "System.Threading.Tasks"
+    ];
+
+    public SnippetAnalysisService(ILogger<SnippetAnalysisService> logger) => _logger = logger;
+
+    public Task<SnippetAnalysisDto> AnalyzeAsync(string code, string[]? usings, string kind, CancellationToken ct)
+    {
+        var allUsings = DefaultUsings
+            .Concat(usings ?? [])
+            .Distinct()
+            .Select(u => $"using {u};");
+
+        var usingBlock = string.Join("\n", allUsings);
+        var wrappedCode = WrapCode(code, kind, usingBlock);
+
+        var tree = CSharpSyntaxTree.ParseText(wrappedCode, cancellationToken: ct);
+
+        // Create a minimal compilation with core references
+        var references = GetCoreReferences();
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "SnippetAnalysis_" + Guid.NewGuid().ToString("N")[..8],
+            syntaxTrees: [tree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        var diagnostics = compilation.GetDiagnostics(ct)
+            .Where(d => d.Severity != DiagnosticSeverity.Hidden)
+            .ToList();
+
+        int errorCount = diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
+        int warningCount = diagnostics.Count(d => d.Severity == DiagnosticSeverity.Warning);
+
+        var diagnosticDtos = diagnostics.Select(d =>
+        {
+            var lineSpan = d.Location.GetMappedLineSpan();
+            return new DiagnosticDto(
+                Id: d.Id,
+                Message: d.GetMessage(),
+                Severity: d.Severity.ToString(),
+                Category: d.Descriptor.Category,
+                FilePath: null,
+                StartLine: lineSpan.IsValid ? lineSpan.StartLinePosition.Line + 1 : null,
+                StartColumn: lineSpan.IsValid ? lineSpan.StartLinePosition.Character + 1 : null,
+                EndLine: lineSpan.IsValid ? lineSpan.EndLinePosition.Line + 1 : null,
+                EndColumn: lineSpan.IsValid ? lineSpan.EndLinePosition.Character + 1 : null);
+        }).ToList();
+
+        // Extract declared symbols from the compilation
+        var declaredSymbols = new List<string>();
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot(ct);
+
+        foreach (var decl in root.DescendantNodes().Where(n =>
+            n is Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax or
+                 Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax or
+                 Microsoft.CodeAnalysis.CSharp.Syntax.PropertyDeclarationSyntax or
+                 Microsoft.CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax))
+        {
+            var symbol = model.GetDeclaredSymbol(decl, ct);
+            if (symbol is not null)
+                declaredSymbols.Add($"{symbol.Kind}: {symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}");
+        }
+
+        return Task.FromResult(new SnippetAnalysisDto(
+            IsValid: errorCount == 0,
+            ErrorCount: errorCount,
+            WarningCount: warningCount,
+            Diagnostics: diagnosticDtos,
+            DeclaredSymbols: declaredSymbols.Count > 0 ? declaredSymbols : null));
+    }
+
+    private static string WrapCode(string code, string kind, string usingBlock) => kind.ToLowerInvariant() switch
+    {
+        "expression" => $"{usingBlock}\npublic static class Snippet {{ public static object Evaluate() => {code}; }}",
+        "statements" => $"{usingBlock}\npublic static class Snippet {{ public static void Run() {{ {code} }} }}",
+        "members" => $"{usingBlock}\npublic class Snippet {{ {code} }}",
+        "program" or "" => $"{usingBlock}\n{code}",
+        _ => throw new ArgumentException($"Invalid snippet kind '{kind}'. Must be 'expression', 'statements', 'members', or 'program'.")
+    };
+
+    private static ImmutableArray<MetadataReference> GetCoreReferences()
+    {
+        var trustedAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?.Split(Path.PathSeparator) ?? [];
+
+        var coreAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "System.Runtime",
+            "System.Console",
+            "System.Collections",
+            "System.Collections.Generic",
+            "System.Linq",
+            "System.Threading.Tasks",
+            "System.Text",
+            "System.Private.CoreLib",
+            "netstandard",
+            "System.ObjectModel",
+            "System.Runtime.Extensions"
+        };
+
+        return trustedAssemblies
+            .Where(path =>
+            {
+                var name = Path.GetFileNameWithoutExtension(path);
+                return coreAssemblies.Contains(name) ||
+                       name.StartsWith("System.Runtime", StringComparison.OrdinalIgnoreCase);
+            })
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToImmutableArray();
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -45,6 +45,14 @@ public abstract class TestBase
     protected static TypeExtractionService TypeExtractionService { get; private set; } = null!;
     protected static TypeMoveService TypeMoveService { get; private set; } = null!;
     protected static UndoService UndoService { get; private set; } = null!;
+    protected static FlowAnalysisService FlowAnalysisService { get; private set; } = null!;
+    protected static CompileCheckService CompileCheckService { get; private set; } = null!;
+    protected static AnalyzerInfoService AnalyzerInfoService { get; private set; } = null!;
+    protected static FixAllService FixAllService { get; private set; } = null!;
+    protected static OperationService OperationService { get; private set; } = null!;
+    protected static SnippetAnalysisService SnippetAnalysisService { get; private set; } = null!;
+    protected static ScriptingService ScriptingService { get; private set; } = null!;
+    protected static EditorConfigService EditorConfigService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -168,6 +176,29 @@ public abstract class TestBase
             WorkspaceManager,
             PreviewStore,
             NullLogger<TypeMoveService>.Instance);
+        FlowAnalysisService = new FlowAnalysisService(
+            WorkspaceManager,
+            NullLogger<FlowAnalysisService>.Instance);
+        CompileCheckService = new CompileCheckService(
+            WorkspaceManager,
+            NullLogger<CompileCheckService>.Instance);
+        AnalyzerInfoService = new AnalyzerInfoService(
+            WorkspaceManager,
+            NullLogger<AnalyzerInfoService>.Instance);
+        FixAllService = new FixAllService(
+            WorkspaceManager,
+            PreviewStore,
+            NullLogger<FixAllService>.Instance);
+        OperationService = new OperationService(
+            WorkspaceManager,
+            NullLogger<OperationService>.Instance);
+        SnippetAnalysisService = new SnippetAnalysisService(
+            NullLogger<SnippetAnalysisService>.Instance);
+        ScriptingService = new ScriptingService(
+            NullLogger<ScriptingService>.Instance);
+        EditorConfigService = new EditorConfigService(
+            WorkspaceManager,
+            NullLogger<EditorConfigService>.Instance);
 
         RepositoryRootPath = FindRepositoryRoot();
         SampleSolutionPath = FindFixturePath("SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");


### PR DESCRIPTION
## Summary
- Implements the **top 10 recommended capabilities** from a Roslyn SDK gap analysis, adding **13 new experimental tools** (some features have preview/apply pairs)
- New tools: `fix_all_preview/apply`, `analyze_data_flow`, `analyze_control_flow`, `evaluate_csharp`, `analyze_snippet`, `format_range_preview/apply`, `get_editorconfig_options`, `compile_check`, `get_operations`, `list_analyzers`
- Adds `Microsoft.CodeAnalysis.CSharp.Scripting` v5.3.0 for interactive C# script evaluation
- Includes gap analysis document at `ai_docs/roslyn-gap-analysis.md` with full 43-item gap inventory

## New Tools

| Tool | Category | Roslyn API |
|------|----------|------------|
| `fix_all_preview` / `fix_all_apply` | Batch code fix | FixAllProvider |
| `analyze_data_flow` | Flow analysis | SemanticModel.AnalyzeDataFlow |
| `analyze_control_flow` | Flow analysis | SemanticModel.AnalyzeControlFlow |
| `evaluate_csharp` | Scripting | CSharpScript.EvaluateAsync |
| `analyze_snippet` | Snippet analysis | AdhocWorkspace + CSharpCompilation |
| `format_range_preview` / `format_range_apply` | Formatting | Formatter.FormatAsync(span) |
| `get_editorconfig_options` | Configuration | AnalyzerConfigOptionsProvider |
| `compile_check` | Validation | Compilation.GetDiagnostics / Emit |
| `get_operations` | IOperation tree | SemanticModel.GetOperation |
| `list_analyzers` | Analysis | AnalyzerReference.GetAnalyzers |

## Test plan
- [x] `dotnet build RoslynMcp.slnx -c Release` — 0 errors, 0 warnings
- [x] `dotnet test RoslynMcp.slnx -c Release` — 143/143 tests pass
- [ ] Smoke test each new tool with a loaded workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)