### PR TITLE
fix: P3 quick-win audit fixes (AUDIT-03, AUDIT-04, AUDIT-09, AUDIT-13)

### DIFF
--- a/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
@@ -19,6 +19,7 @@ internal static partial class DotnetOutputParser
     /// <returns>A list of parsed diagnostics. Lines that do not match the expected format are silently skipped.</returns>
     public static IReadOnlyList<DiagnosticDto> ParseBuildDiagnostics(string output)
     {
+        var seen = new HashSet<(string Id, string File, int? Line, int? Col)>();
         var diagnostics = new List<DiagnosticDto>();
 
         foreach (var line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
@@ -29,14 +30,23 @@ internal static partial class DotnetOutputParser
                 continue;
             }
 
+            var id = match.Groups["id"].Value;
+            var file = match.Groups["file"].Value;
+            var startLine = ParseNullableInt(match.Groups["line"].Value);
+            var startColumn = ParseNullableInt(match.Groups["column"].Value);
+
+            // Deduplicate by (Id, FilePath, Line, Column) to avoid MSBuild retry duplicates
+            if (!seen.Add((id, file, startLine, startColumn)))
+                continue;
+
             diagnostics.Add(new DiagnosticDto(
-                Id: match.Groups["id"].Value,
+                Id: id,
                 Message: match.Groups["message"].Value,
                 Severity: Capitalize(match.Groups["severity"].Value),
                 Category: "Build",
-                FilePath: match.Groups["file"].Value,
-                StartLine: ParseNullableInt(match.Groups["line"].Value),
-                StartColumn: ParseNullableInt(match.Groups["column"].Value),
+                FilePath: file,
+                StartLine: startLine,
+                StartColumn: startColumn,
                 EndLine: ParseNullableInt(match.Groups["endLine"].Value),
                 EndColumn: ParseNullableInt(match.Groups["endColumn"].Value)));
         }

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -140,8 +140,22 @@ public sealed class ProjectMutationService : IProjectMutationService
         {
             ValidateAllowedProperty(request.PropertyName);
 
-            var propertyGroup = document.Root?.Elements("PropertyGroup").FirstOrDefault()
-                ?? throw new InvalidOperationException("Project file is missing a PropertyGroup element.");
+            var propertyGroup = document.Root?.Elements("PropertyGroup").FirstOrDefault();
+            if (propertyGroup is null)
+            {
+                // Create a new PropertyGroup if none exists (e.g., Directory.Build.props-based projects)
+                propertyGroup = new System.Xml.Linq.XElement("PropertyGroup");
+                document.Root!.AddFirst(propertyGroup);
+            }
+
+            // Detect no-op: check if property already has the target value
+            var existingValue = propertyGroup.Element(request.PropertyName)?.Value;
+            if (string.Equals(existingValue, request.Value, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"No changes needed — property '{request.PropertyName}' is already set to '{request.Value}'.");
+            }
+
             propertyGroup.SetElementValue(request.PropertyName, request.Value);
         }, $"Set project property '{request.PropertyName}'", ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
@@ -59,6 +59,14 @@ public sealed class SymbolNavigationService : ISymbolNavigationService
 
         if (typeSymbol is null) return [];
 
+        // Provide descriptive message for built-in/primitive types that have no source locations
+        if (!typeSymbol.Locations.Any(l => l.IsInSource) && typeSymbol.SpecialType != SpecialType.None)
+        {
+            throw new InvalidOperationException(
+                $"Cannot navigate to type definition for built-in type '{typeSymbol.ToDisplayString()}' — " +
+                "it is defined in the .NET runtime, not in source code.");
+        }
+
         var results = new List<LocationDto>();
         foreach (var location in typeSymbol.Locations.Where(l => l.IsInSource))
         {

--- a/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
@@ -42,7 +42,8 @@ public sealed class TypeMoveService : ITypeMoveService
         if (typeCount < 2)
         {
             throw new InvalidOperationException(
-                $"Source file only contains one type. Move is unnecessary.");
+                "Source file only contains one top-level type. " +
+                "Nested types cannot be extracted with this tool — only top-level type declarations are considered.");
         }
 
         // Determine target file path


### PR DESCRIPTION
## Summary
- **AUDIT-03**: Clarify `move_type_to_file_preview` error for nested types
- **AUDIT-04**: Handle `set_project_property_preview` no-op detection and create PropertyGroup when missing
- **AUDIT-09**: Deduplicate `build_workspace` diagnostics by (Id, FilePath, Line, Column)
- **AUDIT-13**: Return descriptive error from `goto_type_definition` for primitive/built-in types

## Test plan
- [x] `verify-release.ps1` passes (0 errors, 0 warnings, 143/143 tests)
- [ ] Manual verification: `move_type_to_file_preview` on file with nested class
- [ ] Manual verification: `set_project_property_preview` with already-set value
- [ ] Manual verification: `goto_type_definition` on an `int` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)