### PR TITLE
feat: /bump and /publish-preflight skills

### DIFF
--- a/skills/bump/SKILL.md
+++ b/skills/bump/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bump
+description: "Version bump. Use when: bumping the version for a release, preparing a version increment (major/minor/patch), or when code changes require a new version. Takes bump type as input: 'major', 'minor', or 'patch'. Edits all 5 version files and prepends a CHANGELOG.md section."
+user-invocable: true
+argument-hint: "patch | minor | major"
+---
+
+# Version Bump
+
+You are a release engineer. Your job is to increment the project version across all 5 version files and prepare a changelog section.
+
+## Input
+
+`$ARGUMENTS` is the bump type: `patch`, `minor`, or `major`. If not provided, ask the user which type of bump to perform with a brief explanation:
+- **patch** (1.8.2 -> 1.8.3): bug fixes, doc changes, no new features
+- **minor** (1.8.2 -> 1.9.0): new features, new stable tools, backward-compatible changes
+- **major** (1.8.2 -> 2.0.0): breaking changes to stable tool contracts
+
+## Version Files
+
+All 5 files must carry the same version string. See `docs/release-policy.md` § *Where To Bump The Version String* for the canonical reference.
+
+| # | File | Field |
+|---|------|-------|
+| 1 | `Directory.Build.props` | `<Version>X.Y.Z</Version>` |
+| 2 | `.claude-plugin/plugin.json` | `"version": "X.Y.Z"` |
+| 3 | `.claude-plugin/marketplace.json` | `plugins[0].version` (NOT `metadata.version`) |
+| 4 | `manifest.json` | `"version": "X.Y.Z"` |
+| 5 | `CHANGELOG.md` | New `## [X.Y.Z] - YYYY-MM-DD` header at top of entries |
+
+## Workflow
+
+### Step 1: Read Current Version
+
+Read `Directory.Build.props` and extract the current `<Version>` value. Display it to the user.
+
+### Step 2: Compute New Version
+
+Parse the current version as `major.minor.patch`. Apply the bump type:
+- `patch`: increment patch
+- `minor`: increment minor, reset patch to 0
+- `major`: increment major, reset minor and patch to 0
+
+Display the new version and confirm with the user before proceeding.
+
+### Step 3: Edit All 5 Files
+
+Edit each file using the Edit tool, replacing the old version with the new version:
+
+1. **`Directory.Build.props`**: Replace `<Version>OLD</Version>` with `<Version>NEW</Version>`
+2. **`.claude-plugin/plugin.json`**: Replace `"version": "OLD"` with `"version": "NEW"` (the first occurrence)
+3. **`.claude-plugin/marketplace.json`**: Replace `"version": "OLD"` in the `plugins[0]` entry (NOT the `metadata.version` on line 9)
+4. **`manifest.json`**: Replace `"version": "OLD"` with `"version": "NEW"`
+5. **`CHANGELOG.md`**: Insert a new section header `## [NEW] - YYYY-MM-DD` (today's date) with empty `### Fixed`, `### Changed`, `### Added` subsections above the previous top entry. Do NOT remove or edit existing entries.
+
+### Step 4: Verify
+
+Run `eng/verify-version-drift.ps1` via Bash to confirm all 5 files agree on the new version. If it fails, fix the discrepancy and re-run.
+
+### Step 5: Report
+
+Display a summary:
+- Previous version → New version
+- Files modified (list all 5)
+- Reminder: "Fill in the CHANGELOG.md section before shipping. Run `/roslyn-mcp:publish-preflight` when ready to validate the full release."

--- a/skills/publish-preflight/SKILL.md
+++ b/skills/publish-preflight/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: publish-preflight
+description: "Pre-publish validation checklist. Use when: preparing to publish to NuGet, validating release readiness, or running the full pre-publish pipeline. Checks version drift, AI docs, build/test/publish, changelog, security versions, and doc-audit freshness."
+user-invocable: true
+argument-hint: ""
+---
+
+# Publish Pre-flight Checklist
+
+You are a release gatekeeper. Your job is to run every validation step required before a NuGet publish and report a clear pass/fail summary.
+
+## Checklist Steps
+
+Execute ALL steps in order. Track pass/fail for each. Do NOT stop on the first failure — run the full checklist so the user sees everything that needs fixing.
+
+### Step 1: Version Drift Check
+
+Run via Bash:
+```
+pwsh -NoProfile -File eng/verify-version-drift.ps1
+```
+
+**Pass** if exit code 0. **Fail** if any of the 5 version files disagree — report which ones.
+
+### Step 2: AI Documentation Validation
+
+Run via Bash:
+```
+pwsh -NoProfile -File eng/verify-ai-docs.ps1
+```
+
+**Pass** if exit code 0. **Fail** if documentation structure is invalid.
+
+### Step 3: Build, Test, and Publish Validation
+
+Run via Bash:
+```
+pwsh -NoProfile -File eng/verify-release.ps1 -Configuration Release
+```
+
+This runs: version drift (again, harmless), restore, build, test with coverage, publish host binary, and SHA256 manifest generation.
+
+**Pass** if exit code 0. **Fail** if build errors, test failures, or publish errors.
+
+Extract and report:
+- Total tests / passed / failed
+- Coverage output path
+- Hash manifest path
+
+### Step 4: CHANGELOG.md Entry
+
+Read `Directory.Build.props` to get the current version. Read `CHANGELOG.md` and check that a `## [X.Y.Z]` header exists for the current version.
+
+**Pass** if the header exists. **Fail** if missing — remind the user to run `/roslyn-mcp:bump` or manually add the section.
+
+### Step 5: SECURITY.md Supported Versions
+
+Read `SECURITY.md` and extract the supported-versions table. Read the current version from `Directory.Build.props`. Check that the major.minor line (e.g., `1.8.x`) appears in the "Yes" row.
+
+**Pass** if the current major.minor is listed as supported. **Fail** if the table is stale — report what it says vs what it should say.
+
+### Step 6: Doc-Audit (Consumer README Freshness)
+
+Invoke the `/doc-audit` skill to check that consumer-facing documentation is current. If the `/doc-audit` skill is not available, manually check:
+- `src/RoslynMcp.Host.Stdio/README.md` exists and references the current version
+- The tool count in the README roughly matches `server_info` stable + experimental counts
+
+**Pass** if the consumer README is current. **Fail** with specific staleness notes.
+
+### Step 7: Package Build Verification
+
+Run via Bash:
+```
+dotnet pack src/RoslynMcp.Host.Stdio -c Release -o /tmp/preflight-nupkg --nologo
+```
+
+Check that both `.nupkg` and `.snupkg` are produced. Verify the `.nupkg` contains `icon.png` and `README.md`.
+
+**Pass** if both packages exist with expected content. **Fail** with details.
+
+## Summary Report
+
+After all steps, display a table:
+
+```
+Pre-flight Summary for vX.Y.Z
+─────────────────────────────
+Step 1: Version Drift      ✓ PASS / ✗ FAIL
+Step 2: AI Docs             ✓ PASS / ✗ FAIL
+Step 3: Build/Test/Publish  ✓ PASS / ✗ FAIL (N tests, N passed)
+Step 4: CHANGELOG Entry     ✓ PASS / ✗ FAIL
+Step 5: SECURITY Versions   ✓ PASS / ✗ FAIL
+Step 6: Doc-Audit           ✓ PASS / ✗ FAIL
+Step 7: Package Build       ✓ PASS / ✗ FAIL
+
+Overall: READY TO PUBLISH / NOT READY (N issues)
+```
+
+If all pass, tell the user: "All checks passed. To publish: create a GitHub Release (which triggers the publish-nuget workflow) or run `eng/publish-nuget.ps1` manually."
+
+If any fail, list the failures with remediation steps.


### PR DESCRIPTION
## Summary

Two new Claude Code plugin skills for the release workflow:

- **`/roslyn-mcp:bump patch|minor|major`** — edits all 5 version files in one shot, prepends a CHANGELOG.md section, runs `eng/verify-version-drift.ps1` to confirm
- **`/roslyn-mcp:publish-preflight`** — runs the full 7-step pre-publish checklist (version drift, AI docs, build/test/publish, changelog, security versions, doc-audit, package build) and reports a pass/fail summary table

## Test plan

- [x] Skill files follow existing format conventions
- [x] Both skills are user-invocable with argument hints
- [ ] CI green (docs/skills only)
- [ ] Manual: invoke `/roslyn-mcp:bump patch` and verify all 5 files update
- [ ] Manual: invoke `/roslyn-mcp:publish-preflight` and verify 7-step report

🤖 Generated with [Claude Code](https://claude.com/claude-code)