### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {
     "name": "darylmcd",


### PR DESCRIPTION
## Summary
- Bumps version from 1.1.0 to 1.1.1 in `Directory.Build.props` and `manifest.json`
- Ensures the 13 new experimental tools ship under a distinct version number

## Test plan
- [x] `dotnet publish` + reinstall succeeded locally as v1.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)