### PR TITLE
perf: propagate parallelization pattern + wire compilation cache lifecycle

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,7 +41,7 @@ Future direction:
 
 ## Large-Solution Performance Strategy
 
-Decision: ship bounded local behavior now, then add indexing/caching later if real users need it.
+Decision: ship bounded local behavior now, layer in-process caches and parallelism as concrete hot paths emerge, defer cross-session/persistent indexing until real users need it.
 
 Release-1 strategy:
 
@@ -51,9 +51,19 @@ Release-1 strategy:
 - bounded generated-document discovery
 - workspace-count cap
 
+Delivered after release-1 (in-process):
+
+- cross-tool compilation cache (`ICompilationCache`) — per-workspace, version-keyed cache for `Compilation` and `CompilationWithAnalyzers` with task-level dedupe; invalidated on `IWorkspaceManager.WorkspaceClosed`
+- per-workspace diagnostic cache in `DiagnosticService` — solution-wide diagnostics reused by `GetDiagnosticDetailsAsync` instead of recompiling
+- bounded-semaphore parallelism for reference materialization (`ReferenceLocationMaterializer`), reused by `ReferenceService`, `MutationAnalysisService`, and `ConsumerAnalysisService`
+- bounded-semaphore parallelism for `UnusedCodeAnalyzer` Phase 2 (`SymbolFinder.FindReferencesAsync` per candidate)
+- parallel `FindDiagnosticAsync` via `Task.WhenAll` over per-project compilations
+- parallel outer loop in `MutationAnalysisService.FindTypeMutationsAsync` (per mutating member) backed by `ConcurrentDictionary` document caches
+
 Post-release candidates:
 
-- persistent symbol/index cache
+- workspace reader/writer locking — design captured in `ai_docs/reports/2026-04-06-workspace-rw-lock-design-note.md` (would let concurrent reads on the same workspace overlap instead of serializing)
+- persistent (cross-session) symbol/index cache
 - incremental background indexing
 - opt-in warmup for enterprise solutions
 - separate performance profile for remote hosting

--- a/src/RoslynMcp.Core/Services/IWorkspaceManager.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceManager.cs
@@ -10,6 +10,14 @@ namespace RoslynMcp.Core.Services;
 public interface IWorkspaceManager
 {
     /// <summary>
+    /// Raised when a workspace session is closed (via <see cref="Close"/> or process disposal).
+    /// Subscribers receive the closed workspace's identifier and can use it to free their own
+    /// per-workspace state. Handlers must not throw; the manager will swallow exceptions to keep
+    /// the close path reliable.
+    /// </summary>
+    event Action<string>? WorkspaceClosed;
+
+    /// <summary>
     /// Loads a solution or project file from disk into a new named workspace session.
     /// </summary>
     /// <param name="path">The absolute path to the <c>.sln</c>, <c>.slnx</c>, or <c>.csproj</c> file to load.</param>

--- a/src/RoslynMcp.Roslyn/Helpers/ReferenceLocationMaterializer.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ReferenceLocationMaterializer.cs
@@ -1,0 +1,119 @@
+using RoslynMcp.Core.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FindSymbols;
+
+namespace RoslynMcp.Roslyn.Helpers;
+
+/// <summary>
+/// A single reference location resolved against its document, with the per-location artifacts
+/// (preview text, syntax root, semantic model, containing symbol) already materialized.
+/// </summary>
+/// <remarks>
+/// Returned by <see cref="ReferenceLocationMaterializer.MaterializeAsync"/>. Callers that only
+/// want a flat list of <see cref="LocationDto"/>s should use
+/// <see cref="ReferenceLocationMaterializer.MaterializeDtosAsync"/> instead.
+/// </remarks>
+internal sealed record MaterializedReference(
+    ReferenceLocation Source,
+    LocationDto Dto,
+    ISymbol? ContainingSymbol,
+    SyntaxNode? SyntaxRoot,
+    SemanticModel? SemanticModel);
+
+/// <summary>
+/// Resolves a flat list of <see cref="ReferenceLocation"/>s into <see cref="MaterializedReference"/>
+/// records in parallel under a bounded semaphore. Each location triggers async preview-text,
+/// syntax-root, and semantic-model fetches; running them sequentially is the dominant cost for
+/// high-reference symbols on large solutions.
+/// </summary>
+/// <remarks>
+/// The bounded semaphore (<see cref="Parallelism"/>) prevents huge fan-outs from hammering the
+/// Roslyn document cache. The same parallelism heuristic is used in
+/// <c>ReferenceService.MaterializeReferenceLocationsAsync</c> after perf #74; this helper exists
+/// so other services (<c>MutationAnalysisService</c>, <c>ConsumerAnalysisService</c>) can reuse
+/// the pattern instead of re-implementing it per call site.
+/// </remarks>
+internal static class ReferenceLocationMaterializer
+{
+    /// <summary>
+    /// Bounded parallelism for per-location work. Caps at 8 even on high-core machines so that a
+    /// single tool call can't exhaust the global execution gate's slots.
+    /// </summary>
+    private static int Parallelism => Math.Min(Environment.ProcessorCount, 8);
+
+    /// <summary>
+    /// Materializes every reference location into a rich record with the DTO, containing symbol,
+    /// syntax root, and semantic model. Use this overload when callers need the syntax/semantic
+    /// data for downstream classification (e.g., property write detection, type-usage analysis).
+    /// </summary>
+    public static async Task<IReadOnlyList<MaterializedReference>> MaterializeAsync(
+        IReadOnlyList<ReferenceLocation> locations, CancellationToken ct)
+    {
+        if (locations.Count == 0) return [];
+
+        using var semaphore = new SemaphoreSlim(Parallelism, Parallelism);
+        var tasks = new Task<MaterializedReference>[locations.Count];
+        for (var i = 0; i < locations.Count; i++)
+        {
+            tasks[i] = ToRichLocationAsync(locations[i], semaphore, ct);
+        }
+
+        return await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Materializes every reference location into a flat <see cref="LocationDto"/> list.
+    /// Convenience overload for callers (e.g., <c>ReferenceService</c>) that don't need the
+    /// surrounding syntax/semantic data.
+    /// </summary>
+    public static async Task<IReadOnlyList<LocationDto>> MaterializeDtosAsync(
+        IReadOnlyList<ReferenceLocation> locations, CancellationToken ct)
+    {
+        var rich = await MaterializeAsync(locations, ct).ConfigureAwait(false);
+        if (rich.Count == 0) return [];
+
+        var dtos = new LocationDto[rich.Count];
+        for (var i = 0; i < rich.Count; i++)
+        {
+            dtos[i] = rich[i].Dto;
+        }
+        return dtos;
+    }
+
+    private static async Task<MaterializedReference> ToRichLocationAsync(
+        ReferenceLocation refLocation, SemaphoreSlim semaphore, CancellationToken ct)
+    {
+        await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var doc = refLocation.Document;
+
+            // Kick off the three independent fetches concurrently inside the semaphore slot.
+            // Roslyn's per-document caches mean these usually hit warm state, but the rare cold
+            // path benefits from the overlap.
+            var rootTask = doc.GetSyntaxRootAsync(ct);
+            var modelTask = doc.GetSemanticModelAsync(ct);
+            var previewTask = SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct);
+            await Task.WhenAll(rootTask, modelTask, previewTask).ConfigureAwait(false);
+
+            var root = await rootTask.ConfigureAwait(false);
+            var model = await modelTask.ConfigureAwait(false);
+            var preview = await previewTask.ConfigureAwait(false);
+
+            ISymbol? containingSymbol = null;
+            if (root is not null && model is not null)
+            {
+                containingSymbol = SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct);
+            }
+
+            var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
+            var dto = SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification);
+
+            return new MaterializedReference(refLocation, dto, containingSymbol, root, model);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
@@ -19,7 +19,7 @@ namespace RoslynMcp.Roslyn.Services;
 /// each project has at most one slot per cache and stale tasks are released as soon as the
 /// new entry is installed.
 /// </remarks>
-public sealed class CompilationCache : ICompilationCache
+public sealed class CompilationCache : ICompilationCache, IDisposable
 {
     private readonly IWorkspaceManager _workspaceManager;
 
@@ -34,6 +34,16 @@ public sealed class CompilationCache : ICompilationCache
     public CompilationCache(IWorkspaceManager workspaceManager)
     {
         _workspaceManager = workspaceManager;
+        // Free per-workspace cache slots when the workspace closes. Without this hook, closed
+        // workspace IDs (GUIDs) accumulate forever — stale entries are functionally inert
+        // because every read re-checks GetCurrentVersion, but they hold Compilation references
+        // until process exit.
+        _workspaceManager.WorkspaceClosed += Invalidate;
+    }
+
+    public void Dispose()
+    {
+        _workspaceManager.WorkspaceClosed -= Invalidate;
     }
 
     public Task<Compilation?> GetCompilationAsync(string workspaceId, Project project, CancellationToken ct)
@@ -105,12 +115,12 @@ public sealed class CompilationCache : ICompilationCache
 
     public void Invalidate(string workspaceId)
     {
-        // Note: stale entries (workspace closed, version bumped) are functionally inert
-        // because every read re-checks GetCurrentVersion. Invalidate is exposed for callers
-        // that want to free dictionary slots eagerly — currently it's not wired into
-        // WorkspaceManager.Close to avoid a circular DI dependency, but a future event-based
-        // notification could call this. ConcurrentDictionary doesn't support bulk-by-key
-        // removal, so iterate. The set of keys per workspace is small (one per project).
+        // Stale entries (workspace closed, version bumped) are functionally inert because
+        // every read re-checks GetCurrentVersion, but they hold Compilation references until
+        // process exit. This method is wired to IWorkspaceManager.WorkspaceClosed in the
+        // constructor so closed workspace ids are dropped eagerly.
+        // ConcurrentDictionary doesn't support bulk-by-key removal, so iterate. The set of
+        // keys per workspace is small (one per project).
         foreach (var key in _compilations.Keys)
         {
             if (key.WorkspaceId == workspaceId)

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -27,39 +27,35 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
         if (symbol is null) return null;
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
+        var refLocations = references.SelectMany(r => r.Locations).ToList();
+
+        // The materializer fetches syntax roots + semantic models in parallel under a bounded
+        // semaphore. This is the dominant cost for high-fanout types like IWorkspaceManager.
+        var materialized = await ReferenceLocationMaterializer.MaterializeAsync(refLocations, ct).ConfigureAwait(false);
 
         // Group references by containing type and classify dependency kind
         var consumerMap = new Dictionary<INamedTypeSymbol, HashSet<string>>(SymbolEqualityComparer.Default);
 
-        foreach (var refSymbol in references)
+        foreach (var item in materialized)
         {
-            foreach (var refLocation in refSymbol.Locations)
+            if (ct.IsCancellationRequested) break;
+            if (item.SyntaxRoot is null || item.SemanticModel is null) continue;
+
+            var node = item.SyntaxRoot.FindNode(item.Source.Location.SourceSpan);
+            var containingType = FindContainingType(node, item.SemanticModel, ct);
+            if (containingType is null) continue;
+
+            // Don't include self-references
+            if (SymbolEqualityComparer.Default.Equals(containingType, symbol)) continue;
+
+            if (!consumerMap.TryGetValue(containingType, out var kinds))
             {
-                if (ct.IsCancellationRequested) break;
-
-                var doc = refLocation.Document;
-                var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                if (root is null) continue;
-
-                var node = root.FindNode(refLocation.Location.SourceSpan);
-                var semanticModel = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
-                if (semanticModel is null) continue;
-
-                var containingType = FindContainingType(node, semanticModel, ct);
-                if (containingType is null) continue;
-
-                // Don't include self-references
-                if (SymbolEqualityComparer.Default.Equals(containingType, symbol)) continue;
-
-                if (!consumerMap.TryGetValue(containingType, out var kinds))
-                {
-                    kinds = new HashSet<string>(StringComparer.Ordinal);
-                    consumerMap[containingType] = kinds;
-                }
-
-                var kind = ClassifyDependencyKind(node);
-                kinds.Add(kind);
+                kinds = new HashSet<string>(StringComparer.Ordinal);
+                consumerMap[containingType] = kinds;
             }
+
+            var kind = ClassifyDependencyKind(node);
+            kinds.Add(kind);
         }
 
         var consumers = consumerMap.Select(kvp =>

--- a/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DependencyAnalysisService.cs
@@ -14,17 +14,20 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class DependencyAnalysisService : IDependencyAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly IGatedCommandExecutor _executor;
     private readonly ILogger<DependencyAnalysisService> _logger;
     private readonly ValidationServiceOptions _options;
 
     public DependencyAnalysisService(
         IWorkspaceManager workspace,
+        ICompilationCache compilationCache,
         IGatedCommandExecutor executor,
         ILogger<DependencyAnalysisService> logger,
         ValidationServiceOptions? options = null)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _executor = executor;
         _logger = logger;
         _options = options ?? new ValidationServiceOptions();
@@ -43,7 +46,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
         {
             if (ct.IsCancellationRequested) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var tree in compilation.SyntaxTrees)
@@ -192,7 +195,7 @@ public sealed class DependencyAnalysisService : IDependencyAnalysisService
         {
             if (ct.IsCancellationRequested) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var tree in compilation.SyntaxTrees)

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
@@ -27,24 +28,19 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         if (symbol is null) return null;
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
-        var directRefs = new List<LocationDto>();
+        var refLocations = references.SelectMany(r => r.Locations).ToList();
+        var materialized = await ReferenceLocationMaterializer.MaterializeAsync(refLocations, ct).ConfigureAwait(false);
+
+        var directRefs = new List<LocationDto>(materialized.Count);
         var affectedDeclarations = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         var affectedProjects = new HashSet<string>();
 
-        foreach (var refSymbol in references)
+        foreach (var item in materialized)
         {
-            foreach (var refLocation in refSymbol.Locations)
-            {
-                var preview = await SymbolResolver.GetPreviewTextAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
-                var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(refLocation.Document, refLocation.Location, ct).ConfigureAwait(false);
-                var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
-                directRefs.Add(SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification));
-
-                if (containingSymbol is not null)
-                    affectedDeclarations.Add(containingSymbol);
-
-                affectedProjects.Add(refLocation.Document.Project.Name);
-            }
+            directRefs.Add(item.Dto);
+            if (item.ContainingSymbol is not null)
+                affectedDeclarations.Add(item.ContainingSymbol);
+            affectedProjects.Add(item.Source.Document.Project.Name);
         }
 
         if (symbol is INamedTypeSymbol namedType)
@@ -76,40 +72,34 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         if (symbol is not IPropertySymbol property) return [];
 
         var references = await SymbolFinder.FindReferencesAsync(property, solution, ct).ConfigureAwait(false);
+        var refLocations = references.SelectMany(r => r.Locations).ToList();
+        var materialized = await ReferenceLocationMaterializer.MaterializeAsync(refLocations, ct).ConfigureAwait(false);
+
         var results = new List<PropertyWriteDto>();
-
-        foreach (var refSymbol in references)
+        foreach (var item in materialized)
         {
-            foreach (var refLocation in refSymbol.Locations)
-            {
-                var doc = refLocation.Document;
-                var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                if (root is null) continue;
+            if (item.SyntaxRoot is null) continue;
 
-                var refNode = root.FindNode(refLocation.Location.SourceSpan);
+            var refNode = item.SyntaxRoot.FindNode(item.Source.Location.SourceSpan);
 
-                // Determine if this reference is a write (left side of assignment, out/ref arg, or in an initializer)
-                var isWrite = IsWriteReference(refNode);
-                if (!isWrite) continue;
+            // Determine if this reference is a write (left side of assignment, out/ref arg, or in an initializer)
+            if (!IsWriteReference(refNode)) continue;
 
-                var isObjectInitializer = refNode.Ancestors()
-                    .Any(static a => a is InitializerExpressionSyntax init &&
-                        init.Kind() == SyntaxKind.ObjectInitializerExpression);
+            var isObjectInitializer = refNode.Ancestors()
+                .Any(static a => a is InitializerExpressionSyntax init &&
+                    init.Kind() == SyntaxKind.ObjectInitializerExpression);
 
-                var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                var lineSpan = refLocation.Location.GetLineSpan();
+            var lineSpan = item.Source.Location.GetLineSpan();
 
-                results.Add(new PropertyWriteDto(
-                    FilePath: lineSpan.Path,
-                    StartLine: lineSpan.StartLinePosition.Line + 1,
-                    StartColumn: lineSpan.StartLinePosition.Character + 1,
-                    EndLine: lineSpan.EndLinePosition.Line + 1,
-                    EndColumn: lineSpan.EndLinePosition.Character + 1,
-                    ContainingMember: containingSymbol?.ToDisplayString(),
-                    PreviewText: preview,
-                    IsObjectInitializer: isObjectInitializer));
-            }
+            results.Add(new PropertyWriteDto(
+                FilePath: lineSpan.Path,
+                StartLine: lineSpan.StartLinePosition.Line + 1,
+                StartColumn: lineSpan.StartLinePosition.Character + 1,
+                EndLine: lineSpan.EndLinePosition.Line + 1,
+                EndColumn: lineSpan.EndLinePosition.Character + 1,
+                ContainingMember: item.ContainingSymbol?.ToDisplayString(),
+                PreviewText: item.Dto.PreviewText,
+                IsObjectInitializer: isObjectInitializer));
         }
 
         return results;
@@ -122,33 +112,28 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         if (symbol is null) return [];
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
-        var results = new List<TypeUsageDto>();
+        var refLocations = references.SelectMany(r => r.Locations).ToList();
+        var materialized = await ReferenceLocationMaterializer.MaterializeAsync(refLocations, ct).ConfigureAwait(false);
 
-        foreach (var refSymbol in references)
+        var results = new List<TypeUsageDto>(materialized.Count);
+        foreach (var item in materialized)
         {
-            foreach (var refLocation in refSymbol.Locations)
-            {
-                var doc = refLocation.Document;
-                var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                if (root is null) continue;
+            if (item.SyntaxRoot is null) continue;
 
-                var refNode = root.FindNode(refLocation.Location.SourceSpan);
-                var classification = ClassifyTypeUsage(refNode, symbol);
+            var refNode = item.SyntaxRoot.FindNode(item.Source.Location.SourceSpan);
+            var classification = ClassifyTypeUsage(refNode, symbol);
 
-                var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                var lineSpan = refLocation.Location.GetLineSpan();
+            var lineSpan = item.Source.Location.GetLineSpan();
 
-                results.Add(new TypeUsageDto(
-                    FilePath: lineSpan.Path,
-                    StartLine: lineSpan.StartLinePosition.Line + 1,
-                    StartColumn: lineSpan.StartLinePosition.Character + 1,
-                    EndLine: lineSpan.EndLinePosition.Line + 1,
-                    EndColumn: lineSpan.EndLinePosition.Character + 1,
-                    ContainingMember: containingSymbol?.ToDisplayString(),
-                    PreviewText: preview,
-                    Classification: classification));
-            }
+            results.Add(new TypeUsageDto(
+                FilePath: lineSpan.Path,
+                StartLine: lineSpan.StartLinePosition.Line + 1,
+                StartColumn: lineSpan.StartLinePosition.Character + 1,
+                EndLine: lineSpan.EndLinePosition.Line + 1,
+                EndColumn: lineSpan.EndLinePosition.Character + 1,
+                ContainingMember: item.ContainingSymbol?.ToDisplayString(),
+                PreviewText: item.Dto.PreviewText,
+                Classification: classification));
         }
 
         return results;
@@ -160,75 +145,109 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
         if (symbol is not INamedTypeSymbol namedType) return null;
 
-        var mutatingMembers = new List<MutatingMemberDto>();
+        // Filter to mutating members up front so we can fan out the expensive
+        // SymbolFinder.FindReferencesAsync calls in parallel while preserving declaration order.
+        var candidates = namedType.GetMembers()
+            .Where(m => IsMutatingMember(m, namedType))
+            .ToArray();
 
-        // Cache document roots and semantic models to avoid redundant async lookups
-        // across multiple members referencing the same documents.
-        var rootCache = new Dictionary<DocumentId, SyntaxNode?>();
-        var modelCache = new Dictionary<DocumentId, SemanticModel?>();
-
-        foreach (var member in namedType.GetMembers())
+        if (candidates.Length == 0)
         {
-            if (!IsMutatingMember(member, namedType)) continue;
-
-            var callers = new List<MutationCallerDto>();
-            var references = await SymbolFinder.FindReferencesAsync(member, solution, ct).ConfigureAwait(false);
-
-            foreach (var refSymbol in references)
-            {
-                foreach (var refLocation in refSymbol.Locations)
-                {
-                    var doc = refLocation.Document;
-                    if (!rootCache.TryGetValue(doc.Id, out var root))
-                    {
-                        root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                        rootCache[doc.Id] = root;
-                    }
-                    if (!modelCache.TryGetValue(doc.Id, out var model))
-                    {
-                        model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
-                        modelCache[doc.Id] = model;
-                    }
-
-                    // For interface-implemented members (e.g. Dispose), filter to only calls
-                    // where the receiver type matches the target type
-                    if (root is not null && model is not null && !IsReceiverOfTargetType(root, model, refLocation.Location, namedType, ct))
-                        continue;
-
-                    var containingSymbol = root is not null && model is not null
-                        ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
-                        : null;
-
-                    // Skip calls from within the type itself (internal mutators calling each other)
-                    if (containingSymbol is not null &&
-                        SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
-                        continue;
-
-                    var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                    var phase = ClassifyCallerPhase(root, model, refLocation.Location, namedType);
-                    var lineSpan = refLocation.Location.GetLineSpan();
-
-                    callers.Add(new MutationCallerDto(
-                        FilePath: lineSpan.Path,
-                        StartLine: lineSpan.StartLinePosition.Line + 1,
-                        StartColumn: lineSpan.StartLinePosition.Character + 1,
-                        ContainingMember: containingSymbol?.ToDisplayString(),
-                        PreviewText: preview,
-                        CallerPhase: phase));
-                }
-            }
-
-            var memberLoc = member.Locations.FirstOrDefault(l => l.IsInSource);
-            mutatingMembers.Add(new MutatingMemberDto(
-                Name: member.Name,
-                FullyQualifiedName: member.ToDisplayString(),
-                Kind: member.Kind.ToString(),
-                FilePath: memberLoc?.GetLineSpan().Path,
-                Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
-                ExternalCallers: callers));
+            return new TypeMutationDto(
+                Type: SymbolMapper.ToDto(namedType, solution),
+                MutatingMembers: [],
+                Summary: $"Type '{namedType.Name}' has 0 mutating member(s) with 0 external caller(s).");
         }
 
-        var summary = $"Type '{namedType.Name}' has {mutatingMembers.Count} mutating member(s) " +
+        // Concurrent caches shared across the parallel member tasks. Roslyn's per-document
+        // caches mean these are mostly redundant after warmup, but the dictionary still saves
+        // the async-state-machine cost on hot documents.
+        var rootCache = new ConcurrentDictionary<DocumentId, SyntaxNode?>();
+        var modelCache = new ConcurrentDictionary<DocumentId, SemanticModel?>();
+
+        var parallelism = Math.Clamp(Environment.ProcessorCount, 4, 16);
+        using var semaphore = new SemaphoreSlim(parallelism, parallelism);
+
+        async Task<MutatingMemberDto> ProcessMemberAsync(ISymbol member)
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var callers = new List<MutationCallerDto>();
+                var references = await SymbolFinder.FindReferencesAsync(member, solution, ct).ConfigureAwait(false);
+
+                foreach (var refSymbol in references)
+                {
+                    foreach (var refLocation in refSymbol.Locations)
+                    {
+                        var doc = refLocation.Document;
+
+                        // ConcurrentDictionary has no async value factory, so we check-then-add.
+                        // The race is benign: at worst two members fetch the same document's
+                        // root/model concurrently and one TryAdd loses; the result is identical.
+                        if (!rootCache.TryGetValue(doc.Id, out var root))
+                        {
+                            root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                            rootCache.TryAdd(doc.Id, root);
+                        }
+                        if (!modelCache.TryGetValue(doc.Id, out var model))
+                        {
+                            model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+                            modelCache.TryAdd(doc.Id, model);
+                        }
+
+                        // For interface-implemented members (e.g. Dispose), filter to only calls
+                        // where the receiver type matches the target type
+                        if (root is not null && model is not null && !IsReceiverOfTargetType(root, model, refLocation.Location, namedType, ct))
+                            continue;
+
+                        var containingSymbol = root is not null && model is not null
+                            ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
+                            : null;
+
+                        // Skip calls from within the type itself (internal mutators calling each other)
+                        if (containingSymbol is not null &&
+                            SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
+                            continue;
+
+                        var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
+                        var phase = ClassifyCallerPhase(root, model, refLocation.Location, namedType);
+                        var lineSpan = refLocation.Location.GetLineSpan();
+
+                        callers.Add(new MutationCallerDto(
+                            FilePath: lineSpan.Path,
+                            StartLine: lineSpan.StartLinePosition.Line + 1,
+                            StartColumn: lineSpan.StartLinePosition.Character + 1,
+                            ContainingMember: containingSymbol?.ToDisplayString(),
+                            PreviewText: preview,
+                            CallerPhase: phase));
+                    }
+                }
+
+                var memberLoc = member.Locations.FirstOrDefault(l => l.IsInSource);
+                return new MutatingMemberDto(
+                    Name: member.Name,
+                    FullyQualifiedName: member.ToDisplayString(),
+                    Kind: member.Kind.ToString(),
+                    FilePath: memberLoc?.GetLineSpan().Path,
+                    Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
+                    ExternalCallers: callers);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        var memberTasks = new Task<MutatingMemberDto>[candidates.Length];
+        for (var i = 0; i < candidates.Length; i++)
+        {
+            memberTasks[i] = ProcessMemberAsync(candidates[i]);
+        }
+
+        var mutatingMembers = await Task.WhenAll(memberTasks).ConfigureAwait(false);
+
+        var summary = $"Type '{namedType.Name}' has {mutatingMembers.Length} mutating member(s) " +
                       $"with {mutatingMembers.Sum(m => m.ExternalCallers.Count)} external caller(s).";
 
         return new TypeMutationDto(

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -2,8 +2,6 @@ using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.Extensions.Logging;
 
@@ -28,49 +26,7 @@ public sealed class ReferenceService : IReferenceService
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
-        return await MaterializeReferenceLocationsAsync(refLocations, ct).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Resolves a flat list of <see cref="ReferenceLocation"/>s to <see cref="LocationDto"/>s in parallel.
-    /// Each location requires an async preview-text fetch and a containing-symbol lookup; doing them
-    /// sequentially is the dominant cost for high-reference symbols. Uses a bounded semaphore so we
-    /// don't blow up document caches on large fan-outs.
-    /// </summary>
-    private static async Task<IReadOnlyList<LocationDto>> MaterializeReferenceLocationsAsync(
-        IReadOnlyList<ReferenceLocation> refLocations, CancellationToken ct)
-    {
-        if (refLocations.Count == 0) return [];
-
-        var parallelism = Math.Min(Environment.ProcessorCount, 8);
-        using var semaphore = new SemaphoreSlim(parallelism, parallelism);
-
-        var tasks = new Task<LocationDto>[refLocations.Count];
-        for (var i = 0; i < refLocations.Count; i++)
-        {
-            var refLocation = refLocations[i];
-            tasks[i] = ToLocationDtoAsync(refLocation, semaphore, ct);
-        }
-
-        return await Task.WhenAll(tasks).ConfigureAwait(false);
-    }
-
-    private static async Task<LocationDto> ToLocationDtoAsync(
-        ReferenceLocation refLocation, SemaphoreSlim semaphore, CancellationToken ct)
-    {
-        await semaphore.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            var doc = refLocation.Document;
-            var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-            var containingSymbol = await SymbolServiceHelpers.GetContainingSymbolAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-            var classification = SymbolMapper.ClassifyReferenceLocation(refLocation);
-            return SymbolMapper.ToLocationDto(refLocation.Location, containingSymbol, preview, classification);
-        }
-        finally
-        {
-            semaphore.Release();
-        }
+        return await ReferenceLocationMaterializer.MaterializeDtosAsync(refLocations, ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<LocationDto>> FindImplementationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
@@ -128,8 +84,8 @@ public sealed class ReferenceService : IReferenceService
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
         // Outer fan-out: how many bulk symbols we resolve concurrently. Each task may itself
-        // spawn parallel preview fetches inside MaterializeReferenceLocationsAsync, so keep
-        // the outer cap modest on big boxes to avoid runaway document-cache pressure.
+        // spawn parallel preview fetches inside ReferenceLocationMaterializer, so keep the outer
+        // cap modest on big boxes to avoid runaway document-cache pressure.
         var bulkParallelism = Math.Clamp(Environment.ProcessorCount / 2, 4, 8);
         using var semaphore = new SemaphoreSlim(bulkParallelism, bulkParallelism);
 
@@ -162,7 +118,7 @@ public sealed class ReferenceService : IReferenceService
                 }
 
                 var refLocations = references.SelectMany(r => r.Locations).ToList();
-                var refDtos = await MaterializeReferenceLocationsAsync(refLocations, ct).ConfigureAwait(false);
+                var refDtos = await ReferenceLocationMaterializer.MaterializeDtosAsync(refLocations, ct).ConfigureAwait(false);
                 locations.AddRange(refDtos);
 
                 return new BulkReferenceResultDto(key, symbol.ToDisplayString(), locations.Count, locations, null);

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -91,7 +91,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
         var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
         if (root is null) return [];
 
-        return CollectSymbols(root);
+        return CollectSymbols(root, ct);
     }
 
     private static bool MatchesKind(ISymbol symbol, string kindFilter)
@@ -105,12 +105,14 @@ public sealed class SymbolSearchService : ISymbolSearchService
         return kinds.Any(kind => string.Equals(kind, kindFilter, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static IReadOnlyList<DocumentSymbolDto> CollectSymbols(SyntaxNode node)
+    private static IReadOnlyList<DocumentSymbolDto> CollectSymbols(SyntaxNode node, CancellationToken ct)
     {
         var symbols = new List<DocumentSymbolDto>();
 
         foreach (var child in node.ChildNodes())
         {
+            if (ct.IsCancellationRequested) break;
+
             switch (child)
             {
                 case NamespaceDeclarationSyntax ns:
@@ -118,10 +120,10 @@ public sealed class SymbolSearchService : ISymbolSearchService
                         ns.Name.ToString(), "Namespace", null,
                         ns.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
                         ns.GetLocation().GetLineSpan().EndLinePosition.Line + 1,
-                        CollectSymbols(ns)));
+                        CollectSymbols(ns, ct)));
                     break;
                 case FileScopedNamespaceDeclarationSyntax fns:
-                    symbols.AddRange(CollectSymbols(fns));
+                    symbols.AddRange(CollectSymbols(fns, ct));
                     break;
                 case TypeDeclarationSyntax typeDecl:
                     var kind = typeDecl switch
@@ -137,7 +139,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
                         typeDecl.Modifiers.Select(m => m.Text).ToList(),
                         typeDecl.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
                         typeDecl.GetLocation().GetLineSpan().EndLinePosition.Line + 1,
-                        CollectMembers(typeDecl)));
+                        CollectMembers(typeDecl, ct)));
                     break;
                 case EnumDeclarationSyntax enumDecl:
                     symbols.Add(new DocumentSymbolDto(
@@ -167,12 +169,14 @@ public sealed class SymbolSearchService : ISymbolSearchService
         return symbols;
     }
 
-    private static IReadOnlyList<DocumentSymbolDto> CollectMembers(TypeDeclarationSyntax typeDecl)
+    private static IReadOnlyList<DocumentSymbolDto> CollectMembers(TypeDeclarationSyntax typeDecl, CancellationToken ct)
     {
         var members = new List<DocumentSymbolDto>();
 
         foreach (var member in typeDecl.Members)
         {
+            if (ct.IsCancellationRequested) break;
+
             switch (member)
             {
                 case MethodDeclarationSyntax method:
@@ -232,7 +236,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
                         nestedType.Modifiers.Select(m => m.Text).ToList(),
                         nestedType.GetLocation().GetLineSpan().StartLinePosition.Line + 1,
                         nestedType.GetLocation().GetLineSpan().EndLinePosition.Line + 1,
-                        CollectMembers(nestedType)));
+                        CollectMembers(nestedType, ct)));
                     break;
             }
         }

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -52,6 +52,9 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     /// <summary>Limits concurrent workspace sessions; paired with <see cref="Close"/> and <see cref="Dispose"/>.</summary>
     private readonly SemaphoreSlim _workspaceSlots;
 
+    /// <inheritdoc />
+    public event Action<string>? WorkspaceClosed;
+
     public WorkspaceManager(
         ILogger<WorkspaceManager> logger,
         IPreviewStore previewStore,
@@ -147,8 +150,28 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         _previewStore.InvalidateAll(workspaceId);
         session.Dispose();
         _workspaceSlots.Release();
+        RaiseWorkspaceClosed(workspaceId);
         LogWorkspaceClosed(_logger, workspaceId, null);
         return true;
+    }
+
+    /// <summary>
+    /// Notifies subscribers (e.g., <see cref="ICompilationCache"/>) that a workspace has been
+    /// closed. Wrapped so that handler exceptions cannot break the close path.
+    /// </summary>
+    private void RaiseWorkspaceClosed(string workspaceId)
+    {
+        var handler = WorkspaceClosed;
+        if (handler is null) return;
+
+        try
+        {
+            handler(workspaceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "WorkspaceClosed handler threw for {WorkspaceId}", workspaceId);
+        }
     }
 
     public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces()
@@ -362,6 +385,11 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     public void Dispose()
     {
         _fileWatcher.Dispose();
+
+        // Capture session ids before dispose so we can raise WorkspaceClosed for each one.
+        // This lets singletons like ICompilationCache free per-workspace state on host shutdown
+        // (or test-assembly teardown) instead of leaking until process exit.
+        var ids = _sessions.Keys.ToArray();
         foreach (var session in _sessions.Values)
         {
             session.Dispose();
@@ -371,6 +399,11 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         for (var i = 0; i < n; i++)
         {
             _workspaceSlots.Release();
+        }
+
+        foreach (var id in ids)
+        {
+            RaiseWorkspaceClosed(id);
         }
 
         _workspaceSlots.Dispose();

--- a/tests/RoslynMcp.Tests/CompilationCacheTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheTests.cs
@@ -115,11 +115,15 @@ public sealed class CompilationCacheTests
         public string WorkspaceId { get; }
         public int Version { get; set; }
 
+        public event Action<string>? WorkspaceClosed;
+
         public FakeWorkspaceManager(string workspaceId, int initialVersion)
         {
             WorkspaceId = workspaceId;
             Version = initialVersion;
         }
+
+        public void RaiseWorkspaceClosed(string workspaceId) => WorkspaceClosed?.Invoke(workspaceId);
 
         public int GetCurrentVersion(string workspaceId) => Version;
 

--- a/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -103,6 +103,8 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
 
     private sealed class FakeWorkspaceManager : IWorkspaceManager
     {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+
         public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => !string.IsNullOrWhiteSpace(workspaceId);

--- a/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -94,6 +94,8 @@ public class PerformanceBehaviorTests : SharedWorkspaceTestBase
 
     private sealed class FakeWorkspaceManager : IWorkspaceManager
     {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+
         public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
 
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -70,6 +70,8 @@ public sealed class SurfaceCatalogTests
 
     private sealed class FakeWorkspaceManager : IWorkspaceManager
     {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+
         public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -78,6 +78,7 @@ internal sealed class TestServiceContainer
         var undoService = new UndoService();
         var dependencyAnalysisService = new DependencyAnalysisService(
             workspaceManager,
+            compilationCache,
             gatedCommandExecutor,
             NullLogger<DependencyAnalysisService>.Instance,
             validationOptions);


### PR DESCRIPTION
## Summary

Propagation pass after #74 (parallelization) and #75 (compilation cache). Applies the existing patterns to the remaining hot paths and ties up loose ends from the original design notes.

- Extract `ReferenceLocationMaterializer` helper from `ReferenceService` and reuse it in `MutationAnalysisService.AnalyzeImpactAsync` / `FindPropertyWritesAsync` / `FindTypeUsagesAsync` and `ConsumerAnalysisService.FindConsumersAsync` (the slowest variant — both `GetSyntaxRootAsync` + `GetSemanticModelAsync` per location).
- Parallelize the outer loop of `MutationAnalysisService.FindTypeMutationsAsync` with a `Math.Clamp(ProcessorCount, 4, 16)` semaphore + `ConcurrentDictionary` document caches; preserve declaration order via `Task.WhenAll` over an indexed array.
- Wire `CompilationCache` invalidation to a new `IWorkspaceManager.WorkspaceClosed` event so closed workspace ids are dropped eagerly instead of leaking until process exit. Resolves the circular-DI caveat captured in the original cache comment.
- Inject `ICompilationCache` into `DependencyAnalysisService` so `get_namespace_dependencies` / `get_di_registrations` reuse the warm cache populated by diagnostics tools.
- Add `CancellationToken` propagation to `SymbolSearchService.CollectSymbols` / `CollectMembers` so document-symbol walks on large files can be cancelled mid-tree.
- Update `docs/roadmap.md` to reflect the in-process caches + parallelism delivered after release-1 and cross-reference the workspace RW-lock design note as a remaining post-release candidate.

RW-lock implementation is intentionally **out of scope**: it's a multi-step structural change tracked separately under `ai_docs/reports/2026-04-06-workspace-rw-lock-design-note.md`.

## Test plan

- [x] `dotnet build RoslynMcp.slnx -c Release` — clean (0 warnings, 0 errors)
- [x] `dotnet test RoslynMcp.slnx -c Release --no-build` — 214/214 passing
- [x] MCP smoke calls against a high-fanout symbol (`IWorkspaceManager`): `find_consumers` returns 59 consumers / 4 projects, `find_type_usages` returns 47 results / 5 classifications, `impact_analysis` returns the expected reference + affected-declaration set

Generated with [Claude Code](https://claude.com/claude-code)