### PR TITLE
fix(tests): detect xUnit/NUnit test projects (BUG-03, BUG-10)

### DIFF
--- a/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
@@ -21,6 +21,13 @@ internal static class ProjectMetadataParser
         return allFrameworks.Count > 0 ? allFrameworks : ["unknown"];
     }
 
+    private static readonly HashSet<string> TestPackageNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "xunit", "xunit.core", "xunit.v3", "xunit.v3.core",
+        "NUnit", "nunit", "NUnit3TestAdapter",
+        "MSTest.TestFramework", "Microsoft.NET.Test.Sdk",
+    };
+
     public static bool IsTestProject(XDocument? document)
     {
         if (document is null)
@@ -28,8 +35,25 @@ internal static class ProjectMetadataParser
             return false;
         }
 
+        // Explicit <IsTestProject>true</IsTestProject> (MSTest SDK sets this automatically)
         var isTestProject = document.Descendants("IsTestProject").FirstOrDefault()?.Value;
-        return bool.TryParse(isTestProject, out var parsed) && parsed;
+        if (bool.TryParse(isTestProject, out var parsed) && parsed)
+        {
+            return true;
+        }
+
+        // Heuristic: check for test framework package references (xUnit, NUnit, MSTest)
+        var packageReferences = document.Descendants("PackageReference");
+        foreach (var pkgRef in packageReferences)
+        {
+            var include = pkgRef.Attribute("Include")?.Value;
+            if (include is not null && TestPackageNames.Contains(include))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static string GetOutputType(XDocument? document)

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -205,6 +205,16 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         return new RelatedTestsForFilesDto(results, dotnetFilter);
     }
 
+    private static readonly HashSet<string> TestAttributeNames = new(StringComparer.Ordinal)
+    {
+        // MSTest
+        "TestMethod", "TestMethodAttribute", "DataTestMethod", "DataTestMethodAttribute",
+        // xUnit
+        "Fact", "FactAttribute", "Theory", "TheoryAttribute",
+        // NUnit
+        "Test", "TestAttribute", "TestCase", "TestCaseAttribute", "TestCaseSource", "TestCaseSourceAttribute",
+    };
+
     private static bool HasTestAttribute(MethodDeclarationSyntax method)
     {
         foreach (var attributeList in method.AttributeLists)
@@ -212,7 +222,9 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             foreach (var attribute in attributeList.Attributes)
             {
                 var attributeName = attribute.Name.ToString();
-                if (attributeName is "TestMethod" or "Fact" or "Theory" or "Test" or "TestCase")
+                // Handle both short (Fact) and qualified (Xunit.FactAttribute) forms
+                var simpleName = attributeName.Contains('.') ? attributeName[(attributeName.LastIndexOf('.') + 1)..] : attributeName;
+                if (TestAttributeNames.Contains(simpleName))
                 {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- **BUG-03**: IsTestProject only checked MSTest's auto-inserted `<IsTestProject>` element. Now also checks for xUnit/NUnit/MSTest PackageReference.
- **BUG-10**: test_discover returned empty for non-MSTest projects. Extended HasTestAttribute to 14 names including Attribute-suffix and qualified forms.

## Test plan
- [x] All 143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)