### PR TITLE
feat: NuGet version check in server_info + /update skill + update hook

### DIFF
--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -20,6 +20,15 @@ This document is the canonical runtime and execution-context reference for AI ag
   - `dotnet test RoslynMcp.slnx --nologo`
   - `dotnet run --project src/RoslynMcp.Host.Stdio`
 
+## Package Identity
+
+- **NuGet package ID:** `Darylmcd.RoslynMcp` (NOT `RoslynMcp` — that is a different publisher's package)
+- **CLI command after install:** `roslynmcp`
+- **Install:** `dotnet tool install -g Darylmcd.RoslynMcp`
+- **Update:** `dotnet tool update -g Darylmcd.RoslynMcp`
+
+The project name `RoslynMcp.Host.Stdio` is the .csproj assembly name, not the NuGet package ID. Always use `Darylmcd.RoslynMcp` in `dotnet tool` commands.
+
 ## Environment variables (stdio host)
 
 Optional overrides read at startup from `src/RoslynMcp.Host.Stdio/Program.cs`. Values must be positive integers unless noted.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,6 +13,15 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "mcp__roslyn__server_info",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check the server_info response for the 'update' field. If 'update.updateAvailable' is true, briefly tell the user that a newer version of the Roslyn MCP plugin is available (mention the current and latest versions) and suggest running /roslyn-mcp:update. If update is null or updateAvailable is false, respond with 'ok' and do not mention updates."
+          }
+        ]
+      },
+      {
         "matcher": "mcp__roslyn__(rename_apply|extract_interface_apply|extract_type_apply|move_type_to_file_apply|bulk_replace_type_apply|remove_dead_code_apply|apply_composite_preview|move_file_apply|create_file_apply)",
         "hooks": [
           {

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: update
+description: "Update the Roslyn MCP plugin. Use when: server_info shows an update is available, the user wants to update to the latest version, or the plugin reports an older version than NuGet. Handles both the global tool binary (Layer 1) and the Claude Code plugin metadata (Layer 2)."
+user-invocable: true
+---
+
+# Update Roslyn MCP Plugin
+
+You are an update assistant. Your job is to update both layers of the Roslyn MCP plugin to the latest version.
+
+## Background
+
+The plugin has two layers that must be updated together:
+
+| Layer | Provides | Update command |
+|-------|----------|----------------|
+| 1 — Global tool | The `roslynmcp` MCP server binary | `dotnet tool update -g Darylmcd.RoslynMcp` |
+| 2 — Claude Code plugin | Skills, hooks, marketplace metadata | `/plugin marketplace update` + `/plugin install` |
+
+**Important:** The NuGet package ID is `Darylmcd.RoslynMcp` (NOT `RoslynMcp` — that is a different publisher's package).
+
+## Workflow
+
+### Step 1: Check Current Version
+
+Call `server_info` to get the current running version and check for updates. Report to the user:
+- Current version (from `version` field, strip the `+hash` suffix)
+- Latest NuGet version (from `update.latest` if available)
+- Whether an update is available (from `update.updateAvailable`)
+
+If `update` is `null`, the NuGet check hasn't completed yet. Tell the user the check is still pending and proceed to update anyway if they want the latest.
+
+### Step 2: Update Layer 1 — Global Tool
+
+Run via Bash:
+
+```bash
+dotnet tool update -g Darylmcd.RoslynMcp
+```
+
+Report the result. If the tool reports "already up to date", note that and continue to Layer 2.
+
+### Step 3: Update Layer 2 — Claude Code Plugin
+
+Tell the user to run these two commands in the Claude Code chat input (they are slash commands handled by the Claude Code client, not by the agent):
+
+```
+/plugin marketplace update roslyn-mcp-marketplace
+/plugin install roslyn-mcp@roslyn-mcp-marketplace
+```
+
+**Note:** If the user's Claude Code client does not support `/plugin` slash commands (i.e., they get a normal chat response instead of the client executing the command), tell them to run this PowerShell command instead from the repo root:
+
+```powershell
+pwsh ./eng/update-claude-plugin.ps1
+```
+
+### Step 4: Report
+
+Display a summary:
+- Previous version
+- New version (or "already up to date")
+- Layers updated
+- **Reminder: "Restart Claude Code to load the updated binary, skills, and hooks."**

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -27,6 +27,9 @@ builder.Services.AddSingleton(BindExecutionGateOptions());
 builder.Services.AddSingleton(BindSecurityOptions());
 builder.Services.AddSingleton(BindScriptingServiceOptions());
 
+builder.Services.AddSingleton<HttpClient>();
+builder.Services.AddSingleton<RoslynMcp.Host.Stdio.Services.NuGetVersionChecker>();
+
 builder.Services.AddRoslynServices();
 builder.Services
     .AddMcpServer(options =>

--- a/src/RoslynMcp.Host.Stdio/Services/NuGetVersionChecker.cs
+++ b/src/RoslynMcp.Host.Stdio/Services/NuGetVersionChecker.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace RoslynMcp.Host.Stdio.Services;
+
+/// <summary>
+/// Lazily checks NuGet for the latest published version of Darylmcd.RoslynMcp
+/// and caches the result. Never throws — returns null when the check is pending,
+/// failed, or timed out.
+/// </summary>
+public sealed class NuGetVersionChecker
+{
+    private const string PackageId = "darylmcd.roslynmcp";
+    private static readonly Uri FlatContainerUri = new($"https://api.nuget.org/v3-flatcontainer/{PackageId}/index.json");
+    private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+
+    private readonly HttpClient _http;
+    private readonly object _lock = new();
+    private string? _latestVersion;
+    private DateTime _checkedAtUtc;
+    private Task? _pendingCheck;
+
+    public NuGetVersionChecker(HttpClient http)
+    {
+        _http = http;
+    }
+
+    /// <summary>
+    /// Returns the latest stable version string from NuGet, or null if the check
+    /// hasn't completed yet / failed / is stale and a refresh is in progress.
+    /// Calling this kicks off a background fetch on first access and after cache expiry.
+    /// </summary>
+    public string? GetLatestVersion()
+    {
+        lock (_lock)
+        {
+            var cacheValid = _latestVersion is not null
+                             && (DateTime.UtcNow - _checkedAtUtc) < CacheDuration;
+
+            if (cacheValid)
+                return _latestVersion;
+
+            // Kick off a background refresh if one isn't already running
+            if (_pendingCheck is null || _pendingCheck.IsCompleted)
+                _pendingCheck = Task.Run(FetchLatestVersionAsync);
+
+            // Return stale value (or null on first call) while refresh runs
+            return _latestVersion;
+        }
+    }
+
+    private async Task FetchLatestVersionAsync()
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(HttpTimeout);
+            var json = await _http.GetStringAsync(FlatContainerUri, cts.Token).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("versions", out var versions))
+                return;
+
+            // Walk backwards to find the latest stable version (no '-' prerelease tag)
+            string? latest = null;
+            foreach (var v in versions.EnumerateArray())
+            {
+                var ver = v.GetString();
+                if (ver is not null && !ver.Contains('-'))
+                    latest = ver;
+            }
+
+            if (latest is not null)
+            {
+                lock (_lock)
+                {
+                    _latestVersion = latest;
+                    _checkedAtUtc = DateTime.UtcNow;
+                }
+            }
+        }
+        catch
+        {
+            // Swallow — version check is best-effort
+        }
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text.Json;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -14,7 +15,8 @@ public static class ServerTools
     [McpServerTool(Name = "server_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      Description("Get server version, capabilities, runtime information, and loaded workspace count. workspaceCount reflects sessions at call time and may briefly lag if invoked in parallel with or immediately after workspace_load; use workspace_list for authoritative session enumeration. Prompts tier note: the response carries prompts.stable and prompts.experimental counts to mirror the tool/resource tiering convention, but all currently-exposed prompts are experimental. A report like stable=0, experimental=16 is intentional and means 'no prompts have been promoted to the stable tier yet' — it is NOT a missing-surface bug.")]
     public static Task<string> GetServerInfo(
-        IWorkspaceManager workspace)
+        IWorkspaceManager workspace,
+        NuGetVersionChecker versionChecker)
     {
         return ToolErrorHandler.ExecuteAsync("server_info", () =>
         {
@@ -24,6 +26,13 @@ public static class ServerTools
 
             var catalogSummary = ServerSurfaceCatalog.GetSummary();
             var wsCount = workspace.ListWorkspaces().Count;
+
+            // Best-effort: returns cached latest version or null if pending/failed
+            var latestVersion = versionChecker.GetLatestVersion();
+            var currentSemver = version.Split('+')[0]; // strip git hash suffix
+            var updateAvailable = latestVersion is not null
+                                  && !string.Equals(currentSemver, latestVersion, StringComparison.OrdinalIgnoreCase);
+
             var info = new
             {
                 server = "roslyn-mcp",
@@ -68,7 +77,14 @@ public static class ServerTools
                     prompts = true,
                     logging = true,
                     progress = true
-                }
+                },
+                update = latestVersion is not null ? new
+                {
+                    current = currentSemver,
+                    latest = latestVersion,
+                    updateAvailable,
+                    command = updateAvailable ? "dotnet tool update -g Darylmcd.RoslynMcp" : (string?)null
+                } : null
             };
 
             return Task.FromResult(JsonSerializer.Serialize(info, JsonDefaults.Indented));

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Services;
 using RoslynMcp.Host.Stdio.Tools;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -34,7 +35,7 @@ public sealed class SurfaceCatalogTests
     [TestMethod]
     public async Task ServerInfo_IncludesSurfaceSupportSummary()
     {
-        var json = await ServerTools.GetServerInfo(new FakeWorkspaceManager());
+        var json = await ServerTools.GetServerInfo(new FakeWorkspaceManager(), new NuGetVersionChecker(new HttpClient()));
         using var doc = JsonDocument.Parse(json);
 
         Assert.IsTrue(doc.RootElement.TryGetProperty("surface", out var surface));


### PR DESCRIPTION
## Summary
- Add `NuGetVersionChecker` service — queries NuGet v3 API for latest `Darylmcd.RoslynMcp` version (3s timeout, 1hr cache, lazy, never throws)
- Wire `update` field into `server_info` response showing current vs latest version and update command
- Add `/roslyn-mcp:update` skill that updates both layers (global tool binary + plugin metadata) in one guided workflow
- Add `PostToolUse` hook on `server_info` that notifies users when a newer version is available
- Add Package Identity section to `ai_docs/runtime.md` so AI agents use the correct NuGet package ID

## Test plan
- [x] `dotnet build RoslynMcp.slnx` — builds clean
- [x] `dotnet test RoslynMcp.slnx` — all 328 tests pass
- [x] `server_info` returns `update` field (verified live after reinstall)
- [ ] CI passes
- [ ] After merge + plugin update, `/roslyn-mcp:update` skill appears in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)