### PR TITLE
fix: use exact match in semantic_search implementing predicate

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -482,9 +482,12 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
         if (string.IsNullOrEmpty(ifaceName)) return;
 
         var requireClass = Regex.IsMatch(q, @"\bclasses?\b");
+        // dr-semantic-search-idisposable-predicate-accuracy: Use exact match on
+        // ToDisplayString() instead of Contains() to prevent false positives (e.g.,
+        // "IDisposable" matching "IAsyncDisposable" via substring).
         predicates.Add(s => s is INamedTypeSymbol t &&
             (!requireClass || t.TypeKind == TypeKind.Class) &&
             t.AllInterfaces.Any(i => i.Name.Equals(ifaceName, StringComparison.OrdinalIgnoreCase) ||
-                i.ToDisplayString().Contains(ifaceName, StringComparison.OrdinalIgnoreCase)));
+                i.ToDisplayString().Equals(ifaceName, StringComparison.OrdinalIgnoreCase)));
     }
 }


### PR DESCRIPTION
## Summary
- Replace `Contains()` with `Equals()` on `ToDisplayString()` in `AddImplementingPredicate`
- Prevents false positives where "IDisposable" matched "IAsyncDisposable" via substring

## Test plan
- [x] 7/7 semantic search tests pass
- [x] Full suite: 328/328

Closes `dr-semantic-search-idisposable-predicate-accuracy`.

Generated with [Claude Code](https://claude.com/claude-code)