### PR TITLE
chore: 1.8.2 — version bump + automated drift check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 147 tools for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 147 tools for navigation, diagnostics, refactoring, security, and more.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Roslyn-Backed MCP Server will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.8.2] - 2026-04-09
+
+### Fixed
+
+- **Structured `test_run` failure envelope** (`test-run-failure-envelope`). When `dotnet test` exits without TRX output (MSB3027/3021 file locks, build failures, timeouts), the result now carries a `TestRunFailureEnvelopeDto` with `ErrorKind` (FileLock/BuildFailure/Timeout/Unknown), `IsRetryable`, `Summary`, and `StdOutTail`/`StdErrTail` instead of throwing a bare invocation error.
+- **`apply_text_edit` range validation** (`apply-text-edit-invalid-edit-corrupt-diff`). Malformed `TextEditDto` values (null `NewText`, non-positive line/column, out-of-bounds, reversed ranges) are now rejected with a structured `ArgumentException` before any disk write or diff generation.
+- **`revert_last_apply` disk consistency** (`revert-last-apply-disk-consistency`). `IUndoService` now accepts explicit `FileSnapshotDto` pairs; `RevertAsync` restores disk directly from these authoritative snapshots instead of relying on the fragile `Solution.GetChanges` path. Legacy solution-based path gains a disk-walk safety net.
+- **`set_editorconfig_option` undo retrofit** (`set-editorconfig-option-not-undoable`). Now participates in the undo stack via the file-snapshot path; `revert_last_apply` restores pre-write content or deletes the file if the set call created it. Tool description updated.
+- **`semantic_search` verbose-query fallback** (`semantic-search-zero-results-verbose-query`). Long natural-language queries that fail structured parsing decompose into stopword-filtered tokens; the token-OR fallback matches symbols whose names contain any token. New `SemanticSearchDebugDto` on the response shows parsed tokens, applied predicates, and fallback strategy.
+- **`workspace_load` idempotent by path** (`workspace-session-deduplication`). Repeat loads of the same solution path return the existing `WorkspaceId` instead of creating a duplicate. Includes a race-window check for concurrent callers.
+- **`find_overrides` auto-promotes to virtual root** (`find-overrides-virtual-declaration-site-doc`). Invoking at an override site now walks back to the original virtual/interface declaration before the search, producing the same complete result set as invoking at the virtual declaration.
+- **`find_type_usages` cref classification** (`find-type-usages-cref-classification`). New `TypeUsageClassification.Documentation` value; `<see cref="X"/>` doc-comment references are now classified as `Documentation` instead of `Other`.
+- **`find_references_bulk` schema error UX** (`find-references-bulk-schema-error-ux`). Invalid `BulkSymbolLocator` shapes now include an inline JSON example in the error message.
+- **MSBuild tools bad-argument message** (`msbuild-tools-bad-argument-message`). `ResolveRoslynProject` now lists loaded project names in the error when the caller passes an unknown project.
+- **`move_file_preview` truncation marker** (`move-file-preview-large-diff-truncation`). The FLAG-6A truncation marker now includes the paths of omitted files.
+- **`analyze_snippet` CS0029 span** (`analyze-snippet-cs0029-literal-span`). Regression test confirms the diagnostic span covers the string literal in user coordinates.
+
+### Changed
+
+- Tool description clarifications for `compile_check`, `project_diagnostics`, `workspace_load`, `evaluate_msbuild_items`, `evaluate_msbuild_property`, `add_package_reference_preview`, `semantic_search`, `symbol_search`, `server_info`, `set_editorconfig_option`, `find_overrides`, `test_run`.
+- `eng/verify-release.ps1` now passes `--logger "console;verbosity=normal"` so failing test names surface through wrapper scripts.
+- `eng/verify-version-drift.ps1` — new automated version-string drift check across all 5 version files; wired into `verify-release.ps1`.
+- Deep-review audit intake: 3 raw audit reports, 1 rollup, updated procedures and eng scripts.
+
 ## [1.8.1] - 2026-04-08
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -65,7 +65,7 @@ The grep is intentionally inclusive. When eyeballing the output:
 - **Must agree on the new version:** `Directory.Build.props:<line>`, `.claude-plugin/plugin.json:3`, `.claude-plugin/marketplace.json` plugin entry (the `plugins[].version` line, **not** line 9), `manifest.json:4`, and the **top** `CHANGELOG.md` `## [X.Y.Z]` header.
 - **Ignore:** `.claude-plugin/marketplace.json:9` is the marketplace catalog's own `metadata.version` schema version (`1.0.0`) — it does not track the plugin version. Older `## [X.Y.Z]` headers further down `CHANGELOG.md` are historical entries, not drift.
 
-If you ever automate this drift check, add it to `eng/verify-release.ps1` and remove this manual step from the checklist below.
+This drift check is now automated: `eng/verify-version-drift.ps1` runs at the top of `eng/verify-release.ps1` and exits non-zero if any of the five files disagree. The manual grep is still useful for quick eyeballing but is no longer the only gate.
 
 ## Release Checklist
 

--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -17,6 +17,10 @@ New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
 New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
 New-Item -ItemType Directory -Path $coverageDir -Force | Out-Null
 
+# Version-string drift check across all 5 version files.
+# Runs before build so a drift-only mistake fails fast without waiting for compilation.
+& (Join-Path $PSScriptRoot 'verify-version-drift.ps1')
+
 dotnet restore $solutionPath --nologo
 dotnet build $solutionPath -c $Configuration --no-restore --nologo
 dotnet test $solutionPath -c $Configuration --no-build --nologo `

--- a/eng/verify-version-drift.ps1
+++ b/eng/verify-version-drift.ps1
@@ -1,0 +1,84 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Validates that all five version-string locations in the repo agree.
+
+.DESCRIPTION
+  Reads the canonical version from Directory.Build.props <Version> and asserts
+  that manifest.json, .claude-plugin/plugin.json, .claude-plugin/marketplace.json
+  (plugins[].version), and the top CHANGELOG.md [X.Y.Z] header all carry the
+  same value.
+
+  Called by verify-release.ps1 as a merge-gate check. Can also be run standalone.
+
+  Exit codes:
+    0  All five files agree.
+    1  At least one file disagrees or is missing.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+# 1. Directory.Build.props — canonical source
+$propsPath = Join-Path $repoRoot 'Directory.Build.props'
+[xml]$props = Get-Content $propsPath
+$canonical = $props.Project.PropertyGroup.Version
+if (-not $canonical) {
+    Write-Error "Could not read <Version> from $propsPath"
+    exit 1
+}
+Write-Host "Canonical version (Directory.Build.props): $canonical"
+
+$errors = @()
+
+# 2. manifest.json
+$manifestPath = Join-Path $repoRoot 'manifest.json'
+$manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+if ($manifest.version -ne $canonical) {
+    $errors += "manifest.json: expected '$canonical', got '$($manifest.version)'"
+}
+
+# 3. .claude-plugin/plugin.json
+$pluginPath = Join-Path $repoRoot '.claude-plugin' 'plugin.json'
+$plugin = Get-Content $pluginPath -Raw | ConvertFrom-Json
+if ($plugin.version -ne $canonical) {
+    $errors += ".claude-plugin/plugin.json: expected '$canonical', got '$($plugin.version)'"
+}
+
+# 4. .claude-plugin/marketplace.json — plugins[0].version (NOT metadata.version)
+$marketplacePath = Join-Path $repoRoot '.claude-plugin' 'marketplace.json'
+$marketplace = Get-Content $marketplacePath -Raw | ConvertFrom-Json
+$pluginEntry = $marketplace.plugins | Select-Object -First 1
+if ($pluginEntry.version -ne $canonical) {
+    $errors += ".claude-plugin/marketplace.json plugins[0].version: expected '$canonical', got '$($pluginEntry.version)'"
+}
+
+# 5. CHANGELOG.md — top ## [X.Y.Z] header
+$changelogPath = Join-Path $repoRoot 'CHANGELOG.md'
+$changelogLines = Get-Content $changelogPath
+$topHeader = $changelogLines | Where-Object { $_ -match '^\#\# \[(\d+\.\d+\.\d+)\]' } | Select-Object -First 1
+if ($topHeader -match '^\#\# \[(\d+\.\d+\.\d+)\]') {
+    $changelogVersion = $Matches[1]
+    if ($changelogVersion -ne $canonical) {
+        $errors += "CHANGELOG.md top header: expected '$canonical', got '$changelogVersion'"
+    }
+} else {
+    $errors += "CHANGELOG.md: no ## [X.Y.Z] header found"
+}
+
+if ($errors.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'VERSION DRIFT DETECTED:' -ForegroundColor Red
+    foreach ($e in $errors) {
+        Write-Host "  - $e" -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host "All five files must carry version '$canonical'. See docs/release-policy.md § Where To Bump The Version String." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "All 5 version files agree on $canonical" -ForegroundColor Green
+exit 0

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

- Bump all 5 version files to `1.8.2` for the backlog-fix batch (PRs #108-#114)
- New `eng/verify-version-drift.ps1` — reads canonical version from `Directory.Build.props` and asserts the other 4 files match. Exits non-zero on drift.
- Wired into `eng/verify-release.ps1` (runs before `dotnet restore`) so CI catches version drift before build/test/publish
- Updated `docs/release-policy.md` to note the drift check is now automated

## Test plan

- [x] `eng/verify-version-drift.ps1` exits 0 with all 5 files at `1.8.2`
- [x] `dotnet build RoslynMcp.slnx --nologo` — clean
- [ ] CI: `verify-release.ps1 -Configuration Release` (drift check runs first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)