### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />


### PR DESCRIPTION
## Summary

- Bumps `Version` in `Directory.Build.props` from `1.2.0` → `1.3.0`
- Follows the P0-P2 backlog implementation in #49 (new `IGatedCommandExecutor` interface, hardening, DRY refactors, 11 new tests)

Generated with [Claude Code](https://claude.com/claude-code)