### PR TITLE
fix: firewall analyzer MCP audit (FLAGS 001-025)

### DIFF
--- a/REINSTALL.md
+++ b/REINSTALL.md
@@ -1,0 +1,168 @@
+# Reinstalling the roslyn-mcp Claude Code plugin
+
+There are **two layers** that need to be reinstalled when you change this
+codebase, and they run in different places. Both layers are required — Layer 1
+gives you the new server binary, Layer 2 gives Claude Code the new skills,
+hooks, and marketplace metadata.
+
+After both layers are updated, **restart Claude Code** so the new server
+binary, skills, and hooks are loaded.
+
+## Layer 1 — `roslynmcp` global .NET tool (the MCP server binary)
+
+**Where to run:** any OS terminal (Git Bash, PowerShell, cmd) at the repo root
+`C:\Code-Repo\Roslyn-Backed-MCP`. **Not** inside the Claude Code chat input.
+
+**Command:**
+
+```bash
+dotnet publish src/RoslynMcp.Host.Stdio -c Release -p:ReinstallTool=true
+```
+
+This single command:
+
+1. Restores and builds `RoslynMcp.Host.Stdio` in `Release` configuration.
+2. Packs the NuGet package into `nupkg/RoslynMcp.<version>.nupkg`.
+3. Kills any running `roslynmcp.exe` processes.
+4. Uninstalls the existing `roslynmcp` global tool (if any).
+5. Reinstalls the freshly built tool from the local `nupkg` source.
+
+After it finishes, `roslynmcp` on your `PATH` points at the new build.
+
+> **Git Bash on Windows note:** the README shows `/p:ReinstallTool=true`. On
+> Git Bash, the leading `/` is mangled into a path and MSBuild errors out with
+> `MSB1008: Only one project can be specified.` Use `-p:ReinstallTool=true`
+> instead. PowerShell and cmd accept either form.
+
+## Layer 2 — Claude Code plugin (skills, hooks, marketplace metadata)
+
+There are two ways to do this. **Pick the one that matches your Claude Code
+client.**
+
+### Option A — `eng/update-claude-plugin.ps1` (recommended; works everywhere)
+
+**Where to run:** any PowerShell 7+ terminal at the repo root.
+
+**Command:**
+
+```powershell
+pwsh ./eng/update-claude-plugin.ps1
+```
+
+The script performs the equivalent of `/plugin marketplace update` and
+`/plugin install` by directly manipulating the same files those slash commands
+write:
+
+1. `git pull` in `~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/` (the
+   marketplace clone Claude Code reads from).
+2. Wipes and re-syncs the plugin cache directory at
+   `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<version>/`,
+   copying only git-tracked files from the marketplace clone.
+3. Updates `lastUpdated` and `gitCommitSha` in
+   `~/.claude/plugins/known_marketplaces.json` and
+   `~/.claude/plugins/installed_plugins.json`.
+
+Use this path if your Claude Code client does **not** intercept `/plugin` as a
+built-in slash command. You can verify that's the case if typing
+`/plugin marketplace update roslyn-mcp-marketplace` into the chat input
+produces a normal LLM response (e.g. *"I don't recognize that command"*)
+instead of being parsed and executed by the client.
+
+> **Pre-requisite:** you must have installed the plugin at least once via a
+> client that supports the slash commands (or by some other means) so the
+> marketplace clone and metadata files exist. The script refuses to run on a
+> machine that has never had the plugin installed.
+
+### Option B — Slash commands (only if your Claude Code client supports them)
+
+**Where to run:** inside the Claude Code REPL chat input box, the same place
+you type prompts to the assistant.
+
+**First-time install:**
+
+```text
+/plugin marketplace add darylmcd/Roslyn-Backed-MCP
+/plugin install roslyn-mcp@roslyn-mcp-marketplace
+```
+
+**Update an already-installed plugin:**
+
+```text
+/plugin marketplace update roslyn-mcp-marketplace
+/plugin install roslyn-mcp@roslyn-mcp-marketplace
+```
+
+What each command does:
+
+- `/plugin marketplace update` re-fetches the marketplace's git repo
+  (`darylmcd/Roslyn-Backed-MCP`) into
+  `~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/`.
+- `/plugin install` re-clones the plugin contents into the cache directory
+  and rewrites `~/.claude/plugins/installed_plugins.json` with the new commit
+  SHA.
+
+If your client returns an LLM response instead of executing the command, it
+doesn't have the plugin slash-command parser. Use **Option A** instead.
+
+## Full sequence after a code change
+
+1. **Push your change to GitHub `main`.** Layer 2 only sees commits that are
+   on `main` of `darylmcd/Roslyn-Backed-MCP` — local-only changes are invisible
+   to the marketplace. Use `/ship` (or your normal PR + merge flow) first.
+2. **Rebuild the global tool** in a terminal at the repo root:
+
+   ```bash
+   dotnet publish src/RoslynMcp.Host.Stdio -c Release -p:ReinstallTool=true
+   ```
+
+3. **Refresh the plugin** in PowerShell at the repo root:
+
+   ```powershell
+   pwsh ./eng/update-claude-plugin.ps1
+   ```
+
+   *(Or, if your Claude Code client supports slash commands, run them inside
+   the REPL chat input instead — see Option B above.)*
+
+4. **Restart Claude Code.**
+
+## Why both layers are needed
+
+| Layer | Provides | Updated by |
+|---|---|---|
+| 1 — global tool | The `roslynmcp` MCP server executable (C# tools, services, transports) | `dotnet publish ... -p:ReinstallTool=true` |
+| 2 — Claude Code plugin | Skill definitions (`/roslyn-mcp:*`), pre/post-apply hooks, marketplace manifest | `eng/update-claude-plugin.ps1` (or `/plugin` slash commands) |
+
+If you only do Layer 1, your skills and hooks stay on the old commit. If you
+only do Layer 2, the slash commands launch the old `roslynmcp` binary. Always
+do both after a substantive change.
+
+## Troubleshooting
+
+- **`MSB1008: Only one project can be specified.`** — You're on Git Bash and
+  used `/p:ReinstallTool=true`. Switch to `-p:ReinstallTool=true`.
+- **Slash commands like `/plugin install` come back as a normal chat reply.**
+  Your Claude Code client doesn't intercept the `/plugin` slash command. Use
+  `eng/update-claude-plugin.ps1` instead (Layer 2 → Option A).
+- **`update-claude-plugin.ps1` fails with "Marketplace clone not found".**
+  The plugin has never been installed on this machine. Install it once via a
+  client that supports the slash commands, then use the script for updates.
+- **`update-claude-plugin.ps1` runs but Claude Code still shows the old
+  skills.** Restart Claude Code — skills and hooks are loaded at session
+  start, not on the fly.
+- **`/plugin install` reports the same version as before** (Option B). The
+  marketplace cache is stale. Run `/plugin marketplace update
+  roslyn-mcp-marketplace` first, then re-run `/plugin install`.
+- **`roslynmcp` command not found after Layer 1.** Confirm
+  `%USERPROFILE%\.dotnet\tools` is on your `PATH`. Reinstall with
+  `dotnet tool install -g RoslynMcp` if the publish step skipped install.
+- **Hooks block `*_apply` calls unexpectedly.** That's the pre-apply guard
+  doing its job; you must call the matching `*_preview` first. This is
+  documented in `README.md` § *Plugin Hooks*.
+
+## Related docs
+
+- [`README.md`](README.md) — primary install instructions and MCP client config
+- [`docs/setup.md`](docs/setup.md) — packaging, Docker, CI artifacts
+- [`ai_docs/runtime.md`](ai_docs/runtime.md) — runtime assumptions for AI
+  sessions, including Roslyn MCP client policy

--- a/ai_docs/audit-reports/2026-04-06_firewallanalyzer_mcp-server-audit.md
+++ b/ai_docs/audit-reports/2026-04-06_firewallanalyzer_mcp-server-audit.md
@@ -1,0 +1,308 @@
+# Roslyn MCP Server Audit Report
+
+**repo:** FirewallAnalyzer (DotNet-Firewall-Analyzer)
+**date:** 2026-04-06
+**server version:** Roslyn MCP v1.6.0 — catalog 2026.03
+**roslyn version:** 5.3.0.0 / .NET 10
+**workspace:** `FirewallAnalyzer.slnx` — 11 projects, 230 documents, 0 workspace diagnostics
+**audit mode:** conservative (preview-only; no applies to main branch)
+**auditor:** Claude Sonnet 4.6 via deep-review-and-refactor prompt
+
+---
+
+## Catalog Surface
+
+| Category | Stable | Experimental | Total |
+|----------|--------|-------------|-------|
+| Tools | 56 | 67 | 123 |
+| Resources | 7 | — | 7 |
+| Prompts | — | 16 | 16 |
+
+All 18 audit phases executed (Phase 18 N/A — no prior MCP issues in backlog).
+
+---
+
+## FLAGS (Bugs / Incorrect Behavior)
+
+### FLAG-001 — `compile_check`: emitValidation speedup claim inaccurate
+**Severity:** Low (doc only)
+**Tool:** `compile_check`
+**Description:** Documentation states `emitValidation=true` is "10-18x slower". Measured: 17ms (false) → 1598ms (true) ≈ **94× slower** on this solution.
+**Impact:** Misleading perf guidance; agents may use emitValidation more liberally than warranted.
+
+---
+
+### FLAG-002 — `get_nuget_dependencies`: CPM versions not resolved
+**Severity:** Medium
+**Tool:** `get_nuget_dependencies`
+**Description:** In a Central Package Management repo, all package versions are reported as `"centrally-managed"` — actual resolved version numbers (from `Directory.Packages.props`) are not surfaced.
+**Impact:** Manual security auditing of versions requires a separate tool (`nuget_vulnerability_scan` uses dotnet CLI and resolves correctly; `get_nuget_dependencies` is not a reliable source for version data in CPM repos).
+
+---
+
+### FLAG-003 — `impact_analysis` vs `find_references`: inconsistent `Classification` contract
+**Severity:** Medium
+**Tools:** `impact_analysis`, `find_references`
+**Description:** `impact_analysis` returns `"Classification": null` for all reference entries. `find_references` returns `"Classification": "Read"` for the same references. Sibling tools with different response contracts for the same field on the same symbol (`YamlConfigLoader.CollectUnknownYamlKeyMessages`, 19 references).
+**Impact:** Consumers cannot rely on `Classification` from `impact_analysis` for cross-reference categorisation.
+
+---
+
+### FLAG-004 — `callers_callees`: duplicate callee entries for chained calls
+**Severity:** Medium
+**Tool:** `callers_callees`
+**Description:** Calling `callers_callees` on `DriftDetector.RulesEqual` returns 9 duplicate callee entries for `ListsEqual` all pointing to the same file/line (line 67), all with `PreviewText: null`. `ListsEqual` is called 9 times in a `&&` expression chain; each call produces a separate (identical) callee record rather than being de-duplicated.
+**Impact:** Callee lists are noisy/misleading for methods called multiple times in the same expression.
+
+---
+
+### FLAG-005 — `find_type_usages`: all static-class call sites classified as `"other"`
+**Severity:** Low
+**Tool:** `find_type_usages`
+**Description:** All 18 usages of `TrafficSimulator` (a static class) are classified as `"other"` rather than more specific categories (e.g. `MethodInvocation`). The classification appears to only activate for type usages in declarations (variable types, base types), not for method-call-site references to static classes.
+**Impact:** Reduced utility for automated static analysis; call-site usages are indistinguishable from other references.
+
+---
+
+### FLAG-006 — `symbol_signature_help`: cursor at return type resolves to return type, not method
+**Severity:** Low
+**Tool:** `symbol_signature_help`
+**Description:** When called at a method signature declaration's return type position (e.g. line 84 col 28 of `YamlConfigLoader.cs`, inside `IReadOnlyList<string>`), the tool resolves the BCL type token rather than the method being declared. The documentation notes caret position matters but does not warn that positions within the return type of a method declaration resolve to the return type, not the method itself.
+**Impact:** Confusing results; no actionable signature help for the intended method.
+
+---
+
+### FLAG-007 — `analyze_snippet` kind=`statements`: `return <value>` fails CS0127
+**Severity:** Low
+**Tool:** `analyze_snippet`
+**Description:** The `statements` kind wraps code in a `void Run()` method, so `return y;` fails with CS0127. The `evaluate_csharp` scripting API handles `return` fine. The documentation describes `statements` as "method body" but does not clarify the void return constraint.
+**Impact:** Confusing failures for users migrating snippets between `analyze_snippet` and `evaluate_csharp`.
+
+---
+
+### FLAG-008 — `evaluate_csharp`: `AppliedScriptTimeoutSeconds` always null
+**Severity:** Low
+**Tool:** `evaluate_csharp`
+**Description:** `AppliedScriptTimeoutSeconds` field is always `null` in every response, regardless of execution time. The tool description says "The server enforces a script timeout (default 10 seconds)" but this cannot be verified from client-side results.
+**Impact:** Agents cannot confirm whether server timeout protection is active for long-running scripts.
+
+---
+
+### FLAG-009 — `rename_preview`: non-differentiating error for BCL/metadata symbols
+**Severity:** Low
+**Tool:** `rename_preview`
+**Description:** When called at a BCL type position (e.g. `IReadOnlyList` in a return type), returns `category: "InvalidArgument"` with "Symbol 'IReadOnlyList' is not from source" — the same error category used for genuinely invalid arguments (wrong types, out-of-range values). Should use a distinct category or message (e.g. "cannot rename metadata symbols").
+**Impact:** Hard to distinguish invalid argument from "cannot rename this symbol type" in automated pipelines.
+
+---
+
+### FLAG-010 — `get_code_actions`: consistently returns 0 actions
+**Severity:** High
+**Tool:** `get_code_actions`
+**Description:** Returns 0 actions at every tested position: class name (`JobTracker` line 9 col 14), switch expression range (lines 117-126), catch clause (lines 142-145). Expected Roslyn refactoring suggestions (Extract Interface, Move to File, Convert switch, etc.) are never surfaced.
+**Impact:** The tool is non-functional in practice for this solution; agents using it to discover available refactorings get no results.
+
+---
+
+### FLAG-011 — Misleading "workspace may need to be reloaded" suffix on non-stale errors
+**Severity:** Medium
+**Tools:** `remove_dead_code_preview`, `evaluate_msbuild_property`, `analyze_data_flow`, and others
+**Description:** Multiple tools append "The workspace may need to be reloaded (workspace_reload) if the state is stale." to `InvalidOperation` errors that have nothing to do with workspace staleness — e.g. "Symbol 'JobTracker' still has references and cannot be removed safely" or "Project 'NonExistentProject' not found in workspace."
+**Impact:** Agents may attempt unnecessary workspace reloads, or mistrust valid error messages. The suffix should only appear when staleness is a plausible cause (e.g., file-not-found-in-workspace after external edits).
+
+---
+
+### FLAG-012 — `extract_type_preview`: generated field declaration has no whitespace
+**Severity:** High
+**Tool:** `extract_type_preview`
+**Description:** The patch for `JobTracker.cs` after extracting 3 members into `JobTrackerScavenger` inserts the new field as `privatereadonlyJobTrackerScavenger_jobTrackerScavenger;` — all tokens concatenated with no whitespace. This is non-compilable output.
+**Impact:** Applying this preview would break the source file. The preview itself is silently incorrect.
+
+---
+
+### FLAG-013 — `extract_type_preview`: extracted class references parent-only fields — non-compilable
+**Severity:** High
+**Tool:** `extract_type_preview`
+**Description:** `JobTrackerScavenger.cs` references `_cancellationTokens`, `_jobs`, `_retentionPeriod`, and `MaxRetainedJobs`, which are fields/constants of `JobTracker` and are not injected into the extracted class. No constructor, no parameters, no warning emitted. The resulting code would fail to compile.
+**Impact:** Applying this preview would produce non-compilable code with no advance warning.
+
+---
+
+### FLAG-014 — `extract_interface_preview` / `extract_interface_cross_project_preview`: missing space before `{`
+**Severity:** Low
+**Tools:** `extract_interface_preview`, `extract_interface_cross_project_preview`
+**Description:** Both tools generate a `JobTracker.cs` patch with `public class JobTracker\n+: IJobTracker{` — no space between `IJobTracker` and `{`. Violates standard C# formatting conventions and the project's own editorconfig (`csharp_new_line_before_open_brace: all`).
+**Impact:** Minor formatting debt; would be caught by `format_document_preview` after apply.
+
+---
+
+### FLAG-015 — `extract_interface_cross_project_preview`: wrong target directory + spurious using
+**Severity:** Medium
+**Tool:** `extract_interface_cross_project_preview`
+**Description:** When extracting `IJobTracker` to `FirewallAnalyzer.Domain`, the interface file is placed at the project root (`src/FirewallAnalyzer.Domain/IJobTracker.cs`) rather than the existing `Interfaces/` subdirectory that holds `IPanosClient.cs` and `ISnapshotStore.cs`. Also adds `using System.Collections.Concurrent;` which is not used in the interface contract.
+**Impact:** Convention violation; spurious import would be flagged by `organize_usings_preview`.
+
+---
+
+### FLAG-016 — `move_type_to_file_preview`: 3 leading blank lines + lost property spacing
+**Severity:** Low
+**Tool:** `move_type_to_file_preview`
+**Description:** Generated `DriftReport.cs` has 3 leading blank lines before the namespace declaration and collapses the blank lines between properties that existed in the source file. Formatting is inconsistent with the project's editorconfig style.
+**Impact:** Minor formatting debt; would be caught by `format_document_preview` after apply.
+
+---
+
+### FLAG-017 — `scaffold_test_preview`: generates MSTest despite project using xUnit
+**Severity:** High
+**Tool:** `scaffold_test_preview`
+**Description:** Scaffolds `[TestClass]`, `[TestMethod]`, `Assert.IsNotNull`, `Assert.Fail` (MSTest API) when the target test project (`FirewallAnalyzer.Infrastructure.Tests`) uses xUnit. The project has no MSTest dependency, so applying this scaffold would produce unresolvable references.
+**Impact:** Applying the scaffold would produce non-compilable test files. No test framework detection is performed.
+
+---
+
+### FLAG-018 — `scaffold_test_preview`: does not call the requested private method
+**Severity:** Medium
+**Tool:** `scaffold_test_preview`
+**Description:** When `targetMethodName: "ScavengeUnsafe"` is specified (a `private` method), the scaffold creates an `[TestMethod]` that instantiates `JobTracker` and then calls `Assert.Fail("Add real assertions.")` — `ScavengeUnsafe` is never mentioned. There is no access-modifier warning.
+**Impact:** The scaffold is a non-functional placeholder that doesn't reflect the requested test target.
+
+---
+
+### FLAG-019 — `set_project_property_preview`: malformed XML — inline `<PropertyGroup>`
+**Severity:** High
+**Tool:** `set_project_property_preview`
+**Description:** When setting `LangVersion=13` on `FirewallAnalyzer.Api`, the generated diff appends `<PropertyGroup><LangVersion>13</LangVersion></PropertyGroup>` on the same line as the opening `<Project>` tag: `<Project Sdk="..."><PropertyGroup>...`. This produces malformed, unreadable XML that violates standard `.csproj` structure.
+**Impact:** Applying this preview would produce a csproj that may confuse MSBuild or tooling that formats project files.
+
+---
+
+### FLAG-020 — `add_package_reference_preview`: missing newline before `</Project>`
+**Severity:** Low
+**Tool:** `add_package_reference_preview`
+**Description:** The generated diff places `</ItemGroup></Project>` on the same line without a separating newline. The resulting csproj would have the closing `</Project>` on the same line as `</ItemGroup>`.
+**Impact:** Minor formatting issue; MSBuild handles this but tooling/diffing is harder to read.
+
+---
+
+### FLAG-021 — `go_to_definition` + `impact_analysis`: `Classification: null` for all results
+**Severity:** Low
+**Tools:** `go_to_definition`, `impact_analysis`
+**Description:** Both tools return `"Classification": null` for all results. `find_references` returns `"Classification": "Read"` for the same symbol. Inconsistent classification contract across three related navigation tools.
+**Impact:** Automated post-processing of results cannot rely on classification across tool families.
+
+---
+
+### FLAG-022 — `get_completions`: `InlineDescription` always empty; no pagination
+**Severity:** Low
+**Tool:** `get_completions`
+**Description:** `InlineDescription` is `""` for every completion item regardless of type — no type signatures or documentation snippets are included. `IsIncomplete: true` indicates a larger list exists, but there is no `limit` or `offset` parameter to retrieve the remaining items.
+**Impact:** Completions are less informative than IDE IntelliSense; paginating through completions is impossible.
+
+---
+
+### FLAG-023 — `go_to_definition` out-of-bounds line: exposes internal parameter name
+**Severity:** Low
+**Tool:** `go_to_definition`
+**Description:** Requesting line 99999 (beyond file length) returns `ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')`. "Parameter 'index'" is an internal implementation detail; the user-facing message should say "line 99999 is beyond the file's line count".
+**Impact:** Confusing error message for invalid line numbers.
+
+---
+
+### FLAG-024 — `document_symbols` on nonexistent file: silent empty result
+**Severity:** Medium
+**Tool:** `document_symbols`
+**Description:** Requesting `document_symbols` on `src/DOES_NOT_EXIST/Fake.cs` returns `[]` with no error. This is identical to the result for a valid file that contains no type declarations.
+**Impact:** Agents cannot distinguish "file not found" from "file exists but has no symbols". Should return an error or include a `found: false` field.
+
+---
+
+### FLAG-025 — Resource discovery gap: workspace-scoped resources not in `resources/list`
+**Severity:** Low
+**Tool:** `ListMcpResourcesTool` / MCP resource surface
+**Description:** `resources/list` returns only 3 static resources (`workspaces`, `server/catalog`, `server/resource-templates`). The 4 workspace-scoped resource templates (`source_file`, `workspace_diagnostics`, `workspace_projects`, `workspace_status`) are invisible without first reading `roslyn://server/resource-templates`. The `resource-templates` description does acknowledge this, but it requires a priori knowledge to discover.
+**Impact:** MCP clients that rely solely on `resources/list` for discovery will miss 4 of 7 resources.
+
+---
+
+## Observations (Not Bugs)
+
+| # | Tool / Area | Observation |
+|---|-------------|-------------|
+| OBS-1 | Project config | `AnalysisLevel=9.0` with `TargetFramework=net10.0` — analysis level trails TFM by one version; .NET 10 analyzer rules inactive |
+| OBS-2 | Project config | `EnforceCodeStyleInBuild=false` — editorconfig `warning`-severity rules (namespace declarations, using placement) are IDE-only; won't fail CI |
+| OBS-3 | Coverage | `ObjectInventoryQuery` (412 lines) and `RuleQuery` (162 lines) both at 0% line coverage in Application.Tests |
+| OBS-4 | Usings | 2 unused imports in `ApiHostBuilder.cs` (`PanosClient`, `Microsoft.Extensions.Logging`) — found by `organize_usings_preview`, not enforced in CI |
+| OBS-5 | `IpInCidr` / `CollectUnknownYamlKeyMessages` | Both use catch-all exception handlers that silently swallow exceptions — intentional design per code comments |
+| OBS-6 | `Build` (ApiHostBuilder) | `settings` and `resilienceTimeoutSeconds` captured by closures; 40 local variables — CC=18 is accurate; method is a structural startup orchestration method, not algorithm logic |
+| OBS-7 | `callers_callees` on `Simulate` | 18 callers correctly found across 2 projects — 14 test, 4 production |
+| OBS-8 | `semantic_search` | `Signature` field omits return type and `async` keyword — cannot verify query match from result alone |
+| OBS-9 | `fix_all_preview` for IDE0005 | Correctly redirects to `organize_usings_preview` with a guidance message — good defensive UX |
+| OBS-10 | `revert_last_apply` | Correctly returns `reverted: false` on empty undo stack with clear message |
+
+---
+
+## Tool Coverage Ledger
+
+Tools exercised by category during this audit:
+
+| Category | Exercised | Notes |
+|----------|-----------|-------|
+| **Workspace** | `workspace_load`, `workspace_list`, `workspace_status`, `workspace_close` (via load), `workspace_reload` (indirect) | All stable workspace ops covered |
+| **Diagnostics** | `project_diagnostics`, `compile_check`, `security_diagnostics`, `nuget_vulnerability_scan`, `list_analyzers`, `diagnostic_details` | Full diagnostic surface |
+| **Metrics** | `get_complexity_metrics`, `get_cohesion_metrics`, `get_namespace_dependencies`, `get_coupling_metrics` | All 4 metric tools |
+| **Symbol analysis** | `find_references`, `find_references_bulk`, `impact_analysis`, `callers_callees`, `find_shared_members`, `find_type_mutations`, `find_type_usages`, `symbol_signature_help`, `find_property_writes`, `member_hierarchy`, `find_implementations`, `find_consumers`, `symbol_relationships`, `find_base_members`, `find_overrides` | Near-complete symbol surface |
+| **Flow analysis** | `analyze_data_flow`, `analyze_control_flow`, `get_operations`, `get_syntax_tree`, `get_source_text` | All 5 flow tools |
+| **Snippet/Script** | `analyze_snippet`, `evaluate_csharp` | Both tools |
+| **Refactoring** | `rename_preview`, `format_document_preview`, `organize_usings_preview`, `extract_interface_preview`, `extract_interface_cross_project_preview`, `extract_type_preview`, `remove_dead_code_preview`, `get_code_actions`, `code_fix_preview`, `fix_all_preview`, `move_file_preview`, `move_type_to_file_preview`, `create_file_preview`, `revert_last_apply` | All major refactoring preview ops |
+| **EditorConfig/MSBuild** | `get_editorconfig_options`, `evaluate_msbuild_property`, `evaluate_msbuild_items`, `get_msbuild_properties` (skipped — large), `set_editorconfig_option` (skipped — no preview) | Core MSBuild evaluation covered |
+| **Build/Test** | `build_workspace`, `test_discover`, `test_run`, `test_coverage` | All 4 tools |
+| **Project mutation** | `add_package_reference_preview`, `set_project_property_preview` | Core mutation previews |
+| **Scaffolding** | `scaffold_test_preview`, `scaffold_type_preview` | Both tools |
+| **Navigation** | `go_to_definition`, `goto_type_definition`, `document_symbols`, `get_completions`, `symbol_search`, `semantic_search` | Core navigation tools |
+| **Search** | `find_unused_symbols`, `symbol_search`, `semantic_search` | Dead code + semantic search |
+| **Resources** | `roslyn://workspaces`, `roslyn://server/catalog`, `roslyn://server/resource-templates` | All 3 static resources; 4 workspace-scoped verified via templates |
+| **Prompts** | Verified via catalog (16 prompts listed) | All experimental; verified names and summaries |
+| **Boundary testing** | Invalid workspaceId, OOB line, nonexistent file, same-name rename, keyword rename, inverted range, missing project | 7 negative cases |
+
+**Tools not exercised** (experimental / out-of-scope for this audit):
+- `apply_*` family (conservative mode)
+- `set_diagnostic_severity`, `add_pragma_suppression`
+- `split_class_preview`, `dependency_inversion_preview`
+- `bulk_replace_type_*`
+- `evaluate_msbuild_items` for Compile items (large output)
+- `source_generated_documents`
+- `get_inlay_hints`, `get_semantic_tokens`, `get_folding_ranges`, `selection_range`
+
+---
+
+## Codebase Health Summary
+
+| Metric | Value |
+|--------|-------|
+| Build | ✅ 0 errors, 0 warnings |
+| Tests (unit + integration) | ✅ 297/297 pass |
+| Security diagnostics | ✅ 0 findings |
+| Unused symbols (private/internal) | ✅ 0 |
+| Nullable annotations | ✅ enabled |
+| TreatWarningsAsErrors | ✅ true |
+| Cyclomatic complexity hotspots | `Build` CC=18, `CollectUnknownYamlKeyMessages` CC=20, `IpInCidr` CC=14 |
+| Line coverage (Application.Tests) | 56% line / 47.6% branch |
+| Zero-coverage classes | `ObjectInventoryQuery` (412L), `RuleQuery` (162L) |
+
+---
+
+## Priority Summary
+
+| Priority | Count | IDs |
+|----------|-------|-----|
+| **High** | 4 | FLAG-010, FLAG-012, FLAG-013, FLAG-017, FLAG-019 |
+| **Medium** | 7 | FLAG-002, FLAG-003, FLAG-004, FLAG-011, FLAG-015, FLAG-018, FLAG-021(?), FLAG-024 |
+| **Low** | 14 | FLAG-001, FLAG-005 through FLAG-009, FLAG-014, FLAG-016, FLAG-020, FLAG-021, FLAG-022, FLAG-023, FLAG-025 |
+
+> **High** = would produce non-compilable output on apply, or a major tool surface that returns nothing useful
+> **Medium** = incorrect data or misleading behavior that could misdirect agent workflows
+> **Low** = documentation gaps, minor formatting issues, convenience deficits
+
+---
+
+*Report generated by Claude Sonnet 4.6 via `ai_docs/prompts/deep-review-and-refactor.md`*

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-06T03:00:00Z
+**updated_at:** 2026-04-06T18:15:00Z
 
 ## Agent contract
 

--- a/ai_docs/procedures/deep-review-command-reference.md
+++ b/ai_docs/procedures/deep-review-command-reference.md
@@ -91,6 +91,43 @@ Use `-Force` only when you intentionally want to replace the canonical raw copy.
 | External repo raw files need to be staged first | `import-deep-review-audit.ps1` → `new-deep-review-rollup.ps1` |
 | External repo batch, common path | `new-deep-review-batch.ps1` |
 
+## Helper/background test run pattern
+
+Use this when the MCP client supports subagents, background agents, or another background execution facility. The exact helper command is client-specific, so structure the run like this rather than trying to standardize one shell wrapper here.
+
+1. In the **primary agent**, keep workspace setup, repo-shape checks, and test selection (`test_discover`, `test_related_files`, `test_related`). Decide exactly which heavy validations need to run.
+2. Send only the heavy validation step to the helper/background worker: filtered `test_run`, full-suite `test_run`, `test_coverage`, or an equivalent fallback shell test command if the client cannot run the MCP test tools directly.
+3. Point the helper/background worker at the **same repo, branch/worktree, and disposable checkout** as the primary agent. Do not delegate preview/apply chains or other workspace-version-sensitive mutation steps.
+4. Require the helper/background worker to return a **summary only**: tool or command used, filter or scope, pass/fail counts, failing test names, approximate duration, coverage headline, and any anomalies or client/tool errors.
+5. Back in the **primary agent**, convert that summary into PASS / FLAG / FAIL judgments, update the coverage ledger, and record any helper/runtime constraints in the raw audit report.
+
+### Example operator prompt
+
+Use or adapt this when your client can launch a subagent or background worker:
+
+```text
+Run a helper/background validation pass in the same repo, branch/worktree, and disposable checkout as the primary deep-review audit.
+
+Constraints:
+- Do not change code, run preview/apply mutations, or alter workspace state beyond the requested test/build execution.
+- Do not paste raw logs unless execution fails so badly that a short summary is impossible.
+
+Tasks:
+1. Run `test_run` with filter `<related-test-filter>`.
+2. Run full-suite `test_run` with no filter.
+3. Run `test_coverage`.
+4. If the MCP test tools are unavailable in this client, use the approved fallback shell test command for the repo instead.
+
+Return summary only:
+- tool or command used for each step
+- filter or scope
+- pass/fail/skipped counts
+- failing test names
+- approximate duration per step
+- coverage headline
+- anomalies, timeouts, or client/tool errors
+```
+
 ## Related
 
 - `deep-review-program.md` — full workflow, repo matrix, and backlog intake rules

--- a/ai_docs/procedures/deep-review-program.md
+++ b/ai_docs/procedures/deep-review-program.md
@@ -53,6 +53,16 @@ If no repo matches a bucket, record that gap in the rollup rather than inventing
 
 At least one full-surface client lane must run before treating prompt/resource families as adequately covered.
 
+## Helper execution and context conservation
+
+Use helper execution when the client/runtime supports it so long-running validation does not consume the primary agent's context window.
+
+1. If the client/runtime supports **subagents**, **background agents**, or another background execution facility, operators SHOULD prefer them for long-running or high-output validation work.
+2. Prioritize delegation for full-solution build/test/coverage work and other log-heavy operations, especially `test_run` with no filter, `test_coverage`, and equivalent shell-based validation. Keep repo selection, scenario selection, and short low-output probes in the primary agent unless delegation clearly reduces noise.
+3. Delegation changes execution ownership, not audit ownership. The primary agent still owns audit mode, workspace/disposable-checkout context, PASS / FLAG / FAIL judgment, coverage-ledger updates, and the final raw audit report.
+4. Require helpers to return a concise structured summary rather than raw logs: tool or command used, scope or filter, pass/fail counts, failing test names, approximate duration, coverage headline, and any anomalies or client/tool errors.
+5. Do not delegate preview/apply chains or workspace-version-sensitive mutation sequences unless the helper can operate against the same disposable checkout and workspace state safely. If helper/background execution is unavailable, run the steps directly and record that constraint only if it materially affected the run.
+
 ## Cadence
 
 | Trigger | Recommended scope |
@@ -75,6 +85,7 @@ Each raw audit or batch manifest should capture these fields so rollups are comp
 | Audit mode | Distinguish `full-surface` from `conservative`. |
 | Repo-shape tags | Explain why some families were or were not applicable. |
 | Client capability notes | Record prompt/resource availability or `blocked` limitations. |
+| Helper execution notes | Record whether subagents/background agents handled long-running validation and any related client/runtime limits. |
 | Coverage counts by status | Compare exercised vs skipped vs blocked across runs. |
 | New issue count / candidate closure count | Support rollup triage. |
 

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -38,6 +38,14 @@ You are a senior .NET architect. Your **primary mission** is to **audit the Rosl
 6. Record repo-shape constraints up front: single vs multi-project, tests present, analyzers present, source generators present, DI usage present, `.editorconfig` present, Central Package Management / `Directory.Packages.props`, multi-targeting, and network/package-restore constraints.
 7. Do not invent applicability. If the repo has no tests, no DI, no source generators, no multi-targeting, or only one project, record that explicitly and treat the corresponding steps as `skipped-repo-shape`.
 
+### Execution strategy and context conservation
+
+1. If the client/runtime supports **subagents**, **background agents**, or another background execution facility, you MAY and generally SHOULD use them for long-running or high-output validation work to conserve the primary agent's context window.
+2. Prioritize delegation for full-solution build/test/coverage work and other log-heavy operations, especially Phase 8 `test_run` with no filter, `test_coverage`, and any equivalent shell-based validation. Keep short, low-output probes inline unless delegation meaningfully reduces noise.
+3. Delegation changes execution ownership, not audit ownership. The primary agent still chooses the scenario, preserves workspace/mode context, evaluates PASS / FLAG / FAIL, updates the coverage ledger, and writes the final report.
+4. Require helpers to return a concise structured summary instead of raw logs: tool or command used, scope or filter, pass/fail counts, failing test names, approximate duration, coverage headline, and any anomalies or client/tool errors.
+5. Do not delegate preview/apply chains or workspace-version-sensitive mutation sequences unless the helper can operate against the same disposable checkout and workspace state safely. If helper/background execution is unavailable, run the steps directly and continue the audit.
+
 Work through each phase below **in order** (including the Phase 10 -> Phase 9 sequence), then complete the **Final surface closure** step before you write the report. After each tool call, evaluate whether the result is correct and complete. If a tool returns an error, empty results when data was expected, or results that seem wrong, record it for the MCP Server Audit Report.
 
 ### Cross-cutting audit principles (apply to every phase)
@@ -259,6 +267,8 @@ For each method with high complexity:
 ---
 
 ### Phase 8: Build & Test Validation
+
+**Execution note:** If the client supports subagents or background agents/tasks, prefer keeping test selection (`test_discover`, `test_related_files`, `test_related`) in the primary agent, then delegate the heavy runs (`test_run` with filters, `test_run` for the full suite, `test_coverage`, and any fallback shell test command). Bring back only the structured summary needed for the audit report and coverage ledger.
 
 1. Call `workspace_reload` to refresh the workspace after all refactoring file changes.
 2. Call `build_workspace` to do a full MSBuild build after all refactoring.

--- a/eng/update-claude-plugin.ps1
+++ b/eng/update-claude-plugin.ps1
@@ -1,0 +1,137 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Updates the locally cached roslyn-mcp Claude Code plugin to match the
+    latest commit on GitHub main.
+
+.DESCRIPTION
+    Performs the equivalent of running these slash commands inside Claude Code:
+
+        /plugin marketplace update roslyn-mcp-marketplace
+        /plugin install roslyn-mcp@roslyn-mcp-marketplace
+
+    Use this script when your Claude Code client does not intercept the
+    `/plugin` slash commands (some channels and older builds do not), or when
+    you want to refresh the plugin from a terminal without opening the REPL.
+
+    The script:
+      1. git-pulls the marketplace clone under
+         ~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/
+      2. Wipes and re-syncs the plugin cache directory
+         (~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<ver>/)
+         from the marketplace clone, copying only git-tracked files.
+      3. Updates lastUpdated and gitCommitSha in
+         ~/.claude/plugins/known_marketplaces.json and installed_plugins.json.
+
+    After this script finishes, restart Claude Code so the new MCP server
+    binary, skills, and hooks are loaded.
+
+    This script does NOT rebuild the `roslynmcp` global .NET tool. Run
+    `dotnet publish src/RoslynMcp.Host.Stdio -c Release -p:ReinstallTool=true`
+    separately for that.
+
+.EXAMPLE
+    pwsh ./eng/update-claude-plugin.ps1
+
+.EXAMPLE
+    pwsh ./eng/update-claude-plugin.ps1 -PluginVersion 1.6.0
+#>
+
+[CmdletBinding()]
+param(
+    [string] $MarketplaceName = 'roslyn-mcp-marketplace',
+    [string] $PluginName = 'roslyn-mcp',
+    [string] $PluginVersion,
+    [string] $ClaudeHome = (Join-Path $HOME '.claude')
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string] $Message) {
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+$pluginsDir = Join-Path $ClaudeHome 'plugins'
+$marketplaceDir = Join-Path $pluginsDir "marketplaces/$MarketplaceName"
+$knownMarketplacesPath = Join-Path $pluginsDir 'known_marketplaces.json'
+$installedPluginsPath = Join-Path $pluginsDir 'installed_plugins.json'
+
+if (-not (Test-Path $marketplaceDir)) {
+    throw "Marketplace clone not found at $marketplaceDir. Install the plugin from Claude Code at least once before running this script."
+}
+if (-not (Test-Path $knownMarketplacesPath)) {
+    throw "known_marketplaces.json not found at $knownMarketplacesPath."
+}
+if (-not (Test-Path $installedPluginsPath)) {
+    throw "installed_plugins.json not found at $installedPluginsPath."
+}
+
+# 1. Pull the marketplace clone.
+Write-Step "Pulling marketplace clone in $marketplaceDir"
+Push-Location $marketplaceDir
+try {
+    git fetch origin | Out-Null
+    git checkout main | Out-Null
+    git pull --ff-only origin main | Out-Null
+    $headSha = (git rev-parse HEAD).Trim()
+    Write-Host "    HEAD is now $headSha"
+}
+finally {
+    Pop-Location
+}
+
+# 2. Resolve plugin version + cache dir.
+$installed = Get-Content $installedPluginsPath -Raw | ConvertFrom-Json
+$installKey = "$PluginName@$MarketplaceName"
+$installEntries = $installed.plugins.$installKey
+if (-not $installEntries) {
+    throw "No installed plugin entry found for '$installKey' in installed_plugins.json. Install via Claude Code first."
+}
+$installEntry = $installEntries[0]
+
+if (-not $PluginVersion) {
+    $PluginVersion = $installEntry.version
+}
+$cacheDir = Join-Path $pluginsDir "cache/$MarketplaceName/$PluginName/$PluginVersion"
+Write-Host "    Plugin cache target: $cacheDir"
+
+# 3. Re-sync the plugin cache from the marketplace clone (git-tracked files only).
+Write-Step "Re-syncing plugin cache from marketplace clone"
+if (Test-Path $cacheDir) {
+    Remove-Item $cacheDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $cacheDir | Out-Null
+
+Push-Location $marketplaceDir
+try {
+    $trackedFiles = git ls-files
+    foreach ($relPath in $trackedFiles) {
+        $src = Join-Path $marketplaceDir $relPath
+        $dst = Join-Path $cacheDir $relPath
+        $dstDir = Split-Path $dst -Parent
+        if (-not (Test-Path $dstDir)) {
+            New-Item -ItemType Directory -Path $dstDir -Force | Out-Null
+        }
+        Copy-Item $src $dst -Force
+    }
+    Write-Host "    Copied $($trackedFiles.Count) files"
+}
+finally {
+    Pop-Location
+}
+
+# 4. Update metadata.
+Write-Step "Updating plugin metadata"
+$nowIso = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+
+$known = Get-Content $knownMarketplacesPath -Raw | ConvertFrom-Json
+$known.$MarketplaceName.lastUpdated = $nowIso
+($known | ConvertTo-Json -Depth 10) | Set-Content -NoNewline -Encoding UTF8 $knownMarketplacesPath
+
+$installEntry.lastUpdated = $nowIso
+$installEntry.gitCommitSha = $headSha
+($installed | ConvertTo-Json -Depth 10) | Set-Content -NoNewline -Encoding UTF8 $installedPluginsPath
+
+Write-Host ""
+Write-Host "Plugin '$PluginName' updated to commit $headSha." -ForegroundColor Green
+Write-Host "Restart Claude Code to pick up the new skills, hooks, and MCP server binary." -ForegroundColor Yellow

--- a/src/RoslynMcp.Core/Models/NuGetDependencyDto.cs
+++ b/src/RoslynMcp.Core/Models/NuGetDependencyDto.cs
@@ -28,4 +28,5 @@ public sealed record NuGetProjectDto(
 /// </summary>
 public sealed record NuGetPackageReferenceDto(
     string PackageId,
-    string Version);
+    string Version,
+    string? ResolvedCentralVersion = null);

--- a/src/RoslynMcp.Core/Models/ScaffoldingDtos.cs
+++ b/src/RoslynMcp.Core/Models/ScaffoldingDtos.cs
@@ -18,7 +18,7 @@ public sealed record ScaffoldTestDto(
     string TestProjectName,
     string TargetTypeName,
     string? TargetMethodName = null,
-    string TestFramework = "mstest");
+    string TestFramework = "auto");
 
 /// <summary>
 /// Represents a request to remove dead code symbols.

--- a/src/RoslynMcp.Core/Models/TypeUsageDto.cs
+++ b/src/RoslynMcp.Core/Models/TypeUsageDto.cs
@@ -17,6 +17,7 @@ public enum TypeUsageClassification
     ObjectCreation,
     Constructor,
     DIRegistration,
+    StaticMemberAccess,
     Other
 }
 

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -91,7 +91,7 @@ public static class ServerSurfaceCatalog
         Tool("apply_project_mutation", "project-mutation", "experimental", false, true, "Apply a previously previewed project file mutation."),
         Tool("scaffold_type_preview", "scaffolding", "experimental", true, false, "Preview scaffolding a new type file in a project."),
         Tool("scaffold_type_apply", "scaffolding", "experimental", false, true, "Apply a previously previewed type scaffolding operation."),
-        Tool("scaffold_test_preview", "scaffolding", "experimental", true, false, "Preview scaffolding a new MSTest file for a target type."),
+        Tool("scaffold_test_preview", "scaffolding", "experimental", true, false, "Preview scaffolding a new test file (MSTest, xUnit, or NUnit; auto-detect or specify testFramework)."),
         Tool("scaffold_test_apply", "scaffolding", "experimental", false, true, "Apply a previously previewed test scaffolding operation."),
         Tool("remove_dead_code_preview", "dead-code", "experimental", true, false, "Preview removing unused symbols by handle."),
         Tool("remove_dead_code_apply", "dead-code", "experimental", false, true, "Apply a previously previewed dead-code removal operation."),

--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -11,7 +11,7 @@ public static class WorkspaceResources
 {
 
     [McpServerResource(UriTemplate = "roslyn://workspaces", Name = "workspaces", MimeType = "application/json")]
-    [Description("List all currently loaded workspace sessions with their status")]
+    [Description("List all currently loaded workspace sessions with their status. Workspace-scoped resources (status, projects, diagnostics, source_file) use URI templates — if your MCP client only shows static resources from resources/list, read roslyn://server/resource-templates to discover those templates.")]
     public static string GetWorkspaces(IWorkspaceManager workspace)
     {
         try

--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class CompileCheckTools
 {
     [McpServerTool(Name = "compile_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
-     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation. Note: only reports compiler diagnostics (CS*); analyzer diagnostics (CA*, IDE*) are excluded — use project_diagnostics for those. The emitValidation option is 10-18x slower but catches emit-time issues.")]
+     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation. Note: only reports compiler diagnostics (CS*); analyzer diagnostics (CA*, IDE*) are excluded — use project_diagnostics for those. The emitValidation option is often much slower than GetDiagnostics-only (frequently 50–100x or more on large solutions) but catches emit-time issues.")]
     public static Task<string> CompileCheck(
         IWorkspaceExecutionGate gate,
         ICompileCheckService compileCheckService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -56,7 +56,7 @@ public static class ScaffoldingTools
     }
 
     [McpServerTool(Name = "scaffold_test_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
-     Description("Preview scaffolding a new MSTest file for a target type.")]
+     Description("Preview scaffolding a new test file for a target type. Supports MSTest, xUnit, and NUnit (use testFramework or auto-detect from the test project's package references).")]
     public static Task<string> PreviewScaffoldTest(
         IWorkspaceExecutionGate gate,
         IScaffoldingService scaffoldingService,
@@ -64,6 +64,7 @@ public static class ScaffoldingTools
         [Description("Test project name or project file path within the loaded workspace")] string testProjectName,
         [Description("Target type name for the generated test")] string targetTypeName,
         [Description("Optional: target method name for the generated test stub")] string? targetMethodName = null,
+        [Description("Test framework: mstest, xunit, nunit, or auto (infer from PackageReference in the test csproj)")] string testFramework = "auto",
         CancellationToken ct = default)
     {
         return ToolErrorHandler.ExecuteAsync(() =>
@@ -71,7 +72,7 @@ public static class ScaffoldingTools
             {
                 var result = await scaffoldingService.PreviewScaffoldTestAsync(
                     workspaceId,
-                    new ScaffoldTestDto(testProjectName, targetTypeName, targetMethodName),
+                    new ScaffoldTestDto(testProjectName, targetTypeName, targetMethodName, testFramework),
                     c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(result, JsonDefaults.Indented);
             }, ct));

--- a/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
@@ -9,7 +9,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class SnippetAnalysisTools
 {
     [McpServerTool(Name = "analyze_snippet", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
-     Description("Analyze a C# code snippet for compilation errors and declared symbols without loading a full solution. Uses an ephemeral workspace for quick validation of code fragments, diffs, or pasted code.")]
+     Description("Analyze a C# code snippet for compilation errors and declared symbols without loading a full solution. Uses an ephemeral workspace for quick validation of code fragments, diffs, or pasted code. For kind 'statements', code is wrapped in a void method — use evaluate_csharp for top-level scripts that return values.")]
     public static Task<string> AnalyzeSnippet(
         ISnippetAnalysisService snippetAnalysisService,
         [Description("The C# code to analyze")] string code,

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -205,7 +205,7 @@ public static class SymbolTools
             }, ct));
     }
 
-    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get display signature, parameters, return type, and documentation for the symbol resolved at the exact line/column (or handle/metadata name). The caret position matters: on a field identifier you get the field's type/signature, not the enclosing method.")]
+    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get display signature, parameters, return type, and documentation for the symbol resolved at the exact line/column (or handle/metadata name). The caret position matters: on a field identifier you get the field's type/signature, not the enclosing method. On a method declaration, placing the caret on the return type resolves that type symbol, not the method — use the method name identifier for method signature help.")]
     public static Task<string> GetSignatureHelp(
         IWorkspaceExecutionGate gate,
         ISymbolRelationshipService symbolRelationshipService,
@@ -355,7 +355,7 @@ public static class SymbolTools
             }, ct));
     }
 
-    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file")]
+    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file. Returns up to 100 items; IsIncomplete indicates more exist but this tool does not support offset/limit pagination. InlineDescription may be empty when Roslyn does not supply inline text for an item.")]
     public static Task<string> GetCompletions(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -22,7 +22,9 @@ internal static class ToolErrorHandler
         [typeof(InvalidOperationException)] = (ex, _) => ex.Message.Contains("Rate limit")
             ? new("RateLimited", ex.Message)
             : new("InvalidOperation",
-                $"Invalid operation: {ex.Message}. The workspace may need to be reloaded (workspace_reload) if the state is stale."),
+                ShouldSuggestReloadAfterInvalidOperation(ex.Message)
+                    ? $"Invalid operation: {ex.Message}. The workspace may need to be reloaded (workspace_reload) if the state is stale."
+                    : $"Invalid operation: {ex.Message}."),
     };
 
     /// <summary>
@@ -71,6 +73,21 @@ internal static class ToolErrorHandler
         return new("InternalError",
             $"Internal error in {toolName}: {detail}. " +
             "If this persists, try reloading the workspace (workspace_reload).");
+    }
+
+    /// <summary>
+    /// Only suggest workspace_reload when the message plausibly indicates stale or missing workspace state.
+    /// </summary>
+    private static bool ShouldSuggestReloadAfterInvalidOperation(string message)
+    {
+        if (string.IsNullOrEmpty(message)) return false;
+        return message.Contains("stale", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("not found in workspace", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("Document not found", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("workspace changed", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("workspace version", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("outside the workspace", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("preview token", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string GetInnerExceptionChain(Exception ex)

--- a/src/RoslynMcp.Roslyn/Helpers/MsBuildMetadataHelper.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/MsBuildMetadataHelper.cs
@@ -62,6 +62,22 @@ internal static class MsBuildMetadataHelper
             string.Equals((string?)element.Attribute("Include"), packageId, StringComparison.OrdinalIgnoreCase));
     }
 
+    /// <summary>
+    /// Returns the <c>Version</c> attribute for a <c>PackageVersion</c> with matching <c>Include</c>, or <see langword="null"/>.
+    /// </summary>
+    public static string? TryGetCentralPackageVersion(string packagesPropsPath, string packageId)
+    {
+        if (!File.Exists(packagesPropsPath))
+        {
+            return null;
+        }
+
+        var document = XDocument.Load(packagesPropsPath, LoadOptions.PreserveWhitespace);
+        var element = document.Descendants("PackageVersion").FirstOrDefault(e =>
+            string.Equals((string?)e.Attribute("Include"), packageId, StringComparison.OrdinalIgnoreCase));
+        return element?.Attribute("Version")?.Value;
+    }
+
     private static string? FindNearestFile(string? loadedPath, string fileName)
     {
         var directory = ResolveDirectory(loadedPath);

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
@@ -54,7 +54,15 @@ public static class SymbolResolver
         var syntaxTree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
         if (syntaxTree is null) return null;
 
-        var position = syntaxTree.GetText(ct).Lines[line - 1].Start + (column - 1);
+        var text = syntaxTree.GetText(ct);
+        if (line < 1 || line > text.Lines.Count)
+        {
+            throw new ArgumentException(
+                $"Line {line} is out of range. The file has {text.Lines.Count} line(s).",
+                nameof(line));
+        }
+
+        var position = text.Lines[line - 1].Start + (column - 1);
         var root = await syntaxTree.GetRootAsync(ct).ConfigureAwait(false);
 
         // Try the token at the exact position first, then also try FindToken with

--- a/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
-using System.Composition.Hosting;
 using System.Reflection;
 
 namespace RoslynMcp.Roslyn.Services;
@@ -165,11 +164,29 @@ public sealed class CodeActionService : ICodeActionService
         return TextSpan.FromBounds(startPosition, lineEnd);
     }
 
+    private static Assembly? LoadCSharpFeaturesAssembly()
+    {
+        try
+        {
+            return Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
     private ImmutableArray<CodeFixProvider> LoadCodeFixProviders()
     {
         try
         {
-            var featuresAssembly = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions).Assembly;
+            var featuresAssembly = LoadCSharpFeaturesAssembly();
+            if (featuresAssembly is null)
+            {
+                _logger.LogWarning("Could not load Microsoft.CodeAnalysis.CSharp.Features assembly for code fix providers");
+                return [];
+            }
+
             var providers = featuresAssembly.GetTypes()
                 .Where(t => !t.IsAbstract && typeof(CodeFixProvider).IsAssignableFrom(t))
                 .Select(t =>
@@ -181,7 +198,7 @@ public sealed class CodeActionService : ICodeActionService
                 .Cast<CodeFixProvider>()
                 .ToImmutableArray();
 
-            _logger.LogInformation("Loaded {Count} code fix providers from CSharp Features", providers.Length);
+            _logger.LogInformation("Loaded {Count} code fix providers from Microsoft.CodeAnalysis.CSharp.Features", providers.Length);
             return providers;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -195,7 +212,13 @@ public sealed class CodeActionService : ICodeActionService
     {
         try
         {
-            var featuresAssembly = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions).Assembly;
+            var featuresAssembly = LoadCSharpFeaturesAssembly();
+            if (featuresAssembly is null)
+            {
+                _logger.LogWarning("Could not load Microsoft.CodeAnalysis.CSharp.Features assembly for code refactoring providers");
+                return [];
+            }
+
             var providers = featuresAssembly.GetTypes()
                 .Where(t => !t.IsAbstract && typeof(CodeRefactoringProvider).IsAssignableFrom(t))
                 .Select(t =>
@@ -207,7 +230,7 @@ public sealed class CodeActionService : ICodeActionService
                 .Cast<CodeRefactoringProvider>()
                 .ToImmutableArray();
 
-            _logger.LogInformation("Loaded {Count} code refactoring providers from CSharp Features", providers.Length);
+            _logger.LogInformation("Loaded {Count} code refactoring providers from Microsoft.CodeAnalysis.CSharp.Features", providers.Length);
             return providers;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/RoslynMcp.Roslyn/Services/CompletionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompletionService.cs
@@ -35,6 +35,13 @@ public sealed class CompletionService : ICompletionService
         }
 
         var text = await document.GetTextAsync(ct).ConfigureAwait(false);
+        if (line < 1 || line > text.Lines.Count)
+        {
+            throw new ArgumentException(
+                $"Line {line} is out of range. The file has {text.Lines.Count} line(s).",
+                nameof(line));
+        }
+
         var position = text.Lines[line - 1].Start + (column - 1);
 
         var completions = await completionService.GetCompletionsAsync(document, position, cancellationToken: ct).ConfigureAwait(false);
@@ -49,11 +56,19 @@ public sealed class CompletionService : ICompletionService
                 DisplayText: item.DisplayText,
                 FilterText: item.FilterText,
                 SortText: item.SortText,
-                InlineDescription: item.InlineDescription,
+                InlineDescription: BuildCompletionInlineDescription(item),
                 Kind: item.Tags.Length > 0 ? item.Tags[0] : "Unknown",
                 Tags: item.Tags.Length > 0 ? item.Tags.ToList() : null))
             .ToList();
 
         return new CompletionResultDto(items, completions.ItemsList.Count > 100);
+    }
+
+    private static string? BuildCompletionInlineDescription(CompletionItem item)
+    {
+        if (!string.IsNullOrEmpty(item.InlineDescription))
+            return item.InlineDescription;
+
+        return item.Properties.TryGetValue("Description", out var desc) ? desc : null;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
@@ -130,7 +130,10 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         await DetectExistingTypeConflictAsync(solution, namespaceName, resolvedInterfaceName, ct).ConfigureAwait(false);
 
         var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, resolvedInterfaceName, namespaceName, isCrossProject);
-        var interfaceFilePath = Path.Combine(targetProjectDirectory, resolvedInterfaceName + ".cs");
+        var interfaceDirectory = isCrossProject
+            ? ResolvePreferredInterfaceSubdirectory(solution, targetProject, targetProjectDirectory)
+            : targetProjectDirectory;
+        var interfaceFilePath = Path.Combine(interfaceDirectory, resolvedInterfaceName + ".cs");
         if (File.Exists(interfaceFilePath))
         {
             throw new InvalidOperationException($"Target interface file already exists: {interfaceFilePath}");
@@ -138,6 +141,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         var updatedTypeDeclaration = AddBaseType(typeDeclaration, resolvedInterfaceName);
         var updatedSourceRoot = sourceRoot.ReplaceNode(typeDeclaration, updatedTypeDeclaration);
+        if (updatedSourceRoot is CompilationUnitSyntax updatedCu)
+            updatedSourceRoot = updatedCu.NormalizeWhitespace();
 
         var updatedSolution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, updatedSourceRoot)
             .AddDocument(
@@ -230,6 +235,34 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         return new RefactoringPreviewDto(token, description, changes, null);
     }
 
+    private static string ResolvePreferredInterfaceSubdirectory(Solution solution, Project targetProject, string projectDirectory)
+    {
+        var conventional = new[] { "Interfaces", "Abstractions", "Contracts" };
+        foreach (var dir in conventional)
+        {
+            var path = Path.Combine(projectDirectory, dir);
+            if (Directory.Exists(path))
+                return path;
+        }
+
+        foreach (var doc in targetProject.Documents)
+        {
+            if (doc.FilePath is null || !doc.FilePath.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var rel = Path.GetRelativePath(projectDirectory, doc.FilePath);
+            var firstSegment = rel.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+            if (firstSegment is not null &&
+                conventional.Any(s => string.Equals(s, firstSegment, StringComparison.OrdinalIgnoreCase)))
+            {
+                return Path.Combine(projectDirectory, firstSegment);
+            }
+        }
+
+        return projectDirectory;
+    }
+
     private static Project ResolveProject(Solution solution, string targetProjectName)
     {
         return solution.Projects.FirstOrDefault(project =>
@@ -306,6 +339,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         SyntaxList<UsingDirectiveSyntax> sourceUsings,
         MemberDeclarationSyntax member)
     {
+        var memberText = member.ToFullString();
+
         // Collect all type names referenced in the interface member signatures
         var referencedNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (var node in member.DescendantNodes())
@@ -323,6 +358,12 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         {
             var name = u.Name?.ToString();
             if (name is null) return false;
+            if (string.Equals(name, "System.Collections.Concurrent", StringComparison.Ordinal) &&
+                !memberText.Contains("Concurrent", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             if (name is "System") return true;
             // Keep the using if its last segment matches any referenced name
             var lastSegment = name.Contains('.') ? name[(name.LastIndexOf('.') + 1)..] : name;
@@ -466,7 +507,10 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         await DetectExistingTypeConflictAsync(solution, namespaceName, interfaceName, ct).ConfigureAwait(false);
 
         var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, interfaceName, namespaceName, isCrossProject);
-        var interfaceFilePath = Path.Combine(targetProjectDirectory, interfaceName + ".cs");
+        var interfaceFileDirectory = isCrossProject
+            ? ResolvePreferredInterfaceSubdirectory(solution, targetProject, targetProjectDirectory)
+            : targetProjectDirectory;
+        var interfaceFilePath = Path.Combine(interfaceFileDirectory, interfaceName + ".cs");
         if (File.Exists(interfaceFilePath))
         {
             throw new InvalidOperationException($"Target interface file already exists: {interfaceFilePath}");
@@ -474,6 +518,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         var updatedTypeDeclaration = AddBaseType(typeDeclaration, interfaceName);
         var updatedSourceRoot = sourceRoot.ReplaceNode(typeDeclaration, updatedTypeDeclaration);
+        if (updatedSourceRoot is CompilationUnitSyntax updatedCu)
+            updatedSourceRoot = updatedCu.NormalizeWhitespace();
 
         var updatedSolution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, updatedSourceRoot)
             .AddDocument(

--- a/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
@@ -113,6 +113,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var projectDtos = new List<NuGetProjectDto>();
         var packageMap = new Dictionary<(string Id, string Version), List<string>>();
+        var packagesPropsPath = MsBuildMetadataHelper.FindDirectoryPackagesProps(_workspace.GetStatus(workspaceId).LoadedPath);
 
         foreach (var project in solution.Projects)
         {
@@ -132,7 +133,14 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
                     var version = pkgRef.Attribute("Version")?.Value ?? "centrally-managed";
                     if (id is null) continue;
 
-                    packages.Add(new NuGetPackageReferenceDto(id, version));
+                    string? resolvedCentral = null;
+                    if (string.Equals(version, "centrally-managed", StringComparison.OrdinalIgnoreCase) &&
+                        packagesPropsPath is not null)
+                    {
+                        resolvedCentral = MsBuildMetadataHelper.TryGetCentralPackageVersion(packagesPropsPath, id);
+                    }
+
+                    packages.Add(new NuGetPackageReferenceDto(id, version, resolvedCentral));
 
                     var key = (id, version);
                     if (!packageMap.TryGetValue(key, out var users))
@@ -152,7 +160,22 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
         }
 
         var packageDtos = packageMap.Select(kvp =>
-            new NuGetPackageDto(kvp.Key.Id, kvp.Key.Version, kvp.Value)).ToList();
+        {
+            var displayVersion = kvp.Key.Version;
+            if (string.Equals(kvp.Key.Version, "centrally-managed", StringComparison.OrdinalIgnoreCase))
+            {
+                var resolved = projectDtos
+                    .SelectMany(p => p.PackageReferences)
+                    .Where(pr => string.Equals(pr.PackageId, kvp.Key.Id, StringComparison.OrdinalIgnoreCase) &&
+                                 string.Equals(pr.Version, "centrally-managed", StringComparison.OrdinalIgnoreCase))
+                    .Select(pr => pr.ResolvedCentralVersion)
+                    .FirstOrDefault(rv => !string.IsNullOrEmpty(rv));
+                if (resolved is not null)
+                    displayVersion = resolved;
+            }
+
+            return new NuGetPackageDto(kvp.Key.Id, displayVersion, kvp.Value);
+        }).ToList();
 
         return new NuGetDependencyResultDto(packageDtos, projectDtos);
     }

--- a/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
@@ -65,6 +65,9 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         }
 
         var updatedSourceRoot = sourceRoot.ReplaceNode(typeDecl, updatedTypeDecl);
+        if (updatedSourceRoot is CompilationUnitSyntax updatedCu)
+            updatedSourceRoot = updatedCu.NormalizeWhitespace();
+
         var newSolution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, updatedSourceRoot);
 
         // Add interface document

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -37,7 +37,8 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
             {
                 var preview = await SymbolResolver.GetPreviewTextAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
                 var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
-                directRefs.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview));
+                var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
+                directRefs.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
 
                 if (containingSymbol is not null)
                     affectedDeclarations.Add(containingSymbol);
@@ -132,7 +133,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
                 if (root is null) continue;
 
                 var refNode = root.FindNode(refLocation.Location.SourceSpan);
-                var classification = ClassifyTypeUsage(refNode);
+                var classification = ClassifyTypeUsage(refNode, symbol);
 
                 var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
                 var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
@@ -262,7 +263,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         return false;
     }
 
-    private static TypeUsageClassification ClassifyTypeUsage(SyntaxNode refNode)
+    private static TypeUsageClassification ClassifyTypeUsage(SyntaxNode refNode, ISymbol referencedSymbol)
     {
         var parent = refNode.Parent;
         if (parent is null) return TypeUsageClassification.Other;
@@ -275,11 +276,19 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
             if (parent is null) return TypeUsageClassification.Other;
         }
 
-        return ClassifyTypeUsageAfterWalk(typeNode, parent);
+        return ClassifyTypeUsageAfterWalk(typeNode, parent, referencedSymbol);
     }
 
-    private static TypeUsageClassification ClassifyTypeUsageAfterWalk(SyntaxNode typeNode, SyntaxNode parent)
+    private static TypeUsageClassification ClassifyTypeUsageAfterWalk(SyntaxNode typeNode, SyntaxNode parent, ISymbol referencedSymbol)
     {
+        // Static class usage at call sites: TypeName.Member (expression is the type identifier).
+        if (referencedSymbol is INamedTypeSymbol { IsStatic: true } &&
+            parent is MemberAccessExpressionSyntax ma &&
+            ma.Expression.Equals(typeNode))
+        {
+            return TypeUsageClassification.StaticMemberAccess;
+        }
+
         if (parent is TypeArgumentListSyntax)
             return TypeUsageClassification.GenericArgument;
 

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -144,9 +144,10 @@ public sealed class ProjectMutationService : IProjectMutationService
             var propertyGroup = document.Root?.Elements("PropertyGroup").FirstOrDefault();
             if (propertyGroup is null)
             {
-                // Create a new PropertyGroup if none exists (e.g., Directory.Build.props-based projects)
-                propertyGroup = new System.Xml.Linq.XElement("PropertyGroup");
-                document.Root!.AddFirst(propertyGroup);
+                // Create a new PropertyGroup if none exists (e.g., Directory.Build.props-based projects).
+                // Insert with line breaks so the project file does not become a single-line malformed document.
+                propertyGroup = new XElement("PropertyGroup");
+                InsertFirstElementChildWithFormatting(document, propertyGroup);
             }
 
             // Detect no-op: check if property already has the target value
@@ -389,8 +390,55 @@ public sealed class ProjectMutationService : IProjectMutationService
         }
 
         var itemGroup = new XElement("ItemGroup");
-        document.Root?.Add(itemGroup);
+        var root = document.Root;
+        if (root is null)
+        {
+            return itemGroup;
+        }
+
+        var lineEnding = DetectLineEnding(document);
+        const string indent = "  ";
+        if (root.Elements().Any())
+        {
+            var lastElement = root.Elements().Last();
+            lastElement.AddAfterSelf(new XText(lineEnding + indent));
+            lastElement.AddAfterSelf(itemGroup);
+        }
+        else
+        {
+            root.Add(new XText(lineEnding + "  "));
+            root.Add(itemGroup);
+            root.Add(new XText(lineEnding));
+        }
+
         return itemGroup;
+    }
+
+    /// <summary>
+    /// Inserts an element as the first child of the document root with a leading newline and indent,
+    /// avoiding inline concatenation on the same line as the opening <c>&lt;Project&gt;</c> tag.
+    /// </summary>
+    private static void InsertFirstElementChildWithFormatting(XDocument document, XElement element)
+    {
+        var root = document.Root;
+        if (root is null)
+        {
+            return;
+        }
+
+        var lineEnding = DetectLineEnding(document);
+        const string indent = "  ";
+        var firstElement = root.Elements().FirstOrDefault();
+        if (firstElement is not null)
+        {
+            firstElement.AddBeforeSelf(element);
+            firstElement.AddBeforeSelf(new XText(lineEnding + indent));
+            return;
+        }
+
+        root.Add(new XText(lineEnding + indent));
+        root.Add(element);
+        root.Add(new XText(lineEnding));
     }
 
     private static void AddChildElementPreservingIndentation(XElement parent, XElement child)

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -42,6 +42,12 @@ public sealed class RefactoringService : IRefactoringService
         if (symbol is null)
             throw new InvalidOperationException("No symbol found for the provided rename target.");
 
+        if (!symbol.Locations.Any(static l => l.IsInSource))
+        {
+            throw new InvalidOperationException(
+                $"Cannot rename metadata or built-in symbol '{symbol.ToDisplayString()}' — renames require a source declaration.");
+        }
+
         var newSolution = await Renamer.RenameSymbolAsync(
             solution, symbol, new SymbolRenameOptions(), newName, ct).ConfigureAwait(false);
 

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -34,24 +35,71 @@ public sealed class ScaffoldingService : IScaffoldingService
 
     public async Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(string workspaceId, ScaffoldTestDto request, CancellationToken ct)
     {
-        if (!string.Equals(request.TestFramework, "mstest", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException("Only MSTest scaffolding is currently supported.");
-        }
-
         var project = ResolveProject(workspaceId, request.TestProjectName);
         var projectDirectory = Path.GetDirectoryName(project.FilePath)
             ?? throw new InvalidOperationException($"Project directory could not be resolved for '{project.FilePath}'.");
         var testFilePath = Path.Combine(projectDirectory, $"{request.TargetTypeName}GeneratedTests.cs");
         var testNamespace = project.Name;
 
-        var typeInfo = await ResolveTargetTypeAsync(workspaceId, request.TestProjectName, request.TargetTypeName, ct).ConfigureAwait(false);
-        var content = BuildTestContent(testNamespace, request, typeInfo.targetNamespace, typeInfo.constructorArgs);
-        return await _fileOperationService.PreviewCreateFileAsync(workspaceId, new CreateFileDto(project.Name, testFilePath, content), ct).ConfigureAwait(false);
+        var framework = ResolveTestFramework(request.TestFramework, project.FilePath);
+
+        var typeInfo = await ResolveTargetTypeAndMethodAsync(
+            workspaceId, request.TestProjectName, request.TargetTypeName, request.TargetMethodName, ct).ConfigureAwait(false);
+        var content = BuildTestContent(testNamespace, request, typeInfo.targetNamespace, typeInfo.constructorArgs, framework, typeInfo.targetMethod);
+        var preview = await _fileOperationService.PreviewCreateFileAsync(workspaceId, new CreateFileDto(project.Name, testFilePath, content), ct).ConfigureAwait(false);
+
+        if (typeInfo.warnings is null || typeInfo.warnings.Count == 0)
+            return preview;
+
+        return preview with { Warnings = typeInfo.warnings };
     }
 
-    private async Task<(string targetNamespace, string constructorArgs)> ResolveTargetTypeAsync(
-        string workspaceId, string testProjectName, string targetTypeName, CancellationToken ct)
+    private static string ResolveTestFramework(string? requested, string? projectFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(requested) ||
+            string.Equals(requested, "auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return DetectTestFrameworkFromProjectFile(projectFilePath);
+        }
+
+        if (string.Equals(requested, "mstest", StringComparison.OrdinalIgnoreCase)) return "mstest";
+        if (string.Equals(requested, "xunit", StringComparison.OrdinalIgnoreCase)) return "xunit";
+        if (string.Equals(requested, "nunit", StringComparison.OrdinalIgnoreCase)) return "nunit";
+
+        throw new InvalidOperationException(
+            $"Unsupported testFramework '{requested}'. Use mstest, xunit, nunit, or auto.");
+    }
+
+    private static string DetectTestFrameworkFromProjectFile(string? projectFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilePath) || !File.Exists(projectFilePath))
+            return "mstest";
+
+        try
+        {
+            var doc = XDocument.Load(projectFilePath, LoadOptions.None);
+            var includes = doc.Descendants("PackageReference")
+                .Select(e => e.Attribute("Include")?.Value)
+                .Where(i => !string.IsNullOrWhiteSpace(i))
+                .Select(i => i!.ToLowerInvariant())
+                .ToList();
+
+            if (includes.Any(i => i.Contains("xunit", StringComparison.Ordinal)))
+                return "xunit";
+            if (includes.Any(i => i.Contains("nunit", StringComparison.Ordinal)))
+                return "nunit";
+        }
+        catch
+        {
+            // Fall through to default
+        }
+
+        return "mstest";
+    }
+
+    private async Task<(string targetNamespace, string constructorArgs, IMethodSymbol? targetMethod, List<string>? warnings)>
+        ResolveTargetTypeAndMethodAsync(
+            string workspaceId, string testProjectName, string targetTypeName, string? targetMethodName, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var testProject = solution.Projects.FirstOrDefault(p =>
@@ -59,9 +107,8 @@ public sealed class ScaffoldingService : IScaffoldingService
             string.Equals(p.FilePath, testProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (testProject is null)
-            return (string.Empty, string.Empty);
+            return (string.Empty, string.Empty, null, null);
 
-        // Search the test project and all its referenced projects for the target type
         var projectsToSearch = new List<Project> { testProject };
         foreach (var projectRef in testProject.ProjectReferences)
         {
@@ -98,19 +145,41 @@ public sealed class ScaffoldingService : IScaffoldingService
         }
 
         if (matchedType is null)
-            return (string.Empty, string.Empty);
+            return (string.Empty, string.Empty, null, null);
 
         var ns = matchedType.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : matchedType.ContainingNamespace.ToDisplayString();
 
         var constructorArgs = BuildConstructorArgs(matchedType);
-        return (ns, constructorArgs);
+
+        IMethodSymbol? targetMethod = null;
+        List<string>? warnings = null;
+        if (!string.IsNullOrWhiteSpace(targetMethodName))
+        {
+            targetMethod = matchedType.GetMembers(targetMethodName)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => m.MethodKind is MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation);
+
+            if (targetMethod is null)
+            {
+                warnings ??= [];
+                warnings.Add($"Target method '{targetMethodName}' was not found on type '{matchedType.Name}'.");
+            }
+            else if (targetMethod.DeclaredAccessibility == Accessibility.Private)
+            {
+                warnings ??= [];
+                warnings.Add(
+                    $"Target method '{targetMethodName}' is private — the scaffold uses reflection to invoke it; " +
+                    "prefer InternalsVisibleTo or testing via public API when possible.");
+            }
+        }
+
+        return (ns, constructorArgs, targetMethod, warnings);
     }
 
     private static string BuildConstructorArgs(INamedTypeSymbol type)
     {
-        // Find the most accessible constructor, preferring parameterless
         var constructors = type.Constructors
             .Where(c => !c.IsImplicitlyDeclared || c.Parameters.Length == 0)
             .Where(c => c.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal)
@@ -162,7 +231,13 @@ public sealed class ScaffoldingService : IScaffoldingService
         return $"namespace {typeNamespace};\n\npublic {typeKeyword} {request.TypeName}{inheritanceClause}\n{{\n}}\n";
     }
 
-    private static string BuildTestContent(string testNamespace, ScaffoldTestDto request, string targetNamespace, string constructorArgs)
+    private static string BuildTestContent(
+        string testNamespace,
+        ScaffoldTestDto request,
+        string targetNamespace,
+        string constructorArgs,
+        string framework,
+        IMethodSymbol? targetMethod)
     {
         var methodName = string.IsNullOrWhiteSpace(request.TargetMethodName)
             ? "Generated_Test"
@@ -176,6 +251,135 @@ public sealed class ScaffoldingService : IScaffoldingService
             ? $"new {request.TargetTypeName}()"
             : $"new {request.TargetTypeName}({constructorArgs})";
 
-        return $"using Microsoft.VisualStudio.TestTools.UnitTesting;\n{usingDirective}\nnamespace {testNamespace};\n\n[TestClass]\npublic class {request.TargetTypeName}GeneratedTests\n{{\n    [TestMethod]\n    public void {methodName}()\n    {{\n        var subject = {ctorCall};\n\n        Assert.IsNotNull(subject);\n        Assert.Fail(\"Add real assertions.\");\n    }}\n}}\n";
+        var methodTargetBlock = BuildMethodTargetInvocationBlock(framework, request.TargetTypeName, request.TargetMethodName, targetMethod);
+
+        return framework switch
+        {
+            "xunit" => BuildXUnitTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock),
+            "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock),
+            _ => BuildMSTestTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock),
+        };
+    }
+
+    private static string BuildMethodTargetInvocationBlock(
+        string framework,
+        string targetTypeName,
+        string? targetMethodName,
+        IMethodSymbol? targetMethod)
+    {
+        if (string.IsNullOrWhiteSpace(targetMethodName))
+        {
+            return "        // No target method specified.\n";
+        }
+
+        if (targetMethod is null)
+        {
+            return $"        // Target method '{targetMethodName}' was not resolved on {targetTypeName}.\n";
+        }
+
+        if (targetMethod.DeclaredAccessibility == Accessibility.Private)
+        {
+            var assertNotNull = framework switch
+            {
+                "xunit" => "Assert.NotNull(__method);",
+                "nunit" => "Assert.That(__method, Is.Not.Null);",
+                _ => "Assert.IsNotNull(__method);",
+            };
+            return
+                "        // Private method — invoke via reflection (replace with InternalsVisibleTo or a public API test if preferred).\n" +
+                $"        var __method = typeof({targetTypeName}).GetMethod(\n" +
+                $"            \"{targetMethodName}\",\n" +
+                "            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);\n" +
+                "        " + assertNotNull + "\n" +
+                "        __method!.Invoke(subject, null);\n";
+        }
+
+        if (targetMethod.Parameters.Length == 0 && !targetMethod.ReturnsVoid)
+        {
+            return $"        _ = subject.{targetMethodName}();\n";
+        }
+
+        if (targetMethod.Parameters.Length == 0 && targetMethod.ReturnsVoid)
+        {
+            return $"        subject.{targetMethodName}();\n";
+        }
+
+        return
+            $"        // Target method '{targetMethodName}' has parameters — add arguments or use a wrapper.\n" +
+            $"        // Example: subject.{targetMethodName}(/* args */);\n";
+    }
+
+    private static string BuildMSTestTestContent(
+        string testNamespace,
+        string usingDirective,
+        string targetTypeName,
+        string methodName,
+        string ctorCall,
+        string methodBlock)
+    {
+        return
+            "using Microsoft.VisualStudio.TestTools.UnitTesting;\n" +
+            usingDirective +
+            "\nnamespace " + testNamespace + ";\n\n" +
+            "[TestClass]\n" +
+            "public class " + targetTypeName + "GeneratedTests\n" +
+            "{\n" +
+            "    [TestMethod]\n" +
+            "    public void " + methodName + "()\n" +
+            "    {\n" +
+            "        var subject = " + ctorCall + ";\n\n" +
+            methodBlock +
+            "        Assert.IsNotNull(subject);\n" +
+            "    }\n" +
+            "}\n";
+    }
+
+    private static string BuildXUnitTestContent(
+        string testNamespace,
+        string usingDirective,
+        string targetTypeName,
+        string methodName,
+        string ctorCall,
+        string methodBlock)
+    {
+        return
+            "using Xunit;\n" +
+            usingDirective +
+            "\nnamespace " + testNamespace + ";\n\n" +
+            "public class " + targetTypeName + "GeneratedTests\n" +
+            "{\n" +
+            "    [Fact]\n" +
+            "    public void " + methodName + "()\n" +
+            "    {\n" +
+            "        var subject = " + ctorCall + ";\n\n" +
+            methodBlock +
+            "        Assert.NotNull(subject);\n" +
+            "    }\n" +
+            "}\n";
+    }
+
+    private static string BuildNUnitTestContent(
+        string testNamespace,
+        string usingDirective,
+        string targetTypeName,
+        string methodName,
+        string ctorCall,
+        string methodBlock)
+    {
+        return
+            "using NUnit.Framework;\n" +
+            usingDirective +
+            "\nnamespace " + testNamespace + ";\n\n" +
+            "[TestFixture]\n" +
+            "public class " + targetTypeName + "GeneratedTests\n" +
+            "{\n" +
+            "    [Test]\n" +
+            "    public void " + methodName + "()\n" +
+            "    {\n" +
+            "        var subject = " + ctorCall + ";\n\n" +
+            methodBlock +
+            "        Assert.That(subject, Is.Not.Null);\n" +
+            "    }\n" +
+            "}\n";
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
@@ -58,7 +58,7 @@ public sealed class ScriptingService : IScriptingService
                 Error: null,
                 CompilationErrors: null,
                 ElapsedMs: sw.ElapsedMilliseconds,
-                AppliedScriptTimeoutSeconds: null);
+                AppliedScriptTimeoutSeconds: TimeoutSeconds);
         }
         catch (CompilationErrorException ex)
         {
@@ -88,7 +88,7 @@ public sealed class ScriptingService : IScriptingService
                 Error: ex.Message,
                 CompilationErrors: compilationErrors,
                 ElapsedMs: sw.ElapsedMilliseconds,
-                AppliedScriptTimeoutSeconds: null);
+                AppliedScriptTimeoutSeconds: TimeoutSeconds);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -112,7 +112,7 @@ public sealed class ScriptingService : IScriptingService
                 Error: $"Runtime error: {ex.GetType().Name}: {ex.Message}",
                 CompilationErrors: null,
                 ElapsedMs: sw.ElapsedMilliseconds,
-                AppliedScriptTimeoutSeconds: null);
+                AppliedScriptTimeoutSeconds: TimeoutSeconds);
         }
     }
 

--- a/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
@@ -33,7 +33,7 @@ public sealed class SymbolNavigationService : ISymbolNavigationService
         {
             var doc = solution.GetDocument(location.SourceTree!);
             var preview = doc is not null ? await SymbolResolver.GetPreviewTextAsync(doc, location, ct).ConfigureAwait(false) : null;
-            results.Add(SymbolMapper.ToLocationDto(location, symbol, preview));
+            results.Add(SymbolMapper.ToLocationDto(location, symbol, preview, "Definition"));
         }
 
         return results;
@@ -72,7 +72,7 @@ public sealed class SymbolNavigationService : ISymbolNavigationService
         {
             var doc = solution.GetDocument(location.SourceTree!);
             var preview = doc is not null ? await SymbolResolver.GetPreviewTextAsync(doc, location, ct).ConfigureAwait(false) : null;
-            results.Add(SymbolMapper.ToLocationDto(location, typeSymbol, preview));
+            results.Add(SymbolMapper.ToLocationDto(location, typeSymbol, preview, "Definition"));
         }
 
         return results;
@@ -91,6 +91,13 @@ public sealed class SymbolNavigationService : ISymbolNavigationService
         if (syntaxTree is null) return null;
 
         var text = await syntaxTree.GetTextAsync(ct).ConfigureAwait(false);
+        if (line < 1 || line > text.Lines.Count)
+        {
+            throw new ArgumentException(
+                $"Line {line} is out of range. The file has {text.Lines.Count} line(s).",
+                nameof(line));
+        }
+
         var position = text.Lines[line - 1].Start + (column - 1);
         var root = await syntaxTree.GetRootAsync(ct).ConfigureAwait(false);
         var node = root.FindToken(position).Parent;

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -174,6 +174,7 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         }
 
         var callees = new List<LocationDto>();
+        var seenCalleeKeys = new HashSet<string>(StringComparer.Ordinal);
         if (symbol is IMethodSymbol methodSymbol)
         {
             foreach (var location in methodSymbol.Locations.Where(l => l.IsInSource))
@@ -197,6 +198,12 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
                     if (invokedSymbol is not null)
                     {
                         var invokedLoc = invokedSymbol.Locations.FirstOrDefault(l => l.IsInSource) ?? invocation.GetLocation();
+                        var lineSpan = invokedLoc.GetLineSpan();
+                        var dedupeKey =
+                            $"{invokedSymbol.ToDisplayString()}|{lineSpan.Path}|{lineSpan.StartLinePosition.Line}|{lineSpan.StartLinePosition.Character}";
+                        if (!seenCalleeKeys.Add(dedupeKey))
+                            continue;
+
                         callees.Add(SymbolMapper.ToLocationDto(invokedLoc, invokedSymbol));
                     }
                 }

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -85,7 +85,8 @@ public sealed class SymbolSearchService : ISymbolSearchService
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var document = SymbolResolver.FindDocument(solution, filePath);
-        if (document is null) return [];
+        if (document is null)
+            throw new FileNotFoundException($"Source file not found in the loaded workspace: {filePath}");
 
         var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
         if (root is null) return [];

--- a/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
@@ -74,6 +74,8 @@ public sealed class TypeExtractionService : ITypeExtractionService
         if (membersToExtract.Count == 0)
             throw new InvalidOperationException("No members matched for extraction.");
 
+        var warnings = CollectExtractTypeDanglingReferenceWarnings(semanticModel, typeSymbol, membersToExtract, ct);
+
         // Determine target file path
         var sourceDir = Path.GetDirectoryName(sourceDocument.FilePath!)!;
         var resolvedTargetPath = newFilePath ?? Path.Combine(sourceDir, $"{newTypeName}.cs");
@@ -158,8 +160,11 @@ public sealed class TypeExtractionService : ITypeExtractionService
         updatedTypeDecl = updatedTypeDecl.WithMembers(
             updatedTypeDecl.Members.Insert(0, fieldDecl));
 
-        // Replace in source root
+        // Replace in source root (normalize so field/modifier tokens get proper spacing)
         var updatedSourceRoot = sourceRoot.ReplaceNode(typeDecl, updatedTypeDecl);
+        if (updatedSourceRoot is CompilationUnitSyntax normalizedRoot)
+            updatedSourceRoot = normalizedRoot.NormalizeWhitespace();
+
         var newSolution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, updatedSourceRoot);
 
         // Add new document
@@ -173,7 +178,72 @@ public sealed class TypeExtractionService : ITypeExtractionService
         var description = $"Extract {membersToExtract.Count} member(s) from '{sourceTypeName}' into new type '{newTypeName}'";
         var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description);
 
-        return new RefactoringPreviewDto(token, description, changes, null);
+        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
+    }
+
+    /// <summary>
+    /// Warns when extracted members reference symbols that remain on the original type (not moved with the extraction).
+    /// </summary>
+    private static List<string> CollectExtractTypeDanglingReferenceWarnings(
+        SemanticModel semanticModel,
+        INamedTypeSymbol typeSymbol,
+        IReadOnlyList<MemberDeclarationSyntax> membersToExtract,
+        CancellationToken ct)
+    {
+        var extractedDeclared = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        foreach (var m in membersToExtract)
+        {
+            var sym = semanticModel.GetDeclaredSymbol(m, ct);
+            if (sym is not null)
+                extractedDeclared.Add(sym);
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var warnings = new List<string>();
+
+        foreach (var member in membersToExtract)
+        {
+            foreach (var node in member.DescendantNodesAndSelf())
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var sym = semanticModel.GetSymbolInfo(node, ct).Symbol;
+                if (sym is null) continue;
+
+                if (sym is ILocalSymbol or IParameterSymbol or ILabelSymbol)
+                    continue;
+
+                if (extractedDeclared.Contains(sym))
+                    continue;
+
+                if (!IsDeclaredInOrUnderType(sym, typeSymbol))
+                    continue;
+
+                if (sym is INamedTypeSymbol nt && SymbolEqualityComparer.Default.Equals(nt, typeSymbol))
+                    continue;
+
+                var msg =
+                    $"Extracted member may reference '{sym.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}' " +
+                    $"which remains on the original type '{typeSymbol.Name}' and is not available in the new type.";
+                if (seen.Add(msg))
+                    warnings.Add(msg);
+            }
+        }
+
+        return warnings;
+    }
+
+    private static bool IsDeclaredInOrUnderType(ISymbol sym, INamedTypeSymbol typeSymbol)
+    {
+        INamedTypeSymbol? t = sym.ContainingType;
+        while (t is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(t, typeSymbol))
+                return true;
+            t = t.ContainingType;
+        }
+
+        return false;
     }
 
     private static string? GetMemberName(MemberDeclarationSyntax member)

--- a/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
@@ -73,7 +73,7 @@ public sealed class TypeMoveService : ITypeMoveService
             var newNs = SyntaxFactory.FileScopedNamespaceDeclaration(fileScopedNs.Name)
                 .WithNamespaceKeyword(fileScopedNs.NamespaceKeyword)
                 .WithSemicolonToken(fileScopedNs.SemicolonToken)
-                .WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(movedTypeDecl.WithLeadingTrivia(SyntaxFactory.ElasticLineFeed)));
+                .WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(movedTypeDecl));
 
             newFileRoot = SyntaxFactory.CompilationUnit()
                 .WithUsings(usings)
@@ -107,8 +107,9 @@ public sealed class TypeMoveService : ITypeMoveService
 
         // Add the new document
         var targetFileName = Path.GetFileName(resolvedTargetPath);
+        var newFileText = newFileRoot.ToFullString().TrimStart('\r', '\n');
         var newDocument = newSolution.GetProject(sourceDocument.Project.Id)!
-            .AddDocument(targetFileName, newFileRoot.ToFullString(), filePath: resolvedTargetPath);
+            .AddDocument(targetFileName, newFileText, filePath: resolvedTargetPath);
         newSolution = newDocument.Project.Solution;
 
         // Remove unnecessary usings from the new file by checking for CS8019 diagnostics

--- a/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
+++ b/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
@@ -60,7 +60,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public async Task NegativeLineColumn_ThrowsArgumentOutOfRange()
+    public async Task NegativeLineColumn_ThrowsArgumentException()
     {
         var status = WorkspaceManager.GetStatus(WorkspaceId);
         var project = status.Projects.First(p => !p.IsTestProject);
@@ -69,8 +69,9 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
             .Documents.First(d => d.FilePath?.EndsWith(".cs") == true);
 
         var locator = SymbolLocator.BySource(doc.FilePath!, -1, -1);
-        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
             SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "out of range");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Implements audit remediation across Roslyn services, host tools, DTOs, and tests (CPM NuGet resolution, code actions provider loading, scaffolding/test frameworks, project XML formatting, classifications, docs, and edge-case alignment).
- Adds REINSTALL.md, eng/update-claude-plugin.ps1, and the firewall analyzer audit report artifact.

## Test plan
- [x] \./eng/verify-release.ps1 -Configuration Release\ (214 tests, publish, coverage)

## Notes
Ship pipeline: squash merge per repo default.

Made with [Cursor](https://cursor.com)