### PR TITLE
fix: enable .NET SDK analyzers in InsecureLib test fixture

### DIFF
--- a/samples/SecurityTestProject/InsecureLib/InsecureLib.csproj
+++ b/samples/SecurityTestProject/InsecureLib/InsecureLib.csproj
@@ -4,5 +4,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- dr-security-integration-insecurelib-not-in-sln: Ensure .NET SDK security
+         analyzers (CA5350, CA5351) fire for MSBuildWorkspace loading. -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add `EnableNETAnalyzers=true` and `AnalysisLevel=latest-all` to InsecureLib.csproj
- Ensures CA5350/CA5351 security diagnostics fire when MSBuildWorkspace loads the project
- Fixes 4 failing `SecurityDiagnosticIntegrationTests`

## Test plan
- [x] All 21 security tests pass (previously 4 failed)
- [x] Full suite: 328/328

Closes `dr-security-integration-insecurelib-not-in-sln`.

Generated with [Claude Code](https://claude.com/claude-code)