### PR TITLE
feat: extract_method_preview / extract_method_apply — custom extract method refactoring (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - **Selection-range code action tests** — verified which Roslyn refactoring providers work in MSBuildWorkspace with non-zero-length TextSpans. Introduce parameter and inline temporary variable work; extract method and introduce local variable do not (providers require internal IDE services). Updated `get_code_actions` tool description and added "Selection-Range Refactoring" workflow hint.
 - **`RefactoringProbe.cs`** sample fixture for selection-range refactoring tests.
+- **`extract_method_preview` / `extract_method_apply`** — custom extract-method refactoring tool pair using Roslyn's `DataFlowAnalysis` for parameter inference and `ControlFlowAnalysis` for single-exit validation. Supports void and single-return-value extraction with automatic call-site generation. 125 tools total (66 stable / 59 experimental).
 
 ## [1.9.0] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/i
 
 ## Supported Surface
 
-Catalog **`2026.04`** ships **123 tools** (66 stable / 57 experimental), **9 resources** (all stable), and **16 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
+Catalog **`2026.04`** ships **125 tools** (66 stable / 59 experimental), **9 resources** (all stable), and **16 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
 
 ### Stable tool families
 

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -102,7 +102,7 @@ For tool selection and workflows, see `domains/tool-usage-guide.md`.
 The current stable/experimental tool, resource, and prompt counts are owned by the live `server_info` tool and the `roslyn://server/catalog` resource — query those for an authoritative answer rather than relying on this document. As of catalog `2026.04`:
 
 - Stable tools: 66
-- Experimental tools: 57
+- Experimental tools: 59
 - Stable resources: 9 (3 static + 6 workspace-scoped templates, including the verbose siblings of `roslyn://workspaces` and `roslyn://workspace/{id}/status` added in v1.8 for opt-in full payloads)
 - Experimental prompts: 16
 

--- a/src/RoslynMcp.Core/Services/IExtractMethodService.cs
+++ b/src/RoslynMcp.Core/Services/IExtractMethodService.cs
@@ -1,0 +1,11 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+public interface IExtractMethodService
+{
+    Task<RefactoringPreviewDto> PreviewExtractMethodAsync(
+        string workspaceId, string filePath,
+        int startLine, int startColumn, int endLine, int endColumn,
+        string methodName, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -125,6 +125,9 @@ public static class ServerSurfaceCatalog
         Tool("extract_type_preview", "refactoring", "experimental", true, false, "Preview extracting selected members from a type into a new type. Adds a private field and constructor parameter for composition. Use get_cohesion_metrics and find_shared_members to plan the extraction."),
         Tool("extract_type_apply", "refactoring", "experimental", false, true, "Apply a previewed type extraction. Moves members to the new type file and wires composition in the source type."),
 
+        Tool("extract_method_preview", "refactoring", "experimental", true, false, "Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values."),
+        Tool("extract_method_apply", "refactoring", "experimental", false, true, "Apply a previously previewed extract method refactoring."),
+
         Tool("revert_last_apply", "undo", "experimental", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace."),
 
         Tool("analyze_data_flow", "advanced-analysis", "stable", true, false, "Analyze variable flow through a code region: reads, writes, captures, always-assigned."),

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -81,7 +81,7 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **123 tools** (66 stable / 57 experimental), **9 resources**, and **16 prompts**. Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **125 tools** (66 stable / 59 experimental), **9 resources**, and **16 prompts**. Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class ExtractMethodTools
+{
+    [McpServerTool(Name = "extract_method_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
+    [Description("Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values. Selection must cover complete statements in the same block without return statements.")]
+    public static Task<string> PreviewExtractMethod(
+        IWorkspaceExecutionGate gate,
+        IExtractMethodService extractMethodService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based start line of the selection")] int startLine,
+        [Description("1-based start column of the selection")] int startColumn,
+        [Description("1-based end line of the selection")] int endLine,
+        [Description("1-based end column of the selection")] int endColumn,
+        [Description("Name for the extracted method")] string methodName,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync("extract_method_preview", () =>
+            gate.RunReadAsync(workspaceId, async c =>
+            {
+                var result = await extractMethodService.PreviewExtractMethodAsync(
+                    workspaceId, filePath, startLine, startColumn, endLine, endColumn, methodName, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct));
+    }
+
+    [McpServerTool(Name = "extract_method_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
+    [Description("Apply a previously previewed extract method refactoring.")]
+    public static Task<string> ApplyExtractMethod(
+        IWorkspaceExecutionGate gate,
+        IRefactoringService refactoringService,
+        IPreviewStore previewStore,
+        [Description("The preview token returned by extract_method_preview")] string previewToken,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync("extract_method_apply", () =>
+        {
+            var wsId = previewStore.PeekWorkspaceId(previewToken)
+                ?? throw new KeyNotFoundException($"Preview token '{previewToken}' not found or expired.");
+            return gate.RunWriteAsync(wsId, async c =>
+            {
+                var result = await refactoringService.ApplyRefactoringAsync(previewToken, c);
+                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            }, ct);
+        });
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISnippetAnalysisService, SnippetAnalysisService>();
         services.AddSingleton<IScriptingService, ScriptingService>();
         services.AddSingleton<IEditorConfigService, EditorConfigService>();
+        services.AddSingleton<IExtractMethodService, ExtractMethodService>();
         return services;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
@@ -1,0 +1,303 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Extracts a selection of statements into a new method, using Roslyn's DataFlowAnalysis
+/// to infer parameters (DataFlowsIn) and return values (DataFlowsOut).
+/// </summary>
+public sealed class ExtractMethodService : IExtractMethodService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly IPreviewStore _previewStore;
+    private readonly ILogger<ExtractMethodService> _logger;
+
+    public ExtractMethodService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        ILogger<ExtractMethodService> logger)
+    {
+        _workspace = workspace;
+        _previewStore = previewStore;
+        _logger = logger;
+    }
+
+    public async Task<RefactoringPreviewDto> PreviewExtractMethodAsync(
+        string workspaceId, string filePath,
+        int startLine, int startColumn, int endLine, int endColumn,
+        string methodName, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(methodName))
+            throw new ArgumentException("Method name must not be empty.", nameof(methodName));
+
+        if (startLine > endLine || (startLine == endLine && startColumn > endColumn))
+            throw new ArgumentException("Start position must be before end position.");
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var document = SymbolResolver.FindDocument(solution, filePath)
+            ?? throw new InvalidOperationException($"Document not found: {filePath}");
+
+        var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false) as CompilationUnitSyntax
+            ?? throw new InvalidOperationException("Source document must be a C# compilation unit.");
+
+        var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Semantic model could not be created.");
+
+        var text = await document.GetTextAsync(ct).ConfigureAwait(false);
+
+        // Build the selection span
+        var startPosition = text.Lines[startLine - 1].Start + (startColumn - 1);
+        var endPosition = text.Lines[endLine - 1].Start + (endColumn - 1);
+        var selectionSpan = Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(startPosition, endPosition);
+
+        // Find the enclosing method
+        var enclosingMember = root.FindNode(selectionSpan)
+            .AncestorsAndSelf()
+            .OfType<MemberDeclarationSyntax>()
+            .FirstOrDefault(m => m is MethodDeclarationSyntax)
+            ?? throw new InvalidOperationException(
+                "Selection must be inside a method body.");
+
+        // Collect all statements that overlap the selection
+        var statementsInSelection = FindStatementsInSelection(enclosingMember, selectionSpan);
+        if (statementsInSelection.Count == 0)
+            throw new InvalidOperationException(
+                "No complete statements found in selection. Select one or more complete statements.");
+
+        // Verify all statements share the same parent block
+        var parentBlock = statementsInSelection[0].Parent;
+        if (parentBlock is null || statementsInSelection.Any(s => s.Parent != parentBlock))
+            throw new InvalidOperationException(
+                "All selected statements must be in the same block scope.");
+
+        // Data flow analysis for parameter and return value inference
+        var firstStatement = statementsInSelection[0];
+        var lastStatement = statementsInSelection[^1];
+
+        DataFlowAnalysis? dataFlow;
+        try
+        {
+            dataFlow = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException(
+                $"Data flow analysis failed: {ex.Message}. " +
+                "Ensure the selection covers complete statements within a single block.", ex);
+        }
+
+        if (dataFlow is null || !dataFlow.Succeeded)
+            throw new InvalidOperationException(
+                "Data flow analysis did not succeed for the selected region.");
+
+        // Control flow analysis to validate single-exit
+        var controlFlow = semanticModel.AnalyzeControlFlow(firstStatement, lastStatement);
+        if (controlFlow is null || !controlFlow.Succeeded)
+            throw new InvalidOperationException(
+                "Control flow analysis did not succeed for the selected region.");
+
+        if (controlFlow.ReturnStatements.Length > 0)
+            throw new InvalidOperationException(
+                "Cannot extract: the selection contains return statements. " +
+                "Extract method requires a single-exit region without return statements.");
+
+        // Determine parameters: variables that flow in from outside
+        var parameters = dataFlow.DataFlowsIn
+            .Where(s => s is ILocalSymbol or IParameterSymbol)
+            .Select(s => (s.Name, Type: GetSymbolType(s)))
+            .Where(p => p.Type is not null)
+            .ToList();
+
+        // Determine return: variables that flow out (used after the selection)
+        var flowsOut = dataFlow.DataFlowsOut
+            .Where(s => s is ILocalSymbol or IParameterSymbol)
+            .Select(s => (s.Name, Type: GetSymbolType(s)))
+            .Where(p => p.Type is not null)
+            .ToList();
+
+        if (flowsOut.Count > 1)
+            throw new InvalidOperationException(
+                $"Cannot extract: {flowsOut.Count} variables flow out of the selection " +
+                $"({string.Join(", ", flowsOut.Select(v => v.Name))}). " +
+                "Extract method supports at most one output variable as a return value.");
+
+        // Determine method return type
+        var returnType = flowsOut.Count == 1
+            ? SyntaxFactory.ParseTypeName(flowsOut[0].Type!.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))
+            : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword));
+
+        // Determine the access modifier from the enclosing member
+        var accessModifier = SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
+
+        // Determine if static
+        var isStatic = enclosingMember.Modifiers.Any(SyntaxKind.StaticKeyword);
+
+        // Build the parameter list
+        var parameterList = SyntaxFactory.ParameterList(
+            SyntaxFactory.SeparatedList(
+                parameters.Select(p =>
+                    SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
+                        .WithType(SyntaxFactory.ParseTypeName(
+                            p.Type!.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))
+                            .WithTrailingTrivia(SyntaxFactory.Space)))));
+
+        // Build the method body
+        var extractedStatements = new List<StatementSyntax>(statementsInSelection);
+
+        // If there's a return value, add a return statement at the end
+        if (flowsOut.Count == 1)
+        {
+            extractedStatements.Add(
+                SyntaxFactory.ReturnStatement(
+                    SyntaxFactory.IdentifierName(flowsOut[0].Name))
+                .WithLeadingTrivia(SyntaxFactory.Whitespace("        "))
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+        }
+
+        var body = SyntaxFactory.Block(extractedStatements);
+
+        // Build the new method declaration
+        var newMethod = SyntaxFactory.MethodDeclaration(returnType, SyntaxFactory.Identifier(methodName))
+            .WithModifiers(SyntaxFactory.TokenList(
+                isStatic
+                    ? [accessModifier, SyntaxFactory.Token(SyntaxKind.StaticKeyword)]
+                    : [accessModifier]))
+            .WithParameterList(parameterList)
+            .WithBody(body)
+            .NormalizeWhitespace();
+
+        // Build the call expression
+        var arguments = SyntaxFactory.ArgumentList(
+            SyntaxFactory.SeparatedList(
+                parameters.Select(p =>
+                    SyntaxFactory.Argument(SyntaxFactory.IdentifierName(p.Name)))));
+
+        var callExpression = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.IdentifierName(methodName), arguments);
+
+        StatementSyntax callStatement;
+        if (flowsOut.Count == 1)
+        {
+            // var x = NewMethod(args);
+            callStatement = SyntaxFactory.LocalDeclarationStatement(
+                SyntaxFactory.VariableDeclaration(
+                    SyntaxFactory.IdentifierName("var").WithTrailingTrivia(SyntaxFactory.Space),
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.VariableDeclarator(flowsOut[0].Name)
+                            .WithInitializer(SyntaxFactory.EqualsValueClause(callExpression)))));
+        }
+        else
+        {
+            // NewMethod(args);
+            callStatement = SyntaxFactory.ExpressionStatement(callExpression);
+        }
+
+        // Preserve the leading trivia of the first statement on the call site
+        callStatement = callStatement
+            .WithLeadingTrivia(firstStatement.GetLeadingTrivia())
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
+        // Replace the statements in the original code
+        var newStatements = new List<SyntaxNode>();
+        var parentBlockNode = (BlockSyntax)parentBlock!;
+        var inSelection = false;
+        var replacedCallSite = false;
+
+        foreach (var statement in parentBlockNode.Statements)
+        {
+            if (statementsInSelection.Contains(statement))
+            {
+                if (!replacedCallSite)
+                {
+                    newStatements.Add(callStatement);
+                    replacedCallSite = true;
+                }
+                inSelection = true;
+            }
+            else
+            {
+                newStatements.Add(statement);
+                if (inSelection) inSelection = false;
+            }
+        }
+
+        var newBlock = parentBlockNode.WithStatements(
+            SyntaxFactory.List(newStatements.Cast<StatementSyntax>()));
+
+        // Insert the new method after the enclosing member
+        var topLevelMember = enclosingMember.AncestorsAndSelf()
+            .OfType<MemberDeclarationSyntax>()
+            .LastOrDefault(m => m.Parent is TypeDeclarationSyntax)
+            ?? enclosingMember;
+
+        var typeDecl = topLevelMember.Parent as TypeDeclarationSyntax
+            ?? throw new InvalidOperationException("Could not find the enclosing type declaration.");
+
+        // Apply changes to the syntax tree
+        var newRoot = root.ReplaceNode(parentBlockNode, newBlock);
+
+        // Re-find the type declaration in the new tree
+        var newTypeDecl = newRoot.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .First(t => t.Identifier.Text == typeDecl.Identifier.Text);
+
+        // Find the top-level member by position matching
+        var topMemberIndex = typeDecl.Members.IndexOf(topLevelMember);
+        if (topMemberIndex >= 0 && topMemberIndex < newTypeDecl.Members.Count)
+        {
+            var insertionPoint = newTypeDecl.Members[topMemberIndex];
+            var memberIndex = newTypeDecl.Members.IndexOf(insertionPoint);
+            var updatedMembers = newTypeDecl.Members.Insert(memberIndex + 1, newMethod);
+            var updatedTypeDecl = newTypeDecl.WithMembers(updatedMembers);
+            newRoot = newRoot.ReplaceNode(newTypeDecl, updatedTypeDecl);
+        }
+        else
+        {
+            // Fallback: add at the end of the type
+            var updatedMembers = newTypeDecl.Members.Add(newMethod);
+            var updatedTypeDecl = newTypeDecl.WithMembers(updatedMembers);
+            newRoot = newRoot.ReplaceNode(newTypeDecl, updatedTypeDecl);
+        }
+
+        // Format the modified tree
+        newRoot = newRoot.NormalizeWhitespace();
+
+        // Build the new solution
+        var newSolution = solution.WithDocumentSyntaxRoot(document.Id, newRoot);
+
+        // Compute diff and store preview
+        var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
+        var description = $"Extract {statementsInSelection.Count} statement(s) into method '{methodName}'";
+        var token = _previewStore.Store(
+            workspaceId, newSolution,
+            _workspace.GetCurrentVersion(workspaceId), description);
+
+        _logger.LogDebug("Extract method preview: {Description}", description);
+
+        return new RefactoringPreviewDto(token, description, changes, null);
+    }
+
+    private static List<StatementSyntax> FindStatementsInSelection(
+        SyntaxNode enclosingMember, Microsoft.CodeAnalysis.Text.TextSpan selectionSpan)
+    {
+        return enclosingMember
+            .DescendantNodes()
+            .OfType<StatementSyntax>()
+            .Where(s => s.Parent is BlockSyntax
+                     && selectionSpan.Contains(s.Span))
+            .OrderBy(s => s.SpanStart)
+            .ToList();
+    }
+
+    private static ITypeSymbol? GetSymbolType(ISymbol symbol) => symbol switch
+    {
+        ILocalSymbol local => local.Type,
+        IParameterSymbol param => param.Type,
+        _ => null
+    };
+}

--- a/tests/RoslynMcp.Tests/ExtractMethodTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodTests.cs
@@ -1,0 +1,144 @@
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Integration tests for the custom extract_method_preview / extract_method_apply pipeline.
+/// Uses RefactoringProbe.cs in the sample solution as the extraction target.
+/// </summary>
+[TestClass]
+public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Extract 3 statements (lines 13-15) from ComputeAndPrint into a new method.
+    /// Verifies preview produces a diff with the new method and the call site.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_ThreeStatements_ProducesPreviewWithNewMethod()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        var result = await ExtractMethodService.PreviewExtractMethodAsync(
+            workspace.WorkspaceId,
+            filePath,
+            startLine: 13, startColumn: 9,
+            endLine: 15, endColumn: 39,
+            "ComputeCore",
+            CancellationToken.None);
+
+        Assert.IsNotNull(result.PreviewToken);
+        Assert.IsTrue(result.Changes.Count > 0, "Expected at least one file change.");
+        Assert.IsTrue(result.Description.Contains("ComputeCore"),
+            "Description should mention the extracted method name.");
+
+        // The diff should contain the new method name
+        var diff = result.Changes[0].UnifiedDiff;
+        Assert.IsTrue(diff.Contains("ComputeCore"),
+            "Diff should contain the extracted method.");
+    }
+
+    /// <summary>
+    /// Preview + apply extract method, then verify the solution compiles.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_PreviewAndApply_CompilationSucceeds()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        var preview = await ExtractMethodService.PreviewExtractMethodAsync(
+            workspace.WorkspaceId,
+            filePath,
+            startLine: 13, startColumn: 9,
+            endLine: 15, endColumn: 39,
+            "ComputeCore",
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken, CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, "Apply should succeed.");
+
+        // Verify compilation
+        var compileResult = await CompileCheckService.CheckAsync(
+            workspace.WorkspaceId, projectFilter: null, emitValidation: false,
+            severityFilter: null, fileFilter: null, offset: 0, limit: 50,
+            CancellationToken.None);
+
+        Assert.IsTrue(compileResult.Success,
+            $"Compilation should succeed after extract method. Errors: " +
+            $"{string.Join("; ", compileResult.Diagnostics?.Select(d => $"{d.Id}: {d.Message}") ?? [])}");
+    }
+
+    /// <summary>
+    /// Extract a statement block where a variable flows out (used after selection).
+    /// Verifies the extracted method has a return value.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_WithReturnValue_ProducesReturnStatement()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        // Select lines 13-14: var sum = a + b; var doubled = sum * 2;
+        // 'doubled' flows out (used on line 15 and returned on line 16)
+        var result = await ExtractMethodService.PreviewExtractMethodAsync(
+            workspace.WorkspaceId,
+            filePath,
+            startLine: 13, startColumn: 9,
+            endLine: 14, endColumn: 34,
+            "ComputeDoubled",
+            CancellationToken.None);
+
+        Assert.IsNotNull(result.PreviewToken);
+        var diff = result.Changes[0].UnifiedDiff;
+        Assert.IsTrue(diff.Contains("return"),
+            "Diff should contain a return statement for the outflowing variable.");
+    }
+
+    /// <summary>
+    /// Reject extraction when selection contains return statements.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_WithReturnStatement_Throws()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        // Select lines 13-16 including "return doubled;"
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            ExtractMethodService.PreviewExtractMethodAsync(
+                workspace.WorkspaceId,
+                filePath,
+                startLine: 13, startColumn: 9,
+                endLine: 16, endColumn: 25,
+                "BadExtract",
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "return");
+    }
+
+    /// <summary>
+    /// Empty method name is rejected.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_EmptyName_Throws()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            ExtractMethodService.PreviewExtractMethodAsync(
+                workspace.WorkspaceId,
+                filePath,
+                startLine: 13, startColumn: 9,
+                endLine: 14, endColumn: 34,
+                "",
+                CancellationToken.None));
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -65,6 +65,7 @@ public abstract class TestBase
     protected static ScriptingService ScriptingService { get; private set; } = null!;
     protected static EditorConfigService EditorConfigService { get; private set; } = null!;
     protected static MsBuildEvaluationService MsBuildEvaluationService { get; private set; } = null!;
+    protected static ExtractMethodService ExtractMethodService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -149,6 +150,7 @@ public abstract class TestBase
         ScriptingService = services.ScriptingService;
         EditorConfigService = services.EditorConfigService;
         MsBuildEvaluationService = services.MsBuildEvaluationService;
+        ExtractMethodService = services.ExtractMethodService;
 
         RepositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
         SampleSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -52,6 +52,7 @@ internal sealed class TestServiceContainer
     public required ScriptingService ScriptingService { get; init; }
     public required EditorConfigService EditorConfigService { get; init; }
     public required MsBuildEvaluationService MsBuildEvaluationService { get; init; }
+    public required ExtractMethodService ExtractMethodService { get; init; }
 
     public static TestServiceContainer Create(ValidationServiceOptions validationOptions)
     {
@@ -228,7 +229,11 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 NullLogger<EditorConfigService>.Instance,
                 undoService),
-            MsBuildEvaluationService = msBuildEvaluationService
+            MsBuildEvaluationService = msBuildEvaluationService,
+            ExtractMethodService = new ExtractMethodService(
+                workspaceManager,
+                previewStore,
+                NullLogger<ExtractMethodService>.Instance)
         };
     }
 }


### PR DESCRIPTION
## Summary
- Implemented custom `extract_method_preview` / `extract_method_apply` tool pair — the most-requested missing refactoring
- Uses Roslyn's `DataFlowAnalysis` for parameter inference (`DataFlowsIn` → params, `DataFlowsOut` → return value)
- Uses `ControlFlowAnalysis` to validate single-exit regions (rejects selections with return statements)
- Supports void extraction and single-return-value extraction with automatic call-site generation
- Follows the established 6-step tool registration pattern (interface → service → DI → tools → catalog → tests)
- Catalog: 125 tools (66 stable / 59 experimental)

## New files
- `src/RoslynMcp.Core/Services/IExtractMethodService.cs`
- `src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs`
- `src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs`
- `tests/RoslynMcp.Tests/ExtractMethodTests.cs`

## Test plan
- [x] `just ci` passes — 337 tests, 0 warnings, 0 vulnerabilities
- [x] 3-statement extraction produces preview with new method and call site
- [x] Preview + apply + compile_check succeeds (compilation green after extraction)
- [x] 2-statement extraction with return value produces return statement in diff
- [x] Selection with return statements is rejected
- [x] Empty method name is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)