### PR TITLE
chore: Source Link + NuGet packaging polish

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,19 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <Version>1.8.2</Version>
+
+    <!-- Source Link: embeds commit hash + repo URL in PDBs so NuGet consumers
+         can step into source and GitHub can link stack traces to specific lines.
+         See https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SecurityCodeScan.VS2019" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,5 +25,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
     <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
   </ItemGroup>
 </Project>

--- a/src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj
+++ b/src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj
@@ -21,12 +21,15 @@
     <RepositoryUrl>https://github.com/darylmcd/Roslyn-Backed-MCP</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>mcp;roslyn;csharp;code-analysis;ai</PackageTags>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- The project-local README.md is the package consumer's view (install + use + config + safety).
          The repo root README.md stays focused on contributors and is intentionally not packed. -->
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <!-- Pack the repo root icon into the nupkg so NuGet gallery shows it. -->
+    <None Include="../../icon.png" Pack="true" PackagePath="\" />
     <InternalsVisibleTo Include="RoslynMcp.Tests" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Add `Microsoft.SourceLink.GitHub` (10.0.102) — embeds commit hash + repo URL in PDBs for source stepping
- Enable deterministic builds (`ContinuousIntegrationBuild` on CI), embedded PDBs, `.snupkg` symbol packages
- Add `PackageIcon` referencing repo-root `icon.png` — NuGet gallery now shows the project icon
- Verified: `dotnet pack` produces both `.nupkg` and `.snupkg` with icon.png, README.md, and nuspec

## Test plan

- [x] `dotnet build RoslynMcp.slnx --nologo` — clean
- [x] `dotnet pack src/RoslynMcp.Host.Stdio -c Release` — produces `.nupkg` + `.snupkg`; icon.png and README.md present in package
- [ ] CI: `verify-release.ps1 -Configuration Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)