### PR TITLE
chore: update SECURITY.md supported versions + add THIRD-PARTY-NOTICES

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.10.x  | Yes       |
-| < 0.10  | No        |
+| 1.8.x   | Yes       |
+| < 1.8   | No        |
 
 ## Reporting a Vulnerability
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,44 @@
+# Third-Party Notices
+
+Roslyn-Backed MCP Server uses the following open-source libraries. Each is distributed under its own license terms as noted below.
+
+## Runtime Dependencies
+
+| Package | Version | License | Project |
+|---------|---------|---------|---------|
+| ModelContextProtocol | 1.1.0 | MIT | https://github.com/modelcontextprotocol/csharp-sdk |
+| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp.Features | 5.3.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.Features | 5.3.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.3.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp.Scripting | 5.3.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.Build.Locator | 1.11.2 | MIT | https://github.com/microsoft/MSBuildLocator |
+| Microsoft.Extensions.Hosting | 10.0.3 | MIT | https://github.com/dotnet/runtime |
+| Microsoft.Extensions.Logging | 10.0.3 | MIT | https://github.com/dotnet/runtime |
+| Microsoft.Extensions.Logging.Console | 10.0.3 | MIT | https://github.com/dotnet/runtime |
+| DiffPlex | 1.7.2 | Apache-2.0 | https://github.com/mmanela/diffplex |
+| Nito.AsyncEx | 5.1.2 | MIT | https://github.com/StephenCleary/AsyncEx |
+
+## Build-Time Dependencies
+
+| Package | Version | License | Project |
+|---------|---------|---------|---------|
+| Microsoft.Build | 17.11.48 | MIT | https://github.com/dotnet/msbuild |
+| Microsoft.Build.Framework | 17.11.48 | MIT | https://github.com/dotnet/msbuild |
+| Microsoft.Build.Tasks.Core | 17.11.48 | MIT | https://github.com/dotnet/msbuild |
+| Microsoft.Build.Utilities.Core | 17.11.48 | MIT | https://github.com/dotnet/msbuild |
+| Microsoft.SourceLink.GitHub | 10.0.102 | MIT | https://github.com/dotnet/sourcelink |
+| SecurityCodeScan.VS2019 | 5.6.7 | LGPL-3.0 | https://github.com/security-code-scan/security-code-scan |
+
+## Test Dependencies
+
+| Package | Version | License | Project |
+|---------|---------|---------|---------|
+| Microsoft.NET.Test.Sdk | 17.14.0 | MIT | https://github.com/microsoft/vstest |
+| MSTest.TestAdapter | 3.8.3 | MIT | https://github.com/microsoft/testfx |
+| MSTest.TestFramework | 3.8.3 | MIT | https://github.com/microsoft/testfx |
+| coverlet.collector | 6.0.4 | MIT | https://github.com/coverlet-coverage/coverlet |
+
+---
+
+This file is generated from `Directory.Packages.props`. To verify or update, review the centrally managed package versions in that file and cross-reference each package's license on nuget.org.


### PR DESCRIPTION
## Summary

- Update `SECURITY.md` supported-versions table from `0.10.x` to `1.8.x`
- Add `THIRD-PARTY-NOTICES.md` listing all 22 direct NuGet dependencies with license types and project URLs

## Test plan

- [x] No code changes — docs only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)