### PR TITLE
feat: add plugin docs and improve test infrastructure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,15 @@ For session bootstrap and workflow, follow `AGENTS.md` first.
 - Run `dotnet test RoslynMcp.slnx --nologo` before declaring work merge-ready
 - Current coverage baseline (from Cobertura root after `./eng/verify-release.ps1`): **~60.7% line / ~47.3% branch** — do not regress it; see `docs/coverage-baseline.md`
 
+## Claude Code Plugin
+
+The server ships as a Claude Code plugin with 10 skills and safety hooks. When modifying plugin artifacts:
+
+- **Skills** (`skills/*/SKILL.md`): Reference MCP tools by their tool names. Skills are orchestration prompts, not code — they compose existing tools into workflows.
+- **Hooks** (`hooks/hooks.json`): Matchers use regex against tool names prefixed with `mcp__roslyn__`. Keep matchers in sync when tools are renamed or added.
+- **Plugin manifest** (`.claude-plugin/plugin.json`): Bump `version` when skills or hooks change. Keep `userConfig` entries in sync with env vars documented in `ai_docs/runtime.md`.
+- **Marketplace** (`.claude-plugin/marketplace.json`): Bump `version` to match `plugin.json`.
+
 ## Safety Guardrails
 
 - Never write to `stdout` from service or domain code — MCP protocol owns that stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Code plugin**: packaged as a first-class Claude Code plugin installable via `/plugin install`. Includes plugin manifest (`.claude-plugin/plugin.json`), marketplace descriptor (`.claude-plugin/marketplace.json`), and user-configurable environment variables.
+- **10 plugin skills**: `/roslyn-mcp:analyze` (solution health), `/roslyn-mcp:refactor` (guided refactoring), `/roslyn-mcp:review` (semantic code review), `/roslyn-mcp:document` (XML doc generation), `/roslyn-mcp:security` (security audit), `/roslyn-mcp:dead-code` (dead code cleanup), `/roslyn-mcp:test-coverage` (coverage analysis), `/roslyn-mcp:migrate-package` (NuGet migration), `/roslyn-mcp:explain-error` (diagnostic fixer), `/roslyn-mcp:complexity` (hotspot analysis).
+- **Plugin safety hooks**: PreToolUse guard enforcing preview-before-apply pattern; PostToolUse reminder to compile-check after structural refactorings.
+- `ValidationServiceOptions.VulnerabilityScanTimeout` (default 2 minutes) and `ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS` env var to make the NuGet vulnerability scan timeout configurable.
+
+### Fixed
+
+- **Test infrastructure: eliminate MSBuild contention causing intermittent 5-minute timeouts.** Previously every `[ClassInitialize]` called `InitializeServices()` which constructed a new `WorkspaceManager`, and 22 test classes called `WorkspaceManager.LoadAsync(SampleSolutionPath)` independently — spawning 22 separate `MSBuildWorkspace` instances with overlapping file locks on the shared sample fixture. Under load this caused `dotnet build` invocations to hit the service-level cancellation timeout (5 min) and fail. `TestBase` is now idempotent: services are created once per assembly, the workspace manager is disposed in `[AssemblyCleanup]`, and a new `GetOrLoadWorkspaceIdAsync` cache helper makes 22 redundant `LoadAsync` calls collapse into a single MSBuild evaluation. Total test runtime dropped from ~2.3 min to ~2.0 min on a clean run, with the timeout-flake mode eliminated.
+- `DependencyAnalysisService.ScanNuGetVulnerabilitiesAsync` no longer hard-codes a 120-second timeout; it now honors `ValidationServiceOptions.VulnerabilityScanTimeout` (still 2 min default). Previously this ignored every `ROSLYNMCP_*_TIMEOUT_SECONDS` env var.
+
+### Changed
+
+- `ValidationServiceOptions` is now a `record` (was `sealed class`), enabling `with` expression updates for cleaner option-binding code in `Program.cs`.
+- Test workspace cap raised to 64 (from production default of 8) since the shared `WorkspaceManager` now retains workspaces across the full assembly run instead of per-class disposal cycles.
+
 ## [1.6.0] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/i
 - `tests/RoslynMcp.Tests/`: integration and behavior coverage across stable and experimental surfaces.
 - `samples/`: fixture solutions used by tests for realistic workflows.
 - `eng/verify-release.ps1`: release verification path for publish and hashes.
+- `.claude-plugin/`: Claude Code plugin manifest and marketplace descriptor.
+- `skills/`: 10 Claude Code skill definitions composing MCP tools into guided workflows.
+- `hooks/`: plugin safety hooks enforcing preview/apply and compile-check patterns.
 
 ## Supported Surface
 
@@ -314,14 +317,17 @@ The server exposes a larger surface than earlier versions of the README document
 ## Architecture
 
 ```
+.claude-plugin/              Claude Code plugin manifest + marketplace
+skills/                      10 plugin skills (orchestration prompts)
+hooks/                       Plugin safety hooks (preview/apply guard)
 src/
-  RoslynMcp.Host.Stdio/    MCP stdio host (thin tool wrappers)
-  RoslynMcp.Core/          DTOs, service interfaces, PreviewStore
-  RoslynMcp.Roslyn/        Roslyn workspace/symbol/refactoring services
+  RoslynMcp.Host.Stdio/      MCP stdio host (thin tool wrappers)
+  RoslynMcp.Core/            DTOs, service interfaces, PreviewStore
+  RoslynMcp.Roslyn/          Roslyn workspace/symbol/refactoring services
 tests/
-  RoslynMcp.Tests/         Unit + integration tests
+  RoslynMcp.Tests/           Unit + integration tests
 samples/
-  SampleSolution/                  Multi-project test solution
+  SampleSolution/            Multi-project test solution
 ```
 
 ## Agent Workflow (End-To-End)

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -39,6 +39,7 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | `prompts/standardize-documentation.md` | Cross-repo prompt: run `/doc-audit` first, then align human + AI docs, packaging/install inventory, stale ref removal |
 | `prompts/standardize-backlog-hygiene.md` | Align backlog hygiene across repos with `backlog.md` and `workflow.md` |
 | `prompts/deep-review-and-refactor.md` | Living reusable prompt for comprehensive code review and MCP server audit (all 18 phases). Keep in sync with project surface. Do not delete. |
+| `prompts/test-suite-audit.md` | Audit tests for performance smells, workspace/init issues, SRP, and tight focus—suite should not introduce slowness or instability |
 | `audit-reports/README.md` | Where to store MCP deep-review audit outputs; links baseline template |
 | `audit-reports/deep-review-baseline-2026-04-04.md` | Baseline checklist for a full deep-review session (update when tool surface changes) |
 | `audit-reports/2026-04-04-post-1.5-surface-audit.md` | Example post-release surface audit snapshot |
@@ -61,10 +62,12 @@ This directory is the canonical AI-facing documentation tree. Read this file to 
 | Add or change a tool | `domains/host-stdio/reference.md` → `domains/roslyn-services/reference.md` → `references/testing.md` |
 | Evolve a DTO or contract | `domains/core-contracts/reference.md` → `architecture.md` |
 | Write or update tests | `references/testing.md` → `runtime.md` |
+| Audit test suite (performance, SRP, workspace/init smells) | `prompts/test-suite-audit.md` → `references/testing.md` |
 | Merge-ready handoff | `CI_POLICY.md` → `workflow.md` |
 | Doc-only change | `CI_POLICY.md` (run `verify-ai-docs.ps1`) |
 | Planning new features | `backlog.md` → `architecture.md` → `docs/roadmap.md` |
 | Human setup / Docker / CI artifacts | `docs/setup.md` |
+| Claude Code plugin / skills / hooks | `README.md` § *Claude Code Plugin Installation* → `docs/setup.md` § *Claude Code Plugin* |
 | Release parity / must-have matrix | `docs/parity-gap-implementation-plan.md` |
 | Coverage baseline / CI artifacts | `docs/coverage-baseline.md` → `references/testing.md` |
 | Experimental → stable promotion review | `docs/experimental-promotion-analysis.md` |

--- a/ai_docs/architecture.md
+++ b/ai_docs/architecture.md
@@ -65,6 +65,19 @@ Operational logs → `stderr` only (stdout reserved for MCP protocol traffic).
 - Validate with build/tests before merge-ready handoff.
 - Update docs/tests when behavior or surface contracts change.
 
+## Claude Code Plugin Layer
+
+The server is also distributed as a Claude Code plugin. Plugin artifacts live outside the C# project structure:
+
+| Directory | Purpose |
+|-----------|---------|
+| `.claude-plugin/` | Plugin manifest (`plugin.json`) and marketplace descriptor (`marketplace.json`) |
+| `skills/` | 10 SKILL.md skill definitions composing Roslyn MCP tools into guided workflows |
+| `hooks/` | `hooks.json` with safety hooks (preview-before-apply guard, post-refactoring compile-check reminder) |
+| `.mcp.json` | MCP server config with userConfig env var passthrough |
+
+The plugin layer is a pure orchestration concern — it does not add code to the C# projects. Skills reference tools by their MCP names and compose them into multi-step workflows. Hooks enforce safety patterns (preview before apply, compile after refactor).
+
 ## Known Gaps
 
 - IDE and CA analyzers not loaded in MSBuildWorkspace — only SDK-implicit diagnostics active at runtime (AUDIT-21).

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-04T22:30:00Z
+**updated_at:** 2026-04-06T03:00:00Z
 
 ## Agent contract
 
@@ -28,7 +28,10 @@ These are **not** backlog rows; do not delete them when clearing completed work.
 
 | id | blocker | deps | do |
 |----|---------|------|-----|
-| *(none)* | — | — | No open backlog rows. Add rows here when work is actionable and incomplete. |
+| `testbase-srp-split` | none | — | **P3 / refactor.** `TestBase` is a 318-line god class owning: 40+ static service properties, MSBuild init, filesystem helpers, path resolution, fixture copy logic, and now workspace caching. The recent fix made it idempotent and added a workspace cache, but the class still violates SRP. Plan: extract `TestServiceContainer` (services + lifecycle), `TestFixtures` (path resolution + copy helpers), and keep `TestBase` as a thin pass-through. Defer until a touch-the-class change is needed — the current split would touch 30+ test classes. |
+| `vuln-scan-network-mock` | none | — | **P3 / test isolation.** `ScanNuGetVulnerabilitiesAsync_ReturnsStructuredResult` shells out to `dotnet list package --vulnerable`, which hits `api.nuget.org`. Now passes reliably with the workspace-cache fix, but still fails in air-gapped environments. Consider mocking the NuGet client at the gated-executor boundary, or marking the test `[Category("Network")]` so it can be filtered. |
+| `verify-release-test-output-policy` | none | — | **P3 / process.** `eng/verify-release.ps1` runs `dotnet test` with default verbosity. Add `--logger "console;verbosity=normal"` and `$ErrorActionPreference = 'Stop'` so failing tests are not masked by tail/pipe operations in any wrapper script. |
+| `semantic-search-async-modifier-doc` | none | — | **P3 / docs.** `semantic_search` query `async methods returning Task<bool>` returns 0 because Roslyn `IMethodSymbol.IsAsync` requires the `async` modifier on the declaration; pass-through `Task.FromResult` methods are not matched. Document this gotcha in `CodePatternAnalyzer` tool description and the `/roslyn-mcp:review` skill so users know to query for "methods returning Task<bool>" without "async" if they want all Task-returning methods. |
 
 ## Refs
 

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -6,7 +6,7 @@
      with the project's actual tool, resource, and prompt surface at all times.
      When tools, resources, or prompts are added, removed, or renamed,
      update the Tools Reference appendix accordingly.
-     Last surface audit: 2026-04-04 (see appendix; 123 tools, 7 resources, 16 prompts). -->
+   Last surface audit: 2026-04-06 (catalog 2026.03; 123 tools = 56 stable / 67 experimental, 7 resources, 16 prompts). -->
 
 > Use this prompt with an AI coding agent that has access to the Roslyn MCP server.
 > **Primary purpose:** produce an MCP server audit (bugs, incorrect results, gaps). **Mechanism:** real refactoring plus tool calls that exercise the full surface.
@@ -20,11 +20,22 @@ You are a senior .NET architect. Your **primary mission** is to **audit the Rosl
 1. **MCP server audit (primary)** — For every tool call, ask whether the result is correct, complete, and consistent with sibling tools. Record issues in the mandatory audit file (see Output Format). Also record **tool coverage** (what was exercised vs skipped) and **verified working** tools — not only failures.
 2. **Refactor the codebase (supporting)** — In **Phase 6 only**, apply meaningful improvements (fixes, renames, extractions, dead code removal, format, organize). Verify with `compile_check` and `test_run`. Those changes belong in the target repo’s git history. Summarize what you applied in the audit report’s **Phase 6 refactor summary** subsection (see Output Format); that summary is part of the single MCP audit file, not a separate deliverable.
 
-**Known issues:** Open MCP server work is tracked in [`ai_docs/backlog.md`](../backlog.md) in the **Roslyn-Backed-MCP** repository (the repo that ships this server). If you hit a known issue, cite the backlog item briefly (e.g. “matches AUDIT-23”) and put **detail only on new or divergent behavior**.
+**Known issues / prior findings:** If you are auditing from within **Roslyn-Backed-MCP** or you otherwise have access to the server backlog, cross-check open MCP issues in [`ai_docs/backlog.md`](../backlog.md) and cite matching ids briefly (for example `semantic-search-async-modifier-doc`). If you are auditing from another repo and do not have that backlog available, use the closest equivalent prior source you do have (previous audit report, issue tracker, saved repro list). If no prior source exists, mark the regression section **N/A** instead of inventing one.
 
 **Phase order note:** After Phase 8, run **Phase 10** before **Phase 9** (Undo). Phase 9 is placed after Phase 10 so `revert_last_apply` does **not** undo Phase 6 refactoring — see Phase 9.
 
-Work through each phase below **in order** (including the Phase 10 → Phase 9 sequence). After each tool call, evaluate whether the result is correct and complete. If a tool returns an error, empty results when data was expected, or results that seem wrong, record it for the MCP Server Audit Report.
+**Portability and completeness contract:**
+
+1. This prompt is intended to run against **any loadable C# repo**. Prefer a `.sln` or `.slnx`; if the repo has no solution file, use a `.csproj`.
+2. **Default to `full-surface`.** Only opt into `conservative` when you cannot safely use a disposable branch/worktree/clone.
+   - **`full-surface` (default):** disposable branch/worktree/clone; drive preview -> apply families end-to-end where safe and clean up or reverse audit-only mutations.
+   - **`conservative` (opt-in):** non-disposable repo; keep high-impact families preview-only and mark the skipped apply siblings as `skipped-safety`.
+3. Treat `server_info`, `roslyn://server/catalog`, and `roslyn://server/resource-templates` as the **authoritative live surface**. If this prompt's appendix disagrees with the running server, the live catalog wins and the mismatch is itself a finding.
+4. Build a live **coverage ledger** from the catalog. Every live tool, resource, and prompt must end with exactly one final status: `exercised`, `exercised-apply`, `exercised-preview-only`, `skipped-repo-shape`, `skipped-safety`, or `blocked`. Silent omissions mean the audit is incomplete.
+5. Record repo-shape constraints up front: single vs multi-project, tests present, analyzers present, source generators present, DI usage present, `.editorconfig` present, Central Package Management / `Directory.Packages.props`, multi-targeting, and network/package-restore constraints.
+6. Do not invent applicability. If the repo has no tests, no DI, no source generators, no multi-targeting, or only one project, record that explicitly and treat the corresponding steps as `skipped-repo-shape`.
+
+Work through each phase below **in order** (including the Phase 10 -> Phase 9 sequence), then complete the **Final surface closure** step before you write the report. After each tool call, evaluate whether the result is correct and complete. If a tool returns an error, empty results when data was expected, or results that seem wrong, record it for the MCP Server Audit Report.
 
 ### Cross-cutting audit principles (apply to every phase)
 
@@ -35,18 +46,25 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 3. **Performance observation:** Note any tool call that is notably slow (>5 s for a simple single-symbol operation, >15 s for a solution-wide scan). Record the tool name, input scale, and approximate wall-clock time for the report's **Performance observations** subsection.
 4. **Error message quality:** When a tool returns an error, evaluate the message itself: Is it **actionable** (tells the caller what went wrong and what to do differently)? **Vague** (generic message with no remediation hint)? Or **unhelpful** (raw exception / stack trace)? Record the rating in the report.
 5. **Response contract consistency:** Across tool calls, note inconsistencies in response contracts: Are line numbers 0-based or 1-based consistently? Do related tools (`find_consumers`, `find_references`, `find_type_usages`) use the same field names for the same concepts? Are classification values always strings or sometimes numeric codes? Note inconsistencies in the report.
+6. **Precondition discipline:** Distinguish server defects from repo/environment constraints. If a tool depends on tests, analyzers, network access, source generators, DI registrations, Central Package Management, or a multi-project graph, record whether the precondition is absent in the repo, blocked by the environment, or mishandled by the server. A clear, actionable dependency or not-applicable response is not the same as a server bug.
 
 ---
 
-### Phase 0: Setup
+### Phase 0: Setup, live surface baseline, and repo shape
 
-1. Call `workspace_load` with the solution path.
-2. Call `workspace_list` to confirm the session appears.
-3. Call `workspace_status` to confirm the workspace loaded cleanly. Note any load errors.
-4. Call `server_info` to record the server version, Roslyn version, and tool counts.
-5. Call `project_graph` to understand the project dependency structure.
+1. Pick the entrypoint you will load: prefer a `.sln` or `.slnx`; fall back to a `.csproj` if needed.
+2. Record whether this session is running in the default `full-surface` mode or an explicitly opted-in `conservative` mode.
+3. Call `server_info` to record the server version, Roslyn version, catalog version, and live stable/experimental counts.
+4. Read `roslyn://server/catalog` to capture the authoritative live surface inventory.
+5. Read `roslyn://server/resource-templates` to capture all resource URI templates.
+6. Call `workspace_load` with the chosen entrypoint.
+7. Call `workspace_list` to confirm the session appears.
+8. Call `workspace_status` to confirm the workspace loaded cleanly. Note any load errors.
+9. Call `project_graph` to understand the project dependency structure.
+10. From the loaded repo, record the repo-shape constraints that affect later phases (projects, tests, analyzers, DI, source generators, Central Package Management, multi-targeting, network limits).
+11. Seed or update the coverage ledger so every live tool/resource/prompt already has a planned phase or a provisional skip reason.
 
-**MCP audit checkpoint:** Did `workspace_load` succeed? Does `workspace_list` show the new session? Did `workspace_status` report any stale documents or missing projects? Does `server_info` report the expected tool counts?
+**MCP audit checkpoint:** Did `server_info` and `roslyn://server/catalog` agree on live counts and tiers? Did `workspace_load` succeed on the chosen entrypoint? Does `workspace_list` show the new session? Did `workspace_status` report any stale documents or missing projects? Did you explicitly confirm either the default `full-surface` mode or a justified `conservative` opt-in, plus the repo shape and an initial coverage ledger with no silent omissions?
 
 ---
 
@@ -60,7 +78,7 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 6. Call `list_analyzers` to enumerate all loaded analyzers and their rules. Note total rule count.
 7. Call `diagnostic_details` on a representative error and a representative warning to inspect full detail.
 
-**MCP audit checkpoint:** Do `project_diagnostics` and `compile_check` agree on error counts? Does `compile_check` with `emitValidation=true` find additional issues? Does `nuget_vulnerability_scan` find any known CVEs, and does it return structured results with package name, advisory URL, and severity? Does `list_analyzers` return data for all projects? Are there any analyzers that fail to load (look for LOAD_ERROR entries)? Does `diagnostic_details` return accurate location and message information?
+**MCP audit checkpoint:** Do `project_diagnostics` and `compile_check` agree on error counts? Does `compile_check` with `emitValidation=true` find additional issues? Does `nuget_vulnerability_scan` find any known CVEs, and does it return structured results with package name, advisory URL, and severity? If the environment blocks network or package metadata access, does `nuget_vulnerability_scan` fail fast with a clear explanation instead of hanging or returning misleading success? Does `list_analyzers` return data for all projects? Are there any analyzers that fail to load (look for LOAD_ERROR entries)? Does `diagnostic_details` return accurate location and message information?
 
 ---
 
@@ -211,6 +229,8 @@ For each method with high complexity:
 
 **Cross-tool chain validation (Phase 6):** After `rename_apply`, call `find_references` on the new name — does the count match the preview? After `extract_interface_apply`, call `type_hierarchy` on the new interface — does it show the implementor? After `fix_all_apply`, call `project_diagnostics` with the same diagnostic ID — did the count drop to zero? After `organize_usings_apply`, call `get_source_text` — are usings actually sorted? These chains verify that workspace state stays consistent across mutations.
 
+**Mutation-family coverage note:** By the end of Phase 6 plus the later file/scaffolding/project-mutation phases, every write-capable family exposed by the live catalog must be either exercised end-to-end or explicitly marked `skipped-safety` / `skipped-repo-shape`. Do not assume a preview-only call covers an apply sibling unless the catalog exposes no separate apply tool.
+
 ---
 
 ### Phase 7: EditorConfig & Configuration
@@ -242,29 +262,32 @@ For each method with high complexity:
 8. Call `test_run` with no filter to run the full suite.
 9. Call `test_coverage` to measure coverage.
 
+If `test_discover` returns zero tests, still record that result. Then explicitly distinguish one of these outcomes: `test_run` returns a clean zero-test result, `test_run` / `test_coverage` are `skipped-repo-shape`, or the server mishandles the no-test case.
+
 **MCP audit checkpoint:** Does `build_workspace` match `compile_check` results (same error count, same diagnostic IDs, same locations)? Does `test_related_files` correctly identify related tests? Does `test_related` find the right tests for the symbol? Does `test_run` produce structured results with pass/fail counts — and do the aggregated counts reflect the full solution or only the last assembly? Does `test_coverage` produce coverage data?
 
-**Do not** call `revert_last_apply` yet — that would undo the most recent Phase 6 apply. Continue to **Phase 10** (preview-only), then **Phase 9** (Undo verification).
+**Do not** call `revert_last_apply` yet — that would undo the most recent Phase 6 apply. Continue to **Phase 10**, then **Phase 9** (Undo verification).
 
 ---
 
-### Phase 10: Cross-Project Operations (preview only — if multi-project solution)
+### Phase 10: File, Cross-Project, and Orchestration Operations
 
-**PREVIEW ONLY — do not apply.** Exercise preview and composite tools; inspect diffs and JSON. Applying moves, deletes, scaffolds, or package migrations here leaves audit artifacts in the repo and is **out of scope** for this prompt.
+**Default behavior:** inspect previews for every applicable family. In `full-surface` mode on a disposable checkout, you SHOULD also drive at least one safe preview -> apply -> verification -> cleanup chain for the families that expose apply tools here (`move_type_to_file_apply`, `create_file_apply`, `move_file_apply`, `delete_file_apply`, and `apply_composite_preview` when it truly applies a composite result). In `conservative` mode, keep those apply siblings as `skipped-safety`.
 
 1. Call `move_type_to_file_preview` to move a type into its own file.
 2. Call `move_file_preview` to move a file to a different directory with namespace update.
 3. Call `create_file_preview` to preview creating a new source file in a project.
 4. Call `delete_file_preview` to preview deleting an unused source file (pick a path that would be safe if you were applying — do **not** apply).
-5. Call `extract_interface_cross_project_preview` to extract an interface into a different project.
-6. Call `dependency_inversion_preview` to extract interface + update constructor dependencies.
-7. Call `move_type_to_project_preview` to move a type declaration into another project.
-8. Call `extract_and_wire_interface_preview` to extract an interface and rewrite DI registrations.
-9. Call `split_class_preview` to split a type into partial class files.
-10. Call `migrate_package_preview` to replace one NuGet package with another across projects.
-11. Optionally call `apply_composite_preview` **only as a preview path** if the server requires it to materialize a composite diff — if that would write to disk, skip and note in the audit.
+5. If the workspace has multiple projects, call `extract_interface_cross_project_preview` to extract an interface into a different project.
+6. If the workspace has multiple projects, call `dependency_inversion_preview` to extract interface + update constructor dependencies.
+7. If the workspace has multiple projects, call `move_type_to_project_preview` to move a type declaration into another project.
+8. If DI registrations exist or can be inferred, call `extract_and_wire_interface_preview` to extract an interface and rewrite DI registrations.
+9. If a split candidate exists, call `split_class_preview` to split a type into partial class files.
+10. If a package migration candidate exists, call `migrate_package_preview` to replace one NuGet package with another across projects.
+11. In `full-surface` mode on a disposable checkout, execute one safe file/type preview/apply/cleanup loop using the corresponding apply tools (`move_type_to_file_apply`, `create_file_apply`, `move_file_apply`, or `delete_file_apply`). Verify the workspace remains buildable or is restored to its starting state.
+12. If an orchestration preview returns a token that is committed via `apply_composite_preview`, treat `apply_composite_preview` as a **destructive apply tool despite the name**. Only call it in `full-surface` mode on a disposable checkout; otherwise mark it `skipped-safety` and note the naming friction.
 
-**MCP audit checkpoint:** Do cross-project previews produce valid diffs? Do namespace and reference updates look correct in the preview? Does `extract_and_wire_interface_preview` correctly identify DI registrations? Does `split_class_preview` produce valid partial classes? Do file creation and deletion previews produce correct diffs?
+**MCP audit checkpoint:** Do file and cross-project previews produce valid diffs? Do namespace and reference updates look correct in the preview? Does `extract_and_wire_interface_preview` correctly identify DI registrations? Does `split_class_preview` produce valid partial classes? Do file creation and deletion previews produce correct diffs? When you used an apply sibling, did the create/move/delete/apply path behave end-to-end and leave the repo in a clean state?
 
 ---
 
@@ -283,31 +306,33 @@ For each method with high complexity:
 
 ### Phase 11: Semantic Search & Discovery
 
-1. Call `semantic_search` with a natural-language query like `"async methods returning Task<bool>"`. Verify results match the query semantics.
-2. Call `semantic_search` with `"classes implementing IDisposable"`. Cross-check against `find_implementations`.
-3. Call `find_reflection_usages` to locate reflection-heavy code that may resist refactoring.
-4. Call `get_di_registrations` to audit the DI container wiring.
-5. Call `source_generated_documents` to list any source-generator output files.
+1. Call `semantic_search` with a repo-relevant natural-language query like `"async methods returning Task<bool>"` or another pattern that should exist in the target repo.
+2. Call `semantic_search` with a broader paraphrase of the same idea (for example `"methods returning Task<bool>"`) and compare the delta so modifier-sensitive matching is visible.
+3. Call `semantic_search` with `"classes implementing IDisposable"` or another interface-based query you can cross-check against `find_implementations`.
+4. Call `find_reflection_usages` to locate reflection-heavy code that may resist refactoring.
+5. Call `get_di_registrations` to audit the DI container wiring.
+6. Call `source_generated_documents` to list any source-generator output files.
 
-**MCP audit checkpoint:** Does `semantic_search` return relevant results? Does `find_reflection_usages` find all reflection patterns (typeof, GetMethod, Activator, etc.)? Does `get_di_registrations` parse all registration styles?
+**MCP audit checkpoint:** Do the paired `semantic_search` queries return relevant and explainable differences? Does the broader paraphrase expose modifier-sensitive matching issues? Does `find_reflection_usages` find all reflection patterns (typeof, GetMethod, Activator, etc.)? Does `get_di_registrations` parse all registration styles, and is an empty result legitimate for the repo shape? Are source-generated documents correctly listed when generators are present?
 
 ---
 
-### Phase 12: Scaffolding (preview only)
+### Phase 12: Scaffolding
 
-**PREVIEW ONLY — do not apply.** Do not call `scaffold_type_apply` or `scaffold_test_apply`; audit the previews only.
+**Default behavior:** preview-only. In `full-surface` mode on a disposable checkout, apply one scaffold (`scaffold_type_apply` or `scaffold_test_apply`), verify it compiles or is discoverable, then clean it up with file-operation tools or version control. In `conservative` mode, mark the apply siblings `skipped-safety`.
 
 1. Call `scaffold_type_preview` to scaffold a new class in a project. Verify the generated file content and namespace in the preview payload.
-2. Call `scaffold_test_preview` to scaffold a test file for an existing type. Verify it targets the correct type and uses the right test framework in the preview.
-3. Call `compile_check` if the server requires a fresh compilation for previews; otherwise skip (previews alone do not change disk).
+2. If the repo has or can support a test project/framework, call `scaffold_test_preview` to scaffold a test file for an existing type. Verify it targets the correct type and uses the right test framework in the preview.
+3. In `full-surface` mode on a disposable checkout, call the corresponding apply tool for one preview and verify the result with `compile_check`, `test_discover`, or both.
+4. Call `compile_check` if the server requires a fresh compilation for previews; otherwise skip (previews alone do not change disk).
 
-**MCP audit checkpoint:** Does `scaffold_type_preview` infer the correct namespace from the project structure? Does `scaffold_test_preview` generate valid test stubs? Are preview payloads complete and apply-able in principle?
+**MCP audit checkpoint:** Does `scaffold_type_preview` infer the correct namespace from the project structure? Does `scaffold_test_preview` generate valid test stubs when a test target exists? Are preview payloads complete and apply-able in principle? When you used an apply sibling, did the scaffolded file compile or show up in test discovery as expected?
 
 ---
 
-### Phase 13: Project Mutation (preview only)
+### Phase 13: Project Mutation
 
-**PREVIEW ONLY — do not apply.** Do not call `apply_project_mutation` (or any path that writes `.csproj` / `Directory.Packages.props`). Inspect preview XML/diffs only.
+**Default behavior:** preview-only. In `full-surface` mode on a disposable checkout, execute at least one reversible preview -> `apply_project_mutation` -> verification -> inverse-preview -> `apply_project_mutation` loop (for example add then remove a package reference, or set then revert a property). In `conservative` mode, mark `apply_project_mutation` as `skipped-safety`.
 
 1. Call `add_package_reference_preview` to add a NuGet package to a project.
 2. Call `remove_package_reference_preview` to remove a NuGet package.
@@ -318,8 +343,9 @@ For each method with high complexity:
 7. Call `add_target_framework_preview` to add a target framework to a multi-targeting project.
 8. Call `remove_target_framework_preview` to remove a target framework.
 9. If the solution uses Central Package Management, call `add_central_package_version_preview` and `remove_central_package_version_preview` (preview only).
+10. In `full-surface` mode on a disposable checkout, apply one reversible mutation and then reverse it. Verify with `workspace_reload` plus `build_project` or `compile_check`.
 
-**MCP audit checkpoint:** Do project mutation previews produce correct XML diffs? Do `set_conditional_property_preview` conditions evaluate correctly in the preview? Do framework additions/removals look correct in the preview? (Do not verify via apply.)
+**MCP audit checkpoint:** Do project mutation previews produce correct XML diffs? Do `set_conditional_property_preview` conditions evaluate correctly in the preview? Do framework additions/removals look correct in the preview? When you used `apply_project_mutation`, did the forward and reverse mutations both behave correctly? Are multi-targeting and Central Package Management cases correctly marked `skipped-repo-shape` when the repo does not use them?
 
 ---
 
@@ -351,17 +377,17 @@ For each method with high complexity:
 
 ---
 
-### Phase 16: Prompt Verification (pick 4+ prompts)
+### Phase 16: Prompt Verification
 
-The server exposes 16 prompts. Exercise at least 4 representative ones to verify their argument templates, output quality, and accuracy.
+The server currently exposes 16 prompts. In `conservative` mode, exercise at least 6 prompts spanning error explanation, refactoring, review, testing, security, and capability discovery. In `full-surface` mode, exercise all 16 prompts unless a prompt is truly `skipped-repo-shape`.
 
 1. Call `explain_error` with a diagnostic from Phase 1. Verify the explanation is accurate and actionable.
 2. Call `suggest_refactoring` on a symbol or region you analyzed in Phase 3. Verify the suggestions reference real tools and produce sensible guidance.
 3. Call `review_file` on a file modified in Phase 6. Verify the review references actual code and produces useful observations.
 4. Call `discover_capabilities` with a task category (e.g. "refactoring", "testing", "security"). Verify it returns relevant tools for the category.
-5. Optionally call additional prompts (`dead_code_audit`, `review_complexity`, `cohesion_analysis`, `consumer_impact`, `security_review`, `debug_test_failure`, etc.) for broader coverage.
+5. Cover the remaining prompt surface as applicable (`analyze_dependencies`, `debug_test_failure`, `refactor_and_validate`, `fix_all_diagnostics`, `guided_package_migration`, `guided_extract_interface`, `security_review`, `dead_code_audit`, `review_test_coverage`, `review_complexity`, `cohesion_analysis`, `consumer_impact`).
 
-**MCP audit checkpoint:** Do prompt argument templates make sense? Does the prompt output reference correct tools and produce actionable guidance? Are prompt descriptions accurate? Do any prompts fail, return empty output, or produce hallucinated tool names?
+**MCP audit checkpoint:** Do prompt argument templates make sense? Does the prompt output reference correct tools and produce actionable guidance? Does `discover_capabilities` align with the live catalog from Phase 0? Are prompt descriptions accurate? Do any prompts fail, return empty output, or produce hallucinated tool names?
 
 ---
 
@@ -397,18 +423,27 @@ Deliberately probe edge cases and error paths. The goal is to verify that the se
 
 ---
 
-### Phase 18: Regression Verification (re-test backlog items)
+### Phase 18: Regression Verification (re-test known issues or prior findings)
 
-Before writing the report, deliberately re-test 3–5 items from [`ai_docs/backlog.md`](../backlog.md), prioritizing P1 and P2 items.
+Before writing the report, deliberately re-test 3–5 previously recorded issues. Prefer [`ai_docs/backlog.md`](../backlog.md) when auditing **Roslyn-Backed-MCP** or when that file is available. Otherwise use a previous audit report, open issue tracker, or saved repro list. If no prior source exists, mark this phase `N/A` with that reason.
 
-1. Read `ai_docs/backlog.md` and select 3–5 items that can be reproduced with the current workspace.
+1. Read the available prior source and select 3–5 items that can be reproduced with the current workspace.
 2. For each selected item, reproduce the exact scenario described (same tool, similar inputs). Record the result:
    - **Still reproduces** — confirm with current server version.
    - **Partially fixed** — describe what changed and what remains.
    - **No longer reproduces** — mark as **candidate for closure** in the report.
-3. Include findings in the report's **Backlog regression check** section.
+3. Include findings in the report's **Known issue regression check** section.
 
-**MCP audit checkpoint:** Did any previously reported issues get fixed without being removed from the backlog? Did any issues change in character (e.g., different error message, partial fix)?
+**MCP audit checkpoint:** Did any previously reported issues get fixed without being removed from the source tracker? Did any issues change in character (e.g., different error message, partial fix)?
+
+---
+
+### Final surface closure (mandatory before the report)
+
+1. Compare your coverage ledger against the live catalog captured in Phase 0.
+2. For every unaccounted tool, resource, or prompt, either call it now or assign a final explicit status (`skipped-repo-shape`, `skipped-safety`, or `blocked`) with a one-line reason.
+3. If the live catalog exposed entries that had no natural place in the phased plan, record that as prompt drift in **Improvement suggestions** and still include the entries in the ledger.
+4. Confirm that ledger totals match the live catalog totals and that the catalog summary matches `server_info`.
 
 ---
 
@@ -444,17 +479,18 @@ Derive `<repo-id>` from the **audited** solution or repository name:
 
 ### Report contents (required sections)
 
-1. **Header (metadata)** — server version (from `server_info`), Roslyn / .NET versions if available, **audited** solution path and name, date, workspace id, approximate project count and document count from `workspace_load` / `project_graph`.
-2. **Tool coverage** — For each **category** below, state **exercised** / **skipped** (with reason) / **N/A** (e.g. single-project solution and cross-project previews not applicable). Categories: Server; Workspace; Symbols; Analysis; Advanced Analysis; Consumer & Cohesion; Security; Flow; Syntax & Operations; Compilation; Analyzer Info; Snippet & Scripting; Refactoring (rename/format/organize); Code Actions & Fixes; Fix All; Interface/Type extraction; Type movement; Bulk refactor; Cross-project refactor; Orchestration; Dead code; Text edits; File ops; Project mutation (previews); Scaffolding (previews); Build & Test; EditorConfig; MSBuild evaluation; Suppression & severity; Undo; Resources (MCP resources); Prompts; Boundary & Negative Testing; Regression Verification.
-3. **Verified tools (working)** — Bullet list: tool name + one-line evidence (e.g. “`compile_check` — 0 errors after Phase 6”). This distinguishes “tested and fine” from “never called.”
-4. **Phase 6 refactor summary** — Concise record of **applied** Phase 6 work (not preview-only phases). Include: target repo identity (if different from Roslyn-Backed-MCP); **scope** (e.g. fix-all + rename + format — which sub-steps 6a–6i you actually applied); **notable symbols or files** touched; **MCP tools used** for each change (e.g. `rename_apply`, `fix_all_apply`); **verification** (`compile_check` / `test_run` / `build_workspace` outcomes). If Phase 6 had **no** applies (skipped or audit-only), state **N/A** with one line why. Optional: git commit hash or PR link if available.
-5. **MCP server issues (bugs)** — For each issue: **Tool name**, **inputs**, **expected** vs **actual**, **severity** (crash / incorrect result / missing data / degraded performance / cosmetic / error-message-quality), **reproducibility** (always / sometimes / once). Watch for: crashes, wrong or incomplete results, tool-vs-tool inconsistency, missing functionality, slow tools, bad JSON/truncation, bad line/position mapping, unhelpful error messages.
-6. **Improvement suggestions** — Things that work correctly but could work better. UX friction (confusing parameter names, unexpected defaults, verbose output). Missing convenience features (e.g., “I wished tool X also returned Y”). Workflow gaps (sequences of 3+ tool calls that could be a single composite tool). Output enrichment (e.g., numeric codes where string labels would be more useful). Schema/description mismatches (tool description says one thing, actual behavior does another). These are not bugs — they are actionable input for the next release.
-7. **Performance observations** — List any tools that were notably slow, with tool name, input scale, and approximate wall-clock time. If all tools responded within expected bounds, state that.
-8. **Backlog regression check** — For the 3–5 backlog items re-tested in Phase 18, state: **still reproduces**, **partially fixed** (describe), or **candidate for closure** (no longer reproduces). Include the AUDIT-ID and one-line summary for each.
-9. **Known backlog cross-check** — List any *newly observed* issues that match [`ai_docs/backlog.md`](../backlog.md) (e.g. “AUDIT-23 — semantic_search Task<bool>”) with one line each; put **full write-ups only for new or different** behavior.
+1. **Header (metadata)** — server version (from `server_info`), Roslyn / .NET versions if available, **audited** solution path and name, chosen entrypoint (`.sln` / `.slnx` / `.csproj`), audit mode (`full-surface` by default or explicitly opted-in `conservative`), date, workspace id, approximate project count and document count from `workspace_load` / `project_graph`, repo-shape summary, and the prior-issue source used for Phase 18.
+2. **Coverage summary** — Group by the live catalog's `Kind` + `Category` values from `roslyn://server/catalog`. For each group, report counts for `exercised`, `exercised-apply`, `exercised-preview-only`, `skipped-repo-shape`, `skipped-safety`, and `blocked`.
+3. **Coverage ledger (required)** — One row for every live tool, resource, and prompt from `roslyn://server/catalog`. Columns: `kind`, `name`, `tier`, `status`, `phase`, `notes`. The audit is incomplete if the ledger row count does not match the live catalog total or if any entry is omitted.
+4. **Verified tools (working)** — Bullet list: tool name + one-line evidence (e.g. “`compile_check` — 0 errors after Phase 6”). This distinguishes “tested and fine” from “never called.”
+5. **Phase 6 refactor summary** — Concise record of **applied** Phase 6 work (not preview-only phases). Include: target repo identity (if different from Roslyn-Backed-MCP); **scope** (e.g. fix-all + rename + format — which sub-steps 6a–6i you actually applied); **notable symbols or files** touched; **MCP tools used** for each change (e.g. `rename_apply`, `fix_all_apply`); **verification** (`compile_check` / `test_run` / `build_workspace` outcomes). If Phase 6 had **no** applies (skipped or audit-only), state **N/A** with one line why. Optional: git commit hash or PR link if available.
+6. **MCP server issues (bugs)** — For each issue: **Tool name**, **inputs**, **expected** vs **actual**, **severity** (crash / incorrect result / missing data / degraded performance / cosmetic / error-message-quality), **reproducibility** (always / sometimes / once). Watch for: crashes, wrong or incomplete results, tool-vs-tool inconsistency, missing functionality, slow tools, bad JSON/truncation, bad line/position mapping, unhelpful error messages.
+7. **Improvement suggestions** — Things that work correctly but could work better. UX friction (confusing parameter names, unexpected defaults, verbose output). Missing convenience features (e.g., “I wished tool X also returned Y”). Workflow gaps (sequences of 3+ tool calls that could be a single composite tool). Output enrichment (e.g., numeric codes where string labels would be more useful). Schema/description mismatches (tool description says one thing, actual behavior does another). These are not bugs — they are actionable input for the next release.
+8. **Performance observations** — List any tools that were notably slow, with tool name, input scale, and approximate wall-clock time. If all tools responded within expected bounds, state that.
+9. **Known issue regression check** — For the 3–5 items re-tested in Phase 18, state: **still reproduces**, **partially fixed** (describe), or **candidate for closure** (no longer reproduces). Include the source id / issue id and one-line summary for each. If no prior source existed, state **N/A**.
+10. **Known issue cross-check** — List any *newly observed* issues that match the chosen prior source (for example a backlog id, issue number, or previous audit finding) with one line each; put **full write-ups only for new or different** behavior.
 
-If there are **zero** new issues, still write sections 1–4 and 6–9; in section 5 state **“No new issues found”** and confirm the audit ran.
+If there are **zero** new issues, still write sections 1–5 and 7–10; in section 6 state **“No new issues found”** and confirm the audit ran.
 
 ### Markdown template (copy, fill in, save)
 
@@ -464,18 +500,31 @@ If there are **zero** new issues, still write sections 1–4 and 6–9; in secti
 ## Header
 - **Date:**
 - **Audited solution:**
+- **Entrypoint loaded:**
+- **Audit mode:** (`full-surface` by default; state reason if `conservative`)
 - **Workspace id:**
 - **Server:** (from `server_info`)
 - **Roslyn / .NET:** (if reported)
 - **Scale:** ~N projects, ~M documents
+- **Repo shape:**
+- **Prior issue source:**
 - **Report path note:** (if not saved under Roslyn-Backed-MCP, state intended copy destination)
 
-## Tool coverage
-| Category | Status | Notes |
-|----------|--------|--------|
-| Server | exercised / skipped / N/A | |
-| Workspace | | |
-| … | | |
+## Coverage summary
+| Kind | Category | Exercised | Apply | Preview-only | Skipped | Blocked | Notes |
+|------|----------|-----------|-------|--------------|---------|---------|-------|
+| tool | workspace | | | | | | |
+| tool | refactoring | | | | | | |
+| resource | workspace | | n/a | n/a | | | |
+| prompt | prompts | | n/a | n/a | | | |
+
+## Coverage ledger
+| Kind | Name | Tier | Status | Phase | Notes |
+|------|------|------|--------|-------|-------|
+| tool | `workspace_load` | stable | exercised | 0 | |
+| tool | `create_file_apply` | experimental | skipped-safety | 10 | conservative audit on non-disposable repo |
+| resource | `server_catalog` | stable | exercised | 0, 15 | |
+| prompt | `discover_capabilities` | experimental | exercised | 16 | |
 
 ## Verified tools (working)
 - `tool_name` — one-line observation
@@ -506,12 +555,12 @@ If there are **zero** new issues, still write sections 1–4 and 6–9; in secti
 ## Performance observations
 - `tool_name` — input scale, ~Ns wall-clock (or "All tools responded within expected bounds")
 
-## Backlog regression check
-| AUDIT-ID | Summary | Status |
-|----------|---------|--------|
-| AUDIT-XX | one-line summary | still reproduces / partially fixed / candidate for closure |
+## Known issue regression check
+| Source id | Summary | Status |
+|-----------|---------|--------|
+| issue-or-backlog-id | one-line summary | still reproduces / partially fixed / candidate for closure |
 
-## Known backlog cross-check
+## Known issue cross-check
 - …
 ```
 
@@ -524,8 +573,9 @@ The file must exist at the canonical path above (or the documented fallback). Cr
 ## Tools Reference — Complete Surface Inventory
 
 > **Maintenance note:** This appendix must be kept in sync with the actual server surface.
+> The live catalog from Phase 0 is authoritative. Treat this appendix as a convenience snapshot; if it drifts from the running server, record prompt drift and trust the live catalog.
 > When tools, resources, or prompts change, update this section.
-> Last verified: 2026-04-04 — **123 tools | 7 resources | 16 prompts**
+> Last verified: 2026-04-06 against catalog version 2026.03 — **123 tools (56 stable / 67 experimental) | 7 resources (7 stable) | 16 prompts (16 experimental)**
 
 ### Tools by Category (123 total)
 

--- a/ai_docs/prompts/test-suite-audit.md
+++ b/ai_docs/prompts/test-suite-audit.md
@@ -1,0 +1,42 @@
+# Prompt: Comprehensive test suite audit (quality, performance, design)
+
+<!-- purpose: Reusable prompt to audit tests for slowness, duplication, workspace/init smells, and SRP—tests should find bugs, not add risk. -->
+
+**Mission:** Audit every test for speed, focus, and design so the suite validates the product without becoming a source of slowness or instability—especially wherever tests pay repeated or poorly-scoped costs for **initialization**, **shared runtime state**, and **I/O-heavy dependencies** (workspace, filesystem, process, network).
+
+---
+
+## Full prompt (copy for agents)
+
+Perform a **full pass over the automated tests** in this repository. The goal is to ensure the test code **surfaces product defects** without **creating its own** reliability or performance problems.
+
+### Performance and efficiency
+
+Prioritize **categories of risk**, then tie findings to **concrete code paths** (file, type, method).
+
+- Flag patterns that tend to make tests **slow, flaky, or resource-heavy**, including:
+  - **Lifecycle mistakes:** one expensive resource created per test when suite- or class-scoped reuse (with correct isolation) would do; missing teardown; leaks or ordering dependence.
+  - **Duplicate work:** repeated solution/workspace/project loads, repeated DI container builds, redundant builds or file I/O where a narrower or cached setup suffices.
+  - **Contention and ordering:** shared locks, static mutable state, or global gates exercised in parallel without clear rules.
+  - **Time-based hacks:** `Thread.Sleep`, arbitrary timeouts, or polling used in place of deterministic synchronization or proper await boundaries.
+  - **Over-broad tests:** integration surface larger than the behavior under test, when a slimmer test would catch the same defect faster.
+
+**Illustrative hotspots** in this codebase have included paths involving **service initialization** (e.g. patterns around `InitializeServices` and test bootstrapping), **`WorkspaceManager`**, and **async workspace load** (e.g. `LoadAsync` and similar). Treat these names as **examples of expensive lifecycle and I/O boundaries**, not as an exhaustive checklist. **Report any code with comparable cost or coupling**, including renamed APIs, new helpers, or different entry points that play the same role.
+
+**Anti-anchoring:** Do **not** stop after searching for those identifiers. Severity and recommendations should reflect **whether the pattern is inherently expensive or poorly scoped**, not whether it matches a historical name.
+
+### Design and architecture
+
+- Assess **single responsibility** within test classes and helpers: helpers that do too much, “god” fixtures, and tests that assert multiple unrelated behaviors.
+- Call out **architectural smells in tests**: unclear layering (fast unit-style vs heavier integration), tests that depend on implementation details of unrelated modules, and shared mutable state without clear lifecycle rules.
+- Prefer **framework-agnostic language** when describing setup: e.g. “suite-level or class-level one-time setup” rather than assuming only one test framework’s attributes—use the patterns this repo actually uses (MSTest, xUnit, NUnit, etc.) when you cite files.
+
+### Bar for “good” tests
+
+- Prefer **minimal, focused** tests: one clear intent per test, the smallest realistic surface area, and fast feedback.
+- Recommend **concrete refactors** where they reduce duplication and risk without hiding real integration gaps: shared fixtures where isolation allows, **deferring** heavy work until a test actually needs it, substituting **fakes or narrow doubles** for I/O-heavy dependencies when the test does not require the full stack.
+
+### Deliverable
+
+- A structured report: **issues found** (with file/class references), **severity** (e.g. slow, fragile, SRP, duplication), and **actionable recommendations**. Be thorough; prioritize clarity over brevity where tradeoffs matter.
+- Where an issue resembles a known pattern (e.g. repeated workspace load) but uses **different** symbols, say so explicitly so maintainers see the **category**, not only a string match.

--- a/ai_docs/references/tooling/mcp-clients.md
+++ b/ai_docs/references/tooling/mcp-clients.md
@@ -33,9 +33,32 @@
 - Any client that supports **stdio MCP** can run the same command line as above.
 - Pass no extra arguments unless your client documents them; the server uses environment variables for tuning (see `ai_docs/runtime.md` — e.g. execution gate, timeouts where documented).
 
-## Claude Code / Codex / other agents
+## Claude Code
+
+**Plugin install (recommended):**
+
+```
+/plugin marketplace add darylmcd/Roslyn-Backed-MCP
+/plugin install roslyn-mcp@roslyn-mcp-marketplace
+```
+
+This installs the MCP server + 10 curated skills + safety hooks. Requires `roslynmcp` on PATH (`dotnet tool install -g RoslynMcp`).
+
+**Manual MCP config (alternative):**
 
 - Configure the MCP server with the same **stdio** pattern: command `roslynmcp` or `dotnet` with args `run --project ...`.
+
+**Local plugin dev:**
+
+```
+claude --plugin-dir /path/to/Roslyn-Backed-MCP
+```
+
+Point agents at **`ai_docs/README.md`** for bootstrap and **`ai_docs/runtime.md`** for policy.
+
+## Other agents (Codex, etc.)
+
+- Configure the MCP server with **stdio**: command `roslynmcp` or `dotnet` with args `run --project ...`.
 - Point agents at **`ai_docs/README.md`** for bootstrap and **`ai_docs/runtime.md`** for policy.
 
 ## Operational checklist

--- a/ai_docs/reports/2026-04-06-test-suite-audit.md
+++ b/ai_docs/reports/2026-04-06-test-suite-audit.md
@@ -1,0 +1,211 @@
+# Test Suite Audit - 2026-04-06
+
+## Scope
+
+- Reviewed the full test project under `tests/RoslynMcp.Tests/`.
+- Executed `dotnet test RoslynMcp.slnx --nologo`.
+- Current suite state: 210 passed, 0 failed, 0 skipped, test duration 120.6s, overall command duration 127.2s.
+- Reuse vs isolation snapshot:
+  - `GetOrLoadWorkspaceIdAsync(...)`: 18 call sites reusing the shared sample workspace.
+  - `CreateSampleSolutionCopy()`: 41 call sites creating isolated on-disk copies of the sample solution.
+
+## Findings
+
+### 1. High | SRP, shared state, suite throughput
+
+**Where**
+
+- `tests/RoslynMcp.Tests/TestBase.cs:9`
+- `tests/RoslynMcp.Tests/TestBase.cs:73`
+- `tests/RoslynMcp.Tests/TestBase.cs:109`
+- `tests/RoslynMcp.Tests/TestBase.cs:266`
+- `tests/RoslynMcp.Tests/TestBase.cs:298`
+- `tests/RoslynMcp.Tests/TestBase.cs:323`
+- `tests/RoslynMcp.Tests/AssemblyInfo.cs:3`
+- `tests/RoslynMcp.Tests/AssemblyCleanup.cs:6`
+
+**What**
+
+`TestBase` is still the test suite's central god fixture. It owns MSBuild initialization, a large static service graph, workspace lifetime, shared workspace caching, repository path discovery, sample solution copy helpers, and final assembly cleanup. The test assembly is also globally marked `[DoNotParallelize]`, and per-class `DisposeServices()` calls are intentionally no-ops.
+
+**Why it matters**
+
+- Every test class that inherits from `TestBase` is coupled to the same static runtime state.
+- One change to shared service construction or workspace behavior can fan out into broad, hard-to-localize failures.
+- The non-parallel assembly setting keeps the suite stable, but it also means every test pays for serialized execution even when the test itself is read-only and parallel-safe.
+- Raising `MaxConcurrentWorkspaces` to 64 in tests avoids earlier lock contention, but it also shows the fixture has become responsible for suite-wide capacity planning.
+
+**Recommendation**
+
+- Keep the recent workspace-cache mitigation, but split responsibilities now that the root contention issue is understood.
+- Extract a `TestServiceContainer` for service construction/lifetime, a `SharedWorkspaceFixture` for cached sample-solution loading, and a `TestFixtures` helper for path/copy utilities.
+- Move tests that only validate JSON shape, prompt/resource output, or single-service behavior off the global fixture where possible.
+- Revisit assembly-wide `DoNotParallelize` after the shared-state surface shrinks.
+
+**Tracking**
+
+- This aligns with the existing backlog row `testbase-srp-split`.
+
+### 2. Medium | Duplicate I/O-heavy copy/load loops across mutation suites
+
+**Where**
+
+- `tests/RoslynMcp.Tests/TestBase.cs:323`
+- `tests/RoslynMcp.Tests/TestBase.cs:354`
+- `tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs:22`
+- `tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs:225`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:301`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:391`
+- `tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs:21`
+- `tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs:99`
+- `tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs:21`
+- `tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs:101`
+
+**What**
+
+The suite now reuses the shared sample workspace well for read-only integration coverage, but mutation-style tests still repeat the same expensive harness over and over: copy the full sample solution tree to `%TEMP%`, load the copied workspace, mutate files on disk, then recursively delete the copied tree.
+
+`ProjectMutationIntegrationTests` is the clearest example: eight tests each create a fresh solution copy and load a fresh workspace. The same pattern shows up in `IntegrationTests`, `OrchestrationIntegrationTests`, `CrossProjectRefactoringIntegrationTests`, `FileOperationIntegrationTests`, `TypeExtractionTests`, `TypeMoveTests`, `UndoIntegrationTests`, and others.
+
+**Why it matters**
+
+- Full-directory copies are expensive compared with the actual assertions in many of these tests.
+- The setup boilerplate dominates the test bodies, which increases maintenance cost and hides the true intent of each test.
+- Cleanup is best-effort recursive deletion, so file handle timing problems can leave temp trees behind.
+- The suite is stable today, but this pattern is the main reason growth will push runtime upward.
+
+**Recommendation**
+
+- Introduce a per-class copied-workspace fixture for mutation-heavy suites, with explicit reset helpers for the few files each test actually changes.
+- Keep full isolated copies for cross-project and graph-shape tests, but avoid paying that cost when only one project file or one source file changes.
+- Consolidate the repeated `copy -> load -> mutate -> delete` harness into one helper per concern instead of open-coded copies in many classes.
+
+### 3. Medium | Kitchen-sink integration classes blur concerns and widen failure radius
+
+**Where**
+
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:7`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:25`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:100`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:227`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:301`
+- `tests/RoslynMcp.Tests/IntegrationTests.cs:391`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:11`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:29`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:70`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:234`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:262`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:282`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:348`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:394`
+
+**What**
+
+`IntegrationTests` mixes workspace metadata, symbol search, navigation, diagnostics, and refactoring preview/apply coverage in one class. `ExpandedSurfaceIntegrationTests` mixes JSON contract checks, prompt/resource validation, repo-solution analysis, edit application, and coverage-tool orchestration.
+
+**Why it matters**
+
+- Failures become harder to triage because the class is organized around history, not one behavior area.
+- Broad classes encourage broad class initialization and make it harder to reason about which setup is actually necessary.
+- The suite loses a clean separation between fast contract tests and heavier end-to-end behavior tests.
+
+**Recommendation**
+
+- Split `IntegrationTests` into smaller classes such as workspace-core, symbol-navigation, diagnostics, and preview-apply.
+- Split `ExpandedSurfaceIntegrationTests` into tool-contract, resources-prompts, edit-apply, and heavy repo-solution/process coverage.
+- Keep each class on one setup pattern so the cost of its fixture is obvious.
+
+### 4. Medium | External and process-heavy tests are mixed into the default lane without explicit categorization
+
+**Where**
+
+- `tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs:19`
+- `tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs:21`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:234`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:237`
+- `tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs:394`
+- `tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs:22`
+- `tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs:225`
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:85`
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:93`
+
+**What**
+
+Several tests exercise heavier boundaries than the default sample-workspace path:
+
+- `ScanNuGetVulnerabilitiesAsync_ReturnsStructuredResult` depends on a vulnerability scan path that shells out and can hit NuGet infrastructure.
+- `Reflection_And_Di_Analysis_Run_On_Repo_Solution` loads the repository solution itself instead of the small sample fixture.
+- `TestCoverageTool_Returns_Structured_Response` drives coverage execution through the tool surface.
+- `SecurityDiagnosticIntegrationTests` loads a second solution and reruns analyzer-backed checks over it.
+- `PerformanceBaselineTests` intentionally perform wall-clock checks with real workspace loads.
+
+**Why it matters**
+
+- These tests are valid, but they are materially slower and more environment-sensitive than the rest of the suite.
+- They raise the floor for every local default test run.
+- When one of them flakes, the failure mode looks like a normal integration failure even though the root cause is usually process, network, analyzer availability, or broader machine state.
+
+**Recommendation**
+
+- Add explicit categories such as `Network`, `Process`, `RepoSolution`, and `Performance`.
+- Keep them in full validation, but allow fast local runs and focused CI lanes to exclude them when appropriate.
+- The NuGet vulnerability scan test already has a matching backlog item (`vuln-scan-network-mock`); the other heavy categories are still untracked.
+
+### 5. Low/Medium | One test still uses arbitrary delay for synchronization
+
+**Where**
+
+- `tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs:65`
+- `tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs:84`
+
+**What**
+
+`Validation_Service_Serializes_Commands_For_The_Same_Workspace` correctly uses a controllable fake runner for the long-running command, but it still pauses for 150ms before asserting that only one command is running.
+
+**Why it matters**
+
+- Fixed delays are fragile on slow agents and wasteful on fast ones.
+- The test already owns the fake runner, so a deterministic signal is available with a small helper change.
+
+**Recommendation**
+
+- Replace the delay with an explicit second-invocation signal or queue-entered signal emitted by `BlockingDotnetCommandRunner`.
+- Keep the test in this class; only the synchronization mechanism needs to change.
+
+### 6. Low | Performance baseline tests are useful smoke checks, but they are coarse and environment-sensitive
+
+**Where**
+
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:20`
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:85`
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:93`
+- `tests/RoslynMcp.Tests/PerformanceBaselineTests.cs:96`
+
+**What**
+
+The current budgets are intentionally generous: 10 seconds for symbol search and reference search, 15 seconds for complexity metrics, and 30 seconds for unused symbol scan and workspace load. They catch catastrophic regressions, not nuanced drift.
+
+**Why it matters**
+
+- They are not wrong, but they are noisy as default-lane assertions because the signal is wall-clock time on a mutable local machine.
+- Their value is much higher as a categorized smoke gate than as an always-on precise performance detector.
+
+**Recommendation**
+
+- Keep these tests, but treat them as performance smoke coverage.
+- If the suite grows further, move them behind a dedicated category or validation lane rather than tightening the thresholds in the default lane.
+
+## Positive Notes
+
+- The suite currently passes end to end; this audit found structural and cost risks, not active failures.
+- The shared sample-workspace cache in `GetOrLoadWorkspaceIdAsync(...)` is a real improvement over the old repeated-load pattern.
+- Mutation tests generally do the right thing by operating on isolated copies rather than mutating the shared sample fixture in place.
+- No `Thread.Sleep(...)` usage was found in the test project.
+
+## Suggested Follow-Up Work
+
+If maintainers want to track the unaddressed items from this audit, the cleanest backlog candidates are:
+
+- `test-suite-parallel-lane-split`
+- `test-suite-heavy-fixture-reuse`
+- `test-suite-remove-fixed-delay`

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -30,6 +30,7 @@ Optional overrides read at startup from `src/RoslynMcp.Host.Stdio/Program.cs`. V
 | `ROSLYNMCP_MAX_SOURCE_GENERATED_DOCS` | `WorkspaceManagerOptions.MaxSourceGeneratedDocuments` | 500 |
 | `ROSLYNMCP_BUILD_TIMEOUT_SECONDS` | `ValidationServiceOptions.BuildTimeout` | 5 minutes |
 | `ROSLYNMCP_TEST_TIMEOUT_SECONDS` | `ValidationServiceOptions.TestTimeout` | 10 minutes |
+| `ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS` | `ValidationServiceOptions.VulnerabilityScanTimeout` | 2 minutes |
 | `ROSLYNMCP_MAX_RELATED_FILES` | `ValidationServiceOptions.MaxRelatedFiles` | 25 |
 | `ROSLYNMCP_PREVIEW_MAX_ENTRIES` | `PreviewStoreOptions.MaxEntries` | 20 |
 | `ROSLYNMCP_PREVIEW_TTL_MINUTES` | `PreviewStoreOptions.TtlMinutes` | 5 minutes |
@@ -37,6 +38,16 @@ Optional overrides read at startup from `src/RoslynMcp.Host.Stdio/Program.cs`. V
 | `ROSLYNMCP_RATE_LIMIT_WINDOW_SECONDS` | `ExecutionGateOptions.RateLimitWindow` | 60 |
 | `ROSLYNMCP_REQUEST_TIMEOUT_SECONDS` | `ExecutionGateOptions.RequestTimeout` | 120 |
 | `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` | `SecurityOptions.PathValidationFailOpen` | `false` (must parse as `true`/`false` to override) |
+
+## Claude Code Plugin
+
+The server is also distributed as a Claude Code plugin. Plugin-relevant configuration:
+
+- `.mcp.json` passes user-configurable env vars via `${user_config.*}` placeholders to the `roslynmcp` process.
+- `hooks/hooks.json` defines PreToolUse and PostToolUse hooks for safety enforcement.
+- Plugin skills in `skills/` compose multiple MCP tools into guided workflows; they run as Claude Code skill prompts, not as MCP protocol extensions.
+
+Install via: `/plugin marketplace add darylmcd/Roslyn-Backed-MCP` then `/plugin install roslyn-mcp@roslyn-mcp-marketplace`
 
 ## MCP Runtime Notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,16 @@ Human-facing documentation for the Roslyn-Backed MCP Server.
 | `experimental-promotion-analysis.md` | Stable vs experimental tool counts and promotion notes |
 | `large-solution-profiling-baseline.md` | Methodology and notes for profiling large MSBuild solutions |
 
+## Claude Code Plugin
+
+The server ships as a Claude Code plugin. Plugin-specific documentation:
+
+- `README.md` § *Claude Code Plugin Installation* — install commands, skill table, hook descriptions
+- `setup.md` § *Claude Code Plugin* — plugin packaging, local dev, validation commands
+- `product-contract.md` § *Claude Code Plugin Surface* — how skills relate to the MCP tool tiers
+
+Plugin source files: `.claude-plugin/`, `skills/`, `hooks/`, `.mcp.json`
+
 ## Related
 
 - For AI agent session bootstrap: `AGENTS.md`

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -74,6 +74,18 @@ Current experimental families:
 - Visual Studio or editor-backed live-workspace parity is a separate integration path, not a promise of the current host.
 - Destructive operations remain bounded to explicit edit requests or preview/apply flows.
 
+## Claude Code Plugin Surface
+
+The server is also distributed as a Claude Code plugin (`roslyn-mcp`) providing:
+
+- **MCP server**: `roslynmcp` via stdio with user-configurable env vars
+- **10 skills**: analyze, refactor, review, document, security, dead-code, test-coverage, migrate-package, explain-error, complexity
+- **Safety hooks**: PreToolUse guard (blocks apply without prior preview) and PostToolUse reminder (compile-check after structural refactoring)
+
+Skills compose multiple Roslyn MCP tools into guided workflows. They are not part of the MCP protocol surface — they are Claude Code-specific orchestration on top of the stable and experimental tool tiers documented above.
+
+Install: `/plugin marketplace add darylmcd/Roslyn-Backed-MCP` then `/plugin install roslyn-mcp@roslyn-mcp-marketplace`
+
 ## Agent Guidance
 
 - Load a workspace first and keep using the returned `workspaceId`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,6 +58,28 @@ Post-release candidates:
 - opt-in warmup for enterprise solutions
 - separate performance profile for remote hosting
 
+## Claude Code Plugin Distribution
+
+Decision: ship as a Claude Code plugin alongside the existing dotnet global tool and Docker distribution.
+
+Reason:
+
+- plugin bundles MCP server + curated skills + safety hooks into a single installable unit
+- lowers barrier to entry for Claude Code users (two-command install)
+- skills compose the 147 MCP tools into guided workflows for common tasks
+- hooks enforce safety patterns (preview-before-apply, post-refactoring compile-check)
+
+Delivered:
+
+- `.claude-plugin/plugin.json` and `marketplace.json` for distribution via GitHub
+- 10 skills: analyze, refactor, review, document, security, dead-code, test-coverage, migrate-package, explain-error, complexity
+- Safety hooks: PreToolUse apply guard, PostToolUse compile-check reminder
+
+Future direction:
+
+- publish to the MCP Registry for broader discoverability beyond GitHub
+- add skills as the MCP tool surface grows (e.g., architecture analysis, migration planning)
+
 ## Execution Tracks And Primary Touchpoints
 
 Use these tracks to quickly identify where to implement follow-up work:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -35,6 +35,26 @@ GitHub Actions `ci` workflow uploads:
 
 Download from the workflow run’s **Artifacts** section. Requires a GitHub account with access to the repository.
 
+## Claude Code Plugin
+
+The server is also packaged as a **Claude Code plugin** with 10 curated skills and safety hooks.
+
+| Form | Config or source | Command(s) | Notes |
+|------|------------------|------------|-------|
+| Plugin marketplace install | `.claude-plugin/marketplace.json` | `/plugin marketplace add darylmcd/Roslyn-Backed-MCP` then `/plugin install roslyn-mcp@roslyn-mcp-marketplace` | Installs MCP server + 10 skills + hooks. Requires `roslynmcp` on PATH. |
+| Plugin local dev | `.claude-plugin/plugin.json`, `skills/`, `hooks/` | `claude --plugin-dir /path/to/Roslyn-Backed-MCP` | Load plugin from local checkout for testing. |
+| Plugin validation | `.claude-plugin/` | `claude plugin validate .` | Validates plugin and marketplace manifests. |
+
+Plugin components:
+
+| Directory | Contents |
+|-----------|----------|
+| `.claude-plugin/` | Plugin manifest (`plugin.json`) and marketplace descriptor (`marketplace.json`) |
+| `skills/` | 10 SKILL.md files: analyze, refactor, review, document, security, dead-code, test-coverage, migrate-package, explain-error, complexity |
+| `hooks/` | `hooks.json` with PreToolUse (preview-before-apply guard) and PostToolUse (compile-check reminder) |
+
+See `README.md` § *Claude Code Plugin Installation* for the full skill table.
+
 ## Related
 
 - Agent-facing commands and MCP policy: `ai_docs/runtime.md`

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -78,13 +78,16 @@ static ValidationServiceOptions BindValidationServiceOptions()
     var opts = new ValidationServiceOptions();
     var buildSec = Environment.GetEnvironmentVariable("ROSLYNMCP_BUILD_TIMEOUT_SECONDS");
     var testSec = Environment.GetEnvironmentVariable("ROSLYNMCP_TEST_TIMEOUT_SECONDS");
+    var vulnSec = Environment.GetEnvironmentVariable("ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS");
 
     if (int.TryParse(buildSec, out var bs) && bs > 0)
-        opts = new ValidationServiceOptions { BuildTimeout = TimeSpan.FromSeconds(bs), TestTimeout = opts.TestTimeout, MaxRelatedFiles = opts.MaxRelatedFiles };
+        opts = opts with { BuildTimeout = TimeSpan.FromSeconds(bs) };
     if (int.TryParse(testSec, out var ts) && ts > 0)
-        opts = new ValidationServiceOptions { BuildTimeout = opts.BuildTimeout, TestTimeout = TimeSpan.FromSeconds(ts), MaxRelatedFiles = opts.MaxRelatedFiles };
+        opts = opts with { TestTimeout = TimeSpan.FromSeconds(ts) };
     if (int.TryParse(Environment.GetEnvironmentVariable("ROSLYNMCP_MAX_RELATED_FILES"), out var mrf) && mrf > 0)
-        opts = new ValidationServiceOptions { BuildTimeout = opts.BuildTimeout, TestTimeout = opts.TestTimeout, MaxRelatedFiles = mrf };
+        opts = opts with { MaxRelatedFiles = mrf };
+    if (int.TryParse(vulnSec, out var vs) && vs > 0)
+        opts = opts with { VulnerabilityScanTimeout = TimeSpan.FromSeconds(vs) };
 
     return opts;
 }

--- a/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
@@ -16,15 +16,18 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
     private readonly IWorkspaceManager _workspace;
     private readonly IGatedCommandExecutor _executor;
     private readonly ILogger<DependencyAnalysisService> _logger;
+    private readonly ValidationServiceOptions _options;
 
     public DependencyAnalysisService(
         IWorkspaceManager workspace,
         IGatedCommandExecutor executor,
-        ILogger<DependencyAnalysisService> logger)
+        ILogger<DependencyAnalysisService> logger,
+        ValidationServiceOptions? options = null)
     {
         _workspace = workspace;
         _executor = executor;
         _logger = logger;
+        _options = options ?? new ValidationServiceOptions();
     }
 
     public async Task<NamespaceDependencyGraphDto> GetNamespaceDependenciesAsync(
@@ -396,7 +399,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
             workspaceId,
             targetPath,
             args,
-            TimeSpan.FromSeconds(120),
+            _options.VulnerabilityScanTimeout,
             ct).ConfigureAwait(false);
 
         sw.Stop();

--- a/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
@@ -3,7 +3,7 @@ namespace RoslynMcp.Roslyn.Services;
 /// <summary>
 /// Configuration options for <c>ValidationService</c> build and test timeouts.
 /// </summary>
-public sealed class ValidationServiceOptions
+public sealed record ValidationServiceOptions
 {
     /// <summary>
     /// Gets the maximum time allowed for a build operation before it is cancelled.
@@ -23,4 +23,11 @@ public sealed class ValidationServiceOptions
     /// Defaults to 25.
     /// </summary>
     public int MaxRelatedFiles { get; init; } = 25;
+
+    /// <summary>
+    /// Gets the maximum time allowed for a NuGet vulnerability scan
+    /// (<c>dotnet list package --vulnerable</c>) before it is cancelled.
+    /// Defaults to 2 minutes.
+    /// </summary>
+    public TimeSpan VulnerabilityScanTimeout { get; init; } = TimeSpan.FromMinutes(2);
 }

--- a/tests/RoslynMcp.Tests/AssemblyCleanup.cs
+++ b/tests/RoslynMcp.Tests/AssemblyCleanup.cs
@@ -6,6 +6,11 @@ public static class AssemblyLifecycle
     [AssemblyCleanup]
     public static void Cleanup()
     {
+        // Dispose shared services owned by TestBase (workspace manager, file watchers,
+        // build host subprocesses). Must run before tempRoot cleanup so we do not race
+        // with file watcher disposal.
+        TestBase.DisposeAssemblyResources();
+
         var tempRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpTests");
         if (Directory.Exists(tempRoot))
         {

--- a/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
+++ b/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
@@ -11,8 +11,7 @@ public sealed class BulkRefactoringTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -11,8 +11,7 @@ public sealed class CohesionAnalysisTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -11,8 +11,7 @@ public sealed class ConsumerAnalysisTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
@@ -9,8 +9,7 @@ public class DiagnosticFixIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -16,8 +16,7 @@ public sealed class ExpandedSurfaceIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
@@ -15,8 +15,7 @@ public sealed class HighValueCoverageIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        SampleWorkspaceId = status.WorkspaceId;
+        SampleWorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/IntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/IntegrationTests.cs
@@ -12,8 +12,7 @@ public class IntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
+++ b/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
@@ -11,8 +11,7 @@ public sealed class NegativeEdgeCaseTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
@@ -9,8 +9,7 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -81,7 +81,10 @@ public class PerformanceBehaviorTests : TestBase
         await commandRunner.FirstInvocationStarted.Task;
 
         var secondTask = buildService.BuildWorkspaceAsync("workspace-a", cts.Token);
-        await Task.Delay(150, cts.Token);
+
+        Assert.IsFalse(
+            secondTask.IsCompleted,
+            "Second build should be waiting on the workspace command gate while the first build is blocked.");
 
         Assert.AreEqual(1, commandRunner.MaxConcurrentCalls);
 

--- a/tests/RoslynMcp.Tests/PromptSmokeTests.cs
+++ b/tests/RoslynMcp.Tests/PromptSmokeTests.cs
@@ -15,8 +15,7 @@ public sealed class PromptSmokeTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
         SecurityService = new SecurityDiagnosticService(
             DiagnosticService,
             WorkspaceManager,

--- a/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
@@ -12,8 +12,7 @@ public sealed class RefactoringToolsIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
@@ -16,8 +16,7 @@ public class SecurityDiagnosticIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
 
         var secTestPath = Path.Combine(RepositoryRootPath, "samples", "SecurityTestProject", "SecurityTestProject.slnx");
         var insecureStatus = await WorkspaceManager.LoadAsync(secTestPath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
@@ -11,8 +11,7 @@ public class SemanticExpansionTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
@@ -11,8 +11,7 @@ public class ServiceCoverageTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -10,6 +10,16 @@ public abstract class TestBase
 {
     private static readonly object _initLock = new();
     private static bool _msbuildInitialized;
+    private static bool _servicesInitialized;
+    private static readonly WorkspaceIdCache _workspaceIdCache = new();
+
+    /// <summary>
+    /// Validation timeouts for integration tests. These match production defaults
+    /// (<see cref="ValidationServiceOptions"/>): timeouts should fail loudly when a real
+    /// regression appears, not be padded to mask perf smells. The shared workspace cache
+    /// below eliminated the previous MSBuild contention that caused 5-minute hangs.
+    /// </summary>
+    private static readonly ValidationServiceOptions TestValidationOptions = new();
 
     protected static IPreviewStore PreviewStore { get; private set; } = null!;
     protected static WorkspaceManager WorkspaceManager { get; private set; } = null!;
@@ -61,20 +71,41 @@ public abstract class TestBase
 
     protected static void InitializeServices()
     {
+        // Idempotent: services and workspace manager are created once per test assembly,
+        // not once per test class. Previously each [ClassInitialize] disposed and recreated
+        // the WorkspaceManager (32 times per run), causing MSBuild file-lock contention on
+        // the shared sample fixtures and unbounded build hangs under load.
         lock (_initLock)
         {
+            if (_servicesInitialized)
+            {
+                return;
+            }
+
             if (!_msbuildInitialized)
             {
                 MsBuildInitializer.EnsureInitialized();
                 _msbuildInitialized = true;
             }
-        }
 
+            InitializeServicesCore();
+            _servicesInitialized = true;
+        }
+    }
+
+    private static void InitializeServicesCore()
+    {
         PreviewStore = new PreviewStore();
+        // Tests retain workspaces across the full assembly run instead of disposing them
+        // per-class. We need a higher limit than the production default (8) because
+        // ~22 test classes load fixture solutions (some loading multiple) without ever
+        // closing them. The cap is still bounded so a runaway test that loads in a loop
+        // will fail loudly rather than exhaust memory.
         WorkspaceManager = new WorkspaceManager(
             NullLogger<WorkspaceManager>.Instance,
             PreviewStore,
-            new FileWatcherService(NullLogger<FileWatcherService>.Instance));
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 64 });
         WorkspaceExecutionGate = new WorkspaceExecutionGate(new ExecutionGateOptions(), WorkspaceManager);
         DotnetCommandRunner = new DotnetCommandRunner();
         GatedCommandExecutor = new GatedCommandExecutor(
@@ -109,14 +140,17 @@ public abstract class TestBase
         BuildService = new BuildService(
             WorkspaceManager,
             GatedCommandExecutor,
-            NullLogger<BuildService>.Instance);
+            NullLogger<BuildService>.Instance,
+            TestValidationOptions);
         TestRunnerService = new TestRunnerService(
             WorkspaceManager,
             GatedCommandExecutor,
-            NullLogger<TestRunnerService>.Instance);
+            NullLogger<TestRunnerService>.Instance,
+            TestValidationOptions);
         TestDiscoveryService = new TestDiscoveryService(
             WorkspaceManager,
-            NullLogger<TestDiscoveryService>.Instance);
+            NullLogger<TestDiscoveryService>.Instance,
+            TestValidationOptions);
         CompletionService = new CompletionService(
             WorkspaceManager,
             NullLogger<CompletionService>.Instance);
@@ -133,7 +167,8 @@ public abstract class TestBase
         DependencyAnalysisService = new DependencyAnalysisService(
             WorkspaceManager,
             GatedCommandExecutor,
-            NullLogger<DependencyAnalysisService>.Instance);
+            NullLogger<DependencyAnalysisService>.Instance,
+            TestValidationOptions);
         CodePatternAnalyzer = new CodePatternAnalyzer(
             WorkspaceManager,
             NullLogger<CodePatternAnalyzer>.Instance);
@@ -206,112 +241,71 @@ public abstract class TestBase
             WorkspaceManager,
             NullLogger<EditorConfigService>.Instance);
 
-        RepositoryRootPath = FindRepositoryRoot();
-        SampleSolutionPath = FindFixturePath("SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");
-        BuildFailureSolutionPath = FindFixturePath("BuildFailureSolution", "BuildFailureSolution.slnx", "BuildFailureSolution.sln");
-        GeneratedDocumentSolutionPath = FindFixturePath("GeneratedDocumentSolution", "GeneratedDocumentSolution.slnx", "GeneratedDocumentSolution.sln");
+        RepositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
+        SampleSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");
+        BuildFailureSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "BuildFailureSolution", "BuildFailureSolution.slnx", "BuildFailureSolution.sln");
+        GeneratedDocumentSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "GeneratedDocumentSolution", "GeneratedDocumentSolution.slnx", "GeneratedDocumentSolution.sln");
     }
 
+    /// <summary>
+    /// No-op since the test assembly now owns service lifetime. Disposal happens in
+    /// <see cref="AssemblyLifecycle.Cleanup"/> after all tests complete. Kept for source
+    /// compatibility with existing <c>[ClassCleanup]</c> hooks across test classes.
+    /// </summary>
     protected static void DisposeServices()
     {
-        WorkspaceManager?.Dispose();
+        // Intentional no-op. See AssemblyLifecycle.Cleanup.
+    }
+
+    /// <summary>
+    /// Disposes the shared <see cref="WorkspaceManager"/> and resets the workspace cache.
+    /// Called from <see cref="AssemblyLifecycle.Cleanup"/> after the entire test assembly
+    /// finishes. Test code should not call this directly.
+    /// </summary>
+    internal static void DisposeAssemblyResources()
+    {
+        lock (_initLock)
+        {
+            if (!_servicesInitialized)
+            {
+                return;
+            }
+
+            try
+            {
+                WorkspaceManager?.Dispose();
+            }
+            catch
+            {
+                // Best-effort: avoid masking real test failures with cleanup errors.
+            }
+
+            _workspaceIdCache.Clear();
+            _servicesInitialized = false;
+        }
+    }
+
+    /// <summary>
+    /// Loads a workspace from the given solution path, caching the resulting <c>WorkspaceId</c>
+    /// so multiple test classes that need the same fixture share a single
+    /// <see cref="Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace"/> instance. Eliminates the
+    /// 22× duplicate <c>SampleSolution</c> loads that previously caused MSBuild file-lock
+    /// contention. Test classes can still call <see cref="WorkspaceManager"/>.<c>LoadAsync</c>
+    /// directly for fixtures they want isolated (e.g., temp copies via
+    /// <see cref="CreateSampleSolutionCopy"/>).
+    /// </summary>
+    protected static async Task<string> GetOrLoadWorkspaceIdAsync(string solutionPath, CancellationToken ct = default)
+    {
+        return await _workspaceIdCache.GetOrLoadAsync(WorkspaceManager, solutionPath, ct).ConfigureAwait(false);
     }
 
     protected static string CreateSampleSolutionCopy()
     {
-        var sampleRoot = Path.GetDirectoryName(SampleSolutionPath)
-            ?? throw new InvalidOperationException("Sample solution root could not be resolved.");
-        var tempRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpTests", Guid.NewGuid().ToString("N"));
-        CopyDirectory(sampleRoot, tempRoot);
-        CopyRepositorySupportFiles(tempRoot);
-
-        var slnxPath = Path.Combine(tempRoot, "SampleSolution.slnx");
-        if (File.Exists(slnxPath))
-        {
-            return slnxPath;
-        }
-
-        var slnPath = Path.Combine(tempRoot, "SampleSolution.sln");
-        if (File.Exists(slnPath))
-        {
-            return slnPath;
-        }
-
-        throw new InvalidOperationException("Copied sample solution is missing a solution file.");
+        return TestFixtureFileSystem.CreateSampleSolutionCopy(RepositoryRootPath, SampleSolutionPath);
     }
 
     protected static void DeleteDirectoryIfExists(string path)
     {
-        if (Directory.Exists(path))
-        {
-            Directory.Delete(path, recursive: true);
-        }
-    }
-
-    private static void CopyDirectory(string sourceDir, string destinationDir)
-    {
-        Directory.CreateDirectory(destinationDir);
-
-        foreach (var file in Directory.GetFiles(sourceDir))
-        {
-            var destinationFile = Path.Combine(destinationDir, Path.GetFileName(file));
-            File.Copy(file, destinationFile, overwrite: true);
-        }
-
-        foreach (var directory in Directory.GetDirectories(sourceDir))
-        {
-            var destinationSubdirectory = Path.Combine(destinationDir, Path.GetFileName(directory));
-            CopyDirectory(directory, destinationSubdirectory);
-        }
-    }
-
-    private static string FindFixturePath(string fixtureDirectory, params string[] candidateFiles)
-    {
-        var dir = RepositoryRootPath;
-        while (dir is not null)
-        {
-            foreach (var candidateFile in candidateFiles)
-            {
-                var candidate = Path.Combine(dir, "samples", fixtureDirectory, candidateFile);
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-
-            dir = Directory.GetParent(dir)?.FullName;
-        }
-
-        throw new InvalidOperationException(
-            $"Could not find fixture '{fixtureDirectory}'. Ensure the samples directory exists at the repo root.");
-    }
-
-    private static string FindRepositoryRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir, "RoslynMcp.slnx")) &&
-                File.Exists(Path.Combine(dir, "Directory.Build.props")))
-            {
-                return dir;
-            }
-
-            dir = Directory.GetParent(dir)?.FullName;
-        }
-
-        throw new InvalidOperationException("Could not find the repository root.");
-    }
-
-    private static void CopyRepositorySupportFiles(string destinationRoot)
-    {
-        foreach (var fileName in new[] { "Directory.Build.props", "Directory.Packages.props", "global.json" })
-        {
-            var sourcePath = Path.Combine(RepositoryRootPath, fileName);
-            if (File.Exists(sourcePath))
-            {
-                File.Copy(sourcePath, Path.Combine(destinationRoot, fileName), overwrite: true);
-            }
-        }
+        TestFixtureFileSystem.DeleteDirectoryIfExists(path);
     }
 }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestFixtureFileSystem.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestFixtureFileSystem.cs
@@ -1,0 +1,102 @@
+namespace RoslynMcp.Tests;
+
+internal static class TestFixtureFileSystem
+{
+    public static string CreateSampleSolutionCopy(string repositoryRootPath, string sampleSolutionPath)
+    {
+        var sampleRoot = Path.GetDirectoryName(sampleSolutionPath)
+            ?? throw new InvalidOperationException("Sample solution root could not be resolved.");
+        var tempRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpTests", Guid.NewGuid().ToString("N"));
+        CopyDirectory(sampleRoot, tempRoot);
+        CopyRepositorySupportFiles(repositoryRootPath, tempRoot);
+
+        var slnxPath = Path.Combine(tempRoot, "SampleSolution.slnx");
+        if (File.Exists(slnxPath))
+        {
+            return slnxPath;
+        }
+
+        var slnPath = Path.Combine(tempRoot, "SampleSolution.sln");
+        if (File.Exists(slnPath))
+        {
+            return slnPath;
+        }
+
+        throw new InvalidOperationException("Copied sample solution is missing a solution file.");
+    }
+
+    public static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    public static string FindFixturePath(string repositoryRootPath, string fixtureDirectory, params string[] candidateFiles)
+    {
+        var dir = repositoryRootPath;
+        while (dir is not null)
+        {
+            foreach (var candidateFile in candidateFiles)
+            {
+                var candidate = Path.Combine(dir, "samples", fixtureDirectory, candidateFile);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find fixture '{fixtureDirectory}'. Ensure the samples directory exists at the repo root.");
+    }
+
+    public static string FindRepositoryRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "RoslynMcp.slnx")) &&
+                File.Exists(Path.Combine(dir, "Directory.Build.props")))
+            {
+                return dir;
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new InvalidOperationException("Could not find the repository root.");
+    }
+
+    private static void CopyDirectory(string sourceDir, string destinationDir)
+    {
+        Directory.CreateDirectory(destinationDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            var destinationFile = Path.Combine(destinationDir, Path.GetFileName(file));
+            File.Copy(file, destinationFile, overwrite: true);
+        }
+
+        foreach (var directory in Directory.GetDirectories(sourceDir))
+        {
+            var destinationSubdirectory = Path.Combine(destinationDir, Path.GetFileName(directory));
+            CopyDirectory(directory, destinationSubdirectory);
+        }
+    }
+
+    private static void CopyRepositorySupportFiles(string repositoryRootPath, string destinationRoot)
+    {
+        foreach (var fileName in new[] { "Directory.Build.props", "Directory.Packages.props", "global.json" })
+        {
+            var sourcePath = Path.Combine(repositoryRootPath, fileName);
+            if (File.Exists(sourcePath))
+            {
+                File.Copy(sourcePath, Path.Combine(destinationRoot, fileName), overwrite: true);
+            }
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
@@ -1,0 +1,39 @@
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Tests;
+
+internal sealed class WorkspaceIdCache
+{
+    private readonly Dictionary<string, string> _workspaceIds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+
+    public async Task<string> GetOrLoadAsync(IWorkspaceManager workspaceManager, string solutionPath, CancellationToken ct = default)
+    {
+        if (_workspaceIds.TryGetValue(solutionPath, out var cachedId))
+        {
+            return cachedId;
+        }
+
+        await _loadGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_workspaceIds.TryGetValue(solutionPath, out cachedId))
+            {
+                return cachedId;
+            }
+
+            var status = await workspaceManager.LoadAsync(solutionPath, ct).ConfigureAwait(false);
+            _workspaceIds[solutionPath] = status.WorkspaceId;
+            return status.WorkspaceId;
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    public void Clear()
+    {
+        _workspaceIds.Clear();
+    }
+}

--- a/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
@@ -9,8 +9,7 @@ public class ValidationIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -12,8 +12,7 @@ public sealed class ValidationToolsIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
@@ -12,8 +12,7 @@ public sealed class WorkspaceResourceTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
@@ -12,8 +12,7 @@ public sealed class WorkspaceToolsIntegrationTests : TestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        var status = await WorkspaceManager.LoadAsync(SampleSolutionPath, CancellationToken.None);
-        WorkspaceId = status.WorkspaceId;
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]


### PR DESCRIPTION
## Summary
- add Claude Code plugin and runtime documentation updates
- wire configurable vulnerability scan timeout through validation options
- improve test infrastructure with shared workspace caching, extracted fixture helpers, and a deterministic performance test

## Test plan
- [x] dotnet test RoslynMcp.slnx --nologo --filter FullyQualifiedName~PerformanceBehaviorTests
- [x] dotnet test RoslynMcp.slnx --nologo --filter "FullyQualifiedName~IntegrationTests|FullyQualifiedName~ProjectMutationIntegrationTests|FullyQualifiedName~HardeningBehaviorTests"
- [x] dotnet test RoslynMcp.slnx --nologo
- [x] ./eng/verify-ai-docs.ps1

Generated with [Claude Code](https://claude.com/claude-code)