### PR TITLE
Release hardening: coverage, CI artifacts, baseline docs

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -17,8 +17,8 @@
 - **Last audit:** 2026-04-04
 - **Last audit mode:** initial
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 17 (excluding archive content files; archive tracks README only)
-- **docs/ file count:** 7
+- **ai_docs/ file count:** 18+ (excluding archive content files; archive tracks README only; includes `audit-reports/`)
+- **docs/ file count:** 10+ (includes `coverage-baseline.md`, `experimental-promotion-analysis.md`, `large-solution-profiling-baseline.md`)
 - **Agent instruction files:** AGENTS.md, CLAUDE.md, .github/copilot-instructions.md, .cursor/rules/operational-essentials.md, CI_POLICY.md
 
 ## Structure Compliance
@@ -37,7 +37,7 @@
 | ai_docs/runtime.md | present | — |
 | ai_docs/domains/ | present | Domain refs + tool-usage-guide |
 | ai_docs/references/ | present | testing, tooling/* |
-| docs/ | present | `docs/setup.md`, `docs/parity-gap-implementation-plan.md` |
+| docs/ | present | `docs/setup.md`, `docs/parity-gap-implementation-plan.md`, `docs/coverage-baseline.md`, promotion + profiling docs |
 | docs/adr/ | not-needed | — |
 
 ## Known Gaps
@@ -46,6 +46,7 @@
 
 ## Findings from Last Audit
 
+- **2026-04-04 (release hardening):** `eng/verify-release.ps1` collects Cobertura coverage; CI artifact `code-coverage`; `docs/coverage-baseline.md` records ~59.3% / ~46.4% aggregate; `docs/` adds experimental promotion + large-solution profiling guides; `ai_docs/audit-reports/` baseline for deep-review MCP audits; parity-gap plan updated with verification evidence.
 - **2026-04-04 (follow-up):** `docs/parity-gap-implementation-plan.md` added; `references/tooling/mcp-clients.md` expanded; `README.md` SDK line aligned with `global.json`.
 - **Initial pass (2026-04-04):** Ran `standardize-documentation.md`: Phase 1 inventory captured in `docs/setup.md`; removed broken index links to non-existent `archive/*.md` reports; fixed `backlog.md` standing rules (fake `ai_docs/reports/` and missing archive paths); added `<!-- purpose: -->` lines after first heading across `ai_docs/**/*.md`; indexed `prompts/standardize-backlog-hygiene.md`; root `README.md` points to `docs/setup.md`.
 
@@ -74,4 +75,4 @@
 |------|---------------------|
 | Global tool | `dotnet pack` / `dotnet tool install -g RoslynMcp` — see `docs/setup.md` |
 | Docker | `docker build` / `docker run` — `Dockerfile`, `docs/setup.md` |
-| CI artifacts | `host-stdio-publish`, `release-manifests` — `.github/workflows/ci.yml`, `docs/setup.md` |
+| CI artifacts | `host-stdio-publish`, `release-manifests`, `code-coverage` — `.github/workflows/ci.yml`, `docs/setup.md` |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ For session bootstrap and workflow, follow `AGENTS.md` first.
 - Prefer integration tests over unit tests — mock-only tests have previously masked real failures
 - Use sample solutions in `samples/` for workspace-level tests
 - Run `dotnet test RoslynMcp.slnx --nologo` before declaring work merge-ready
-- Current coverage baseline: ~49.8% line / ~37.6% branch — do not regress it
+- Current coverage baseline (from Cobertura root after `./eng/verify-release.ps1`): **~59.3% line / ~46.4% branch** — do not regress it; see `docs/coverage-baseline.md`
 
 ## Safety Guardrails
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ jobs:
         shell: pwsh
         run: ./eng/verify-release.ps1 -Configuration Release
 
+      - name: Generate coverage HTML summary
+        shell: pwsh
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.4.7 --no-cache
+          $tools = Join-Path $env:HOME ".dotnet/tools"
+          $env:PATH = "$tools$([IO.Path]::PathSeparator)$env:PATH"
+          $files = Get-ChildItem -Path "artifacts/coverage" -Recurse -Filter "coverage.cobertura.xml" -ErrorAction SilentlyContinue
+          if (-not $files) { throw "No coverage.cobertura.xml under artifacts/coverage" }
+          $reports = ($files | ForEach-Object { $_.FullName }) -join ";"
+          $target = Join-Path $PWD "artifacts/coverage/report"
+          reportgenerator "-reports:$reports" "-targetdir:$target" -reporttypes:HtmlSummary
+
       - name: Audit packages for known vulnerabilities
         shell: pwsh
         run: dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive
@@ -43,3 +55,9 @@ jobs:
         with:
           name: release-manifests
           path: artifacts/manifests
+
+      - name: Upload code coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: artifacts/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Roslyn-Backed MCP Server will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- `eng/verify-release.ps1` collects **XPlat Code Coverage** (Cobertura) under `artifacts/coverage`; CI uploads **`code-coverage`** artifact and generates ReportGenerator **HtmlSummary**.
+- `docs/coverage-baseline.md` — measured line/branch baseline and test-priority notes.
+- `docs/experimental-promotion-analysis.md` — promotion scoring dimensions and candidate tiers.
+- `docs/large-solution-profiling-baseline.md` — P50/P95 methodology for large-solution performance decisions.
+- `ai_docs/audit-reports/` — README and deep-review baseline template for MCP audit sessions.
+- Integration tests for `compile_check` (`ValidationToolsIntegrationTests`).
+
+### Changed
+
+- `.github/copilot-instructions.md` — coverage baseline updated to match current Cobertura aggregate.
+- `docs/parity-gap-implementation-plan.md` — release verification evidence for 2026-04-04.
+- `CI_POLICY.md` — documents coverage + artifacts.
+
 ## [1.5.0] - 2026-04-04
 
 ### Added

--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -6,7 +6,7 @@ This document is the single canonical source for validation requirements and mer
 
 - `.github/workflows/ci.yml` runs on pull requests, pushes to `main`, and manual dispatch.
 - CI currently runs `./eng/verify-ai-docs.ps1`.
-- CI currently runs `./eng/verify-release.ps1 -Configuration Release`.
+- CI currently runs `./eng/verify-release.ps1 -Configuration Release` (includes `dotnet test` with **XPlat Code Coverage** to `artifacts/coverage`, then **ReportGenerator** HTML summary under `artifacts/coverage/report`).
 - CI currently runs `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`.
 - `.github/workflows/codeql.yml` runs the **Analyze C#** CodeQL job on every pull request, push to `main`, weekly schedule, and manual dispatch so the check stays required and always completes. On pull requests, a path filter runs first: if the diff only touches documentation or other non-code paths, CodeQL skips `init`/build/analyze (the job still succeeds). Pull requests that run CodeQL use the `security-extended` query suite; pushes to `main` and scheduled runs use `security-and-quality`. SARIF upload to GitHub Code Scanning is disabled (`upload: never`).
 
@@ -14,7 +14,7 @@ This document is the single canonical source for validation requirements and mer
 
 - For AI-doc changes, run `./eng/verify-ai-docs.ps1`.
 - For release-impacting or code changes, run `./eng/verify-release.ps1`.
-- `eng/verify-release.ps1` performs restore, build, test, publish, and hash-manifest generation.
+- `eng/verify-release.ps1` performs restore, build, test (with Cobertura coverage under `artifacts/coverage`), publish, and hash-manifest generation.
 
 ## Merge Gating Expectations
 

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -39,6 +39,7 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | `prompts/standardize-documentation.md` | Cross-repo prompt: run `/doc-audit` first, then align human + AI docs, packaging/install inventory, stale ref removal |
 | `prompts/standardize-backlog-hygiene.md` | Align backlog hygiene across repos with `backlog.md` and `workflow.md` |
 | `prompts/deep-review-and-refactor.md` | Living reusable prompt for comprehensive code review and MCP server audit (all 18 phases). Keep in sync with project surface. Do not delete. |
+| `audit-reports/README.md` | Where to store MCP deep-review audit outputs; links baseline template |
 
 ## Archive
 
@@ -63,3 +64,7 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | Planning new features | `backlog.md` → `architecture.md` → `docs/roadmap.md` |
 | Human setup / Docker / CI artifacts | `docs/setup.md` |
 | Release parity / must-have matrix | `docs/parity-gap-implementation-plan.md` |
+| Coverage baseline / CI artifacts | `docs/coverage-baseline.md` → `references/testing.md` |
+| Experimental → stable promotion review | `docs/experimental-promotion-analysis.md` |
+| Large-solution profiling method | `docs/large-solution-profiling-baseline.md` |
+| MCP deep-review audit session | `prompts/deep-review-and-refactor.md` → `audit-reports/` |

--- a/ai_docs/audit-reports/README.md
+++ b/ai_docs/audit-reports/README.md
@@ -1,0 +1,16 @@
+# MCP deep-review audit reports
+
+Use the living prompt [`ai_docs/prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md) with an MCP client connected to **roslyn-mcp** to exercise the full tool surface against a real solution.
+
+## Outputs
+
+- **Single audit file** per run (PASS/FLAG/FAIL per tool, performance notes, schema-vs-behavior findings).
+- **FAIL** items that represent product defects should be tracked in **`ai_docs/backlog.md`** (open rows only).
+
+## Baseline session template
+
+| File | Purpose |
+|------|---------|
+| [`deep-review-baseline-2026-04-04.md`](deep-review-baseline-2026-04-04.md) | Structure and checklist for a full audit; update when the tool/resource/prompt surface changes. |
+
+Re-run the deep-review prompt after major surface changes (see appendix version line in the prompt).

--- a/ai_docs/audit-reports/deep-review-baseline-2026-04-04.md
+++ b/ai_docs/audit-reports/deep-review-baseline-2026-04-04.md
@@ -1,0 +1,61 @@
+# Deep review & MCP audit — baseline session (2026-04-04)
+
+This file is a **baseline template** for executing [`ai_docs/prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md). A full PASS/FAIL matrix requires an **interactive MCP session** (Cursor or other client) with the server running (`dotnet run --project src/RoslynMcp.Host.Stdio` or global `roslynmcp`).
+
+## Session parameters
+
+| Field | Value |
+|-------|--------|
+| Target solution | Default: `samples/SampleSolution/` — substitute a richer repo if needed |
+| Server version | Assembly version from `server_info` at session start |
+| Host | stdio (`RoslynMcp.Host.Stdio`) |
+
+## Automated pre-checks (repository)
+
+The following run in CI and locally without MCP:
+
+- `./eng/verify-ai-docs.ps1`
+- `./eng/verify-release.ps1 -Configuration Release` (build, tests with coverage, publish, manifests)
+- `SurfaceCatalogTests` — catalog matches registered tools/resources/prompts
+
+## Audit sections (fill during MCP session)
+
+### 1. Tool coverage matrix
+
+For each phase in the deep-review prompt, record tools **called** vs **skipped** and a **PASS / FLAG / FAIL** tag.
+
+### 2. Schema vs behavior
+
+| Tool | Schema accurate? | Notes |
+|------|------------------|-------|
+| *(fill)* | | |
+
+### 3. Performance observations
+
+| Tool | Approx. wall time | Input scale |
+|------|-------------------|-------------|
+| *(fill)* | | |
+
+### 4. Error message quality
+
+| Tool | Actionable / Vague / Unhelpful | Notes |
+|------|-------------------------------|-------|
+| *(fill)* | | |
+
+### 5. Response contract consistency
+
+Note 0-based vs 1-based lines, field naming across related tools, etc.
+
+### 6. Phase 6 refactor summary
+
+If refactors were applied in the **target** repo during the audit, list commits/files here.
+
+## Findings routed to backlog
+
+| id | Summary | Severity |
+|----|---------|----------|
+| *(none yet)* | File new rows in `ai_docs/backlog.md` for FAIL-grade defects. | |
+
+## Safe refactors applied in **this** repo (roslyn-mcp)
+
+During implementation of the release-hardening plan (same date), no separate deep-review MCP session was executed in this workspace; **integration tests** for `compile_check` were added in `ValidationToolsIntegrationTests.cs`, and **coverage** was wired into `verify-release.ps1`. Re-run this audit file with a live MCP session when validating a release candidate.

--- a/ai_docs/references/testing.md
+++ b/ai_docs/references/testing.md
@@ -6,6 +6,12 @@
 
 - `dotnet test RoslynMcp.slnx --nologo`
 
+## Coverage
+
+- Full release validation (`./eng/verify-release.ps1`) runs tests with **XPlat Code Coverage** and writes Cobertura XML under `artifacts/coverage/`.
+- Baseline numbers and test-priority notes: `docs/coverage-baseline.md`.
+- CI artifact: `code-coverage` (see `CI_POLICY.md`).
+
 ## Build + Test Baseline
 
 1. `dotnet build RoslynMcp.slnx --nologo`

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -1,0 +1,45 @@
+# Code coverage baseline
+
+This document records **measured** line/branch coverage from **Coverlet** (XPlat Code Coverage) via `eng/verify-release.ps1`, and lists **priority areas** for additional integration tests.
+
+## How to reproduce
+
+1. Run `./eng/verify-release.ps1 -Configuration Release` from the repository root.
+2. Open `artifacts/coverage/**/coverage.cobertura.xml` (path includes a test-run GUID folder).
+3. Optional HTML summary: install ReportGenerator (`dotnet tool install --global dotnet-reportgenerator-globaltool`) then:
+   ```bash
+   reportgenerator -reports:"artifacts/coverage/**/coverage.cobertura.xml" -targetdir:artifacts/coverage/report -reporttypes:HtmlSummary
+   ```
+
+CI uploads the **`code-coverage`** artifact (Cobertura + HTML summary when the workflow runs ReportGenerator).
+
+## Current baseline (root aggregate)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Line coverage | **~59.3%** | `<coverage line-rate="…">` in Cobertura (e.g. ~0.593) |
+| Branch coverage | **~46.4%** | `<coverage branch-rate="…">` |
+
+**Updated:** 2026-04-04 — measured after integrating coverage collection into `verify-release.ps1`.
+
+Historical note: older docs cited ~50% line / ~34% branch from an earlier toolchain or partial collection; the **do not regress** rule applies to this **current** baseline.
+
+## Priority areas for new tests (from Cobertura + risk)
+
+Use this list when expanding `tests/RoslynMcp.Tests/` integration coverage. Prefer **behavior-heavy services** over DTO-only types (many DTOs show 0% line coverage because they are never constructed in isolation).
+
+| Priority | Area | Rationale |
+|----------|------|-----------|
+| P1 | `CompileCheckService`, `CodeActionService` hot paths | Validation and code-action flows; previously under-covered async paths. |
+| P1 | `DependencyAnalysisService`, `DeadCodeService` branches | Large surface; mutation-adjacent behavior. |
+| P2 | `BoundedStore<T>` via preview stores | Eviction/TTL paths; exercise through preview/apply integration tests. |
+| P2 | `ServiceCollectionExtensions` (DI registration) | Low direct coverage; optional smoke test that builds host `ServiceProvider`. |
+| P3 | Core DTOs | Improve only when tied to a behavioral regression or serialization contract test. |
+
+After adding tests, re-run `verify-release.ps1` and update the **Current baseline** table and `.github/copilot-instructions.md` if the aggregate moves materially.
+
+## Related
+
+- `CI_POLICY.md` — CI runs coverage as part of `verify-release.ps1`
+- `ai_docs/references/testing.md` — primary test commands
+- `docs/parity-gap-implementation-plan.md` — release verification context

--- a/docs/experimental-promotion-analysis.md
+++ b/docs/experimental-promotion-analysis.md
@@ -1,0 +1,63 @@
+# Experimental → stable promotion analysis
+
+This document supports the post-release roadmap item **“promote experimental → stable”** (`docs/roadmap.md`, `docs/parity-gap-matrix.md`). It does **not** change the catalog by itself — promotions ship via `ServerSurfaceCatalog.cs`, `docs/product-contract.md`, semver bump, and `CHANGELOG.md` per `docs/release-policy.md`.
+
+## Scoring dimensions (per tool)
+
+| Dimension | Weight | Notes |
+|-----------|--------|--------|
+| **Read-only vs mutation** | High | Read-only tools are easier to stabilize; destructive tools need stronger preview/apply evidence. |
+| **Integration test coverage** | High | Prefer evidence in `tests/RoslynMcp.Tests/` (see `docs/coverage-baseline.md`). |
+| **Contract simplicity** | Medium | Narrow JSON DTOs with few optional branches reduce breaking-change risk. |
+| **Operational usage** | Medium | Field feedback, audit runs (`ai_docs/prompts/deep-review-and-refactor.md`), or dogfood sessions. |
+| **Schema/description accuracy** | Medium | Tool description matches behavior (audit PASS on schema-vs-behavior). |
+
+## Aggregate surface (reference)
+
+| Tier | Tools | Resources | Prompts |
+|------|-------|-----------|---------|
+| Stable | 50 | 8 stable / 0 experimental | 0 stable / 18 experimental |
+| Experimental | 73 | — | — |
+
+Authoritative counts: `ServerSurfaceCatalog.GetSummary()` / `server_info` / `roslyn://server/catalog`.
+
+## Tier 1 — candidates for **future** promotion (pending review)
+
+These are **read-only or preview-first** tools that align with stable contract themes (navigation, diagnostics, validation) and already have integration-test adjacency or clear user value. **No promotion is approved here** — use this as a backlog for human/product review.
+
+| Tool | Category | Rationale for review |
+|------|----------|----------------------|
+| `compile_check` | validation | Fast compileability signal without `dotnet build`; complements stable build/test tools. |
+| `list_analyzers` | analysis | Supports diagnostics workflows; read-only. |
+| `find_consumers` | analysis | Consumer/impact analysis; read-only. |
+| `get_cohesion_metrics` | analysis | Cohesion metrics; read-only. |
+| `find_shared_members` | analysis | Supports refactor planning; read-only. |
+| `analyze_snippet` | analysis | Ephemeral analysis without workspace; read-only. |
+
+## Tier 2 — needs stronger evidence before promotion
+
+| Bucket | Examples | Blocker |
+|--------|----------|---------|
+| Direct file / project mutation | `apply_text_edit`, `set_editorconfig_option`, `apply_project_mutation` | Requires documented preview/apply + negative tests for path safety. |
+| Code actions | `get_code_actions`, `preview_code_action`, `apply_code_action` | Large Roslyn surface; schema stability and idempotency need explicit policy. |
+| Orchestration / cross-project | `migrate_package_preview`, `move_type_to_project_preview` | Multi-step previews; need characterization tests per workflow. |
+
+## Tier 3 — intentionally long-tail experimental
+
+- **Prompts** — excluded from compatibility API per `docs/product-contract.md`.
+- **Dead-code / scaffolding / orchestration apply** — remain experimental until operational evidence and test depth justify stable tier.
+
+## Promotion checklist (when executing a promotion)
+
+1. Confirm tests + coverage for the tool’s service path.
+2. Update `ServerSurfaceCatalog` entry from `"experimental"` to `"stable"`.
+3. Update `docs/product-contract.md` stable tool families list.
+4. Minor semver bump; `CHANGELOG.md` **Added** under stable surface.
+5. Run `./eng/verify-release.ps1` and `./eng/verify-ai-docs.ps1`.
+6. Re-run catalog parity: `SurfaceCatalogTests`.
+
+## Related
+
+- `docs/release-policy.md` — versioning and compatibility
+- `docs/coverage-baseline.md` — measured coverage
+- `docs/parity-gap-implementation-plan.md` — release verification context

--- a/docs/large-solution-profiling-baseline.md
+++ b/docs/large-solution-profiling-baseline.md
@@ -1,0 +1,66 @@
+# Large-solution profiling baseline
+
+This document implements **Phase 6** of the release-hardening plan: a **repeatable method** to decide whether to invest in indexing/caching (`docs/roadmap.md` — Large-Solution Performance Strategy) versus staying on hardening.
+
+## Purpose
+
+- Establish **P50 / P95 / P99** wall-clock times for representative operations on a **large** solution (target: 50+ projects, or your worst-case customer repo).
+- If P95 is acceptable for single-symbol and common scans, **defer** performance-engineering until metrics justify it.
+
+## Prerequisites
+
+- Same machine class as typical developers (or document CPU/RAM/disk).
+- Cold vs warm: document whether the workspace was just loaded or reused.
+- `ROSLYNMCP_*` env vars at default unless testing specific caps (`ai_docs/runtime.md`).
+
+## Operations to measure
+
+| Operation | Tool / API | Notes |
+|-----------|------------|--------|
+| Workspace load | `workspace_load` | End-to-end open + first `workspace_status`. |
+| Symbol search | `symbol_search` | Bounded query; record limit and pattern. |
+| Find references | `find_references` | Single symbol with typical fan-out. |
+| Compile check | `compile_check` | `emitValidation: false` vs `true` separately. |
+| Build | `build_project` or full solution | As used in practice. |
+| Test run | `test_run` | Smallest test project if full suite is too slow. |
+
+## Procedure
+
+1. Load workspace once; discard first timing if including JIT/warmup (or report separately).
+2. For each operation, run **at least 5** iterations; record milliseconds.
+3. Compute P50 / P95 / P99 (spreadsheet or script).
+4. Record solution stats: project count, document count, approximate LOC if available.
+
+## Decision gate (example thresholds)
+
+| Signal | Stay on hardening | Open performance epic |
+|--------|-------------------|-------------------------|
+| Single-symbol navigation (`go_to_definition`, `find_references`) P95 | &lt; 5 s | &gt; 5 s consistently |
+| Solution-wide search P95 | &lt; 30 s | &gt; 30 s on representative queries |
+| Workspace load P95 | &lt; 2 min | &gt; 2 min blocking daily use |
+
+Thresholds are **examples** — adjust for your user expectations.
+
+## Result template (fill per run)
+
+| Field | Value |
+|-------|--------|
+| Date | |
+| Solution path (describe only; no secrets) | |
+| Project count | |
+| roslyn-mcp version / commit | |
+| workspace_load P50 / P95 | |
+| symbol_search P50 / P95 | |
+| find_references P50 / P95 | |
+| compile_check (no emit) P50 / P95 | |
+| compile_check (emit) P50 / P95 | |
+| Decision | Stay on hardening / Open performance backlog item |
+
+## Backlog linkage
+
+If performance work is justified, add a row to `ai_docs/backlog.md` with **measured** P95, operation name, and solution profile — not generic “make it faster.”
+
+## Related
+
+- `docs/parity-gap-implementation-plan.md` — hardening vs performance recommendation
+- `docs/roadmap.md` — indexing/caching direction

--- a/docs/parity-gap-implementation-plan.md
+++ b/docs/parity-gap-implementation-plan.md
@@ -18,14 +18,20 @@ This document walks **`docs/parity-gap-matrix.md`** and records **what is alread
 
 | Matrix item | Status | Evidence / next steps |
 |-------------|--------|------------------------|
-| `server_catalog` | Done | Resource `roslyn://server/catalog` (`ServerResources.GetServerCatalog`), `ServerSurfaceCatalog` + `CatalogVersion`. **Verify:** diff JSON against `docs/product-contract.md` before tagging. |
-| `server_info` + tiers | Done | `ServerTools`, `ServerSurfaceCatalog` stable/experimental labels; **Verify:** spot-check `server_info` and catalog after surface changes. |
-| Explicit stable vs experimental surface | Done | `docs/product-contract.md`, `ServerSurfaceCatalog`, catalog JSON. **Verify:** no experimental tool promoted without doc + release note. |
-| Wrapper/integration tests for under-tested tool families | Done | Added: `WorkspaceToolsIntegrationTests`, `RefactoringToolsIntegrationTests`, `ValidationToolsIntegrationTests`, `WorkspaceResourceTests`, `PromptSmokeTests` (sample solution). **Verify:** run full `dotnet test RoslynMcp.slnx` before each release; extend when adding tools. Catalog parity remains covered by `SurfaceCatalogTests`. |
-| Workspace/session limits and failed-load cleanup | Done | `WorkspaceManagerOptions` (`MaxConcurrentWorkspaces` default 8, `MaxSourceGeneratedDocuments` 500), `WorkspaceManager` semaphore + slot release, `WorkspaceExecutionGate` workspace validation and bounded gates. **Verify:** env table in `ai_docs/runtime.md`. |
-| Bounded related-test scans and command timeouts | Done | `ValidationServiceOptions` (build/test timeouts), `WorkspaceExecutionGate` per-request timeout, `TestRunnerService`, `TestDiscoveryService` related-test limits. **Verify:** defaults match ops expectations for largest target solution. |
-| Canonical CI and publish verification path | Done | `.github/workflows/ci.yml`, `eng/verify-release.ps1`, `eng/verify-ai-docs.ps1` (see `CI_POLICY.md`). **Verify:** artifacts `host-stdio-publish`, `release-manifests` on green `main`. |
-| Documented compatibility, deprecation, release policy | Done | `docs/release-policy.md`, `README.md`, `AGENTS.md`. **Verify:** version bump + changelog entry match release. |
+| `server_catalog` | Done | Resource `roslyn://server/catalog` (`ServerResources.GetServerCatalog`), `ServerSurfaceCatalog` + `CatalogVersion`. **Release check 2026-04-04:** `SurfaceCatalogTests.ServerSurfaceCatalog_CoversAllRegisteredToolsResourcesAndPrompts` passes; catalog aligns with registered MCP surface. Family-level contract in `docs/product-contract.md` matches tier intent (stable vs experimental). |
+| `server_info` + tiers | Done | `ServerTools`, `ServerSurfaceCatalog` stable/experimental labels. **Release check 2026-04-04:** `SurfaceCatalogTests.ServerInfo_IncludesSurfaceSupportSummary` passes; `eng/verify-release.ps1 -Configuration Release` green (196 tests). |
+| Explicit stable vs experimental surface | Done | `docs/product-contract.md`, `ServerSurfaceCatalog`, catalog JSON. **Release check 2026-04-04:** no drift; promotion remains gated by `docs/release-policy.md` + release notes. |
+| Wrapper/integration tests for under-tested tool families | Done | `WorkspaceToolsIntegrationTests`, `RefactoringToolsIntegrationTests`, `ValidationToolsIntegrationTests`, `WorkspaceResourceTests`, `PromptSmokeTests`; `SurfaceCatalogTests` for catalog parity. **Release check 2026-04-04:** full `dotnet test` via `verify-release` — 196 passed. |
+| Workspace/session limits and failed-load cleanup | Done | `WorkspaceManagerOptions` (defaults 8 / 500), `WorkspaceManager`, `WorkspaceExecutionGate`. **Release check 2026-04-04:** env defaults in `ai_docs/runtime.md` verified against `Program.cs` + `WorkspaceManagerOptions` / `ValidationServiceOptions` / `PreviewStoreOptions` / `ExecutionGateOptions` / `SecurityOptions`. |
+| Bounded related-test scans and command timeouts | Done | `ValidationServiceOptions` (5 min build / 10 min test / 25 related files default), `WorkspaceExecutionGate`, `TestRunnerService`, `TestDiscoveryService`. **Release check 2026-04-04:** defaults documented in `ai_docs/runtime.md` match code. |
+| Canonical CI and publish verification path | Done | `.github/workflows/ci.yml`, `eng/verify-release.ps1`, `eng/verify-ai-docs.ps1` (see `CI_POLICY.md`). **Release check 2026-04-04:** local `verify-release` produced `artifacts/publish/host-stdio` and `artifacts/manifests/host-stdio-sha256.txt`; CI uploads `host-stdio-publish` and `release-manifests` on green runs. |
+| Documented compatibility, deprecation, release policy | Done | `docs/release-policy.md`, `README.md`, `AGENTS.md`. **Release check 2026-04-04:** policy unchanged; `CHANGELOG.md` [1.5.0] documents current release line. |
+
+### Release verification log (automatable evidence)
+
+| When | Commit | Check |
+|------|--------|--------|
+| 2026-04-04 | `1f2e4fb8382666da0bf7f15b456ff2f72931eed3` | `./eng/verify-release.ps1 -Configuration Release` — build OK, **196** tests passed, publish + SHA-256 manifest written. |
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,7 +15,7 @@
 | Local build | `RoslynMcp.slnx` | `dotnet build RoslynMcp.slnx --nologo` | Primary solution file. |
 | Test | `RoslynMcp.slnx` | `dotnet test RoslynMcp.slnx --nologo` | |
 | Run from source (stdio MCP) | `src/RoslynMcp.Host.Stdio/` | `dotnet run --project src/RoslynMcp.Host.Stdio` | |
-| Full release validation | `eng/verify-release.ps1` | `./eng/verify-release.ps1` (or `-Configuration Release`) | Restore, build, test, publish to `artifacts/publish/host-stdio`, SHA256 manifest under `artifacts/manifests/`. |
+| Full release validation | `eng/verify-release.ps1` | `./eng/verify-release.ps1` (or `-Configuration Release`) | Restore, build, test (with Cobertura under `artifacts/coverage/`), publish to `artifacts/publish/host-stdio`, SHA256 manifest under `artifacts/manifests/`. See `docs/coverage-baseline.md`. |
 | AI documentation validation | `eng/verify-ai-docs.ps1` | `./eng/verify-ai-docs.ps1` | Same script as CI. |
 | NuGet global tool | `src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj` (`PackAsTool`, `ToolCommandName`: `roslynmcp`) | `dotnet pack src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj -c Release -o ./nupkg` then `dotnet tool install -g RoslynMcp --add-source ./nupkg` | Package id `RoslynMcp`; see `.csproj` for metadata. |
 | Publish + reinstall local tool | MSBuild target `PackAndReinstallGlobalTool` | `dotnet publish -c Release /p:ReinstallTool=true` (Windows) | Uninstalls prior global install, packs to `nupkg/`, reinstalls. Uses `taskkill` on `roslynmcp.exe`. |
@@ -31,6 +31,7 @@ GitHub Actions `ci` workflow uploads:
 |-----------------|----------|
 | `host-stdio-publish` | `artifacts/publish/host-stdio` — published host output. |
 | `release-manifests` | `artifacts/manifests` — e.g. SHA256 manifest from `verify-release.ps1`. |
+| `code-coverage` | `artifacts/coverage` — Cobertura XML from tests; CI also generates `artifacts/coverage/report` (HtmlSummary) via ReportGenerator. |
 
 Download from the workflow run’s **Artifacts** section. Requires a GitHub account with access to the repository.
 

--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -10,14 +10,18 @@ $solutionPath = Join-Path $repoRoot "RoslynMcp.slnx"
 $hostProject = Join-Path $repoRoot "src\RoslynMcp.Host.Stdio\RoslynMcp.Host.Stdio.csproj"
 $publishDir = Join-Path $repoRoot "$OutputRoot\publish\host-stdio"
 $manifestDir = Join-Path $repoRoot "$OutputRoot\manifests"
+$coverageDir = Join-Path $repoRoot "$OutputRoot\coverage"
 $hashManifestPath = Join-Path $manifestDir "host-stdio-sha256.txt"
 
 New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
 New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+New-Item -ItemType Directory -Path $coverageDir -Force | Out-Null
 
 dotnet restore $solutionPath --nologo
 dotnet build $solutionPath -c $Configuration --no-restore --nologo
-dotnet test $solutionPath -c $Configuration --no-build --nologo
+dotnet test $solutionPath -c $Configuration --no-build --nologo `
+    --collect:"XPlat Code Coverage" `
+    --results-directory $coverageDir
 dotnet publish $hostProject -c $Configuration --no-build -o $publishDir
 
 $hashLines = Get-ChildItem -Path $publishDir -File -Recurse |
@@ -32,3 +36,4 @@ Set-Content -Path $hashManifestPath -Value $hashLines
 
 Write-Host "Publish directory: $publishDir"
 Write-Host "Hash manifest: $hashManifestPath"
+Write-Host "Code coverage (Cobertura): $coverageDir"

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -48,6 +48,40 @@ public sealed class ValidationToolsIntegrationTests : TestBase
     }
 
     [TestMethod]
+    public async Task CompileCheck_Service_GetDiagnostics_Succeeds_For_SampleSolution()
+    {
+        var result = await CompileCheckService.CheckAsync(WorkspaceId, projectFilter: null, emitValidation: false, CancellationToken.None);
+        Assert.IsTrue(result.Success, "Sample solution should compile without errors.");
+        Assert.AreEqual(0, result.ErrorCount);
+        Assert.IsNotNull(result.Diagnostics);
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_Service_EmitValidation_Completes_For_SampleLib()
+    {
+        var result = await CompileCheckService.CheckAsync(WorkspaceId, projectFilter: "SampleLib", emitValidation: true, CancellationToken.None);
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.ElapsedMs >= 0);
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_Tool_Returns_Valid_Json()
+    {
+        var json = await CompileCheckTools.CompileCheck(
+            WorkspaceExecutionGate,
+            CompileCheckService,
+            WorkspaceId,
+            project: null,
+            emitValidation: false,
+            CancellationToken.None);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.IsTrue(
+            root.TryGetProperty("Success", out _) || root.TryGetProperty("success", out _),
+            "Expected Success in JSON output.");
+    }
+
+    [TestMethod]
     public async Task TestRelated_Returns_Json_For_File()
     {
         var programPath = FindDocumentPath("Program.cs");


### PR DESCRIPTION
## Summary
This PR ships the release-hardening plan: measured test coverage in \erify-release.ps1\, CI visibility (Cobertura + ReportGenerator HtmlSummary), updated coverage baseline in copilot instructions, parity-gap verification evidence, \compile_check\ integration tests, and supporting docs (coverage baseline, experimental promotion analysis, large-solution profiling methodology, audit-reports baseline for deep-review).

## Test plan
- [x] Local: \dotnet test RoslynMcp.slnx -c Release\ (199 tests)
- [x] \./eng/verify-ai-docs.ps1\
- [ ] CI \alidate\ job green after merge

## Files
- \ng/verify-release.ps1\, \.github/workflows/ci.yml\, \CI_POLICY.md\
- \docs/coverage-baseline.md\, \docs/experimental-promotion-analysis.md\, \docs/large-solution-profiling-baseline.md\
- \i_docs/audit-reports/*\, index and testing reference updates
- \CHANGELOG.md\ [Unreleased]


Made with [Cursor](https://cursor.com)