### PR TITLE
MCP server audit fixes (test_run, diagnostics, handles, metrics)

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-04T12:00:00Z
+**updated_at:** 2026-04-04T22:30:00Z
 
 ## Agent contract
 

--- a/ai_docs/refactor/firewallanalyzer_mcp-server-audit.md
+++ b/ai_docs/refactor/firewallanalyzer_mcp-server-audit.md
@@ -1,0 +1,197 @@
+# MCP Server Audit Report
+
+**Report path note:** This workspace is **DotNet-Firewall-Analyzer** (not the Roslyn-Backed-MCP repo). *Intended final path for server-repo backlog review:* `<Roslyn-Backed-MCP-root>/ai_docs/refactor/firewallanalyzer_mcp-server-audit.md` — copy this file there if that repo maintains canonical audit artifacts.
+
+## Header
+
+- **Date:** 2026-04-04
+- **Audited solution:** `c:\Code-Repo\DotNet-Firewall-Analyzer\FirewallAnalyzer.slnx`
+- **Workspace id:** `328380a5719d401ea19b3f3a549d1a3c` (session closed at end of audit)
+- **Server:** `roslyn-mcp` **1.6.0+e0ca703807a8634baf0781efa5aed532a1f0e77e** (from `server_info`)
+- **Roslyn / .NET:** Roslyn **5.3.0.0**, runtime **.NET 10.0.5**, OS Windows 10.0.26200
+- **Scale:** **11** projects, **230** documents (from `workspace_load` / `workspace_status`)
+- **Catalog (resource `roslyn://server/catalog`):** **123** tools (56 stable + 67 experimental), **7** stable resources, **16** experimental prompts (stable prompt count **0** in catalog summary)
+
+## Tool coverage
+
+| Category | Status | Notes |
+|----------|--------|--------|
+| Server | exercised | `server_info` |
+| Workspace | exercised | `workspace_load`, `workspace_list`, `workspace_status`, `workspace_reload`, `project_graph`, `workspace_close` |
+| Symbols | partial | `symbol_search`, `symbol_info`, `document_symbols`, `find_references`, `find_consumers` (not all navigation tools) |
+| Analysis | partial | `type_hierarchy`, `project_diagnostics`, `compile_check` (incl. emitValidation); skipped `diagnostic_details` (no diagnostics) |
+| Advanced Analysis | partial | `get_complexity_metrics`, `get_cohesion_metrics`, `find_unused_symbols`, `get_namespace_dependencies`, `get_nuget_dependencies`, `semantic_search`, `get_di_registrations`; skipped `find_reflection_usages`, full `semantic_search` cross-checks |
+| Consumer & Cohesion | partial | `find_consumers`, `get_cohesion_metrics`; skipped `find_shared_members`, `find_type_mutations`, `find_type_usages`, `impact_analysis`, `callers_callees`, etc. |
+| Security | exercised | `security_diagnostics`, `security_analyzer_status`, `nuget_vulnerability_scan` |
+| Flow | partial | `analyze_data_flow`, `analyze_control_flow`; skipped `get_operations`, `get_syntax_tree` |
+| Syntax & Operations | skipped | — |
+| Compilation | exercised | `compile_check` |
+| Analyzer Info | partial | `list_analyzers` (first page); not all pages enumerated |
+| Snippet & Scripting | partial | `analyze_snippet` (expression/program/error), `evaluate_csharp` (sum + runtime error); skipped **infinite-loop timeout** test (risk of long hang) |
+| Refactoring (rename/format/organize) | partial | `format_document_preview` / `format_document_apply`, `organize_usings_preview` (empty changes) |
+| Code Actions & Fixes | skipped | — |
+| Fix All | skipped | No solution diagnostics to target |
+| Interface/Type extraction | skipped | Preview-only policy / not needed for clean tree |
+| Type movement | partial | `move_type_to_file_preview` only (Phase 10) |
+| Bulk refactor | skipped | — |
+| Cross-project refactor | skipped | Preview-only (not exercised in this run) |
+| Orchestration | skipped | Preview-only |
+| Dead code | skipped | `find_unused_symbols` with `includePublic=false` returned **0** hits |
+| Text edits | exercised | `apply_text_edit` (temporary marker; see Phase 6) |
+| File ops | partial | `move_type_to_file_preview` only |
+| Project mutation (previews) | skipped | — |
+| Scaffolding (previews) | skipped | — |
+| Build & Test | exercised | `build_workspace`, `test_run` (filter `Category!=E2E`) |
+| EditorConfig | skipped | — |
+| MSBuild evaluation | skipped | — |
+| Suppression & severity | skipped | — |
+| Undo | exercised | `revert_last_apply` (with `workspaceId`) |
+| Resources (MCP resources) | exercised | `roslyn://server/catalog` |
+| Prompts | skipped | MCP **prompts** are catalogued but not invoked via this client’s tool surface in this session |
+| Boundary & Negative Testing | partial | Invalid `workspaceId` on `workspace_status`; skipped fabricated handle / stale token matrix |
+| Regression Verification | N/A | See **Backlog regression check** |
+
+## Verified tools (working)
+
+- `workspace_load` — Loaded `FirewallAnalyzer.slnx`; 11 projects, 230 documents; `WorkspaceDiagnostics` empty.
+- `workspace_list` / `workspace_status` — Session visible; no stale flag.
+- `project_graph` — Matches dependency expectations (Domain ← Application ← Infrastructure; Api references all three).
+- `server_info` — Returns version, Roslyn, runtime, surface counts (`stable`/`experimental` split).
+- `project_diagnostics` — **0** errors/warnings/info for full solution (limit 500).
+- `compile_check` — **0** errors; **~21 ms** without emit; **~1547 ms** with `emitValidation: true` (schema notes slower path).
+- `security_diagnostics` / `security_analyzer_status` — No findings; NetAnalyzers + SecurityCodeScan present.
+- `nuget_vulnerability_scan` — **0** CVEs, 11 projects scanned, **~4167 ms**; `IncludesTransitive: false` noted.
+- `list_analyzers` — **25** analyzer assemblies, **492** total rules (paginated; `hasMore: true` with limit 200).
+- `get_complexity_metrics` — Returns plausible CC/nesting (e.g. `CollectUnknownYamlKeyMessages` CC 20, nesting 5).
+- `get_cohesion_metrics` — High LCOM4 on test classes (expected); cohesive types like `JobTracker` LCOM4 **1**.
+- `find_unused_symbols` — `includePublic=false` → **0**; `includePublic=true` → many **expected false positives** (middleware `InvokeAsync`, test types, DTOs) with confidence labels.
+- `get_namespace_dependencies` — Large graph returned (output file).
+- `get_nuget_dependencies` — Lists packages (central-managed versions).
+- `symbol_search` / `symbol_info` / `document_symbols` — Consistent handles and member outline for `TrafficSimulator`.
+- `find_references` — **18** refs for `TrafficSimulator` type; classifications and previews coherent.
+- `find_consumers` — **3** consumer types for `TrafficSimulator`; summary string correct.
+- `type_hierarchy` — Static class: no bases/derived (nulls) — expected.
+- `analyze_data_flow` — Lists parameters, locals, reads/writes for `Simulate` body.
+- `analyze_control_flow` — Reports entry reachability and return sites (see **issues** for endpoint reachability nuance).
+- `analyze_snippet` — Expression/program valid; broken code returns CS diagnostics.
+- `evaluate_csharp` — `Enumerable.Range(1,10).Sum()` → **55**; `int.Parse("abc")` → graceful runtime error string.
+- `format_document_preview` / `format_document_apply` — Empty `Changes` for already-formatted file; apply reported success.
+- `build_workspace` — **Exit 0**, 0 warnings/errors in MSBuild output.
+- `test_run` — **Exit 0**; per-assembly passes logged (see **issues** for aggregate counts).
+- `semantic_search` — Query “async methods returning Task<bool>” returned `TestConnectivityAsync` (plausible).
+- `get_di_registrations` — **24** registrations with file/line/method (includes test projects).
+- `apply_text_edit` — Applied single-line change with unified diff in response.
+- `move_type_to_file_preview` — Valid multi-file diff for `PanoramaSettingsView` (preview only).
+- `revert_last_apply` — With **`workspaceId`**, reverted last **Roslyn** apply (`Format document 'TrafficSimulator.cs'`).
+- Resource `roslyn://server/catalog` — JSON inventory matches `server_info` surface summary (123 tools, 7 resources, 16 prompts).
+
+## Phase 6 refactor summary
+
+- **Target repo:** DotNet-Firewall-Analyzer (`FirewallAnalyzer.slnx`)
+- **Scope:** **6e** partially — `format_document_preview`/`format_document_apply` on `TrafficSimulator.cs` (no textual changes). **6h** — `apply_text_edit` appended a temporary comment on `HasAny` for tool verification; **reverted in working tree** (not left in product code). **6a–6d, 6f, 6f-ii, 6g, 6i** not run — **no diagnostics** to fix-all/code-fix; no dead-code removal; no rename/extract.
+- **Changes:** None intended to remain; `TrafficSimulator.cs` required a **manual fix** after `revert_last_apply` left a duplicate `HasAny` declaration when combined with prior `apply_text_edit` + disk edit (see issue **#6**).
+- **Verification:** `dotnet build FirewallAnalyzer.slnx` — **PASS** after duplicate line removed. `build_workspace` — **PASS** during session before the conflict.
+- **Optional commit / PR:** None (audit-only).
+
+## MCP server issues (bugs)
+
+### 1. `server_info.workspaceCount` lag vs `workspace_list`
+
+| Field | Detail |
+|--------|--------|
+| Tool | `server_info` |
+| Input | (none) immediately after `workspace_load` |
+| Expected | `workspaceCount` reflects at least one loaded session |
+| Actual | `workspaceCount`: **0** while `workspace_list` showed **1** session |
+| Severity | cosmetic / documentation (schema already warns of brief lag) |
+| Reproducibility | sometimes |
+
+### 2. `test_run` aggregate totals vs per-assembly stdout
+
+| Field | Detail |
+|--------|--------|
+| Tool | `test_run` |
+| Input | `filter`: `Category!=E2E`, full solution |
+| Expected | Structured `Total`/`Passed` reflect **all** assemblies’ tests |
+| Actual | JSON showed e.g. `Total`: **126**, `Passed`: **126** while stdout listed **6+110+6+49+126** passed across assemblies |
+| Severity | incorrect result or misleading aggregation for multi-project runs |
+| Reproducibility | always (this run) |
+
+### 3. `analyze_control_flow` — `EndPointIsReachable` for method-body range
+
+| Field | Detail |
+|--------|--------|
+| Tool | `analyze_control_flow` |
+| Input | `TrafficSimulator.Simulate` lines **13–55** |
+| Expected | End of region interpretable as “method exit” or documented |
+| Actual | `EndPointIsReachable`: **false** despite two return paths listed |
+| Severity | cosmetic / semantic ambiguity (may be “selection end” vs “exit node”) |
+| Reproducibility | always (this selection) |
+
+### 4. `revert_last_apply` — parameter required; empty stack error from client
+
+| Field | Detail |
+|--------|--------|
+| Tool | `revert_last_apply` |
+| Input | Omitted `workspaceId` (first call) |
+| Expected | Clear JSON error listing required `workspaceId` |
+| Actual | Client reported generic invocation error (tool **does** document `workspaceId` as required) |
+| Severity | error-message-quality (caller-side clarity) |
+| Reproducibility | always if args omitted |
+
+### 5. `apply_text_edit` not revertible by `revert_last_apply`
+
+| Field | Detail |
+|--------|--------|
+| Tool | `revert_last_apply` / `apply_text_edit` |
+| Input | Apply text edit, then `revert_last_apply` |
+| Expected | Documented: only Roslyn preview/apply stack — **actual behavior matches schema** |
+| Actual | Revert reverted prior **format** apply, not text edit (per schema: disk-direct not revertible) |
+| Severity | cosmetic (documentation is correct; worth highlighting in audit) |
+| Reproducibility | always |
+
+### 6. Workspace vs disk inconsistency after `apply_text_edit` + `revert_last_apply`
+
+| Field | Detail |
+|--------|--------|
+| Tools | `apply_text_edit`, manual file fix, `revert_last_apply` |
+| Input | Text edit on `HasAny`; manual removal of audit comment on disk; then `revert_last_apply` (Roslyn format undo) |
+| Expected | File remains syntactically valid |
+| Actual | `TrafficSimulator.cs` contained **duplicate** `HasAny` method declaration lines (CS1525). Required manual deletion of the extra line to restore build. |
+| Severity | **incorrect result** / state corruption risk when mixing **experimental text edits** with **Roslyn undo** and out-of-band disk edits |
+| Reproducibility | sometimes (ordering-dependent) |
+
+**No new crash or data-loss observed** beyond the above line-duplication incident (recovered by manual edit).
+
+## Improvement suggestions
+
+- **`test_run`:** Return per-assembly breakdown in JSON **or** document that `Total`/`Passed` reflect the last TRX aggregation / final assembly only.
+- **`server_info`:** Consider bumping `workspaceCount` synchronously after `workspace_load` success **or** always recommending `workspace_list` first (schema already hints).
+- **`nuget_vulnerability_scan`:** Surface `IncludesTransitive: false` prominently in tool description so clients do not assume full transitive CVE coverage.
+- **Catalog vs prompts:** `server_info` reports `prompts.stable: 0`, `experimental: 16`; align naming with “all prompts are experimental tier” in consumer UIs.
+- **`list_analyzers`:** Default limit 100 with 492 rules — consumers need pagination discipline (documented in schema).
+
+## Performance observations
+
+- `compile_check` with `emitValidation: true`: **~1547 ms** vs **~21 ms** without — **expected** per schema.
+- `nuget_vulnerability_scan`: **~4167 ms** for 11 projects — acceptable; note for CI-style budgets.
+- `list_analyzers` (200 rules): large payload — acceptable.
+- All other exercised tools completed in under **5 s** for single operations.
+
+## Backlog regression check
+
+| AUDIT-ID | Summary | Status |
+|----------|---------|--------|
+| — | `ai_docs/backlog.md` in this repo has **no** open Roslyn-MCP / AUDIT rows | **N/A** |
+
+No Roslyn MCP backlog items in **this** repository to re-test. Cross-check against **Roslyn-Backed-MCP** `ai_docs/backlog.md` when auditing that repo.
+
+## Known backlog cross-check
+
+- None in **DotNet-Firewall-Analyzer** backlog matching new server defects (this file’s issues are **new observations** for the MCP product team).
+
+---
+
+## Appendix: session tool call index (abbrev.)
+
+Phases covered: **0–2** full; **3** partial (key type `TrafficSimulator`); **4** partial (data/control flow on `Simulate`); **5** partial (snippet/script, no infinite loop); **6** minimal (format + text edit probe); **8** build + test; **10** one cross-file preview; **9** `revert_last_apply` with `workspaceId`; **11** partial; **15** catalog resource; **16–17** partial/negative (invalid workspace); **workspace_close** at end.

--- a/ai_docs/refactor/itchatbot_mcp-server-audit.md
+++ b/ai_docs/refactor/itchatbot_mcp-server-audit.md
@@ -1,0 +1,173 @@
+# MCP Server Audit Report
+
+## Header
+
+- **Date:** 2026-04-04
+- **Audited solution:** `c:\Code-Repo\IT-Chat-Bot\ITChatBot.sln`
+- **Workspace id:** `cfd6094faf5d4954b81e2ea0a0bbf7f8` (closed at end of audit)
+- **Server:** `roslyn-mcp` **1.6.0+e0ca703807a8634baf0781efa5aed532a1f0e77e** (`server_info`)
+- **Roslyn / .NET:** Roslyn **5.3.0.0**; runtime **.NET 10.0.5** (Windows 10.0.26200)
+- **Scale:** **32** projects, **736** documents (`workspace_load`)
+- **Report path note:** Audit run from IT-Chat-Bot workspace. If the canonical Roslyn-Backed-MCP repo is elsewhere, copy this file to `<Roslyn-Backed-MCP-root>/ai_docs/refactor/itchatbot_mcp-server-audit.md` for backlog review.
+
+## Tool coverage
+
+| Category | Status | Notes |
+|----------|--------|--------|
+| Server | exercised | `server_info` |
+| Workspace | exercised | `workspace_load`, `workspace_list`, `workspace_status`, `workspace_reload`, `project_graph`, `workspace_close` |
+| Symbols | partial | `symbol_search`, `symbol_info`, `document_symbols`, `find_references` (incl. invalid handle), `type_hierarchy`; not all Phase 3 tools (e.g. `find_consumers`, `impact_analysis`, `callers_callees`, `find_type_usages`, …) |
+| Analysis | partial | `project_diagnostics`, `diagnostic_details`, `type_hierarchy`; skipped deep pass on all Phase 3 analysis tools |
+| Advanced Analysis | partial | `get_complexity_metrics`, `find_unused_symbols`, `get_namespace_dependencies`, `semantic_search`; `get_cohesion_metrics` returned large output (exercised); `get_nuget_dependencies` not called |
+| Consumer & Cohesion | skipped | Time — not invoked |
+| Security | exercised | `security_diagnostics`, `security_analyzer_status`, `nuget_vulnerability_scan` |
+| Flow | partial | `analyze_data_flow`, `analyze_control_flow`; `get_operations`, `get_syntax_tree` not called |
+| Syntax & Operations | skipped | — |
+| Compilation | exercised | `compile_check` (solution + project filter) |
+| Analyzer Info | partial | `list_analyzers` (first page; `hasMore: true`) |
+| Snippet & Scripting | partial | `analyze_snippet` (expression + program), `evaluate_csharp` (success + runtime error); infinite-loop timeout not run |
+| Refactoring (rename/format/organize) | partial | `organize_usings_preview` / `organize_usings_apply`, `format_document_preview` / `format_document_apply` (empty diff) |
+| Code Actions & Fixes | skipped | — |
+| Fix All | exercised (failure path) | `fix_all_preview` for `IDE0005` — no provider |
+| Interface/Type extraction | skipped | Preview-only risk; not exercised |
+| Type movement | skipped | — |
+| Bulk refactor | skipped | — |
+| Cross-project refactor | skipped | Preview-only phases not fully run |
+| Orchestration | skipped | — |
+| Dead code | partial | `find_unused_symbols` only |
+| Text edits | skipped | — |
+| File ops | skipped | Preview-only |
+| Project mutation (previews) | skipped | — |
+| Scaffolding (previews) | skipped | — |
+| Build & Test | partial | `workspace_reload`, `test_run` (`ITChatBot.Retrieval.Tests`); `build_workspace`, `build_project`, `test_discover`, `test_related*`, `test_coverage` not run |
+| EditorConfig | skipped | — |
+| MSBuild evaluation | skipped | — |
+| Suppression & severity | skipped | — |
+| Undo | exercised | `revert_last_apply` ×2 (success + no-op) |
+| Resources (MCP resources) | exercised | `roslyn://server/catalog` via resource fetch |
+| Prompts | skipped | MCP prompts (`explain_error`, etc.) not invocable via this client’s tool surface in this session; catalog lists 16 experimental prompts |
+| Boundary & Negative Testing | partial | Bad `workspaceId` (actionable error); bad `symbol_handle` for `find_references` |
+| Regression Verification | N/A | `ai_docs/backlog.md` has **no** Roslyn MCP `AUDIT-*` rows; see **Backlog regression check** |
+
+## Verified tools (working)
+
+- `workspace_load` — Loaded `ITChatBot.sln`; reported 32 projects / 736 documents; surfaced `WORKSPACE_FAILURE` diagnostics for `ITChatBot.Channels.csproj` (package pruning messages).
+- `workspace_list` / `workspace_status` — Session listed; status matched load metadata.
+- `project_graph` — Project list consistent with load payload.
+- `server_info` — Reported **56** stable + **67** experimental tools, **7** resources, **16** experimental prompts; `catalogVersion` **2026.03** (aligns with `roslyn://server/catalog` **Summary**).
+- `project_diagnostics` — Returned paginated diagnostics; totals: 3 workspace + compiler/analyzer mix (`TotalErrors: 3` counts workspace failures).
+- `compile_check` — **0** errors for full solution (2 CS0618 warnings); **0** errors for `ITChatBot.Retrieval` after Phase 6 apply.
+- `security_diagnostics` / `security_analyzer_status` — NetAnalyzers + SecurityCodeScan present; **0** security findings.
+- `nuget_vulnerability_scan` — **0** CVEs; **32** projects scanned; `ScanDurationMs` **~11091**.
+- `list_analyzers` — **34** analyzers, **663** rules (paginated; first page returned).
+- `diagnostic_details` — Returned help links and descriptions for CS0618 and CA1002.
+- `get_complexity_metrics` — Top methods include `HandleSlackPostAsync` CC=21, `TryValidate` nesting depth 4, etc.
+- `find_unused_symbols` (`includePublic: false`) — **1** high-confidence unused type (`ChatBotDbContextModelSnapshot` — EF migration artifact; expected false positive class).
+- `get_namespace_dependencies` (`circularOnly: true`) — **No** circular namespace cycles.
+- `symbol_search` / `symbol_info` / `document_symbols` / `type_hierarchy` / `find_references` — Coherent results for `RetrievalExecutor`.
+- `analyze_data_flow` — Rich variable/capture lists for `ExecuteAsync` region.
+- `analyze_snippet` — Valid expression and small program analyzed.
+- `evaluate_csharp` — `Enumerable.Range(1,10).Sum()` → **55**; runtime error surfaced as structured failure.
+- `organize_usings_preview` / `organize_usings_apply` — Produced diff removing unused `using ITChatBot.Adapters.Abstractions.Evidence;` from `RetrievalExecutor.cs`; apply succeeded.
+- `format_document_preview` / `format_document_apply` — Preview token issued; **no** textual diff (`AppliedFiles: []` on apply).
+- `test_run` — `ITChatBot.Retrieval.Tests`: **139** passed, **0** failed.
+- `semantic_search` — Returned plausible `async` methods for query `"async methods returning Task<bool>"`.
+- `revert_last_apply` — First call reverted **Format document** (no disk change); second call reported **no operation to revert** (clear message).
+- `workspace_close` — Session closed successfully.
+- `roslyn://server/catalog` — JSON inventory matches `server_info` surface counts (**123** tools, **7** resources, **16** prompts).
+
+## Phase 6 refactor summary
+
+- **Target repo:** `c:\Code-Repo\IT-Chat-Bot` (same as audited solution).
+- **Scope:** **6e** (`organize_usings_preview` / `organize_usings_apply`) on `RetrievalExecutor.cs`. **6a** (`fix_all_preview` `IDE0005`) attempted — **not applied** (no fix provider; server directed to `organize_usings_preview`). Other 6b–6d, 6f–6i not executed in this pass.
+- **Changes:**
+  - `src/retrieval/Execution/RetrievalExecutor.cs` — removed unused `using ITChatBot.Adapters.Abstractions.Evidence;` (via `organize_usings_apply`).
+- **Verification:**
+  - `compile_check` (`project`: `ITChatBot.Retrieval`): **Success**, **0** errors.
+  - `test_run` (`projectName`: `ITChatBot.Retrieval.Tests`): **139** passed, **0** failed.
+- **Optional:** No commit/PR created in this session.
+
+## MCP server issues (bugs)
+
+### 1. Workspace diagnostics: pruning messages surfaced as `Error` / `WORKSPACE_FAILURE`
+
+| Field | Detail |
+|--------|--------|
+| Tool | `workspace_load`, `workspace_status`, `project_diagnostics` |
+| Input | Load `ITChatBot.sln` |
+| Expected | Pruning hints from SDK should be **warning/info**-style workspace messages, or suppressed from Roslyn workspace errors if they do not block compilation. |
+| Actual | Three `WORKSPACE_FAILURE` entries for `ITChatBot.Channels.csproj` (“PackageReference X will not be pruned…”) with `Severity: Error`. |
+| Severity | incorrect result / error-message-quality |
+| Reproducibility | always (this repo + SDK) |
+
+### 2. `project_diagnostics` “TotalErrors” vs `compile_check` CS error count
+
+| Field | Detail |
+|--------|--------|
+| Tool | `project_diagnostics` vs `compile_check` |
+| Input | Same workspace |
+| Expected | Clear distinction: workspace load failures vs **compiler** error count; or aligned totals when comparing tools. |
+| Actual | `project_diagnostics` reports `TotalErrors: 3` (workspace failures); `compile_check` reports **0** CS errors — easy to misread as “3 CS errors” when paging diagnostics. |
+| Severity | missing data / cosmetic (documentation + aggregation) |
+| Reproducibility | always |
+
+### 3. `fix_all_preview` for `IDE0005` — no provider
+
+| Field | Detail |
+|--------|--------|
+| Tool | `fix_all_preview` |
+| Input | `diagnosticId`: `IDE0005`, `scope`: `document`, `RetrievalExecutor.cs` |
+| Expected | Either preview of unused-using removal or a single clear reason **without** suggesting a conflicting path. |
+| Actual | `InvalidOperationException`: no code fix provider; message suggests `organize_usings_preview` — **actionable** and helpful. |
+| Severity | not a crash — **workflow gap** between Fix All and IDE-style hidden diagnostics |
+| Reproducibility | always (for this diagnostic id in this workspace) |
+
+### 4. `find_references` with invalid `symbolHandle`
+
+| Field | Detail |
+|--------|--------|
+| Tool | `find_references` |
+| Input | `symbolHandle`: `invalid-handle-xyz` |
+| Expected | Actionable error (bad token) or validation failure. |
+| Actual | **0** references, `totalCount: 0` — indistinguishable from a genuinely unused symbol. |
+| Severity | incorrect result / weak validation |
+| Reproducibility | always |
+
+### 5. `analyze_control_flow` `EndPointIsReachable` for `ExecuteAsync` body region
+
+| Field | Detail |
+|--------|--------|
+| Tool | `analyze_control_flow` |
+| Input | `RetrievalExecutor.cs` lines **33–91** (`ExecuteAsync`) |
+| Expected | For async methods with awaits, reachability may be partial; tool should document limitation or set `Warning`. |
+| Actual | `EndPointIsReachable: false` despite `StartPointIsReachable: true` and exit/return points listed — may confuse consumers comparing to `analyze_data_flow`. |
+| Severity | incorrect result **or** missing caveat (needs product clarification) |
+| Reproducibility | always (this method region) |
+
+## Improvement suggestions
+
+- **`fix_all_preview` + IDE0005:** Surface a dedicated hint in-tool: “IDE0005 may require `organize_usings_preview` / `organize_usings_apply` when no FixAll provider is registered.”
+- **`find_references`:** Validate base64/handle format before returning empty success.
+- **`project_diagnostics`:** Split counters: `WorkspaceFailureCount` vs `CompilerErrorCount` vs `AnalyzerWarningCount` to match mental model of `compile_check`.
+- **`list_analyzers`:** Expose total pages or recommend `offset`/`limit` in description (already paginates).
+- **Catalog vs MCP tool list:** Local MCP descriptors enumerate **123** tools; `server_info` reports stable/experimental split — keep client UIs aligned with `Summary` in `roslyn://server/catalog`.
+
+## Performance observations
+
+- `nuget_vulnerability_scan` — **32** projects, **~11 s** wall-clock (`ScanDurationMs: 11091`) — acceptable but worth noting for CI-sized solutions.
+- `compile_check` (full solution) — **~70 ms** (`ElapsedMs` in one call) — fast.
+- `list_analyzers` / `get_cohesion_metrics` — Large payloads; ensure clients stream or paginate cohesion output.
+
+## Backlog regression check
+
+| AUDIT-ID | Summary | Status |
+|----------|---------|--------|
+| — | `ai_docs/backlog.md` contains **no** Roslyn MCP `AUDIT-*` items (open work is `queue-*` / RR-* only). | **N/A — no MCP regression rows to re-test** |
+
+## Known backlog cross-check
+
+- No new Roslyn MCP issues were matched to `AUDIT-*` rows in this repo’s backlog (none listed). Full write-ups for **new** behavior are in **MCP server issues (bugs)** above.
+
+---
+
+*Generated by executing `ai_docs/prompts/deep-review-and-refactor.md` against the live `user-roslyn-mcp` session (representative phases; not every appendix tool invoked).*

--- a/ai_docs/refactor/networkdocumentation_mcp-server-audit.md
+++ b/ai_docs/refactor/networkdocumentation_mcp-server-audit.md
@@ -1,0 +1,155 @@
+# MCP Server Audit Report
+
+**Report path note:** Saved under `DotNet-Network-Documentation` per prompt fallback (Roslyn-Backed-MCP repo not this workspace). Intended for maintainers: copy alongside server releases or merge into `ai_docs/reports/mcp-server-audit-report.md` if consolidating.
+
+## Header
+
+- **Date:** 2026-04-04
+- **Audited solution:** `c:\Code-Repo\DotNet-Network-Documentation\NetworkDocumentation.sln`
+- **Workspace id:** `36d9530937e843179b537c247be70096` (session closed at end of audit)
+- **Server:** `roslyn-mcp` **1.6.0+e0ca703807a8634baf0781efa5aed532a1f0e77e` (from `server_info`)
+- **Roslyn / .NET:** Roslyn **5.3.0.0**; runtime **.NET 10.0.5**; OS Windows 10.0.26200
+- **Scale:** **8** projects, **363** documents (`workspace_load` / `workspace_reload` after edits)
+- **Catalog:** `2026.03` — `server_info.surface`: **56** stable + **67** experimental tools (**123** total), **7** stable resources, **16** experimental prompts (`roslyn://server/catalog` **Summary** matches)
+
+## Tool coverage
+
+| Category | Status | Notes |
+|----------|--------|--------|
+| Server | exercised | `server_info` |
+| Workspace | exercised | `workspace_load`, `workspace_list`, `workspace_status`, `workspace_reload`, `project_graph`, `workspace_close` |
+| Symbols | partial | `symbol_search`, `symbol_info`, `document_symbols`, `find_references`, `find_consumers`, `type_hierarchy`, `impact_analysis`; not all Phase 3 tools (e.g. `callers_callees`, `member_hierarchy`, `find_shared_members` on same type) invoked for brevity |
+| Analysis | exercised | `project_diagnostics`, `compile_check` (with/without `emitValidation`), `find_type_mutations`, `find_type_usages`, `diagnostic_details` N/A (zero diagnostics) |
+| Advanced Analysis | exercised | `get_complexity_metrics`, `get_cohesion_metrics`, `find_unused_symbols` (×2), `get_namespace_dependencies`, `get_nuget_dependencies`, `semantic_search` |
+| Consumer & Cohesion | exercised | `find_consumers`, `get_cohesion_metrics` |
+| Security | exercised | `security_diagnostics`, `security_analyzer_status`, `nuget_vulnerability_scan` |
+| Flow | exercised | `analyze_data_flow`, `analyze_control_flow` on `ToDeviceInfoRow` region; `get_operations` / `get_syntax_tree` not called (time scope) |
+| Syntax & Operations | skipped | `get_syntax_tree`, `get_operations` — not run this pass |
+| Compilation | exercised | `compile_check` |
+| Analyzer Info | exercised | `list_analyzers` (paginated; `hasMore` true at limit 50) |
+| Snippet & Scripting | exercised | `analyze_snippet` (expression), `evaluate_csharp` (sum + runtime error); infinite-loop timeout not exercised |
+| Refactoring (rename/format/organize) | exercised | `format_document_preview`/`apply`, `organize_usings_preview`/`apply` |
+| Code Actions & Fixes | skipped | `get_code_actions` / `code_fix_*` — no diagnostics to target |
+| Fix All | skipped | No diagnostic IDs to batch-fix |
+| Interface/Type extraction | skipped | Preview-only risk; not required for clean solution |
+| Type movement | skipped | Phase 10 previews not fully run |
+| Bulk refactor | skipped | — |
+| Cross-project refactor | skipped | Preview-only in prompt |
+| Orchestration | skipped | — |
+| Dead code | partial | `find_unused_symbols` only; `remove_dead_code_*` not applied |
+| Text edits | skipped | — |
+| File ops | skipped | Preview-only phases deferred |
+| Project mutation (previews) | skipped | — |
+| Scaffolding (previews) | skipped | — |
+| Build & Test | exercised | `build_workspace`, `test_discover`, `test_run` (filtered + MCP), local `dotnet build` / `dotnet test` |
+| EditorConfig | skipped | — |
+| MSBuild evaluation | skipped | — |
+| Suppression & severity | skipped | — |
+| Undo | exercised | `revert_last_apply` after audit-only `format_document_apply` |
+| Resources (MCP resources) | exercised | `roslyn://server/catalog` via `fetch_mcp_resource` |
+| Prompts | skipped | MCP prompt templates not invoked via prompt API this pass |
+| Boundary & Negative Testing | partial | Bad `workspaceId` → actionable error; empty `symbol_search` → `[]`; stale token / double revert not exercised |
+| Regression Verification | partial | Compared against `ai_docs/reports/mcp-server-audit-report.md` (2026-04-03) |
+
+## Verified tools (working)
+
+- `workspace_load` — 8 projects, 363 documents, no workspace diagnostics
+- `workspace_list` / `workspace_status` — consistent with load
+- `server_info` — `workspaceCount: 1` matched `workspace_list` after load (prior report noted mismatch **sometimes**)
+- `project_graph` — aligned with solution structure
+- `project_diagnostics` / `compile_check` — 0 issues; `emitValidation=true` ~2.1s, no extra findings
+- `security_*` / `nuget_vulnerability_scan` — structured output; 0 CVEs (transitive not included per response)
+- `list_analyzers` — 33 analyzers, 832 rules total; pagination works
+- `get_complexity_metrics` / `get_cohesion_metrics` — plausible metrics for this solution
+- `find_unused_symbols` — results include confidence; test types flagged with `includePublic=true` expected noise
+- `get_namespace_dependencies` / `get_nuget_dependencies` — large structured output
+- `symbol_search` / `symbol_info` / `document_symbols` / `type_hierarchy` — coherent for `NetworkInventory`
+- `find_references` — 166 total for type; classifications present
+- `find_consumers` — 48 consumers summarized
+- `find_type_mutations` — **2** mutating members (`AddDevice`, `SetDeviceRegionAndArea`) with external callers (see regression)
+- `find_type_usages` — string bucket keys (e.g. `methodParameter`) in this build
+- `impact_analysis` — large structured output (file spill in agent log)
+- `analyze_data_flow` — structured variable roles for `ToDeviceInfoRow` region
+- `analyze_snippet` / `evaluate_csharp` — expression valid; `Sum()` → 55; runtime parse error surfaced as message
+- `organize_usings_apply` — removed unused `using NetworkDocumentation.Core.CiscoEol;` from `PipelineOrchestrator.cs`
+- `format_document_preview`/`apply` — applied formatting to `PipelineOrchestrator.cs` for undo test
+- `revert_last_apply` — reverted format; reported operation name and timestamp
+- `workspace_reload` — snapshot advanced (version 6 after edits)
+- `build_workspace` — exit 0, 0 warnings/errors
+- `test_discover` / `test_run` — structured TRX path; filtered run 11 passed
+- `fetch_mcp_resource` `roslyn://server/catalog` — JSON **Summary** matches tool/resource/prompt counts
+- `workspace_close` — success
+
+## Phase 6 refactor summary
+
+- **Target repo:** DotNet-Network-Documentation (this repo)
+- **Scope:** **6e** — `organize_usings_preview` / `organize_usings_apply` on `PipelineOrchestrator.cs` (removed unused import). **6e** — `format_document_preview` / `format_document_apply` used only for **Phase 9** undo verification; **reverted** via `revert_last_apply`. Sub-steps 6a–6d, 6f–6i not run (no diagnostics / scope).
+- **Changes:**
+  - `PipelineOrchestrator.cs` — dropped unused `using NetworkDocumentation.Core.CiscoEol;` (Roslyn organize usings)
+- **MCP tools:** `organize_usings_preview` → `organize_usings_apply`; `format_document_preview` → `format_document_apply` → `revert_last_apply` (undoes format only)
+- **Verification:** `compile_check` Success after organize; after revert Success; `build_workspace` Success; MCP `test_run` (Cli-related filter) 11/11 passed; local `dotnet build` + `dotnet test --filter "Category!=Playwright"` **8041 passed**, 9 skipped (known graph/Excel skips), 0 failed
+- **Optional commit / PR:** not created unless requested
+
+## MCP server issues (bugs)
+
+### 1. `semantic_search` — signature-style query returns empty
+
+| Field | Detail |
+|--------|--------|
+| Tool | `semantic_search` |
+| Input | `query`: `"async methods returning Task<bool>"`, `limit`: 8 |
+| Expected | Either ranked matches or explicit “no semantic matches” guidance |
+| Actual | `count`: 0, empty `results` (matches prior `ai_docs/reports/mcp-server-audit-report.md` finding #5) |
+| Severity | Missing data / weak relevance for natural-language signature queries |
+| Reproducibility | Always in this solution for this query style |
+
+### 2. `analyze_control_flow` — `EndPointIsReachable` false for method region ending in `return`
+
+| Field | Detail |
+|--------|--------|
+| Tool | `analyze_control_flow` |
+| Input | `InventoryProjection.cs` lines 114–170 (`ToDeviceInfoRow` body) |
+| Expected | End of region reachable if return is valid exit |
+| Actual | `EndPointIsReachable`: **false** despite `StartPointIsReachable`: true and a return at line 123 |
+| Severity | Incorrect or misleading (may be definition of “end point” vs exit nodes) |
+| Reproducibility | Always for this range |
+
+**No new crashes**, **no malformed JSON**, **no server hang** observed this pass.
+
+## Improvement suggestions
+
+- `semantic_search` — Document supported query shapes; return a warning when the query looks like a C# signature only (prior repo notes in `ai_docs/reports/mcp-server-audit-report.md`).
+- `analyze_control_flow` — Clarify in schema/description what “end point” means vs `return` exits, or align `EndPointIsReachable` with intuitive “normal completion” of a region.
+- `nuget_vulnerability_scan` — Response notes `IncludesTransitive: false`; document how to opt into transitive if/when supported.
+- `list_analyzers` — Expose a way to request total count without paging (or document pagination contract), when agents need rule totals only.
+
+## Performance observations
+
+- `compile_check` with `emitValidation: true` ~**2135 ms** vs ~**123 ms** without — consistent with schema note (expected).
+- `nuget_vulnerability_scan` ~**6 s** for 8 projects — acceptable; note in report.
+- `get_namespace_dependencies` large payload (~70KB agent log) — acceptable for full solution.
+- Remaining tools in this pass under **~5 s** for single operations.
+
+## Backlog regression check
+
+Cross-reference: prior point-in-time findings in `ai_docs/reports/mcp-server-audit-report.md` (2026-04-03). This repo’s `ai_docs/backlog.md` has **no** AUDIT-* MCP rows.
+
+| Prior finding | Summary | Status (2026-04-04) |
+|---------------|---------|---------------------|
+| Prior #1 `server_info.workspaceCount` vs `workspace_list` | Count mismatch | **candidate for closure** — `server_info` showed `workspaceCount: 1` matching one session |
+| Prior #2 `find_type_mutations` / `NetworkInventory` | 0 mutations | **candidate for closure** — now reports **2** mutating members with callers |
+| Prior #3 `find_type_usages` classifications | Numeric vs string | **improved** — `usagesByClassification` uses string keys and per-entry `Classification` strings |
+| Prior #4 `get_complexity_metrics` `MaxNestingDepth` | 0 for deep methods | **still reproduces** for some methods — e.g. `ApplyFromJson` CC 21 reports `MaxNestingDepth` **1**; `ToDeviceInfoRow` CC 18 reports **1** (not 0 in this sample — still verify metric definition vs nested `?:` / LINQ) |
+| Prior #5 `semantic_search` | Task<bool> query | **still reproduces** — 0 results |
+
+## Known backlog cross-check
+
+- No `AUDIT-xx` rows in `ai_docs/backlog.md` for Roslyn MCP. Prior consolidated report: `ai_docs/reports/mcp-server-audit-report.md`.
+- **New observation:** None beyond sections above; `find_type_mutations` behavior **no longer matches** prior #2 — treat as **server fix or environment delta**, not duplicate backlog row here.
+
+---
+
+## Completion
+
+- Single audit file written: `ai_docs/refactor/networkdocumentation_mcp-server-audit.md`
+- Workspace session closed: `workspace_close` on audited id after phases

--- a/ai_docs/refactor/roslyn-backed-mcp_mcp-server-audit.md
+++ b/ai_docs/refactor/roslyn-backed-mcp_mcp-server-audit.md
@@ -1,0 +1,147 @@
+# MCP Server Audit Report
+
+## Header
+
+- **Date:** 2026-04-04
+- **Audited solution:** `c:\Code-Repo\Roslyn-Backed-MCP\Roslyn-Backed-MCP.sln`
+- **Workspace id (final session):** `c655b134156b4529836624cf4373d8a4`
+- **Server:** `roslyn-mcp` **1.6.0+e0ca703807a8634baf0781efa5aed532a1f0e77e** (from `server_info`)
+- **Roslyn / .NET:** Roslyn **5.3.0.0**, runtime **.NET 10.0.5**, OS Windows 10.0.26200
+- **Scale:** **6** projects, **298** documents (from `workspace_load`)
+- **Surface (from `server_info` / `roslyn://server/catalog`):** tools stable **56** + experimental **67** = **123**; resources stable **7**; prompts experimental **16** (stable prompts **0**). Matches catalog `Summary` block.
+- **Report path note:** Canonical path under this repo: `ai_docs/refactor/roslyn-backed-mcp_mcp-server-audit.md`.
+
+## Tool coverage
+
+| Category | Status | Notes |
+|----------|--------|--------|
+| Server | exercised | `server_info`; catalog via `roslyn://server/catalog` |
+| Workspace | exercised | `workspace_load`, `workspace_list`, `workspace_status`, `workspace_reload`, `project_graph`, `get_source_text` (earlier pass) |
+| Symbols | exercised | `symbol_search`, `symbol_info`, `document_symbols`, `find_references`, `find_consumers`, `find_implementations`, `find_type_usages`, `symbol_relationships`, `symbol_signature_help`, `callers_callees` |
+| Analysis | exercised | `project_diagnostics`, `compile_check`, `diagnostic_details`, `type_hierarchy`, `impact_analysis`, `find_type_mutations` |
+| Advanced analysis | exercised | `get_complexity_metrics`, `get_cohesion_metrics`, `find_unused_symbols`, `get_namespace_dependencies`, `get_nuget_dependencies`, `semantic_search` |
+| Consumer & cohesion | exercised | `find_shared_members`, `find_consumers`, `get_cohesion_metrics` |
+| Security | exercised | `security_diagnostics`, `security_analyzer_status`, `nuget_vulnerability_scan` |
+| Flow | exercised | `analyze_data_flow`, `analyze_control_flow`, `get_operations` |
+| Syntax & operations | exercised | `get_syntax_tree`, `get_operations` |
+| Compilation | exercised | `compile_check` (including `emitValidation: true` once) |
+| Analyzer info | exercised | `list_analyzers` (paged; totalRules **451**, analyzerCount **17**) |
+| Snippet & scripting | exercised | `analyze_snippet`, `evaluate_csharp` |
+| Refactoring (rename/format/organize) | partial | `organize_usings_preview` / `organize_usings_apply`; `format_document_preview` (no diff); `format_range_preview` (no diff) |
+| Code actions & fixes | skipped | Not invoked this run (time); `diagnostic_details` showed curated fix for CS0414 |
+| Fix all | skipped | **Intentionally not applied:** sole workspace warning is **CS0414** on `DiagnosticsProbe` (integration tests: `DiagnosticFixIntegrationTests`) |
+| Interface/type extraction | skipped | Preview-only per prompt for cross-cutting moves; not required for this solution pass |
+| Type movement | skipped | Previews not run in final completion pass |
+| Bulk refactor | skipped | — |
+| Cross-project refactor | skipped | Previews not run in final completion pass |
+| Orchestration | skipped | Previews not run in final completion pass |
+| Dead code | skipped | No apply (removing probe or test-flagged symbols would break tests) |
+| Text edits | skipped | — |
+| File ops | skipped | — |
+| Project mutation (previews) | skipped | — |
+| Scaffolding (previews) | skipped | — |
+| Build & test | partial | `build_workspace` **succeeded**; `test_run` **MCP tool errored**; validation via host `dotnet test` **209 passed** |
+| EditorConfig | skipped | — |
+| MSBuild evaluation | skipped | — |
+| Suppression & severity | skipped | — |
+| Undo | exercised | `revert_last_apply` after audit-only `organize_usings_apply` on `ReferenceService.cs` |
+| Resources | exercised | `roslyn://server/catalog` |
+| Prompts | partial | Prompts are MCP **prompt** entries (catalog lists 16); not invoked as tools in this agent session |
+| Boundary & negative testing | partial | `workspace_status` with bogus id → structured **NotFound** (actionable) |
+| Regression verification | N/A | `ai_docs/backlog.md` has **no open rows** (2026-04-04) |
+
+## Verified tools (working)
+
+- `workspace_load` / `workspace_list` / `workspace_status` — session `c655b134…`, 6 projects, clean load.
+- `server_info` — version and surface counts consistent with catalog.
+- `project_diagnostics` / `compile_check` — **1** warning (**CS0414**), **0** errors; aligns with intentional sample probe.
+- `compile_check` + `emitValidation: true` — same warning; ~**1.3 s** vs ~**35 ms** without emit (expected per tool description).
+- `diagnostic_details` (CS0414) — help link + curated `remove_unused_field` fix metadata.
+- `security_diagnostics` / `nuget_vulnerability_scan` — **0** CVEs; scan **~4.3 s** for 6 projects.
+- `list_analyzers` — **451** rules, **17** analyzer assemblies (first page sampled).
+- `get_complexity_metrics` — top methods include `ClassifyTypeUsageAfterWalk` (CC **28**), `ParseNuGetVulnerabilityJson` (CC **27**).
+- `get_cohesion_metrics` — e.g. `McpLogger` LCOM4 **3**, multiple types LCOM4 **2** / **1**.
+- `find_unused_symbols` — **high** confidence hits include `GetBaseTypes` (private) and sample `DiagnosticsProbe` type (expected for unused sample type).
+- `get_namespace_dependencies` — **CircularDependencies: []**; edges list coherent.
+- `get_nuget_dependencies` — central package management reflected as `centrally-managed` where applicable.
+- `symbol_search` / `symbol_info` / `document_symbols` / `type_hierarchy` / `find_references` / `find_consumers` / `find_type_usages` / `find_implementations` / `impact_analysis` / `find_type_mutations` — coherent results for `ReferenceService` / `IReferenceService`.
+- `analyze_data_flow` / `analyze_control_flow` / `get_operations` / `get_syntax_tree` — `ClassifyTypeUsageAfterWalk` region (lines 281–330) analyzed.
+- `analyze_snippet` — valid expression/program; broken code returns CS diagnostics.
+- `evaluate_csharp` — `Enumerable.Range(1,10).Sum()` → **55**; runtime error surfaced as message (FormatException).
+- `semantic_search` — query `"async methods returning Task<bool>"` returned `RevertAsync`, `ReturnsBoolAsync`.
+- `build_workspace` — **exit 0**, same CS0414 warning as Roslyn diagnostics.
+- `organize_usings_preview` / `organize_usings_apply` — real unified diff on `OrchestrationService.cs` (using order / grouping).
+- `revert_last_apply` — reverted **Organize usings in 'ReferenceService.cs'**; reported `revertedOperation` and timestamp.
+- `workspace_status` (invalid id) — **actionable** error listing `workspace_list` hint.
+
+## Phase 6 refactor summary
+
+- **Target repo:** `Roslyn-Backed-MCP` (same as audited solution).
+- **Scope:** **6e** (`organize_usings_preview` / `organize_usings_apply`) only for **product** refactor. **Not applied:** **6a** fix-all for **CS0414** (would remove `DiagnosticsProbe._unusedForDiagnostics` and break `DiagnosticFixIntegrationTests`). **6b–6d, 6f–6i** not executed in this completion pass (preview-only phases deferred where noted in coverage table).
+- **Changes:**
+  - **`OrchestrationService.cs`** — using directives reorganized (Roslyn-standard ordering: `System.Xml.Linq` + `Microsoft.CodeAnalysis.*` block before project usings).
+- **Tools used:** `organize_usings_preview` → `organize_usings_apply` (preview token applied successfully).
+- **Verification:**
+  - `compile_check` — **0** errors, **1** warning (CS0414 unchanged).
+  - `build_workspace` — **Succeeded** (0 errors, 1 warning).
+  - Host **`dotnet test`** on solution — **209 passed**, 0 failed (~2 m 24 s).
+- **Phase 9 (undo check):** Applied **audit-only** `organize_usings` to **`ReferenceService.cs`**, then **`revert_last_apply`** — reverted that apply only; **`OrchestrationService.cs`** organize **remains** (confirmed on disk).
+
+## MCP server issues (bugs)
+
+### 1. `test_run` failed when invoked via MCP tool bridge
+
+| Field | Detail |
+|--------|--------|
+| Tool | `test_run` |
+| Input | `workspaceId: c655b134156b4529836624cf4373d8a4`, `projectName: RoslynMcp.Tests` |
+| Expected | Structured test results (pass/fail counts). |
+| Actual | **"An error occurred invoking 'test_run'."** (no structured payload in client). |
+| Severity | **incorrect result** / **integration** — host `dotnet test` succeeded, so execution environment is fine. |
+| Reproducibility | Observed **once** this session; retry not performed. |
+
+### 2. `callers_callees` / `symbol_signature_help` resolution at method body position
+
+| Field | Detail |
+|--------|--------|
+| Tools | `callers_callees`, `symbol_signature_help` |
+| Input | `ReferenceService.cs` line **25**, column **25** (inside `FindReferencesAsync`, on `_workspace` token region). |
+| Expected | Per tool description, best-effort **enclosing method** when caret semantics ambiguous; user expectation is often **method**-level symbol. |
+| Actual | Resolved to **field** `_workspace` (callers are ctor + other methods using `_workspace`); signature help returned **field** type, not `FindReferencesAsync`. |
+| Severity | **cosmetic / UX** — confusing for “method analysis” workflows; not a crash. |
+| Reproducibility | **always** for this position if column points at field identifier. |
+
+### 3. No new correctness bugs found
+
+Other observations (e.g. `analyze_control_flow` **EndPointIsReachable: false** for a method whose body is all `return` arms) match **early-exit** control flow and are **not** classified as defects.
+
+**No additional new issues** beyond the above.
+
+## Improvement suggestions
+
+- **`test_run`** — When the MCP host returns a generic invocation error, surface **stderr/inner message** (or server log id) so agents can distinguish “dotnet missing” vs “timeout” vs “protocol”.
+- **`find_type_usages` vs `find_consumers`** — Align **classification string casing** (e.g. `genericArgument` vs `GenericArgument`) across tools for JSON consumers.
+- **`nuget_vulnerability_scan`** — Document or expose **`IncludesTransitive: false`** prominently when comparing to full `dotnet list package --vulnerable --include-transitive` expectations.
+- **Prompts (16)** — Catalog lists **experimental** prompts; agent sessions that only expose **tools** cannot “exercise” prompts unless the client adds prompt invocation; consider documenting that in the deep-review prompt.
+
+## Performance observations
+
+- `compile_check` without emit — **~35–242 ms** (solution-wide).
+- `compile_check` with **`emitValidation: true`** — **~1267 ms** (matches “10–18x slower” ballpark vs fast path).
+- `nuget_vulnerability_scan` — **~4362 ms** (6 projects, 0 vulns).
+- `list_analyzers` / `get_namespace_dependencies` — large JSON; acceptable for audit, not “interactive snappy” for huge graphs.
+- **Default:** Other tools **&lt; 5 s** for single-symbol / single-file operations in this run.
+
+## Backlog regression check
+
+| AUDIT-ID | Summary | Status |
+|----------|---------|--------|
+| *(none)* | `ai_docs/backlog.md` contains **no open rows** (agent contract: unfinished work only). | **N/A** |
+
+## Known backlog cross-check
+
+- **No open backlog items** to match; no new AUDIT-* cross-references required.
+
+---
+
+*Completion: mandatory report file written; Phase 6 product change = `OrchestrationService.cs` organize usings; Phase 9 revert verified; tests **209 passed** via `dotnet test`.*

--- a/src/RoslynMcp.Core/Models/DiagnosticsResultDto.cs
+++ b/src/RoslynMcp.Core/Models/DiagnosticsResultDto.cs
@@ -3,10 +3,17 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents grouped diagnostic results for a workspace analysis run.
 /// </summary>
+/// <param name="TotalErrors">Sum of compiler, analyzer, and workspace error severities (backward-compatible aggregate).</param>
+/// <param name="CompilerErrors">Count of compiler diagnostics with Error severity.</param>
+/// <param name="AnalyzerErrors">Count of analyzer diagnostics with Error severity.</param>
+/// <param name="WorkspaceErrors">Count of workspace diagnostics with Error severity.</param>
 public sealed record DiagnosticsResultDto(
     IReadOnlyList<DiagnosticDto> WorkspaceDiagnostics,
     IReadOnlyList<DiagnosticDto> CompilerDiagnostics,
     IReadOnlyList<DiagnosticDto> AnalyzerDiagnostics,
     int TotalErrors,
     int TotalWarnings,
-    int TotalInfo);
+    int TotalInfo,
+    int CompilerErrors = 0,
+    int AnalyzerErrors = 0,
+    int WorkspaceErrors = 0);

--- a/src/RoslynMcp.Core/Models/FixAllPreviewDto.cs
+++ b/src/RoslynMcp.Core/Models/FixAllPreviewDto.cs
@@ -8,4 +8,5 @@ public sealed record FixAllPreviewDto(
     string DiagnosticId,
     string Scope,
     int FixedCount,
-    IReadOnlyList<FileChangeDto> Changes);
+    IReadOnlyList<FileChangeDto> Changes,
+    string? GuidanceMessage = null);

--- a/src/RoslynMcp.Core/Models/TypeUsageDto.cs
+++ b/src/RoslynMcp.Core/Models/TypeUsageDto.cs
@@ -15,6 +15,8 @@ public enum TypeUsageClassification
     Cast,
     TypeCheck,
     ObjectCreation,
+    Constructor,
+    DIRegistration,
     Other
 }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -50,9 +50,12 @@ public static class AnalysisTools
 
                 return JsonSerializer.Serialize(new
                 {
-                    results.TotalErrors,
-                    results.TotalWarnings,
-                    results.TotalInfo,
+                    totalErrors = results.TotalErrors,
+                    totalWarnings = results.TotalWarnings,
+                    totalInfo = results.TotalInfo,
+                    compilerErrors = results.CompilerErrors,
+                    analyzerErrors = results.AnalyzerErrors,
+                    workspaceErrors = results.WorkspaceErrors,
                     totalDiagnostics = allDiagnostics.Count,
                     offset,
                     limit,
@@ -116,7 +119,7 @@ public static class AnalysisTools
             }, ct));
     }
 
-    [McpServerTool(Name = "callers_callees", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find direct callers and callees of a method at the given position. For best results, place the caret on the method identifier; the server falls back to the enclosing method when the caret resolves to a type name or constructor call.")]
+    [McpServerTool(Name = "callers_callees", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find direct callers and callees of the symbol resolved at the exact line/column (or symbolHandle). Resolution uses the token at that position — e.g. a caret on a field name inside a method resolves the field, not the enclosing method. Place the caret on the method name to analyze the method.")]
     public static Task<string> GetCallersCallees(
         IWorkspaceExecutionGate gate,
         ISymbolRelationshipService symbolRelationshipService,

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
@@ -11,7 +11,7 @@ public static class AnalyzerInfoTools
     [McpServerTool(Name = "list_analyzers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description(
         "List all loaded Roslyn analyzers and their supported diagnostic rules. Use to understand what analysis coverage exists and which diagnostic IDs are available for code_fix_preview or fix_all_preview. " +
-        "Response JSON: analyzerCount = total distinct analyzer assemblies (unpaged); totalRules = sum of rules across all assemblies; offset/limit paginate the flattened rule list (not whole analyzers). " +
+        "Response JSON: analyzerCount = total distinct analyzer assemblies (unpaged); totalRules = sum of rules across all assemblies — use this for total rule count without paging the full list; offset/limit paginate the flattened rule list (not whole analyzers). " +
         "returnedRules = rules in this page; returnedAnalyzerCount = distinct assemblies that contributed at least one rule in this page; hasMore = true when offset + returnedRules < totalRules.")]
     public static Task<string> ListAnalyzers(
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -11,7 +11,7 @@ public static class EditTools
 {
 
     [McpServerTool(Name = "apply_text_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
-     Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned.")]
+     Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned. Text edits are disk-direct and are not registered for revert_last_apply; use Roslyn preview/apply tools when you need undo.")]
     public static Task<string> ApplyTextEdit(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class FixAllTools
 {
     [McpServerTool(Name = "fix_all_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
-     Description("Preview applying a code fix to ALL instances of a diagnostic across a scope (document, project, or solution). Dramatically faster than fixing diagnostics one at a time. Use list_analyzers or project_diagnostics to find diagnostic IDs.")]
+     Description("Preview applying a code fix to ALL instances of a diagnostic across a scope (document, project, or solution). Dramatically faster than fixing diagnostics one at a time. Use list_analyzers or project_diagnostics to find diagnostic IDs. When no provider or no FixAll support exists, the response includes guidanceMessage with next steps (e.g. organize_usings_preview for IDE0005).")]
     public static Task<string> PreviewFixAll(
         IWorkspaceExecutionGate gate,
         IFixAllService fixAllService,

--- a/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
@@ -28,7 +28,7 @@ public static class FlowAnalysisTools
     }
 
     [McpServerTool(Name = "analyze_control_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
-     Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. Use to detect unreachable code and validate all code paths.")]
+     Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. EndPointIsReachable follows Roslyn semantics (whether execution can fall through the end of the region without return/throw), not whether the method can complete; see Warning when returns exist but EndPointIsReachable is false.")]
     public static Task<string> AnalyzeControlFlow(
         IWorkspaceExecutionGate gate,
         IFlowAnalysisService flowAnalysisService,

--- a/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
@@ -42,7 +42,7 @@ public static class SecurityTools
     }
 
     [McpServerTool(Name = "nuget_vulnerability_scan", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
-     Description("Scan NuGet package references for known security vulnerabilities (CVEs) using the NuGet vulnerability database via dotnet list package. Returns affected packages with severity, advisory links, and project locations. Requires .NET 8+ SDK with JSON output support.")]
+     Description("Scan NuGet package references for known security vulnerabilities (CVEs) using the NuGet vulnerability database via dotnet list package. Returns affected packages with severity, advisory links, and project locations. Response includes IncludesTransitive: when false, results match direct references only — use includeTransitive=true (and CLI transitive flags) when you need full transitive CVE coverage. Requires .NET 8+ SDK with JSON output support.")]
     public static Task<string> ScanNuGetVulnerabilities(
         IWorkspaceExecutionGate gate,
         IDependencyAnalysisService dependencyService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -23,6 +23,7 @@ public static class ServerTools
                           ?? assembly.GetName().Version?.ToString() ?? "unknown";
 
             var catalogSummary = ServerSurfaceCatalog.GetSummary();
+            var wsCount = workspace.ListWorkspaces().Count;
             var info = new
             {
                 server = "roslyn-mcp",
@@ -31,7 +32,10 @@ public static class ServerTools
                 runtime = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
                 os = System.Runtime.InteropServices.RuntimeInformation.OSDescription,
                 roslynVersion = typeof(Microsoft.CodeAnalysis.SyntaxNode).Assembly.GetName().Version?.ToString() ?? "unknown",
-                workspaceCount = workspace.ListWorkspaces().Count,
+                workspaceCount = wsCount,
+                workspaceCountHint = wsCount == 0
+                    ? "If you just called workspace_load, workspaceCount may still be 0 briefly; call workspace_list for authoritative session ids."
+                    : null,
                 catalogVersion = ServerSurfaceCatalog.CatalogVersion,
                 surface = new
                 {

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -205,7 +205,7 @@ public static class SymbolTools
             }, ct));
     }
 
-    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get display signature, parameters, return type, and documentation for a symbol")]
+    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get display signature, parameters, return type, and documentation for the symbol resolved at the exact line/column (or handle/metadata name). The caret position matters: on a field identifier you get the field's type/signature, not the enclosing method.")]
     public static Task<string> GetSignatureHelp(
         IWorkspaceExecutionGate gate,
         ISymbolRelationshipService symbolRelationshipService,

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class UndoTools
 {
     [McpServerTool(Name = "revert_last_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
-     Description("Revert the most recent apply operation for a workspace, restoring the previous solution state. Only Roslyn solution-level changes (renames, code fixes, format, organize usings) can be reverted. Disk-direct operations (file create/delete/move, project mutations, composite orchestrations) are not revertible.")]
+     Description("Revert the most recent apply operation for a workspace, restoring the previous solution state. Only Roslyn preview/apply operations (renames, code fixes, format, organize usings) register for undo. apply_text_edit and other disk-direct edits are not revertible here. workspaceId is required.")]
     public static Task<string> RevertLastApply(
         IWorkspaceExecutionGate gate,
         IUndoService undoService,
@@ -20,6 +20,11 @@ public static class UndoTools
         return ToolErrorHandler.ExecuteAsync(() =>
             gate.RunAsync(workspaceId, async c =>
             {
+                if (string.IsNullOrWhiteSpace(workspaceId))
+                {
+                    throw new ArgumentException("workspaceId is required. Pass the session id returned by workspace_load.");
+                }
+
                 var entry = undoService.GetLastOperation(workspaceId);
                 if (entry is null)
                 {

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -107,7 +107,7 @@ public static class ValidationTools
                 var result = await testRunnerService.RunTestsAsync(workspaceId, projectName, filter, c);
                 ProgressHelper.Report(progress, 1, 1);
                 return JsonSerializer.Serialize(result, JsonDefaults.Indented);
-            }, ct));
+            }, ct), toolName: "test_run");
     }
 
     [McpServerTool(Name = "test_related", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find likely related tests for a symbol by source location or symbol handle. Results use heuristic name matching and may not be exhaustive.")]

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
@@ -43,24 +43,11 @@ internal static class SymbolHandleSerializer
     /// <param name="solution">The solution to search.</param>
     /// <param name="symbolHandle">The base-64-encoded handle string.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The resolved symbol, or <see langword="null"/> if the handle is malformed or the symbol cannot be found.</returns>
+    /// <returns>The resolved symbol, or <see langword="null"/> if the handle decodes correctly but the symbol cannot be found in the solution.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="symbolHandle"/> is empty, not valid base64, not valid JSON, or not a well-formed handle payload.</exception>
     public static async Task<ISymbol?> ResolveHandleAsync(Solution solution, string symbolHandle, CancellationToken ct)
     {
-        SymbolHandlePayload? payload;
-        try
-        {
-            var json = Encoding.UTF8.GetString(Convert.FromBase64String(symbolHandle));
-            payload = JsonSerializer.Deserialize<SymbolHandlePayload>(json);
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-
-        if (payload is null)
-        {
-            return null;
-        }
+        var payload = ParseHandlePayload(symbolHandle);
 
         if (!string.IsNullOrWhiteSpace(payload.MetadataName))
         {
@@ -93,7 +80,56 @@ internal static class SymbolHandleSerializer
         return null;
     }
 
-    private sealed record SymbolHandlePayload(
+    /// <summary>
+    /// Decodes a symbol handle string. Throws <see cref="ArgumentException"/> if the string is not a valid handle
+    /// (distinguishes malformed handles from "valid handle, symbol not found" at resolution time).
+    /// </summary>
+    internal static SymbolHandlePayload ParseHandlePayload(string symbolHandle)
+    {
+        if (string.IsNullOrWhiteSpace(symbolHandle))
+        {
+            throw new ArgumentException("symbolHandle is empty.", nameof(symbolHandle));
+        }
+
+        string json;
+        try
+        {
+            json = Encoding.UTF8.GetString(Convert.FromBase64String(symbolHandle.Trim()));
+        }
+        catch (FormatException ex)
+        {
+            throw new ArgumentException("symbolHandle is not valid base64.", nameof(symbolHandle), ex);
+        }
+
+        SymbolHandlePayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<SymbolHandlePayload>(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException("symbolHandle is not valid JSON.", nameof(symbolHandle), ex);
+        }
+
+        if (payload is null)
+        {
+            throw new ArgumentException("symbolHandle JSON deserialized to null.", nameof(symbolHandle));
+        }
+
+        var hasMetadata = !string.IsNullOrWhiteSpace(payload.MetadataName);
+        var hasSource = !string.IsNullOrWhiteSpace(payload.FilePath) && payload.Line.HasValue && payload.Column.HasValue;
+        var hasDisplay = !string.IsNullOrWhiteSpace(payload.DisplayName);
+        if (!hasMetadata && !hasSource && !hasDisplay)
+        {
+            throw new ArgumentException(
+                "symbolHandle payload must include MetadataName, source location (filePath, line, column), or DisplayName.",
+                nameof(symbolHandle));
+        }
+
+        return payload;
+    }
+
+    internal sealed record SymbolHandlePayload(
         string? MetadataName,
         string? DisplayName,
         string? FilePath,

--- a/src/RoslynMcp.Roslyn/Services/CodeMetricsService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodeMetricsService.cs
@@ -62,7 +62,7 @@ public sealed class CodeMetricsService : ICodeMetricsService
                 if (minComplexity.HasValue && complexity < minComplexity.Value) continue;
 
                 var loc = CalculateLinesOfCode(decl);
-                var nesting = CalculateMaxNestingDepth(decl);
+                var nesting = CalculateMaxNestingDepthForMember(decl);
                 var paramCount = symbol is IMethodSymbol m ? m.Parameters.Length : 0;
 
                 var lineSpan = decl.GetLocation().GetLineSpan();
@@ -132,36 +132,152 @@ public sealed class CodeMetricsService : ICodeMetricsService
         return span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
     }
 
-    private static int CalculateMaxNestingDepth(SyntaxNode node)
+    /// <summary>
+    /// Maximum control-flow nesting depth inside a method, constructor, or property accessor body.
+    /// Counts single-statement bodies (e.g. <c>if (x) Foo();</c>) and expression-bodied members, not only braced blocks.
+    /// </summary>
+    private static int CalculateMaxNestingDepthForMember(SyntaxNode decl)
     {
         var maxDepth = 0;
-        CalculateNestingDepthRecursive(node, 0, ref maxDepth);
+        switch (decl)
+        {
+            case MethodDeclarationSyntax m:
+                if (m.Body is not null)
+                    VisitControlFlowNesting(m.Body, 0, ref maxDepth);
+                else if (m.ExpressionBody is not null)
+                    VisitControlFlowNesting(m.ExpressionBody.Expression, 0, ref maxDepth);
+                break;
+            case ConstructorDeclarationSyntax c:
+                if (c.Body is not null)
+                    VisitControlFlowNesting(c.Body, 0, ref maxDepth);
+                break;
+            case PropertyDeclarationSyntax p:
+                if (p.ExpressionBody is not null)
+                    VisitControlFlowNesting(p.ExpressionBody.Expression, 0, ref maxDepth);
+                else if (p.AccessorList is not null)
+                {
+                    foreach (var accessor in p.AccessorList.Accessors)
+                    {
+                        if (accessor.Body is not null)
+                            VisitControlFlowNesting(accessor.Body, 0, ref maxDepth);
+                        else if (accessor.ExpressionBody is not null)
+                            VisitControlFlowNesting(accessor.ExpressionBody.Expression, 0, ref maxDepth);
+                    }
+                }
+
+                break;
+        }
+
         return maxDepth;
     }
 
-    private static void CalculateNestingDepthRecursive(SyntaxNode node, int currentDepth, ref int maxDepth)
+    private static void VisitControlFlowNesting(SyntaxNode node, int depth, ref int maxDepth)
     {
+        if (depth > maxDepth)
+        {
+            maxDepth = depth;
+        }
+
         foreach (var child in node.ChildNodes())
         {
-            var newDepth = child switch
+            switch (child)
             {
-                BlockSyntax when child.Parent is IfStatementSyntax or ElseClauseSyntax
-                    or WhileStatementSyntax or ForStatementSyntax or ForEachStatementSyntax
-                    or DoStatementSyntax or TryStatementSyntax or CatchClauseSyntax
-                    or LockStatementSyntax or UsingStatementSyntax or FixedStatementSyntax
-                    or CheckedStatementSyntax or UnsafeStatementSyntax or SwitchStatementSyntax
-                    or SwitchSectionSyntax => currentDepth + 1,
-                // Nested blocks inside another block (e.g. extra braces, local scopes)
-                BlockSyntax when child.Parent is BlockSyntax => currentDepth + 1,
-                // Method / accessor / constructor / local function body block
-                BlockSyntax when child.Parent is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax
-                    or LocalFunctionStatementSyntax => currentDepth + 1,
-                SwitchExpressionSyntax => currentDepth + 1,
-                _ => currentDepth
-            };
+                case IfStatementSyntax ifs:
+                    VisitControlFlowNesting(ifs.Condition, depth, ref maxDepth);
+                    VisitControlFlowNesting(ifs.Statement, depth + 1, ref maxDepth);
+                    if (ifs.Else is not null)
+                    {
+                        VisitControlFlowNesting(ifs.Else.Statement, depth + 1, ref maxDepth);
+                    }
 
-            if (newDepth > maxDepth) maxDepth = newDepth;
-            CalculateNestingDepthRecursive(child, newDepth, ref maxDepth);
+                    break;
+                case WhileStatementSyntax ws:
+                    VisitControlFlowNesting(ws.Statement, depth + 1, ref maxDepth);
+                    break;
+                case DoStatementSyntax ds:
+                    VisitControlFlowNesting(ds.Statement, depth + 1, ref maxDepth);
+                    break;
+                case ForStatementSyntax fs:
+                    if (fs.Declaration is not null)
+                    {
+                        VisitControlFlowNesting(fs.Declaration, depth, ref maxDepth);
+                    }
+
+                    foreach (var init in fs.Initializers)
+                    {
+                        VisitControlFlowNesting(init, depth, ref maxDepth);
+                    }
+
+                    if (fs.Condition is not null)
+                    {
+                        VisitControlFlowNesting(fs.Condition, depth, ref maxDepth);
+                    }
+
+                    VisitControlFlowNesting(fs.Statement, depth + 1, ref maxDepth);
+                    break;
+                case ForEachStatementSyntax fes:
+                    VisitControlFlowNesting(fes.Statement, depth + 1, ref maxDepth);
+                    break;
+                case SwitchStatementSyntax sw:
+                    foreach (var section in sw.Sections)
+                    {
+                        foreach (var stmt in section.Statements)
+                        {
+                            VisitControlFlowNesting(stmt, depth + 1, ref maxDepth);
+                        }
+                    }
+
+                    break;
+                case TryStatementSyntax tr:
+                    VisitControlFlowNesting(tr.Block, depth + 1, ref maxDepth);
+                    foreach (var c in tr.Catches)
+                    {
+                        VisitControlFlowNesting(c.Block, depth + 1, ref maxDepth);
+                    }
+
+                    if (tr.Finally is not null)
+                    {
+                        VisitControlFlowNesting(tr.Finally.Block, depth + 1, ref maxDepth);
+                    }
+
+                    break;
+                case LockStatementSyntax lk:
+                    VisitControlFlowNesting(lk.Statement, depth + 1, ref maxDepth);
+                    break;
+                case UsingStatementSyntax us:
+                    VisitControlFlowNesting(us.Statement, depth + 1, ref maxDepth);
+                    break;
+                case FixedStatementSyntax fx:
+                    VisitControlFlowNesting(fx.Statement, depth + 1, ref maxDepth);
+                    break;
+                case CheckedStatementSyntax chk:
+                    VisitControlFlowNesting(chk.Block, depth + 1, ref maxDepth);
+                    break;
+                case UnsafeStatementSyntax uns:
+                    VisitControlFlowNesting(uns.Block, depth + 1, ref maxDepth);
+                    break;
+                case SwitchExpressionSyntax se:
+                    foreach (var arm in se.Arms)
+                    {
+                        VisitControlFlowNesting(arm.Expression, depth + 1, ref maxDepth);
+                    }
+
+                    break;
+                case LocalFunctionStatementSyntax lf:
+                    if (lf.Body is not null)
+                    {
+                        VisitControlFlowNesting(lf.Body, depth, ref maxDepth);
+                    }
+                    else if (lf.ExpressionBody is not null)
+                    {
+                        VisitControlFlowNesting(lf.ExpressionBody.Expression, depth, ref maxDepth);
+                    }
+
+                    break;
+                default:
+                    VisitControlFlowNesting(child, depth, ref maxDepth);
+                    break;
+            }
         }
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -136,19 +136,25 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
         var results = new List<SemanticSearchResultDto>();
         var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter);
 
-        var predicates = ParseSemanticQuery(query);
+        var (predicates, usedImplicitNameOnly) = ParseSemanticQuery(query);
         bool Combined(ISymbol s) => predicates.All(p => p(s));
         await CollectSemanticSearchMatchesAsync(solution, projects, Combined, limit, results, ct).ConfigureAwait(false);
 
         string? warning = null;
-        if (results.Count == 0 && query.Trim().Length >= 2)
+        if (results.Count == 0 && query.Trim().Length >= 2 && !usedImplicitNameOnly)
         {
             var term = query.Trim();
             bool NameMatch(ISymbol s) => s.Name.Contains(term, StringComparison.OrdinalIgnoreCase);
             await CollectSemanticSearchMatchesAsync(solution, projects, NameMatch, limit, results, ct)
                 .ConfigureAwait(false);
             if (results.Count > 0)
+            {
                 warning = "No structured query match; results use a name substring fallback.";
+            }
+            else
+            {
+                warning = $"No symbols matched this semantic query: {term}";
+            }
         }
 
         return new SemanticSearchResponseDto(results, warning);
@@ -235,7 +241,8 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
         ["protected"] = Accessibility.Protected,
     };
 
-    private static List<Func<ISymbol, bool>> ParseSemanticQuery(string query)
+    /// <returns>Predicate list and whether the query fell back to name-only matching (no structured keywords).</returns>
+    private static (List<Func<ISymbol, bool>> Predicates, bool UsedImplicitNameOnly) ParseSemanticQuery(string query)
     {
         var predicates = new List<Func<ISymbol, bool>>();
         var q = query.ToLowerInvariant().Trim();
@@ -289,9 +296,12 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
 
         // Fallback: name-based search
         if (predicates.Count == 0)
+        {
             predicates.Add(s => s.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
+            return (predicates, UsedImplicitNameOnly: true);
+        }
 
-        return predicates;
+        return (predicates, UsedImplicitNameOnly: false);
     }
 
     private static void AddReturnTypePredicate(List<Func<ISymbol, bool>> predicates, string q)

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -116,7 +116,7 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
             parent = parent.Parent;
         }
 
-        if (parent is null) return "Other";
+        if (parent is null) return nameof(TypeUsageClassification.Other);
 
         // services.AddSingleton<IFoo, Foo>() — type appears inside generic argument list
         if (parent is TypeArgumentListSyntax typeArgs &&
@@ -124,41 +124,41 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
             inv.Expression is MemberAccessExpressionSyntax ma &&
             ma.Name.Identifier.Text is "AddSingleton" or "AddScoped" or "AddTransient" or "AddHostedService"
                 or "AddKeyedSingleton" or "AddKeyedScoped" or "AddKeyedTransient")
-            return "DIRegistration";
+            return nameof(TypeUsageClassification.DIRegistration);
 
         // Constructor parameter
         if (parent is ParameterSyntax param)
         {
             var paramParent = param.Parent?.Parent;
             if (paramParent is ConstructorDeclarationSyntax)
-                return "Constructor";
-            return "Parameter";
+                return nameof(TypeUsageClassification.Constructor);
+            return nameof(TypeUsageClassification.MethodParameter);
         }
 
         // Field declaration
         if (parent is VariableDeclarationSyntax varDecl)
         {
             if (varDecl.Parent is FieldDeclarationSyntax)
-                return "Field";
-            return "LocalVariable";
+                return nameof(TypeUsageClassification.FieldType);
+            return nameof(TypeUsageClassification.LocalVariable);
         }
 
         // Base type list
         if (parent is SimpleBaseTypeSyntax or BaseListSyntax)
-            return "BaseType";
+            return nameof(TypeUsageClassification.BaseType);
 
         // Property type
         if (parent is PropertyDeclarationSyntax)
-            return "Property";
+            return nameof(TypeUsageClassification.PropertyType);
 
         // Method return type
         if (parent is MethodDeclarationSyntax)
-            return "ReturnType";
+            return nameof(TypeUsageClassification.MethodReturnType);
 
         // Type argument (e.g., List<T>)
         if (parent is TypeArgumentListSyntax)
-            return "GenericArgument";
+            return nameof(TypeUsageClassification.GenericArgument);
 
-        return "Other";
+        return nameof(TypeUsageClassification.Other);
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -26,8 +26,9 @@ public sealed class DiagnosticService : IDiagnosticService
         // Default to Warning severity when no filter specified to avoid multi-MB Hidden output
         DiagnosticSeverity? minSeverity = ParseSeverity(severityFilter) ?? DiagnosticSeverity.Warning;
 
+        var rawWorkspace = (await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false)).WorkspaceDiagnostics;
         var workspaceDiagnostics = FilterDiagnostics(
-            (await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false)).WorkspaceDiagnostics,
+            NormalizeWorkspaceDiagnostics(rawWorkspace),
             fileFilter,
             minSeverity: minSeverity);
 
@@ -88,19 +89,68 @@ public sealed class DiagnosticService : IDiagnosticService
         var compilerDiagnostics = results.SelectMany(r => r.compiler).ToList();
         var analyzerDiagnostics = results.SelectMany(r => r.analyzer).ToList();
 
+        var compilerErrors = compilerDiagnostics.Count(d => d.Severity == "Error");
+        var analyzerErrors = analyzerDiagnostics.Count(d => d.Severity == "Error");
+        var workspaceErrors = workspaceDiagnostics.Count(d => d.Severity == "Error");
+
         return new DiagnosticsResultDto(
             workspaceDiagnostics,
             compilerDiagnostics,
             analyzerDiagnostics,
-            TotalErrors: compilerDiagnostics.Count(d => d.Severity == "Error")
-                + analyzerDiagnostics.Count(d => d.Severity == "Error")
-                + workspaceDiagnostics.Count(d => d.Severity == "Error"),
+            TotalErrors: compilerErrors + analyzerErrors + workspaceErrors,
             TotalWarnings: compilerDiagnostics.Count(d => d.Severity == "Warning")
                 + analyzerDiagnostics.Count(d => d.Severity == "Warning")
                 + workspaceDiagnostics.Count(d => d.Severity == "Warning"),
             TotalInfo: compilerDiagnostics.Count(d => d.Severity == "Info")
                 + analyzerDiagnostics.Count(d => d.Severity == "Info")
-                + workspaceDiagnostics.Count(d => d.Severity == "Info"));
+                + workspaceDiagnostics.Count(d => d.Severity == "Info"),
+            CompilerErrors: compilerErrors,
+            AnalyzerErrors: analyzerErrors,
+            WorkspaceErrors: workspaceErrors);
+    }
+
+    /// <summary>
+    /// Downgrades known informational SDK/workspace messages that MSBuildWorkspace surfaces as failures.
+    /// </summary>
+    private static IReadOnlyList<DiagnosticDto> NormalizeWorkspaceDiagnostics(IReadOnlyList<DiagnosticDto> diagnostics)
+    {
+        if (diagnostics.Count == 0)
+        {
+            return diagnostics;
+        }
+
+        var list = new List<DiagnosticDto>(diagnostics.Count);
+        foreach (var d in diagnostics)
+        {
+            if (string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(d.Category, "Workspace", StringComparison.OrdinalIgnoreCase) &&
+                IsInformationalWorkspaceFailureMessage(d.Message))
+            {
+                list.Add(d with { Severity = "Warning" });
+            }
+            else
+            {
+                list.Add(d);
+            }
+        }
+
+        return list;
+    }
+
+    private static bool IsInformationalWorkspaceFailureMessage(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        // SDK package pruning hints (e.g. "PackageReference X will not be pruned...")
+        if (message.Contains("pruned", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public async Task<DiagnosticDetailsDto?> GetDiagnosticDetailsAsync(

--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -39,15 +39,36 @@ public sealed class FixAllService : IFixAllService
         var staticProviders = _codeFixProviders.Value;
         var analyzerAssemblyProviders = LoadCodeFixProvidersFromAnalyzerReferences(solution);
         var provider = FindCodeFixProvider(staticProviders, diagnosticId)
-            ?? FindCodeFixProvider(analyzerAssemblyProviders, diagnosticId)
-            ?? throw new InvalidOperationException(
-                $"No code fix provider found for diagnostic '{diagnosticId}'. " +
-                "Restore analyzer packages (IDE/CA rules) or use organize_usings_preview for unused usings. " +
-                "Use list_analyzers to see loaded diagnostic IDs.");
+            ?? FindCodeFixProvider(analyzerAssemblyProviders, diagnosticId);
+        if (provider is null)
+        {
+            return new FixAllPreviewDto(
+                PreviewToken: "",
+                DiagnosticId: diagnosticId,
+                Scope: scope,
+                FixedCount: 0,
+                Changes: [],
+                GuidanceMessage:
+                    $"No code fix provider is loaded for diagnostic '{diagnosticId}'. " +
+                    "Restore analyzer packages (IDE/CA rules) or use organize_usings_preview / organize_usings_apply for unused usings (IDE0005). " +
+                    "Use list_analyzers to see loaded diagnostic IDs.");
+        }
 
-        var fixAllProvider = provider.GetFixAllProvider()
-            ?? throw new InvalidOperationException(
-                $"The code fix provider for '{diagnosticId}' does not support FixAll operations.");
+        var fixAllProvider = provider.GetFixAllProvider();
+        if (fixAllProvider is null)
+        {
+            var hint = diagnosticId.StartsWith("IDE", StringComparison.OrdinalIgnoreCase)
+                ? $"The IDE code fix provider for '{diagnosticId}' does not support FixAll in this workspace. " +
+                  "For IDE0005 (unnecessary usings), use organize_usings_preview / organize_usings_apply instead."
+                : $"The code fix provider for '{diagnosticId}' does not support FixAll; use code_fix_preview on individual instances or a narrower scope.";
+            return new FixAllPreviewDto(
+                PreviewToken: "",
+                DiagnosticId: diagnosticId,
+                Scope: scope,
+                FixedCount: 0,
+                Changes: [],
+                GuidanceMessage: hint);
+        }
 
         // Determine target document and project
         var (targetDocument, targetProject) = ResolveTargets(solution, fixAllScope, filePath, projectName);

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
@@ -95,6 +95,13 @@ public sealed class FlowAnalysisService : IFlowAnalysisService
             warning =
                 "Control-flow results may be incomplete for this line range. Prefer a range that covers full statement blocks within a single method body (not a partial slice of a method).";
         }
+        else if (!result.EndPointIsReachable &&
+                 (returnStatements.Count > 0 || exitPoints.Count > 0))
+        {
+            warning =
+                "EndPointIsReachable is false because Roslyn models whether execution can fall through the end of the analyzed region without an explicit return/throw — not whether the method can complete. " +
+                "If return/exit points are listed, the region still exits via those paths.";
+        }
 
         return new ControlFlowAnalysisDto(
             Succeeded: result.Succeeded,

--- a/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
@@ -1,10 +1,10 @@
 using System.Xml.Linq;
-using RoslynMcp.Core.Models;
-using RoslynMcp.Core.Services;
-using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
 
 namespace RoslynMcp.Roslyn.Services;
 

--- a/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
@@ -56,17 +56,17 @@ public sealed class TestRunnerService : ITestRunnerService
 
         var resultsDirectory = Path.Combine(Path.GetTempPath(), "RoslynMcpTestResults", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(resultsDirectory);
-        var trxPath = Path.Combine(resultsDirectory, "results.trx");
 
         try
         {
+            // Do not set LogFileName: solution-level runs emit one TRX per test project; a fixed name would overwrite.
             var arguments = new List<string>
             {
                 "test",
                 targetPath,
                 "--nologo",
                 "--logger",
-                $"trx;LogFileName={Path.GetFileName(trxPath)}",
+                "trx",
                 "--results-directory",
                 resultsDirectory
             };
@@ -85,6 +85,16 @@ public sealed class TestRunnerService : ITestRunnerService
                 ct).ConfigureAwait(false);
 
             var trxFiles = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.TopDirectoryOnly);
+            if (trxFiles.Length == 0 && !execution.Succeeded)
+            {
+                var tail = execution.StdOut.Length > 2000
+                    ? execution.StdOut[^2000..]
+                    : execution.StdOut;
+                throw new InvalidOperationException(
+                    $"dotnet test exited with code {execution.ExitCode} and produced no TRX output. " +
+                    $"StdErr: {execution.StdErr}\nStdOut (tail): {tail}");
+            }
+
             return DotnetOutputParser.ParseTestRun(execution, trxFiles);
         }
         finally

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -130,6 +130,27 @@ public sealed class ExpandedSurfaceIntegrationTests : TestBase
     }
 
     [TestMethod]
+    public async Task ProjectDiagnostics_IncludesSplitErrorCounts()
+    {
+        var diagnosticsJson = await AnalysisTools.GetProjectDiagnostics(
+            WorkspaceExecutionGate,
+            DiagnosticService,
+            WorkspaceId,
+            project: "SampleLib",
+            file: null,
+            severity: null,
+            offset: 0,
+            limit: 50,
+            CancellationToken.None);
+        using var diagnosticsDoc = JsonDocument.Parse(diagnosticsJson);
+        Assert.IsTrue(diagnosticsDoc.RootElement.TryGetProperty("compilerErrors", out var ce));
+        Assert.IsTrue(diagnosticsDoc.RootElement.TryGetProperty("analyzerErrors", out var ae));
+        Assert.IsTrue(diagnosticsDoc.RootElement.TryGetProperty("workspaceErrors", out var we));
+        var total = diagnosticsDoc.RootElement.GetProperty("totalErrors").GetInt32();
+        Assert.AreEqual(total, ce.GetInt32() + ae.GetInt32() + we.GetInt32());
+    }
+
+    [TestMethod]
     public async Task Symbol_And_Usage_Tools_Apply_Pagination_Metadata()
     {
         var animalServicePath = FindDocumentPath("AnimalService.cs");

--- a/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
+++ b/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
@@ -26,22 +26,22 @@ public sealed class NegativeEdgeCaseTests : TestBase
     }
 
     [TestMethod]
-    public async Task MalformedSymbolHandle_InvalidBase64_ReturnsGracefully()
+    public async Task MalformedSymbolHandle_InvalidBase64_ThrowsArgumentException()
     {
         var locator = SymbolLocator.ByHandle("not-valid-base64!!!");
-        var result = await SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(0, result.Count);
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "base64", StringComparison.OrdinalIgnoreCase);
     }
 
     [TestMethod]
-    public async Task MalformedSymbolHandle_ValidBase64InvalidJson_ReturnsGracefully()
+    public async Task MalformedSymbolHandle_ValidBase64InvalidJson_ThrowsArgumentException()
     {
         var handle = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("this is not json"));
         var locator = SymbolLocator.ByHandle(handle);
-        var result = await SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(0, result.Count);
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "JSON", StringComparison.OrdinalIgnoreCase);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Implements the consolidated MCP server audit plan: correctness fixes, clearer diagnostics and tool behavior, aligned consumer classification strings, and documentation/tool descriptions. Adds i_docs/refactor/ audit report copies.

## Changes

- **test_run:** Unique TRX files per test project; throw with stderr/stdout tail when dotnet test fails without TRX; pass 	oolName for structured errors.
- **Symbol handles:** Malformed base64/JSON throws ArgumentException (invalid handle) vs empty resolution (not found).
- **project_diagnostics:** compilerErrors / nalyzerErrors / workspaceErrors; workspace pruning messages downgraded to warnings; JSON uses explicit camelCase totals.
- **Metrics:** Nesting depth counts control-flow without requiring braced blocks only.
- **Flow / search:** Warnings for Roslyn end-point semantics and empty structured semantic queries.
- **fix_all_preview:** GuidanceMessage when no provider or no FixAll support.
- **find_consumers:** Dependency kinds aligned with TypeUsageClassification (+ Constructor, DIRegistration).
- **Tools:** Descriptions for server_info, 
uget_vulnerability_scan, list_analyzers, nalyze_control_flow, pply_text_edit, evert_last_apply, callers_callees, symbol_signature_help, ix_all_preview.
- **Tests:** Updated negative handle tests; split error count integration test.

## Test plan

- [x] dotnet build RoslynMcp.slnx
- [x] dotnet test RoslynMcp.slnx
- [x] ./eng/verify-ai-docs.ps1


Made with [Cursor](https://cursor.com)