### PR TITLE
docs: Phase 8b RW-lock audit with auto-detected four-step dance

### DIFF
--- a/ai_docs/audit-reports/README.md
+++ b/ai_docs/audit-reports/README.md
@@ -13,6 +13,27 @@ Use immutable raw file naming: `yyyyMMddTHHmmssZ_<repo-id>_mcp-server-audit.md`.
 
 Do **not** store synthesized cross-repo actioning summaries here. Those belong in [`../reports/README.md`](../reports/README.md).
 
+### Lock-mode tagging and filenames
+
+Every raw audit produced after the addition of Phase 8b populates two pieces of lock-mode metadata, both auto-filled by the deep-review prompt:
+
+1. **Filename:** `<timestamp>_<repo-id>_<lockMode>_mcp-server-audit.md`. The `<lockMode>` segment is `legacy-mutex` or `rw-lock`, derived from the agent's Phase 0 step 4 `evaluate_csharp` call (which reads `ROSLYNMCP_WORKSPACE_RW_LOCK` from inside the running server). The agent never asks the operator for the filename.
+2. **Header field `Lock mode at audit time`:** the same value as the filename segment, set automatically by the agent.
+
+The legacy `dual-mode (legacy-mutex → rw-lock)` header value is no longer used for fresh audits — see *Auto-pair model* below for the replacement.
+
+### Auto-pair model — every raw audit is one of three shapes
+
+Phase 8b cannot toggle the lock mode mid-session, so a complete dual-mode lane is produced by running the prompt twice: once per mode, with `eng/flip-rw-lock.ps1` between the runs. The agent auto-pairs the runs by globbing `ai_docs/audit-reports/*_<repo-id>_<oppositeMode>_mcp-server-audit.md` in Phase 0 step 15.
+
+| Shape | When it is produced | Concurrency matrix state | Notes |
+|-------|---------------------|----------------------------|-------|
+| **Mode-N partial (run 1 of a planned pair, or single-mode lane)** | Operator runs the prompt once. Phase 0 step 15 finds no opposite-mode partial to pair with. | Session A columns populated; Session B columns marked `skipped-pending-second-run`. | The `<lockMode>` segment in the filename matches whichever mode the server was in. The **Report path note** instructs the operator to run `./eng/flip-rw-lock.ps1`, restart the MCP client, and re-invoke the prompt to pair this file. |
+| **Run-2 dual-mode (canonical)** | Operator runs the prompt a second time after `flip-rw-lock.ps1` and a client restart. Phase 0 step 15 finds the run-1 partial. | Session A columns inherited from the run-1 partial; Session B columns measured in this run. **Both columns populated in this single file.** | This is the canonical dual-mode raw audit. The **Report path note** points at the run-1 partial it paired with. The run-1 file remains on disk as immutable run-1 evidence; the run-2 file is the input the rollup pipeline uses for dual-mode coverage. |
+| **Single-mode (operator never plans a second run)** | Operator runs the prompt once and explicitly tells the agent this is a single-mode lane. | Session A columns populated; Session B columns marked `skipped-single-mode-lane`. | Identical filename shape to the run-1 partial above; the only difference is the **Report path note** wording. Acceptable for routine smoke runs; not acceptable for release-candidate runs (see `../procedures/deep-review-program.md`). |
+
+Rollups must dedupe lock-mode-specific defects by `tool + symptom + catalog-version + client-family + lock-mode` (see `../procedures/deep-review-program.md`). Run-2 dual-mode files are the preferred rollup input because they contain both modes' evidence in one place; run-1 partials are still valid inputs when used in pairs alongside their run-2 counterpart, but the rollup tool should prefer the run-2 file when both exist for the same `<repo-id>`.
+
 ## Intake rule
 
 - Keep raw audit files immutable once written.

--- a/ai_docs/procedures/deep-review-command-reference.md
+++ b/ai_docs/procedures/deep-review-command-reference.md
@@ -23,6 +23,120 @@ Set-Location C:\Code-Repo\Roslyn-Backed-MCP
 | One-command batch helper | `eng/new-deep-review-batch.ps1` |
 | Import-only helper | `eng/import-deep-review-audit.ps1` |
 | Rollup-only helper | `eng/new-deep-review-rollup.ps1` |
+| Lock-mode auto-flip (recommended) | `eng/flip-rw-lock.ps1` |
+| Lock-mode force enable rw-lock | `eng/rw-lock-on.ps1` |
+| Lock-mode force disable rw-lock (default) | `eng/rw-lock-off.ps1` |
+| Lock-mode shared helper (dot-sourced by the three above) | `eng/rw-lock-common.ps1` |
+
+## Concurrency lock-mode launch (Phase 8b)
+
+The deep-review prompt's **Phase 8b** exercises `ROSLYNMCP_WORKSPACE_RW_LOCK`. The flag is bound at server startup and never re-read, so toggling it requires a server restart. Capture the launch command in the raw audit header so the lock mode is auditable.
+
+### Recommended: use `flip-rw-lock.ps1` (auto-detect, one command)
+
+The primary helper is `eng/flip-rw-lock.ps1`. It reads the current User-scope value of `ROSLYNMCP_WORKSPACE_RW_LOCK`, decides the inverse, kills any running `roslynmcp.exe` / `RoslynMcp.Host.Stdio.exe` process, and writes the new value. The operator never has to think about which "side" they are on — the script auto-flips. This is the script the four-step operator dance below uses in step 2.
+
+```powershell
+# Auto-detect current mode and flip to the inverse
+./eng/flip-rw-lock.ps1
+
+# Dry-run first to see what would be killed and what mode the script will set
+./eng/flip-rw-lock.ps1 -WhatIf
+```
+
+Two explicit-mode helpers are also available for cases where the operator wants a known target regardless of current state (e.g., the very first run before any User-scope value has been set, or a CI pipeline that needs a deterministic starting mode):
+
+```powershell
+# Force mode to rw-lock (sets ROSLYNMCP_WORKSPACE_RW_LOCK=true)
+./eng/rw-lock-on.ps1
+
+# Force mode to legacy-mutex (clears the env var)
+./eng/rw-lock-off.ps1
+```
+
+All three scripts share `eng/rw-lock-common.ps1` (kill-server, set/clear env var, verify, print next steps), accept `-WhatIf`, and never touch generic `dotnet` processes. After running any of them, **fully close and reopen the MCP client** (Claude Code, Cursor, Continue, etc.) so it spawns a fresh server subprocess that inherits the new env var. Restarting just the chat tab is not enough — the client process must exit. The scripts print this reminder at the end of each run.
+
+The helpers are Windows-only. For bash/zsh/macOS/Linux operators, use the manual env-var commands below; the agent's `evaluate_csharp`-based mode detection in Phase 0 step 4 still works regardless of how the env var was set.
+
+### Manual: set the flag for the current shell session (PowerShell)
+
+```powershell
+# rw-lock mode (opt-in path under audit)
+$env:ROSLYNMCP_WORKSPACE_RW_LOCK = 'true'
+
+# legacy-mutex mode (default — clear the override)
+Remove-Item Env:\ROSLYNMCP_WORKSPACE_RW_LOCK -ErrorAction SilentlyContinue
+```
+
+### Manual: set the flag for the current shell session (bash / zsh)
+
+```bash
+# rw-lock mode (opt-in path under audit)
+export ROSLYNMCP_WORKSPACE_RW_LOCK=true
+
+# legacy-mutex mode (default — clear the override)
+unset ROSLYNMCP_WORKSPACE_RW_LOCK
+```
+
+### Manual: set the flag in the MCP client launch config
+
+Most MCP clients pass an `env` block to the spawned server process. For Claude Code / Cursor / similar clients with a `.mcp.json` (or equivalent) file, add the variable to the `env` of the `roslyn` (or `roslynmcp`) entry:
+
+```jsonc
+{
+  "mcpServers": {
+    "roslyn": {
+      "type": "stdio",
+      "command": "roslynmcp",
+      "env": {
+        "ROSLYNMCP_WORKSPACE_RW_LOCK": "true"
+      }
+    }
+  }
+}
+```
+
+After editing the launch config, **restart the MCP server session** (some clients require restarting the entire client). Confirm the new mode in Phase 8b via the parallel-fan-out micro-benchmark.
+
+### Dual-mode deep-review — the four-step flow
+
+**The complete operator dance.** The agent and the helper script handle all bookkeeping, so the operator only does four things:
+
+| # | Operator action | What auto-detection does for you |
+|---|-----------------|----------------------------------|
+| 1 | **Invoke the deep-review prompt** against the target repo. | Phase 0 step 4 calls `evaluate_csharp` to read `ROSLYNMCP_WORKSPACE_RW_LOCK` from inside the server — that is the canonical lock mode. Phase 0 step 15 globs `ai_docs/audit-reports/` for an opposite-mode partial of the same `<repo-id>`; if none is found, this is run 1. The agent auto-names the audit file `<timestamp>_<repo-id>_<lockMode>_mcp-server-audit.md` and marks Session B columns `skipped-pending-second-run`. |
+| 2 | **Run `./eng/flip-rw-lock.ps1`.** | The script reads the current User-scope env var, decides the inverse, kills any running `roslynmcp.exe` / `RoslynMcp.Host.Stdio.exe` process, and writes the new value. No operator decision about which side you are on — the script flips. |
+| 3 | **Fully close and reopen the MCP client.** | The next server subprocess spawned by the client inherits the flipped env var. (Restart the chat tab is not enough; the client process must exit.) |
+| 4 | **Invoke the deep-review prompt a second time** against the same disposable checkout. | Phase 0 step 4 detects the new lock mode. Phase 0 step 15 finds the run-1 partial in the audit-reports directory and recognises this is run 2 of a pair. Phase 8b.6 inherits the run-1 probe slot definitions, re-runs sub-phases 8b.1, 8b.2, 8b.3, 8b.5 to fill Session B, carries forward run 1's Session A columns into the matrix, and saves the run-2 audit file. The run-2 file is the **canonical dual-mode raw audit** — both sessions are populated in one file. No manual merge step. |
+
+**That is the entire dance.** No operator-supplied filenames. No "decide which mode is run 1". No manual matrix merge. No notes to the agent about which run is which. The four operator inputs are *invoke prompt*, *run script*, *restart client*, *invoke prompt*.
+
+**Single-mode lane** is what happens when the operator runs the prompt only once (skipping steps 2–4). The Session B columns stay `skipped-pending-second-run` in the saved file. A future second run (with the env var flipped) will still pair with it via the auto-pair logic in Phase 0 step 15 — no expiration as long as both files live in `ai_docs/audit-reports/` with matching `<repo-id>`.
+
+**On non-Windows hosts** the helper script is unavailable. Use the manual env-var commands in *Concurrency lock-mode launch* above, then proceed with steps 1, 3, 4 as described. The agent still auto-detects the lock mode via `evaluate_csharp` regardless of how the env var was set.
+
+### Verify the flag took effect
+
+`evaluate_csharp` reads the actual env var inside the running server process, so the deep-review prompt's Phase 0 step 4 already verifies the flag end-to-end: if the flip succeeded, Phase 0 reports the new mode; if it didn't (typo, wrong env block, server reused a stale process), Phase 0 reports the unchanged mode and the audit fails fast.
+
+If you want a quick standalone check without launching a deep-review run, ask the agent to call `evaluate_csharp` with the same script Phase 0 uses:
+
+```csharp
+var raw = System.Environment.GetEnvironmentVariable("ROSLYNMCP_WORKSPACE_RW_LOCK");
+var parsed = false;
+var isOn = bool.TryParse(raw, out parsed) && parsed;
+new {
+    Raw = raw ?? "(unset)",
+    LockMode = isOn ? "rw-lock" : "legacy-mutex"
+}
+```
+
+The Phase 8b parallel fan-out micro-benchmark also serves as a behavioral fingerprint when needed:
+
+| Mode | Expected speedup for R1 × N (N = `min(4, max(2, logical_cores))`) |
+|------|------------------------------|
+| `legacy-mutex` | ~1.0× (≤1.3×) — calls serialize behind the per-workspace `SemaphoreSlim` |
+| `rw-lock` | between `0.7 × N` and `N` (≥1.6× when N=2; ≥2.5× when N=4) — calls overlap behind the `AsyncReaderWriterLock`, bounded by global throttle |
 
 ## Example 1: Raw audit already in the canonical store
 

--- a/ai_docs/procedures/deep-review-program.md
+++ b/ai_docs/procedures/deep-review-program.md
@@ -53,6 +53,41 @@ If no repo matches a bucket, record that gap in the rollup rather than inventing
 
 At least one full-surface client lane must run before treating prompt/resource families as adequately covered.
 
+## Concurrency lock-mode lane (`ROSLYNMCP_WORKSPACE_RW_LOCK`)
+
+The deep-review prompt's **Phase 8b** exercises the per-workspace `AsyncReaderWriterLock` feature flag. The flag is bound at server startup, but the agent reads its actual value from inside the running server process via `evaluate_csharp` (Phase 0 step 4), so the audited lock mode is always known with certainty regardless of how the operator launched the server. The audit prompt also auto-pairs run 1 and run 2 of a dual-mode lane by globbing `ai_docs/audit-reports/` for an opposite-mode partial of the same `<repo-id>`, so the operator does not have to track which run is which.
+
+| Mode | Env var | Server gate | Use |
+|------|---------|-------------|-----|
+| `legacy-mutex` (default) | `ROSLYNMCP_WORKSPACE_RW_LOCK` unset or `false` | per-workspace `SemaphoreSlim(1,1)` | Default lane. Establishes the parity baseline used by every routine deep-review run. |
+| `rw-lock` (opt-in) | `ROSLYNMCP_WORKSPACE_RW_LOCK=true` | per-workspace `Nito.AsyncEx.AsyncReaderWriterLock` | Required lane for any release candidate, perf-claim verification, or backlog item that touches `workspace-rw-lock-flag-flip`. Drives the read-heavy unlock from the deep-review survey. |
+| `dual-mode` | sequential sessions, one per value | both, in two consecutive prompt invocations paired automatically by `<repo-id>` | Required for full-surface release candidates and any audit that needs the concurrency mode matrix populated under both modes. Dual-mode is the only way to surface lock-mode-specific defects (issues that reproduce under one mode but not the other). |
+
+### The four-step operator dance for a dual-mode run
+
+The complete dual-mode lane is:
+
+1. Operator invokes the deep-review prompt against the target repo.
+2. Operator runs `./eng/flip-rw-lock.ps1`. The script reads the current User-scope env var, kills any running server process, and writes the inverse value.
+3. Operator fully closes and reopens the MCP client so the next server subprocess inherits the flipped env var.
+4. Operator invokes the deep-review prompt a second time against the same disposable checkout.
+
+The agent handles the rest:
+- Phase 0 step 4 calls `evaluate_csharp` to read `ROSLYNMCP_WORKSPACE_RW_LOCK` from inside the running server process. This is the canonical lock mode and is recorded in the report header.
+- Phase 0 step 15 globs `ai_docs/audit-reports/*_<repo-id>_<oppositeMode>_mcp-server-audit.md`. If a recent partial exists with `skipped-pending-second-run` markers, this is run 2 of a dual-mode pair.
+- Phase 8b.6 either marks Session B columns `skipped-pending-second-run` (run 1) or inherits the run-1 partial's probe slot ids and fills both Session A and Session B columns in this run's file (run 2).
+- Audit files are auto-named `<timestamp>_<repo-id>_<lockMode>_mcp-server-audit.md`. The run-2 file is the canonical dual-mode raw audit and is self-contained.
+
+There is no manual filename, no manual matrix merge, and no operator decision about which run is which. See `deep-review-command-reference.md` → *Dual-mode deep-review — the four-step flow* for the concrete command sequence.
+
+### Operator rules
+
+1. The **default** lane for every routine smoke run is whichever mode the operator's MCP client is currently launched in. Phase 0 step 4 records the actual mode regardless.
+2. **Release-candidate runs** and any pass that consumes the `workspace-rw-lock-flag-flip` backlog row must be **dual-mode** (i.e., the operator must do the four steps, not just one). The run-2 file populates the concurrency mode matrix in both columns.
+3. **Performance investigations** triggered by the large-solution lane should always be dual-mode so the wall-clock comparison is grounded in matched probe-set evidence.
+4. The lock mode is tracked in the raw audit header (`Lock mode at audit time`) and propagated into every per-call evidence row by the audit prompt's cross-cutting principle #8. Rollups must dedupe by `tool + symptom + catalog-version + client-family + lock-mode` whenever a defect is plausibly mode-specific.
+5. Dual-mode runs must use the **same disposable checkout** in both prompt invocations so the workspace state is identical and the matrix is mechanically diffable. The agent's auto-pair logic relies on `<repo-id>` matching, so the second invocation must target a checkout whose entrypoint resolves to the same repo identity as the first.
+
 ## Helper execution and context conservation
 
 Use helper execution when the client/runtime supports it so long-running validation does not consume the primary agent's context window.
@@ -65,12 +100,13 @@ Use helper execution when the client/runtime supports it so long-running validat
 
 ## Cadence
 
-| Trigger | Recommended scope |
-|---------|-------------------|
-| Routine internal change with no surface or tiering impact | Smoke subset: 2-3 representative repos on the primary client. |
-| Material tool/resource/prompt surface change, schema change, or preview/apply behavior change | Full repo-shape matrix plus at least one full-surface client lane. |
-| Release candidate or experimental-to-stable promotion pass | Full matrix, full-surface client lane, and synthesized rollup review before sign-off. |
-| Performance concern on customer-scale repos | Add the large-solution lane and follow `docs/large-solution-profiling-baseline.md`. |
+| Trigger | Recommended scope | Lock-mode lane |
+|---------|-------------------|----------------|
+| Routine internal change with no surface or tiering impact | Smoke subset: 2-3 representative repos on the primary client. | Single mode (whichever the client is launched with). Record it. |
+| Material tool/resource/prompt surface change, schema change, or preview/apply behavior change | Full repo-shape matrix plus at least one full-surface client lane. | Dual-mode for at least one repo in the matrix. |
+| Release candidate or experimental-to-stable promotion pass | Full matrix, full-surface client lane, and synthesized rollup review before sign-off. | Dual-mode for all repos in the matrix. |
+| Performance concern on customer-scale repos | Add the large-solution lane and follow `docs/large-solution-profiling-baseline.md`. | Dual-mode required for the large-solution lane so the parallel-fan-out matrix is comparable. |
+| Closing the `workspace-rw-lock-flag-flip` backlog row | Full matrix, full-surface client lane, dual-mode for every repo, plus the soak duration noted in the backlog row. | Dual-mode required. Rollup must include the `parallel_speedup` numbers from every repo. |
 
 ## Normalized metadata
 
@@ -83,10 +119,14 @@ Each raw audit or batch manifest should capture these fields so rollups are comp
 | Client name / version | Separate server defects from client limitations. |
 | Server version and catalog version | Keep evidence aligned with the live surface. |
 | Audit mode | Distinguish `full-surface` from `conservative`. |
+| Lock mode at audit time | `legacy-mutex` / `rw-lock` / `dual-mode (legacy-mutex → rw-lock)` / `dual-mode (rw-lock → legacy-mutex)`. Required so rollups can dedupe lock-mode-specific defects. |
+| Lock mode source of truth | `launch-config` / `shell-env` / `behavioral-fingerprint`. Documents how the operator established what value the server was running with. |
 | Repo-shape tags | Explain why some families were or were not applicable. |
 | Client capability notes | Record prompt/resource availability or `blocked` limitations. |
+| Debug log channel | `yes` / `partial` / `no` — whether the client surfaced MCP `notifications/message` log entries. Drives whether the rollup can rely on captured server-side log evidence. |
 | Helper execution notes | Record whether subagents/background agents handled long-running validation and any related client/runtime limits. |
 | Coverage counts by status | Compare exercised vs skipped vs blocked across runs. |
+| Concurrency probe wall-clocks | Required when Phase 8b ran. Pulled from the raw audit's *Concurrency mode matrix → Sequential baseline* and *Parallel fan-out* tables; needed by the rollup to compare wall-clocks across repos and modes. |
 | New issue count / candidate closure count | Support rollup triage. |
 
 Use these fields as the manifest schema for manual review, future automation, or the lightweight scaffold script.
@@ -107,7 +147,9 @@ Each batch rollup in `ai_docs/reports/` should include:
 | Input files | Flat list of raw audit file paths from `ai_docs/audit-reports/`. |
 | Repo coverage | Which repo-shape buckets ran and which were missing. |
 | Client coverage | Full-surface vs constrained lanes and `blocked` families. |
-| Unique issues | Deduped findings table keyed by tool + symptom + catalog version + client family. |
+| Lock mode coverage | Which lock modes were exercised across the batch (`legacy-mutex` / `rw-lock` / dual-mode) and which repos were single-mode only. Required when any input audit reports a non-default lock mode or any input audit ran Phase 8b. |
+| Concurrency matrix rollup | Aggregated `parallel_speedup` numbers per repo per mode (pulled from the raw *Parallel fan-out* tables). Required when ≥2 input audits exercised Phase 8b dual-mode. |
+| Unique issues | Deduped findings table keyed by tool + symptom + catalog version + client family **+ lock mode** (when the defect is plausibly mode-specific). |
 | Blocked-by-client summary | Prompt/resource or client-surface limitations that are not server defects by default. |
 | Candidate closures | Prior issues that no longer reproduce, with raw evidence links. |
 | Backlog actions | New rows to open, existing rows to update, and items intentionally not backlogged. |
@@ -115,8 +157,9 @@ Each batch rollup in `ai_docs/reports/` should include:
 ## Backlog intake rules
 
 - Open or update backlog rows from the rollup, not directly from raw per-repo audits.
-- Default dedupe key: `tool + symptom + catalog-version + client-family`.
-- If the same defect reproduces across multiple repos, keep one backlog row and cite all evidence in the rollup.
+- Default dedupe key: `tool + symptom + catalog-version + client-family`. Add `lock-mode` to the key whenever a defect plausibly differs between `legacy-mutex` and `rw-lock` (any concurrency, lifecycle, gate, or apply/preview behavior).
+- If the same defect reproduces across multiple repos under the same lock mode, keep one backlog row and cite all evidence in the rollup.
+- If a defect reproduces under one lock mode but not the other, open a separate row tagged `lock-mode:<mode>` so the `workspace-rw-lock-flag-flip` rollout can use it as gate evidence.
 - Pure client limitations stay in the rollup unless they belong to an explicit client/plugin backlog.
 - Candidate closures require the prior source id and current raw evidence path.
 

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -1,12 +1,13 @@
 # Deep Code Review & Refactor Agent Prompt
 
-<!-- purpose: Exhaustive living prompt for MCP audits and refactor exercises against the real tool surface. -->
+<!-- purpose: Exhaustive living prompt for MCP audits and refactor exercises against the real tool surface. Output is optimized for downstream agentic consumption (machine-parseable tables, fixed schemas, dense per-call evidence). -->
 <!-- DO NOT DELETE THIS FILE.
      This is a living document that must be maintained and kept in sync
      with the project's actual tool, resource, and prompt surface at all times.
      When tools, resources, or prompts are added, removed, or renamed,
      update the Tools Reference appendix accordingly.
-   Last surface audit: 2026-04-06 (catalog 2026.03; 123 tools = 56 stable / 67 experimental, 7 resources, 16 prompts). -->
+   Last surface audit: 2026-04-06 (catalog 2026.03; 123 tools = 56 stable / 67 experimental, 7 resources, 16 prompts).
+   Concurrency feature flags exercised: `ROSLYNMCP_WORKSPACE_RW_LOCK` (Phase 8b). -->
 
 > Use this prompt with an AI coding agent that has access to the Roslyn MCP server.
 > **Primary purpose:** produce an MCP server audit (bugs, incorrect results, gaps). **Mechanism:** real refactoring plus tool calls that exercise the full surface.
@@ -22,7 +23,7 @@ You are a senior .NET architect. Your **primary mission** is to **audit the Rosl
 
 **Known issues / prior findings:** If you are auditing from within **Roslyn-Backed-MCP** or you otherwise have access to the server backlog, cross-check open MCP issues in [`ai_docs/backlog.md`](../backlog.md) and cite matching ids briefly (for example `semantic-search-async-modifier-doc`). If you are auditing from another repo and do not have that backlog available, use the closest equivalent prior source you do have (previous audit report, issue tracker, saved repro list). If no prior source exists, mark the regression section **N/A** instead of inventing one.
 
-**Phase order note:** After Phase 8, run **Phase 10** before **Phase 9** (Undo). Phase 9 is placed after Phase 10 so `revert_last_apply` does **not** undo Phase 6 refactoring — see Phase 9.
+**Phase order note:** Run phases in this order: **0 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 8b → 10 → 9 → 11 → 12 → 13 → 14 → 15 → 16 → 17 → 18**. Phase **8b** (Concurrency / RW lock audit) runs immediately after Phase 8 so it sees the post-refactor workspace state and can compare wall-clock against the Phase 8 baseline. **Phase 9** (Undo) runs after **Phase 10** so `revert_last_apply` does **not** undo Phase 6 refactoring — see Phase 9.
 
 **Portability and completeness contract:**
 
@@ -59,6 +60,8 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 5. **Response contract consistency:** Across tool calls, note inconsistencies in response contracts: Are line numbers 0-based or 1-based consistently? Do related tools (`find_consumers`, `find_references`, `find_type_usages`) use the same field names for the same concepts? Are classification values always strings or sometimes numeric codes? Note inconsistencies in the report.
 6. **Parameter-path coverage:** Happy-path defaults are not enough. For each major family you exercise, probe at least one non-default path when the live schema exposes it: project/file filters, severity filters, offset/limit pagination, boolean flags, alternate `kind` values, or similar. If the running schema does not expose a parameter mentioned in this prompt, record that as `N/A` rather than inventing it.
 7. **Precondition discipline:** Distinguish server defects from repo/environment constraints. If a tool depends on tests, analyzers, network access, source generators, DI registrations, Central Package Management, or a multi-project graph, record whether the precondition is absent in the repo, blocked by the environment, or mishandled by the server. A clear, actionable dependency or not-applicable response is not the same as a server bug.
+8. **Lock mode tagging:** Every tool call must be associated with the **lock mode** the server was launched in for that call (`legacy-mutex` when `ROSLYNMCP_WORKSPACE_RW_LOCK` is unset/`false`, `rw-lock` when set to `true`). The flag is bound at process startup, so a single server session always has one mode. If the audit includes a dual-mode lane (Phase 8b), record the mode in every per-call evidence row so wall-clock and behavioral differences can be attributed correctly. `server_info` does **not** report this flag — track it via the launch config the operator used and confirm via the Phase 8b behavioral probes.
+9. **Debug log capture:** If the MCP client surfaces server-emitted `notifications/message` log entries (the `McpLoggingProvider` forwards .NET `ILogger` events with structured payloads, including a `correlationId`), keep that channel visible for the entire run and record any `Warning`/`Error`/`Critical` entry verbatim in the report. Record `Information` entries that mention workspace lifecycle (`workspace_load`, `workspace_close`, `workspace_reload`), gate acquisition, lock contention, rate-limit hits, or request timeouts. If the client cannot show these notifications, record that as a client limitation in the header rather than silently dropping the channel.
 
 ---
 
@@ -67,17 +70,37 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 1. Pick the entrypoint you will load: prefer a `.sln` or `.slnx`; fall back to a `.csproj` if needed.
 2. Record whether this session is running in the default `full-surface` mode or an explicitly opted-in `conservative` mode.
 3. If `full-surface`, record the disposable branch/worktree/clone path you will mutate and how audit-only changes will be cleaned up. If `conservative`, record why safe disposable isolation is unavailable.
-4. Call `server_info` to record the server version, Roslyn version, catalog version, and live stable/experimental counts.
-5. Read `roslyn://server/catalog` to capture the authoritative live surface inventory.
-6. Read `roslyn://server/resource-templates` to capture all resource URI templates.
-7. Call `workspace_load` with the chosen entrypoint.
-8. Call `workspace_list` to confirm the session appears.
-9. Call `workspace_status` to confirm the workspace loaded cleanly. Note any load errors.
-10. Call `project_graph` to understand the project dependency structure.
-11. From the loaded repo, record the repo-shape constraints that affect later phases (projects, tests, analyzers, DI, source generators, Central Package Management, multi-targeting, network limits).
-12. Seed or update the coverage ledger so every live tool/resource/prompt already has a planned phase or a provisional skip reason.
+4. **Lock-mode capture via `evaluate_csharp` (source of truth, mandatory).** The server reads `ROSLYNMCP_WORKSPACE_RW_LOCK` once at process startup. The active value is **not** exposed by `server_info` or any other tool, but `evaluate_csharp` runs C# inside the running server process so it can read the server's own environment block — that read is the canonical source of truth. Call `evaluate_csharp` with this script and record the returned `LockMode` literally:
 
-**MCP audit checkpoint:** Did `server_info` and `roslyn://server/catalog` agree on live counts and tiers? Did `workspace_load` succeed on the chosen entrypoint? Does `workspace_list` show the new session? Did `workspace_status` report any stale documents or missing projects? Did you explicitly record either the disposable isolation path for `full-surface` or a justified `conservative` rationale, plus the repo shape and an initial coverage ledger with no silent omissions? If every candidate entrypoint failed to load, did you mark workspace-scoped rows `blocked` and continue only with workspace-independent families?
+   ```csharp
+   var raw = System.Environment.GetEnvironmentVariable("ROSLYNMCP_WORKSPACE_RW_LOCK");
+   var parsed = false;
+   var isOn = bool.TryParse(raw, out parsed) && parsed;
+   new {
+       Raw = raw ?? "(unset)",
+       LockMode = isOn ? "rw-lock" : "legacy-mutex"
+   }
+   ```
+
+   Record the result as the **canonical lock mode** in the report header. Do **not** infer the mode from launch-config inspection or behavioral fingerprints when this call works — it is the authoritative answer. If `evaluate_csharp` is itself unavailable (server defect, scripting disabled, sandbox restriction), fall back to launch-config inspection and record that the audit was forced to use a less reliable source.
+5. **Debug log channel check.** Verify that the MCP client is actively surfacing server-emitted `notifications/message` log entries (the `McpLoggingProvider` forwards .NET `ILogger` events with a structured payload that includes `correlationId`, `level`, `logger`, `message`, `eventId`, `eventName`, and any exception). If the client cannot show those notifications, note the limitation in the header and proceed; the audit must still record any structured log entries it can see.
+6. Call `server_info` to record the server version, Roslyn version, catalog version, live stable/experimental counts, and `runtime` / `os` strings.
+7. Read `roslyn://server/catalog` to capture the authoritative live surface inventory.
+8. Read `roslyn://server/resource-templates` to capture all resource URI templates.
+9. Call `workspace_load` with the chosen entrypoint.
+10. Call `workspace_list` to confirm the session appears.
+11. Call `workspace_status` to confirm the workspace loaded cleanly. Note any load errors.
+12. Call `project_graph` to understand the project dependency structure.
+13. From the loaded repo, record the repo-shape constraints that affect later phases (projects, tests, analyzers, DI, source generators, Central Package Management, multi-targeting, network limits).
+14. Seed or update the coverage ledger so every live tool/resource/prompt already has a planned phase or a provisional skip reason.
+15. **Auto-pair detection (run-1 vs run-2 of a dual-mode pair).** Before doing any other work, glob `ai_docs/audit-reports/*_<repo-id>_<oppositeMode>_mcp-server-audit.md` (where `<oppositeMode>` is the mode opposite to the one captured in step 4). If you find a recent partial (within the last 24 hours) whose **Concurrency mode matrix** has `skipped-pending-second-run` markers, this prompt invocation is **run 2 of a dual-mode pair**. Record:
+    - The path of the matched run-1 partial (will be reused in Phase 8b.6).
+    - The fact that this run is the "second half" (so the agent fills Session B columns when it reaches Phase 8b).
+    - If multiple partials match, pick the most recent one and note the others as `superseded` in the report header.
+
+    If no matching partial exists, this prompt invocation is **run 1** (or a single-mode lane). The audit file produced at the end will be saved with the lock mode embedded in the filename (`<timestamp>_<repo-id>_<lockMode>_mcp-server-audit.md`); the agent does this automatically based on step 4's result. No operator-supplied filename is needed.
+
+**MCP audit checkpoint:** Did `evaluate_csharp` return a clean `LockMode` value, and does it match what you would expect from the operator's launch config (if known)? Did `server_info` and `roslyn://server/catalog` agree on live counts and tiers? Did `workspace_load` succeed on the chosen entrypoint? Does `workspace_list` show the new session? Did `workspace_status` report any stale documents or missing projects? Did you explicitly record the disposable isolation path / conservative rationale, the repo shape, the **lock mode from `evaluate_csharp`**, the **debug log channel availability**, the **auto-pair detection result** (run 1 / run 2 / single-mode), and an initial coverage ledger with no silent omissions? If every candidate entrypoint failed to load, did you mark workspace-scoped rows `blocked` and continue only with workspace-independent families?
 
 ---
 
@@ -284,7 +307,140 @@ If `test_discover` returns zero tests, still record that result. Then explicitly
 
 **MCP audit checkpoint:** Does `build_workspace` match `compile_check` results (same error count, same diagnostic IDs, same locations)? Does `test_related_files` correctly identify related tests? Does `test_related` find the right tests for the symbol? Does `test_run` produce structured results with pass/fail counts — and do the aggregated counts reflect the full solution or only the last assembly? Does `test_coverage` produce coverage data?
 
-**Do not** call `revert_last_apply` yet — that would undo the most recent Phase 6 apply. Continue to **Phase 10**, then **Phase 9** (Undo verification).
+**Do not** call `revert_last_apply` yet — that would undo the most recent Phase 6 apply. Continue to **Phase 8b** (concurrency / RW lock), then **Phase 10**, then **Phase 9** (Undo verification).
+
+---
+
+### Phase 8b: Concurrency / RW Lock Audit (`ROSLYNMCP_WORKSPACE_RW_LOCK`)
+
+**Purpose:** Exercise the per-workspace reader/writer lock feature flag and produce a machine-readable concurrency matrix that downstream agents can compare across runs. The flag (`ROSLYNMCP_WORKSPACE_RW_LOCK`) replaces the legacy per-workspace `SemaphoreSlim` with a per-workspace `Nito.AsyncEx.AsyncReaderWriterLock`. Under the new mode, multiple reads against the same workspace overlap, writes are exclusive against in-flight reads, and `workspace_close` / `workspace_reload` block on the per-workspace write lock so they wait for in-flight readers.
+
+#### Operational model — auto-detected, four-step operator dance
+
+The flag is bound at server startup, so a single MCP server session can only test one lock mode. To populate both halves of the matrix the operator runs the prompt **twice**, with the lock mode flipped between runs by `eng/flip-rw-lock.ps1`. Everything else is auto-detected: the agent reads the actual lock mode from inside the running server via `evaluate_csharp` (Phase 0 step 4), names the audit file with the mode in it automatically, and decides whether this is run 1 or run 2 by globbing for an opposite-mode partial of the same `<repo-id>` (Phase 0 step 15).
+
+**The full operator dance is exactly four steps:**
+
+| # | Operator action |
+|---|-----------------|
+| 1 | Invoke the deep-review prompt against the target repo. The agent runs Phases 0–8 → 8b → 10 → 9 → 11 → 18 in whichever mode the server is currently in, auto-names the audit file `<timestamp>_<repo-id>_<lockMode>_mcp-server-audit.md`, and marks the Session B columns of the concurrency matrix `skipped-pending-second-run`. |
+| 2 | Run `./eng/flip-rw-lock.ps1`. The script reads the current User-scope env var, kills any running `roslynmcp.exe` / `RoslynMcp.Host.Stdio.exe` process, and writes the inverse value. No operator decision about which mode to set — the script flips. |
+| 3 | Fully close and reopen the MCP client so it spawns a fresh server subprocess that inherits the flipped env var. (Restarting just the chat tab is not enough; the client process must exit.) |
+| 4 | Invoke the deep-review prompt a second time against the **same disposable checkout** used in step 1. The agent again calls `evaluate_csharp` to detect the new mode, globs the audit-reports directory to find the run-1 partial of the opposite mode, recognises that this is run 2 of a dual-mode pair, re-runs Phase 8b sub-phases 8b.1, 8b.2, 8b.3, 8b.5 against the same probe slot ids it inherited from the run-1 partial, fills the Session B columns of the matrix, and writes the resulting audit as `<timestamp>_<repo-id>_<oppositeLockMode>_mcp-server-audit.md`. The run-2 audit file is self-contained and has both Session A (copied from the run-1 partial) and Session B (measured this run) columns populated — it is the canonical dual-mode raw audit. |
+
+That is the entire sequence. There is no operator decision about "which mode is this run", no manual filename, no manual matrix merge, no manual flag management. The only operator inputs are *invoke prompt*, *run script*, *restart client*, *invoke prompt*.
+
+**Single-mode lane** is what happens when the operator runs the prompt only once (skipping steps 2–4). The Session B columns remain `skipped-pending-second-run` in the saved file, and a future second run of the prompt (with the lock mode flipped) will pair with it via the auto-pair logic in Phase 0 step 15 to produce a complete dual-mode audit. Single-mode is acceptable for routine smoke runs; dual-mode is required for release candidates per `ai_docs/procedures/deep-review-program.md` → *Concurrency lock-mode lane*.
+
+**Mid-session server restart (formerly Path B) is not supported.** It was unreliable on every stdio MCP client (Claude Code, Cursor, Continue, etc.) because killing the server subprocess broke the client's stdio handshake. The four-step flow above is the only supported dance.
+
+#### Sessions vocabulary used in the sub-phases below
+- **Session A** = the run-1 server session (first prompt invocation, whichever mode the operator started with).
+- **Session B** = the run-2 server session (second prompt invocation, opposite mode after `flip-rw-lock.ps1`).
+
+In a single-mode lane, Session B is empty (`skipped-pending-second-run`) until a future run-2 fills it via auto-pair. In a complete dual-mode lane, the run-2 audit file holds both sessions' data.
+
+#### 8b.0 — Probe set definition (run before any timing)
+
+Pick a stable, repeatable probe set that exercises *reader* code paths and a small number of *writer* code paths against the workspace. The probes must be re-runnable byte-for-byte across both sessions. Record the chosen probes in the report under **Concurrency probe set** so the matrix is reproducible.
+
+| Slot | Suggested probe (substitute repo-specific equivalents) | Classification |
+|------|--------------------------------------------------------|----------------|
+| R1 | `find_references` on a hot symbol used 50+ times | reader |
+| R2 | `project_diagnostics` (no filters) | reader |
+| R3 | `symbol_search` with a broad query that returns >100 hits | reader |
+| R4 | `find_unused_symbols` `includePublic=false` | reader |
+| R5 | `get_complexity_metrics` (no filters) | reader |
+| W1 | `format_document_preview` then `format_document_apply` on a single file already touched in Phase 6 | writer |
+| W2 | `set_editorconfig_option` with a benign key (immediately reverted) | writer (reclassified) |
+
+If a probe is not applicable to the repo shape (e.g. no public-only dead-code surface), substitute the closest reader of equivalent cost and record the substitution.
+
+#### 8b.1 — Sequential baseline (Session A, current mode)
+
+1. Record `Session A` lock mode (`legacy-mutex` or `rw-lock`) from Phase 0 capture.
+2. For each reader R1–R5, call the tool **once sequentially** and record wall-clock in milliseconds. These are the **single-call baselines**.
+3. Record any structured log entries received from the MCP server during the calls (correlation IDs, gate-related warnings, rate-limit hits, request timeouts).
+
+#### 8b.2 — Parallel-read fan-out (Session A)
+
+1. Determine the **fan-out N** = `min(4, max(2, Environment.ProcessorCount))`. The server's global throttle is `max(2, Environment.ProcessorCount)` (`src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs:35`), so on a 2-core CI host, parallel speedup is bounded above by 2× even under `rw-lock`. Record the host's logical core count and chosen N in the report so the speedup ratio is interpretable.
+2. Issue **R1 N times in parallel** against the same workspace id (N concurrent `find_references` calls). Record the wall-clock from request submission to last response.
+3. Compute the **parallel speedup** = `N × baseline(R1) / parallel_wall_clock`. Expected ranges, given the global throttle ceiling at N:
+   - `legacy-mutex`: ~1.0× (≤ 1.3×) — calls serialize behind the per-workspace `SemaphoreSlim`.
+   - `rw-lock`: between `0.7 × N` and `N` (≥ 2.5× when N=4; ≥ 1.6× when N=2). Anything below `0.7 × N` is a FLAG.
+4. Repeat the fan-out for R2 (`project_diagnostics` ×N) and R3 (`symbol_search` ×N). Record each parallel wall-clock and speedup.
+5. If the client cannot issue concurrent tool calls (some clients serialize internally — that is itself a finding), mark this sub-phase `blocked` with the client limitation and continue.
+
+#### 8b.3 — Read/write exclusion behavioral probe (Session A)
+
+1. Start a long-running reader: call R1 (`find_references` on the hot symbol) and immediately, while it is still in flight, issue W1 (`format_document_preview` followed by `format_document_apply` on a Phase 6-touched file).
+2. Record whether W1 **starts immediately** (legacy mode: writer is on a separate `__apply__:<ws>` semaphore today, so it overlaps with the reader) or **waits** for the reader (rw-lock mode: writer blocks until the reader releases). Capture the inter-call timing.
+3. **Inverse probe.** Start W1 first (begin `format_document_apply`) and immediately issue R1 against the same workspace. Under rw-lock, R1 must wait for W1 to complete; under legacy, it queues against the reader semaphore separately and does not wait for W1.
+4. Tag any deviation from the expected behavior as a FLAG (the lock-mode contract is the most observable correctness signal of this phase).
+
+#### 8b.4 — Lifecycle stress probe (Session A)
+
+> Reference for expected behavior: under `rw-lock`, `workspace_reload` and `workspace_close` both wrap a per-workspace **write** lock acquire inside the global `__load__` gate (`src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs:46-73`), so they wait for in-flight readers to release the per-workspace lock before proceeding. Under `legacy-mutex`, the writer is routed to a **separate** `__apply__:<wsId>` semaphore that is independent from the reader's `<wsId>` semaphore, so the writer and reader run concurrently.
+
+1. Start a long-running reader (R2 — `project_diagnostics`) and, while it is in flight, call `workspace_reload(workspaceId)`. Record the observed behavior with one of these labels:
+   - `waits-for-reader` — reload blocks until the reader returns (expected under `rw-lock`)
+   - `runs-concurrently` — reload completes while the reader is still in flight (expected under `legacy-mutex`)
+   - `errors` — reload raises an exception (FLAG candidate under either mode)
+2. Record whether the in-flight reader returns **stale** results, **fresh post-reload** results, or **errors** (the third is a FLAG candidate). Note the `correlationId` of both calls if available.
+3. Start a long-running reader (R3 — `symbol_search`) and call `workspace_close(workspaceId)`. Use the same labels as step 1. Under `rw-lock`, the reader should complete cleanly and the close should `waits-for-reader`. Under `legacy-mutex`, the close may `runs-concurrently` — and the reader may then throw `KeyNotFoundException` because of the post-acquire `EnsureWorkspaceStillExists` recheck inside `WorkspaceExecutionGate.RunPerWorkspaceAsync` (`src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs:244-251`). Record exactly which exception (if any) the reader raises and whether the message is actionable.
+4. After the close, immediately call `workspace_load` again to re-establish a session for the remaining sub-phases. Record any errors.
+
+#### 8b.5 — Writer reclassification verification (Session A)
+
+The `perf/workspace-rw-lock` change reclassified six tools that were silently using the read gate while mutating workspace state. Verify each one still completes successfully and observably takes the writer code path. The point of this sub-phase is to catch a regression where one of these tools accidentally drops back to reader semantics (which would be a correctness FLAG under rw-lock).
+
+| # | Tool | Verification |
+|---|------|--------------|
+| 1 | `apply_text_edit` | Apply a single trivial text edit on a Phase 6-touched file; verify the file content changes and `compile_check` still passes. |
+| 2 | `apply_multi_file_edit` | Apply a coordinated trivial edit across two files; verify both files change and `compile_check` still passes. |
+| 3 | `revert_last_apply` | Call after sub-phase 1 or 2 above; verify the prior edit is reverted and the workspace is consistent. (This counts toward the Phase 9 audit-only revert step — record it once and reuse the evidence.) |
+| 4 | `set_editorconfig_option` | Set a benign key (e.g. `dotnet_sort_system_directives_first = true`) and verify `get_editorconfig_options` reflects it. |
+| 5 | `set_diagnostic_severity` | Set `dotnet_diagnostic.<some-IDE-id>.severity = suggestion` and verify it appears in the relevant `.editorconfig`. |
+| 6 | `add_pragma_suppression` | Insert `#pragma warning disable <id>` before a known diagnostic line and verify `get_source_text` shows the pragma. |
+
+For each row, also record whether the tool returned in the same wall-clock budget as Session A's reader baseline (writers should be measurably slower because they actually mutate disk state).
+
+#### 8b.6 — Auto-detect run-1 vs run-2 and act accordingly
+
+This sub-phase branches on the **auto-pair detection result** that Phase 0 step 15 already recorded. The agent does not ask the operator anything — Phase 0's glob result is the answer.
+
+**Case A — This is run 1 (no opposite-mode partial found in audit-reports):**
+
+1. Mark **all Session B columns** of the concurrency matrix with the literal string `skipped-pending-second-run` and a one-line note: `paired second run will fill these columns`.
+2. **Do not stop and wait.** Continue with the rest of this run (Phases 10 → 9 → 11 → 18) so this run produces a complete mode-1 raw audit. The audit file will be saved at the end of the prompt as `<timestamp>_<repo-id>_<currentLockMode>_mcp-server-audit.md`.
+3. At the end of the report, in **Report path note**, write: `This is the mode-1 partial of a deep-review pair. Run \`./eng/flip-rw-lock.ps1\`, restart the MCP client, and re-invoke the deep-review prompt to populate the Session B columns.` This gives the operator a single, unambiguous next instruction.
+
+**Case B — This is run 2 (Phase 0 found a recent opposite-mode partial for the same `<repo-id>`):**
+
+1. Read the run-1 partial file path that Phase 0 captured. Open it and extract:
+   - The **Concurrency probe set** table (so this run uses the exact same probe slot ids).
+   - The **Sequential baseline** Session A column values (so this run can carry them forward into the run-2 file's matrix).
+   - The **Parallel fan-out** Session A rows.
+   - The **Lifecycle stress** Session A rows.
+   - The **Writer reclassification verification** Session A column.
+   - The **Debug log capture** entries from run 1 (to be merged with run 2's debug entries in the run-2 file).
+2. Re-load the same workspace via `workspace_load` against the same disposable checkout used in Phase 0. Run sub-phase 8b.0 to confirm the inherited probe slot ids still resolve to valid symbols/files in this workspace; substitute and note any drift.
+3. Re-run sub-phases 8b.1 (sequential baseline), 8b.2 (parallel fan-out), 8b.3 (read/write exclusion), and 8b.5 (writer reclassification) against the **same probe slot ids** so the matrix can be diffed mechanically. Record the new wall-clocks and behavioral observations under the **Session B columns** of the matrix.
+4. Repeat 8b.4 (lifecycle stress) **only** if the disposable checkout is still clean and re-runnable. Otherwise carry forward run 1's lifecycle rows and mark the run-2 lifecycle column `inherited-from-run-1`.
+5. **Carry forward** the Session A column values from the run-1 partial into the run-2 matrix so the run-2 file is self-contained — when both Session A and Session B columns are populated in one file, that file is the canonical dual-mode raw audit.
+6. At the end of the report, in **Report path note**, write: `This is the canonical dual-mode raw audit. Paired with run-1 partial: <run-1 path>. Phase 8b.6 carried forward run 1's Session A columns and measured Session B in this run.`
+7. Continue with Phases 10 → 9 → 11 → 18 normally so the run-2 file also has full per-tool coverage.
+
+**Case C — Single-mode lane (operator does not plan a second run):**
+
+The agent cannot tell the difference between Case A and Case C from the audit-reports glob alone — both have no opposite-mode partial. To distinguish: if the operator told the agent at the start of the prompt invocation that this is a single-mode lane, mark Session B columns `skipped-single-mode-lane` with the operator's reason. Otherwise default to **Case A** (treat as run 1 of a pending pair). Either way, continue with Phases 10–18 normally; the only difference is the **Report path note** wording. Default-to-Case-A is the safer choice because it leaves the door open for a future run-2 to auto-pair.
+
+#### 8b.7 — Concurrency matrix output (mandatory)
+
+Write the matrix into the report using the schema in **Output Format → Concurrency mode matrix** below. Every cell must have a value or `N/A`; do not leave blanks. Include both Session A and Session B rows even if Session B was `skipped-safety` (with the reason in the cell).
+
+**MCP audit checkpoint:** Did parallel reads under `rw-lock` measurably overlap (speedup ≥ `0.7 × N` for N concurrent reads, where N is the host-bounded fan-out from sub-phase 8b.2.1)? Did parallel reads under `legacy-mutex` measurably serialize (speedup ≤ 1.3×)? Did the speedup signature on this host roughly match the 4-slot benchmark in `tests/RoslynMcp.Tests/Benchmarks/WorkspaceReadConcurrencyBenchmark.cs` (recorded against `Math.Max(2, Environment.ProcessorCount)` as the expected ceiling)? Did the read/write exclusion probe (8b.3) match the documented contract under both modes? Did the lifecycle stress probe (8b.4) reveal any TOCTOU or stale-result issues? Did all six writer-reclassification tools (8b.5) return identical post-state under both modes? Were there any structured log entries that mentioned gate contention, rate-limit rejections, request timeouts, or deadlocks? Was the `parallel_speedup` field stable across two consecutive parallel runs in the same session (within ±15%), or did jitter make it unreliable?
 
 ---
 
@@ -462,8 +618,10 @@ Before writing the report, deliberately re-test 3–5 previously recorded issues
 1. Compare your coverage ledger against the live catalog captured in Phase 0.
 2. For every unaccounted tool, resource, or prompt, either call it now or assign a final explicit status (`skipped-repo-shape`, `skipped-safety`, or `blocked`) with a one-line reason.
 3. If the live catalog exposed entries that had no natural place in the phased plan, record that as prompt drift in **Improvement suggestions** and still include the entries in the ledger.
-4. Confirm that all audit-only mutations from Phases 9-13 were reverted or cleaned up. Only intentional Phase 6 product improvements should remain.
+4. Confirm that all audit-only mutations from Phases **8b**, 9-13 were reverted or cleaned up. Only intentional Phase 6 product improvements should remain. (Phase 8b's writer-reclassification probes and the W2 `set_editorconfig_option` probe must each be reverted; the W1 `format_document_apply` probe is the audit-only apply that Phase 9 reverts.)
 5. Confirm that ledger totals match the live catalog totals and that the catalog summary matches `server_info`.
+6. Confirm the **Concurrency mode matrix** is fully populated when Phase 8b ran in any mode, with `N/A` (and a one-line reason) in cells the audit could not fill.
+7. Confirm the **Debug log capture** section either has at least one entry or explicitly states `client did not surface MCP log notifications`.
 
 ---
 
@@ -506,18 +664,23 @@ Derive `<repo-id>` from the **audited** solution or repository name:
 
 ### Report contents (required sections)
 
-1. **Header (metadata)** — server version (from `server_info`), Roslyn / .NET versions if available, MCP client name/version if available, **audited** solution path and name, audited repo revision/branch if available, chosen entrypoint (`.sln` / `.slnx` / `.csproj`), audit mode (`full-surface` by default or explicitly opted-in `conservative`), disposable isolation path or conservative rationale, date, workspace id, approximate project count and document count from `workspace_load` / `project_graph`, repo-shape summary, and the prior-issue source used for Phase 18.
+The report is consumed by **downstream agents**, not humans browsing prose. Prefer dense tables, fixed schemas, and one-line entries. Avoid narrative paragraphs unless an issue genuinely requires them.
+
+1. **Header (metadata)** — server version (from `server_info`), Roslyn / .NET versions if available, MCP client name/version if available, **audited** solution path and name, audited repo revision/branch if available, chosen entrypoint (`.sln` / `.slnx` / `.csproj`), audit mode (`full-surface` by default or explicitly opted-in `conservative`), disposable isolation path or conservative rationale, date, workspace id, approximate project count and document count from `workspace_load` / `project_graph`, repo-shape summary, the prior-issue source used for Phase 18, **lock mode at audit time** (`legacy-mutex` / `rw-lock` / `dual-mode`), and **debug log channel availability** (`yes` / `no` / `partial`).
 2. **Coverage summary** — Group by the live catalog's `Kind` + `Category` values from `roslyn://server/catalog`. For each group, report counts for `exercised`, `exercised-apply`, `exercised-preview-only`, `skipped-repo-shape`, `skipped-safety`, and `blocked`.
 3. **Coverage ledger (required)** — One row for every live tool, resource, and prompt from `roslyn://server/catalog`. Columns: `kind`, `name`, `tier`, `status`, `phase`, `notes`. The audit is incomplete if the ledger row count does not match the live catalog total or if any entry is omitted. For `blocked` rows, say whether the blocker was a client limitation, workspace-load failure, or server/runtime fault.
 4. **Verified tools (working)** — Bullet list: tool name + one-line evidence (e.g. “`compile_check` — 0 errors after Phase 6”). This distinguishes “tested and fine” from “never called.”
 5. **Phase 6 refactor summary** — Concise record of **applied** Phase 6 work (not preview-only phases). Include: target repo identity (if different from Roslyn-Backed-MCP); **scope** (e.g. fix-all + rename + format — which sub-steps 6a–6i you actually applied); **notable symbols or files** touched; **MCP tools used** for each change (e.g. `rename_apply`, `fix_all_apply`); **verification** (`compile_check` / `test_run` / `build_workspace` outcomes). If Phase 6 had **no** applies (skipped or audit-only), state **N/A** with one line why. Optional: git commit hash or PR link if available.
-6. **MCP server issues (bugs)** — For each issue: **Tool name**, **inputs**, **expected** vs **actual**, **severity** (crash / incorrect result / missing data / degraded performance / cosmetic / error-message-quality), **reproducibility** (always / sometimes / once). Watch for: crashes, wrong or incomplete results, tool-vs-tool inconsistency, missing functionality, slow tools, bad JSON/truncation, bad line/position mapping, unhelpful error messages.
-7. **Improvement suggestions** — Things that work correctly but could work better. UX friction (confusing parameter names, unexpected defaults, verbose output). Missing convenience features (e.g., “I wished tool X also returned Y”). Workflow gaps (sequences of 3+ tool calls that could be a single composite tool). Output enrichment (e.g., numeric codes where string labels would be more useful). Schema/description mismatches (tool description says one thing, actual behavior does another). These are not bugs — they are actionable input for the next release.
-8. **Performance observations** — List any tools that were notably slow, with tool name, input scale, and approximate wall-clock time. If all tools responded within expected bounds, state that.
-9. **Known issue regression check** — For the 3–5 items re-tested in Phase 18, state: **still reproduces**, **partially fixed** (describe), or **candidate for closure** (no longer reproduces). Include the source id / issue id and one-line summary for each. If no prior source existed, state **N/A**.
-10. **Known issue cross-check** — List any *newly observed* issues that match the chosen prior source (for example a backlog id, issue number, or previous audit finding) with one line each; put **full write-ups only for new or different** behavior.
+6. **Concurrency mode matrix (Phase 8b)** — Required when Phase 8b ran in either single-mode or dual-mode. Three sub-tables (probe set, sequential baseline, parallel fan-out + behavioral verification) using the schema in the markdown template below. Every cell filled or `N/A`. If Phase 8b was `blocked` for the entire run, write a one-line reason in this section instead of the tables and continue.
+7. **Writer reclassification verification (Phase 8b.5)** — One-row-per-tool table for the six writers (`apply_text_edit`, `apply_multi_file_edit`, `revert_last_apply`, `set_editorconfig_option`, `set_diagnostic_severity`, `add_pragma_suppression`). Columns: `tool`, `session-A status`, `session-B status`, `wall-clock A (ms)`, `wall-clock B (ms)`, `notes`. Use `skipped-safety` cells when only one session ran.
+8. **Debug log capture** — Verbatim copy of every `Warning`/`Error`/`Critical` MCP log notification surfaced during the audit, plus any `Information` notification that mentions workspace lifecycle, gate acquisition, lock contention, rate-limit hits, or request timeouts. Each entry on its own line with `correlationId` (if present), `timestamp`, `level`, `logger`, and `message`. If the client did not surface log notifications, state `client did not surface MCP log notifications` here and in the header.
+9. **MCP server issues (bugs)** — For each issue: **Tool name**, **inputs**, **expected** vs **actual**, **severity** (crash / incorrect result / missing data / degraded performance / cosmetic / error-message-quality), **reproducibility** (always / sometimes / once), **lock mode** (`legacy-mutex` / `rw-lock` / `both`). Watch for: crashes, wrong or incomplete results, tool-vs-tool inconsistency, missing functionality, slow tools, bad JSON/truncation, bad line/position mapping, unhelpful error messages, **lock-mode-specific** misbehavior (different result under one mode but not the other).
+10. **Improvement suggestions** — Things that work correctly but could work better. UX friction (confusing parameter names, unexpected defaults, verbose output). Missing convenience features (e.g., “I wished tool X also returned Y”). Workflow gaps (sequences of 3+ tool calls that could be a single composite tool). Output enrichment (e.g., numeric codes where string labels would be more useful). Schema/description mismatches (tool description says one thing, actual behavior does another). These are not bugs — they are actionable input for the next release.
+11. **Performance observations** — List any tools that were notably slow, with tool name, input scale, lock mode, and approximate wall-clock time. If all tools responded within expected bounds, state that.
+12. **Known issue regression check** — For the 3–5 items re-tested in Phase 18, state: **still reproduces**, **partially fixed** (describe), or **candidate for closure** (no longer reproduces). Include the source id / issue id and one-line summary for each. If no prior source existed, state **N/A**.
+13. **Known issue cross-check** — List any *newly observed* issues that match the chosen prior source (for example a backlog id, issue number, or previous audit finding) with one line each; put **full write-ups only for new or different** behavior.
 
-If there are **zero** new issues, still write sections 1–5 and 7–10; in section 6 state **“No new issues found”** and confirm the audit ran.
+If there are **zero** new issues, still write sections 1–8 and 10–13; in section 9 state **“No new issues found”** and confirm the audit ran.
 
 ### Markdown template (copy, fill in, save)
 
@@ -538,6 +701,9 @@ If there are **zero** new issues, still write sections 1–5 and 7–10; in sect
 - **Scale:** ~N projects, ~M documents
 - **Repo shape:**
 - **Prior issue source:**
+- **Lock mode at audit time:** (`legacy-mutex` / `rw-lock` / `dual-mode (legacy-mutex → rw-lock)` / `dual-mode (rw-lock → legacy-mutex)`)
+- **Lock mode source of truth:** (`launch-config` / `shell-env` / `behavioral-fingerprint`)
+- **Debug log channel:** (`yes` — MCP `notifications/message` surfaced; `partial` — only some levels; `no` — client did not surface log notifications)
 - **Report path note:** (if not saved under Roslyn-Backed-MCP, state intended copy destination)
 
 ## Coverage summary
@@ -569,6 +735,76 @@ If there are **zero** new issues, still write sections 1–5 and 7–10; in sect
 - **Verification:** `compile_check` / `test_run` / `build_workspace` — outcome
 - **Optional:** commit / PR reference
 
+## Concurrency mode matrix (Phase 8b)
+
+> Required when Phase 8b ran. If Phase 8b was `blocked` for the entire run, replace these tables with one line: `Phase 8b blocked — <reason>`.
+
+### Concurrency probe set
+| Slot | Tool | Inputs (concise) | Classification | Notes |
+|------|------|------------------|----------------|-------|
+| R1 | `find_references` | symbol=…, file=…, line=…, col=… | reader | hot symbol used N times |
+| R2 | `project_diagnostics` | no filters | reader | |
+| R3 | `symbol_search` | query=…, limit=… | reader | |
+| R4 | `find_unused_symbols` | includePublic=false | reader | |
+| R5 | `get_complexity_metrics` | no filters | reader | |
+| W1 | `format_document_preview` → `format_document_apply` | filePath=… | writer | Phase 6-touched file |
+| W2 | `set_editorconfig_option` (then revert) | key=…, value=… | writer (reclassified) | |
+
+### Sequential baseline (single call wall-clock, ms)
+| Slot | Session A mode | Session A ms | Session B mode | Session B ms | Δ ms (B − A) | Notes |
+|------|----------------|---------------|----------------|---------------|---------------|-------|
+| R1 | | | | | | |
+| R2 | | | | | | |
+| R3 | | | | | | |
+| R4 | | | | | | |
+| R5 | | | | | | |
+| W1 | | | | | | |
+| W2 | | | | | | |
+
+### Parallel fan-out and behavioral verification
+- **Host logical cores:** _(record before filling the table — drives the chosen N)_
+- **Chosen N (fan-out):** _N = `min(4, max(2, logical_cores))`_
+
+| Slot | Mode | Parallel wall-clock (ms) | Speedup vs baseline | Expected (legacy ≤1.3× / rw-lock ≥`0.7 × N`) | Pass / FLAG / FAIL | Notes |
+|------|------|---------------------------|----------------------|------------------------------------------------|---------------------|-------|
+| R1 ×N | legacy-mutex | | | ≤1.3× | | |
+| R1 ×N | rw-lock | | | ≥`0.7 × N` | | |
+| R2 ×N | legacy-mutex | | | ≤1.3× | | |
+| R2 ×N | rw-lock | | | ≥`0.7 × N` | | |
+| R3 ×N | legacy-mutex | | | ≤1.3× | | |
+| R3 ×N | rw-lock | | | ≥`0.7 × N` | | |
+
+### Read/write exclusion behavioral probe (Phase 8b.3)
+| Mode | Reader→Writer (`waits` / `does-not-wait`) | Writer→Reader (`waits` / `does-not-wait`) | Expected | Pass / FLAG / FAIL | Notes |
+|------|--------------------------------------------|--------------------------------------------|----------|---------------------|-------|
+| legacy-mutex | | | both `does-not-wait` (separate `<wsId>` and `__apply__:<wsId>` semaphores) | | |
+| rw-lock | | | both `waits` (single per-workspace `AsyncReaderWriterLock`) | | |
+
+### Lifecycle stress (Phase 8b.4)
+| Probe | Mode | Observed (`waits-for-reader` / `runs-concurrently` / `errors`) | Reader saw (`stale` / `fresh` / `error`) | Reader exception (if any) | `correlationId` | Expected | Pass / FLAG / FAIL | Notes |
+|-------|------|---------|---------|----------|-----------------|----------|---------------------|-------|
+| reader + `workspace_reload` | legacy-mutex | | | | | `runs-concurrently` (separate `__apply__:<wsId>` semaphore) | | |
+| reader + `workspace_reload` | rw-lock | | | | | `waits-for-reader` (per-workspace write lock) | | |
+| reader + `workspace_close` | legacy-mutex | | | | | `runs-concurrently`; reader may surface `KeyNotFoundException` via post-acquire recheck | | |
+| reader + `workspace_close` | rw-lock | | | | | `waits-for-reader`; reader completes cleanly | | |
+
+## Writer reclassification verification (Phase 8b.5)
+| # | Tool | Session A status | Session B status | Wall-clock A (ms) | Wall-clock B (ms) | Notes |
+|---|------|-------------------|-------------------|--------------------|--------------------|-------|
+| 1 | `apply_text_edit` | | | | | |
+| 2 | `apply_multi_file_edit` | | | | | |
+| 3 | `revert_last_apply` | | | | | shared with Phase 9 evidence |
+| 4 | `set_editorconfig_option` | | | | | |
+| 5 | `set_diagnostic_severity` | | | | | |
+| 6 | `add_pragma_suppression` | | | | | |
+
+## Debug log capture
+> Verbatim copy of structured `notifications/message` log entries surfaced by the MCP client during the audit. Filter to: every `Warning`/`Error`/`Critical` entry, plus any `Information` entry that mentions workspace lifecycle, gate acquisition, lock contention, rate-limit hits, or request timeouts. If the client did not surface log notifications, write: `client did not surface MCP log notifications` and skip the table.
+
+| `timestamp` | `level` | `logger` | `correlationId` | `eventName` | `message` | Phase | Tool in flight |
+|-------------|---------|----------|-----------------|-------------|-----------|-------|----------------|
+| | | | | | | | |
+
 ## MCP server issues (bugs)
 ### 1. (title or tool name)
 | Field | Detail |
@@ -579,13 +815,18 @@ If there are **zero** new issues, still write sections 1–5 and 7–10; in sect
 | Actual | |
 | Severity | |
 | Reproducibility | |
+| Lock mode (legacy-mutex / rw-lock / both) | |
 
 ## Improvement suggestions
 - `tool_name` — suggestion (UX friction / missing feature / workflow gap / output enrichment / schema mismatch)
 - …
 
 ## Performance observations
-- `tool_name` — input scale, ~Ns wall-clock (or "All tools responded within expected bounds")
+| Tool | Input scale | Lock mode | Wall-clock (ms) | Notes |
+|------|-------------|-----------|------------------|-------|
+| | | | | |
+
+(or state "All tools responded within expected bounds")
 
 ## Known issue regression check
 | Source id | Summary | Status |

--- a/ai_docs/reports/README.md
+++ b/ai_docs/reports/README.md
@@ -26,7 +26,9 @@ Each rollup should include:
 | Inputs | Raw audit file list from `../audit-reports/` |
 | Repo matrix coverage | Covered buckets and missing buckets |
 | Client coverage | Full-surface vs constrained lanes and blocked families |
-| Deduped issues | Unique defect key and linked evidence |
+| Lock mode coverage | Which lock modes (`legacy-mutex` / `rw-lock` / dual-mode) the batch exercised, plus any single-mode-only raw audits. Required when at least one input audit reports a non-default lock mode or ran Phase 8b. |
+| Concurrency matrix rollup | Aggregated `parallel_speedup` numbers per repo per mode pulled from each raw audit's *Concurrency mode matrix → Parallel fan-out* table. Required when ≥2 input audits ran Phase 8b dual-mode. |
+| Deduped issues | Unique defect key (`tool + symptom + catalog-version + client-family`, plus `lock-mode` for plausibly mode-specific defects) and linked evidence |
 | Candidate closures | Prior ids and current evidence |
 | Backlog actions | Rows to open, update, or intentionally leave out |
 

--- a/eng/flip-rw-lock.ps1
+++ b/eng/flip-rw-lock.ps1
@@ -1,0 +1,87 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Flip the roslyn-mcp lock mode to the opposite of its current value.
+
+.DESCRIPTION
+    Reads the current User-scope value of ROSLYNMCP_WORKSPACE_RW_LOCK,
+    decides the inverse, kills any running roslyn-mcp server processes, and
+    writes the new value. The operator does not need to know which mode they
+    are currently in — the script handles the toggle automatically.
+
+    This is the primary helper for the deep-review-and-refactor.md Phase 8b
+    dual-mode lane (Path A). The simplified Path A flow is:
+
+        1. Operator: invoke deep-review prompt (run 1, current mode).
+        2. Operator: ./eng/flip-rw-lock.ps1 (auto-flip).
+        3. Operator: fully close and reopen the MCP client.
+        4. Operator: invoke deep-review prompt (run 2, opposite mode).
+
+    The agent auto-detects the lock mode in Phase 0 via evaluate_csharp and
+    auto-pairs the second run with the first run's partial via filename glob,
+    so no operator-side bookkeeping is required.
+
+    The script never touches generic 'dotnet' processes — only 'roslynmcp.exe'
+    and 'RoslynMcp.Host.Stdio.exe'.
+
+    Companion explicit-mode scripts (rarely needed):
+        eng/rw-lock-on.ps1   — force mode to rw-lock
+        eng/rw-lock-off.ps1  — force mode to legacy-mutex (default)
+
+.PARAMETER WhatIf
+    Show what would happen without killing processes or changing env vars.
+
+.EXAMPLE
+    ./eng/flip-rw-lock.ps1
+    Detects current mode and flips to the inverse.
+
+.EXAMPLE
+    ./eng/flip-rw-lock.ps1 -WhatIf
+    Dry-run: prints current mode, target mode, and what would happen.
+
+.NOTES
+    Windows-only. The User-scope env var read/write uses
+    [Environment]::GetEnvironmentVariable / SetEnvironmentVariable with
+    'User' scope, which only takes effect on Windows. For bash/zsh/macOS/Linux
+    equivalents, see ai_docs/procedures/deep-review-command-reference.md →
+    'Concurrency lock-mode launch'.
+
+    Edge case: if the operator's MCP client launch config sets
+    ROSLYNMCP_WORKSPACE_RW_LOCK explicitly (e.g. in .mcp.json env block), the
+    User-scope value this script reads may not match what the running server
+    actually sees. The deep-review prompt's Phase 0 uses evaluate_csharp to
+    read the value from inside the server process, which is the source of
+    truth — that always wins over what this script reports.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'rw-lock-common.ps1')
+
+$ScriptName = $MyInvocation.MyCommand.Name
+Test-IsWindowsHost -ScriptName $ScriptName
+
+# 1. Detect current mode from User-scope env var.
+$current = Get-RwLockCurrentMode
+$targetMode = if ($current.Mode -eq 'rw-lock') { 'legacy-mutex' } else { 'rw-lock' }
+
+Write-Host ''
+Write-Host "[$ScriptName] Current User-scope $(Get-RwLockEnvVarName) = $($current.Raw)" -ForegroundColor Cyan
+Write-Host "[$ScriptName] Detected current mode: $($current.Mode)" -ForegroundColor Cyan
+Write-Host "[$ScriptName] Flipping to: $targetMode" -ForegroundColor Cyan
+Write-Host ''
+
+# 2. Stop any running roslyn-mcp server processes.
+Stop-RwLockServerProcesses -ScriptName $ScriptName -Cmdlet $PSCmdlet
+
+# 3. Set or clear the env var according to the target mode.
+Set-RwLockMode -Mode $targetMode -ScriptName $ScriptName -Cmdlet $PSCmdlet
+
+# 4. Verify by reading back from User scope (skipped under -WhatIf).
+Test-RwLockReadback -ExpectedMode $targetMode -ScriptName $ScriptName
+
+# 5. Print operator next steps.
+Write-RwLockNextSteps -NewMode $targetMode -ScriptName $ScriptName

--- a/eng/rw-lock-common.ps1
+++ b/eng/rw-lock-common.ps1
@@ -1,0 +1,253 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Shared helper functions for the roslyn-mcp lock-mode flip scripts.
+
+.DESCRIPTION
+    Dot-sourced by rw-lock-on.ps1, rw-lock-off.ps1, and flip-rw-lock.ps1.
+    Provides:
+
+    - Get-RwLockEnvVarName       : the env var name (single source of truth)
+    - Get-RwLockProcessNames     : the process names that may host the server
+    - Test-IsWindowsHost         : Windows guard usable from PS 5.1 and PS 7+
+    - Get-RwLockCurrentMode      : reads User-scope env var and returns the
+                                   current mode label as 'rw-lock' or 'legacy-mutex'
+    - Stop-RwLockServerProcesses : kills any running roslyn-mcp server process
+                                   (never touches generic dotnet processes),
+                                   honors -WhatIf via the caller's $PSCmdlet
+    - Set-RwLockMode             : writes/clears the User-scope env var and
+                                   mirrors the change into the current shell,
+                                   honors -WhatIf via the caller's $PSCmdlet
+    - Write-RwLockNextSteps      : prints the standard operator next-steps block
+
+    The helper does not run anything itself when dot-sourced — it only defines
+    functions. Each wrapper script calls them in the right order.
+
+.NOTES
+    This file is a helper, not a standalone script. Do not run it directly;
+    dot-source it from a wrapper.
+
+    Windows-only. Throws on non-Windows from Test-IsWindowsHost.
+#>
+
+Set-StrictMode -Version Latest
+
+function Get-RwLockEnvVarName {
+    return 'ROSLYNMCP_WORKSPACE_RW_LOCK'
+}
+
+function Get-RwLockProcessNames {
+    # Process names that may host the roslyn-mcp server. Listed exhaustively so
+    # both the installed dotnet tool and a build-from-source exe are caught.
+    # We deliberately do NOT touch generic 'dotnet' processes — they almost
+    # always belong to other work and killing them would break the operator's
+    # environment.
+    return @(
+        'roslynmcp',            # Installed dotnet tool wrapper (apphost-based)
+        'RoslynMcp.Host.Stdio'  # Built-from-source exe in bin/Debug or bin/Release
+    )
+}
+
+function Test-IsWindowsHost {
+    <#
+    .SYNOPSIS
+        Throw with an actionable message if not running on Windows.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ScriptName
+    )
+
+    # PS 7+ exposes $IsWindows; Windows PowerShell 5.1 does not but is always
+    # Windows. Either of those is acceptable; anything else is a hard error.
+    $isOnWindows = if ($PSVersionTable.PSVersion.Major -le 5) { $true } else { [bool]$IsWindows }
+    if (-not $isOnWindows) {
+        throw "$ScriptName is Windows-only. For bash/zsh equivalents see ai_docs/procedures/deep-review-command-reference.md → 'Concurrency lock-mode launch'."
+    }
+}
+
+function Get-RwLockCurrentMode {
+    <#
+    .SYNOPSIS
+        Read the current User-scope env var and return the mode label.
+    .OUTPUTS
+        PSCustomObject with .Mode ('rw-lock' or 'legacy-mutex') and .Raw (the
+        raw env var value, or '(unset)').
+    #>
+    [CmdletBinding()]
+    param()
+
+    $envVarName = Get-RwLockEnvVarName
+    $raw = [Environment]::GetEnvironmentVariable($envVarName, 'User')
+    $isOn = $false
+    if (-not [string]::IsNullOrWhiteSpace($raw)) {
+        $isOn = [bool]::TryParse($raw, [ref]$isOn) -and $isOn
+    }
+
+    return [pscustomobject]@{
+        Mode = if ($isOn) { 'rw-lock' } else { 'legacy-mutex' }
+        Raw  = if ([string]::IsNullOrWhiteSpace($raw)) { '(unset)' } else { $raw }
+    }
+}
+
+function Stop-RwLockServerProcesses {
+    <#
+    .SYNOPSIS
+        Kill any running roslyn-mcp server processes. Honors -WhatIf via the
+        caller's $PSCmdlet.
+    .PARAMETER ScriptName
+        Caller's script name (used in log lines).
+    .PARAMETER Cmdlet
+        The caller's $PSCmdlet so ShouldProcess works correctly under -WhatIf.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ScriptName,
+        [Parameter(Mandatory)][System.Management.Automation.PSCmdlet]$Cmdlet
+    )
+
+    $processNames = Get-RwLockProcessNames
+    $matched = @()
+    foreach ($name in $processNames) {
+        $found = Get-Process -Name $name -ErrorAction SilentlyContinue
+        if ($found) {
+            $matched += $found
+        }
+    }
+
+    if ($matched.Count -eq 0) {
+        Write-Host "[$ScriptName] No running roslyn-mcp processes found." -ForegroundColor DarkGray
+        return
+    }
+
+    Write-Host "[$ScriptName] Found $($matched.Count) roslyn-mcp process(es):" -ForegroundColor Yellow
+    $matched | Format-Table -AutoSize Id, ProcessName, Path | Out-Host
+    foreach ($proc in $matched) {
+        $target = "$($proc.ProcessName) (PID $($proc.Id))"
+        if ($Cmdlet.ShouldProcess($target, 'Stop-Process -Force')) {
+            try {
+                Stop-Process -Id $proc.Id -Force -ErrorAction Stop
+                Write-Host "[$ScriptName]   killed $target" -ForegroundColor Yellow
+            }
+            catch {
+                Write-Warning "[$ScriptName]   failed to kill $target : $($_.Exception.Message)"
+            }
+        }
+    }
+}
+
+function Set-RwLockMode {
+    <#
+    .SYNOPSIS
+        Set or clear the User-scope env var for the lock mode and mirror into
+        the current shell. Honors -WhatIf via the caller's $PSCmdlet.
+    .PARAMETER Mode
+        Target mode: 'rw-lock' (sets to 'true') or 'legacy-mutex' (clears).
+    .PARAMETER ScriptName
+        Caller's script name (used in log lines).
+    .PARAMETER Cmdlet
+        The caller's $PSCmdlet so ShouldProcess works correctly under -WhatIf.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateSet('rw-lock', 'legacy-mutex')][string]$Mode,
+        [Parameter(Mandatory)][string]$ScriptName,
+        [Parameter(Mandatory)][System.Management.Automation.PSCmdlet]$Cmdlet
+    )
+
+    $envVarName = Get-RwLockEnvVarName
+
+    if ($Mode -eq 'rw-lock') {
+        $value = 'true'
+        $envTarget = "$envVarName=$value (User and Process scope)"
+        if ($Cmdlet.ShouldProcess($envTarget, 'Set environment variable')) {
+            [Environment]::SetEnvironmentVariable($envVarName, $value, 'User')
+            Set-Item -Path "Env:\$envVarName" -Value $value
+            Write-Host ''
+            Write-Host "[$ScriptName] $envVarName set to '$value' (User scope and current shell)." -ForegroundColor Green
+        }
+    }
+    else {
+        $envTarget = "$envVarName (User and Process scope)"
+        if ($Cmdlet.ShouldProcess($envTarget, 'Clear environment variable')) {
+            [Environment]::SetEnvironmentVariable($envVarName, $null, 'User')
+            if (Test-Path "Env:\$envVarName") {
+                Remove-Item -Path "Env:\$envVarName" -ErrorAction SilentlyContinue
+            }
+            Write-Host ''
+            Write-Host "[$ScriptName] $envVarName cleared (User scope and current shell). Server will fall back to default legacy-mutex mode." -ForegroundColor Green
+        }
+    }
+}
+
+function Test-RwLockReadback {
+    <#
+    .SYNOPSIS
+        Verify the User-scope env var matches the expected mode after a set/clear.
+        Skipped under -WhatIf.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateSet('rw-lock', 'legacy-mutex')][string]$ExpectedMode,
+        [Parameter(Mandatory)][string]$ScriptName
+    )
+
+    if ($WhatIfPreference) { return }
+
+    $envVarName = Get-RwLockEnvVarName
+    $readback = [Environment]::GetEnvironmentVariable($envVarName, 'User')
+
+    if ($ExpectedMode -eq 'rw-lock') {
+        if ($readback -ne 'true') {
+            Write-Warning "[$ScriptName] Verification failed: User-scope $envVarName reads back as '$readback' (expected 'true')."
+        }
+    }
+    else {
+        if (-not [string]::IsNullOrEmpty($readback)) {
+            Write-Warning "[$ScriptName] Verification failed: User-scope $envVarName still reads back as '$readback' (expected empty)."
+        }
+    }
+}
+
+function Write-RwLockNextSteps {
+    <#
+    .SYNOPSIS
+        Print the standard operator next-steps block after a successful flip.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateSet('rw-lock', 'legacy-mutex')][string]$NewMode,
+        [Parameter(Mandatory)][string]$ScriptName
+    )
+
+    $envVarName = Get-RwLockEnvVarName
+
+    Write-Host ''
+    Write-Host "[$ScriptName] Next steps for the operator:" -ForegroundColor Cyan
+    Write-Host '  1. Fully close your MCP client (Claude Code, Cursor, Continue, etc.).'
+    Write-Host '     Restarting just the chat is NOT enough — the client process must exit'
+    Write-Host '     so the next launch inherits the new env var.'
+    if ($NewMode -eq 'rw-lock') {
+        Write-Host "  2. Reopen the MCP client. It will spawn a fresh roslyn-mcp server with"
+        Write-Host "     $envVarName='true'."
+    }
+    else {
+        Write-Host "  2. Reopen the MCP client. It will spawn a fresh roslyn-mcp server with no"
+        Write-Host "     $envVarName set, falling back to the default legacy-mutex mode."
+    }
+    Write-Host '  3. Run the deep-review prompt (ai_docs/prompts/deep-review-and-refactor.md).'
+    Write-Host "     The agent will detect the '$NewMode' lock mode in Phase 0 via evaluate_csharp"
+    Write-Host '     and name the audit file accordingly.'
+    Write-Host ''
+    if ($NewMode -eq 'rw-lock') {
+        Write-Host "[$ScriptName] If your MCP client does NOT inherit user-scope env vars (rare)," -ForegroundColor DarkGray
+        Write-Host "  set the variable explicitly in the client's launch config (.mcp.json env block)." -ForegroundColor DarkGray
+    }
+    else {
+        Write-Host "[$ScriptName] If your MCP client has $envVarName explicitly set in its launch" -ForegroundColor DarkGray
+        Write-Host "  config (.mcp.json env block), this User-scope clear will NOT override that." -ForegroundColor DarkGray
+        Write-Host '  Edit the .mcp.json env block manually to remove the override.' -ForegroundColor DarkGray
+    }
+    Write-Host "  See ai_docs/procedures/deep-review-command-reference.md → 'Concurrency lock-mode launch'." -ForegroundColor DarkGray
+    Write-Host ''
+}

--- a/eng/rw-lock-off.ps1
+++ b/eng/rw-lock-off.ps1
@@ -1,0 +1,53 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Force the roslyn-mcp lock mode to legacy-mutex (clears ROSLYNMCP_WORKSPACE_RW_LOCK).
+
+.DESCRIPTION
+    Explicit-mode helper. Use the auto-flip script flip-rw-lock.ps1 instead
+    when you want a toggle. Use this script when you want a known target mode
+    regardless of the current state — for example, the very first run when
+    no User-scope env var has been set yet, or in a CI pipeline that needs a
+    deterministic starting state.
+
+    Clears ROSLYNMCP_WORKSPACE_RW_LOCK at User scope, removes it from the
+    current shell, and stops any running roslyn-mcp server processes so the
+    next launch falls back to the default legacy-mutex mode. Never touches
+    generic 'dotnet' processes.
+
+    Companion scripts:
+        eng/flip-rw-lock.ps1  — auto-detect current mode and flip to opposite
+        eng/rw-lock-on.ps1    — force mode to rw-lock
+
+.PARAMETER WhatIf
+    Show what would happen without killing processes or changing env vars.
+
+.EXAMPLE
+    ./eng/rw-lock-off.ps1
+
+.NOTES
+    Windows-only. See flip-rw-lock.ps1 for design notes and edge cases.
+
+    If the MCP client has ROSLYNMCP_WORKSPACE_RW_LOCK explicitly set in its
+    launch config (.mcp.json env block), this User-scope clear will NOT
+    override that. Edit the .mcp.json env block manually to remove the override.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'rw-lock-common.ps1')
+
+$ScriptName = $MyInvocation.MyCommand.Name
+Test-IsWindowsHost -ScriptName $ScriptName
+
+Write-Host ''
+Write-Host "[$ScriptName] Forcing roslyn-mcp lock mode to: legacy-mutex (default)" -ForegroundColor Cyan
+Write-Host ''
+
+Stop-RwLockServerProcesses -ScriptName $ScriptName -Cmdlet $PSCmdlet
+Set-RwLockMode -Mode 'legacy-mutex' -ScriptName $ScriptName -Cmdlet $PSCmdlet
+Test-RwLockReadback -ExpectedMode 'legacy-mutex' -ScriptName $ScriptName
+Write-RwLockNextSteps -NewMode 'legacy-mutex' -ScriptName $ScriptName

--- a/eng/rw-lock-on.ps1
+++ b/eng/rw-lock-on.ps1
@@ -1,0 +1,48 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Force the roslyn-mcp lock mode to rw-lock (sets ROSLYNMCP_WORKSPACE_RW_LOCK=true).
+
+.DESCRIPTION
+    Explicit-mode helper. Use the auto-flip script flip-rw-lock.ps1 instead
+    when you want a toggle. Use this script when you want a known target mode
+    regardless of the current state — for example, the very first run when
+    no User-scope env var has been set yet, or in a CI pipeline that needs a
+    deterministic starting state.
+
+    Sets ROSLYNMCP_WORKSPACE_RW_LOCK=true at User scope, mirrors it into the
+    current shell, and stops any running roslyn-mcp server processes so the
+    next launch picks up the new flag. Never touches generic 'dotnet' processes.
+
+    Companion scripts:
+        eng/flip-rw-lock.ps1  — auto-detect current mode and flip to opposite
+        eng/rw-lock-off.ps1   — force mode to legacy-mutex
+
+.PARAMETER WhatIf
+    Show what would happen without killing processes or changing env vars.
+
+.EXAMPLE
+    ./eng/rw-lock-on.ps1
+
+.NOTES
+    Windows-only. See flip-rw-lock.ps1 for design notes and edge cases.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'rw-lock-common.ps1')
+
+$ScriptName = $MyInvocation.MyCommand.Name
+Test-IsWindowsHost -ScriptName $ScriptName
+
+Write-Host ''
+Write-Host "[$ScriptName] Forcing roslyn-mcp lock mode to: rw-lock" -ForegroundColor Cyan
+Write-Host ''
+
+Stop-RwLockServerProcesses -ScriptName $ScriptName -Cmdlet $PSCmdlet
+Set-RwLockMode -Mode 'rw-lock' -ScriptName $ScriptName -Cmdlet $PSCmdlet
+Test-RwLockReadback -ExpectedMode 'rw-lock' -ScriptName $ScriptName
+Write-RwLockNextSteps -NewMode 'rw-lock' -ScriptName $ScriptName


### PR DESCRIPTION
## Summary

Adds a concurrency / RW-lock audit phase (**Phase 8b**) to the deep-review-and-refactor prompt and a set of operator helper scripts so a dual-mode lane only requires four operator inputs:

1. Invoke deep-review prompt (run 1)
2. `./eng/flip-rw-lock.ps1`
3. Fully close + reopen MCP client
4. Invoke deep-review prompt (run 2)

Everything else (lock-mode detection, audit filename, run-1/run-2 pairing, matrix carry-forward) is auto-detected by the agent and the helper scripts.

## What's new

- **Source-of-truth lock-mode detection.** Phase 0 calls `evaluate_csharp` to read `ROSLYNMCP_WORKSPACE_RW_LOCK` from inside the running server process — no launch-config inspection, no behavioral fingerprint, no operator memory.
- **Auto-pair detection.** Phase 0 globs `ai_docs/audit-reports/*_<repo-id>_<oppositeMode>_mcp-server-audit.md` to figure out whether this prompt invocation is run 1 or run 2 of a dual-mode pair, and inherits run-1's probe slot ids when this is run 2.
- **Phase 8b (8 sub-phases):** probe set definition, sequential baseline, parallel-read fan-out (host-bounded N), read/write exclusion behavioral probe, lifecycle stress probe, writer reclassification verification (the six tools reclassified by `perf/workspace-rw-lock`), auto-detected run-1 vs run-2 handling, and the dense concurrency matrix output schema.
- **`eng/flip-rw-lock.ps1`** (primary) plus `rw-lock-on.ps1` / `rw-lock-off.ps1` (explicit-mode helpers), all sharing `eng/rw-lock-common.ps1`. Never touch generic `dotnet` processes — only `roslynmcp.exe` and `RoslynMcp.Host.Stdio.exe`. All support `-WhatIf`.
- **Path B removed.** Mid-session server restart never worked on any stdio MCP client because killing the server subprocess broke the client's stdio handshake.
- **Report template** gains Concurrency mode matrix, Writer reclassification verification, and Debug log capture sections; existing sections gain a `lock mode` column where relevant. Output is dense, table-driven, and optimised for downstream agentic consumption.

## Files

- `ai_docs/prompts/deep-review-and-refactor.md` — Phase 0 + Phase 8b + report template
- `ai_docs/procedures/deep-review-command-reference.md` — 4-step operator dance, helper script docs
- `ai_docs/procedures/deep-review-program.md` — concurrency lock-mode lane, cadence, normalized metadata
- `ai_docs/audit-reports/README.md` — auto-pair model, three raw audit shapes
- `ai_docs/reports/README.md` — rollup minimum-contents adds lock-mode coverage
- `eng/rw-lock-common.ps1`, `eng/flip-rw-lock.ps1`, `eng/rw-lock-on.ps1`, `eng/rw-lock-off.ps1`

## Test plan

- [x] `./eng/verify-ai-docs.ps1` — passes
- [x] All three helper scripts tested with `-WhatIf` — correctly detect running `roslynmcp.exe` processes and preview kill + env var changes
- [x] `evaluate_csharp` reading `ROSLYNMCP_WORKSPACE_RW_LOCK` verified live in a development conversation: returns `{ Raw = (unset), LockMode = legacy-mutex }` against an unset env var, proving the in-process source-of-truth read works
- [ ] First end-to-end dual-mode run of the four-step dance against a small target repo (this will also be the first non-`-WhatIf` execution of the kill + env var write paths and the first real exercise of the auto-pair glob + matrix carry-forward logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)