### PR TITLE
feat: paginate high-volume diagnostics surfaces and resolve inherited TFMs

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -10,6 +10,12 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class AnalysisTools
 {
+    private enum DiagnosticBucket
+    {
+        Workspace,
+        Compiler,
+        Analyzer,
+    }
 
     [McpServerTool(Name = "project_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get compiler diagnostics (errors, warnings) for the workspace, optionally filtered by project, file, or severity")]
     public static Task<string> GetProjectDiagnostics(
@@ -19,15 +25,52 @@ public static class AnalysisTools
         [Description("Optional: filter by project name")] string? project = null,
         [Description("Optional: filter by file path")] string? file = null,
         [Description("Optional: minimum severity filter (Error, Warning, Info, Hidden)")] string? severity = null,
+        [Description("Number of diagnostics to skip before returning results (default: 0)")] int offset = 0,
+        [Description("Maximum number of diagnostics to return (default: 100)")] int limit = 100,
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
         {
             ParameterValidation.ValidateSeverity(severity);
+            ParameterValidation.ValidatePagination(offset, limit);
             return gate.RunAsync(workspaceId, async c =>
             {
                 var results = await diagnosticService.GetDiagnosticsAsync(workspaceId, project, file, severity, c);
-                return JsonSerializer.Serialize(results, JsonDefaults.Indented);
+
+                var allDiagnostics = results.WorkspaceDiagnostics
+                    .Select(diagnostic => (Bucket: DiagnosticBucket.Workspace, Diagnostic: diagnostic))
+                    .Concat(results.CompilerDiagnostics.Select(diagnostic => (Bucket: DiagnosticBucket.Compiler, Diagnostic: diagnostic)))
+                    .Concat(results.AnalyzerDiagnostics.Select(diagnostic => (Bucket: DiagnosticBucket.Analyzer, Diagnostic: diagnostic)))
+                    .ToList();
+
+                var pagedDiagnostics = allDiagnostics
+                    .Skip(offset)
+                    .Take(limit)
+                    .ToList();
+
+                return JsonSerializer.Serialize(new
+                {
+                    results.TotalErrors,
+                    results.TotalWarnings,
+                    results.TotalInfo,
+                    totalDiagnostics = allDiagnostics.Count,
+                    offset,
+                    limit,
+                    returnedDiagnostics = pagedDiagnostics.Count,
+                    hasMore = offset + pagedDiagnostics.Count < allDiagnostics.Count,
+                    workspaceDiagnostics = pagedDiagnostics
+                        .Where(entry => entry.Bucket == DiagnosticBucket.Workspace)
+                        .Select(entry => entry.Diagnostic)
+                        .ToList(),
+                    compilerDiagnostics = pagedDiagnostics
+                        .Where(entry => entry.Bucket == DiagnosticBucket.Compiler)
+                        .Select(entry => entry.Diagnostic)
+                        .ToList(),
+                    analyzerDiagnostics = pagedDiagnostics
+                        .Where(entry => entry.Bucket == DiagnosticBucket.Analyzer)
+                        .Select(entry => entry.Diagnostic)
+                        .ToList(),
+                }, JsonDefaults.Indented);
             }, ct);
         });
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
@@ -15,14 +15,42 @@ public static class AnalyzerInfoTools
         IAnalyzerInfoService analyzerInfoService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name")] string? project = null,
+        [Description("Number of analyzer rules to skip before returning results (default: 0)")] int offset = 0,
+        [Description("Maximum number of analyzer rules to return (default: 100)")] int limit = 100,
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                ParameterValidation.ValidatePagination(offset, limit);
                 var results = await analyzerInfoService.ListAnalyzersAsync(workspaceId, project, c);
                 var totalRules = results.Sum(a => a.Rules.Count);
-                return JsonSerializer.Serialize(new { analyzerCount = results.Count, totalRules, analyzers = results }, JsonDefaults.Indented);
+
+                var pagedRules = results
+                    .SelectMany(analyzer => analyzer.Rules.Select(rule => new { analyzer.AssemblyName, Rule = rule }))
+                    .Skip(offset)
+                    .Take(limit)
+                    .ToList();
+
+                var pagedAnalyzers = pagedRules
+                    .GroupBy(entry => entry.AssemblyName, StringComparer.OrdinalIgnoreCase)
+                    .Select(group => new RoslynMcp.Core.Models.AnalyzerInfoDto(
+                        group.Key,
+                        group.Select(entry => entry.Rule).ToList()))
+                    .OrderBy(analyzer => analyzer.AssemblyName, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                return JsonSerializer.Serialize(new
+                {
+                    analyzerCount = results.Count,
+                    totalRules,
+                    offset,
+                    limit,
+                    returnedRules = pagedRules.Count,
+                    returnedAnalyzerCount = pagedAnalyzers.Count,
+                    hasMore = offset + pagedRules.Count < totalRules,
+                    analyzers = pagedAnalyzers,
+                }, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
@@ -33,4 +33,14 @@ internal static class ParameterValidation
             throw new ArgumentException(
                 $"Invalid scope '{scope}'. Must be one of: {string.Join(", ", BulkReplaceScopeValues)}");
     }
+
+    /// <summary>Validates pagination parameters.</summary>
+    public static void ValidatePagination(int offset, int limit)
+    {
+        if (offset < 0)
+            throw new ArgumentException($"Invalid offset '{offset}'. Offset must be greater than or equal to 0.");
+
+        if (limit <= 0)
+            throw new ArgumentException($"Invalid limit '{limit}'. Limit must be greater than 0.");
+    }
 }

--- a/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
@@ -1,11 +1,18 @@
-using Microsoft.CodeAnalysis;
+using Microsoft.Build.Evaluation;
 using Microsoft.Extensions.Logging;
 using System.Xml.Linq;
+using RoslynProject = Microsoft.CodeAnalysis.Project;
 
 namespace RoslynMcp.Roslyn.Helpers;
 
 internal static class ProjectMetadataParser
 {
+    public static IReadOnlyList<string> GetTargetFrameworks(RoslynProject project, XDocument? document, ILogger? logger = null)
+    {
+        var evaluatedFrameworks = GetEvaluatedTargetFrameworks(project.FilePath, logger);
+        return evaluatedFrameworks.Count > 0 ? evaluatedFrameworks : GetTargetFrameworks(document);
+    }
+
     public static IReadOnlyList<string> GetTargetFrameworks(XDocument? document)
     {
         if (document is null)
@@ -19,6 +26,52 @@ internal static class ProjectMetadataParser
                 .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         var allFrameworks = targetFramework.Concat(targetFrameworks).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         return allFrameworks.Count > 0 ? allFrameworks : ["unknown"];
+    }
+
+    private static IReadOnlyList<string> GetEvaluatedTargetFrameworks(string? projectFilePath, ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilePath) || !File.Exists(projectFilePath))
+        {
+            return [];
+        }
+
+        var projectCollection = new ProjectCollection();
+
+        try
+        {
+            var evaluatedProject = projectCollection.LoadProject(projectFilePath);
+            var frameworks = ParseTargetFrameworkValues(
+                evaluatedProject.GetPropertyValue("TargetFramework"),
+                evaluatedProject.GetPropertyValue("TargetFrameworks"));
+
+            return frameworks;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed to evaluate target frameworks for project {Path}", projectFilePath);
+            return [];
+        }
+        finally
+        {
+            projectCollection.UnloadAllProjects();
+        }
+    }
+
+    private static IReadOnlyList<string> ParseTargetFrameworkValues(string? targetFramework, string? targetFrameworks)
+    {
+        var singleFrameworks = string.IsNullOrWhiteSpace(targetFramework)
+            ? Array.Empty<string>()
+            : new[] { targetFramework.Trim() };
+        var multiFrameworks = string.IsNullOrWhiteSpace(targetFrameworks)
+            ? Array.Empty<string>()
+            : targetFrameworks
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return singleFrameworks
+            .Concat(multiFrameworks)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private static readonly HashSet<string> TestPackageNames = new(StringComparer.OrdinalIgnoreCase)
@@ -61,7 +114,7 @@ internal static class ProjectMetadataParser
         return document?.Descendants("OutputType").FirstOrDefault()?.Value.Trim() ?? "Library";
     }
 
-    public static string GetAssemblyName(Project project)
+    public static string GetAssemblyName(RoslynProject project)
     {
         if (project.CompilationOptions?.AssemblyIdentityComparer is not null && !string.IsNullOrWhiteSpace(project.AssemblyName))
         {

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -487,7 +487,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 ProjectReferences: project.ProjectReferences
                     .Select(reference => solution.GetProject(reference.ProjectId)?.Name ?? "unknown")
                     .ToList(),
-                TargetFrameworks: Helpers.ProjectMetadataParser.GetTargetFrameworks(projectDoc),
+                TargetFrameworks: Helpers.ProjectMetadataParser.GetTargetFrameworks(project, projectDoc, _logger),
                 IsTestProject: Helpers.ProjectMetadataParser.IsTestProject(projectDoc),
                 AssemblyName: Helpers.ProjectMetadataParser.GetAssemblyName(project),
                 OutputType: Helpers.ProjectMetadataParser.GetOutputType(projectDoc));

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -93,6 +93,70 @@ public sealed class ExpandedSurfaceIntegrationTests : TestBase
     }
 
     [TestMethod]
+    public async Task AdvancedAnalysisTools_And_Diagnostics_Support_Pagination()
+    {
+        var analyzersJson = await AnalyzerInfoTools.ListAnalyzers(
+            WorkspaceExecutionGate,
+            AnalyzerInfoService,
+            WorkspaceId,
+            project: null,
+            offset: 0,
+            limit: 2,
+            CancellationToken.None);
+        using var analyzersDoc = JsonDocument.Parse(analyzersJson);
+        Assert.IsTrue(analyzersDoc.RootElement.GetProperty("totalRules").GetInt32() >= 1);
+        Assert.IsTrue(analyzersDoc.RootElement.GetProperty("returnedRules").GetInt32() <= 2);
+        Assert.IsTrue(analyzersDoc.RootElement.TryGetProperty("hasMore", out _));
+
+        var diagnosticsJson = await AnalysisTools.GetProjectDiagnostics(
+            WorkspaceExecutionGate,
+            DiagnosticService,
+            WorkspaceId,
+            project: "SampleLib",
+            file: null,
+            severity: null,
+            offset: 0,
+            limit: 1,
+            CancellationToken.None);
+        using var diagnosticsDoc = JsonDocument.Parse(diagnosticsJson);
+        var returnedDiagnostics = diagnosticsDoc.RootElement.GetProperty("returnedDiagnostics").GetInt32();
+        var pagedCount = diagnosticsDoc.RootElement.GetProperty("workspaceDiagnostics").GetArrayLength()
+            + diagnosticsDoc.RootElement.GetProperty("compilerDiagnostics").GetArrayLength()
+            + diagnosticsDoc.RootElement.GetProperty("analyzerDiagnostics").GetArrayLength();
+
+        Assert.AreEqual(returnedDiagnostics, pagedCount);
+        Assert.IsTrue(diagnosticsDoc.RootElement.GetProperty("totalDiagnostics").GetInt32() >= returnedDiagnostics);
+    }
+
+    [TestMethod]
+    public async Task Reflection_And_Di_Analysis_Run_On_Repo_Solution()
+    {
+        var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
+        var status = await WorkspaceManager.LoadAsync(repositorySolutionPath, CancellationToken.None);
+
+        try
+        {
+            var reflectionUsages = await CodePatternAnalyzer.FindReflectionUsagesAsync(
+                status.WorkspaceId,
+                "RoslynMcp.Roslyn",
+                CancellationToken.None);
+            var diRegistrations = await DependencyAnalysisService.GetDiRegistrationsAsync(
+                status.WorkspaceId,
+                "RoslynMcp.Roslyn",
+                CancellationToken.None);
+
+            Assert.IsTrue(reflectionUsages.Count > 0, "Expected reflection analysis to complete with results on the repo solution.");
+            Assert.IsTrue(diRegistrations.Any(registration =>
+                registration.FilePath.EndsWith("ServiceCollectionExtensions.cs", StringComparison.OrdinalIgnoreCase)),
+                "Expected DI registrations from ServiceCollectionExtensions.cs.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(status.WorkspaceId);
+        }
+    }
+
+    [TestMethod]
     public void Resources_Return_Machine_Readable_Contracts()
     {
         using var catalogDoc = JsonDocument.Parse(ServerResources.GetServerCatalog());

--- a/tests/RoslynMcp.Tests/IntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/IntegrationTests.cs
@@ -68,6 +68,18 @@ public class IntegrationTests : TestBase
     }
 
     [TestMethod]
+    public void Workspace_Status_And_Project_Graph_Resolve_TargetFrameworks_From_DirectoryBuildProps()
+    {
+        var status = WorkspaceManager.GetStatus(WorkspaceId);
+        var sampleTestsStatus = status.Projects.First(project => project.Name == "SampleLib.Tests");
+        CollectionAssert.Contains(sampleTestsStatus.TargetFrameworks.ToList(), "net10.0");
+
+        var graph = WorkspaceManager.GetProjectGraph(WorkspaceId);
+        var sampleTestsGraph = graph.Projects.First(project => project.ProjectName == "SampleLib.Tests");
+        CollectionAssert.Contains(sampleTestsGraph.TargetFrameworks.ToList(), "net10.0");
+    }
+
+    [TestMethod]
     public async Task Symbol_Search_Finds_Dog()
     {
         var results = await SymbolSearchService.SearchSymbolsAsync(WorkspaceId, "Dog", null, null, null, 10, CancellationToken.None);


### PR DESCRIPTION
## Summary
- add offset/limit pagination support to project_diagnostics output in the host layer
- add offset/limit pagination support to list_analyzers output in the host layer
- resolve project target frameworks from evaluated MSBuild properties before XML fallback
- add integration tests for pagination, BUG-08 reflection/DI analysis behavior, and inherited TargetFramework resolution

## Test plan
- [x] ./eng/verify-release.ps1 -Configuration Release
- [x] dotnet test RoslynMcp.slnx --nologo

Generated with GitHub Copilot