### PR TITLE
perf: cross-tool compilation cache + RW-lock design spike

### DIFF
--- a/ai_docs/reports/2026-04-06-workspace-rw-lock-design-note.md
+++ b/ai_docs/reports/2026-04-06-workspace-rw-lock-design-note.md
@@ -1,0 +1,118 @@
+# Workspace read-write lock — design note (perf lever #6)
+
+<!-- purpose: Spike findings and proposed approach for converting the per-workspace mutex in WorkspaceExecutionGate to a reader-writer model. No code yet. -->
+
+**Status:** spike + design only. Implementation deferred to a follow-up PR.
+**Owner:** perf quick-wins program (deep-review-2026-04-06).
+**Related:** PRs #74 (perf batch 1), #75 (perf batch 2 — `CompilationCache`).
+
+## Why this exists
+
+The deep-review survey identified `WorkspaceExecutionGate`'s per-workspace `SemaphoreSlim(1,1)` as a serialization bottleneck for read-heavy tools running against the same workspace. Two parallel `find_references` calls on workspace `foo` cannot run concurrently — they queue behind the same gate.
+
+Before designing a fix, this note captures what the current locking model **actually does**, because the survey description ("a single semaphore per workspace serializes all work") turned out to be incomplete.
+
+## Audit findings — current locking model
+
+### 1. The gate has *three* key namespaces, not one
+
+`WorkspaceExecutionGate.RunAsync` (`src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs:44-92`) routes the call to a `SemaphoreSlim` chosen by string key:
+
+| Key shape | Purpose | Backing semaphore |
+|---|---|---|
+| `__load__` (well-known) | `workspace_load`, `workspace_reload` | shared `_loadGate` |
+| `<workspaceId>` | Read tools that take a workspaceId | per-workspace entry in `_workspaceGates` |
+| `__apply__:<workspaceId>` | Code-fix / refactor / project-mutation **apply** operations | **separate** per-workspace entry in `_workspaceGates` |
+
+The dictionary key is the raw string, so `foo` and `__apply__:foo` map to **different** semaphore instances.
+
+### 2. Reads and applies on the same workspace are NOT serialized against each other
+
+Because `foo` and `__apply__:foo` are different keys, an in-flight `find_references(foo)` does not block `code_fix_apply(foo)` and vice versa. The current code intentionally lets reads run concurrently with writes.
+
+This is only safe because:
+
+- Roslyn `Solution` is immutable. Reads operate on whatever snapshot they captured via `IWorkspaceManager.GetCurrentSolution`. When an apply runs, it produces a *new* snapshot; concurrent readers continue to see their stale (but consistent) one.
+- `MSBuildWorkspace.TryApplyChanges` is internally synchronized.
+- `WorkspaceManager.TryApplyChanges` (`src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs:339-360`) bumps `session.Version` on success, which transparently invalidates anything keyed by version (e.g. the new `CompilationCache`).
+
+### 3. The serialization that *does* exist is read-vs-read on the same workspace
+
+Two concurrent `find_references(foo)` calls both want gate `foo`, so they queue. **This is the bottleneck the original survey was pointing at.**
+
+### 4. The global throttle is still in front of all of this
+
+`_globalThrottle = SemaphoreSlim(max(2, ProcessorCount))` (`WorkspaceExecutionGate.cs:30`) bounds the total number of concurrent operations across the whole server. This is unrelated to the per-workspace gating and stays exactly as is.
+
+### 5. Caller surface area
+
+`grep -r "RunAsync(.*workspaceId\|RunAsync(.*LoadGateKey\|RunAsync(.*__apply__" src/RoslynMcp.Host.Stdio/Tools/` returns ~100 call sites across 33 tool files. Categorized by gate-key intent:
+
+| Category | Gate key today | Tool files (representative) |
+|---|---|---|
+| Workspace lifecycle | `__load__` | `WorkspaceTools` |
+| Apply (writes via `TryApplyChanges`, project file mutation, file CRUD) | `__apply__:<ws>` | `RefactoringTools`, `BulkRefactoringTools`, `CrossProjectRefactoringTools`, `TypeMoveTools`, `TypeExtractionTools`, `InterfaceExtractionTools`, `CodeActionTools`, `FixAllTools`, `ProjectMutationTools`, `ScaffoldingTools`, `EditTools`, `MultiFileEditTools`, `FileOperationTools`, `EditorConfigTools`, `SuppressionTools`, `OrchestrationTools` (some), `UndoTools` |
+| Read (analysis, navigation, search, diagnostics) | `<ws>` | `AnalysisTools`, `AdvancedAnalysisTools`, `SymbolTools`, `ConsumerAnalysisTools`, `FlowAnalysisTools`, `CohesionAnalysisTools`, `SyntaxTools`, `ValidationTools`, `AnalyzerInfoTools`, `DeadCodeTools`, `CompileCheckTools`, `TestCoverageTools`, `SecurityTools`, `OperationTools`, `MSBuildTools`, `OrchestrationTools` (some) |
+
+**Note on `ValidationTools` and `BuildService`/`TestRunnerService`**: these tools shell out to `dotnet build` / `dotnet test` against the on-disk solution. They do not mutate the in-memory `Solution`, but they *do* race with on-disk file mutations (`apply_text_edit`, project mutations). They're currently classified as reads against the workspace, which is consistent with how they're used today and is not changed by this design.
+
+## Proposed model
+
+Replace the per-workspace `SemaphoreSlim(1,1)` with `ReaderWriterLockSlim` (or equivalent `AsyncReaderWriterLock`) per workspace, **and merge the `__apply__:foo` gate into the same lock as `foo`** so that writes are properly exclusive against reads on the same workspace.
+
+| Operation | Today | Proposed |
+|---|---|---|
+| `workspace_load` / `workspace_reload` | `__load__` shared mutex | unchanged — still `__load__` |
+| Read tools (analysis, navigation, search, diagnostics) | per-workspace mutex via `<ws>` | per-workspace **read** lock |
+| Apply tools (refactor apply, code-fix apply, project mutation, file CRUD) | per-workspace mutex via `__apply__:<ws>` (independent of read gate!) | per-workspace **write** lock |
+
+### What this gains
+
+- **N concurrent reads on the same workspace** instead of 1. Two parallel `find_references` / `project_diagnostics` / `symbol_search` calls run truly in parallel, bounded only by `_globalThrottle`. This is the intended unlock.
+- **Writes are now correctly exclusive against reads on the same workspace** — a latent correctness improvement. Today's model relies entirely on Solution immutability + version-keyed caches for stale-snapshot safety; the new model adds an actual happens-before edge so an applier sees no in-flight readers operating against the workspace's mutable state (e.g., on-disk files for tools that touch them).
+
+### What needs care
+
+1. **Reader/writer classification per call site.** Every `gate.RunAsync(...)` in `src/RoslynMcp.Host.Stdio/Tools/` must be classified explicitly. The category table above is the starting point but needs a manual verification pass — anything mis-classified as a reader that actually mutates state is a bug.
+2. **`OrchestrationTools` is mixed.** Composite operations sometimes include applies. The gate key is currently chosen by a `wsId != null ? "__apply__:..." : "__apply__"` helper. This needs to become writer-by-default for any composite that may apply, and reader for read-only composites.
+3. **`UndoTools.revert_last_apply` is a writer**, not a reader, despite the "revert" name — it calls back into the workspace mutation path.
+4. **Reader/writer fairness.** `ReaderWriterLockSlim` defaults to non-reentrant, no-recursion mode with reader preference. We want **writer preference** to avoid writer starvation in read-heavy workloads (the common case for an MCP server). This needs an explicit policy choice when constructing the lock.
+5. **Async-aware vs sync.** `ReaderWriterLockSlim` is sync-only and ties up a thread. We use `await` heavily inside gated actions, so we need either:
+   - A third-party `AsyncReaderWriterLock` (e.g. `Nito.AsyncEx.AsyncReaderWriterLock` — already a transitive dep? to verify), or
+   - A hand-rolled implementation built on `SemaphoreSlim` (small but easy to get wrong).
+6. **`workspace_status` and other "metadata" calls** that currently take `__load__` because they read load-time state may need to become readers against the per-workspace lock instead. To verify per call site.
+7. **`__load__` interaction.** Today, `__load__` is a separate semaphore and does not interact with per-workspace gates. With per-workspace RW locks, `workspace_reload(foo)` should also acquire workspace `foo`'s **write** lock, not just `__load__`, so that in-flight readers on `foo` complete before the reload yanks the solution out from under them. This is a behavioral change worth calling out.
+
+### Validation plan
+
+1. Land the RW lock behind a feature flag (env var: `ROSLYNMCP_WORKSPACE_RW_LOCK=1`), default off.
+2. Run the full test matrix in both modes; gate any merge on parity.
+3. Add a benchmark: two parallel `find_references` against the same workspace. Today they serialize; under the new model they should run in roughly the time of one.
+4. Soak-test against a large solution (the Roslyn repo itself is the obvious target) for a 30-minute mixed-workload run.
+5. After at least one full release cycle of opt-in success, flip the default to on and remove the flag in a follow-up.
+
+### What this design *does not* propose
+
+- Splitting reads further into "pure semantic" vs "filesystem-touching" lanes. Premature.
+- Removing `_globalThrottle`. It still serves its purpose (bounding total CPU/memory).
+- Touching `__load__`'s shared-across-workspaces semantics. That's an unrelated lever.
+
+## Open questions
+
+1. Is `Nito.AsyncEx` already a transitive dependency, or do we need to add it (or hand-roll the async RW lock)?
+2. Are there tools currently using gate key `<ws>` that internally call `TryApplyChanges`? If so they're misclassified today and would fail under the new model — worth a one-pass audit before implementation.
+3. Should `workspace_reload` block on the per-workspace write lock, or keep its current "fire and forget the old solution" semantics? (Recommendation: block, for predictability.)
+
+## Decision needed before implementation
+
+- Approve / reject the proposal.
+- Pick async lock implementation (`Nito.AsyncEx` vs hand-rolled).
+- Approve the feature-flag gating + soak strategy.
+
+Once these are answered, the implementation is a single PR scoped to:
+
+- New `IWorkspaceLock` (or extend `IWorkspaceExecutionGate`) abstraction
+- Per-workspace `AsyncReaderWriterLock` instances
+- Caller-by-caller migration with explicit read/write classification at every `RunAsync` site
+- Feature flag + opt-in
+- Benchmarks

--- a/src/RoslynMcp.Core/Services/ICompilationCache.cs
+++ b/src/RoslynMcp.Core/Services/ICompilationCache.cs
@@ -1,0 +1,55 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Per-workspace, version-keyed cache for Roslyn <see cref="Compilation"/> and
+/// <see cref="CompilationWithAnalyzers"/> instances.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Compilations are the most expensive object Roslyn produces — many analysis tools repeat
+/// the same <c>project.GetCompilationAsync()</c> call across requests, throwing the result
+/// away each time. This cache lets independent services share warm compilations as long as
+/// the workspace version is unchanged.
+/// </para>
+/// <para>
+/// Cache invalidation is keyed on the monotonic <see cref="IWorkspaceManager.GetCurrentVersion"/>
+/// counter. <see cref="IWorkspaceManager.TryApplyChanges"/> bumps the version on every successful
+/// apply, and a workspace reload bumps it as well, so any mutation transparently invalidates
+/// previously cached compilations. Workspace close calls <see cref="Invalidate"/> to free
+/// the dictionary slots.
+/// </para>
+/// <para>
+/// Implementations must be safe for concurrent use. The first caller for a
+/// <c>(workspaceId, projectId, version)</c> tuple starts the underlying compilation; subsequent
+/// concurrent callers await the same in-flight task instead of racing.
+/// </para>
+/// </remarks>
+public interface ICompilationCache
+{
+    /// <summary>
+    /// Returns the cached <see cref="Compilation"/> for the given project, or computes and caches it.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier the project belongs to.</param>
+    /// <param name="project">The Roslyn project whose compilation is requested.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<Compilation?> GetCompilationAsync(string workspaceId, Project project, CancellationToken ct);
+
+    /// <summary>
+    /// Returns the cached <see cref="CompilationWithAnalyzers"/> for the given project, or
+    /// computes and caches it. Returns <see langword="null"/> if the project has no analyzers
+    /// configured or its compilation cannot be obtained.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier the project belongs to.</param>
+    /// <param name="project">The Roslyn project whose analyzer-bound compilation is requested.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct);
+
+    /// <summary>
+    /// Drops every cached compilation for a workspace. Called by
+    /// <see cref="IWorkspaceManager"/> when the workspace is closed.
+    /// </summary>
+    void Invalidate(string workspaceId);
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddRoslynServices(this IServiceCollection services)
     {
         services.AddSingleton<IWorkspaceManager, WorkspaceManager>();
+        services.AddSingleton<ICompilationCache, CompilationCache>();
         services.AddSingleton<IWorkspaceExecutionGate>(sp =>
         {
             var opts = sp.GetService<ExecutionGateOptions>() ?? new ExecutionGateOptions();

--- a/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
@@ -1,0 +1,130 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Per-workspace, version-keyed cache for <see cref="Compilation"/> and
+/// <see cref="CompilationWithAnalyzers"/>. See <see cref="ICompilationCache"/> for the
+/// rationale and concurrency contract.
+/// </summary>
+/// <remarks>
+/// The cache stores <see cref="Task{TResult}"/> values rather than materialized compilations,
+/// so concurrent first-callers awaiting the same key share a single compilation pass instead
+/// of racing to start their own. Stale entries are replaced atomically when a higher
+/// workspace version is observed; we don't bother evicting older entries proactively because
+/// each project has at most one slot per cache and stale tasks are released as soon as the
+/// new entry is installed.
+/// </remarks>
+public sealed class CompilationCache : ICompilationCache
+{
+    private readonly IWorkspaceManager _workspaceManager;
+
+    private sealed record CompilationEntry(int Version, Task<Compilation?> Compilation);
+    private sealed record AnalyzerEntry(int Version, Task<CompilationWithAnalyzers?> Bound);
+
+    // Two parallel maps. Splitting them lets a service that only needs the raw Compilation
+    // (e.g., dead-code analysis) skip warming the analyzer pipeline.
+    private readonly ConcurrentDictionary<(string WorkspaceId, ProjectId ProjectId), CompilationEntry> _compilations = new();
+    private readonly ConcurrentDictionary<(string WorkspaceId, ProjectId ProjectId), AnalyzerEntry> _analyzerBound = new();
+
+    public CompilationCache(IWorkspaceManager workspaceManager)
+    {
+        _workspaceManager = workspaceManager;
+    }
+
+    public Task<Compilation?> GetCompilationAsync(string workspaceId, Project project, CancellationToken ct)
+    {
+        var version = _workspaceManager.GetCurrentVersion(workspaceId);
+        var key = (workspaceId, project.Id);
+
+        if (_compilations.TryGetValue(key, out var existing) && existing.Version == version)
+        {
+            return existing.Compilation;
+        }
+
+        // Cache miss or stale: install a fresh task. Multiple concurrent first-callers may
+        // race here; AddOrUpdate's atomicity ensures only one entry is stored, and any racer
+        // that lost will see the winner's task on the next read. The lost-racer's task will
+        // run to completion but its result is discarded — acceptable cost for the simplicity
+        // of not holding a per-key lock.
+        var compilationTask = project.GetCompilationAsync(ct);
+        var entry = new CompilationEntry(version, compilationTask);
+        _compilations.AddOrUpdate(key, entry, (_, current) => current.Version >= version ? current : entry);
+
+        // Return whichever entry actually won the AddOrUpdate so all callers observe the
+        // same task instance.
+        return _compilations.TryGetValue(key, out var winner) && winner.Version == version
+            ? winner.Compilation
+            : compilationTask;
+    }
+
+    public async Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct)
+    {
+        var version = _workspaceManager.GetCurrentVersion(workspaceId);
+        var key = (workspaceId, project.Id);
+
+        if (_analyzerBound.TryGetValue(key, out var existing) && existing.Version == version)
+        {
+            return await existing.Bound.ConfigureAwait(false);
+        }
+
+        var task = BuildCompilationWithAnalyzersAsync(workspaceId, project, ct);
+        var entry = new AnalyzerEntry(version, task);
+        _analyzerBound.AddOrUpdate(key, entry, (_, current) => current.Version >= version ? current : entry);
+
+        var winner = _analyzerBound.TryGetValue(key, out var stored) && stored.Version == version
+            ? stored.Bound
+            : task;
+        return await winner.ConfigureAwait(false);
+    }
+
+    private async Task<CompilationWithAnalyzers?> BuildCompilationWithAnalyzersAsync(
+        string workspaceId, Project project, CancellationToken ct)
+    {
+        var compilation = await GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
+        if (compilation is null) return null;
+
+        var analyzers = project.AnalyzerReferences
+            .SelectMany(reference => reference.GetAnalyzers(project.Language))
+            .ToImmutableArray();
+        if (analyzers.Length == 0) return null;
+
+        return compilation.WithAnalyzers(
+            analyzers,
+            new CompilationWithAnalyzersOptions(
+                options: project.AnalyzerOptions,
+                onAnalyzerException: null,
+                concurrentAnalysis: true,
+                logAnalyzerExecutionTime: false,
+                reportSuppressedDiagnostics: false));
+    }
+
+    public void Invalidate(string workspaceId)
+    {
+        // Note: stale entries (workspace closed, version bumped) are functionally inert
+        // because every read re-checks GetCurrentVersion. Invalidate is exposed for callers
+        // that want to free dictionary slots eagerly — currently it's not wired into
+        // WorkspaceManager.Close to avoid a circular DI dependency, but a future event-based
+        // notification could call this. ConcurrentDictionary doesn't support bulk-by-key
+        // removal, so iterate. The set of keys per workspace is small (one per project).
+        foreach (var key in _compilations.Keys)
+        {
+            if (key.WorkspaceId == workspaceId)
+            {
+                _compilations.TryRemove(key, out _);
+            }
+        }
+
+        foreach (var key in _analyzerBound.Keys)
+        {
+            if (key.WorkspaceId == workspaceId)
+            {
+                _analyzerBound.TryRemove(key, out _);
+            }
+        }
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
@@ -12,6 +11,7 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class DiagnosticService : IDiagnosticService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<DiagnosticService> _logger;
 
     /// <summary>
@@ -25,9 +25,10 @@ public sealed class DiagnosticService : IDiagnosticService
 
     private sealed record DiagnosticCacheEntry(int Version, IReadOnlyList<Diagnostic> Diagnostics);
 
-    public DiagnosticService(IWorkspaceManager workspace, ILogger<DiagnosticService> logger)
+    public DiagnosticService(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<DiagnosticService> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -54,7 +55,9 @@ public sealed class DiagnosticService : IDiagnosticService
             var analyzer = new List<DiagnosticDto>();
             var raw = new List<Diagnostic>();
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            // Use the shared compilation cache so independent tools (and the diagnostic
+            // detail cold path) reuse the same warm Compilation across requests.
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null)
             {
                 compiler.Add(new DiagnosticDto(
@@ -72,20 +75,13 @@ public sealed class DiagnosticService : IDiagnosticService
                 }
             }
 
-            var analyzers = project.AnalyzerReferences
-                .SelectMany(reference => reference.GetAnalyzers(project.Language))
-                .ToImmutableArray();
-            if (analyzers.Length > 0)
+            // CompilationWithAnalyzers is also cached: subsequent diagnostic calls (and
+            // related tools that need analyzer diagnostics) reuse the same instance.
+            var compilationWithAnalyzers = await _compilationCache
+                .GetCompilationWithAnalyzersAsync(workspaceId, project, ct)
+                .ConfigureAwait(false);
+            if (compilationWithAnalyzers is not null)
             {
-                var compilationWithAnalyzers = compilation.WithAnalyzers(
-                    analyzers,
-                    new CompilationWithAnalyzersOptions(
-                        options: project.AnalyzerOptions,
-                        onAnalyzerException: null,
-                        concurrentAnalysis: true,
-                        logAnalyzerExecutionTime: false,
-                        reportSuppressedDiagnostics: false));
-
                 var projectAnalyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(ct).ConfigureAwait(false);
                 foreach (var diagnostic in projectAnalyzerDiagnostics)
                 {
@@ -352,7 +348,7 @@ public sealed class DiagnosticService : IDiagnosticService
         // Walk all projects in parallel — each one is an independent compilation+analyzer
         // pass, and there's no reason to serialize them. Roslyn's compilation and analyzer
         // APIs are thread-safe over immutable Project/Compilation objects.
-        var projectTasks = solution.Projects.Select(project => CollectProjectDiagnosticsAsync(project, ct));
+        var projectTasks = solution.Projects.Select(project => CollectProjectDiagnosticsAsync(workspaceId, project, ct));
         var perProjectResults = await Task.WhenAll(projectTasks).ConfigureAwait(false);
 
         // Warm the cache so a follow-up details lookup (or a project_diagnostics call that
@@ -369,27 +365,18 @@ public sealed class DiagnosticService : IDiagnosticService
         return null;
     }
 
-    private static async Task<IReadOnlyList<Diagnostic>> CollectProjectDiagnosticsAsync(Project project, CancellationToken ct)
+    private async Task<IReadOnlyList<Diagnostic>> CollectProjectDiagnosticsAsync(string workspaceId, Project project, CancellationToken ct)
     {
-        var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+        var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
         if (compilation is null) return [];
 
         var collected = new List<Diagnostic>();
         collected.AddRange(compilation.GetDiagnostics(ct));
 
-        var analyzers = project.AnalyzerReferences
-            .SelectMany(reference => reference.GetAnalyzers(project.Language))
-            .ToImmutableArray();
-        if (analyzers.Length == 0) return collected;
-
-        var compilationWithAnalyzers = compilation.WithAnalyzers(
-            analyzers,
-            new CompilationWithAnalyzersOptions(
-                options: project.AnalyzerOptions,
-                onAnalyzerException: null,
-                concurrentAnalysis: true,
-                logAnalyzerExecutionTime: false,
-                reportSuppressedDiagnostics: false));
+        var compilationWithAnalyzers = await _compilationCache
+            .GetCompilationWithAnalyzersAsync(workspaceId, project, ct)
+            .ConfigureAwait(false);
+        if (compilationWithAnalyzers is null) return collected;
 
         var analyzerDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync(ct).ConfigureAwait(false);
         collected.AddRange(analyzerDiagnostics);

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -40,11 +40,13 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     ];
 
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<UnusedCodeAnalyzer> _logger;
 
-    public UnusedCodeAnalyzer(IWorkspaceManager workspace, ILogger<UnusedCodeAnalyzer> logger)
+    public UnusedCodeAnalyzer(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<UnusedCodeAnalyzer> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -67,7 +69,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         {
             if (ct.IsCancellationRequested || results.Count >= limit) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             // Phase 1 (sequential, cheap): walk syntax and collect candidates that survive
@@ -124,7 +126,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                     if (refCount == 0 && NeedsCrossCompilationCheck(symbol))
                     {
                         refCount = await CountCrossCompilationReferencesAsync(
-                            symbol, capturedProject, capturedSolution, ct).ConfigureAwait(false);
+                            workspaceId, symbol, capturedProject, capturedSolution, ct).ConfigureAwait(false);
                     }
 
                     return refCount == 0 ? BuildUnusedDto(symbol) : null;
@@ -244,8 +246,8 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     /// Re-resolves a symbol through dependent projects' compilations and checks for
     /// references from each. Returns the total reference count found, or 0 if none.
     /// </summary>
-    private static async Task<int> CountCrossCompilationReferencesAsync(
-        ISymbol symbol, Project declaringProject, Solution solution, CancellationToken ct)
+    private async Task<int> CountCrossCompilationReferencesAsync(
+        string workspaceId, ISymbol symbol, Project declaringProject, Solution solution, CancellationToken ct)
     {
         var containingType = symbol.ContainingType;
         if (containingType is null) return 0;
@@ -263,7 +265,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             if (!project.ProjectReferences.Any(r => r.ProjectId == declaringProject.Id))
                 continue;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             var resolvedType = compilation.GetTypeByMetadataName(metadataName);

--- a/tests/RoslynMcp.Tests/CompilationCacheTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct unit tests for <see cref="CompilationCache"/>. Uses an in-memory
+/// <see cref="AdhocWorkspace"/> so the cache can be exercised without spinning up a real
+/// MSBuildWorkspace, and a tiny <see cref="IWorkspaceManager"/> stub so we can drive the
+/// version counter directly to verify invalidation.
+/// </summary>
+[TestClass]
+public sealed class CompilationCacheTests
+{
+    [TestMethod]
+    public async Task GetCompilationAsync_ReturnsSameInstance_OnRepeatedCall_AtSameVersion()
+    {
+        var (cache, project, ws) = CreateCacheWithProject(initialVersion: 1);
+
+        var first = await cache.GetCompilationAsync(ws.WorkspaceId, project, default);
+        var second = await cache.GetCompilationAsync(ws.WorkspaceId, project, default);
+
+        Assert.IsNotNull(first);
+        Assert.AreSame(first, second, "Cache should return the same Compilation instance for the same version.");
+    }
+
+    [TestMethod]
+    public async Task GetCompilationAsync_PicksUpNewProjectState_AfterVersionBump()
+    {
+        // Roslyn caches Compilation on the Project itself, so we can't observe invalidation
+        // by calling twice on the same Project — Roslyn returns the same instance regardless
+        // of our cache. To prove the cache actually re-binds on a version bump we mutate the
+        // solution between calls and pass the *new* Project; the cache must store the new
+        // entry rather than handing back the stale one.
+        const string workspaceId = "test-ws";
+        var adhoc = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        adhoc.AddProject(ProjectInfo.Create(
+            projectId, VersionStamp.Create(),
+            name: "TestProject", assemblyName: "TestProject",
+            language: LanguageNames.CSharp));
+        var v1Project = adhoc.CurrentSolution.GetProject(projectId)!;
+
+        var ws = new FakeWorkspaceManager(workspaceId, initialVersion: 1);
+        var cache = new CompilationCache(ws);
+
+        var first = await cache.GetCompilationAsync(workspaceId, v1Project, default);
+        Assert.IsNotNull(first);
+        Assert.AreEqual(0, first!.SyntaxTrees.Count(), "Initial compilation should have no source files.");
+
+        // Mutate the project: add a syntax tree and bump the workspace version.
+        var docId = DocumentId.CreateNewId(projectId);
+        var newSolution = adhoc.CurrentSolution.AddDocument(
+            docId, "Sample.cs", "namespace N { class C { } }");
+        var v2Project = newSolution.GetProject(projectId)!;
+        ws.Version = 2;
+
+        var second = await cache.GetCompilationAsync(workspaceId, v2Project, default);
+        Assert.IsNotNull(second);
+        Assert.AreEqual(1, second!.SyntaxTrees.Count(),
+            "After version bump, cache must compile the new project state, not return the stale v1 entry.");
+    }
+
+    [TestMethod]
+    public async Task GetCompilationWithAnalyzersAsync_ReturnsNull_WhenProjectHasNoAnalyzers()
+    {
+        var (cache, project, ws) = CreateCacheWithProject(initialVersion: 1);
+
+        var bound = await cache.GetCompilationWithAnalyzersAsync(ws.WorkspaceId, project, default);
+
+        Assert.IsNull(bound, "AdhocWorkspace projects have no AnalyzerReferences, so the cache must return null instead of fabricating an empty bound compilation.");
+    }
+
+    [TestMethod]
+    public void Invalidate_IsSafeToCall_OnEmptyCache()
+    {
+        var ws = new FakeWorkspaceManager("test-ws", initialVersion: 1);
+        var cache = new CompilationCache(ws);
+
+        // Smoke test — Invalidate should be a no-op when nothing is cached for the workspace.
+        // (Roslyn's Project-level Compilation cache makes a stronger "evicted-and-rebuilt"
+        // assertion impossible without reflection, but the method must not throw.)
+        cache.Invalidate("test-ws");
+        cache.Invalidate("nonexistent-ws");
+    }
+
+    private static (CompilationCache cache, Project project, FakeWorkspaceManager ws) CreateCacheWithProject(int initialVersion)
+    {
+        const string workspaceId = "test-ws";
+        var adhoc = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "TestProject",
+            assemblyName: "TestProject",
+            language: LanguageNames.CSharp);
+        adhoc.AddProject(projectInfo);
+        var project = adhoc.CurrentSolution.GetProject(projectId)!;
+
+        var ws = new FakeWorkspaceManager(workspaceId, initialVersion);
+        var cache = new CompilationCache(ws);
+        return (cache, project, ws);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IWorkspaceManager"/> stand-in. Only the methods the cache
+    /// actually calls (<see cref="GetCurrentVersion"/>) need real implementations; the rest
+    /// throw to surface accidental coupling immediately.
+    /// </summary>
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public string WorkspaceId { get; }
+        public int Version { get; set; }
+
+        public FakeWorkspaceManager(string workspaceId, int initialVersion)
+        {
+            WorkspaceId = workspaceId;
+            Version = initialVersion;
+        }
+
+        public int GetCurrentVersion(string workspaceId) => Version;
+
+        // ----- Unused by CompilationCache; throw to surface unexpected coupling -----
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => workspaceId == WorkspaceId;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -59,6 +59,7 @@ internal sealed class TestServiceContainer
             new FileWatcherService(NullLogger<FileWatcherService>.Instance),
             new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 64 });
         var workspaceExecutionGate = new WorkspaceExecutionGate(new ExecutionGateOptions(), workspaceManager);
+        var compilationCache = new CompilationCache(workspaceManager);
         var dotnetCommandRunner = new DotnetCommandRunner();
         var gatedCommandExecutor = new GatedCommandExecutor(
             workspaceManager,
@@ -72,6 +73,7 @@ internal sealed class TestServiceContainer
             NullLogger<MutationAnalysisService>.Instance);
         var diagnosticService = new DiagnosticService(
             workspaceManager,
+            compilationCache,
             NullLogger<DiagnosticService>.Instance);
         var undoService = new UndoService();
         var dependencyAnalysisService = new DependencyAnalysisService(
@@ -136,6 +138,7 @@ internal sealed class TestServiceContainer
                 NullLogger<CodeActionService>.Instance),
             UnusedCodeAnalyzer = new UnusedCodeAnalyzer(
                 workspaceManager,
+                compilationCache,
                 NullLogger<UnusedCodeAnalyzer>.Instance),
             CodeMetricsService = new CodeMetricsService(
                 workspaceManager,


### PR DESCRIPTION
## Summary

Second batch of perf levers from the deep-review survey.

### Implemented

- **#5 + #7 — `ICompilationCache`**: a per-workspace, version-keyed cache for `Compilation` and `CompilationWithAnalyzers`. Independent tools now share the same warm compilation across requests; concurrent first-callers share a single in-flight compilation pass via cached `Task<T>` values rather than racing.
- Wired into `DiagnosticService` (both \`GetDiagnosticsAsync\` and the cold-path \`FindDiagnosticAsync\`) and \`UnusedCodeAnalyzer\` (main loop + cross-compilation fallback).
- Cache keys are \`(workspaceId, ProjectId)\` and entries hold the workspace version. Any successful \`TryApplyChanges\` bumps \`session.Version\`, which transparently invalidates stale entries on the next read. \`Invalidate(workspaceId)\` is exposed for future eager-eviction hooks but isn't called from \`WorkspaceManager.Close\` to avoid a circular DI dependency — stale entries are functionally inert because every read re-checks \`GetCurrentVersion\`.
- \`CodeMetricsService\` is intentionally **not** migrated: it consumes \`Document.GetSemanticModelAsync\` (not \`Project.GetCompilationAsync\`), so the cache provides no benefit there without restructuring.

### Spike + design only

- **#6 — RW workspace lock design note** at \`ai_docs/reports/2026-04-06-workspace-rw-lock-design-note.md\`. Key audit finding: \`WorkspaceExecutionGate\` already uses **different** gate keys for reads (\`<ws>\`) and applies (\`__apply__:<ws>\`), so reads and applies on the same workspace are NOT serialized today — only read-vs-read on the same workspace is. The note proposes a per-workspace \`AsyncReaderWriterLock\` that:
  - lets N concurrent reads run in parallel on the same workspace (the actual bottleneck), and
  - adds a proper happens-before edge between writes and concurrent reads (a latent correctness improvement).
- The note includes the caller-classification table for ~100 \`RunAsync\` sites across 33 tool files, open questions, and a feature-flag-gated validation plan. **No #6 code in this PR** — the spike output is the deliverable, per the agreed sequencing.

## Test plan

- [x] \`dotnet build RoslynMcp.slnx\` — clean (0 warnings, 0 errors)
- [x] \`./eng/verify-release.ps1 -Configuration Release\` — **214/214 pass** (was 210; +4 new \`CompilationCacheTests\`)
- [x] \`./eng/verify-ai-docs.ps1\` — pass
- [x] Focused tests for Diagnostic / Reference / DeadCode / Unused — 49/49 pass
- [x] New direct \`CompilationCacheTests\` — 4/4 pass (cache hit, version-bump rebinding, no-analyzers null, invalidate smoke)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)