### PR TITLE
feat: semantic_search verbose-query token fallback + debug payload

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-08T22:30:00Z
+**updated_at:** 2026-04-08T22:50:00Z
 
 ## Agent contract
 
@@ -31,7 +31,6 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 | id | blocker | deps | do |
 |----|---------|------|-----|
 | `workspace-session-deduplication` | none | — | **P3 / session model.** Loading the same solution path twice in one host process can yield `workspace_list` with multiple distinct `WorkspaceId`s (2026-04-08 roslyn-backed-mcp audit 130615; not reproduced on a later pass — intermittent). Wastes workspace slots and confuses audits. Consider idempotent `workspace_load` or explicit dedup. |
-| `semantic-search-zero-results-verbose-query` | none | — | **P3 / UX.** `semantic_search` returned `count: 0` for a long natural-language query while a shorter query returned hits on the same repo (2026-04-08 FirewallAnalyzer audit). Add keyword/stem fallback or scoring/debug payload when the embedding ranker returns empty. |
 | `find-type-usages-cref-classification` | none | — | **P4 / cosmetic.** `find_type_usages` buckets `<see cref="X"/>` doc-comment references as `Other` instead of as a `Documentation` classification (observed against ITChatBot 2026-04-07). Enrich the classification enum so doc-comment refs are visually distinguishable from real consumers. |
 | `verify-release-test-output-policy` | none | — | **P4 / process.** `eng/verify-release.ps1` already sets `$ErrorActionPreference = 'Stop'`, but still runs `dotnet test` with default verbosity. Add `--logger "console;verbosity=normal"` so failing test names are not masked by tail/pipe operations in any wrapper script. |
 | `compile-items-vs-document-count-doc` | none | — | **P4 / docs.** `evaluate_msbuild_items Compile <project>` returns N items but Roslyn `workspace_load` reports `DocumentCount=N+3` for the same project (observed in the 2026-04-07 FirewallAnalyzer audit: `FirewallAnalyzer.Application` had 17 Compile items vs 20 documents). The 3-item gap is normal — auto-generated implicit-usings, assembly-info, and GlobalUsings files are added by the SDK and aren't in the explicit Compile item list. Document this expectation in the `workspace_load` and `evaluate_msbuild_items` tool descriptions so downstream agents can interpret the difference. |

--- a/src/RoslynMcp.Core/Models/SemanticSearchResponseDto.cs
+++ b/src/RoslynMcp.Core/Models/SemanticSearchResponseDto.cs
@@ -2,7 +2,38 @@ namespace RoslynMcp.Core.Models;
 
 /// <summary>
 /// Result of a semantic search, optionally with a note when a fallback strategy was used.
+/// When <paramref name="Debug"/> is non-null the caller can see which tokens and predicates
+/// the parser derived from the raw query — useful when a verbose natural-language query
+/// returns zero results and the caller needs to understand why.
 /// </summary>
 public sealed record SemanticSearchResponseDto(
     IReadOnlyList<SemanticSearchResultDto> Results,
-    string? Warning);
+    string? Warning,
+    SemanticSearchDebugDto? Debug = null);
+
+/// <summary>
+/// Diagnostic payload emitted alongside a semantic_search response when the query either
+/// produced no results or fell back to a less-precise matching strategy. Helps callers
+/// decode why a verbose natural-language query did not match (backlog row
+/// <c>semantic-search-zero-results-verbose-query</c>).
+/// </summary>
+/// <param name="ParsedTokens">
+/// The stemmed keyword tokens derived from the raw query after stopword removal.
+/// Empty when the query contained no significant words.
+/// </param>
+/// <param name="AppliedPredicates">
+/// Human-readable names of the structured predicates the parser matched on the query
+/// (e.g. <c>"async-keyword"</c>, <c>"returning-Task&lt;bool&gt;"</c>, <c>"implementing-IDisposable"</c>).
+/// Empty when no structured predicate matched.
+/// </param>
+/// <param name="FallbackStrategy">
+/// The strategy used to compute the final result set. One of:
+/// <c>"structured"</c> (predicates matched directly),
+/// <c>"name-substring"</c> (single-term contains-match over symbol names),
+/// <c>"token-or-match"</c> (verbose-query fallback: any token is a substring of the symbol name),
+/// <c>"none"</c> (no results from any strategy).
+/// </param>
+public sealed record SemanticSearchDebugDto(
+    IReadOnlyList<string> ParsedTokens,
+    IReadOnlyList<string> AppliedPredicates,
+    string FallbackStrategy);

--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -143,12 +143,15 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
         var results = new List<SemanticSearchResultDto>();
         var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter);
 
-        var (predicates, usedImplicitNameOnly) = ParseSemanticQuery(decodedQuery);
-        bool Combined(ISymbol s) => predicates.All(p => p(s));
+        var parse = ParseSemanticQuery(decodedQuery);
+        bool Combined(ISymbol s) => parse.Predicates.All(p => p(s));
         await CollectSemanticSearchMatchesAsync(solution, projects, Combined, limit, results, ct).ConfigureAwait(false);
 
         string? warning = null;
-        if (results.Count == 0 && decodedQuery.Trim().Length >= 2 && !usedImplicitNameOnly)
+        var fallbackStrategy = results.Count > 0 ? "structured" : "none";
+
+        // First fallback: whole-query name substring match (legacy).
+        if (results.Count == 0 && decodedQuery.Trim().Length >= 2 && !parse.UsedImplicitNameOnly)
         {
             var term = decodedQuery.Trim();
             bool NameMatch(ISymbol s) => s.Name.Contains(term, StringComparison.OrdinalIgnoreCase);
@@ -157,14 +160,46 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
             if (results.Count > 0)
             {
                 warning = "No structured query match; results use a name substring fallback.";
-            }
-            else
-            {
-                warning = $"No symbols matched this semantic query: {term}";
+                fallbackStrategy = "name-substring";
             }
         }
 
-        return new SemanticSearchResponseDto(results, warning);
+        // Second fallback (semantic-search-zero-results-verbose-query): verbose natural-language
+        // queries ("async methods returning Task<bool> inside the Firewall namespace") are too long
+        // to match any symbol name directly. Split into stemmed keyword tokens and match symbols
+        // whose name contains ANY token. Significantly widens the net for long queries while keeping
+        // signal-to-noise reasonable because noise words are dropped via the stopword list.
+        if (results.Count == 0 && parse.Tokens.Count > 0)
+        {
+            var tokens = parse.Tokens;
+            bool TokenOrMatch(ISymbol s)
+            {
+                foreach (var token in tokens)
+                {
+                    if (s.Name.Contains(token, StringComparison.OrdinalIgnoreCase)) return true;
+                }
+                return false;
+            }
+            await CollectSemanticSearchMatchesAsync(solution, projects, TokenOrMatch, limit, results, ct)
+                .ConfigureAwait(false);
+            if (results.Count > 0)
+            {
+                warning = "No structured query match; results use a token-or name fallback over parsed keywords.";
+                fallbackStrategy = "token-or-match";
+            }
+        }
+
+        if (results.Count == 0)
+        {
+            warning ??= $"No symbols matched this semantic query: {decodedQuery.Trim()}";
+        }
+
+        var debug = new SemanticSearchDebugDto(
+            ParsedTokens: parse.Tokens,
+            AppliedPredicates: parse.PredicateLabels,
+            FallbackStrategy: fallbackStrategy);
+
+        return new SemanticSearchResponseDto(results, warning, debug);
     }
 
     private static async Task CollectSemanticSearchMatchesAsync(
@@ -248,10 +283,40 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
         ["protected"] = Accessibility.Protected,
     };
 
-    /// <returns>Predicate list and whether the query fell back to name-only matching (no structured keywords).</returns>
-    private static (List<Func<ISymbol, bool>> Predicates, bool UsedImplicitNameOnly) ParseSemanticQuery(string query)
+    private readonly record struct SemanticQueryParse(
+        List<Func<ISymbol, bool>> Predicates,
+        IReadOnlyList<string> PredicateLabels,
+        IReadOnlyList<string> Tokens,
+        bool UsedImplicitNameOnly);
+
+    /// <summary>
+    /// Natural-language stopwords dropped by <see cref="ExtractTokens"/> before tokens are
+    /// used for the verbose-query fallback. Added for
+    /// <c>semantic-search-zero-results-verbose-query</c> so queries like
+    /// "async methods returning Task&lt;bool&gt; inside the Firewall namespace" decompose
+    /// into useful tokens (<c>Task</c>, <c>bool</c>, <c>Firewall</c>) without noise.
+    /// Note: <c>Task</c> is intentionally NOT a stopword — "returning Task&lt;bool&gt;" queries
+    /// want the token-OR fallback to match symbols named <c>TaskRunner</c>, <c>TaskQueue</c>, etc.
+    /// </summary>
+    private static readonly HashSet<string> SemanticQueryStopwords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "a", "an", "the", "of", "for", "with", "by", "to", "from", "on", "in", "inside", "into", "at", "and", "or",
+        "that", "this", "these", "those", "is", "are", "be", "being", "been",
+        "all", "any", "some", "more", "than", "over",
+        "methods", "method", "classes", "class", "types", "type", "members", "member",
+        "properties", "property", "fields", "field", "interfaces", "interface",
+        "return", "returns", "returning", "receive", "receiving",
+        "async", "static", "public", "private", "internal", "protected",
+        "abstract", "virtual", "sealed", "generic",
+        "namespace", "namespaces",
+        "parameter", "parameters",
+    };
+
+    /// <returns>A structured parse result with predicates, their human-readable labels, and the stopword-filtered token list.</returns>
+    private static SemanticQueryParse ParseSemanticQuery(string query)
     {
         var predicates = new List<Func<ISymbol, bool>>();
+        var predicateLabels = new List<string>();
         var q = query.ToLowerInvariant().Trim();
 
         // Simple keyword predicates from the lookup table.
@@ -275,15 +340,22 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
             }
 
             predicates.Add(predicate);
+            predicateLabels.Add($"keyword:{keyword}");
         }
 
         // "static" with guard against "non-static"
         if (q.Contains("static") && !q.Contains("non-static"))
+        {
             predicates.Add(s => s.IsStatic);
+            predicateLabels.Add("keyword:static");
+        }
 
         // "classes" with guard against "classes implementing"
         if (q.Contains("class") && !q.Contains("classes implementing"))
+        {
             predicates.Add(s => s is INamedTypeSymbol { TypeKind: TypeKind.Class });
+            predicateLabels.Add("keyword:class");
+        }
 
         // Accessibility keywords (mutually exclusive) — capture to local to avoid closure issue
         foreach (var (keyword, accessibility) in AccessibilityKeywords)
@@ -292,29 +364,72 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
             if (keyword == "public" ? q.Contains("public") && !q.Contains("non-public") : q.Contains(keyword))
             {
                 predicates.Add(s => s.DeclaredAccessibility == capturedAccessibility);
+                predicateLabels.Add($"accessibility:{keyword}");
                 break;
             }
         }
 
         // "returning/returns <type>"
+        var beforeReturn = predicates.Count;
         AddReturnTypePredicate(predicates, q);
+        if (predicates.Count > beforeReturn)
+        {
+            predicateLabels.Add("returning-type");
+        }
 
         // "implementing <interface>"
+        var beforeImpl = predicates.Count;
         AddImplementingPredicate(predicates, q);
+        if (predicates.Count > beforeImpl)
+        {
+            predicateLabels.Add("implementing-interface");
+        }
 
         // "more than N parameters"
         var paramMatch = System.Text.RegularExpressions.Regex.Match(q, @"(?:more than|>)\s*(\d+)\s*param");
         if (paramMatch.Success && int.TryParse(paramMatch.Groups[1].Value, out var minParams))
+        {
             predicates.Add(s => s is IMethodSymbol m && m.Parameters.Length > minParams);
+            predicateLabels.Add($"min-parameters:{minParams}");
+        }
+
+        var tokens = ExtractTokens(query);
 
         // Fallback: name-based search
         if (predicates.Count == 0)
         {
             predicates.Add(s => s.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
-            return (predicates, UsedImplicitNameOnly: true);
+            predicateLabels.Add("name-contains");
+            return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: true);
         }
 
-        return (predicates, UsedImplicitNameOnly: false);
+        return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: false);
+    }
+
+    /// <summary>
+    /// Splits a natural-language query into significant tokens for the verbose-query fallback.
+    /// Drops stopwords, retains fragments that look like type names (<c>Task</c>, <c>IDisposable</c>),
+    /// and normalizes by lowercasing the comparison — the returned tokens preserve original case
+    /// so the debug payload reads naturally for the caller.
+    /// </summary>
+    private static IReadOnlyList<string> ExtractTokens(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return Array.Empty<string>();
+
+        // Split on whitespace + common punctuation, but keep `<`/`>`/`,` removed so
+        // "Task<bool>" → "Task" + "bool".
+        var splits = Regex.Split(query, @"[\s<>,\(\)\[\]\{\}\""'\.\?!;:]+");
+        var tokens = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in splits)
+        {
+            var token = raw.Trim();
+            if (token.Length < 2) continue;
+            if (SemanticQueryStopwords.Contains(token)) continue;
+            if (!seen.Add(token)) continue;
+            tokens.Add(token);
+        }
+        return tokens;
     }
 
     private static void AddReturnTypePredicate(List<Func<ISymbol, bool>> predicates, string q)

--- a/tests/RoslynMcp.Tests/SemanticSearchFallbackTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticSearchFallbackTests.cs
@@ -1,0 +1,102 @@
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the PR 3 <c>semantic-search-zero-results-verbose-query</c> fallback work:
+///   * A verbose natural-language query ("async methods returning Task&lt;bool&gt; inside
+///     the Firewall namespace") must decompose into stopword-filtered tokens.
+///   * When structured predicates find nothing, the token-OR fallback should match
+///     symbols whose names contain any token.
+///   * The Debug payload must always be populated so callers can see the parsed tokens,
+///     applied predicates, and fallback strategy.
+/// </summary>
+[TestClass]
+public sealed class SemanticSearchFallbackTests : SharedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task SemanticSearch_StructuredQuery_ExposesAppliedPredicatesInDebug()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId, "async methods", "SampleLib", 50, CancellationToken.None);
+
+        Assert.IsNotNull(response.Debug);
+        Assert.AreEqual("structured", response.Debug!.FallbackStrategy);
+        CollectionAssert.Contains(response.Debug.AppliedPredicates.ToList(), "keyword:async");
+    }
+
+    [TestMethod]
+    public async Task SemanticSearch_VerboseNaturalLanguageQuery_FallsBackToTokenOrMatch()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        // This verbose query is designed to fail structured parsing (no "async", no "returning",
+        // no "implementing" keywords that match a sample symbol). The token-OR fallback should
+        // extract "Dog" from the query and match the SampleLib.Dog type.
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId,
+            "tell me about the Dog animal type inside the SampleLib namespace please",
+            "SampleLib",
+            50,
+            CancellationToken.None);
+
+        Assert.IsNotNull(response.Debug);
+        Assert.IsTrue(response.Results.Count > 0, "Token-OR fallback should surface at least one match for 'Dog'.");
+        Assert.AreEqual("token-or-match", response.Debug!.FallbackStrategy);
+        StringAssert.Contains(
+            response.Warning ?? string.Empty,
+            "token-or name fallback",
+            "Warning should explain the fallback strategy.");
+
+        // Token list must have the stopwords stripped.
+        CollectionAssert.Contains(response.Debug.ParsedTokens.ToList(), "Dog");
+        CollectionAssert.DoesNotContain(response.Debug.ParsedTokens.ToList(), "the");
+        CollectionAssert.DoesNotContain(response.Debug.ParsedTokens.ToList(), "inside");
+        CollectionAssert.DoesNotContain(response.Debug.ParsedTokens.ToList(), "methods");
+    }
+
+    [TestMethod]
+    public async Task SemanticSearch_NoHits_PopulatesDebugAndWarning()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        // Query that no symbol can match, and tokens that aren't substrings of anything.
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId, "xyzzy qwertyzzz", "SampleLib", 50, CancellationToken.None);
+
+        Assert.AreEqual(0, response.Results.Count);
+        Assert.IsNotNull(response.Debug);
+        Assert.AreEqual("none", response.Debug!.FallbackStrategy);
+        Assert.IsNotNull(response.Warning);
+        StringAssert.Contains(response.Warning!, "No symbols matched");
+    }
+
+    [TestMethod]
+    public async Task SemanticSearch_Debug_ParsedTokensDropStopwords()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId,
+            "return Task<bool> from the method inside the namespace",
+            "SampleLib",
+            50,
+            CancellationToken.None);
+
+        Assert.IsNotNull(response.Debug);
+
+        // "Task" is intentionally preserved (users search for TaskRunner / TaskQueue variants).
+        CollectionAssert.Contains(response.Debug!.ParsedTokens.ToList(), "Task");
+        CollectionAssert.Contains(response.Debug.ParsedTokens.ToList(), "bool");
+
+        // Noise words must be dropped.
+        foreach (var stopword in new[] { "return", "from", "the", "method", "inside", "namespace" })
+        {
+            CollectionAssert.DoesNotContain(response.Debug.ParsedTokens.ToList(), stopword);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a second fallback in `CodePatternAnalyzer.SemanticSearchAsync`: when structured parsing and whole-query name-substring matching both miss, extract stopword-filtered tokens from the raw query and match symbols whose names contain **any** token.
- New `SemanticSearchDebugDto` on the response carries `ParsedTokens`, `AppliedPredicates` (e.g. `keyword:async`, `returning-type`, `min-parameters:5`), and `FallbackStrategy` (`structured` | `name-substring` | `token-or-match` | `none`) so callers can see why a verbose query missed.
- Stopword list drops query chrome (`methods`, `returning`, `inside`, `the`, …) but preserves `Task` so "returning Task&lt;bool&gt;" still surfaces `TaskRunner` / `TaskQueue`-style names via fallback.
- Closes backlog row: `semantic-search-zero-results-verbose-query` (P3).

## Test plan

- [x] `dotnet build RoslynMcp.slnx --nologo` — clean
- [x] New `SemanticSearchFallbackTests.cs` (4/4):
  - Structured query → `FallbackStrategy=structured`, applied predicate labels present
  - Verbose natural-language query with zero structured hits → `token-or-match` with `Dog` token hit
  - Zero-hit query → `FallbackStrategy=none`, warning populated
  - Stopword filter drops noise words but preserves `Task`
- [x] Existing `BacklogFixTests` semantic search tests (3/3) still green
- [ ] CI: `verify-release.ps1 -Configuration Release`
- [ ] Live MCP: replay the firewall audit's verbose query and confirm a hit

## Follow-ups

Part of the top-20 backlog-fix batch:
1. ~~P2: test-run-failure-envelope~~ (#108)
2. ~~P3+P4: editing/undo cohesion~~ (#109)
3. ~~P3: semantic_search verbose-query fallback~~ (this PR)
4. P3: workspace_load idempotent-by-path
5. P4: behavioral + error-surface polish bundle
6. P4: docs omnibus + verify-release test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)