### PR TITLE
perf: parallelize reference, unused-symbol, and diagnostic hot paths

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -12,6 +13,17 @@ public sealed class DiagnosticService : IDiagnosticService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly ILogger<DiagnosticService> _logger;
+
+    /// <summary>
+    /// Cache of full per-project diagnostic lists, keyed by workspaceId. The detail-lookup
+    /// path (<see cref="GetDiagnosticDetailsAsync"/>) is almost always called immediately
+    /// after <see cref="GetDiagnosticsAsync"/>, so we keep the warm Diagnostic objects
+    /// around to skip recompiling and re-running analyzers. Invalidates on workspace
+    /// version bump.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, DiagnosticCacheEntry> _diagnosticCache = new();
+
+    private sealed record DiagnosticCacheEntry(int Version, IReadOnlyList<Diagnostic> Diagnostics);
 
     public DiagnosticService(IWorkspaceManager workspace, ILogger<DiagnosticService> logger)
     {
@@ -40,6 +52,7 @@ public sealed class DiagnosticService : IDiagnosticService
         {
             var compiler = new List<DiagnosticDto>();
             var analyzer = new List<DiagnosticDto>();
+            var raw = new List<Diagnostic>();
 
             var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
             if (compilation is null)
@@ -47,11 +60,12 @@ public sealed class DiagnosticService : IDiagnosticService
                 compiler.Add(new DiagnosticDto(
                     "WORKSPACE001", $"Could not get compilation for project '{project.Name}'",
                     "Error", "Workspace", project.FilePath, null, null, null, null));
-                return (compiler, analyzer);
+                return (compiler, analyzer, raw);
             }
 
             foreach (var diagnostic in compilation.GetDiagnostics(ct))
             {
+                raw.Add(diagnostic);
                 if (MatchesFilter(diagnostic, fileFilter, minSeverity))
                 {
                     compiler.Add(SymbolMapper.ToDiagnosticDto(diagnostic));
@@ -75,6 +89,7 @@ public sealed class DiagnosticService : IDiagnosticService
                 var projectAnalyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(ct).ConfigureAwait(false);
                 foreach (var diagnostic in projectAnalyzerDiagnostics)
                 {
+                    raw.Add(diagnostic);
                     if (MatchesFilter(diagnostic, fileFilter, minSeverity))
                     {
                         analyzer.Add(SymbolMapper.ToDiagnosticDto(diagnostic));
@@ -82,12 +97,22 @@ public sealed class DiagnosticService : IDiagnosticService
                 }
             }
 
-            return (compiler, analyzer);
+            return (compiler, analyzer, raw);
         });
 
         var results = await Task.WhenAll(projectTasks).ConfigureAwait(false);
         var compilerDiagnostics = results.SelectMany(r => r.compiler).ToList();
         var analyzerDiagnostics = results.SelectMany(r => r.analyzer).ToList();
+
+        // Cache the unfiltered Diagnostic objects so the detail-lookup path (which is
+        // almost always called next) can skip recompilation. Only cache when this call
+        // covered the whole solution; partial filters would produce a misleading cache.
+        if (projectFilter is null && fileFilter is null)
+        {
+            var version = _workspace.GetCurrentVersion(workspaceId);
+            var allRaw = results.SelectMany(r => r.raw).ToList();
+            _diagnosticCache[workspaceId] = new DiagnosticCacheEntry(version, allRaw);
+        }
 
         var compilerErrors = compilerDiagnostics.Count(d => d.Severity == "Error");
         var analyzerErrors = analyzerDiagnostics.Count(d => d.Severity == "Error");
@@ -161,19 +186,32 @@ public sealed class DiagnosticService : IDiagnosticService
         int column,
         CancellationToken ct)
     {
-        var solution = _workspace.GetCurrentSolution(workspaceId);
-        var diagnostic = await FindDiagnosticAsync(solution, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
-        if (diagnostic is null)
+        // Fast path: most callers invoke this immediately after GetDiagnosticsAsync, so the
+        // exact Diagnostic they want is already in the cache. Skip the recompile entirely.
+        var version = _workspace.GetCurrentVersion(workspaceId);
+        if (_diagnosticCache.TryGetValue(workspaceId, out var cached) && cached.Version == version)
         {
-            return null;
+            foreach (var d in cached.Diagnostics)
+            {
+                if (DiagnosticMatchesLocation(d, diagnosticId, filePath, line, column))
+                {
+                    return BuildDetailsDto(d);
+                }
+            }
         }
 
-        return new DiagnosticDetailsDto(
-            Diagnostic: SymbolMapper.ToDiagnosticDto(diagnostic),
-            Description: BuildDiagnosticDescription(diagnostic),
-            HelpLinkUri: BuildHelpLink(diagnostic.Id),
-            SupportedFixes: GetSupportedFixes(diagnostic.Id));
+        // Cold path: cache miss (no prior list call, or workspace was reloaded). Re-run
+        // the search across projects in parallel and warm the cache for next time.
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var diagnostic = await FindDiagnosticAsync(workspaceId, solution, version, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
+        return diagnostic is null ? null : BuildDetailsDto(diagnostic);
     }
+
+    private static DiagnosticDetailsDto BuildDetailsDto(Diagnostic diagnostic) => new(
+        Diagnostic: SymbolMapper.ToDiagnosticDto(diagnostic),
+        Description: BuildDiagnosticDescription(diagnostic),
+        HelpLinkUri: BuildHelpLink(diagnostic.Id),
+        SupportedFixes: GetSupportedFixes(diagnostic.Id));
 
     private static string BuildDiagnosticDescription(Diagnostic diagnostic)
     {
@@ -301,49 +339,60 @@ public sealed class DiagnosticService : IDiagnosticService
                lineSpan.StartLinePosition.Character + 1 == column;
     }
 
-    private static async Task<Diagnostic?> FindDiagnosticAsync(
+    private async Task<Diagnostic?> FindDiagnosticAsync(
+        string workspaceId,
         Solution solution,
+        int version,
         string diagnosticId,
         string filePath,
         int line,
         int column,
         CancellationToken ct)
     {
-        foreach (var project in solution.Projects)
+        // Walk all projects in parallel — each one is an independent compilation+analyzer
+        // pass, and there's no reason to serialize them. Roslyn's compilation and analyzer
+        // APIs are thread-safe over immutable Project/Compilation objects.
+        var projectTasks = solution.Projects.Select(project => CollectProjectDiagnosticsAsync(project, ct));
+        var perProjectResults = await Task.WhenAll(projectTasks).ConfigureAwait(false);
+
+        // Warm the cache so a follow-up details lookup (or a project_diagnostics call that
+        // hits an unrelated diagnostic on the same workspace) hits the fast path.
+        var allDiagnostics = perProjectResults.SelectMany(d => d).ToList();
+        _diagnosticCache[workspaceId] = new DiagnosticCacheEntry(version, allDiagnostics);
+
+        foreach (var diagnostic in allDiagnostics)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
-            if (compilation is null)
-                continue;
-
-            foreach (var diagnostic in compilation.GetDiagnostics(ct))
-            {
-                if (DiagnosticMatchesLocation(diagnostic, diagnosticId, filePath, line, column))
-                    return diagnostic;
-            }
-
-            var analyzers = project.AnalyzerReferences
-                .SelectMany(reference => reference.GetAnalyzers(project.Language))
-                .ToImmutableArray();
-            if (analyzers.Length == 0)
-                continue;
-
-            var compilationWithAnalyzers = compilation.WithAnalyzers(
-                analyzers,
-                new CompilationWithAnalyzersOptions(
-                    options: project.AnalyzerOptions,
-                    onAnalyzerException: null,
-                    concurrentAnalysis: true,
-                    logAnalyzerExecutionTime: false,
-                    reportSuppressedDiagnostics: false));
-
-            var analyzerDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync(ct).ConfigureAwait(false);
-            foreach (var diagnostic in analyzerDiagnostics)
-            {
-                if (DiagnosticMatchesLocation(diagnostic, diagnosticId, filePath, line, column))
-                    return diagnostic;
-            }
+            if (DiagnosticMatchesLocation(diagnostic, diagnosticId, filePath, line, column))
+                return diagnostic;
         }
 
         return null;
+    }
+
+    private static async Task<IReadOnlyList<Diagnostic>> CollectProjectDiagnosticsAsync(Project project, CancellationToken ct)
+    {
+        var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+        if (compilation is null) return [];
+
+        var collected = new List<Diagnostic>();
+        collected.AddRange(compilation.GetDiagnostics(ct));
+
+        var analyzers = project.AnalyzerReferences
+            .SelectMany(reference => reference.GetAnalyzers(project.Language))
+            .ToImmutableArray();
+        if (analyzers.Length == 0) return collected;
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            analyzers,
+            new CompilationWithAnalyzersOptions(
+                options: project.AnalyzerOptions,
+                onAnalyzerException: null,
+                concurrentAnalysis: true,
+                logAnalyzerExecutionTime: false,
+                reportSuppressedDiagnostics: false));
+
+        var analyzerDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync(ct).ConfigureAwait(false);
+        collected.AddRange(analyzerDiagnostics);
+        return collected;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -27,22 +27,50 @@ public sealed class ReferenceService : IReferenceService
         if (symbol is null) return [];
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
-        var results = new List<LocationDto>();
+        var refLocations = references.SelectMany(r => r.Locations).ToList();
+        return await MaterializeReferenceLocationsAsync(refLocations, ct).ConfigureAwait(false);
+    }
 
-        foreach (var refSymbol in references)
+    /// <summary>
+    /// Resolves a flat list of <see cref="ReferenceLocation"/>s to <see cref="LocationDto"/>s in parallel.
+    /// Each location requires an async preview-text fetch and a containing-symbol lookup; doing them
+    /// sequentially is the dominant cost for high-reference symbols. Uses a bounded semaphore so we
+    /// don't blow up document caches on large fan-outs.
+    /// </summary>
+    private static async Task<IReadOnlyList<LocationDto>> MaterializeReferenceLocationsAsync(
+        IReadOnlyList<ReferenceLocation> refLocations, CancellationToken ct)
+    {
+        if (refLocations.Count == 0) return [];
+
+        var parallelism = Math.Min(Environment.ProcessorCount, 8);
+        using var semaphore = new SemaphoreSlim(parallelism, parallelism);
+
+        var tasks = new Task<LocationDto>[refLocations.Count];
+        for (var i = 0; i < refLocations.Count; i++)
         {
-            foreach (var refLocation in refSymbol.Locations)
-            {
-                var doc = refLocation.Document;
-                var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-
-                var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
-                results.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
-            }
+            var refLocation = refLocations[i];
+            tasks[i] = ToLocationDtoAsync(refLocation, semaphore, ct);
         }
 
-        return results;
+        return await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private static async Task<LocationDto> ToLocationDtoAsync(
+        ReferenceLocation refLocation, SemaphoreSlim semaphore, CancellationToken ct)
+    {
+        await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var doc = refLocation.Document;
+            var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
+            var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
+            var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
+            return SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
     }
 
     public async Task<IReadOnlyList<LocationDto>> FindImplementationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
@@ -99,7 +127,11 @@ public sealed class ReferenceService : IReferenceService
             throw new ArgumentException("Maximum of 50 symbols per bulk request.");
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var semaphore = new SemaphoreSlim(6, 6);
+        // Outer fan-out: how many bulk symbols we resolve concurrently. Each task may itself
+        // spawn parallel preview fetches inside MaterializeReferenceLocationsAsync, so keep
+        // the outer cap modest on big boxes to avoid runaway document-cache pressure.
+        var bulkParallelism = Math.Clamp(Environment.ProcessorCount / 2, 4, 8);
+        using var semaphore = new SemaphoreSlim(bulkParallelism, bulkParallelism);
 
         async Task<BulkReferenceResultDto> ProcessOneAsync(BulkSymbolLocator bulk, int index)
         {
@@ -129,17 +161,9 @@ public sealed class ReferenceService : IReferenceService
                     }
                 }
 
-                foreach (var refSymbol in references)
-                {
-                    foreach (var refLocation in refSymbol.Locations)
-                    {
-                        var doc = refLocation.Document;
-                        var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                        var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                        var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
-                        locations.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
-                    }
-                }
+                var refLocations = references.SelectMany(r => r.Locations).ToList();
+                var refDtos = await MaterializeReferenceLocationsAsync(refLocations, ct).ConfigureAwait(false);
+                locations.AddRange(refDtos);
 
                 return new BulkReferenceResultDto(key, symbol.ToDisplayString(), locations.Count, locations, null);
             }

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -70,18 +70,20 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
+            // Phase 1 (sequential, cheap): walk syntax and collect candidates that survive
+            // the pre-filter. The HashSet de-dup must run on a single thread.
+            var candidates = new List<ISymbol>();
             foreach (var tree in compilation.SyntaxTrees)
             {
-                if (ct.IsCancellationRequested || results.Count >= limit) break;
+                if (ct.IsCancellationRequested) break;
                 if (PathFilter.IsGeneratedOrContentFile(tree.FilePath)) continue;
 
                 var semanticModel = compilation.GetSemanticModel(tree);
                 var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
 
-                var declarations = root.DescendantNodes().OfType<MemberDeclarationSyntax>();
-                foreach (var decl in declarations)
+                foreach (var decl in root.DescendantNodes().OfType<MemberDeclarationSyntax>())
                 {
-                    if (ct.IsCancellationRequested || results.Count >= limit) break;
+                    if (ct.IsCancellationRequested) break;
 
                     var symbol = semanticModel.GetDeclaredSymbol(decl, ct);
                     if (symbol is null) continue;
@@ -92,7 +94,26 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                     if (ShouldSkipSymbolForUnusedAnalysis(symbol, includePublic, excludeEnums, excludeRecordProperties))
                         continue;
 
-                    var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
+                    candidates.Add(symbol);
+                }
+            }
+
+            if (candidates.Count == 0) continue;
+
+            // Phase 2 (parallel, expensive): each candidate fans out to a SymbolFinder lookup
+            // (and possibly a cross-compilation fallback). Roslyn's Solution is immutable, so
+            // SymbolFinder is safe under concurrency. Bound parallelism by CPU count.
+            var parallelism = Math.Clamp(Environment.ProcessorCount, 4, 16);
+            using var semaphore = new SemaphoreSlim(parallelism, parallelism);
+            var capturedProject = project;
+            var capturedSolution = solution;
+
+            var tasks = candidates.Select(async symbol =>
+            {
+                await semaphore.WaitAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    var refs = await SymbolFinder.FindReferencesAsync(symbol, capturedSolution, ct).ConfigureAwait(false);
                     var refCount = refs.Sum(r => r.Locations.Count());
 
                     // Fallback: cross-compilation re-resolution for symbols prone to
@@ -103,30 +124,46 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                     if (refCount == 0 && NeedsCrossCompilationCheck(symbol))
                     {
                         refCount = await CountCrossCompilationReferencesAsync(
-                            symbol, project, solution, ct).ConfigureAwait(false);
+                            symbol, capturedProject, capturedSolution, ct).ConfigureAwait(false);
                     }
 
-                    if (refCount == 0)
-                    {
-                        var location = symbol.Locations.FirstOrDefault(l => l.IsInSource);
-                        if (location is null) continue;
-                        var lineSpan = location.GetLineSpan();
-
-                        results.Add(new UnusedSymbolDto(
-                            symbol.Name,
-                            symbol.Kind.ToString(),
-                            lineSpan.Path,
-                            lineSpan.StartLinePosition.Line + 1,
-                            lineSpan.StartLinePosition.Character + 1,
-                            symbol.ContainingType?.Name,
-                            SymbolHandleSerializer.CreateHandle(symbol),
-                            ComputeUnusedConfidence(symbol)));
-                    }
+                    return refCount == 0 ? BuildUnusedDto(symbol) : null;
                 }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            // Preserve original ordering (project → tree → declaration order) by awaiting
+            // in input order, not completion order.
+            var unusedDtos = await Task.WhenAll(tasks).ConfigureAwait(false);
+            foreach (var dto in unusedDtos)
+            {
+                if (dto is null) continue;
+                results.Add(dto);
+                if (results.Count >= limit) break;
             }
         }
 
         return results;
+    }
+
+    private static UnusedSymbolDto? BuildUnusedDto(ISymbol symbol)
+    {
+        var location = symbol.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location is null) return null;
+        var lineSpan = location.GetLineSpan();
+
+        return new UnusedSymbolDto(
+            symbol.Name,
+            symbol.Kind.ToString(),
+            lineSpan.Path,
+            lineSpan.StartLinePosition.Line + 1,
+            lineSpan.StartLinePosition.Character + 1,
+            symbol.ContainingType?.Name,
+            SymbolHandleSerializer.CreateHandle(symbol),
+            ComputeUnusedConfidence(symbol));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

First batch of perf quick wins from the deep-review survey. All five
items are narrow, low-risk, and validated by the existing test suite.

- **#1 Parallel preview-text fetch in `ReferenceService.FindReferencesAsync`** — was sequential per location; now bounded parallel via `min(ProcessorCount, 8)` semaphore. Same helper reused inside `FindReferencesBulkAsync`.
- **#3 Bulk semaphore sized by ProcessorCount** — `FindReferencesBulkAsync` outer fan-out is now `Clamp(ProcessorCount/2, 4, 8)` instead of hardcoded `6`, so >6-core boxes actually use their cores while still capping document-cache pressure.
- **#4 `UnusedCodeAnalyzer` parallelism** — split into a cheap sequential collection phase (syntax walk + dedup) and a parallel `SymbolFinder.FindReferencesAsync` phase bounded by `Clamp(ProcessorCount, 4, 16)`. Original ordering is preserved.
- **#2 Diagnostic cache for detail lookup** — `DiagnosticService` now caches the unfiltered per-workspace diagnostic list keyed by workspace version. `GetDiagnosticDetailsAsync` consults it as the fast path; the cold path warms it.
- **#8 Parallel `FindDiagnosticAsync` project walk** — replaced the sequential per-project loop with `Task.WhenAll` over independent compilations.

Net effect: latency reduction on the hottest read paths without changing public API surface or thread-safety assumptions. No interface changes.

## Test plan

- [x] `dotnet build RoslynMcp.slnx` — clean
- [x] `./eng/verify-release.ps1 -Configuration Release` — 210/210 pass
- [x] `./eng/verify-ai-docs.ps1` — pass
- [x] Focused tests for `Reference`/`Diagnostic`/`DeadCode`/`Unused` — 49/49 pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)