### PR TITLE
docs: refresh audit — purge resolved backlog, fix stale gaps and index

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -14,10 +14,10 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-03-31
-- **Last audit mode:** initial
+- **Last audit:** 2026-04-03
+- **Last audit mode:** refresh
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 15 (excluding archive/)
+- **ai_docs/ file count:** 16 (excluding archive/)
 - **docs/ file count:** 5
 - **Agent instruction files:** AGENTS.md, CLAUDE.md, .github/copilot-instructions.md, .cursor/rules/operational-essentials.md, CI_POLICY.md
 
@@ -42,23 +42,17 @@
 
 ## Known Gaps
 
-- `ai_docs/backlog.md` BUG-08 needs a retest pass against v1.3.0 to confirm crash regression resolved.
 - `references/tooling/mcp-clients.md` is thin (14 lines) — could benefit from more detail on client configuration.
 - Domain reference files (core-contracts, host-stdio, roslyn-services) are minimal (~21 lines each) — adequate for now but could be expanded if agents need more orientation.
 - `docs/adr/` not present — if significant architectural decisions are made, consider adding ADRs.
 
 ## Findings from Last Audit
 
-- **AGENTS.md:** Removed dead link to `ai_docs/archive/legacy-agents-guide.md` (file deleted in 2026-03-30 cleanup).
-- **CLAUDE.md:** Replaced Claude-specific bootstrap format with AGENTS.md mirror + sync-rule header per standard.
-- **.github/copilot-instructions.md:** Rewrote from thin bootstrap pointer to prescriptive rules covering code style, layering, mutation safety, testing, safety guardrails, naming conventions, security.
-- **.cursor/rules/operational-essentials.md:** Expanded from 19 lines to include build/test/lint command table and commit format guidance.
-- **mcp-server-audit-report.md / deep-review-report.md:** Both moved from active `ai_docs/` to `ai_docs/archive/`. Both were point-in-time reports from 2026-03-30; action items already extracted to `backlog.md`.
-- **ai_docs/architecture.md:** Expanded from 24 lines to full layer table, dependency graph, data flow diagram, key abstractions table, surface tiers, and known gaps.
-- **ai_docs/runtime.md:** SDK version inlined (was pointer to README.md). `dotnet run` command added.
-- **ai_docs/README.md:** Rewritten with table format, task-scoped reading guide, and accurate archive section.
-- **docs/README.md:** Created as human-facing index for the 4 existing docs files.
-- **ai_docs/archive/README.md:** Updated to list the two newly archived reports.
+- **backlog.md:** Removed 12 resolved items (P0–P2 empty, P3 purged). Only open items remain per standard.
+- **architecture.md:** Removed stale DATA-03 and DATA-06 from Known Gaps (both resolved 2026-04-03).
+- **ai_docs/README.md:** Added `prompts/add-nuget-vulnerability-surface.prompt.md` (FEAT-06) to index.
+- **CLAUDE.md:** Synced with AGENTS.md — added missing item 8 (`CLAUDE.md`) to read order.
+- **.ai-doc-audit.md:** Updated known gaps (removed resolved BUG-08, DATA-03), bumped file count to 16.
 
 ## Codebase Domains
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Read these canonical files in order:
 5. `ai_docs/backlog.md`
 6. `.github/copilot-instructions.md`
 7. `.cursor/rules/operational-essentials.md`
+8. `CLAUDE.md`
 
 Policy ownership:
 

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -36,6 +36,7 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | `procedures/doc-migration-checklist.md` | Checklist for documentation migrations |
 | `prompts/deep-review-and-refactor.md` | Living reusable prompt for comprehensive code review (all 16 phases). Keep in sync with project surface. Do not delete. |
 | `prompts/add-security-diagnostic-surface.prompt.md` | Feature specification for FEAT-01 |
+| `prompts/add-nuget-vulnerability-surface.prompt.md` | Feature specification for FEAT-06 (NuGet vulnerability scanning) |
 
 ## Archive
 

--- a/ai_docs/architecture.md
+++ b/ai_docs/architecture.md
@@ -65,8 +65,6 @@ Operational logs → `stderr` only (stdout reserved for MCP protocol traffic).
 
 ## Known Gaps
 
-- `TargetFrameworks` resolution shows "unknown" for most projects — MSBuildWorkspace TFM resolution not fully wired (DATA-03).
-- `get_code_actions` returns empty at most positions — additional code fix providers needed (DATA-06).
 - IDE and CA analyzers not loaded in MSBuildWorkspace — only SDK-implicit diagnostics active at runtime (AUDIT-21).
 
 ## Deep Material

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,38 +2,12 @@
 
 Canonical location for all unfinished work items. Prioritized by impact.
 
-Last audit: 2026-03-30. Updated 2026-04-03 (pagination, TFM, BUG-08 regression, P2/P3 data-quality batch, FEAT-01 security surface). Consolidated from deep-review-report.md, mcp-server-audit-report.md (35 issues across 4 solutions), and prior backlog.
-
----
-
-## P0 — Critical Server Bugs (blocking core workflows)
-
-_All P0 items resolved._
-
----
-
-## P1 — High-Priority Server Bugs (crashes or wrong output on some solutions)
-
-- [x] **BUG-08**: `find_reflection_usages` / `get_di_registrations` previously crashed on ITChatBot.sln (2026-03-28 audit). Regression coverage added 2026-04-03 — integration tests exercise both tools against the repo solution without crash. ✓ resolved.
-
----
-
-## P2 — Code Quality Improvements
-
-- [x] **CODE-11**: Increase test coverage from 49.8% line / 37.6% branch. Focus on high-complexity methods in Roslyn.Services layer. Expanded coverage added 2026-04-03 — 157→162 total tests with new integration coverage for cohesion/interface handling and pagination metadata. ✓ resolved.
+Last audit: 2026-04-03. Consolidated from deep-review-report.md, mcp-server-audit-report.md (35 issues across 4 solutions), and prior backlog.
 
 ---
 
 ## P3 — Server Data Quality & Usability
 
-- [x] **DATA-01**: `find_shared_members` returns empty for types with readonly fields and static classes. Fixed 2026-04-03 — static type/member analysis now includes static private members and static call sites. ✓ resolved.
-- [x] **DATA-02**: `find_unused_symbols` false positives — deduplication and generated-file filtering fixed (AUDIT-19, AUDIT-20). Fixed 2026-04-03 — added attribute-aware skipping for framework-invoked members (e.g. `[Fact]`, `[TestMethod]`, `[DataMember]`, MVC HTTP attributes). ✓ resolved.
-- [x] **DATA-03**: `TargetFrameworks` shows "unknown" for most projects across all solutions. Fixed 2026-04-03 — `ProjectMetadataParser` now evaluates TFM via MSBuild `ProjectCollection` before falling back to raw XML, resolving inherited values from `Directory.Build.props`. ✓ resolved.
-- [x] **DATA-05**: `get_cohesion_metrics` includes interfaces in LCOM4 results (trivially LCOM4 = method count). Fixed 2026-04-03 — added `includeInterfaces` option and `TypeKind` output field to flag interfaces explicitly. ✓ resolved.
-- [x] **DATA-06**: `get_code_actions` returns empty at most positions. Fixed 2026-04-03 — default zero-length spans now expand to line-end to improve diagnostic intersection for code fix discovery. ✓ resolved.
-- [x] **DATA-07**: Add `limit`/`offset` to `find_references`, `find_type_mutations`, `find_type_usages`, `symbol_relationships`, `callers_callees` — prevent multi-hundred-KB output overflows. Fixed 2026-04-03 — tools now enforce limit/offset or per-bucket limits and return paging metadata (`totalCount`, `hasMore`, etc.). ✓ resolved.
-- [x] **DATA-09**: `extract_interface_preview` missing spaces in generated base type list. Also copies unnecessary usings. Fixed 2026-04-03 — base list spacing corrected and generated interface now filters copied usings. ✓ resolved.
-- [x] **AUDIT-08**: `list_analyzers` (175K-252K chars) and `project_diagnostics` (626K chars on ITChatBot) have no effective pagination. Fixed 2026-04-03 — both tools now accept `offset`/`limit` parameters with `hasMore`/`totalRules`/`totalDiagnostics` response metadata. ✓ resolved.
 - [ ] **AUDIT-10**: `split_class_preview` reformats unrelated code during partial class split.
 - [ ] **AUDIT-11**: `source_generated_documents` shows duplicate entries for Debug/Release/platform obj folders.
 - [ ] **AUDIT-12**: `add_package_reference_preview` generates inline XML without indentation.
@@ -51,7 +25,6 @@ _All P0 items resolved._
 
 ## P4 — Feature Additions
 
-- [x] **FEAT-01**: Add security diagnostic surface — curated mapping of Roslyn diagnostic IDs to OWASP categories with fix guidance. Implemented: `SecurityDiagnosticRegistry` (80+ IDs), `security_diagnostics` and `security_analyzer_status` tools, `security_review` prompt, `SecurityTestProject` fixture with positive-detection tests (5 new, 167 total passing). ✓ resolved.
 - [ ] **FEAT-06**: NuGet vulnerability scanning — scan workspace package references for known CVEs via `dotnet list package --vulnerable --format json`. Extends `IDependencyAnalysisService` with a `nuget_vulnerability_scan` tool. Addresses OWASP A06:2021 (Vulnerable and Outdated Components). See `ai_docs/prompts/add-nuget-vulnerability-surface.prompt.md` for full specification.
 - [ ] **FEAT-02**: `.editorconfig` write support — current `get_editorconfig_options` is read-only. Add ability to modify style rules programmatically.
 - [ ] **FEAT-03**: MSBuild property/item evaluation — query resolved MSBuild properties, conditional values, SDK metadata.


### PR DESCRIPTION
## Summary

- **backlog.md**: Removed 12 resolved items (BUG-08, CODE-11, DATA-01/02/03/05/06/07/09, AUDIT-08, FEAT-01). Only open items remain per doc standard.
- **architecture.md**: Removed resolved DATA-03 and DATA-06 from Known Gaps.
- **ai_docs/README.md**: Added FEAT-06 prompt (`add-nuget-vulnerability-surface.prompt.md`) to index.
- **CLAUDE.md**: Synced item 8 with AGENTS.md read order.
- **.ai-doc-audit.md**: Updated audit date, file count (15→16), refreshed known gaps and findings.

## Test plan
- [x] Doc-only change — no code impact
- [x] All cross-references verified

Generated with [Claude Code](https://claude.com/claude-code)