### PR TITLE
fix: ship plugin .mcp.json with marketplace install + import deep-review audit batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -484,3 +484,7 @@ $RECYCLE.BIN/
 # Local AI/MCP client configuration (developer machine specific)
 .claude/
 .mcp.json
+# ...except the plugin's own .mcp.json at the repo root, which is the
+# Claude Code plugin loader's canonical MCP-server descriptor and must
+# ship with the marketplace install.
+!/.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "roslyn": {
+      "type": "stdio",
+      "command": "roslynmcp",
+      "env": {
+        "ROSLYNMCP_MAX_WORKSPACES": "${user_config.ROSLYNMCP_MAX_WORKSPACES}",
+        "ROSLYNMCP_BUILD_TIMEOUT_SECONDS": "${user_config.ROSLYNMCP_BUILD_TIMEOUT_SECONDS}",
+        "ROSLYNMCP_TEST_TIMEOUT_SECONDS": "${user_config.ROSLYNMCP_TEST_TIMEOUT_SECONDS}",
+        "ROSLYNMCP_RATE_LIMIT_MAX_REQUESTS": "${user_config.ROSLYNMCP_RATE_LIMIT_MAX_REQUESTS}",
+        "ROSLYNMCP_REQUEST_TIMEOUT_SECONDS": "${user_config.ROSLYNMCP_REQUEST_TIMEOUT_SECONDS}"
+      }
+    }
+  }
+}

--- a/ai_docs/audit-reports/20260407T223900Z_dotnet-firewall-analyzer_rw-lock_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260407T223900Z_dotnet-firewall-analyzer_rw-lock_mcp-server-audit.md
@@ -1,0 +1,153 @@
+# MCP Server Audit — DotNet-Firewall-Analyzer (Roslyn MCP)
+
+**generated_at (UTC):** 2026-04-08T03:40:00Z  
+**repo-id:** `dotnet-firewall-analyzer`  
+**entrypoint:** `c:\Code-Repo\DotNet-Firewall-Analyzer\FirewallAnalyzer.slnx`  
+**workspace_session:** `4769c188593641658af9bd3f5cd12142` (through most phases)  
+**audit_mode:** `conservative` — mutations kept minimal; working tree is the main repo (no disposable worktree created for this session).  
+**expected_lock_mode (env):** `rw-lock` (`ROSLYNMCP_WORKSPACE_RW_LOCK=true`, confirmed via `evaluate_csharp` reading the env var).  
+**server:** `roslyn-mcp` **1.6.1+f16452924ef03cd3ed17dc36b53efab29c72217a**, catalog **2026.03**, Roslyn **5.3.0.0**, runtime **.NET 10.0.5**, OS **Microsoft Windows 10.0.26200**  
+**live_surface:** 56 stable + 67 experimental tools; 7 stable resources; 0 stable + 16 experimental prompts (matches `server_info` and `roslyn://server/catalog`).  
+**debug_log_channel:** Not verified from this agent loop — Cursor did not surface `notifications/message` payloads in tool results; treat as **client limitation** for this run.
+
+**completeness:** This file is a **representative deep-review pass** (Phases 0–3, 5, partial 1–2, 8 test execution). It does **not** satisfy the living prompt’s exhaustive per-tool ledger or Phase **8b** wall-clock matrix (second lock-mode lane not run). Remaining catalog entries are marked **`skipped-session-depth`** below.
+
+**auto-pair (Phase 0.16):** Run **1** of a dual-mode pair. No matching `*_*_legacy-mutex_mcp-server-audit.md` partial found under `ai_docs/audit-reports/`.
+
+**Report path note:** This is the mode-1 (`rw-lock`) partial. For a full concurrency matrix, run `./eng/flip-rw-lock.ps1` (or equivalent), restart the MCP host so it picks up the flipped env var, and re-invoke `ai_docs/prompts/deep-review-and-refactor.md` so Phase **8b** Session B columns can be filled.
+
+---
+
+## Repo shape
+
+| Constraint | Value |
+|------------|--------|
+| Projects | 11 (5 product + 1 CLI + 5 test + E2E) |
+| Multi-targeting | No (`net10.0` only) |
+| Central Package Management | Yes (`centrally-managed` + `ResolvedCentralVersion` in `get_nuget_dependencies`) |
+| Tests | Yes — xUnit; `test_run` **297 passed** with filter `Category!=E2E` |
+| Analyzers | Yes — **25** assemblies, **492** rules (`list_analyzers` totals) |
+| Source generators | Not specialized in this pass (`source_generated_documents` not called — **skipped-session-depth**) |
+| DI | Yes (minimal Web API wiring; `get_di_registrations` not called — **skipped-session-depth**) |
+| `.editorconfig` | Present (not re-verified in Phase 7 this session) |
+| Restore | `dotnet restore FirewallAnalyzer.slnx` **PASS** before semantic tools |
+
+---
+
+## Phase checkpoints (evidence summary)
+
+### Phase 0 — PASS
+- `server_info`, `roslyn://server/catalog`, `roslyn://server/resource-templates`: consistent counts.
+- `workspace_load` / `workspace_list` / `workspace_status` / `project_graph`: **PASS**; workspace clean (`WorkspaceDiagnostics` empty).
+- Tool `_meta.gateMode` on workspace calls: **`rw-lock`** (useful signal; complements env-based tracking).
+
+### Phase 1 — PASS (diagnostic_details N/A)
+- `project_diagnostics` (paged + filtered): **0** issues; paging behaved (`hasMore: false`).
+- `compile_check` default + `emitValidation: true`: **0** CS diagnostics; emit path ~2.5s vs ~1.9s for default page (expected magnitude gap per tool description).
+- `security_diagnostics` / `security_analyzer_status`: structured; **0** findings; SecurityCodeScan present.
+- `nuget_vulnerability_scan`: **0** CVEs, 11 projects, ~4.4s; `IncludesTransitive: false` noted.
+- `list_analyzers`: totals **25** / **492**; first page `hasMore: true` **PASS**.
+- **`diagnostic_details`:** **skipped-repo-shape** (no error/warning instances to target).
+
+### Phase 2 — PASS
+- `get_complexity_metrics`: plausible hotspots (`CollectUnknownYamlKeyMessages` CC=20, nesting 4).
+- `get_cohesion_metrics`: high LCOM on xUnit test classes expected; `JobProcessor` / `FileSnapshotStore` clusters plausible.
+- `find_unused_symbols` `includePublic=false`: **0**; `includePublic=true`: **50** hits — many are **false-positive-prone** (tests, middleware `InvokeAsync`, enum members, DTO properties) — **aligns with `ai_docs/backlog.md` standing rule** to verify before deletion.
+- `get_namespace_dependencies`: **exercised** (large JSON; ~52 KB agent spill file).
+- `get_nuget_dependencies`: **PASS**; CPM surfaced correctly.
+
+### Phase 3 — PASS (subset)
+- Focus type: **`DriftDetector`**
+- `symbol_search` → `symbol_info`, `document_symbols`, `type_hierarchy`, `find_references` (10 refs), `find_consumers`, `impact_analysis`: **PASS**; reference counts consistent with `impact_analysis` (10 direct refs, 10 affected declarations).
+- **FLAG (minor):** `find_consumers` reported `DependencyKinds: ["Other"]` for all three consumers — less granular than constructor/field/parameter taxonomy for this static type.
+- Not exercised this session: `find_implementations`, `find_type_usages`, `find_type_mutations`, `find_property_writes`, `member_hierarchy`, `symbol_relationships`, `symbol_signature_help`, `callers_callees`, etc. → **`skipped-session-depth`**.
+
+### Phase 4 — skipped-session-depth
+- Flow tools not invoked to save scope.
+
+### Phase 5 — PASS
+- `analyze_snippet` `kind=expression` `1+2`: valid.
+- `analyze_snippet` broken `kind=statements`: **CS0029** at line 1, columns **9–16** (points into assignment / value region — acceptable versus old wrapper-column bug).
+- `evaluate_csharp` `Enumerable.Range(1,10).Sum()`: **55** (**PASS**).
+- `evaluate_csharp` `while(true){}`: **FAIL** as expected after **~20s** with explicit abandonment message (10s script budget + 10s watchdog grace), `ProgressHeartbeatCount: 10` — **PASS** (no unbounded hang).
+
+### Phase 6 refactor summary
+- **`organize_usings_preview`** on `DriftDetector.cs`: **empty `Changes`** → no apply.
+- **`fix_all_*` / `rename_*` / extractions:** not executed — solution has **zero** analyzer/compiler issues to drive batched fixes; applying large refactors would be out-of-scope cosmetic churn.
+- **Net repo diff from Phase 6:** none.
+
+### Phase 7–18
+- **skipped-session-depth** except: `test_discover` (large output), `test_run` (below), and env lock probe via `evaluate_csharp`.
+- **Phase 8b concurrency matrix:** Session B columns **`skipped-pending-second-run`**; no parallel R1–R5 timings or lifecycle stress in this session.
+
+### Phase 8 — PASS (filtered tests)
+- `test_discover`: exercised (full listing large).
+- `test_run` `Category!=E2E`: **ExitCode 0**, **297 passed**, 0 failed. E2E assembly reported no tests matching filter (expected).
+
+---
+
+## MCP server issues (FAIL / FLAG)
+
+| id | severity | area | observation |
+|----|----------|------|-------------|
+| DOC-001 | FLAG | prompt vs binary | Living prompt footer references **server v1.7+** pagination/`analyze_snippet` fixes; this host is **1.6.1** — docs/prompt revision lag, not necessarily a runtime bug. |
+| UX-001 | FLAG | `find_consumers` | Dependency kind granularity coarse (`Other` only) for `DriftDetector` static usage. |
+| COV-001 | INFO | process | Exhaustive catalog coverage + dual-mode Phase **8b** not completed in one agent session. |
+
+No tool crashes, empty success on failure, or schema contradictions observed in exercised calls.
+
+---
+
+## Coverage ledger (abbreviated)
+
+**Legend:** `exercised` · `exercised-preview-only` · `skipped-repo-shape` · `skipped-session-depth` · `skipped-safety` · `blocked`
+
+### Exercised (this run)
+`server_info`, `workspace_load`, `workspace_list`, `workspace_status`, `project_graph`, `project_diagnostics`, `compile_check`, `security_diagnostics`, `security_analyzer_status`, `nuget_vulnerability_scan`, `list_analyzers`, `get_complexity_metrics`, `get_cohesion_metrics`, `find_unused_symbols` (×2), `get_namespace_dependencies`, `get_nuget_dependencies`, `symbol_search`, `symbol_info`, `document_symbols`, `type_hierarchy`, `find_references`, `find_consumers`, `impact_analysis`, `analyze_snippet` (×2), `evaluate_csharp` (×3), `organize_usings_preview`, `test_discover`, `test_run`.
+
+### Resources
+`roslyn://server/catalog`, `roslyn://server/resource-templates` — **exercised**.  
+Workspace-scoped resources (`roslyn://workspaces`, `…/status`, `…/projects`, `…/diagnostics`, `…/file/…`) — **`skipped-session-depth`**.
+
+### Prompts (×16 experimental)
+MCP **prompt** invocation from `call_mcp_tool` not used in this session — all prompts **`skipped-session-depth`** / **`blocked`** depending on client capability (prompts are MCP prompt templates, not JSON tools in this Cursor wiring).
+
+### All other catalog tools
+Default **`skipped-session-depth`** unless listed above.
+
+---
+
+## Concurrency mode matrix (Phase 8b) — partial
+
+| Probe | Session A (`rw-lock`) | Session B (`legacy-mutex`) |
+|-------|------------------------|-----------------------------|
+| Lock mode evidence | `evaluate_csharp` → env `"true"`; `_meta.gateMode` `rw-lock` on tools | `skipped-pending-second-run` |
+| R1–R5 sequential baselines (ms) | not measured | `skipped-pending-second-run` |
+| Parallel fan-out speedup | not measured | `skipped-pending-second-run` |
+| Read/write exclusion | not measured | `skipped-pending-second-run` |
+| Lifecycle stress | not measured | `skipped-pending-second-run` |
+| Writer reclassification (8b.5) | not measured | `skipped-pending-second-run` |
+
+---
+
+## Regression / backlog cross-check
+
+- `ai_docs/backlog.md`: no open Roslyn-MCP defect rows; **standing rule** on `find_unused_symbols` public results matches observed need for human verification before removal.
+
+---
+
+## Performance notes
+
+| Tool | Approx heldMs / duration | Note |
+|------|--------------------------|------|
+| `project_diagnostics` | ~4.2–4.6s | Clean solution; acceptable cold path |
+| `compile_check` emitValidation | ~2.5s | Empty diagnostic set |
+| `nuget_vulnerability_scan` | ~4.4s | Network/metadata dependent |
+| `find_unused_symbols` public | ~560ms | 50-symbol cap in response |
+| `test_run` filtered | ~11.9s | Local workstation |
+
+---
+
+## Prior findings alignment
+
+N/A — no Roslyn-Backed-MCP issue ids provided for this workspace; backlog MCP-specific rows absent.

--- a/ai_docs/audit-reports/20260408T033920Z_itchatbot_rw-lock_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260408T033920Z_itchatbot_rw-lock_mcp-server-audit.md
@@ -1,0 +1,256 @@
+# MCP Server Audit Report
+
+## Header
+- **Date:** 2026-04-08 (UTC tool timestamps ~03:39–03:40Z)
+- **Audited solution:** ITChatBot.sln — IT-Chat-Bot
+- **Audited revision:** 8c2e3f6 (short)
+- **Entrypoint loaded:** c:\Code-Repo\IT-Chat-Bot\ITChatBot.sln
+- **Audit mode:** conservative — primary worktree; no disposable clone/worktree; partial phase coverage in one agent session
+- **Isolation:** N/A (same as audited path); high-impact preview/apply families not run end-to-end
+- **Client:** Cursor (MCP server id: user-roslyn); MCP **prompts** not invoked via prompts API
+- **Workspace id:** 7e4b839b24784118b953b0c03a4676fa
+- **Server:** roslyn-mcp 1.6.1+f16452924ef03cd3ed17dc36b53efab29c72217a; catalog 2026.03; tools 56 stable / 67 experimental; resources 7; prompts 16 experimental
+- **Roslyn / .NET:** Roslyn 5.3.0.0; runtime .NET 10.0.5; OS Windows 10.0.26200
+- **Scale:** 34 projects, 750 documents
+- **Repo shape:** multi-project net10.0; test projects present; analyzers present (663 rules / 34 analyzer assemblies per `list_analyzers`); `dotnet restore` clean before semantic tools; no multi-targeting
+- **Prior issue source:** ai_docs/backlog.md — no Roslyn MCP issue ids; Phase 18 MCP regression list N/A
+- **Lock mode at audit time:** rw-lock (`ROSLYNMCP_WORKSPACE_RW_LOCK=true` in process env; `evaluate_csharp` returned `"true"`; workspace tool responses often `_meta.gateMode`: `rw-lock`)
+- **Lock mode source of truth:** launch-config + behavioral fingerprint
+- **Debug log channel:** no — MCP `notifications/message` not surfaced in this agent turn
+- **Report path note:** Saved under IT-Chat-Bot per deep-review fallback. Copy to Roslyn-Backed-MCP `ai_docs/audit-reports/` if that repo owns rollups.
+- **Auto-pair detection:** run 1; Session B matrix `skipped-pending-second-run`
+- **Run scope:** Mandatory sections present; **not** an exhaustive execution of every phase step in deep-review-and-refactor.md (representative diagnostics, symbols, snippets, tests only).
+
+## Coverage summary
+
+| Kind | Category | Exercised | Exercised-apply | Preview-only | Skipped-repo-shape | Skipped-safety | Blocked | Notes |
+|------|----------|-----------|-----------------|--------------|--------------------|----------------|---------|-------|
+| tool | (all categories) | 19 | 0 | 0 | 0 | 104 | 0 | Partial session |
+| resource | server + workspace | 4 | n/a | n/a | 0 | 3 | 0 | projects/diagnostics/source_file URI not fetched |
+| prompt | prompts | 0 | n/a | n/a | 0 | 0 | 16 | Client limitation |
+
+## Coverage ledger
+
+| Kind | Name | Tier | Status | Phase | Notes |
+|------|------|------|--------|-------|-------|
+| tool | `server_info` | stable | exercised | 0-8 | See Verified tools |
+| tool | `workspace_load` | stable | exercised | 0-8 | See Verified tools |
+| tool | `workspace_reload` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `workspace_close` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `workspace_list` | stable | exercised | 0-8 | See Verified tools |
+| tool | `workspace_status` | stable | exercised | 0-8 | See Verified tools |
+| tool | `project_graph` | stable | exercised | 0-8 | See Verified tools |
+| tool | `source_generated_documents` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_source_text` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `symbol_search` | stable | exercised | 0-8 | See Verified tools |
+| tool | `symbol_info` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `go_to_definition` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_references` | stable | exercised | 0-8 | See Verified tools |
+| tool | `find_implementations` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `document_symbols` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_overrides` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_base_members` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `member_hierarchy` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `symbol_signature_help` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `symbol_relationships` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_references_bulk` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_property_writes` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `enclosing_symbol` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `goto_type_definition` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_completions` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `project_diagnostics` | stable | exercised | 0-8 | See Verified tools |
+| tool | `diagnostic_details` | stable | exercised | 0-8 | See Verified tools |
+| tool | `type_hierarchy` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `callers_callees` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `impact_analysis` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_type_mutations` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_type_usages` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `build_workspace` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `build_project` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `test_discover` | stable | exercised | 0-8 | See Verified tools |
+| tool | `test_run` | stable | exercised | 0-8 | See Verified tools |
+| tool | `test_related` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `test_related_files` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `rename_preview` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `rename_apply` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `organize_usings_preview` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `organize_usings_apply` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `format_document_preview` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `format_document_apply` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `code_fix_preview` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `code_fix_apply` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_unused_symbols` | experimental | exercised | 0-8 | See Verified tools |
+| tool | `get_di_registrations` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_complexity_metrics` | experimental | exercised | 0-8 | See Verified tools |
+| tool | `find_reflection_usages` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_namespace_dependencies` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_nuget_dependencies` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `semantic_search` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `apply_text_edit` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `apply_multi_file_edit` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `create_file_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `create_file_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `delete_file_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `delete_file_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `move_file_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `move_file_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `add_package_reference_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_package_reference_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `add_project_reference_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_project_reference_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `set_project_property_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `add_target_framework_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_target_framework_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `set_conditional_property_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `add_central_package_version_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_central_package_version_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `apply_project_mutation` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `scaffold_type_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `scaffold_type_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `scaffold_test_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `scaffold_test_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_dead_code_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `remove_dead_code_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `move_type_to_project_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_interface_cross_project_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `dependency_inversion_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `migrate_package_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `split_class_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_and_wire_interface_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `apply_composite_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `test_coverage` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_syntax_tree` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_code_actions` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `preview_code_action` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `apply_code_action` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `security_diagnostics` | stable | exercised | 0-8 | See Verified tools |
+| tool | `security_analyzer_status` | stable | exercised | 0-8 | See Verified tools |
+| tool | `nuget_vulnerability_scan` | stable | exercised | 0-8 | See Verified tools |
+| tool | `find_consumers` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_cohesion_metrics` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `find_shared_members` | stable | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `move_type_to_file_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `move_type_to_file_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_interface_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_interface_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `bulk_replace_type_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `bulk_replace_type_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_type_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `extract_type_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `revert_last_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `analyze_data_flow` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `analyze_control_flow` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `compile_check` | stable | exercised | 0-8 | See Verified tools |
+| tool | `list_analyzers` | stable | exercised | 0-8 | See Verified tools |
+| tool | `fix_all_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `fix_all_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_operations` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `format_range_preview` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `format_range_apply` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `analyze_snippet` | stable | exercised | 0-8 | See Verified tools |
+| tool | `evaluate_csharp` | experimental | exercised | 0-8 | See Verified tools |
+| tool | `get_editorconfig_options` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `set_editorconfig_option` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `evaluate_msbuild_property` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `evaluate_msbuild_items` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `get_msbuild_properties` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `set_diagnostic_severity` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| tool | `add_pragma_suppression` | experimental | skipped-safety | - | Partial deep-review; not invoked this session; primary worktree conservative cut |
+| resource | `server_catalog` | stable | exercised | 0,15 | fetch_mcp_resource |
+| resource | `resource_templates` | stable | exercised | 0,15 | fetch_mcp_resource |
+| resource | `workspaces` | stable | exercised | 0,15 | fetch_mcp_resource |
+| resource | `workspace_status` | stable | exercised | 0,15 | fetch_mcp_resource |
+| resource | `workspace_projects` | stable | skipped-safety | 15 | not fetched this session |
+| resource | `workspace_diagnostics` | stable | skipped-safety | 15 | not fetched this session |
+| resource | `source_file` | stable | skipped-safety | 15 | not fetched this session |
+| prompt | `explain_error` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `suggest_refactoring` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `review_file` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `analyze_dependencies` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `debug_test_failure` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `refactor_and_validate` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `fix_all_diagnostics` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `guided_package_migration` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `guided_extract_interface` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `security_review` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `discover_capabilities` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `dead_code_audit` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `review_test_coverage` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `review_complexity` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `cohesion_analysis` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+| prompt | `consumer_impact` | experimental | blocked | 16 | MCP prompts not invocable from this Cursor agent turn |
+
+## Verified tools (working)
+- `server_info` — surface counts match catalog Summary (56/67 tools, 7 resources, 16 prompts).
+- `workspace_load` / `workspace_list` / `workspace_status` / `project_graph` — 34 projects, 750 docs, IsStale false.
+- `project_diagnostics` — 0 errors, 143 warnings; paging + project/severity filters coherent (ITChatBot.Configuration + Warning: 2 warnings, hasMore false).
+- `compile_check` — 0 CS diagnostics on paginated full-solution pass (~10 s); second pass with `emitValidation=true` ~4.8 s, same empty diagnostic page for returned window.
+- `security_diagnostics` / `security_analyzer_status` — 0 security findings; SecurityCodeScan present.
+- `nuget_vulnerability_scan` — 0 CVEs, 34 projects, ~10.6 s.
+- `list_analyzers` — 34 assemblies, 663 rules; offset/limit paging (hasMore true on first page).
+- `diagnostic_details` — CA1002 / CA1032 returned descriptions and help links; SupportedFixes empty (acceptable for those rules).
+- `get_complexity_metrics` — minComplexity 15 surfaces known hot spots (Slack webhook, aggregation jobs, ChatEndpoints).
+- `symbol_search` — resolves HandleQueryAsync / IChatOrchestrator; broad `Async` query returns large hit set.
+- `find_references` — `IChatOrchestrator` yields 12 refs; caret placement matters (method-only cursor gave 1 ref).
+- `find_unused_symbols` — 1 high-confidence unused symbol (EF snapshot) in ~1.1 s.
+- `analyze_snippet` — expression valid; invalid assignment reports CS0029 (see issues).
+- `evaluate_csharp` — `Enumerable.Range(1,10).Sum()` => 55; env read confirms RW lock flag `"true"`; ~142 ms / ~18 ms.
+- `test_discover` — large structured test inventory.
+- `test_run` — `ITChatBot.Configuration.Tests`: 14 passed, 0 failed, exit 0, ~5.9 s.
+- Resources: `roslyn://server/catalog`, `roslyn://server/resource-templates`, `roslyn://workspaces`, `roslyn://workspace/{id}/status` — readable.
+- `compile_check` — invalid `workspaceId` returns structured NotFound with actionable message (Phase 17 sample).
+
+## Phase 6 refactor summary
+- **N/A** — No apply-capable refactor chains executed; conservative partial audit on primary worktree (no 6a–6i applies).
+
+## Concurrency mode matrix (Phase 8b)
+
+**Single-mode lane (rw-lock).** Parallel fan-out, read/write interleave, lifecycle stress, and writer reclassification runs were **not** executed (partial session). Session B columns: **skipped-pending-second-run**.
+
+### Sequential baseline (Session A, rw-lock)
+| Slot | Tool | Inputs | Wall-clock (ms) | Notes |
+|------|------|--------|-----------------|-------|
+| R1 | `find_references` | IChatOrchestrator.cs L8 C22 | 5 | 12 refs |
+| R2 | `project_diagnostics` | offset 0 limit 30 | 15130 | first page |
+| R3 | `symbol_search` | query `Async` limit 100 | N/A | response without `_meta.heldMs`; large payload |
+| R4 | `find_unused_symbols` | includePublic false | 1126 | |
+| R5 | `get_complexity_metrics` | minComplexity 15 limit 15 | 88 | |
+
+### Parallel fan-out / 8b.3 / 8b.4 / 8b.5
+**N/A — partial run**
+
+## Debug log capture
+client did not surface MCP log notifications
+
+## MCP server issues (bugs)
+No hard failures in exercised calls. Observations:
+
+| # | Title | Severity | Detail |
+|---|-------|----------|--------|
+| 1 | `analyze_snippet` CS0029 span | cosmetic | `int x = "hello";` reports StartLine 1, StartColumn 9, EndColumn 16. Deep-review text references literal-column behavior for v1.7+; server **1.6.1** — verify after upgrade. |
+| 2 | `find_references` targeting | UX | Caret on method identifier vs type name changes reference count sharply; expected Roslyn resolution behavior — document for agents. |
+
+**Negative test:** `compile_check` with bogus workspaceId → `KeyNotFoundException` message lists `workspace_list` remediation — **PASS** (actionable).
+
+## Improvement suggestions
+- Include `_meta` on array-returning tools (`symbol_search`) for performance auditing.
+- Operators: deep-review prompt appendix mentions v1.7+ behaviors; live host 1.6.1 — align docs or server version notes.
+
+## Performance observations
+| Tool | Input scale | Lock mode | Wall-clock (ms) | Notes |
+|------|-------------|-----------|-----------------|-------|
+| `project_diagnostics` | first 30 rows, full sln | rw-lock | 15130 | |
+| `compile_check` | limit 40 full sln | rw-lock | 10060 | |
+| `nuget_vulnerability_scan` | 34 projects | rw-lock | 10624 | |
+| `compile_check` | emitValidation limit 10 | rw-lock | 4811 | |
+| `test_run` | Configuration.Tests | rw-lock | 5863 | |
+
+## Known issue regression check
+**N/A** — no Roslyn MCP backlog entries in ai_docs/backlog.md to re-test against this server build.
+
+## Known issue cross-check
+- Deep-review appendix “Last verified: 2026-04-06 … 123 tools” matches catalog enum; running server **1.6.1** vs narrative that references **v1.7+** features (e.g. `compile_check` pagination notes) — treat as version skew for operators, not a live bug.
+
+---
+
+**Report path note (Phase 8b.6 Case A):** This is the mode-1 partial audit. For a full dual-mode concurrency matrix, run `eng/flip-rw-lock.ps1` (or equivalent), restart the MCP host, and re-invoke deep-review per `ai_docs/prompts/deep-review-and-refactor.md`.

--- a/ai_docs/audit-reports/20260408T034457Z_networkdocumentation_rw-lock_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260408T034457Z_networkdocumentation_rw-lock_mcp-server-audit.md
@@ -1,0 +1,207 @@
+# MCP Server Audit Report
+
+## Completion status (read first)
+
+**Partial session.** The living prompt [`ai_docs/prompts/deep-review-and-refactor.md`](../prompts/deep-review-and-refactor.md) defines an **exhaustive** multi-phase audit (Phases 0–18, full coverage ledger, dual-mode concurrency pairing, and Phase 6 product refactors). This file records **evidence from a single Cursor agent session**: Phases **0**, **1** (mostly), **2** (start), **5** (complete), plus **spot checks** (`symbol_search`, `find_references`, `evaluate_csharp` env probe, `workspace_close`). **Phases 3–4, 6–4, 7–18 and full Phase 8b timing matrices were not executed** in this session. Remaining catalog entries require a **continuation run** (or multiple runs) using the same prompt; treat non-invoked tools as **not yet dispositioned** rather than “green.”
+
+**Intended canonical store:** This audit targets solution `NetworkDocumentation.sln` in **DotNet-Network-Documentation**. If your rollup pipeline expects raw audits under **Roslyn-Backed-MCP**, copy this file there via `eng/import-deep-review-audit.ps1` when available.
+
+## Header
+
+- **Date:** 2026-04-08 (UTC run; filename timestamp `20260408T034457Z`)
+- **Audited solution:** `c:\Code-Repo\DotNet-Network-Documentation\NetworkDocumentation.sln`
+- **Audited revision:** `main` @ `8d103fe` (short); working tree had uncommitted `ai_docs` edits at run time
+- **Entrypoint loaded:** `NetworkDocumentation.sln`
+- **Audit mode:** `conservative` — shared developer workspace with pending local changes; no disposable worktree was created for this invocation. Write/apply families (Phase 6, 8b writers, 10–13 applies) were **not** exercised end-to-end here.
+- **Isolation:** Shared path `c:\Code-Repo\DotNet-Network-Documentation` (rationale: conservative)
+- **Client:** Cursor agent with `user-roslyn` MCP (`roslyn-mcp` host **1.6.1+f16452924ef03cd3ed17dc36b53efab29c72217a**)
+- **Workspace id (released):** `242c3dec0b9d44efbf2025e7ad601979`
+- **Server:** `server_info`: catalog **2026.03**; tools **56 stable / 67 experimental**; resources **7 stable**; prompts **16 experimental**; `runtime` **.NET 10.0.5**; `roslynVersion` **5.3.0.0**
+- **Roslyn / .NET:** as above
+- **Scale:** **8** projects, **361** documents (`workspace_load`)
+- **Repo shape:** Multi-project (`Core`, `Parsers`, `Excel`, `Diagrams`, `Cli`, `Web`, `Reports`, `Tests`); **tests present**; **analyzers present** (Meziantou, Microsoft, Puma, etc.); **no** Central Package Management in tree; **single** target framework **net10.0** per project; **DI** in Web host; **source generators** not emphasized (confirm in continuation via `source_generated_documents`).
+- **Prior issue source for Phase 18:** `ai_docs/backlog.md` — no Roslyn MCP defect rows; product backlog only. Prior MCP narrative: `ai_docs/reports/mcp-server-audit-report.md` (reference only).
+- **Lock mode at audit time:** `rw-lock` (single-mode lane; Session B columns **skipped-pending-second-run**)
+- **Lock mode source of truth:** `launch-config` / OS env (**User** + **Machine** `ROSLYNMCP_WORKSPACE_RW_LOCK` = `true`); **confirmed** by `workspace_status._meta.gateMode` = `rw-lock`; **confirmed** by `evaluate_csharp` returning `"true"` for `Environment.GetEnvironmentVariable("ROSLYNMCP_WORKSPACE_RW_LOCK")`
+- **Debug log channel:** `no` — MCP `notifications/message` not surfaced in this Cursor agent transcript for verbatim capture
+- **Auto-pair detection (Phase 0.16):** No `*networkdocumentation*legacy-mutex*_mcp-server-audit.md` partial found under `ai_docs/audit-reports/` → **run 1 of dual-mode pair** (if operator wants dual-mode matrix completion).
+- **Report path note:** This is the **mode-1 partial** of a deep-review pair for **rw-lock**. To populate **Session B** (legacy-mutex) columns, run `./eng/flip-rw-lock.ps1` (Roslyn-Backed-MCP repo), restart the MCP client fully, and re-invoke the deep-review prompt against the **same** checkout — **or** accept single-mode lane for smoke audits.
+
+## Phase notes (this session)
+
+### Phase 0 — PASS/FLAG summary
+
+| Checkpoint | Result |
+|------------|--------|
+| `server_info` vs catalog counts | **PASS** — 56+67=123 tools; 7 resources; 16 prompts; catalog version 2026.03 matches |
+| `workspace_load` | **PASS** — 8 projects, 361 docs, empty `WorkspaceDiagnostics` |
+| `workspace_list` / `workspace_status` | **PASS** — session visible; **not stale** |
+| `project_graph` | **PASS** — dependency edges match expectation (Core ← others; Tests ← all) |
+| `dotnet restore` (host shell) | **PASS** — `NetworkDocumentation.sln` restored cleanly |
+| Resource `roslyn://server/catalog` | **PASS** |
+| Resource `roslyn://server/resource-templates` | **PASS** — 7 URIs |
+| Debug notifications | **FLAG** — not captured (client limitation for this session) |
+
+### Phase 1 — Diagnostics / security
+
+| Step | Result | Notes |
+|------|--------|-------|
+| `project_diagnostics` (full workspace, default page) | **PASS** — `totalDiagnostics=0`; **~12s** `heldMs` (large-solution scan — note performance) |
+| `project_diagnostics` (scoped: project `NetworkDocumentation.Core`, severity `Warning`, limit 10) | **PASS** — stable paging; 0 diagnostics |
+| `compile_check` (default pagination) | **PASS** — 0 CS diagnostics; **~77ms** |
+| `compile_check` (`emitValidation=true`, project `NetworkDocumentation.Core`) | **PASS** — 0 diagnostics; **~571ms** (emit path still cheap when clean / scoped) |
+| `security_diagnostics` | **PASS** — 0 findings; recommends `SecurityCodeScan.VS2019` missing |
+| `security_analyzer_status` | **PASS** — Puma present; SecurityCodeScan absent |
+| `nuget_vulnerability_scan` | **PASS** — 0 vulns; 8 projects; **~5.1s** |
+| `list_analyzers` (paged + project filter) | **PASS** — **832** rules solution-wide page 1; **823** rules in test project slice; pagination metadata coherent |
+| `diagnostic_details` | **N/A** — no diagnostics to target |
+
+### Phase 2 — Quality metrics (partial)
+
+| Tool | Result |
+|------|--------|
+| `get_complexity_metrics` | **PASS** — top hotspots include `QueryEvaluator.EvaluateComparison` (CC 24), parser methods CC 16–24, diagram builders CC 16–18; nesting depth flagged up to **5** in `EigrpParser.ParseShowEigrpTopology` / `L3DiagramBuilder` |
+
+**Not run this session:** `get_cohesion_metrics`, `find_unused_symbols` (both), `get_namespace_dependencies`, `get_nuget_dependencies`.
+
+### Phase 5 — Snippet & script
+
+| Probe | Result |
+|-------|--------|
+| `analyze_snippet` `expression` `1+2` | **PASS** |
+| `analyze_snippet` `program` small class | **PASS** — lists `C`, `X` |
+| `analyze_snippet` broken `statements` | **PASS** — CS0029; **StartColumn=9** (user-relative; literal-aligned — matches FLAG-C fix expectation) |
+| `analyze_snippet` `returnExpression` | **PASS** |
+| `evaluate_csharp` LINQ sum | **PASS** — `55` |
+| `evaluate_csharp` `int.Parse("abc")` | **PASS** — graceful runtime error string |
+| `evaluate_csharp` infinite loop (`timeoutSeconds=2`) | **PASS** — abandoned after **12s** (2s budget + 10s grace); message actionable; `ProgressHeartbeatCount=6` |
+| `evaluate_csharp` env `ROSLYNMCP_WORKSPACE_RW_LOCK` | **PASS** — `"true"` |
+
+### Spot checks (Phase 3 / 8b probe planning)
+
+| Tool | Result |
+|------|--------|
+| `symbol_search` `QueryEvaluator` | **PASS** |
+| `find_references` (`QueryEvaluator` type handle, limit 200) | **PASS** — **11** refs; classifications (`Read`) present; **~426ms** |
+
+**Note:** Deep-review template suggests R1 hot symbol **50+** refs; this repo’s `QueryEvaluator` has **11** — substitute symbol in a full 8b run.
+
+### Phase 6 / 8 / 8b / 9–18
+
+**Not executed** in this session (conservative + partial). `workspace_close` called after evidence capture.
+
+## Coverage summary (approximate)
+
+| Kind | Category | Exercised | Exercised-apply | Preview-only | Skipped-repo-shape | Skipped-safety | Blocked | Notes |
+|------|----------|-----------|-----------------|-------------|--------------------|----------------|---------|-------|
+| tool | mixed | 17 | 0 | 0 | 0 | 106 | 0 | Unique tools invoked; ~25 total MCP tool calls incl. repeats |
+| resource | server/workspace/analysis | 2 | n/a | n/a | 0 | 0 | 5 | Workspaces/diagnostics/file URIs not re-read after close |
+| prompt | prompts | 0 | n/a | n/a | 0 | 0 | 16 | Not invoked — client/session scope |
+
+*Blocked column is 0 — use **skipped-safety / not invoked** interpretation: 101 tools pending disposition in a follow-up run.*
+
+## Coverage ledger — tools invoked this session
+
+| Kind | Name | Tier | Status | Phase | Notes |
+|------|------|------|--------|-------|-------|
+| tool | `server_info` | stable | exercised | 0 | Counts match catalog |
+| tool | `workspace_load` | stable | exercised | 0 | Clean load |
+| tool | `workspace_list` | stable | exercised | 0 | |
+| tool | `workspace_status` | stable | exercised | 0 | `gateMode: rw-lock` |
+| tool | `project_graph` | stable | exercised | 0 | |
+| tool | `project_diagnostics` | stable | exercised | 1 | Full scan ~12s |
+| tool | `compile_check` | stable | exercised | 1 | Default + scoped emitValidation |
+| tool | `security_diagnostics` | stable | exercised | 1 | |
+| tool | `security_analyzer_status` | stable | exercised | 1 | |
+| tool | `nuget_vulnerability_scan` | stable | exercised | 1 | |
+| tool | `list_analyzers` | stable | exercised | 1 | Pagination + project filter |
+| tool | `get_complexity_metrics` | experimental | exercised | 2 | |
+| tool | `analyze_snippet` | stable | exercised | 5 | All probe kinds |
+| tool | `evaluate_csharp` | experimental | exercised | 5 | Sum, error, timeout, env |
+| tool | `symbol_search` | stable | exercised | 3-spot | |
+| tool | `find_references` | stable | exercised | 3-spot | |
+| tool | `workspace_close` | stable | exercised | close | |
+
+## Coverage ledger — remaining catalog tools (123 − 17 = **106** not invoked)
+
+> **Machine enumeration:** Tool names = `mcps/user-roslyn/tools/*.json` (123 files) in Cursor project cache. **Disposition:** `blocked` is **not** claimed — these are **pending continuation** (`deep-review` re-invocation). Do **not** treat as pass.
+
+`add_central_package_version_preview`, `add_package_reference_preview`, `add_pragma_suppression`, `add_project_reference_preview`, `add_target_framework_preview`, `analyze_control_flow`, `analyze_data_flow`, `apply_code_action`, `apply_composite_preview`, `apply_multi_file_edit`, `apply_project_mutation`, `apply_text_edit`, `build_project`, `build_workspace`, `bulk_replace_type_apply`, `bulk_replace_type_preview`, `callers_callees`, `code_fix_apply`, `code_fix_preview`, `create_file_apply`, `create_file_preview`, `delete_file_apply`, `delete_file_preview`, `dependency_inversion_preview`, `diagnostic_details`, `document_symbols`, `enclosing_symbol`, `extract_and_wire_interface_preview`, `extract_interface_apply`, `extract_interface_cross_project_preview`, `extract_interface_preview`, `extract_type_apply`, `extract_type_preview`, `find_base_members`, `find_consumers`, `find_implementations`, `find_overrides`, `find_property_writes`, `find_references_bulk`, `find_reflection_usages`, `find_shared_members`, `find_type_mutations`, `find_type_usages`, `find_unused_symbols`, `fix_all_apply`, `fix_all_preview`, `format_document_apply`, `format_document_preview`, `format_range_apply`, `format_range_preview`, `get_code_actions`, `get_cohesion_metrics`, `get_completions`, `get_di_registrations`, `get_editorconfig_options`, `get_msbuild_properties`, `get_namespace_dependencies`, `get_nuget_dependencies`, `get_operations`, `get_source_text`, `get_syntax_tree`, `go_to_definition`, `goto_type_definition`, `impact_analysis`, `member_hierarchy`, `migrate_package_preview`, `move_file_apply`, `move_file_preview`, `move_type_to_file_apply`, `move_type_to_file_preview`, `move_type_to_project_preview`, `organize_usings_apply`, `organize_usings_preview`, `preview_code_action`, `remove_central_package_version_preview`, `remove_dead_code_apply`, `remove_dead_code_preview`, `remove_package_reference_preview`, `remove_project_reference_preview`, `remove_target_framework_preview`, `rename_apply`, `rename_preview`, `revert_last_apply`, `scaffold_test_apply`, `scaffold_test_preview`, `scaffold_type_apply`, `scaffold_type_preview`, `semantic_search`, `set_conditional_property_preview`, `set_diagnostic_severity`, `set_editorconfig_option`, `set_project_property_preview`, `source_generated_documents`, `split_class_preview`, `symbol_info`, `symbol_relationships`, `symbol_signature_help`, `test_coverage`, `test_discover`, `test_related`, `test_related_files`, `test_run`, `type_hierarchy`, `workspace_reload`.
+
+*(Count verification: 123 total − 17 unique tools invoked = **106** pending.)*
+
+## Resources & prompts
+
+| Kind | Name | Tier | Status | Phase | Notes |
+|------|------|------|--------|-------|-------|
+| resource | `server_catalog` | stable | exercised | 0 | `roslyn://server/catalog` |
+| resource | `resource_templates` | stable | exercised | 0 | |
+| resource | `workspaces` | stable | not invoked | — | Pending |
+| resource | `workspace_status` URI | stable | not invoked | — | Pending |
+| resource | `workspace_projects` URI | stable | not invoked | — | Pending |
+| resource | `workspace_diagnostics` URI | stable | not invoked | — | Pending |
+| resource | `source_file` URI | stable | not invoked | — | Pending |
+| prompt | `explain_error` … `consumer_impact` (16) | experimental | not invoked | — | Regenerate / invoke per Phase 16 in continuation |
+
+## Verified tools (working)
+
+- `server_info` — live surface matches expectations for 2026.03
+- `workspace_load` / `workspace_list` / `workspace_status` / `project_graph` — coherent session + graph
+- `project_diagnostics` — 0-issue workspace; slow first full scan (~12s)
+- `compile_check` — fast CS-only check; scoped `emitValidation` behaved
+- `security_*` + `nuget_vulnerability_scan` — structured empty results
+- `list_analyzers` — 832 rules; paging works
+- `get_complexity_metrics` — plausible CC/nesting for hotspots
+- `analyze_snippet` / `evaluate_csharp` — including timeout + env visibility
+- `symbol_search` / `find_references` — handle + classifications OK
+- `workspace_close` — clean release
+
+## Phase 6 refactor summary
+
+- **Target repo:** DotNet-Network-Documentation (this workspace)
+- **Scope:** **N/A** — no preview/apply refactor chains executed (conservative partial audit)
+- **Changes:** none via MCP applies
+- **Verification:** host `dotnet restore` **PASS**; in-memory diagnostics **PASS**
+
+## Concurrency mode matrix (Phase 8b)
+
+**N/A — partial session:** No sequential baseline, parallel fan-out, read/write exclusion, lifecycle stress, or writer reclassification timings were collected. **Session B** (`legacy-mutex`) columns remain **`skipped-pending-second-run`** per dual-mode procedure.
+
+## Writer reclassification verification (Phase 8b.5)
+
+**N/A** — not executed.
+
+## Debug log capture
+
+`client did not surface MCP log notifications`
+
+## MCP server issues (bugs)
+
+**No new defects observed** in the exercised subset. One **performance FLAG**: first unfiltered `project_diagnostics` took **~12s** (`heldMs` ~12024) on this 8-project / 361-document solution — acceptable for cold graph but worth tracking if repeated probing is needed.
+
+## Improvement suggestions
+
+- Consider raising operator visibility into `gateMode` / lock mode on **`server_info`** (prompt notes `server_info` omits `ROSLYNMCP_WORKSPACE_RW_LOCK`; env + `evaluate_csharp` workaround works but is clunky)
+- **`nuget_vulnerability_scan`**: `IncludesTransitive: false` — document implication for supply-chain audits
+
+## Performance observations
+
+| Tool | Input scale | Lock mode | Wall-clock (ms) | Notes |
+|------|-------------|-----------|-------------------|-------|
+| `project_diagnostics` | full solution | rw-lock | ~12024 | First page (0 issues) |
+| `nuget_vulnerability_scan` | 8 projects | rw-lock | ~5083 | |
+| `find_references` | `QueryEvaluator` | rw-lock | ~426 | 11 refs |
+| `compile_check` | full (default) | rw-lock | ~77 | |
+| `get_complexity_metrics` | default top50 | rw-lock | ~327 | |
+
+## Known issue regression check
+
+**N/A** — `ai_docs/backlog.md` contains **no** Roslyn MCP regression ids; no prior MCP bug backlog cross-walk performed beyond archival reference to `ai_docs/reports/mcp-server-audit-report.md`.
+
+## Known issue cross-check
+
+- None new vs prior audit docs in this short run.
+
+---
+
+*Generated by executing `ai_docs/prompts/deep-review-and-refactor.md` through Phase 0–2/5 scope in one agent session. **Completion gate:** full prompt compliance requires additional sessions.*

--- a/ai_docs/audit-reports/20260408T034600Z_roslynmcp_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260408T034600Z_roslynmcp_mcp-server-audit.md
@@ -1,0 +1,272 @@
+# MCP Server Audit Report
+
+> **Execution scope:** This run exercised Phases **0–1 (core)**, **Phase 5 (subset)**, **Phase 11 (semantic_search)**, **Phase 15 (resources subset)**, **Phase 17 (negative sample)**, plus **host `dotnet restore` / `dotnet test`** for validation. It did **not** complete the full sequential phase plan in `ai_docs/prompts/deep-review-and-refactor.md` (no disposable worktree, no Phase 6 applies, no Phase 8b concurrency matrix, no full prompt invocations). Ledger uses `skipped-safety` / `blocked` with explicit reasons so the live catalog remains fully accounted for.
+
+## Header
+
+- **Date:** 2026-04-08T03:46:00Z (report finalized UTC; tool calls ~03:41–03:45Z)
+- **Audited solution:** `c:\Code-Repo\Roslyn-Backed-MCP\RoslynMcp.slnx`
+- **Audited revision:** (not pinned in session — workspace from local disk)
+- **Entrypoint loaded:** `RoslynMcp.slnx`
+- **Audit mode:** `conservative` — no disposable git worktree; primary repo path `c:\Code-Repo\Roslyn-Backed-MCP`; destructive preview→apply families not driven end-to-end
+- **Isolation:** Same working tree as developer checkout; Phase 6 / 8b / 10–13 applies intentionally omitted
+- **Client:** Cursor agent session with `user-roslyn` MCP; prompts not invoked via MCP prompt API
+- **Workspace id (during run):** `56ed07501b6546c49c3c9b511049ea3c` (closed at end of session)
+- **Server:** `roslyn-mcp` **1.6.1** (commit f16452924ef03cd3ed17dc36b53efab29c72217a per `server_info`)
+- **Roslyn / .NET:** Roslyn **5.3.0.0**, runtime **.NET 10.0.5**, OS Windows 10.0.26200
+- **Scale:** 4 projects, 303 documents (`workspace_load`)
+- **Repo shape:** Multi-project solution; test project **RoslynMcp.Tests**; single target **net10.0** per project; no Central Package Management in tree; analyzers present (e.g. `list_analyzers`: 17 assemblies, 451 rules); restore **passed** before semantic tools
+- **Prior issue source:** `ai_docs/backlog.md` (**updated_at** 2026-04-08T03:00:00Z)
+- **Debug log channel:** `no` — MCP `notifications/message` not surfaced in this Cursor agent transcript
+- **Report path note:** Canonical under Roslyn-Backed-MCP `ai_docs/audit-reports/`
+
+## Coverage summary
+
+| Kind | Category | Exercised | Exercised-apply | Preview-only | Skipped-repo-shape | Skipped-safety | Blocked | Notes |
+|------|----------|-----------|------------------|--------------|--------------------|----------------|---------|-------|
+| tool | mixed | 19 | 0 | 0 | 1 | 103 | 0 | See ledger; `diagnostic_details` skipped (no diagnostics) |
+| resource | server + workspace | 3 | n/a | n/a | 0 | 0 | 4 | Workspace-scoped URIs blocked after intentional `workspace_close` |
+| prompt | prompts | 0 | n/a | n/a | 0 | 0 | 16 | Prompt tools not invoked in this client session |
+
+_Counts align with catalog **2026.03**: 123 tools + 7 resources + 16 prompts = **146** ledger rows._
+
+## Coverage ledger
+
+| Kind | Name | Tier | Status | Phase | Notes |
+|------|------|------|--------|-------|-------|
+| tool | `add_central_package_version_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `add_package_reference_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `add_pragma_suppression` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `add_project_reference_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `add_target_framework_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `analyze_control_flow` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `analyze_data_flow` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `analyze_snippet` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `apply_code_action` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `apply_composite_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `apply_multi_file_edit` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `apply_project_mutation` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `apply_text_edit` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `build_project` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `build_workspace` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `bulk_replace_type_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `bulk_replace_type_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `callers_callees` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `code_fix_apply` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `code_fix_preview` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `compile_check` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `create_file_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `create_file_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `delete_file_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `delete_file_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `dependency_inversion_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `diagnostic_details` | stable | skipped-repo-shape | 1 | No diagnostics in workspace; cannot exercise representative diagnostic_details. |
+| tool | `document_symbols` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `enclosing_symbol` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `evaluate_csharp` | experimental | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `evaluate_msbuild_items` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `evaluate_msbuild_property` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_and_wire_interface_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_interface_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_interface_cross_project_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_interface_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_type_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `extract_type_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_base_members` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_consumers` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_implementations` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_overrides` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_property_writes` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_references` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `find_references_bulk` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_reflection_usages` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_shared_members` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_type_mutations` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_type_usages` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `find_unused_symbols` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `fix_all_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `fix_all_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `format_document_apply` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `format_document_preview` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `format_range_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `format_range_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_code_actions` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_cohesion_metrics` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_completions` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_complexity_metrics` | experimental | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `get_di_registrations` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_editorconfig_options` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_msbuild_properties` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_namespace_dependencies` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_nuget_dependencies` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_operations` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_source_text` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `get_syntax_tree` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `go_to_definition` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `goto_type_definition` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `impact_analysis` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `list_analyzers` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `member_hierarchy` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `migrate_package_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `move_file_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `move_file_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `move_type_to_file_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `move_type_to_file_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `move_type_to_project_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `nuget_vulnerability_scan` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `organize_usings_apply` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `organize_usings_preview` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `preview_code_action` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `project_diagnostics` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `project_graph` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `remove_central_package_version_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `remove_dead_code_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `remove_dead_code_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `remove_package_reference_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `remove_project_reference_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `remove_target_framework_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `rename_apply` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `rename_preview` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `revert_last_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `scaffold_test_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `scaffold_test_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `scaffold_type_apply` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `scaffold_type_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `security_analyzer_status` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `security_diagnostics` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `semantic_search` | experimental | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `server_info` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `set_conditional_property_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `set_diagnostic_severity` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `set_editorconfig_option` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `set_project_property_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `source_generated_documents` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `split_class_preview` | experimental | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `symbol_info` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `symbol_relationships` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `symbol_search` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `symbol_signature_help` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `test_coverage` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `test_discover` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `test_related` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `test_related_files` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `test_run` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `type_hierarchy` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `workspace_close` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `workspace_list` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `workspace_load` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| tool | `workspace_reload` | stable | skipped-safety | partial-session | Partial deep-review session: not invoked here. Operator should rerun full phased prompt or `audit-feasibility-companion-cli` backlog item. |
+| tool | `workspace_status` | stable | exercised | 0-5,17,15(res) | Invoked in this session. |
+| resource | `server_catalog` | stable | exercised | 0,15 | `fetch_mcp_resource` roslyn://server/catalog |
+| resource | `resource_templates` | stable | exercised | 0,15 | `fetch_mcp_resource` roslyn://server/resource-templates |
+| resource | `workspaces` | stable | exercised | 15 | `fetch_mcp_resource` roslyn://workspaces |
+| resource | `workspace_status` | stable | blocked | 15 | Session ended before workspace-scoped URI with live id |
+| resource | `workspace_projects` | stable | blocked | 15 | Same — close before fetch |
+| resource | `workspace_diagnostics` | stable | blocked | 15 | Same |
+| resource | `source_file` | stable | blocked | 15 | Same — no file resource compares post-close |
+| prompt | `explain_error` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `suggest_refactoring` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `review_file` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `analyze_dependencies` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `debug_test_failure` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `refactor_and_validate` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `fix_all_diagnostics` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `guided_package_migration` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `guided_extract_interface` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `security_review` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `discover_capabilities` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `dead_code_audit` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `review_test_coverage` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `review_complexity` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `cohesion_analysis` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+| prompt | `consumer_impact` | experimental | blocked | 16 | Cursor session used tools/resources only; prompt invocation API not exercised |
+
+## Verified tools (working)
+
+- `server_info` — counts match catalog **2026.03** (56/67 tools, 7 resources, 16 prompts)
+- `workspace_load` / `workspace_list` / `workspace_status` — clean load, 4 projects, 303 docs, `_meta.gateMode` rw-lock on readers
+- `project_graph` — consistent project refs with `workspace_load` tree
+- `project_diagnostics` — 0 diagnostics, paging; held ~8–9s wall-clock on full-workspace calls (see performance)
+- `compile_check` — 0 CS diagnostics default path `ElapsedMs` ~2051; `emitValidation=true` ~9127ms, still 0 diagnostics (emit path slower but structured)
+- `security_diagnostics` / `security_analyzer_status` — structured empty findings + analyzer presence
+- `nuget_vulnerability_scan` — 0 CVEs, 4 projects, ~3124ms
+- `list_analyzers` — pagination works (`hasMore: true` with `limit=5`)
+- `get_complexity_metrics` — plausible hotspots (`ParseNuGetVulnerabilityJson` CC=27, etc.)
+- `symbol_search` — resolved `WorkspaceExecutionGate` and related symbols
+- `find_references` — 13 refs for `WorkspaceExecutionGate` class symbol; junk handle returned empty success (issue below)
+- `analyze_snippet` (`kind=expression`) — valid, 0 diagnostics
+- `evaluate_csharp` — `Enumerable.Range(1,10).Sum()` → `55`, `ElapsedMs` 97
+- `semantic_search` — paired queries `"async methods returning Task<bool>"` (2 hits) vs `"methods returning Task<bool>"` (3 hits); demonstrates modifier-sensitive delta on this repo
+- `test_discover` — large structured test list (host `dotnet test` **267 passed**)
+- `workspace_status` (unknown id) — actionable `NotFound` with `tool: workspace_status` (contrast with `find_references` empty success)
+- `workspace_close` — success
+- `roslyn://server/catalog`, `roslyn://server/resource-templates`, `roslyn://workspaces` — fetched via MCP resources
+
+## Phase 6 refactor summary
+
+- **Target repo:** Roslyn-Backed-MCP (this repository)
+- **Scope:** **N/A** — no MCP-driven applies in this conservative/partial session (no `*_apply`, no disk mutations via refactor tools)
+- **Changes:** none
+- **Verification:** Host `dotnet test RoslynMcp.slnx` — **Passed: 267**, Failed: 0, ~2m52s
+
+## Concurrency matrix (Phase 8b)
+
+**N/A — partial session.** Phase 8b (parallel read fan-out, read/write probes, lifecycle stress) was not executed. Backlog `reader-tool-elapsed-ms` notes reader tools often omit `ElapsedMs`, which limits quantitative speedup from inside the agent loop.
+
+## Writer reclassification verification (Phase 8b.5)
+
+**N/A — partial session.** No writer-chain probes in this run.
+
+## Debug log capture
+
+`client did not surface MCP log notifications` for this Cursor agent session.
+
+## MCP server issues (bugs)
+
+### 1. `find_references` — invalid symbol handle returns empty success
+
+| Field | Detail |
+|--------|--------|
+| Tool | `find_references` |
+| Input | `symbolHandle`: base64 payload `{"MetadataName":"fake"}`-style junk (`eyJNZXRhZGF0YU5hbWUiOiJmYWtlIn0=`) |
+| Expected | Structured `NotFound` / validation error (per backlog `error-response-observability`) |
+| Actual | `{ count: 0, totalCount: 0, references: [], hasMore: false }` (indistinguishable from legitimate zero refs) |
+| Severity | incorrect result / error-message-quality (consumer ambiguity) |
+| Reproducibility | always (this session) |
+
+### 2. No new crash or timeout observed
+
+No tool crash or hang within exercised calls; `evaluate_csharp` completed under default script timeout.
+
+## Improvement suggestions
+
+- **`test_run` MCP vs host tests** — session used shell `dotnet test` instead of MCP `test_run`; suggest full deep-review on disposable worktree include `test_run` for ledger parity.
+- **Phase 15 resource parity** — re-run with workspace still open to populate `roslyn://workspace/{id}/diagnostics` vs `project_diagnostics` diff and `source_file` vs `get_source_text`.
+- **Prompt tier documentation** — `server_info` reports `prompts: stable=0, experimental=16`; backlog `server-info-prompts-tier-doc` still relevant for first-time readers.
+- **Companion CLI** — backlog `audit-feasibility-companion-cli` matches observed session limits (full phased walkthrough is larger than one agent pass).
+
+## Performance observations
+
+| Tool | Input scale | Wall-clock (ms) | Notes |
+|------|-------------|------------------|-------|
+| `project_diagnostics` | full solution, limit 30 | ~8900–9300 `_meta.heldMs` | \>5s for simple read — FLAG per deep-review threshold; likely solution-wide analyzer graph |
+| `compile_check` | full solution, limit 30 | ~2051 default; ~9127 `emitValidation=true` | Emit path ~4.4× slower here (not 50–100× on this small solution) |
+| `nuget_vulnerability_scan` | 4 projects | ~3124 | Network/subprocess bounded |
+| `get_complexity_metrics` | limit 15 | ~301 | Fast |
+
+## Known issue regression check
+
+| Source id | Summary | Status |
+|-----------|---------|--------|
+| `semantic-search-async-modifier-doc` | async vs non-async `Task<bool>` query doc gotcha | **partially fixed / context-dependent** — on RoslynMcp.slnx, `semantic_search` `"async methods returning Task<bool>"` returned **2** results (not zero); broader query returned **3** |
+| `compile-check-emit-validation-regression-check` | emitValidation behavior vs unrestored baseline | **still reproduces investigation need** — on restored clean workspace, emitValidation slower (~9s vs ~2s) but diagnostic **count** unchanged (0); investigation remains whether emit adds value when CS clean |
+| `error-response-observability` | junk symbol handle empty success | **still reproduces** — `find_references` with fake handle returned empty graph (see issues §1) |
+| `reader-tool-elapsed-ms` | Phase 8b quantitative matrix | **still reproduces** — partial session; most readers lack `ElapsedMs` in response payloads |
+
+## Known issue cross-check
+
+- New observation this run: `workspace_status` error path correctly sets `"tool": "workspace_status"` for unknown workspace id (good contrast to backlog’s `tool: unknown` note for some other tools — not reproduced here).
+
+---
+
+_End of report._

--- a/ai_docs/reports/20260408T034746Z_deep-review-rollup.md
+++ b/ai_docs/reports/20260408T034746Z_deep-review-rollup.md
@@ -1,0 +1,46 @@
+# Deep-review rollup
+
+## Scope
+- **Generated:** 20260408T034746Z
+- **Purpose:** Deep-review rollup
+- **Input audit count:** 4
+- **Output path:** ai_docs\reports\20260408T034746Z_deep-review-rollup.md
+
+## Input audits
+| Repo | Date | Client | Revision | Server | File |
+|------|------|--------|----------|--------|------|
+| dotnet-firewall-analyzer_rw-lock |  |  |  |  | ai_docs\audit-reports\20260407T223900Z_dotnet-firewall-analyzer_rw-lock_mcp-server-audit.md |
+| itchatbot_rw-lock | 2026-04-08 (UTC tool timestamps ~03:39–03:40Z) | Cursor (MCP server id: user-roslyn); MCP **prompts** not invoked via prompts API | 8c2e3f6 (short) | roslyn-mcp 1.6.1+f16452924ef03cd3ed17dc36b53efab29c72217a; catalog 2026.03; tools 56 stable / 67 experimental; resources 7; prompts 16 experimental | ai_docs\audit-reports\20260408T033920Z_itchatbot_rw-lock_mcp-server-audit.md |
+| networkdocumentation_rw-lock | 2026-04-08 (UTC run; filename timestamp `20260408T034457Z`) | Cursor agent with `user-roslyn` MCP (`roslyn-mcp` host **1.6.1+f16452924ef03cd3ed17dc36b53efab29c72217a**) | `main` @ `8d103fe` (short); working tree had uncommitted `ai_docs` edits at run time | `server_info`: catalog **2026.03**; tools **56 stable / 67 experimental**; resources **7 stable**; prompts **16 experimental**; `runtime` **.NET 10.0.5**; `roslynVersion` **5.3.0.0** | ai_docs\audit-reports\20260408T034457Z_networkdocumentation_rw-lock_mcp-server-audit.md |
+| roslynmcp | 2026-04-08T03:46:00Z (report finalized UTC; tool calls ~03:41–03:45Z) | Cursor agent session with `user-roslyn` MCP; prompts not invoked via MCP prompt API | (not pinned in session — workspace from local disk) | `roslyn-mcp` **1.6.1** (commit f16452924ef03cd3ed17dc36b53efab29c72217a per `server_info`) | ai_docs\audit-reports\20260408T034600Z_roslynmcp_mcp-server-audit.md |
+
+## Repo matrix coverage
+| Bucket | Covered | Evidence | Notes |
+|--------|---------|----------|-------|
+| Small or single-project repo | | | |
+| Multi-project repo with tests | | | |
+| DI-heavy repo | | | |
+| Source-generator repo | | | |
+| Central Package Management or multi-targeting repo | | | |
+| Large solution representative repo | | | |
+
+## Client coverage
+| Client | Full-surface | Notes |
+|--------|--------------|-------|
+| | | |
+
+## Deduped issues
+| Key | Severity | Evidence | Backlog action |
+|-----|----------|----------|----------------|
+| | | | |
+
+## Blocked-by-client summary
+- 
+
+## Candidate closures
+| Source id | Evidence | Notes |
+|-----------|----------|-------|
+| | | |
+
+## Backlog actions
+- 


### PR DESCRIPTION
## Summary

Two related changes that fell out of diagnosing why the Roslyn MCP server was not appearing as a tool surface in Claude Code sessions even though the plugin was enabled.

### 1. Ship the plugin's `.mcp.json` with the marketplace install (commit `b7e1e1b`)

The Claude Code plugin loader looks for `.mcp.json` at the plugin root to register MCP servers, but `.gitignore:486` had a blanket `.mcp.json` rule that swept up the plugin's own descriptor. The marketplace install only pulls tracked files, so installed copies of `roslyn-mcp@roslyn-mcp-marketplace` shipped without any `.mcp.json` — skills loaded fine, but the Roslyn MCP server never came up. Confirmed via the Claude desktop log (`mcp.log` enumerated 6 SDK servers, none of them roslyn).

- `.gitignore` — added `!/.mcp.json` exception so the repo-root descriptor is tracked while still ignoring user-local `.mcp.json` files in subdirs and other dev clones.
- `.mcp.json` (new) — canonical wrapper-format descriptor with the full `${user_config.*}` env wiring (`ROSLYNMCP_MAX_WORKSPACES`, `BUILD_TIMEOUT_SECONDS`, `TEST_TIMEOUT_SECONDS`, `RATE_LIMIT_MAX_REQUESTS`, `REQUEST_TIMEOUT_SECONDS`). The userConfig keys mirror those declared in `.claude-plugin/plugin.json`.

After this lands, `claude plugin update roslyn-mcp@roslyn-mcp-marketplace` (or toggle off/on in Customize) will install the descriptor into `~/.claude/plugins/cache/.../<version>/` and the Roslyn MCP tools will register in fresh sessions automatically.

### 2. Import 4 deep-review audit reports + rollup scaffold (commit `482012a`)

Imports four MCP server audits run in rw-lock mode against external target repos (and one self-audit), plus the rollup scaffold. All audits captured against the host running roslyn-mcp 1.6.1+f1645292 prior to the 1.7.0 cut.

- `audit-reports/20260407T223900Z_dotnet-firewall-analyzer_rw-lock_mcp-server-audit.md`
- `audit-reports/20260408T033920Z_itchatbot_rw-lock_mcp-server-audit.md`
- `audit-reports/20260408T034457Z_networkdocumentation_rw-lock_mcp-server-audit.md`
- `audit-reports/20260408T034600Z_roslynmcp_mcp-server-audit.md` (self-audit)
- `reports/20260408T034746Z_deep-review-rollup.md` (rollup scaffold; deduped-issues table still empty)

No backlog rows added. These are observational reports; any FLAGs they raise that map to existing backlog ids (`workspace-payload-summary-modes`, `workspace-failure-severity-normalize`, `project-diagnostics-filter-totals`, `compile-check-emit-validation-regression-check`) are already tracked.

## Test plan

- [x] `.mcp.json` validates as JSON
- [x] `git check-ignore -v .mcp.json` shows the new `!/.mcp.json` rule winning over the prior `.mcp.json` rule
- [x] Direct stdio probe of `roslynmcp.exe` returns `serverInfo.version = 1.7.0.0` (assembly bump from `46e9f72` already in place)
- [x] In-session `mcp__roslyn__server_info` reports `version: 1.7.0+46e9f7283d18982754724b804991a4356b3285fc`
- [x] In-session `workspace_load` of `Roslyn-Backed-MCP.sln` returns 6 projects / 321 documents, no workspace diagnostics
- [ ] Post-merge: `claude plugin update roslyn-mcp@roslyn-mcp-marketplace` should pull the new `.mcp.json` into the install cache; new sessions then surface `mcp__roslyn-mcp__*` tools without the deferred-tools handshake

🤖 Generated with [Claude Code](https://claude.com/claude-code)