### PR TITLE
fix: analysis crash resilience and mutation scoping (BUG-08, BUG-14)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -37,11 +37,19 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
             {
                 if (ct.IsCancellationRequested) break;
 
-                var semanticModel = compilation.GetSemanticModel(tree);
-                var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    var semanticModel = compilation.GetSemanticModel(tree);
+                    var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
 
-                CollectReflectionInvocations(root, semanticModel, results, ct);
-                CollectTypeofUsages(root, semanticModel, results, ct);
+                    CollectReflectionInvocations(root, semanticModel, results, ct);
+                    CollectTypeofUsages(root, semanticModel, results, ct);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed to analyze syntax tree {Path} for reflection usages, skipping",
+                        tree.FilePath);
+                }
             }
         }
 

--- a/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
@@ -154,8 +154,19 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
             {
                 if (ct.IsCancellationRequested) break;
 
-                var semanticModel = compilation.GetSemanticModel(tree);
-                var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+                SemanticModel semanticModel;
+                SyntaxNode root;
+                try
+                {
+                    semanticModel = compilation.GetSemanticModel(tree);
+                    root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed to analyze syntax tree {Path} for DI registrations, skipping",
+                        tree.FilePath);
+                    continue;
+                }
 
                 var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
                 foreach (var invocation in invocations)

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -189,6 +189,11 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
                         modelCache[doc.Id] = model;
                     }
 
+                    // For interface-implemented members (e.g. Dispose), filter to only calls
+                    // where the receiver type matches the target type
+                    if (root is not null && model is not null && !IsReceiverOfTargetType(root, model, refLocation.Location, namedType, ct))
+                        continue;
+
                     var containingSymbol = root is not null && model is not null
                         ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
                         : null;
@@ -389,6 +394,46 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Checks if the reference location's invocation receiver is of the target type.
+    /// Prevents over-matching for interface-implemented members like Dispose().
+    /// </summary>
+    private static bool IsReceiverOfTargetType(
+        SyntaxNode root, SemanticModel model, Location location, INamedTypeSymbol targetType, CancellationToken ct)
+    {
+        var node = root.FindNode(location.SourceSpan);
+
+        // Walk up to find the invocation or member access
+        var memberAccess = node.FirstAncestorOrSelf<MemberAccessExpressionSyntax>();
+        if (memberAccess is not null)
+        {
+            var receiverTypeInfo = model.GetTypeInfo(memberAccess.Expression, ct);
+            var receiverType = receiverTypeInfo.Type ?? receiverTypeInfo.ConvertedType;
+            if (receiverType is INamedTypeSymbol receiverNamed)
+            {
+                // Accept if receiver IS the target type or derives from it
+                return SymbolEqualityComparer.Default.Equals(receiverNamed, targetType) ||
+                       receiverNamed.AllInterfaces.Concat<INamedTypeSymbol>(GetBaseTypes(receiverNamed))
+                           .Any(b => SymbolEqualityComparer.Default.Equals(b, targetType)) ||
+                       targetType.AllInterfaces.Concat<INamedTypeSymbol>(GetBaseTypes(targetType))
+                           .Any(b => SymbolEqualityComparer.Default.Equals(b, receiverNamed));
+            }
+        }
+
+        // If no receiver found (implicit this or other pattern), accept it
+        return true;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetBaseTypes(INamedTypeSymbol type)
+    {
+        var current = type.BaseType;
+        while (current is not null)
+        {
+            yield return current;
+            current = current.BaseType;
+        }
     }
 
     private static bool IsInstanceMember(string name, INamedTypeSymbol type)


### PR DESCRIPTION
## Summary
- **BUG-08**: Per-tree try-catch in reflection/DI analysis services prevents crashes on complex solutions
- **BUG-14**: find_type_mutations filters Dispose() references by receiver type instead of matching all IDisposable.Dispose() calls

## Test plan
- [x] All 143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)