### PR TITLE
docs: enumerate the 5 version-bump locations in release-policy.md

### DIFF
--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -28,6 +28,45 @@ A release is production-ready when all of the following are true:
 - Experimental-surface changes must still be called out in release notes.
 - Deprecate stable entries for at least one minor release before removal.
 
+## Where To Bump The Version String
+
+The repo has **five** files that hold a literal version string. All five must move together on every release. There is currently no automated drift check (`eng/verify-release.ps1` does not validate them), so every bump PR must touch all five or it will ship inconsistent metadata.
+
+| # | File | Field | Consumer | Notes |
+|---|------|-------|----------|-------|
+| 1 | `Directory.Build.props` | `<Version>` element | MSBuild master | Flows to `AssemblyVersion`, `FileVersion`, and `InformationalVersion` (via SourceLink) for every project that inherits the props. This is what `server_info` returns at runtime and what the MCP `initialize` handshake reports as `serverInfo.version` — `Program.cs` reads it via reflection, so the host code itself is never edited for a version bump. |
+| 2 | `.claude-plugin/plugin.json` | `"version"` | Claude Code plugin loader | Canonical for `/plugin update`. The Claude Code client uses this value to decide whether the cached install in `~/.claude/plugins/cache/.../<version>/` is stale. If you change code without bumping this, existing users will not see your changes (the install cache hash matches the recorded version). |
+| 3 | `.claude-plugin/marketplace.json` | `plugins[].version` | Marketplace catalog entry | Discovery/listing. Per the [Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference#metadata-fields), if both `plugin.json` and the marketplace entry set `version`, `plugin.json` wins. Keep them aligned anyway — drift here surfaces in the `/plugin` discover UI. |
+| 4 | `manifest.json` (repo root) | `"version"` | Legacy DXT-style manifest | Not read by Claude Code's plugin loader (which uses `.claude-plugin/plugin.json` per file #2). Kept for parity with other consumers / older tooling that still parses the DXT format. Bump it together with the others to avoid confusion. |
+| 5 | `CHANGELOG.md` | `## [X.Y.Z] - YYYY-MM-DD` header | Release notes anchor | The new section header for the release line. Must be added (not edited) — historical entries stay in place. |
+
+Locations that are **not** manual bumps (do not edit them):
+
+- `src/RoslynMcp.Host.Stdio/Program.cs` — reads from the assembly attribute at runtime (`typeof(...).Assembly.GetName().Version`).
+- `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs` — reads `AssemblyInformationalVersionAttribute` at runtime for `server_info`.
+- `eng/update-claude-plugin.ps1` — reads version from `~/.claude/plugins/installed_plugins.json` at runtime (the `1.6.0` in the doc-comment example is illustrative only).
+- `eng/verify-release.ps1` — does no version validation today.
+
+### Pre-merge verification command
+
+Run this from the repo root before merging a version-bump PR:
+
+```bash
+grep -n -H -E '"version"|<Version>|^## \[[0-9]' \
+    Directory.Build.props \
+    .claude-plugin/plugin.json \
+    .claude-plugin/marketplace.json \
+    manifest.json \
+    CHANGELOG.md
+```
+
+The grep is intentionally inclusive. When eyeballing the output:
+
+- **Must agree on the new version:** `Directory.Build.props:<line>`, `.claude-plugin/plugin.json:3`, `.claude-plugin/marketplace.json` plugin entry (the `plugins[].version` line, **not** line 9), `manifest.json:4`, and the **top** `CHANGELOG.md` `## [X.Y.Z]` header.
+- **Ignore:** `.claude-plugin/marketplace.json:9` is the marketplace catalog's own `metadata.version` schema version (`1.0.0`) — it does not track the plugin version. Older `## [X.Y.Z]` headers further down `CHANGELOG.md` are historical entries, not drift.
+
+If you ever automate this drift check, add it to `eng/verify-release.ps1` and remove this manual step from the checklist below.
+
 ## Release Checklist
 
 1. Run `eng/verify-release.ps1`.
@@ -35,8 +74,9 @@ A release is production-ready when all of the following are true:
 3. Review dependency audit output from CI.
 4. Confirm `server_info` and `server_catalog` reflect the intended support tiers.
 5. For material surface, preview/apply-behavior, or tiering changes, review the latest deep-review rollup under `ai_docs/reports/` and its raw evidence under `ai_docs/audit-reports/`.
-6. Publish the host executable built from `src/RoslynMcp.Host.Stdio`.
-7. Confirm docs remain synchronized (`README.md`, `AGENTS.md`, and `docs/product-contract.md`) for any surface or tiering change.
+6. **Run the version-string drift check** from [Where To Bump The Version String](#where-to-bump-the-version-string). All five files must agree.
+7. Publish the host executable built from `src/RoslynMcp.Host.Stdio`.
+8. Confirm docs remain synchronized (`README.md`, `AGENTS.md`, and `docs/product-contract.md`) for any surface or tiering change.
 
 ## Agent Session Release Gate
 


### PR DESCRIPTION
## Summary

Diagnosing the 1.6.1 → 1.7.0 transition exposed that there is no automated drift check between the five files that hold a literal version string in this repo. The next person to bump (or any AI agent following the changelog) is one keystroke away from shipping inconsistent metadata: assembly version, plugin loader cache key, marketplace listing, DXT manifest, and changelog header all live in different files with no enforcement linking them.

This PR adds a **Where To Bump The Version String** section to `docs/release-policy.md` so the next bumper has a single, authoritative checklist.

### What the new section covers

**5 manual-bump files** (must move together every release):

1. `Directory.Build.props` `<Version>` — MSBuild master, drives `AssemblyVersion`/`FileVersion`/`InformationalVersion` for every project; `server_info` and the MCP `initialize` handshake report this via reflection.
2. `.claude-plugin/plugin.json` `"version"` — canonical for Claude Code's `/plugin update` cache invalidation.
3. `.claude-plugin/marketplace.json` `plugins[].version` — marketplace catalog discovery entry.
4. `manifest.json` (root) `"version"` — legacy DXT manifest, parallel to #2.
5. `CHANGELOG.md` `## [X.Y.Z] - YYYY-MM-DD` header — release notes anchor.

**4 do-NOT-bump locations** (read versions at runtime, no drift risk):

- `Program.cs` (assembly attribute via reflection)
- `ServerTools.cs` (`AssemblyInformationalVersionAttribute` via reflection)
- `eng/update-claude-plugin.ps1` (reads from `installed_plugins.json`)
- `eng/verify-release.ps1` (does no version validation today — flagged for future automation)

**Pre-merge verification grep** + a short "what to ignore" guide for the two known false positives (`marketplace.json:9` is the marketplace catalog's own `metadata.version` schema field, and CHANGELOG matches every historical release header).

### Release checklist update

Wired the drift check into the existing Release Checklist as new step 6 so it has to be acknowledged before publish.

## Test plan

- [x] Doc renders cleanly (verified inline read-back)
- [x] Verification grep command runs against the live repo and produces the expected output (5 must-agree lines + 2 ignored lines, all currently at 1.7.0)
- [x] All 5 manual-bump locations confirmed at 1.7.0 today
- [x] Hyperlink to the section anchor (`#where-to-bump-the-version-string`) renders correctly in GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)