### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />


### PR DESCRIPTION
## Summary
- Bump version from 1.1.1 to 1.2.0 for the P0-P3 backlog release

## Test plan
- [x] All 143 tests pass in Release config
- [x] NuGet package built and locally installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)