### PR TITLE
fix: structured test_run failure envelope

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-08T19:00:00Z
+**updated_at:** 2026-04-08T22:00:00Z
 
 ## Agent contract
 
@@ -30,7 +30,6 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 
 | id | blocker | deps | do |
 |----|---------|------|-----|
-| `test-run-failure-envelope` | none | — | **P2 / reliability.** 2026-04-08 audits: `test_run` failed with MSB3027/3021 file locks when `testhost` still holds Roslyn DLLs (roslyn-backed-mcp 130615), and with a generic MCP bridge error `An error occurred invoking 'test_run'` with no structured payload (131317). Surface exit code, stdout/stderr excerpts, and whether the failure is retryable; document Windows concurrent-test behavior in the tool description. |
 | `workspace-session-deduplication` | none | — | **P3 / session model.** Loading the same solution path twice in one host process can yield `workspace_list` with multiple distinct `WorkspaceId`s (2026-04-08 roslyn-backed-mcp audit 130615; not reproduced on a later pass — intermittent). Wastes workspace slots and confuses audits. Consider idempotent `workspace_load` or explicit dedup. |
 | `revert-last-apply-disk-consistency` | none | — | **P3 / undo.** `revert_last_apply` reported success while the on-disk file still contained the applied text until manual cleanup and `workspace_reload` (2026-04-08 NetworkDocumentation audit). Align workspace model with disk or document the edge case. |
 | `semantic-search-zero-results-verbose-query` | none | — | **P3 / UX.** `semantic_search` returned `count: 0` for a long natural-language query while a shorter query returned hits on the same repo (2026-04-08 FirewallAnalyzer audit). Add keyword/stem fallback or scoring/debug payload when the embedding ranker returns empty. |

--- a/src/RoslynMcp.Core/Models/TestRunResultDto.cs
+++ b/src/RoslynMcp.Core/Models/TestRunResultDto.cs
@@ -1,7 +1,10 @@
 namespace RoslynMcp.Core.Models;
 
 /// <summary>
-/// Represents the result of executing a test run.
+/// Represents the result of executing a test run. When <paramref name="FailureEnvelope"/>
+/// is non-null, the run terminated without producing structured TRX output and the
+/// envelope carries a typed classification (file lock, build failure, timeout, unknown)
+/// plus the tail of StdOut/StdErr so callers can decide whether to retry.
 /// </summary>
 public sealed record TestRunResultDto(
     CommandExecutionDto Execution,
@@ -9,7 +12,8 @@ public sealed record TestRunResultDto(
     int Passed,
     int Failed,
     int Skipped,
-    IReadOnlyList<TestFailureDto> Failures);
+    IReadOnlyList<TestFailureDto> Failures,
+    TestRunFailureEnvelopeDto? FailureEnvelope = null);
 
 /// <summary>
 /// Represents a failed test case from a test run.
@@ -19,3 +23,33 @@ public sealed record TestFailureDto(
     string? FullyQualifiedName,
     string Message,
     string? StackTrace);
+
+/// <summary>
+/// Structured failure envelope populated when <c>dotnet test</c> exits without producing
+/// TRX output (e.g., MSBuild file locks, build failures, timeouts). Carries an
+/// <see cref="ErrorKind"/> classification, a retry hint, and the tail of the captured
+/// StdOut/StdErr streams so callers do not need to re-run just to see what happened.
+/// </summary>
+/// <param name="ErrorKind">
+/// Classification of the failure. One of: <c>"FileLock"</c> (MSB3027/MSB3021),
+/// <c>"BuildFailure"</c> (compilation errors prevented the test run),
+/// <c>"Timeout"</c> (the invocation exceeded the configured test timeout),
+/// <c>"Unknown"</c> (non-zero exit with no TRX and no recognized pattern).
+/// </param>
+/// <param name="IsRetryable">
+/// True when a retry of the same invocation has a reasonable chance of succeeding
+/// without changing source — e.g., file-lock collisions caused by another test host.
+/// </param>
+/// <param name="Summary">Short human-readable explanation of the detected failure mode.</param>
+/// <param name="StdOutTail">
+/// Last ~2000 characters of captured standard output, or <c>null</c> when nothing was captured.
+/// </param>
+/// <param name="StdErrTail">
+/// Last ~2000 characters of captured standard error, or <c>null</c> when nothing was captured.
+/// </param>
+public sealed record TestRunFailureEnvelopeDto(
+    string ErrorKind,
+    bool IsRetryable,
+    string Summary,
+    string? StdOutTail,
+    string? StdErrTail);

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -135,7 +135,7 @@ public static class ValidationTools
             }, ct));
     }
 
-    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results")]
+    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results. When the run cannot produce TRX output (MSBuild file lock, build failure, timeout, unknown exit) the result carries a populated FailureEnvelope with ErrorKind ('FileLock'|'BuildFailure'|'Timeout'|'Unknown'), IsRetryable, Summary, and tails of StdOut/StdErr — instead of throwing a bare invocation error. Windows note: MSB3027/MSB3021 file-lock failures typically mean another testhost.exe (IDE test runner, background build) is holding the test assembly; the envelope classifies these as retryable so callers can close the conflicting runner and retry without touching source.")]
     public static Task<string> RunTests(
         IWorkspaceExecutionGate gate,
         ITestRunnerService testRunnerService,

--- a/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
@@ -12,6 +12,11 @@ internal static partial class DotnetOutputParser
     [GeneratedRegex(@"^(?<file>.+?)\((?<line>\d+),(?<column>\d+)(,(?<endLine>\d+),(?<endColumn>\d+))?\): (?<severity>error|warning) (?<id>[A-Z]{2,}\d+): (?<message>.+?)( \[(?<project>.+)\])?$", RegexOptions.Compiled)]
     private static partial Regex DiagnosticRegex();
 
+    [GeneratedRegex(@"MSB(3027|3021)", RegexOptions.Compiled)]
+    private static partial Regex MsBuildFileLockRegex();
+
+    private const int FailureTailMaxChars = 2000;
+
     /// <summary>
     /// Parses MSBuild-style diagnostic lines from <c>dotnet build</c> standard output.
     /// </summary>
@@ -56,7 +61,10 @@ internal static partial class DotnetOutputParser
 
     /// <summary>
     /// Parses one or more TRX files produced by <c>dotnet test</c> (solution runs may emit multiple TRX files)
-    /// into a single aggregated <see cref="TestRunResultDto"/>.
+    /// into a single aggregated <see cref="TestRunResultDto"/>. When no TRX files exist and the
+    /// underlying command failed, the result carries a populated <see cref="TestRunFailureEnvelopeDto"/>
+    /// so callers see a structured classification (file lock / build failure / unknown) instead of
+    /// a bare invocation error.
     /// </summary>
     public static TestRunResultDto ParseTestRun(
         CommandExecutionDto execution,
@@ -64,13 +72,18 @@ internal static partial class DotnetOutputParser
     {
         if (trxPaths.Count == 0)
         {
+            var envelope = execution.Succeeded
+                ? null
+                : ClassifyNoTrxFailure(execution);
+
             return new TestRunResultDto(
                 execution,
                 Total: 0,
                 Passed: 0,
                 Failed: execution.Succeeded ? 0 : 1,
                 Skipped: 0,
-                Failures: []);
+                Failures: [],
+                FailureEnvelope: envelope);
         }
 
         var total = 0;
@@ -90,6 +103,85 @@ internal static partial class DotnetOutputParser
         }
 
         return new TestRunResultDto(execution, total, passed, failed, skipped, failures);
+    }
+
+    /// <summary>
+    /// Builds a synthetic <see cref="TestRunResultDto"/> for the case where the test invocation
+    /// was cancelled by a timeout before <c>dotnet test</c> could produce any output. Callers
+    /// supply the truncated <see cref="CommandExecutionDto"/> shell and the timeout message.
+    /// </summary>
+    public static TestRunResultDto BuildTimeoutResult(CommandExecutionDto execution, string timeoutSummary)
+    {
+        var envelope = new TestRunFailureEnvelopeDto(
+            ErrorKind: "Timeout",
+            IsRetryable: false,
+            Summary: timeoutSummary,
+            StdOutTail: Tail(execution.StdOut),
+            StdErrTail: Tail(execution.StdErr));
+
+        return new TestRunResultDto(
+            execution,
+            Total: 0,
+            Passed: 0,
+            Failed: 1,
+            Skipped: 0,
+            Failures: [],
+            FailureEnvelope: envelope);
+    }
+
+    private static TestRunFailureEnvelopeDto ClassifyNoTrxFailure(CommandExecutionDto execution)
+    {
+        var stdOutTail = Tail(execution.StdOut);
+        var stdErrTail = Tail(execution.StdErr);
+
+        // MSB3027 / MSB3021: another process holds the test assembly. This is the
+        // Windows concurrent-testhost collision pattern documented in ai_docs/runtime.md
+        // § *Known issues*. Classify as retryable so callers (or an outer retry loop)
+        // can close the conflicting runner and try again without touching source.
+        var lockHit = MsBuildFileLockRegex().IsMatch(execution.StdErr)
+            || MsBuildFileLockRegex().IsMatch(execution.StdOut);
+        if (lockHit)
+        {
+            return new TestRunFailureEnvelopeDto(
+                ErrorKind: "FileLock",
+                IsRetryable: true,
+                Summary: $"dotnet test exited with code {execution.ExitCode} due to an MSBuild file lock (MSB3027/MSB3021). " +
+                         "Another process (testhost.exe, IDE test runner, or background build) is still holding the test assembly. " +
+                         "Close the conflicting runner and retry the same invocation.",
+                StdOutTail: stdOutTail,
+                StdErrTail: stdErrTail);
+        }
+
+        // Build failure: compilation errors prevented the test step from running.
+        // Not retryable — the caller must fix the source first.
+        var buildFailed = execution.StdOut.Contains("Build FAILED", StringComparison.OrdinalIgnoreCase)
+            || execution.StdErr.Contains("Build FAILED", StringComparison.OrdinalIgnoreCase);
+        if (buildFailed)
+        {
+            return new TestRunFailureEnvelopeDto(
+                ErrorKind: "BuildFailure",
+                IsRetryable: false,
+                Summary: $"dotnet test exited with code {execution.ExitCode} because the build step failed. " +
+                         "Inspect the build diagnostics and fix compilation errors before retrying.",
+                StdOutTail: stdOutTail,
+                StdErrTail: stdErrTail);
+        }
+
+        return new TestRunFailureEnvelopeDto(
+            ErrorKind: "Unknown",
+            IsRetryable: false,
+            Summary: $"dotnet test exited with code {execution.ExitCode} and produced no TRX output. " +
+                     "Inspect StdOutTail/StdErrTail for diagnosis.",
+            StdOutTail: stdOutTail,
+            StdErrTail: stdErrTail);
+    }
+
+    private static string? Tail(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+        return value.Length <= FailureTailMaxChars
+            ? value
+            : value[^FailureTailMaxChars..];
     }
 
     private static (int Total, int Passed, int Failed, int Skipped, List<TestFailureDto> Failures) ParseSingleTrxFile(string trxPath)

--- a/src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj
+++ b/src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj
@@ -28,4 +28,8 @@
     <ProjectReference Include="..\RoslynMcp.Core\RoslynMcp.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="RoslynMcp.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestRunnerService.cs
@@ -77,24 +77,40 @@ public sealed class TestRunnerService : ITestRunnerService
                 arguments.Add(filter);
             }
 
-            var execution = await _executor.ExecuteAsync(
-                workspaceId,
-                targetPath,
-                arguments,
-                _options.TestTimeout,
-                ct).ConfigureAwait(false);
-
-            var trxFiles = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.TopDirectoryOnly);
-            if (trxFiles.Length == 0 && !execution.Succeeded)
+            CommandExecutionDto execution;
+            try
             {
-                var tail = execution.StdOut.Length > 2000
-                    ? execution.StdOut[^2000..]
-                    : execution.StdOut;
-                throw new InvalidOperationException(
-                    $"dotnet test exited with code {execution.ExitCode} and produced no TRX output. " +
-                    $"StdErr: {execution.StdErr}\nStdOut (tail): {tail}");
+                execution = await _executor.ExecuteAsync(
+                    workspaceId,
+                    targetPath,
+                    arguments,
+                    _options.TestTimeout,
+                    ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException ex)
+            {
+                // Synthesize an execution shell so the parser can emit a Timeout envelope
+                // rather than letting the exception escape to ToolErrorHandler as a bare
+                // invocation error. The caller still gets exit code, working directory,
+                // and the configured timeout in the DTO.
+                var workingDirectory = Path.GetDirectoryName(targetPath) ?? Environment.CurrentDirectory;
+                var shell = new CommandExecutionDto(
+                    Command: "dotnet",
+                    Arguments: arguments,
+                    WorkingDirectory: workingDirectory,
+                    TargetPath: targetPath,
+                    ExitCode: -1,
+                    Succeeded: false,
+                    DurationMs: (long)_options.TestTimeout.TotalMilliseconds,
+                    StdOut: string.Empty,
+                    StdErr: ex.Message);
+                return DotnetOutputParser.BuildTimeoutResult(shell, ex.Message);
             }
 
+            var trxFiles = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.TopDirectoryOnly);
+            // FLAG-N1: always pass through to the parser — it handles the no-TRX failure case
+            // by emitting a structured TestRunFailureEnvelopeDto instead of throwing. See
+            // test-run-failure-envelope backlog row (2026-04-08 MSB3027 Windows file-lock audits).
             return DotnetOutputParser.ParseTestRun(execution, trxFiles);
         }
         finally

--- a/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
@@ -1,0 +1,140 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the structured failure envelope for <c>test_run</c> — backlog row
+/// <c>test-run-failure-envelope</c> (P2). When <c>dotnet test</c> exits without
+/// TRX output (MSBuild file locks, build failures, timeouts) the parser must
+/// emit a typed envelope instead of letting a bare invocation error escape to
+/// ToolErrorHandler.
+/// </summary>
+[TestClass]
+public sealed class TestRunFailureEnvelopeTests
+{
+    private static CommandExecutionDto FakeExecution(int exitCode, string stdOut, string stdErr) =>
+        new(
+            Command: "dotnet",
+            Arguments: ["test", "sample.csproj", "--nologo"],
+            WorkingDirectory: "C:/fake/workdir",
+            TargetPath: "C:/fake/workdir/sample.csproj",
+            ExitCode: exitCode,
+            Succeeded: exitCode == 0,
+            DurationMs: 1234,
+            StdOut: stdOut,
+            StdErr: stdErr);
+
+    [TestMethod]
+    public void ParseTestRun_SuccessWithNoTrx_LeavesEnvelopeNull()
+    {
+        var execution = FakeExecution(exitCode: 0, stdOut: "Test run complete.", stdErr: string.Empty);
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNull(result.FailureEnvelope, "Successful runs must not carry a failure envelope.");
+        Assert.AreEqual(0, result.Total);
+        Assert.AreEqual(0, result.Failed);
+    }
+
+    [TestMethod]
+    public void ParseTestRun_NoTrxAndStdErrMsb3027_EmitsRetryableFileLockEnvelope()
+    {
+        const string stdErr =
+            "error MSB3027: Could not copy \"obj/Debug/net10.0/RoslynMcp.Tests.dll\" to \"bin/Debug/net10.0/RoslynMcp.Tests.dll\". " +
+            "Exceeded retry count of 10. Failed. The file is locked by: \"testhost.exe (12345)\"";
+        var execution = FakeExecution(exitCode: 1, stdOut: "Build started", stdErr: stdErr);
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNotNull(result.FailureEnvelope, "File lock failure must populate the envelope.");
+        Assert.AreEqual("FileLock", result.FailureEnvelope!.ErrorKind);
+        Assert.IsTrue(result.FailureEnvelope.IsRetryable,
+            "MSBuild file-lock failures are transient and should be marked retryable.");
+        StringAssert.Contains(result.FailureEnvelope.StdErrTail ?? string.Empty, "MSB3027");
+        StringAssert.Contains(result.FailureEnvelope.Summary, "testhost.exe");
+        Assert.AreEqual(1, result.Failed);
+    }
+
+    [TestMethod]
+    public void ParseTestRun_NoTrxAndStdOutMsb3021_EmitsRetryableFileLockEnvelope()
+    {
+        // MSB3021 variant — the lock may surface in StdOut rather than StdErr depending
+        // on how dotnet test forwards child-process streams. Both paths must classify.
+        const string stdOut = "CSC : error MSB3021: Unable to copy file. Access to the path is denied.";
+        var execution = FakeExecution(exitCode: 1, stdOut: stdOut, stdErr: string.Empty);
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNotNull(result.FailureEnvelope);
+        Assert.AreEqual("FileLock", result.FailureEnvelope!.ErrorKind);
+        Assert.IsTrue(result.FailureEnvelope.IsRetryable);
+    }
+
+    [TestMethod]
+    public void ParseTestRun_NoTrxAndBuildFailedMarker_EmitsNonRetryableBuildFailure()
+    {
+        const string stdOut = "CS0103: The name 'Oops' does not exist in the current context.\nBuild FAILED.";
+        var execution = FakeExecution(exitCode: 1, stdOut: stdOut, stdErr: string.Empty);
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNotNull(result.FailureEnvelope);
+        Assert.AreEqual("BuildFailure", result.FailureEnvelope!.ErrorKind);
+        Assert.IsFalse(result.FailureEnvelope.IsRetryable,
+            "Build failures require a source fix before retrying.");
+        StringAssert.Contains(result.FailureEnvelope.StdOutTail ?? string.Empty, "CS0103");
+    }
+
+    [TestMethod]
+    public void ParseTestRun_NoTrxAndUnknownFailure_EmitsUnknownEnvelope()
+    {
+        var execution = FakeExecution(exitCode: 139, stdOut: "something exploded", stdErr: "segfault");
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNotNull(result.FailureEnvelope);
+        Assert.AreEqual("Unknown", result.FailureEnvelope!.ErrorKind);
+        Assert.IsFalse(result.FailureEnvelope.IsRetryable);
+        StringAssert.Contains(result.FailureEnvelope.Summary, "139");
+    }
+
+    [TestMethod]
+    public void ParseTestRun_NoTrxFailure_TailsAreTruncatedTo2000Chars()
+    {
+        var longStdErr = new string('x', 5000) + "MSB3027";
+        var execution = FakeExecution(exitCode: 1, stdOut: string.Empty, stdErr: longStdErr);
+
+        var result = DotnetOutputParser.ParseTestRun(execution, []);
+
+        Assert.IsNotNull(result.FailureEnvelope);
+        Assert.IsNotNull(result.FailureEnvelope!.StdErrTail);
+        Assert.AreEqual(2000, result.FailureEnvelope.StdErrTail!.Length,
+            "StdErr tail should be capped at 2000 characters.");
+        StringAssert.EndsWith(result.FailureEnvelope.StdErrTail, "MSB3027",
+            "The tail must include the end of the StdErr stream, not the beginning.");
+    }
+
+    [TestMethod]
+    public void BuildTimeoutResult_ProducesNonRetryableTimeoutEnvelope()
+    {
+        var shell = new CommandExecutionDto(
+            Command: "dotnet",
+            Arguments: ["test"],
+            WorkingDirectory: "C:/fake",
+            TargetPath: "C:/fake/proj.csproj",
+            ExitCode: -1,
+            Succeeded: false,
+            DurationMs: 600_000,
+            StdOut: string.Empty,
+            StdErr: "The command 'dotnet test' exceeded the timeout of 10.0 minute(s).");
+
+        var result = DotnetOutputParser.BuildTimeoutResult(shell, shell.StdErr);
+
+        Assert.IsNotNull(result.FailureEnvelope);
+        Assert.AreEqual("Timeout", result.FailureEnvelope!.ErrorKind);
+        Assert.IsFalse(result.FailureEnvelope.IsRetryable);
+        StringAssert.Contains(result.FailureEnvelope.Summary, "timeout");
+        Assert.AreEqual(1, result.Failed);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TestRunFailureEnvelopeDto` (ErrorKind / IsRetryable / Summary / StdOutTail / StdErrTail) populated when `dotnet test` exits without TRX output — MSB3027/3021 file locks, build failures, timeouts, unknown exits.
- `DotnetOutputParser.ParseTestRun` classifies no-TRX failures; `TestRunnerService.RunTestsAsync` no longer throws and converts `TimeoutException` into a `Timeout` envelope via the new `BuildTimeoutResult` helper.
- `test_run` tool description now documents the envelope contract and the Windows concurrent-testhost file-lock gotcha.
- Closes backlog row: ``test-run-failure-envelope`` (P2).

## Test plan

- [x] `dotnet build RoslynMcp.slnx --nologo` — clean
- [x] New unit tests in `TestRunFailureEnvelopeTests.cs` (7/7) covering:
  - Success → envelope null
  - StdErr MSB3027 → FileLock + retryable
  - StdOut MSB3021 → FileLock + retryable
  - "Build FAILED" → BuildFailure + non-retryable
  - Unknown exit code → Unknown + non-retryable
  - Tails capped at 2000 chars and include the END of the stream
  - `BuildTimeoutResult` → Timeout + non-retryable
- [x] `ValidationIntegrationTests` (existing) still green — successful + failing-test paths unchanged
- [ ] CI: `verify-release.ps1 -Configuration Release`
- [ ] Live MCP: reproduce the audit's MSB3027 collision and confirm the envelope is surfaced instead of a bare invocation error

## Follow-ups

Part of the top-20 backlog-fix batch. PRs 2–6 are queued:
1. ~~P2: test-run-failure-envelope~~ (this PR)
2. P3+P4: editing/undo cohesion (apply_text_edit validation + revert_last_apply disk consistency + set_editorconfig_option undo retrofit)
3. P3: semantic_search verbose-query fallback
4. P3: workspace_load idempotent-by-path
5. P4: behavioral + error-surface polish bundle
6. P4: docs omnibus + verify-release test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)