### PR TITLE
fix: async undo, GetStatusAsync, OCE filters, cancellation checks

### DIFF
--- a/ai_docs/prompts/refactor_prompt.md
+++ b/ai_docs/prompts/refactor_prompt.md
@@ -1,0 +1,174 @@
+# Refactor audit prompt (archive)
+<!-- purpose: Archived senior .NET refactor audit prompt for selective use; stack applicability, Roslyn-backed evidence when available. -->
+
+You are a senior C#/.NET engineer performing a codebase sanity check and selective refactor on this repository.
+
+## Mission
+Analyze this C# repository for correctness risks, architectural weaknesses, SRP/cohesion issues, dependency injection problems, async/concurrency issues, exception/nullability weaknesses, data-access boundary problems, maintainability concerns, and test gaps. Then produce a prioritized remediation plan and implement only the highest-confidence, behavior-preserving refactors. This project is still in development, so the focus is on identifying and addressing issues early before they become entrenched, and on setting a strong architectural and code-quality foundation for future work.
+
+**Early project vs. change safety:** Internal and module-level refactors are easier to justify now than after wide adoption; use that freedom for structure and testability *inside* boundaries. Breaking **public** contracts or **observable** behavior should stay rare—reserve those for P0 bugs, security issues, or work explicitly approved as medium/high risk. Prefer incremental, test-backed steps either way. The refactor scope should still be carefully constrained to avoid unnecessary churn and preserve development velocity.
+
+## Primary goals
+1. Identify real issues affecting correctness, reliability, maintainability, testability, observability, or performance.
+2. Distinguish high-value structural improvements from low-value stylistic churn.
+3. Produce a clear, prioritized remediation plan that balances risk and reward.
+
+## Stack applicability
+Infer the actual stack from projects and dependencies. **Skip or lightly treat review bullets that do not apply** (for example: no EF Core layer, no ASP.NET controllers, no hosted health endpoints). Do not invent framework-specific problems where that technology is absent (e.g. console/CLI tools, class libraries, parsers). General C# concerns (async, nullability, boundaries, tests) still apply everywhere they are relevant.
+
+## Evidence and tooling (when available)
+When Roslyn MCP or an equivalent workspace-aware tool is available: load the solution or relevant projects, then use **compiler- and analyzer-backed checks** (for example `compile_check`, `project_diagnostics`) to ground correctness claims before and after edits. Prefer reproducible evidence over intuition; cite tool output or diagnostics when asserting build or analyzer state.
+
+## Review dimensions
+
+### Architecture and boundaries
+- Layer separation and responsibility clarity
+- Domain/business logic mixed with controllers, handlers, persistence, infrastructure, or transport concerns
+- God services, god managers, god helpers, dumping-ground shared/common projects
+- Unstable abstractions or boundary violations
+- Public APIs/components exposing too much internal detail
+- Cross-cutting concern consistency (logging, validation, mapping, authorization, retries, etc.)
+
+### SRP and cohesion
+- Classes with multiple unrelated reasons to change
+- Methods combining validation, orchestration, business logic, persistence, mapping, logging, and formatting
+- Controllers/handlers/services that contain mixed responsibilities
+- Utility/helper classes with unrelated behavior
+- Interface proliferation without meaningful substitution value
+- Over-fragmentation introduced in the name of SRP without practical payoff
+
+### Dependency injection and composition
+- Service lifetime mismatches
+- Constructors with excessive dependencies
+- Hidden service locator patterns
+- Static/global dependencies harming testability
+- Thin pass-through services adding little value
+- Composition root clarity and dependency graph health
+
+### Async, concurrency, and execution flow
+- Blocking on async (`.Result`, `.Wait()`, `.GetAwaiter().GetResult()`)
+- Fire-and-forget tasks without supervision
+- Missing cancellation token propagation
+- Swallowed task exceptions
+- Background worker lifecycle issues
+- Shared mutable state risks
+- Improper parallelism or task coordination
+- Async data-access misuse
+
+### Exceptions, nullability, and correctness
+- Broad catches, swallowed exceptions, missing context
+- Exceptions used as normal control flow
+- Inconsistent failure behavior across layers
+- Nullable reference type misuse
+- Null-forgiving operator misuse
+- Weak contracts leading to possible NullReferenceException or invalid state
+- Invariants not enforced at the right boundary
+
+### Data access and boundaries
+- Persistence concerns mixed into business logic
+- EF Core entities or data models leaking across boundaries
+- Repository abstractions that add little value or hide important behavior
+- Query inefficiencies, N+1 patterns, transaction boundary issues
+- Over-fetching, over-tracking, or mapping sprawl
+
+### Contracts, DTOs, and model design
+- DTO/domain/entity leakage across layers
+- API contracts reused as internal domain models
+- Anemic or redundant mapping layers
+- Stringly-typed or weakly modeled concepts that should be represented more safely
+
+### Testing and change safety
+- Missing unit/integration tests around core behavior
+- Need for characterization tests before risky refactors
+- Fragile tests coupled to implementation details
+- Over-mocked tests with low behavioral confidence
+- Missing edge-case, error-path, async, and boundary coverage
+
+### Observability and operability
+- Logging quality and consistency
+- Structured logging and correlation context
+- Options/configuration validation
+- Fail-fast startup on invalid configuration
+- Health checks/readiness/liveness where relevant
+- Retry/timeout visibility and operational behavior
+
+### C#/.NET hygiene and idioms
+- Misuse of inheritance, records, structs, partial classes, extension methods, static helpers
+- Poor encapsulation or oversized public surface area
+- IDisposable/IAsyncDisposable misuse
+- Event subscription lifetime issues
+- LINQ usage harming clarity or performance
+- Analyzer warnings or code smells worth addressing
+
+## Prioritization model
+Classify findings as:
+- P0: likely bug, data integrity issue, deadlock risk, major nullability/exception issue, security issue
+- P1: major architecture/testability/changeability issue
+- P2: meaningful maintainability/idiomatic improvement
+- P3: minor cleanup or optional polish
+
+For each finding, include:
+- Title
+- Priority
+- Confidence (high/medium/low)
+- Location
+- Why it matters
+- Evidence
+- Recommended action
+- Regression risk
+- Whether it should be fixed now or deferred
+
+## Refactor constraints
+- Preserve behavior unless a bug is explicitly identified and justified
+- Avoid broad rewrites
+- Avoid speculative abstractions
+- Avoid interface proliferation and pattern-driven churn
+- Avoid repo-wide style cleanup
+- Avoid changing public contracts unless explicitly necessary and called out
+- Favor targeted, minimal, high-signal improvements
+- Do not split code solely for theoretical SRP purity
+- Prefer clarity, cohesion, and explicitness over extra layers and indirection
+- Before non-trivial extractions, signature changes, or behavior-sensitive edits, **state the test strategy**: which existing tests cover the behavior, or which characterization test will be added or extended first
+- **Scope each implementation pass:** prefer one cohesive vertical slice (one feature area, boundary, or project) per session; avoid touching many unrelated files in one pass unless the change is mechanical and low-risk (e.g. rename with tooling, obvious move)
+
+## Required workflow
+1. Infer the repository purpose and summarize the current architecture (including which stack-specific sections of this prompt apply).
+2. Produce a prioritized findings list.
+3. Produce a phased remediation plan grouped into low-risk, medium-risk, and high-risk work.
+4. Implement only low-risk/high-confidence refactors, staying within the scope constraints above; keep public API and observable behavior stable unless the finding is P0 or the plan explicitly flags medium/high risk and approval.
+5. Add or update tests for any non-trivial change. If risky code lacks tests, add characterization tests first or defer the refactor.
+6. Re-review the changed code and identify remaining risks or follow-up work.
+
+## Required output format
+
+### 1. Repository summary
+- Purpose
+- Main projects/modules
+- Architectural shape
+- Hotspots / risk areas
+
+### 2. Findings
+Provide a structured list of findings with the required fields above.
+
+### 3. Remediation plan
+Group into:
+- Quick wins
+- Medium-risk structural improvements
+- High-risk items requiring explicit approval
+
+### 4. Implemented refactors
+For each implemented change:
+- Files changed
+- What changed
+- Why
+- Behavior impact
+- Tests added/updated
+- Remaining concerns
+
+### 5. Counterarguments
+For each major recommendation, provide a short argument for why the current design might be acceptable and why the proposed change may not be worth doing.
+
+## Decision standard
+Do not flag normal engineering trade-offs as flaws. Only escalate issues that materially affect correctness, safety, changeability, observability, performance, or operational reliability.
+
+Favor explicitness, readable control flow, strong contracts, sensible boundaries, and pragmatic cohesion over abstraction purity.

--- a/src/RoslynMcp.Core/Services/IUndoService.cs
+++ b/src/RoslynMcp.Core/Services/IUndoService.cs
@@ -25,7 +25,7 @@ public interface IUndoService
     /// Reverts the most recent apply operation for the given workspace.
     /// Returns <see langword="true"/> if the revert succeeded.
     /// </summary>
-    bool Revert(string workspaceId, IWorkspaceManager workspace);
+    Task<bool> RevertAsync(string workspaceId, IWorkspaceManager workspace, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Clears undo history for a workspace (e.g., on workspace close).

--- a/src/RoslynMcp.Core/Services/IWorkspaceManager.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceManager.cs
@@ -48,6 +48,15 @@ public interface IWorkspaceManager
     WorkspaceStatusDto GetStatus(string workspaceId);
 
     /// <summary>
+    /// Returns the current status for the specified workspace session, waiting on the same load lock as
+    /// <see cref="GetStatus"/> without blocking a thread while the lock is held.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown when no session with <paramref name="workspaceId"/> exists.</exception>
+    Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns the project and dependency graph for the specified workspace session.
     /// </summary>
     /// <param name="workspaceId">The workspace session identifier.</param>

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -27,7 +27,7 @@ public static class TestCoverageTools
             gate.RunAsync(workspaceId, async c =>
             {
                 ProgressHelper.Report(progress, 0, 1);
-                var status = workspace.GetStatus(workspaceId);
+                var status = await workspace.GetStatusAsync(workspaceId, c).ConfigureAwait(false);
                 var loadedPath = status.LoadedPath ?? throw new InvalidOperationException("Workspace has no loaded path.");
 
                 var coverageDir = Path.Combine(Path.GetTempPath(), "roslyn-mcp-coverage", Guid.NewGuid().ToString("N"));

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -18,7 +18,7 @@ public static class UndoTools
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(workspaceId, _ =>
+            gate.RunAsync(workspaceId, async c =>
             {
                 var entry = undoService.GetLastOperation(workspaceId);
                 if (entry is null)
@@ -30,10 +30,10 @@ public static class UndoTools
                                   "or the last operation was a disk-direct change (file create/delete/move, " +
                                   "project mutation) which is not revertible."
                     };
-                    return Task.FromResult(JsonSerializer.Serialize(nothingResult, JsonDefaults.Indented));
+                    return JsonSerializer.Serialize(nothingResult, JsonDefaults.Indented);
                 }
 
-                var success = undoService.Revert(workspaceId, workspace);
+                var success = await undoService.RevertAsync(workspaceId, workspace, c).ConfigureAwait(false);
                 if (!success)
                 {
                     var failResult = new
@@ -42,7 +42,7 @@ public static class UndoTools
                         message = "Failed to revert — the workspace state may have changed since the operation was applied.",
                         operation = entry.Description
                     };
-                    return Task.FromResult(JsonSerializer.Serialize(failResult, JsonDefaults.Indented));
+                    return JsonSerializer.Serialize(failResult, JsonDefaults.Indented);
                 }
 
                 var result = new
@@ -51,7 +51,7 @@ public static class UndoTools
                     revertedOperation = entry.Description,
                     appliedAtUtc = entry.AppliedAtUtc
                 };
-                return Task.FromResult(JsonSerializer.Serialize(result, JsonDefaults.Indented));
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -86,10 +86,10 @@ public static class WorkspaceTools
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
-            gate.RunAsync(workspaceId, _ =>
+            gate.RunAsync(workspaceId, async c =>
             {
-                var status = workspace.GetStatus(workspaceId);
-                return Task.FromResult(JsonSerializer.Serialize(status, JsonDefaults.Indented));
+                var status = await workspace.GetStatusAsync(workspaceId, c).ConfigureAwait(false);
+                return JsonSerializer.Serialize(status, JsonDefaults.Indented);
             }, ct));
     }
 

--- a/src/RoslynMcp.Roslyn/Services/AnalyzerInfoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/AnalyzerInfoService.cs
@@ -61,7 +61,7 @@ public sealed class AnalyzerInfoService : IAnalyzerInfoService
                         }
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Failed to load analyzers from {Assembly}", assemblyName);
                     rules.Add(new AnalyzerRuleDto(

--- a/src/RoslynMcp.Roslyn/Services/BuildService.cs
+++ b/src/RoslynMcp.Roslyn/Services/BuildService.cs
@@ -26,7 +26,7 @@ public sealed class BuildService : IBuildService
 
     public async Task<BuildResultDto> BuildWorkspaceAsync(string workspaceId, CancellationToken ct)
     {
-        var status = _workspaceManager.GetStatus(workspaceId);
+        var status = await _workspaceManager.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
         var targetPath = status.LoadedPath ?? throw new InvalidOperationException($"Workspace '{workspaceId}' is not loaded.");
         var execution = await _executor.ExecuteAsync(
             workspaceId,

--- a/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
@@ -123,7 +123,7 @@ public sealed class CodeActionService : ICodeActionService
                 {
                     await provider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogDebug(ex, "Code fix provider {Provider} failed", provider.GetType().Name);
                 }
@@ -145,7 +145,7 @@ public sealed class CodeActionService : ICodeActionService
             {
                 await provider.ComputeRefactoringsAsync(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogDebug(ex, "Code refactoring provider {Provider} failed", provider.GetType().Name);
             }
@@ -175,7 +175,7 @@ public sealed class CodeActionService : ICodeActionService
                 .Select(t =>
                 {
                     try { return (CodeFixProvider?)Activator.CreateInstance(t); }
-                    catch { return null; }
+                    catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
                 })
                 .Where(p => p is not null)
                 .Cast<CodeFixProvider>()
@@ -184,7 +184,7 @@ public sealed class CodeActionService : ICodeActionService
             _logger.LogInformation("Loaded {Count} code fix providers from CSharp Features", providers.Length);
             return providers;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to load code fix providers");
             return [];
@@ -201,7 +201,7 @@ public sealed class CodeActionService : ICodeActionService
                 .Select(t =>
                 {
                     try { return (CodeRefactoringProvider?)Activator.CreateInstance(t); }
-                    catch { return null; }
+                    catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
                 })
                 .Where(p => p is not null)
                 .Cast<CodeRefactoringProvider>()
@@ -210,7 +210,7 @@ public sealed class CodeActionService : ICodeActionService
             _logger.LogInformation("Loaded {Count} code refactoring providers from CSharp Features", providers.Length);
             return providers;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to load code refactoring providers");
             return [];

--- a/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
@@ -140,7 +140,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
                     users.Add(project.Name);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed to parse project file {Path}", project.FilePath);
             }
@@ -376,7 +376,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
         CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
-        var status = _workspace.GetStatus(workspaceId);
+        var status = await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
         if (string.IsNullOrEmpty(status.LoadedPath))
         {
             throw new InvalidOperationException($"Workspace '{workspaceId}' is not loaded.");

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -27,7 +27,7 @@ public sealed class DiagnosticService : IDiagnosticService
         DiagnosticSeverity? minSeverity = ParseSeverity(severityFilter) ?? DiagnosticSeverity.Warning;
 
         var workspaceDiagnostics = FilterDiagnostics(
-            _workspace.GetStatus(workspaceId).WorkspaceDiagnostics,
+            (await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false)).WorkspaceDiagnostics,
             fileFilter,
             minSeverity: minSeverity);
 

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -198,6 +198,7 @@ public sealed class EditorConfigService : IEditorConfigService
     public Task<EditorConfigWriteResultDto> SetOptionAsync(
         string workspaceId, string sourceFilePath, string key, string value, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         _ = _workspace.GetCurrentSolution(workspaceId);
         if (string.IsNullOrWhiteSpace(key))
         {

--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -233,7 +233,7 @@ public sealed class FixAllService : IFixAllService
             {
                 await provider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Some providers may fail on specific diagnostics; try the next one
                 continue;
@@ -370,7 +370,7 @@ public sealed class FixAllService : IFixAllService
                         list.Add(p);
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogDebug(ex, "Could not load code fix providers from analyzer assembly {Path}", analyzerPath);
                 }
@@ -408,7 +408,7 @@ public sealed class FixAllService : IFixAllService
         {
             return Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features");
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return null;
         }
@@ -430,7 +430,7 @@ public sealed class FixAllService : IFixAllService
                 .Select(t =>
                 {
                     try { return (CodeFixProvider?)Activator.CreateInstance(t); }
-                    catch { return null; }
+                    catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
                 })
                 .Where(p => p is not null)
                 .Cast<CodeFixProvider>()
@@ -439,7 +439,7 @@ public sealed class FixAllService : IFixAllService
             _logger.LogInformation("FixAllService loaded {Count} code fix providers from CSharp Features", providers.Length);
             return providers;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to load code fix providers for FixAll");
             return [];
@@ -458,7 +458,7 @@ public sealed class FixAllService : IFixAllService
                 .Select(t =>
                 {
                     try { return (DiagnosticAnalyzer?)Activator.CreateInstance(t); }
-                    catch { return null; }
+                    catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
                 })
                 .Where(a => a is not null)
                 .Cast<DiagnosticAnalyzer>()
@@ -467,7 +467,7 @@ public sealed class FixAllService : IFixAllService
             _logger.LogInformation("FixAllService loaded {Count} diagnostic analyzers from CSharp Features", analyzers.Length);
             return analyzers;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to load diagnostic analyzers for FixAll");
             return [];

--- a/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
@@ -23,6 +23,7 @@ public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
         using var collection = new ProjectCollection();
         try
         {
+            ct.ThrowIfCancellationRequested();
             var msbuildProj = collection.LoadProject(roslynProj.FilePath!);
             var value = msbuildProj.GetPropertyValue(propertyName);
             return Task.FromResult(new MsBuildPropertyEvaluationDto(

--- a/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
@@ -37,7 +37,7 @@ public sealed class OrchestrationService : IOrchestrationService
         string newVersion,
         CancellationToken ct)
     {
-        var status = _workspace.GetStatus(workspaceId);
+        var status = await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
         var workspaceVersion = _workspace.GetCurrentVersion(workspaceId);
         var packagesPropsPath = MsBuildMetadataHelper.FindDirectoryPackagesProps(status.LoadedPath);
         var usesCentralPackageManagement = packagesPropsPath is not null && MsBuildMetadataHelper.IsCentralPackageManagementEnabled(packagesPropsPath);

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -143,7 +143,7 @@ public sealed class ReferenceService : IReferenceService
 
                 return new BulkReferenceResultDto(key, symbol.ToDisplayString(), locations.Count, locations, null);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 return new BulkReferenceResultDto(key, null, 0, [], ex.Message);
             }

--- a/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
@@ -100,6 +100,7 @@ public sealed class SecurityDiagnosticService : ISecurityDiagnosticService
 
     public Task<SecurityAnalyzerStatusDto> GetAnalyzerStatusAsync(string workspaceId, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
         var netAnalyzersPresent = false;
@@ -107,6 +108,7 @@ public sealed class SecurityDiagnosticService : ISecurityDiagnosticService
 
         foreach (var project in solution.Projects)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var analyzerRef in project.AnalyzerReferences)
             {
                 var displayName = analyzerRef.Display ?? string.Empty;

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -33,7 +33,7 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             return cached.Result;
 
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
-        var testProjectNames = _workspaceManager.GetStatus(workspaceId).Projects
+        var testProjectNames = (await _workspaceManager.GetStatusAsync(workspaceId, ct).ConfigureAwait(false)).Projects
             .Where(project => project.IsTestProject)
             .Select(project => project.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -137,7 +137,7 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
 
         foreach (var filePath in filePaths)
         {
-            var document = _workspaceManager.GetCurrentSolution(workspaceId)
+            var document = solution
                 .Projects
                 .SelectMany(p => p.Documents)
                 .FirstOrDefault(d => d.FilePath is not null &&

--- a/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
@@ -26,7 +26,7 @@ public sealed class TestRunnerService : ITestRunnerService
 
     public async Task<TestRunResultDto> RunTestsAsync(string workspaceId, string? projectName, string? filter, CancellationToken ct)
     {
-        var status = _workspaceManager.GetStatus(workspaceId);
+        var status = await _workspaceManager.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
 
         if (projectName is not null)
         {

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -7,7 +7,7 @@ namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
 /// Retains the last pre-apply solution snapshot per workspace so that it can
-/// be restored via <see cref="Revert"/>.
+/// be restored via <see cref="RevertAsync"/>.
 /// </summary>
 public sealed class UndoService : IUndoService
 {
@@ -29,7 +29,7 @@ public sealed class UndoService : IUndoService
         return new UndoEntry(snapshot.WorkspaceId, snapshot.Description, snapshot.AppliedAtUtc);
     }
 
-    public bool Revert(string workspaceId, IWorkspaceManager workspace)
+    public async Task<bool> RevertAsync(string workspaceId, IWorkspaceManager workspace, CancellationToken cancellationToken = default)
     {
         if (!_snapshots.TryRemove(workspaceId, out var snapshot))
             return false;
@@ -47,7 +47,7 @@ public sealed class UndoService : IUndoService
                 var oldDoc = snapshot.PreApplySolution.GetDocument(docId);
                 if (oldDoc is null) continue;
 
-                var oldText = oldDoc.GetTextAsync().GetAwaiter().GetResult();
+                var oldText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 targetSolution = targetSolution.WithDocumentText(docId, oldText);
             }
         }

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -179,6 +179,27 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         }
     }
 
+    public async Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default)
+    {
+        var session = GetRequiredSession(workspaceId);
+
+        if (!await session.LoadLock.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("GetStatus timed out waiting for LoadLock on {WorkspaceId}", workspaceId);
+            throw new TimeoutException(
+                $"Workspace '{workspaceId}' is currently loading. Try again shortly.");
+        }
+
+        try
+        {
+            return BuildStatus(session);
+        }
+        finally
+        {
+            session.LoadLock.Release();
+        }
+    }
+
     public ProjectGraphDto GetProjectGraph(string workspaceId)
     {
         var session = GetRequiredSession(workspaceId);
@@ -290,7 +311,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             var text = await document.GetTextAsync(ct).ConfigureAwait(false);
             return text.ToString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Fall back to reading from disk if workspace text retrieval fails
             _logger.LogWarning(ex, "Failed to get text from workspace for {FilePath}, falling back to disk read", filePath);

--- a/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -128,6 +128,8 @@ public sealed class HardeningBehaviorTests : TestBase
                 IsLoaded: true,
                 IsStale: false,
                 WorkspaceDiagnostics: []);
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(GetStatus(workspaceId));
         public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
         public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
         public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -122,6 +122,9 @@ public class PerformanceBehaviorTests : TestBase
                 IsStale: false,
                 WorkspaceDiagnostics: []);
 
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(GetStatus(workspaceId));
+
         public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
 
         public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) =>

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -76,6 +76,8 @@ public sealed class SurfaceCatalogTests
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
         public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
         public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
         public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
         public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
@@ -57,7 +57,7 @@ public sealed class UndoIntegrationTests : TestBase
             StringAssert.Contains(undoEntry.Description, "Rename");
 
             // Revert
-            var reverted = UndoService.Revert(workspaceId, WorkspaceManager);
+            var reverted = await UndoService.RevertAsync(workspaceId, WorkspaceManager, CancellationToken.None);
             Assert.IsTrue(reverted, "Revert should succeed");
 
             // Verify original name is back
@@ -72,9 +72,9 @@ public sealed class UndoIntegrationTests : TestBase
     }
 
     [TestMethod]
-    public void Revert_Without_Prior_Apply_Returns_False()
+    public async Task Revert_Without_Prior_Apply_Returns_False()
     {
-        var result = UndoService.Revert("nonexistent-workspace", WorkspaceManager);
+        var result = await UndoService.RevertAsync("nonexistent-workspace", WorkspaceManager, CancellationToken.None);
         Assert.IsFalse(result);
     }
 


### PR DESCRIPTION
## Summary
- **Undo:** \IUndoService.RevertAsync\ with awaited \GetTextAsync\ (no sync-over-async); \evert_last_apply\ awaits.
- **Workspace status:** \IWorkspaceManager.GetStatusAsync\ uses \SemaphoreSlim.WaitAsync\; async tools/services use it instead of blocking \GetStatus\.
- **Exception handling:** Broad \catch (Exception)\ paths now use \when (ex is not OperationCanceledException)\ so cancellation propagates (DependencyAnalysis, WorkspaceManager GetSourceTextAsync fallback, ReferenceService bulk refs, AnalyzerInfoService, FixAllService, CodeActionService).
- **Cancellation:** \ThrowIfCancellationRequested\ in \EditorConfigService.SetOptionAsync\, \MsBuildEvaluationService.EvaluatePropertyAsync\, \SecurityDiagnosticService.GetAnalyzerStatusAsync\ (plus per-project loop).

## Validation
- \dotnet build RoslynMcp.slnx\
- \dotnet test RoslynMcp.slnx\ (196 tests)

Made with [Cursor](https://cursor.com)