### PR TITLE
fix: structured NotFound for unresolvable symbols + resource error envelope

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-08T15:25:00Z
+**updated_at:** 2026-04-08T15:50:00Z
 
 ## Agent contract
 
@@ -30,7 +30,6 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 
 | id | blocker | deps | do |
 |----|---------|------|-----|
-| `error-response-observability` | none | — | **P2 / observability.** Two related error-shape gaps surfaced in the 2026-04-07 ITChatBot rw-lock audit: (a) `find_references` (and likely `find_consumers`/`find_type_usages`) with an invalid `symbolHandle` (e.g. fabricated base64 of `{"MetadataName":"fake"}`) returns `{count:0, totalCount:0, references:[], hasMore:false}` instead of a structured NotFound error — callers cannot distinguish "valid handle, zero references" from "junk handle"; (b) error responses on workspace-scoped tools (`workspace_status` and likely siblings sharing the same wrapper) populate `tool: "unknown"` instead of the actual tool name. Fix both: emit a structured NotFound envelope from the symbol-handle tools (matching `workspace_status`'s NotFound shape), and have the error wrapper read the originating tool name from the dispatcher. |
 | `test-run-failure-envelope` | none | — | **P2 / reliability.** 2026-04-08 audits: `test_run` failed with MSB3027/3021 file locks when `testhost` still holds Roslyn DLLs (roslyn-backed-mcp 130615), and with a generic MCP bridge error `An error occurred invoking 'test_run'` with no structured payload (131317). Surface exit code, stdout/stderr excerpts, and whether the failure is retryable; document Windows concurrent-test behavior in the tool description. |
 | `audit-feasibility-companion-cli` | none | `workspace-payload-summary-modes` | **P2 / tooling.** A complete walkthrough of `ai_docs/prompts/deep-review-and-refactor.md` against a 34-project / 751-document solution does not fit in a single Claude Code conversation today, primarily because workspace-payload bloat tools (`workspace_load`, `workspace_status`, `workspace_list`, `roslyn://workspaces`, `get_nuget_dependencies`, `list_analyzers`, `get_msbuild_properties`, `find_unused_symbols`) exhaust the per-turn ~250 KB output budget by mid-prompt — observed against the 34-project ITChatBot.sln in the 2026-04-07 rw-lock audit. Consider shipping a `roslyn-mcp-audit` companion CLI that drives the deep-review prompt headlessly and emits the canonical raw audit file as an artifact, freeing the LLM from having to render every tool result back through context. The payload-summary-modes fix alone may lift this ceiling enough that a CLI is unnecessary — re-evaluate after that lands. |
 | `dependency-service-srp-split` | none | — | **P3 / refactor.** `DependencyAnalysisService` (now 610 LOC, up from 530) owns four responsibilities: namespace dependency graphs, DI registration scanning, NuGet package listing, and NuGet vulnerability scanning. Split into `NamespaceDependencyService`, `DiRegistrationService`, and `NuGetDependencyService`; `DependencyAnalysisService` becomes a façade or is deleted. Also covers `ParseNuGetVulnerabilityJson` (still inline, cyclomatic ~27, ~86 LOC with nested local function capturing outer variables) — extract `NuGetVulnerabilityJsonParser` static class and eliminate the nested function. Defer until a touch-the-class change is needed. |

--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -13,92 +13,71 @@ public static class WorkspaceResources
 
     [McpServerResource(UriTemplate = "roslyn://workspaces", Name = "workspaces", MimeType = "application/json")]
     [Description("List all currently loaded workspace sessions with a lean summary per workspace (counts and load state, no per-project tree). For the verbose payload use roslyn://workspaces/verbose. Workspace-scoped resources (status, projects, diagnostics, source_file) use URI templates — if your MCP client only shows static resources from resources/list, read roslyn://server/resource-templates to discover those templates.")]
-    public static string GetWorkspaces(IWorkspaceManager workspace)
-    {
-        try
+    public static string GetWorkspaces(IWorkspaceManager workspace) =>
+        ToolErrorHandler.ExecuteResource("roslyn://workspaces", () =>
         {
             var workspaces = workspace.ListWorkspaces();
             var summaries = workspaces.Select(WorkspaceStatusSummaryDto.From).ToList();
             return JsonSerializer.Serialize(new { count = summaries.Count, workspaces = summaries }, JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
     [McpServerResource(UriTemplate = "roslyn://workspaces/verbose", Name = "workspaces_verbose", MimeType = "application/json")]
     [Description("Verbose variant of roslyn://workspaces — returns the full per-project tree and workspace diagnostics for every loaded session. Can be large on multi-project solutions; prefer the summary resource at roslyn://workspaces unless you need the full payload.")]
-    public static string GetWorkspacesVerbose(IWorkspaceManager workspace)
-    {
-        try
+    public static string GetWorkspacesVerbose(IWorkspaceManager workspace) =>
+        ToolErrorHandler.ExecuteResource("roslyn://workspaces/verbose", () =>
         {
             var workspaces = workspace.ListWorkspaces();
             return JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/status", Name = "workspace_status", MimeType = "application/json")]
     [Description("Get a lean summary of a loaded workspace's status (counts and load state, no per-project tree). For the verbose payload use roslyn://workspace/{workspaceId}/status/verbose. URI uses the workspace_status template; see roslyn://server/resource-templates if your client does not list template URIs.")]
     public static string GetWorkspaceStatus(
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier")] string workspaceId)
-    {
-        try
+        [Description("The workspace session identifier")] string workspaceId) =>
+        ToolErrorHandler.ExecuteResource("roslyn://workspace/{workspaceId}/status", () =>
         {
             var status = workspace.GetStatus(workspaceId);
             return JsonSerializer.Serialize(WorkspaceStatusSummaryDto.From(status), JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/status/verbose", Name = "workspace_status_verbose", MimeType = "application/json")]
     [Description("Verbose variant of roslyn://workspace/{workspaceId}/status — returns the full per-project tree and workspace diagnostics for the workspace. Prefer the summary resource at roslyn://workspace/{workspaceId}/status unless you need the full payload.")]
     public static string GetWorkspaceStatusVerbose(
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier")] string workspaceId)
-    {
-        try
+        [Description("The workspace session identifier")] string workspaceId) =>
+        ToolErrorHandler.ExecuteResource("roslyn://workspace/{workspaceId}/status/verbose", () =>
         {
             var status = workspace.GetStatus(workspaceId);
             return JsonSerializer.Serialize(status, JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/projects", Name = "workspace_projects", MimeType = "application/json")]
     [Description("Get the project dependency graph and project metadata for a workspace. Requires workspaceId from workspace_load; see roslyn://server/resource-templates for the URI pattern.")]
     public static string GetProjects(
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier")] string workspaceId)
-    {
-        try
+        [Description("The workspace session identifier")] string workspaceId) =>
+        ToolErrorHandler.ExecuteResource("roslyn://workspace/{workspaceId}/projects", () =>
         {
             var graph = workspace.GetProjectGraph(workspaceId);
             return JsonSerializer.Serialize(graph, JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/diagnostics", Name = "workspace_diagnostics", MimeType = "application/json")]
     [Description("Get all compiler diagnostics for a loaded workspace. Workspace-scoped URI; see roslyn://server/resource-templates.")]
-    public static async Task<string> GetDiagnostics(
+    public static Task<string> GetDiagnostics(
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier")] string workspaceId,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/diagnostics", async () =>
         {
             var diagnostics = await diagnosticService.GetDiagnosticsAsync(workspaceId, null, null, null, ct).ConfigureAwait(false);
             return JsonSerializer.Serialize(diagnostics, JsonDefaults.Indented);
-        }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
-    }
+        });
 
+    // source_file is text/x-csharp, not JSON, so we cannot return a JSON envelope on error.
+    // Throwing McpToolException with the OriginatingSource keeps the framework's default
+    // exception path; the MCP client will see a generic error rather than a structured envelope.
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}", Name = "source_file", MimeType = "text/x-csharp")]
     [Description("Read the source text of a file in the loaded workspace. filePath must be URL-encoded; see roslyn://server/resource-templates.")]
     public static async Task<string> GetSourceFile(
@@ -107,6 +86,7 @@ public static class WorkspaceResources
         [Description("Absolute path to the source file (URL-encoded)")] string filePath,
         CancellationToken ct = default)
     {
+        const string source = "roslyn://workspace/{workspaceId}/file/{filePath}";
         try
         {
             var text = await workspace.GetSourceTextAsync(workspaceId, filePath, ct).ConfigureAwait(false);
@@ -114,7 +94,7 @@ public static class WorkspaceResources
                 throw new KeyNotFoundException($"Document not found in workspace: {filePath}");
             return text;
         }
-        catch (KeyNotFoundException ex) { throw new McpToolException($"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException($"Invalid operation: {ex.Message}", ex); }
+        catch (KeyNotFoundException ex) { throw new McpToolException(source, $"Not found: {ex.Message}", ex); }
+        catch (InvalidOperationException ex) { throw new McpToolException(source, $"Invalid operation: {ex.Message}", ex); }
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -39,6 +39,56 @@ internal static class ToolErrorHandler
     };
 
     /// <summary>
+    /// Wraps a synchronous resource action with structured error handling, returning the same
+    /// error envelope shape as <see cref="ExecuteAsync"/> so JSON-MIME resources surface a
+    /// well-formed error document with the correct <c>tool</c> field instead of bubbling an
+    /// exception that the framework labels as <c>tool: "unknown"</c>. The <paramref name="source"/>
+    /// is the resource URI (or its template form) that originated the call.
+    /// </summary>
+    public static string ExecuteResource(string source, Func<string> action, ILogger? auditLogger = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        try
+        {
+            return action();
+        }
+        catch (Exception ex)
+        {
+            var info = ClassifyError(ex, source);
+            auditLogger?.Log(
+                info.Category == "InternalError" ? LogLevel.Error : LogLevel.Warning,
+                ex, "Resource {Source} failed: {ErrorCategory}", source, info.Category);
+            return FormatErrorResponse(info, source, ex);
+        }
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="ExecuteResource"/> for awaitable resource handlers.
+    /// </summary>
+    public static async Task<string> ExecuteResourceAsync(string source, Func<Task<string>> action, ILogger? auditLogger = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        try
+        {
+            return await action().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var info = ClassifyError(ex, source);
+            auditLogger?.Log(
+                info.Category == "InternalError" ? LogLevel.Error : LogLevel.Warning,
+                ex, "Resource {Source} failed: {ErrorCategory}", source, info.Category);
+            return FormatErrorResponse(info, source, ex);
+        }
+    }
+
+    /// <summary>
     /// Wraps a tool action with structured error handling. Returns errors as structured JSON content
     /// so MCP clients always receive actionable error details, regardless of SDK exception handling.
     /// </summary>
@@ -194,6 +244,27 @@ internal static class ToolErrorHandler
 
 /// <summary>
 /// Exception type for tool errors. Can be used by resource handlers and other non-tool contexts
-/// where structured JSON error responses are not applicable.
+/// where structured JSON error responses are not applicable. The optional
+/// <see cref="OriginatingSource"/> property carries the originating tool name or resource URI
+/// so the MCP framework can label error envelopes with the actual originator instead of
+/// "unknown".
 /// </summary>
-public sealed class McpToolException(string message, Exception? inner = null) : Exception(message, inner);
+public sealed class McpToolException : Exception
+{
+    /// <summary>
+    /// Originating tool name or resource URI (e.g., <c>"workspace_status"</c>,
+    /// <c>"roslyn://workspaces"</c>). When null, defaults to "unknown" in the rendered envelope.
+    /// Named with the <c>Originating</c> prefix to avoid colliding with the inherited
+    /// <see cref="Exception.Source"/> property (which is the assembly name by default).
+    /// </summary>
+    public string? OriginatingSource { get; }
+
+    public McpToolException(string message, Exception? inner = null) : base(message, inner)
+    {
+    }
+
+    public McpToolException(string source, string message, Exception? inner = null) : base(message, inner)
+    {
+        OriginatingSource = source;
+    }
+}

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
@@ -39,6 +39,31 @@ public static class SymbolResolver
     }
 
     /// <summary>
+    /// Same as <see cref="ResolveAsync"/> but throws <see cref="KeyNotFoundException"/> when the
+    /// locator does not resolve to a symbol. Used by reader tools (`find_references`,
+    /// `find_consumers`, `find_type_usages`, etc.) so callers see a structured NotFound envelope
+    /// from <see cref="RoslynMcp.Host.Stdio.Tools.ToolErrorHandler"/> instead of an empty result
+    /// that can't be distinguished from a legitimate "valid symbol, zero references" outcome.
+    /// </summary>
+    /// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown when the locator decodes correctly but no symbol can be found in the solution.</exception>
+    /// <exception cref="System.ArgumentException">Thrown when <paramref name="locator"/> does not contain a valid identification strategy.</exception>
+    public static async Task<ISymbol> ResolveOrThrowAsync(Solution solution, SymbolLocator locator, CancellationToken ct)
+    {
+        var symbol = await ResolveAsync(solution, locator, ct).ConfigureAwait(false);
+        if (symbol is not null) return symbol;
+
+        var detail = locator.HasHandle
+            ? "the supplied symbol handle"
+            : locator.HasMetadataName
+                ? $"metadata name '{locator.MetadataName}'"
+                : $"position {locator.FilePath}:{locator.Line}:{locator.Column}";
+
+        throw new KeyNotFoundException(
+            $"No symbol could be resolved for {detail}. The handle may be from a previous workspace " +
+            "version, the symbol may have been removed, or the position may not contain a symbol identifier.");
+    }
+
+    /// <summary>
     /// Resolves the symbol at the given 1-based <paramref name="line"/> and <paramref name="column"/> position
     /// in the specified source file.
     /// </summary>

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -23,8 +23,9 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
         string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return null;
+        // Throw on unresolved symbol so callers see a structured NotFound envelope
+        // (matches find_references contract).
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -28,8 +28,9 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return null;
+        // Throw on unresolved symbol so callers see a structured NotFound envelope
+        // (matches find_references contract).
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
@@ -158,8 +159,9 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
     public async Task<IReadOnlyList<TypeUsageDto>> FindTypeUsagesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return [];
+        // Throw on unresolved symbol so callers see a structured NotFound envelope
+        // (matches find_references contract).
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -21,8 +21,9 @@ public sealed class ReferenceService : IReferenceService
     public async Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return [];
+        // Throw on unresolved symbol so callers get a structured NotFound envelope
+        // instead of an empty list they cannot distinguish from "valid symbol, zero references".
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
@@ -40,8 +41,7 @@ public sealed class ReferenceService : IReferenceService
     public async Task<IReadOnlyList<LocationDto>> FindImplementationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return [];
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var implementations = await SymbolFinder.FindImplementationsAsync(symbol, solution, cancellationToken: ct).ConfigureAwait(false);
         var results = new List<LocationDto>();
@@ -62,11 +62,7 @@ public sealed class ReferenceService : IReferenceService
     public async Task<IReadOnlyList<LocationDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null)
-        {
-            return [];
-        }
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         var overrides = await SymbolFinder.FindOverridesAsync(symbol, solution, cancellationToken: ct).ConfigureAwait(false);
         return await SymbolServiceHelpers.SymbolsToLocationsAsync(overrides, solution, ct).ConfigureAwait(false);
@@ -75,11 +71,7 @@ public sealed class ReferenceService : IReferenceService
     public async Task<IReadOnlyList<LocationDto>> FindBaseMembersAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null)
-        {
-            return [];
-        }
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
         return await SymbolServiceHelpers.SymbolsToLocationsAsync(SymbolServiceHelpers.GetBaseMembers(symbol), solution, ct).ConfigureAwait(false);
     }

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -33,11 +33,15 @@ public sealed class ConsumerAnalysisTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public async Task FindConsumers_NonExistentSymbol_ReturnsNull()
+    public async Task FindConsumers_NonExistentSymbol_ThrowsKeyNotFoundException()
     {
+        // After error-response-observability fix: unresolvable handles/metadata names throw
+        // KeyNotFoundException so the tool layer's ToolErrorHandler emits a structured
+        // NotFound envelope (instead of the old null/empty result that callers could not
+        // distinguish from a legitimate "valid symbol, zero consumers" outcome).
         var locator = SymbolLocator.ByMetadataName("SampleLib.NonExistentType");
-        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
-        Assert.IsNull(result);
+        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(
+            () => ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None));
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
+++ b/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Resources;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class ErrorResponseObservabilityTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task FindReferences_WithUnresolvableHandle_ReturnsStructuredNotFoundEnvelope()
+    {
+        // Fabricated but structurally valid handle: decodes correctly, has a metadata name,
+        // but the symbol does not exist in the workspace. Pre-fix this returned
+        // {count:0, totalCount:0, references:[]} which the caller could not distinguish
+        // from a legitimate "valid handle, zero references" outcome.
+        var fakeHandle = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes("""{"MetadataName":"NonExistentNamespace.NonExistentType"}"""));
+
+        var json = await SymbolTools.FindReferences(
+            WorkspaceExecutionGate,
+            ReferenceService,
+            WorkspaceId,
+            filePath: null,
+            line: null,
+            column: null,
+            symbolHandle: fakeHandle,
+            limit: 100,
+            offset: 0,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
+            $"Expected structured error envelope. Actual: {json}");
+        Assert.IsTrue(errorProp.GetBoolean(),
+            "Error envelope must have error: true.");
+        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString(),
+            "Unresolvable handle should map to NotFound category.");
+        Assert.AreEqual("find_references", doc.RootElement.GetProperty("tool").GetString(),
+            "Tool field must contain the actual tool name, not 'unknown'.");
+    }
+
+    [TestMethod]
+    public void Resource_GetWorkspaceStatus_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
+    {
+        // Pre-fix: a resource exception bubbled to the framework which labelled it
+        // tool: "unknown". Post-fix: ExecuteResource catches the exception and emits
+        // the canonical error envelope with the resource URI as the tool field.
+        var json = WorkspaceResources.GetWorkspaceStatus(WorkspaceManager, "ffffffffffffffffffffffffffffffff");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
+            $"Expected structured error envelope. Actual: {json}");
+        Assert.IsTrue(errorProp.GetBoolean());
+        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("roslyn://workspace/{workspaceId}/status",
+            doc.RootElement.GetProperty("tool").GetString(),
+            "Resource URI must populate the tool field, not 'unknown'.");
+    }
+
+    [TestMethod]
+    public void Resource_GetProjects_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
+    {
+        var json = WorkspaceResources.GetProjects(WorkspaceManager, "ffffffffffffffffffffffffffffffff");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
+        Assert.AreEqual("roslyn://workspace/{workspaceId}/projects",
+            doc.RootElement.GetProperty("tool").GetString());
+    }
+}


### PR DESCRIPTION
## Summary

Two related observability fixes for the symbol-handle and resource error paths.

### Part (a) — symbol-handle tools throw on unresolvable handles
Pre-fix: \`find_references\` (and the other handle-driven tools) returned \`{count:0, totalCount:0, references:[]}\` when handed a structurally valid but unfindable symbol handle. Callers couldn't distinguish junk from zero. Post-fix: a new \`SymbolResolver.ResolveOrThrowAsync\` throws \`KeyNotFoundException\` and the existing \`ToolErrorHandler\` mapping emits the canonical \`category: NotFound\` envelope.

Touches: \`find_references\`, \`find_consumers\`, \`find_type_usages\`, \`find_implementations\`, \`find_overrides\`, \`find_base_members\`, \`impact_analysis\`, \`find_type_mutations\`. (\`find_property_writes\` keeps its tuple-return contract because it intentionally distinguishes "not a property" from "no writes".)

### Part (b) — resource error envelopes carry the source URI
Pre-fix: resource exceptions bubbled to the framework which labelled them \`tool: "unknown"\`. Post-fix: \`McpToolException\` carries an \`OriginatingSource\` property and new \`ToolErrorHandler.ExecuteResource\`/\`ExecuteResourceAsync\` helpers catch exceptions in JSON-MIME resource handlers and emit the canonical error envelope with the resource URI in the \`tool\` field.

\`source_file\` (text/x-csharp) keeps the throwing path but at least carries the URI in \`OriginatingSource\` for any framework-level renderer.

## Test plan
- [x] \`dotnet build RoslynMcp.slnx --nologo\` clean
- [x] \`dotnet test RoslynMcp.slnx --nologo\` 282 passed (3 new + 1 contract update)
- [x] New test: fabricated \`{\"MetadataName\":\"NonExistentNamespace.NonExistentType\"}\` handle on \`find_references\` → structured NotFound envelope with correct \`tool\` field
- [x] New test: \`roslyn://workspace/{workspaceId}/status\` with unknown id returns envelope with the URI in \`tool\`
- [x] Existing \`ConsumerAnalysisTests.FindConsumers_NonExistentSymbol\` flipped from \`ReturnsNull\` to \`ThrowsKeyNotFoundException\` to match the new contract
- [ ] CI: \`verify-ai-docs.ps1\` + \`verify-release.ps1\` + CodeQL

## Backlog
- Closes \`error-response-observability\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)