### PR TITLE
fix(ci): upgrade setup-dotnet to v5, switch to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   validate:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.104",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-dotnet` from **v4 to v5** for proper .NET 10 SDK support
- Switch runner from `windows-latest` to `ubuntu-latest` — faster provisioning, halves Actions minute usage (1x vs 2x multiplier), all CI scripts use cross-platform pwsh
- Relax `global.json` SDK pin from `10.0.104` to `10.0.100` with `latestFeature` rollForward for better CI SDK availability

## Root Cause Analysis
CI has been failing since **2026-03-26** (last success: 2026-03-25). Every run shows `steps: []` with `runner_name: ""` — the runner gets assigned but never executes steps.

**Investigation findings:**
- Run logs show: `Job is about to start running on the hosted runner: GitHub Actions XXXXXXX` but then immediate failure
- The repo is **private** on a personal account — free tier provides 2,000 Actions minutes/month
- Windows runners consume minutes at **2x multiplier** — likely exhausted the monthly quota
- 10 successful runs exist before March 26; 20+ failures after

**This PR fixes the configuration issues.** The billing/quota issue will resolve either when the monthly cycle resets, or if the repo is made public (unlimited free minutes for public repos).

## Test plan
- [x] Local build: `dotnet build RoslynMcp.slnx` — 0 errors, 0 warnings
- [x] Local tests: 143 passed, 0 failed, 0 skipped
- [x] `eng/verify-ai-docs.ps1` — passed
- [ ] CI pipeline runs successfully (blocked by Actions minute quota)

🤖 Generated with [Claude Code](https://claude.com/claude-code)