### PR TITLE
chore: remove dead code and add .editorconfig (CODE-05, CODE-06)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,55 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+# Organize usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# var preferences
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null checking
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Code block preferences
+csharp_prefer_braces = when_multiline:suggestion
+
+# File-scoped namespaces
+csharp_style_namespace_declarations = file_scoped:warning
+
+# Naming conventions
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_underscore
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.camel_case_underscore.required_prefix = _
+dotnet_naming_style.camel_case_underscore.capitalization = camel_case
+
+[*.{json,xml,yml,yaml,props,targets,csproj,slnx}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -234,16 +234,6 @@ public abstract class TestBase
         throw new InvalidOperationException("Copied sample solution is missing a solution file.");
     }
 
-    protected static string CreateFixtureCopy(string fixtureSolutionPath)
-    {
-        var fixtureRoot = Path.GetDirectoryName(fixtureSolutionPath)
-            ?? throw new InvalidOperationException("Fixture root could not be resolved.");
-        var tempRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpTests", Guid.NewGuid().ToString("N"));
-        CopyDirectory(fixtureRoot, tempRoot);
-        CopyRepositorySupportFiles(tempRoot);
-        return Path.Combine(tempRoot, Path.GetFileName(fixtureSolutionPath));
-    }
-
     protected static void DeleteDirectoryIfExists(string path)
     {
         if (Directory.Exists(path))


### PR DESCRIPTION
## Summary
- **CODE-05**: Remove dead `CreateFixtureCopy` method from TestBase.cs (confirmed zero callers)
- **CODE-06**: Add .editorconfig with standard C# rules

## Test plan
- [x] All 143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)