### PR TITLE
chore: sync backlog — remove 9 shipped rows (#121-#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Roslyn-Backed MCP Server will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`apply_text_edit` line-break preservation** (`dr-apply-text-edit-line-break-corruption`). When an edit span ends at column 1 of a line (swallowing the line break), and the replacement text does not end with a newline, the original line ending is now appended to prevent line collapse at method/declaration boundaries. (#121)
+- **`diagnostic_details` curated fix contract** (`dr-code-fix-preview-vs-diagnostic-details-curated-gap`). Removed false curated fix promises for CS0414, CS8600/8602/8603, CA2234, CA1852 from `GetSupportedFixes` — `code_fix_preview` only supports CS8019/IDE0005. Added `GuidanceMessage` field to `DiagnosticDetailsDto` directing users to `get_code_actions` + `preview_code_action`. (#122)
+- **`semantic_search` implementing predicate accuracy** (`dr-semantic-search-idisposable-predicate-accuracy`). Replaced `Contains()` with `Equals()` on `ToDisplayString()` in `AddImplementingPredicate` to prevent false positives where "IDisposable" matched "IAsyncDisposable" via substring. (#123)
+- **`find_shared_members` partial-class crash** (`dr-find-shared-members-locator-invalidargument`). Built a semantic model map for all partial declarations so `MethodAccessesMember` uses the correct model for each method's syntax tree, preventing "Syntax node is not within syntax tree" exceptions. (#124)
+- **`SecurityDiagnosticIntegrationTests` fixture** (`dr-security-integration-insecurelib-not-in-sln`). Added `EnableNETAnalyzers=true` and `AnalysisLevel=latest-all` to InsecureLib.csproj so CA5350/CA5351 fire in MSBuildWorkspace. Fixes 4 previously failing tests. (#125)
+- **`project_diagnostics` empty first page hint** (`dr-project-diagnostics-info-only-empty-first-page`). Added `SeverityHint` field when returned arrays are empty but lower-severity diagnostics exist. (#126)
+- **`get_editorconfig_options` completeness** (`dr-get-editorconfig-options-incomplete-after-set`). Supplemented Roslyn-enumerated keys with on-disk keys from `.editorconfig` after `set_editorconfig_option` writes. (#126)
+- **`get_code_actions` parameter validation** (`dr-get-code-actions-opaque-error-on-bad-contract`). Validates `startLine`/`startColumn` >= 1 with a helpful error when callers pass wrong parameter names. (#126)
+
+### Changed
+
+- **`project_diagnostics` tool description** updated with response JSON field names (`totalErrors`, `totalWarnings`, `totalInfo`, `compilerErrors`, `analyzerErrors`, `workspaceErrors`, `severityHint`) and default severity documentation. (#126)
+- **`find_references_bulk` tool description** now includes a concrete JSON parameter shape example to prevent first-invocation failures. (#127)
+
 ## [1.8.2] - 2026-04-09
 
 ### Fixed

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 
-**updated_at:** 2026-04-09T20:00:00Z
+**updated_at:** 2026-04-09T21:30:00Z
 
 ## Agent contract
 
@@ -30,15 +30,8 @@ Ordered by severity: P2 (contract violations / real-world blockers) → P3 (refa
 
 | id | blocker | deps | do |
 |----|---------|------|-----|
-| `dr-code-fix-preview-vs-diagnostic-details-curated-gap` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.1 (CA1852 / empty `SupportedFixes`); `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §7 (`diagnostic_details` lists `remove_unused_field` for CS0414 but `code_fix_preview` rejects curated fix). Unify contract: which diagnostics have curated fixes vs FixAll vs IDE-only. |
-| `dr-semantic-search-idisposable-predicate-accuracy` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.5 — **`semantic_search` “classes implementing IDisposable”** returns types that are not implementors (e.g. test fixtures). **FLAG** predicate accuracy. |
-| `dr-find-shared-members-locator-invalidargument` | none | — | **P3 / product.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.3 — **`find_shared_members`** → **InvalidArgument** “Syntax node is not within syntax tree” for `ChatOrchestrationPipeline` via handle/locator (partial-class / snapshot mismatch hypothesis). |
-| `dr-security-integration-insecurelib-not-in-sln` | none | — | **P3 / test graph.** **Auto (deep-review).** `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 — Full `dotnet test` on `Roslyn-Backed-MCP.sln`: **4 failures** in `SecurityDiagnosticIntegrationTests` (no findings in `InsecureLib`). Loaded solution lacks insecure fixture projects tests expect — fix test preconditions, sample layout, or conditional skip. |
-| `dr-project-diagnostics-info-only-empty-first-page` | none | — | **P4 / tracking.** **Auto (deep-review).** Merged: `20260409T165230Z_firewallanalyzer_mcp-server-audit.md` §14.1 (null `severity`, non-zero info totals, empty page) + `20260409T165300Z_networkdocumentation_mcp-server-audit.md` §14.2 (first page empty without explicit `severity` when only Info diagnostics exist). **`project_diagnostics` paging / default severity** UX — **FLAG**. |
-| `dr-get-editorconfig-options-incomplete-after-set` | none | — | **P4 / tracking.** **Auto (deep-review).** `20260409T164306Z_itchatbot_mcp-server-audit.md` §14.4 — After `set_editorconfig_option`, **`get_editorconfig_options`** omitted `dotnet_separate_import_directive_groups` from `Options[]` while disk had the line. **FLAG** enumerator completeness vs Roslyn API. |
-| `dr-get-code-actions-opaque-error-on-bad-contract` | none | — | **P4 / UX.** **Auto (deep-review).** `20260409T165300Z_networkdocumentation_mcp-server-audit.md` §14.1 — **`get_code_actions`** called with `line`/`column` instead of `startLine`/`startColumn`: generic “error occurred invoking” without required-property hint — error-message-quality / schema discoverability. |
-| `dr-project-diagnostics-response-total-field-naming` | none | — | **P4 / docs.** **Auto (deep-review).** `20260409T165739Z_roslyn-backed-mcp_mcp-server-audit.md` §7 — **`project_diagnostics`** uses `totalErrors` / `compilerErrors` split vs docs/examples expecting uniform `total*` naming — **FLAG** documentation / contract clarity (not necessarily wrong behavior). |
-| `dr-find-references-bulk-first-invocation-parameter-ux` | none | — | **P4 / UX.** **Auto (deep-review).** `20260408T195030Z_firewall-analyzer_mcp-server-audit.md` §14 — **`find_references_bulk`** first invocation failed until parameter shape corrected; improve schema example in error (cosmetic). |
+
+_All deep-review backlog rows shipped in PRs #121–#127. Next audit pass will refill with new findings._
 
 ## Refs
 


### PR DESCRIPTION
## Summary
- Remove all 9 remaining backlog rows shipped in PRs #121–#127
- Immediate follow-up per agent contract (backlog sync on ship)

## Test plan
- [x] Doc-only change, no code impact

Generated with [Claude Code](https://claude.com/claude-code)