### PR TITLE
docs: fix path reference in .ai-doc-audit.md

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -37,7 +37,7 @@
 | ai_docs/runtime.md | present | SDK version now self-contained (was pointer to README) |
 | ai_docs/domains/ | present | 3 domain references + tool-usage-guide.md |
 | ai_docs/references/ | present | testing.md, tooling/dotnet.md, tooling/mcp-clients.md |
-| docs/ or data/docs/ | present | 5 files including new README.md index |
+| docs/ | present | 5 files including new README.md index |
 | docs/adr/ | not-needed | No ADRs to document at this time |
 
 ## Known Gaps

--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,7 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Local AI/MCP client configuration (developer machine specific)
+.claude/
+.mcp.json


### PR DESCRIPTION
Corrects `docs/ or data/docs/` to `docs/` — the `data/docs/` path never existed in the repo.