### PR TITLE
fix: preserve line breaks in apply_text_edit when span ends at column 1

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-09T00:00:00Z
+**updated_at:** 2026-04-09T20:00:00Z
 
 ## Agent contract
 
@@ -30,8 +30,15 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 
 | id | blocker | deps | do |
 |----|---------|------|-----|
-
-_No open backlog rows at this timestamp — top-20 fix batch shipped across PRs #108-#113. Next audit pass will refill with new findings._
+| `dr-code-fix-preview-vs-diagnostic-details-curated-gap` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.1 (CA1852 / empty `SupportedFixes`); `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §7 (`diagnostic_details` lists `remove_unused_field` for CS0414 but `code_fix_preview` rejects curated fix). Unify contract: which diagnostics have curated fixes vs FixAll vs IDE-only. |
+| `dr-semantic-search-idisposable-predicate-accuracy` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.5 — **`semantic_search` “classes implementing IDisposable”** returns types that are not implementors (e.g. test fixtures). **FLAG** predicate accuracy. |
+| `dr-find-shared-members-locator-invalidargument` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.3 — **`find_shared_members`** → **InvalidArgument** “Syntax node is not within syntax tree” for `ChatOrchestrationPipeline` via handle/locator (partial-class / snapshot mismatch hypothesis). |
+| `dr-security-integration-insecurelib-not-in-sln` | none | — | **P3 / test graph.** **Auto (deep-review).** `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 — Full `dotnet test` on `Roslyn-Backed-MCP.sln`: **4 failures** in `SecurityDiagnosticIntegrationTests` (no findings in `InsecureLib`). Loaded solution lacks insecure fixture projects tests expect — fix test preconditions, sample layout, or conditional skip. |
+| `dr-project-diagnostics-info-only-empty-first-page` | none | — | **P4 / tracking.** **Auto (deep-review).** Merged: `20260409T165230Z_firewallanalyzer_mcp-server-audit.md` §14.1 (null `severity`, non-zero info totals, empty page) + `20260409T165300Z_networkdocumentation_mcp-server-audit.md` §14.2 (first page empty without explicit `severity` when only Info diagnostics exist). **`project_diagnostics` paging / default severity** UX — **FLAG**. |
+| `dr-get-editorconfig-options-incomplete-after-set` | none | — | **P4 / tracking.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.4 — After `set_editorconfig_option`, **`get_editorconfig_options`** omitted `dotnet_separate_import_directive_groups` from `Options[]` while disk had the line. **FLAG** enumerator completeness vs Roslyn API. |
+| `dr-get-code-actions-opaque-error-on-bad-contract` | none | — | **P4 / UX.** **Auto (deep-review).** `20260409T165300Z_networkdocumentation_mcp-server-audit.md` §14.1 — **`get_code_actions`** called with `line`/`column` instead of `startLine`/`startColumn`: generic “error occurred invoking” without required-property hint — error-message-quality / schema discoverability. |
+| `dr-project-diagnostics-response-total-field-naming` | none | — | **P4 / docs.** **Auto (deep-review).** `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §7 — **`project_diagnostics`** uses `totalErrors` / `compilerErrors` split vs docs/examples expecting uniform `total*` naming — **FLAG** documentation / contract clarity (not necessarily wrong behavior). |
+| `dr-find-references-bulk-first-invocation-parameter-ux` | none | — | **P4 / UX.** **Auto (deep-review).** `20260408T195030Z_firewall-analyzer_mcp-server-audit.md` §14 — **`find_references_bulk`** first invocation failed until parameter shape corrected; improve schema example in error (cosmetic). |
 
 ## Refs
 

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -221,7 +221,27 @@ public sealed class EditService : IEditService
             var startPosition = sourceText.Lines.GetPosition(new LinePosition(edit.StartLine - 1, edit.StartColumn - 1));
             var endPosition = sourceText.Lines.GetPosition(new LinePosition(edit.EndLine - 1, edit.EndColumn - 1));
             var span = TextSpan.FromBounds(startPosition, endPosition);
-            textChanges.Add(new TextChange(span, edit.NewText));
+
+            // dr-apply-text-edit-line-break-corruption: When the edit span ends at
+            // column 1 of a line (meaning it swallowed the line break of the previous
+            // line), and NewText does not end with a line break, append the original
+            // line ending to prevent line collapse at method/declaration boundaries.
+            var replacementText = edit.NewText;
+            if (edit.EndColumn == 1 && span.Length > 0 && replacementText.Length > 0)
+            {
+                var lastCharInSpan = sourceText[span.End - 1];
+                var endsWithNewline = replacementText[^1] is '\n' or '\r';
+                if (lastCharInSpan is '\n' or '\r' && !endsWithNewline)
+                {
+                    // Detect the original line ending sequence (CRLF vs LF vs CR)
+                    var lineBreak = (span.End >= 2 && sourceText[span.End - 2] == '\r' && lastCharInSpan == '\n')
+                        ? "\r\n"
+                        : lastCharInSpan == '\n' ? "\n" : "\r";
+                    replacementText += lineBreak;
+                }
+            }
+
+            textChanges.Add(new TextChange(span, replacementText));
         }
 
         var newSourceText = sourceText.WithChanges(textChanges);

--- a/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
@@ -160,6 +160,62 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         StringAssert.Contains(entry.Description, "Dog.cs");
     }
 
+    /// <summary>
+    /// Regression test for dr-apply-text-edit-line-break-corruption: when an edit span
+    /// ends at column 1 of a subsequent line (swallowing the line break), and the
+    /// replacement text does not end with a newline, the original line break must be
+    /// preserved to prevent line collapse at method/declaration boundaries.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyTextEdit_PreservesLineBreak_WhenSpanEndsAtColumn1()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        // Find "public string Speak() => \"Woof\";" — replace the entire line including
+        // the trailing newline (ending at column 1 of the NEXT line) with replacement
+        // text that does NOT end with a newline. Without the fix, this collapses the
+        // Speak line into the Fetch method declaration.
+        var lines = originalText.Split('\n');
+        int speakLineNumber = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains("Speak", StringComparison.Ordinal))
+            {
+                speakLineNumber = i + 1; // 1-based
+                break;
+            }
+        }
+        Assert.IsTrue(speakLineNumber > 0, "Dog.cs must contain a Speak method.");
+
+        // Span: from start of the Speak line to column 1 of the next line (includes line break)
+        var edit = new TextEditDto(
+            speakLineNumber, 1,
+            speakLineNumber + 1, 1,
+            "    public string Speak() => \"Bark\";");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+        Assert.IsTrue(result.Success);
+
+        var afterEdit = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        StringAssert.Contains(afterEdit, "\"Bark\"", "Replacement text should be present.");
+
+        // The critical assertion: the Fetch method must still start on its own line.
+        // Without the line-break preservation fix, "Bark\";" and "public void Fetch"
+        // would be on the same line.
+        var afterLines = afterEdit.Split('\n');
+        var barkLine = Array.FindIndex(afterLines, l => l.Contains("Bark", StringComparison.Ordinal));
+        var fetchLine = Array.FindIndex(afterLines, l => l.Contains("Fetch", StringComparison.Ordinal));
+        Assert.IsTrue(barkLine >= 0 && fetchLine >= 0, "Both Bark and Fetch lines must exist.");
+        Assert.IsTrue(fetchLine > barkLine,
+            "Fetch method must be on a separate line after the Speak replacement — " +
+            "line break at method boundary must be preserved.");
+    }
+
     private static TextEditDto AppendCommentEdit(string fileText, string commentLine)
     {
         var lines = fileText.Split('\n');


### PR DESCRIPTION
## Summary
- When an edit span ends at column 1 of a line (swallowing the line break), and the replacement text doesn't end with a newline, the original line ending is now appended
- Prevents line collapse at method/declaration boundaries flagged in deep-review audit
- Adds regression test verifying Speak/Fetch method boundaries survive replacement

## Test plan
- [x] New test `ApplyTextEdit_PreservesLineBreak_WhenSpanEndsAtColumn1` passes
- [x] All 13 existing edit/undo tests pass (no regression)
- [x] Full suite: 328/328

Closes `dr-apply-text-edit-line-break-corruption`.

Generated with [Claude Code](https://claude.com/claude-code)