### PR TITLE
docs: clarify compile_check tool description (AUDIT-31, AUDIT-26)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class CompileCheckTools
 {
     [McpServerTool(Name = "compile_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
-     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation.")]
+     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation. Note: only reports compiler diagnostics (CS*); analyzer diagnostics (CA*, IDE*) are excluded — use project_diagnostics for those. The emitValidation option is 10-18x slower but catches emit-time issues.")]
     public static Task<string> CompileCheck(
         IWorkspaceExecutionGate gate,
         ICompileCheckService compileCheckService,


### PR DESCRIPTION
## Summary
- **AUDIT-31**: Clarify that `compile_check` excludes analyzer diagnostics (CA*, IDE*)
- **AUDIT-26**: Document `emitValidation` performance impact (10-18x slower)

## Test plan
- [x] `verify-release.ps1` passes (0 errors, 0 warnings, 143/143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)