### PR TITLE
fix: apply/revert/editorconfig undo cohesion (P3+P4)

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-08T22:00:00Z
+**updated_at:** 2026-04-08T22:30:00Z
 
 ## Agent contract
 
@@ -31,7 +31,6 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 | id | blocker | deps | do |
 |----|---------|------|-----|
 | `workspace-session-deduplication` | none | — | **P3 / session model.** Loading the same solution path twice in one host process can yield `workspace_list` with multiple distinct `WorkspaceId`s (2026-04-08 roslyn-backed-mcp audit 130615; not reproduced on a later pass — intermittent). Wastes workspace slots and confuses audits. Consider idempotent `workspace_load` or explicit dedup. |
-| `revert-last-apply-disk-consistency` | none | — | **P3 / undo.** `revert_last_apply` reported success while the on-disk file still contained the applied text until manual cleanup and `workspace_reload` (2026-04-08 NetworkDocumentation audit). Align workspace model with disk or document the edge case. |
 | `semantic-search-zero-results-verbose-query` | none | — | **P3 / UX.** `semantic_search` returned `count: 0` for a long natural-language query while a shorter query returned hits on the same repo (2026-04-08 FirewallAnalyzer audit). Add keyword/stem fallback or scoring/debug payload when the embedding ranker returns empty. |
 | `find-type-usages-cref-classification` | none | — | **P4 / cosmetic.** `find_type_usages` buckets `<see cref="X"/>` doc-comment references as `Other` instead of as a `Documentation` classification (observed against ITChatBot 2026-04-07). Enrich the classification enum so doc-comment refs are visually distinguishable from real consumers. |
 | `verify-release-test-output-policy` | none | — | **P4 / process.** `eng/verify-release.ps1` already sets `$ErrorActionPreference = 'Stop'`, but still runs `dotnet test` with default verbosity. Add `--logger "console;verbosity=normal"` so failing test names are not masked by tail/pipe operations in any wrapper script. |

--- a/src/RoslynMcp.Core/Services/IUndoService.cs
+++ b/src/RoslynMcp.Core/Services/IUndoService.cs
@@ -12,8 +12,23 @@ public interface IUndoService
     /// </summary>
     /// <param name="workspaceId">The workspace being mutated.</param>
     /// <param name="description">Human-readable description of the operation being applied.</param>
-    /// <param name="preApplySolution">The solution snapshot before mutation.</param>
-    void CaptureBeforeApply(string workspaceId, string description, object preApplySolution);
+    /// <param name="preApplySolution">
+    /// The solution snapshot before mutation. May be <see langword="null"/> for direct-apply
+    /// paths that mutate files outside the Roslyn workspace model (e.g., .editorconfig writes).
+    /// </param>
+    /// <param name="fileSnapshots">
+    /// Optional explicit list of <c>(filePath, originalText)</c> pairs captured before the
+    /// mutation. When populated, <see cref="RevertAsync"/> uses this authoritative list to
+    /// restore disk content directly — bypassing the fragile "did the Roslyn <c>Solution</c>
+    /// diff detect a change?" path that fails when <c>MSBuildWorkspace.TryApplyChanges</c>
+    /// silently no-ops (FLAG-9A). Direct-file callers such as <c>EditService</c> and
+    /// <c>EditorConfigService</c> should always populate this.
+    /// </param>
+    void CaptureBeforeApply(
+        string workspaceId,
+        string description,
+        object? preApplySolution,
+        IReadOnlyList<FileSnapshotDto>? fileSnapshots = null);
 
     /// <summary>
     /// Returns metadata about the last undoable operation for the given workspace,
@@ -43,3 +58,12 @@ public sealed record UndoEntry(
     string WorkspaceId,
     string Description,
     DateTime AppliedAtUtc);
+
+/// <summary>
+/// An explicit pre-apply file snapshot passed to <see cref="IUndoService.CaptureBeforeApply"/>
+/// by direct-file callers. Used by <see cref="IUndoService.RevertAsync"/> to restore disk
+/// content even when the workspace <c>Solution</c> diff is empty (FLAG-9A).
+/// </summary>
+/// <param name="FilePath">The absolute path of the file about to be modified.</param>
+/// <param name="OriginalText">The full pre-mutation text of the file (null if it didn't exist yet).</param>
+public sealed record FileSnapshotDto(string FilePath, string? OriginalText);

--- a/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
@@ -26,7 +26,7 @@ public static class EditorConfigTools
     }
 
     [McpServerTool(Name = "set_editorconfig_option", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
-     Description("⚠ DIRECT-APPLY, NOT REVERTIBLE (UX-006): Set or update a key/value in the .editorconfig that applies to the given source file (under the [*.{cs,csx,cake}] section). Creates a new .editorconfig next to the file if none exists in the directory chain. Unlike Roslyn preview/apply tools (rename_*, extract_*, code_fix_*, organize_usings_*), this tool writes to disk immediately and is NOT registered with revert_last_apply — undo is git-only. Read the existing settings first with get_editorconfig_options so you can confirm the change you intend to make before calling this tool.")]
+     Description("Set or update a key/value in the .editorconfig that applies to the given source file (under the [*.{cs,csx,cake}] section). Creates a new .editorconfig next to the file if none exists in the directory chain. Direct-apply (no preview token), but integrated with revert_last_apply: the pre-write .editorconfig content is captured and restored on revert (or the file is deleted on revert if this call created it). Read the existing settings first with get_editorconfig_options so you can confirm the change you intend to make before calling this tool.")]
     public static Task<string> SetEditorConfigOption(
         IWorkspaceExecutionGate gate,
         IEditorConfigService editorConfigService,

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -27,28 +27,57 @@ public sealed class EditService : IEditService
         string workspaceId, string filePath, IReadOnlyList<TextEditDto> edits, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
+        var (document, sourceText) = await ResolveDocumentAndTextAsync(solution, filePath, ct).ConfigureAwait(false);
 
-        // Capture pre-apply snapshot so revert_last_apply can roll back this edit. UndoService
-        // is single-slot per workspace; a stale snapshot from a failed apply is harmless and
-        // gets overwritten by the next successful apply.
+        // apply-text-edit-invalid-edit-corrupt-diff: validate ranges up front so bad
+        // edits throw a structured ArgumentException BEFORE we touch the file or the
+        // unified diff. Without this, a reversed/out-of-bounds range could produce a
+        // corrupt diff (ITChatBot audit I1, 2026-04-08).
+        ValidateEdits(filePath, edits, sourceText);
+
+        // Capture pre-apply snapshot so revert_last_apply can roll back this edit. We
+        // pass BOTH the solution (for the legacy path) AND an explicit file snapshot
+        // (for the authoritative file-based restore path — see FLAG-9A in UndoService).
+        var fileSnapshots = new[]
+        {
+            new FileSnapshotDto(Path.GetFullPath(filePath), sourceText.ToString()),
+        };
         _undoService?.CaptureBeforeApply(
             workspaceId,
             $"Apply text edit to {Path.GetFileName(filePath)}",
-            solution);
+            solution,
+            fileSnapshots);
 
-        return await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, ct).ConfigureAwait(false);
+        return await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, document, sourceText, ct).ConfigureAwait(false);
     }
 
     public async Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
         string workspaceId, IReadOnlyList<FileEditsDto> fileEdits, CancellationToken ct)
     {
+        var initialSolution = _workspace.GetCurrentSolution(workspaceId);
+
+        // apply-text-edit-invalid-edit-corrupt-diff: validate every file's edits BEFORE
+        // we take the undo snapshot and BEFORE any disk write. The whole batch fails
+        // fast if any single edit is malformed, so the caller never sees a half-applied
+        // state or a corrupt diff on the surviving files.
+        var perFileSnapshots = new List<(Document Document, SourceText SourceText, string NormalizedPath)>();
+        foreach (var fileEdit in fileEdits)
+        {
+            var (document, sourceText) = await ResolveDocumentAndTextAsync(initialSolution, fileEdit.FilePath, ct).ConfigureAwait(false);
+            ValidateEdits(fileEdit.FilePath, fileEdit.Edits, sourceText);
+            perFileSnapshots.Add((document, sourceText, Path.GetFullPath(fileEdit.FilePath)));
+        }
+
         // Single snapshot at the top so revert_last_apply rolls back the ENTIRE batch atomically
         // (from an undo perspective; individual disk writes still happen sequentially).
-        var initialSolution = _workspace.GetCurrentSolution(workspaceId);
+        var fileSnapshots = perFileSnapshots
+            .Select(t => new FileSnapshotDto(t.NormalizedPath, t.SourceText.ToString()))
+            .ToList();
         _undoService?.CaptureBeforeApply(
             workspaceId,
             $"Apply edits to {fileEdits.Count} file(s)",
-            initialSolution);
+            initialSolution,
+            fileSnapshots);
 
         var results = new List<FileEditSummaryDto>();
         foreach (var fileEdit in fileEdits)
@@ -57,8 +86,9 @@ public sealed class EditService : IEditService
             // is now committed. Pass it explicitly so the core path doesn't take its own
             // (redundant) snapshot.
             var current = _workspace.GetCurrentSolution(workspaceId);
+            var (document, sourceText) = await ResolveDocumentAndTextAsync(current, fileEdit.FilePath, ct).ConfigureAwait(false);
             var result = await ApplyTextEditsCoreAsync(
-                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, ct).ConfigureAwait(false);
+                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, document, sourceText, ct).ConfigureAwait(false);
             var diff = result.Changes.Count > 0
                 ? string.Join("\n", result.Changes.Select(ch => ch.UnifiedDiff))
                 : null;
@@ -68,16 +98,9 @@ public sealed class EditService : IEditService
         return new MultiFileEditResultDto(true, results.Count, results);
     }
 
-    /// <summary>
-    /// Inner edit-application path that does NOT touch the undo stack. The caller is
-    /// responsible for snapshotting before invoking this method (single-file path
-    /// snapshots once; multi-file path snapshots once at the batch boundary).
-    /// </summary>
-    private async Task<TextEditResultDto> ApplyTextEditsCoreAsync(
-        string workspaceId,
-        string filePath,
-        IReadOnlyList<TextEditDto> edits,
+    private static async Task<(Document Document, SourceText SourceText)> ResolveDocumentAndTextAsync(
         Solution solution,
+        string filePath,
         CancellationToken ct)
     {
         var normalizedPath = Path.GetFullPath(filePath);
@@ -91,6 +114,102 @@ public sealed class EditService : IEditService
             throw new KeyNotFoundException($"Document not found in workspace: {filePath}");
 
         var sourceText = await document.GetTextAsync(ct).ConfigureAwait(false);
+        return (document, sourceText);
+    }
+
+    /// <summary>
+    /// Rejects malformed <see cref="TextEditDto"/> values before the edit ever touches the
+    /// document. The ITChatBot deep-review audit (2026-04-08 incident I1,
+    /// <c>apply-text-edit-invalid-edit-corrupt-diff</c>) showed that an invalid / zero-width
+    /// range could reach the DiffPlex path and produce a corrupt unified diff. The checks
+    /// here short-circuit BEFORE any workspace mutation so the tool surfaces a structured
+    /// <see cref="ArgumentException"/> via <c>ToolErrorHandler</c>.
+    /// </summary>
+    private static void ValidateEdits(
+        string filePath,
+        IReadOnlyList<TextEditDto> edits,
+        SourceText sourceText)
+    {
+        if (edits.Count == 0)
+        {
+            throw new ArgumentException($"At least one text edit is required for '{filePath}'.", nameof(edits));
+        }
+
+        var lineCount = sourceText.Lines.Count;
+
+        for (var i = 0; i < edits.Count; i++)
+        {
+            var edit = edits[i];
+
+            if (edit.NewText is null)
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' has a null NewText. Use an empty string for deletions.",
+                    nameof(edits));
+            }
+
+            if (edit.StartLine < 1 || edit.StartColumn < 1 || edit.EndLine < 1 || edit.EndColumn < 1)
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' has non-positive line/column: " +
+                    $"({edit.StartLine},{edit.StartColumn})-({edit.EndLine},{edit.EndColumn}). " +
+                    "Line and column are 1-based.",
+                    nameof(edits));
+            }
+
+            if (edit.StartLine > lineCount || edit.EndLine > lineCount)
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' references line {Math.Max(edit.StartLine, edit.EndLine)} " +
+                    $"but the file only has {lineCount} line(s).",
+                    nameof(edits));
+            }
+
+            var startLineLength = sourceText.Lines[edit.StartLine - 1].SpanIncludingLineBreak.Length;
+            if (edit.StartColumn > startLineLength + 1)
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' has StartColumn {edit.StartColumn} but line {edit.StartLine} " +
+                    $"only has {startLineLength} character(s). Columns are 1-based and may be one past the end.",
+                    nameof(edits));
+            }
+
+            var endLineLength = sourceText.Lines[edit.EndLine - 1].SpanIncludingLineBreak.Length;
+            if (edit.EndColumn > endLineLength + 1)
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' has EndColumn {edit.EndColumn} but line {edit.EndLine} " +
+                    $"only has {endLineLength} character(s).",
+                    nameof(edits));
+            }
+
+            if (edit.StartLine > edit.EndLine
+                || (edit.StartLine == edit.EndLine && edit.StartColumn > edit.EndColumn))
+            {
+                throw new ArgumentException(
+                    $"Edit #{i} for '{filePath}' has a reversed range: " +
+                    $"start ({edit.StartLine},{edit.StartColumn}) is after end ({edit.EndLine},{edit.EndColumn}). " +
+                    "Zero-width ranges are allowed (inserts) but the end position must not precede the start.",
+                    nameof(edits));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Inner edit-application path that does NOT touch the undo stack. The caller is
+    /// responsible for snapshotting before invoking this method (single-file path
+    /// snapshots once; multi-file path snapshots once at the batch boundary).
+    /// </summary>
+    private async Task<TextEditResultDto> ApplyTextEditsCoreAsync(
+        string workspaceId,
+        string filePath,
+        IReadOnlyList<TextEditDto> edits,
+        Solution solution,
+        Document document,
+        SourceText sourceText,
+        CancellationToken ct)
+    {
+        var normalizedPath = Path.GetFullPath(filePath);
         var originalText = sourceText.ToString();
 
         // Sort edits in reverse order to apply from bottom to top (so offsets remain valid)

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -11,11 +11,13 @@ public sealed class EditorConfigService : IEditorConfigService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly ILogger<EditorConfigService> _logger;
+    private readonly IUndoService? _undoService;
 
-    public EditorConfigService(IWorkspaceManager workspace, ILogger<EditorConfigService> logger)
+    public EditorConfigService(IWorkspaceManager workspace, ILogger<EditorConfigService> logger, IUndoService? undoService = null)
     {
         _workspace = workspace;
         _logger = logger;
+        _undoService = undoService;
     }
 
     public async Task<EditorConfigOptionsDto> GetOptionsAsync(
@@ -210,7 +212,24 @@ public sealed class EditorConfigService : IEditorConfigService
             ?? Path.Combine(Path.GetDirectoryName(normalizedSource) ?? throw new InvalidOperationException("Invalid source path."), ".editorconfig");
 
         var created = !File.Exists(editorconfigPath);
+        var existingText = created ? null : File.ReadAllText(editorconfigPath);
         var lines = created ? new List<string>() : File.ReadAllLines(editorconfigPath).ToList();
+
+        // set-editorconfig-option-not-undoable: capture the pre-apply content so
+        // revert_last_apply can restore the .editorconfig file (or delete it if we created it).
+        // Uses the authoritative FileSnapshotDto path in UndoService (FLAG-9A).
+        if (_undoService is not null)
+        {
+            var snapshot = new[]
+            {
+                new FileSnapshotDto(editorconfigPath, existingText),
+            };
+            _undoService.CaptureBeforeApply(
+                workspaceId,
+                $"Set .editorconfig option '{key.Trim()}' in {Path.GetFileName(editorconfigPath)}",
+                preApplySolution: null,
+                fileSnapshots: snapshot);
+        }
 
         const string csharpSection = "[*.{cs,csx,cake}]";
         UpsertKeyInSection(lines, csharpSection, key.Trim(), value.Trim());

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -7,17 +7,25 @@ using Microsoft.Extensions.Logging;
 namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
-/// Retains the last pre-apply solution snapshot per workspace so that it can
-/// be restored via <see cref="RevertAsync"/>.
+/// Retains the last pre-apply snapshot per workspace so that it can be restored via
+/// <see cref="RevertAsync"/>.
 ///
-/// FLAG-9A: <see cref="MSBuildWorkspace"/>'s <c>TryApplyChanges</c> does not
-/// reliably flush document text to disk. Earlier versions of this service called
-/// only <c>TryApplyChanges</c> and reported <c>reverted: true</c> even though the
-/// disk file still contained the post-apply text. The current implementation
-/// mirrors <c>EditService.PersistDocumentTextToDiskAsync</c> and
-/// <c>RefactoringService.PersistChangedDocumentsFromSolutionAsync</c> by writing
-/// each changed document's text directly to disk after the workspace mutation,
-/// then asking the workspace to reload so the next call sees a coherent state.
+/// FLAG-9A: <see cref="Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace"/>'s
+/// <c>TryApplyChanges</c> does not reliably flush document text to disk. Earlier
+/// versions of this service relied solely on <c>Solution.GetChanges()</c> to decide
+/// which documents to restore and wrote disk only for those — but when the post-apply
+/// workspace solution had reverted silently (or matched the pre-apply snapshot for
+/// unrelated reasons), <c>GetChanges</c> returned empty even though disk still held
+/// the post-apply text, and <c>revert_last_apply</c> reported success without
+/// touching disk. See backlog row <c>revert-last-apply-disk-consistency</c>.
+///
+/// The current implementation adds an authoritative fast path: callers that know
+/// which files they are about to modify (<c>EditService</c>, <c>EditorConfigService</c>)
+/// pass an explicit <see cref="FileSnapshotDto"/> list to
+/// <see cref="CaptureBeforeApply"/>, and <see cref="RevertAsync"/> restores those files
+/// directly from disk — no <c>GetChanges</c> dependency. Solution-based callers
+/// (<c>RefactoringService</c>) keep the legacy path, which has been hardened with a
+/// snapshot-wide document walk so empty-<c>GetChanges</c> no longer silently wins.
 /// </summary>
 public sealed class UndoService : IUndoService
 {
@@ -29,12 +37,26 @@ public sealed class UndoService : IUndoService
         _logger = logger;
     }
 
-    public void CaptureBeforeApply(string workspaceId, string description, object preApplySolution)
+    public void CaptureBeforeApply(
+        string workspaceId,
+        string description,
+        object? preApplySolution,
+        IReadOnlyList<FileSnapshotDto>? fileSnapshots = null)
     {
-        if (preApplySolution is not Solution solution)
-            throw new ArgumentException("preApplySolution must be a Roslyn Solution.", nameof(preApplySolution));
+        Solution? solution = null;
+        if (preApplySolution is not null)
+        {
+            if (preApplySolution is not Solution typed)
+                throw new ArgumentException("preApplySolution must be a Roslyn Solution or null.", nameof(preApplySolution));
+            solution = typed;
+        }
 
-        _snapshots[workspaceId] = new UndoSnapshot(workspaceId, description, solution, DateTime.UtcNow);
+        _snapshots[workspaceId] = new UndoSnapshot(
+            workspaceId,
+            description,
+            solution,
+            fileSnapshots,
+            DateTime.UtcNow);
     }
 
     public UndoEntry? GetLastOperation(string workspaceId)
@@ -50,19 +72,101 @@ public sealed class UndoService : IUndoService
         if (!_snapshots.TryRemove(workspaceId, out var snapshot))
             return false;
 
-        // MSBuildWorkspace.TryApplyChanges only accepts solutions derived from its current
-        // solution. Rebuild the target state by replacing document texts in the workspace's
-        // current solution with the pre-apply snapshot texts.
+        // Fast path: the caller provided an explicit file-snapshot list. Restore those
+        // files directly — authoritative, independent of the workspace solution state.
+        if (snapshot.FileSnapshots is { Count: > 0 })
+        {
+            return await RevertFromFileSnapshotsAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Legacy path: solution-based restore with a snapshot-wide walk so empty-GetChanges
+        // no longer silently wins.
+        return await RevertFromSolutionSnapshotAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> RevertFromFileSnapshotsAsync(
+        string workspaceId,
+        IWorkspaceManager workspace,
+        UndoSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        var diskOk = true;
+        var restoredAny = false;
+
+        foreach (var file in snapshot.FileSnapshots!)
+        {
+            try
+            {
+                if (file.OriginalText is null)
+                {
+                    // The file did not exist before the apply — delete it on revert.
+                    if (File.Exists(file.FilePath))
+                    {
+                        File.Delete(file.FilePath);
+                        restoredAny = true;
+                    }
+                }
+                else
+                {
+                    var directory = Path.GetDirectoryName(file.FilePath);
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+                    await File.WriteAllTextAsync(file.FilePath, file.OriginalText, cancellationToken).ConfigureAwait(false);
+                    restoredAny = true;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "UndoService.RevertAsync (file-snapshot): failed to restore {FilePath}",
+                    file.FilePath);
+                diskOk = false;
+            }
+        }
+
+        if (restoredAny)
+        {
+            try
+            {
+                await workspace.ReloadAsync(workspaceId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or InvalidOperationException or KeyNotFoundException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "UndoService.RevertAsync (file-snapshot): workspace reload after disk restore failed for {WorkspaceId}",
+                    workspaceId);
+            }
+        }
+
+        return diskOk;
+    }
+
+    private async Task<bool> RevertFromSolutionSnapshotAsync(
+        string workspaceId,
+        IWorkspaceManager workspace,
+        UndoSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        if (snapshot.PreApplySolution is null)
+        {
+            _logger.LogWarning(
+                "UndoService.RevertAsync: snapshot for '{WorkspaceId}' has neither a pre-apply Solution nor file snapshots. " +
+                "Nothing to revert.",
+                workspaceId);
+            return false;
+        }
+
         var currentSolution = workspace.GetCurrentSolution(workspaceId);
         var targetSolution = currentSolution;
 
-        // Track the (filePath, oldText) tuples we need to write to disk after the workspace
-        // mutation succeeds. We collect these BEFORE applying so we can persist exactly the
-        // documents we restored. The path comes from the CURRENT solution because the snapshot
-        // and current may have differing project layouts.
         var diskRestores = new List<(string FilePath, string Text)>();
         var changedDocumentCount = 0;
 
+        // Primary pass: trust the Solution diff to tell us what changed.
         foreach (var projectChange in snapshot.PreApplySolution.GetChanges(currentSolution).GetProjectChanges())
         {
             foreach (var docId in projectChange.GetChangedDocuments())
@@ -78,7 +182,41 @@ public sealed class UndoService : IUndoService
                 var path = currentDoc?.FilePath ?? oldDoc.FilePath;
                 if (!string.IsNullOrWhiteSpace(path))
                 {
-                    diskRestores.Add((path, oldText.ToString()));
+                    diskRestores.Add((path!, oldText.ToString()));
+                }
+            }
+        }
+
+        // Safety net (revert-last-apply-disk-consistency): if the Solution diff came up
+        // empty we cannot conclude "nothing changed" — MSBuildWorkspace may have quietly
+        // dropped the apply while leaving disk out of sync. Walk every document in the
+        // pre-apply snapshot, read the on-disk text, and restore any that drifted.
+        if (changedDocumentCount == 0)
+        {
+            foreach (var project in snapshot.PreApplySolution.Projects)
+            {
+                foreach (var oldDoc in project.Documents)
+                {
+                    if (oldDoc.FilePath is null) continue;
+                    if (!File.Exists(oldDoc.FilePath)) continue;
+
+                    string currentDiskText;
+                    try
+                    {
+                        currentDiskText = await File.ReadAllTextAsync(oldDoc.FilePath, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        _logger.LogDebug(ex, "UndoService.RevertAsync: disk-walk read failed for {FilePath}", oldDoc.FilePath);
+                        continue;
+                    }
+
+                    var oldText = (await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false)).ToString();
+                    if (!string.Equals(currentDiskText, oldText, StringComparison.Ordinal))
+                    {
+                        diskRestores.Add((oldDoc.FilePath, oldText));
+                        changedDocumentCount++;
+                    }
                 }
             }
         }
@@ -86,7 +224,7 @@ public sealed class UndoService : IUndoService
         if (changedDocumentCount == 0)
         {
             _logger.LogInformation(
-                "UndoService.RevertAsync: snapshot for '{WorkspaceId}' contained no document differences against the current solution. " +
+                "UndoService.RevertAsync: snapshot for '{WorkspaceId}' contained no document differences against the current solution or disk. " +
                 "Treating revert as a no-op success.",
                 workspaceId);
             return true;
@@ -102,9 +240,6 @@ public sealed class UndoService : IUndoService
                 snapshot.Description);
         }
 
-        // FLAG-9A: explicitly persist the restored text to disk. MSBuildWorkspace.TryApplyChanges
-        // does not always flush — see EditService.PersistDocumentTextToDiskAsync for the same
-        // workaround. Without this, revert_last_apply returns reverted=true while disk is unchanged.
         var diskOk = true;
         var anyDiskWrite = false;
         foreach (var (filePath, text) in diskRestores)
@@ -121,11 +256,6 @@ public sealed class UndoService : IUndoService
             }
         }
 
-        // FLAG-9A: report success only if BOTH the workspace mutation succeeded AND every disk
-        // write succeeded. If the workspace mutation failed but every disk write succeeded, we
-        // still treat the revert as successful — the source files on disk now reflect the
-        // pre-apply state, which is what the operator cares about. Mirror that with a workspace
-        // reload so the in-memory model resyncs.
         if (anyDiskWrite)
         {
             try
@@ -149,6 +279,7 @@ public sealed class UndoService : IUndoService
     private sealed record UndoSnapshot(
         string WorkspaceId,
         string Description,
-        Solution PreApplySolution,
+        Solution? PreApplySolution,
+        IReadOnlyList<FileSnapshotDto>? FileSnapshots,
         DateTime AppliedAtUtc);
 }

--- a/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
@@ -1,0 +1,212 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the PR 2 editing/undo cohesion fixes:
+///   * <c>apply-text-edit-invalid-edit-corrupt-diff</c> — <see cref="IEditService.ApplyTextEditsAsync"/>
+///     must reject malformed ranges (null NewText, out-of-bounds, reversed) BEFORE any disk write
+///     or diff generation so the caller never sees a corrupt unified diff.
+///   * <c>revert-last-apply-disk-consistency</c> — <see cref="IUndoService.RevertAsync"/> must restore
+///     disk even when the Roslyn Solution diff is empty, using either the explicit file-snapshot fast
+///     path or the disk-walk safety net in the legacy solution-based path.
+///   * <c>set-editorconfig-option-not-undoable</c> — <see cref="IEditorConfigService.SetOptionAsync"/>
+///     now participates in the undo stack; revert must restore the pre-write .editorconfig content
+///     (or delete the file if the set operation created it).
+/// </summary>
+[TestClass]
+public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    // ------------------------------------------------------------------
+    // apply-text-edit-invalid-edit-corrupt-diff
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_NullNewText_ThrowsArgumentException()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Intentionally build a malformed edit with null NewText. TextEditDto is a positional
+        // record so we construct it via `default` + expression to bypass nullable analysis.
+        var edit = new TextEditDto(1, 1, 1, 1, null!);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "null NewText");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_ReversedRange_ThrowsArgumentException()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Start (5,10) → End (5,5): end precedes start on the same line.
+        var edit = new TextEditDto(5, 10, 5, 5, "x");
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "reversed range");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_OutOfBoundsLine_ThrowsArgumentException()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Line 9999 is far beyond the file length.
+        var edit = new TextEditDto(9999, 1, 9999, 1, "oops");
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "9999");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_NonPositiveColumn_ThrowsArgumentException()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Column 0 is invalid — line/column are 1-based.
+        var edit = new TextEditDto(1, 0, 1, 1, "oops");
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "1-based");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_RejectsBadEdit_WithoutTouchingDisk()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        var edit = new TextEditDto(5, 10, 5, 5, "x"); // reversed
+        try
+        {
+            await EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+            Assert.Fail("Expected ArgumentException.");
+        }
+        catch (ArgumentException)
+        {
+            // expected
+        }
+
+        var afterReject = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalText, afterReject,
+            "A rejected edit must not leave disk in a mutated state.");
+    }
+
+    // ------------------------------------------------------------------
+    // revert-last-apply-disk-consistency
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Revert_AfterDiskDriftWithEmptySolutionDiff_RestoresDisk()
+    {
+        // Reproduces the NetworkDocumentation audit bug: a snapshot was captured, the file was
+        // mutated directly on disk (simulating the FLAG-9A path where MSBuildWorkspace doesn't
+        // reflect the disk change), and revert must still restore the original content via the
+        // explicit file-snapshot path (UndoService now captures these on apply_text_edit).
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        // Normal apply: capture the file snapshot on the undo stack.
+        var lines = originalText.Split('\n');
+        var appendEdit = new TextEditDto(lines.Length, lines[^1].Length + 1, lines.Length, lines[^1].Length + 1, "\n// apply marker");
+        var applyResult = await EditService.ApplyTextEditsAsync(workspaceId, dogFilePath, new[] { appendEdit }, CancellationToken.None);
+        Assert.IsTrue(applyResult.Success);
+
+        // Simulate post-apply disk drift: a second out-of-band write that the workspace
+        // Solution cannot see (the classic "disk ahead of workspace" FLAG-9A state).
+        await File.AppendAllTextAsync(dogFilePath, "\n// drift from out-of-band edit", CancellationToken.None);
+
+        // Revert must restore the original byte-for-byte — the file-snapshot fast path
+        // writes the pre-apply text regardless of any out-of-band drift.
+        var reverted = await UndoService.RevertAsync(workspaceId, WorkspaceManager, CancellationToken.None);
+        Assert.IsTrue(reverted, "Revert must report success.");
+
+        var afterRevert = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalText, afterRevert,
+            "Disk must match the pre-apply text after revert, even when drift happened between apply and revert.");
+    }
+
+    // ------------------------------------------------------------------
+    // set-editorconfig-option-not-undoable
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SetEditorConfigOption_ThenRevert_RestoresExistingContent()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Seed a pre-existing .editorconfig so we can verify restore-to-original (not delete).
+        var editorconfigPath = Path.Combine(workspace.GetPath("SampleLib"), ".editorconfig");
+        var originalContent = "root = true\n\n[*.{cs,csx,cake}]\nindent_size = 4\n";
+        await File.WriteAllTextAsync(editorconfigPath, originalContent, CancellationToken.None);
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, "dotnet_diagnostic.CA1000.severity", "warning", CancellationToken.None);
+        Assert.AreEqual(editorconfigPath, setResult.EditorConfigPath);
+        Assert.IsFalse(setResult.CreatedNewFile);
+
+        var afterSet = await File.ReadAllTextAsync(editorconfigPath, CancellationToken.None);
+        StringAssert.Contains(afterSet, "dotnet_diagnostic.CA1000.severity = warning");
+
+        var undoEntry = UndoService.GetLastOperation(workspaceId);
+        Assert.IsNotNull(undoEntry, "set_editorconfig_option must register an undo entry.");
+        StringAssert.Contains(undoEntry.Description, ".editorconfig");
+
+        var reverted = await UndoService.RevertAsync(workspaceId, WorkspaceManager, CancellationToken.None);
+        Assert.IsTrue(reverted);
+
+        var afterRevert = await File.ReadAllTextAsync(editorconfigPath, CancellationToken.None);
+        Assert.AreEqual(originalContent, afterRevert,
+            "Revert must restore the .editorconfig to its pre-write content byte-for-byte.");
+    }
+
+    [TestMethod]
+    public async Task SetEditorConfigOption_CreatesNewFile_RevertDeletesIt()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Ensure no .editorconfig exists under the SampleLib folder before the call.
+        var candidatePath = Path.Combine(workspace.GetPath("SampleLib"), ".editorconfig");
+        if (File.Exists(candidatePath)) File.Delete(candidatePath);
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, "dotnet_diagnostic.CA1001.severity", "warning", CancellationToken.None);
+        // The implementation may locate an existing .editorconfig higher in the tree; only assert
+        // the created-on-this-call case, which is what the "revert deletes it" contract covers.
+        if (!setResult.CreatedNewFile)
+        {
+            Assert.Inconclusive("Test environment already had an .editorconfig higher in the directory tree.");
+            return;
+        }
+
+        Assert.IsTrue(File.Exists(setResult.EditorConfigPath), "Set should have created the .editorconfig file.");
+
+        var reverted = await UndoService.RevertAsync(workspaceId, WorkspaceManager, CancellationToken.None);
+        Assert.IsTrue(reverted);
+
+        Assert.IsFalse(File.Exists(setResult.EditorConfigPath),
+            "Revert of a newly-created .editorconfig must delete the file (pre-apply OriginalText was null).");
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -225,7 +225,8 @@ internal sealed class TestServiceContainer
                 new ScriptingServiceOptions()),
             EditorConfigService = new EditorConfigService(
                 workspaceManager,
-                NullLogger<EditorConfigService>.Instance)
+                NullLogger<EditorConfigService>.Instance,
+                undoService)
         };
     }
 }


### PR DESCRIPTION
## Summary

Three related editing/undo correctness fixes:

- **`apply-text-edit-invalid-edit-corrupt-diff`** (P3): `EditService.ValidateEdits` rejects malformed `TextEditDto` values (null `NewText`, non-positive line/column, out-of-bounds, reversed ranges) BEFORE the edit touches the document or the diff is generated. Prevents the corrupt-diff case from ITChatBot audit I1.
- **`revert-last-apply-disk-consistency`** (P3): `IUndoService.CaptureBeforeApply` now accepts an optional explicit `FileSnapshotDto[]` list. `UndoService.RevertAsync` uses that authoritative list to restore disk directly — bypassing the fragile `Solution.GetChanges` path that silently failed when `MSBuildWorkspace.TryApplyChanges` no-opped. The legacy `Solution`-based path also gains a disk-walk safety net when `GetChanges` returns empty.
- **`set-editorconfig-option-not-undoable`** (P4): `EditorConfigService` takes `IUndoService` and captures the pre-write `.editorconfig` content via the new file-snapshot path. Revert restores existing content byte-for-byte or deletes the file if this call created it. Tool description drops the "NOT REVERTIBLE" warning.

## Test plan

- [x] `dotnet build RoslynMcp.slnx --nologo` — clean
- [x] New `EditUndoCohesionTests.cs` (8/8) covering validation rejections (null text, reversed range, out-of-bounds line, non-positive column, disk-untouched-after-reject), the disk-drift safety net, and editorconfig restore-or-delete semantics
- [x] Existing `EditUndoIntegrationTests` (4/4) still green
- [x] Full editing/undo/refactor sweep (33/33) clean
- [ ] CI: `verify-release.ps1 -Configuration Release`
- [ ] Live MCP: reproduce the NetworkDocumentation revert drift and confirm disk restores

## Follow-ups

Part of the top-20 backlog-fix batch. Sequence:
1. ~~P2: test-run-failure-envelope~~ (#108 merged)
2. ~~P3+P4: editing/undo cohesion~~ (this PR)
3. P3: semantic_search verbose-query fallback
4. P3: workspace_load idempotent-by-path
5. P4: behavioral + error-surface polish bundle
6. P4: docs omnibus + verify-release test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)