### PR TITLE
docs: AI doc audit refresh, backlog sync, deep-review prompts

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -7,48 +7,48 @@
 ## Project Identity
 
 - **Name:** Roslyn-Backed MCP Server
-- **Path:** C:\Code-Repo\Roslyn-Backed-MCP
+- **Path:** Roslyn-Backed-MCP
 - **Tech stack:** C# / .NET 10 (SDK 10.0.100) / Roslyn 5.x / Microsoft.CodeAnalysis
 - **Ecosystem role:** Local stdio MCP server providing semantic C# analysis, navigation, and refactoring powered by Roslyn — no Visual Studio required. Used by AI coding agents.
 - **Integration brief:** none
+- **Session-start overrides:** `AGENTS.md` uses an extended eight-file chain: `CI_POLICY.md` → `ai_docs/README.md` → `workflow.md` → `runtime.md` → `backlog.md` → `.github/copilot-instructions.md` → `.cursor/rules/operational-essentials.md` → `CLAUDE.md`. Backlog is read before editor/copilot rules so open work and contract stay visible early.
 
 ## Documentation State
 
 - **Last audit:** 2026-04-04
 - **Last audit mode:** initial
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 18+ (excluding archive content files; archive tracks README only; includes `audit-reports/`)
-- **docs/ file count:** 10+ (includes `coverage-baseline.md`, `experimental-promotion-analysis.md`, `large-solution-profiling-baseline.md`)
+- **ai_docs/ file count:** 21
+- **docs/ file count:** 10
 - **Agent instruction files:** AGENTS.md, CLAUDE.md, .github/copilot-instructions.md, .cursor/rules/operational-essentials.md, CI_POLICY.md
 
 ## Structure Compliance
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| AGENTS.md | present | — |
+| AGENTS.md | present | Backlog contract pointer under Policy ownership |
 | CLAUDE.md | present | Mirrors AGENTS.md |
 | .github/copilot-instructions.md | present | — |
 | .cursor/rules/operational-essentials.md | present | — |
 | CI_POLICY.md | present | — |
-| ai_docs/README.md (index) | present | Index updated; archive entries fixed; `standardize-backlog-hygiene` linked |
-| ai_docs/architecture.md | present | Purpose comment added |
-| ai_docs/backlog.md | present | Stale paths removed |
-| ai_docs/workflow.md | present | — |
+| ai_docs/README.md (index) | present | Indexes audit-reports snapshots; backlog sync pointer |
+| ai_docs/architecture.md | present | — |
+| ai_docs/backlog.md | present | `updated_at` full ISO 8601; Agent contract |
+| ai_docs/workflow.md | present | Backlog closure subsection |
 | ai_docs/runtime.md | present | — |
-| ai_docs/domains/ | present | Domain refs + tool-usage-guide |
+| ai_docs/domains/ | present | host-stdio, core-contracts, roslyn-services + tool-usage-guide |
 | ai_docs/references/ | present | testing, tooling/* |
-| docs/ | present | `docs/setup.md`, `docs/parity-gap-implementation-plan.md`, `docs/coverage-baseline.md`, promotion + profiling docs |
+| docs/ | present | `docs/README.md` indexes all topic files |
 | docs/adr/ | not-needed | — |
 
 ## Known Gaps
 
-- Domain reference files are minimal — adequate unless agents need deeper orientation.
+- Domain reference depth is intentionally concise; expand when agents repeatedly need more orientation.
+- `audit-reports/*.md` session snapshots are point-in-time; refresh or add new files after major surface releases.
 
 ## Findings from Last Audit
 
-- **2026-04-04 (release hardening):** `eng/verify-release.ps1` collects Cobertura coverage; CI artifact `code-coverage`; `docs/coverage-baseline.md` records ~59.3% / ~46.4% aggregate; `docs/` adds experimental promotion + large-solution profiling guides; `ai_docs/audit-reports/` baseline for deep-review MCP audits; parity-gap plan updated with verification evidence.
-- **2026-04-04 (follow-up):** `docs/parity-gap-implementation-plan.md` added; `references/tooling/mcp-clients.md` expanded; `README.md` SDK line aligned with `global.json`.
-- **Initial pass (2026-04-04):** Ran `standardize-documentation.md`: Phase 1 inventory captured in `docs/setup.md`; removed broken index links to non-existent `archive/*.md` reports; fixed `backlog.md` standing rules (fake `ai_docs/reports/` and missing archive paths); added `<!-- purpose: -->` lines after first heading across `ai_docs/**/*.md`; indexed `prompts/standardize-backlog-hygiene.md`; root `README.md` points to `docs/setup.md`.
+- **2026-04-04 (initial):** Normalized `Path` to repo directory name (no absolute path). Set `ai_docs/backlog.md` **`updated_at`** to full ISO 8601 (`2026-04-04T12:00:00Z`). Added `<!-- purpose: -->` after first heading on `audit-reports/README.md`, `audit-reports/deep-review-baseline-2026-04-04.md`, and `audit-reports/2026-04-04-post-1.5-surface-audit.md`. Completed `docs/README.md` index rows for `coverage-baseline.md`, `experimental-promotion-analysis.md`, `large-solution-profiling-baseline.md`. Indexed the two audit snapshot files in `ai_docs/README.md`.
 
 ## Codebase Domains
 

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -40,6 +40,8 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | `prompts/standardize-backlog-hygiene.md` | Align backlog hygiene across repos with `backlog.md` and `workflow.md` |
 | `prompts/deep-review-and-refactor.md` | Living reusable prompt for comprehensive code review and MCP server audit (all 18 phases). Keep in sync with project surface. Do not delete. |
 | `audit-reports/README.md` | Where to store MCP deep-review audit outputs; links baseline template |
+| `audit-reports/deep-review-baseline-2026-04-04.md` | Baseline checklist for a full deep-review session (update when tool surface changes) |
+| `audit-reports/2026-04-04-post-1.5-surface-audit.md` | Example post-release surface audit snapshot |
 
 ## Archive
 

--- a/ai_docs/audit-reports/2026-04-04-post-1.5-surface-audit.md
+++ b/ai_docs/audit-reports/2026-04-04-post-1.5-surface-audit.md
@@ -1,5 +1,7 @@
 # Post-1.5.0 surface audit — 2026-04-04
 
+<!-- purpose: Snapshot PASS/FAIL surface audit after v1.5.x; superseded by later releases as needed. -->
+
 Lightweight audit after v1.5.0 release hardening and concurrent implementation of v1.6.0 (tests, promotions, profiling notes). Full 18-phase execution remains in [`../prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md).
 
 ## Scope

--- a/ai_docs/audit-reports/README.md
+++ b/ai_docs/audit-reports/README.md
@@ -1,5 +1,7 @@
 # MCP deep-review audit reports
 
+<!-- purpose: Index for deep-review audit outputs; points to baseline and session snapshots. -->
+
 Use the living prompt [`ai_docs/prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md) with an MCP client connected to **roslyn-mcp** to exercise the full tool surface against a real solution.
 
 ## Outputs

--- a/ai_docs/audit-reports/deep-review-baseline-2026-04-04.md
+++ b/ai_docs/audit-reports/deep-review-baseline-2026-04-04.md
@@ -1,5 +1,7 @@
 # Deep review & MCP audit — baseline session (2026-04-04)
 
+<!-- purpose: Baseline checklist template for full deep-review MCP sessions; update when surface changes. -->
+
 This file is a **baseline template** for executing [`ai_docs/prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md). A full PASS/FAIL matrix requires an **interactive MCP session** (Cursor or other client) with the server running (`dotnet run --project src/RoslynMcp.Host.Stdio` or global `roslynmcp`).
 
 ## Session parameters

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-04
+**updated_at:** 2026-04-04T12:00:00Z
 
 ## Agent contract
 

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -56,10 +56,11 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 2. Call `compile_check` (no filters) to get in-memory compilation diagnostics. Compare the results with `project_diagnostics` — they should be consistent but may differ in count or detail.
 3. Call `security_diagnostics` to identify security-relevant findings with OWASP categorization.
 4. Call `security_analyzer_status` to check which analyzer packages are installed and what's missing.
-5. Call `list_analyzers` to enumerate all loaded analyzers and their rules. Note total rule count.
-6. Call `diagnostic_details` on a representative error and a representative warning to inspect full detail.
+5. Call `nuget_vulnerability_scan` to scan NuGet references for known CVEs. Compare with `security_diagnostics` — vulnerability scan covers supply-chain CVEs while security diagnostics covers source-level patterns.
+6. Call `list_analyzers` to enumerate all loaded analyzers and their rules. Note total rule count.
+7. Call `diagnostic_details` on a representative error and a representative warning to inspect full detail.
 
-**MCP audit checkpoint:** Do `project_diagnostics` and `compile_check` agree on error counts? Does `compile_check` with `emitValidation=true` find additional issues? Does `list_analyzers` return data for all projects? Are there any analyzers that fail to load (look for LOAD_ERROR entries)? Does `diagnostic_details` return accurate location and message information?
+**MCP audit checkpoint:** Do `project_diagnostics` and `compile_check` agree on error counts? Does `compile_check` with `emitValidation=true` find additional issues? Does `nuget_vulnerability_scan` find any known CVEs, and does it return structured results with package name, advisory URL, and severity? Does `list_analyzers` return data for all projects? Are there any analyzers that fail to load (look for LOAD_ERROR entries)? Does `diagnostic_details` return accurate location and message information?
 
 ---
 
@@ -84,19 +85,20 @@ For each key type in the solution:
 2. Call `symbol_info` to understand the type.
 3. Call `document_symbols` on its file to see its member structure.
 4. Call `type_hierarchy` to understand inheritance.
-5. Call `find_references` to see how widely it's used.
-6. Call `find_consumers` to classify dependency kinds (constructor, field, parameter, etc.).
-7. Call `find_shared_members` to identify private members shared across public methods.
-8. Call `find_type_mutations` to find all mutating members and their external callers.
-9. Call `find_type_usages` to see how the type is used (return types, parameters, fields, casts, etc.).
-10. Call `callers_callees` on 2-3 of its methods to map call chains.
-11. Call `find_property_writes` on any settable properties to classify init vs post-construction writes.
-12. Call `member_hierarchy` on overridden/implemented members.
-13. Call `symbol_relationships` for a combined view.
-14. Call `symbol_signature_help` on a key method to verify signature documentation.
-15. Call `impact_analysis` on a symbol you might refactor to estimate change blast radius.
+5. Call `find_implementations` on any interface or abstract type discovered via `type_hierarchy`. Verify the list is complete.
+6. Call `find_references` to see how widely it's used.
+7. Call `find_consumers` to classify dependency kinds (constructor, field, parameter, etc.).
+8. Call `find_shared_members` to identify private members shared across public methods.
+9. Call `find_type_mutations` to find all mutating members and their external callers.
+10. Call `find_type_usages` to see how the type is used (return types, parameters, fields, casts, etc.).
+11. Call `callers_callees` on 2-3 of its methods to map call chains.
+12. Call `find_property_writes` on any settable properties to classify init vs post-construction writes.
+13. Call `member_hierarchy` on overridden/implemented members.
+14. Call `symbol_relationships` for a combined view.
+15. Call `symbol_signature_help` on a key method to verify signature documentation.
+16. Call `impact_analysis` on a symbol you might refactor to estimate change blast radius.
 
-**MCP audit checkpoint:** Are `find_references` and `find_consumers` consistent? Does `find_type_usages` categorize correctly? Do `callers_callees` results match what you'd expect from reading the code? Does `symbol_relationships` combine data correctly from its sub-tools? Does `impact_analysis` produce a reasonable blast radius estimate?
+**MCP audit checkpoint:** Does `find_implementations` return all concrete implementations of an interface or abstract type? Are `find_references` and `find_consumers` consistent? Does `find_type_usages` categorize correctly? Do `callers_callees` results match what you'd expect from reading the code? Does `symbol_relationships` combine data correctly from its sub-tools? Does `impact_analysis` produce a reasonable blast radius estimate?
 
 ---
 
@@ -183,6 +185,12 @@ For each method with high complexity:
 3. Call `code_fix_apply`.
 4. Call `compile_check`.
 
+#### 6f-ii. Diagnostic Suppression
+1. Pick a diagnostic that should be suppressed rather than fixed (e.g., a deliberate pattern that triggers a style warning).
+2. Call `set_diagnostic_severity` to change the severity of that diagnostic ID in `.editorconfig` (e.g., downgrade to `suggestion` or `none`).
+3. Call `add_pragma_suppression` to insert a `#pragma warning disable` before a specific occurrence in source.
+4. Call `compile_check` to verify the suppression took effect and no new errors were introduced.
+
 #### 6g. Code Actions
 1. Call `get_code_actions` at a position with available refactorings.
 2. Call `preview_code_action` on an interesting action.
@@ -199,7 +207,7 @@ For each method with high complexity:
 3. Call `remove_dead_code_apply`.
 4. Call `compile_check`.
 
-**MCP audit checkpoint:** Does `fix_all_preview` find ALL instances? Does it crash or timeout on large scopes? Does `rename_preview` catch references in comments or strings? Does `extract_interface_preview` generate valid C# syntax? Does `bulk_replace_type_preview` miss any usages? Does `extract_type_preview` handle shared private members correctly? Does `format_range_preview` format only the specified range or does it bleed? Does `remove_dead_code_preview` correctly remove only the targeted symbols? After each apply, does `compile_check` pass?
+**MCP audit checkpoint:** Does `fix_all_preview` find ALL instances? Does it crash or timeout on large scopes? Does `rename_preview` catch references in comments or strings? Does `extract_interface_preview` generate valid C# syntax? Does `bulk_replace_type_preview` miss any usages? Does `extract_type_preview` handle shared private members correctly? Does `format_range_preview` format only the specified range or does it bleed? Does `remove_dead_code_preview` correctly remove only the targeted symbols? Does `set_diagnostic_severity` correctly update or create the `.editorconfig` entry? Does `add_pragma_suppression` insert the pragma at the correct line without breaking surrounding code? After each apply, does `compile_check` pass?
 
 **Cross-tool chain validation (Phase 6):** After `rename_apply`, call `find_references` on the new name — does the count match the preview? After `extract_interface_apply`, call `type_hierarchy` on the new interface — does it show the implementor? After `fix_all_apply`, call `project_diagnostics` with the same diagnostic ID — did the count drop to zero? After `organize_usings_apply`, call `get_source_text` — are usings actually sorted? These chains verify that workspace state stays consistent across mutations.
 
@@ -210,8 +218,15 @@ For each method with high complexity:
 1. Pick a source file and call `get_editorconfig_options` on it.
 2. Verify the returned options match what you'd expect from the .editorconfig files in the repo.
 3. Check if key options like `csharp_style_var_for_built_in_types`, `indent_style`, and `dotnet_sort_system_directives_first` are present and correct.
+4. Call `set_editorconfig_option` to set or update a non-destructive key (e.g., `dotnet_sort_system_directives_first = true`). Verify the `.editorconfig` file was created or updated correctly.
+5. Call `get_editorconfig_options` again on the same file to confirm the change is reflected.
 
-**MCP audit checkpoint:** Does `get_editorconfig_options` return options? Are the values accurate? Does it find the correct .editorconfig file path? Are there options that should appear but don't?
+#### 7b. MSBuild Evaluation
+1. Pick a project and call `get_msbuild_properties` to dump its evaluated MSBuild properties. Verify key properties like `TargetFramework`, `RootNamespace`, and `OutputType` are present and correct.
+2. Call `evaluate_msbuild_property` on a specific property (e.g., `TargetFramework`) for the same project. Verify the result matches the value from `get_msbuild_properties`.
+3. Call `evaluate_msbuild_items` with item type `Compile` to list source files. Verify the count is reasonable and includes files you know exist.
+
+**MCP audit checkpoint:** Does `get_editorconfig_options` return options? Are the values accurate? Does it find the correct .editorconfig file path? Are there options that should appear but don't? Does `set_editorconfig_option` correctly write the key-value pair? Does `get_msbuild_properties` return a complete set of evaluated properties? Does `evaluate_msbuild_property` return the same value as `get_msbuild_properties` for the same key? Does `evaluate_msbuild_items` list items with correct paths and metadata?
 
 ---
 
@@ -430,7 +445,7 @@ Derive `<repo-id>` from the **audited** solution or repository name:
 ### Report contents (required sections)
 
 1. **Header (metadata)** — server version (from `server_info`), Roslyn / .NET versions if available, **audited** solution path and name, date, workspace id, approximate project count and document count from `workspace_load` / `project_graph`.
-2. **Tool coverage** — For each **category** below, state **exercised** / **skipped** (with reason) / **N/A** (e.g. single-project solution and cross-project previews not applicable). Categories: Server; Workspace; Symbols; Analysis; Advanced Analysis; Consumer & Cohesion; Security; Flow; Syntax & Operations; Compilation; Analyzer Info; Snippet & Scripting; Refactoring (rename/format/organize); Code Actions & Fixes; Fix All; Interface/Type extraction; Type movement; Bulk refactor; Cross-project refactor; Orchestration; Dead code; Text edits; File ops; Project mutation (previews); Scaffolding (previews); Build & Test; EditorConfig; Undo; Resources (MCP resources); Prompts; Boundary & Negative Testing; Regression Verification.
+2. **Tool coverage** — For each **category** below, state **exercised** / **skipped** (with reason) / **N/A** (e.g. single-project solution and cross-project previews not applicable). Categories: Server; Workspace; Symbols; Analysis; Advanced Analysis; Consumer & Cohesion; Security; Flow; Syntax & Operations; Compilation; Analyzer Info; Snippet & Scripting; Refactoring (rename/format/organize); Code Actions & Fixes; Fix All; Interface/Type extraction; Type movement; Bulk refactor; Cross-project refactor; Orchestration; Dead code; Text edits; File ops; Project mutation (previews); Scaffolding (previews); Build & Test; EditorConfig; MSBuild evaluation; Suppression & severity; Undo; Resources (MCP resources); Prompts; Boundary & Negative Testing; Regression Verification.
 3. **Verified tools (working)** — Bullet list: tool name + one-line evidence (e.g. “`compile_check` — 0 errors after Phase 6”). This distinguishes “tested and fine” from “never called.”
 4. **Phase 6 refactor summary** — Concise record of **applied** Phase 6 work (not preview-only phases). Include: target repo identity (if different from Roslyn-Backed-MCP); **scope** (e.g. fix-all + rename + format — which sub-steps 6a–6i you actually applied); **notable symbols or files** touched; **MCP tools used** for each change (e.g. `rename_apply`, `fix_all_apply`); **verification** (`compile_check` / `test_run` / `build_workspace` outcomes). If Phase 6 had **no** applies (skipped or audit-only), state **N/A** with one line why. Optional: git commit hash or PR link if available.
 5. **MCP server issues (bugs)** — For each issue: **Tool name**, **inputs**, **expected** vs **actual**, **severity** (crash / incorrect result / missing data / degraded performance / cosmetic / error-message-quality), **reproducibility** (always / sometimes / once). Watch for: crashes, wrong or incomplete results, tool-vs-tool inconsistency, missing functionality, slow tools, bad JSON/truncation, bad line/position mapping, unhelpful error messages.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,9 @@ Human-facing documentation for the Roslyn-Backed MCP Server.
 | `roadmap.md` | Strategic roadmap decisions and planned feature directions |
 | `parity-gap-matrix.md` | Hard boundaries vs roadmap opportunities; what agents should treat as known gaps |
 | `parity-gap-implementation-plan.md` | Status and next steps for matrix “must-have” items; release verify vs roadmap |
+| `coverage-baseline.md` | Aggregate coverage expectations; ties to CI Cobertura artifacts |
+| `experimental-promotion-analysis.md` | Stable vs experimental tool counts and promotion notes |
+| `large-solution-profiling-baseline.md` | Methodology and notes for profiling large MSBuild solutions |
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Refreshed \.ai-doc-audit.md\ and audit report stubs (post-1.5 surface, deep-review baseline).
- Updated \i_docs/README.md\, \docs/README.md\, and audit-reports README.
- Adjusted \i_docs/backlog.md\ and expanded \i_docs/prompts/deep-review-and-refactor.md\.

## Test plan
- [x] \./eng/verify-ai-docs.ps1\ passed locally

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)