### PR TITLE
fix: tighten curated fix contract in diagnostic_details

### DIFF
--- a/src/RoslynMcp.Core/Models/DiagnosticDetailsDto.cs
+++ b/src/RoslynMcp.Core/Models/DiagnosticDetailsDto.cs
@@ -7,7 +7,8 @@ public sealed record DiagnosticDetailsDto(
     DiagnosticDto Diagnostic,
     string? Description,
     string? HelpLinkUri,
-    IReadOnlyList<CodeFixOptionDto> SupportedFixes);
+    IReadOnlyList<CodeFixOptionDto> SupportedFixes,
+    string? GuidanceMessage = null);
 
 /// <summary>
 /// Represents a code fix option available for a diagnostic.

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -207,7 +207,8 @@ public sealed class DiagnosticService : IDiagnosticService
         Diagnostic: SymbolMapper.ToDiagnosticDto(diagnostic),
         Description: BuildDiagnosticDescription(diagnostic),
         HelpLinkUri: BuildHelpLink(diagnostic.Id),
-        SupportedFixes: GetSupportedFixes(diagnostic.Id));
+        SupportedFixes: GetSupportedFixes(diagnostic.Id),
+        GuidanceMessage: GetFixGuidance(diagnostic.Id));
 
     private static string BuildDiagnosticDescription(Diagnostic diagnostic)
     {
@@ -269,6 +270,10 @@ public sealed class DiagnosticService : IDiagnosticService
     private static string BuildHelpLink(string diagnosticId) =>
         $"https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/{diagnosticId.ToLowerInvariant()}";
 
+    // dr-code-fix-preview-vs-diagnostic-details-curated-gap: Only advertise
+    // diagnostics that code_fix_preview (PreviewCodeFixAsync) actually handles.
+    // Previously this map included CS0414, CS8600/8602/8603, CA2234 which were
+    // rejected at apply time — a contract violation surfaced by deep-review audits.
     private static IReadOnlyList<CodeFixOptionDto> GetSupportedFixes(string diagnosticId) =>
         diagnosticId.ToUpperInvariant() switch
         {
@@ -286,28 +291,20 @@ public sealed class DiagnosticService : IDiagnosticService
                     Title: "Remove unnecessary using directive",
                     Description: "IDE-style unused using removal (requires a matching code fix provider in the workspace).")
             ],
-            "CS0414" =>
-            [
-                new CodeFixOptionDto(
-                    FixId: "remove_unused_field",
-                    Title: "Remove unused field",
-                    Description: "Field is assigned but never read; remove or use the field.")
-            ],
-            "CS8600" or "CS8602" or "CS8603" =>
-            [
-                new CodeFixOptionDto(
-                    FixId: "nullable_fix",
-                    Title: "Address nullable reference warning",
-                    Description: "Add null check, use null-forgiving operator, or adjust annotations.")
-            ],
-            "CA2234" =>
-            [
-                new CodeFixOptionDto(
-                    FixId: "pass_system_uri",
-                    Title: "Pass System.Uri instead of string",
-                    Description: "CA2234: use Uri overload for HTTP client calls where applicable.")
-            ],
             _ => []
+        };
+
+    /// <summary>
+    /// Returns a guidance message for diagnostics that do not have curated code_fix_preview
+    /// support but can be addressed via get_code_actions + preview_code_action.
+    /// </summary>
+    private static string? GetFixGuidance(string diagnosticId) =>
+        diagnosticId.ToUpperInvariant() switch
+        {
+            "CS0414" or "CS8600" or "CS8602" or "CS8603" or "CA2234" or "CA1852" =>
+                "This diagnostic does not have a curated code_fix_preview fix. " +
+                "Use get_code_actions at the diagnostic location, then preview_code_action to apply a Roslyn-provided fix.",
+            _ => null
         };
 
     private static bool DiagnosticMatchesLocation(Diagnostic diagnostic, string diagnosticId, string filePath, int line, int column)

--- a/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
@@ -38,7 +38,7 @@ public class DiagnosticFixIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public async Task Diagnostic_Details_For_CS0414_Includes_Curated_RemoveUnusedField_Fix()
+    public async Task Diagnostic_Details_For_CS0414_Returns_Guidance_Instead_Of_Curated_Fix()
     {
         var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
         var probeFile = solution.Projects.SelectMany(project => project.Documents).First(document => document.Name == "DiagnosticsProbe.cs");
@@ -52,8 +52,14 @@ public class DiagnosticFixIntegrationTests : SharedWorkspaceTestBase
             CancellationToken.None);
 
         Assert.IsNotNull(details);
-        Assert.AreEqual(1, details.SupportedFixes.Count);
-        Assert.AreEqual("remove_unused_field", details.SupportedFixes[0].FixId);
+        // dr-code-fix-preview-vs-diagnostic-details-curated-gap: CS0414 no longer
+        // advertises a curated fix (code_fix_preview cannot handle it). Instead,
+        // a guidance message directs users to get_code_actions + preview_code_action.
+        Assert.AreEqual(0, details.SupportedFixes.Count,
+            "CS0414 should not advertise curated fixes that code_fix_preview cannot handle.");
+        Assert.IsNotNull(details.GuidanceMessage,
+            "CS0414 should include guidance pointing to get_code_actions.");
+        StringAssert.Contains(details.GuidanceMessage, "get_code_actions");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Remove false curated fix promises for CS0414, CS8600/8602/8603, CA2234, CA1852 from `GetSupportedFixes`
- `code_fix_preview` only supports CS8019/IDE0005 — other entries were rejected at apply time
- Add `GuidanceMessage` field to `DiagnosticDetailsDto` directing users to `get_code_actions` + `preview_code_action`

## Test plan
- [x] Updated test verifies CS0414 returns empty `SupportedFixes` with guidance message
- [x] CS8019 end-to-end code fix still works
- [x] 3/3 diagnostic fix tests pass

Closes `dr-code-fix-preview-vs-diagnostic-details-curated-gap`.

Generated with [Claude Code](https://claude.com/claude-code)