### PR TITLE
feat: v1.11.0 — suggest_refactorings, code-actions promotion, change tracker expansion (#136)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 147 tools for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 147 tools for navigation, diagnostics, refactoring, security, and more.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-04-13
+
+### Added
+
+- **`suggest_refactorings`** — read-only tool combining complexity metrics, LCOM4 cohesion analysis, and unused symbol detection into ranked refactoring suggestions with recommended tool sequences. Each suggestion includes severity (high/medium/low), category, target symbol location, and the tools to use.
+- **Stable promotions (3 tools):** `get_code_actions`, `preview_code_action`, `apply_code_action` promoted from experimental to stable. Selection-range refactorings (introduce parameter, inline temporary) verified working in v1.10.0.
+- **Change tracker coverage expansion:** `ProjectMutationService.ApplyProjectMutationAsync` and `OrchestrationService.ApplyCompositeAsync` now record changes via `IChangeTracker`, closing the blind spot for project mutations and composite operations.
+- 128 tools (69 stable / 59 experimental).
+
 ## [1.10.0] - 2026-04-12
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.10.0</Version>
+    <Version>1.11.0</Version>
 
     <!-- Source Link: embeds commit hash + repo URL in PDBs so NuGet consumers
          can step into source and GitHub can link stack traces to specific lines.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/i
 
 ## Supported Surface
 
-Catalog **`2026.04`** ships **126 tools** (66 stable / 60 experimental), **9 resources** (all stable), and **16 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
+Catalog **`2026.04`** ships **128 tools** (69 stable / 59 experimental), **9 resources** (all stable), and **16 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
 
 ### Stable tool families
 

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -101,8 +101,8 @@ For tool selection and workflows, see `domains/tool-usage-guide.md`.
 
 The current stable/experimental tool, resource, and prompt counts are owned by the live `server_info` tool and the `roslyn://server/catalog` resource — query those for an authoritative answer rather than relying on this document. As of catalog `2026.04`:
 
-- Stable tools: 66
-- Experimental tools: 60
+- Stable tools: 69
+- Experimental tools: 59
 - Stable resources: 9 (3 static + 6 workspace-scoped templates, including the verbose siblings of `roslyn://workspaces` and `roslyn://workspace/{id}/status` added in v1.8 for opt-in full payloads)
 - Experimental prompts: 16
 

--- a/docs/experimental-promotion-analysis.md
+++ b/docs/experimental-promotion-analysis.md
@@ -16,8 +16,8 @@ This document supports the post-release roadmap item **“promote experimental �
 
 | Tier | Tools | Resources | Prompts |
 |------|-------|-----------|---------|
-| Stable | 66 | 9 stable / 0 experimental | 0 stable / 16 experimental |
-| Experimental | 57 | — | — |
+| Stable | 69 | 9 stable / 0 experimental | 0 stable / 16 experimental |
+| Experimental | 59 | — | — |
 
 Authoritative counts: `ServerSurfaceCatalog.GetSummary()` / `server_info` / `roslyn://server/catalog`.
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -37,6 +37,7 @@ Supported stable tool families:
 - read-only analysis helpers promoted in v1.6.0: `compile_check`, `list_analyzers`, `find_consumers`, `get_cohesion_metrics`, `find_shared_members`, `analyze_snippet`
 - read-only advanced-analysis helpers promoted in v1.8.0: `find_unused_symbols`, `get_di_registrations`, `get_complexity_metrics`, `find_reflection_usages`, `get_namespace_dependencies`, `get_nuget_dependencies`
 - promoted in v1.9.0: `semantic_search`, `analyze_data_flow`, `analyze_control_flow`, `evaluate_csharp`
+- promoted in v1.11.0: `get_code_actions`, `preview_code_action`, `apply_code_action`
 - preview/apply refactoring tools
 
 Stable resources:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {

--- a/skills/bump/SKILL.md
+++ b/skills/bump/SKILL.md
@@ -12,9 +12,9 @@ You are a release engineer. Your job is to increment the project version across 
 ## Input
 
 `$ARGUMENTS` is the bump type: `patch`, `minor`, or `major`. If not provided, ask the user which type of bump to perform with a brief explanation:
-- **patch** (1.10.0 -> 1.10.1): bug fixes, doc changes, no new features
-- **minor** (1.10.0 -> 1.11.0): new features, new stable tools, backward-compatible changes
-- **major** (1.10.0 -> 2.0.0): breaking changes to stable tool contracts
+- **patch** (1.11.0 -> 1.11.1): bug fixes, doc changes, no new features
+- **minor** (1.11.0 -> 1.12.0): new features, new stable tools, backward-compatible changes
+- **major** (1.11.0 -> 2.0.0): breaking changes to stable tool contracts
 
 ## Version Files
 

--- a/src/RoslynMcp.Core/Models/RefactoringSuggestionDto.cs
+++ b/src/RoslynMcp.Core/Models/RefactoringSuggestionDto.cs
@@ -1,0 +1,10 @@
+namespace RoslynMcp.Core.Models;
+
+public sealed record RefactoringSuggestionDto(
+    string Severity,
+    string Category,
+    string Description,
+    string TargetSymbol,
+    string FilePath,
+    int Line,
+    IReadOnlyList<string> RecommendedTools);

--- a/src/RoslynMcp.Core/Services/IRefactoringSuggestionService.cs
+++ b/src/RoslynMcp.Core/Services/IRefactoringSuggestionService.cs
@@ -1,0 +1,9 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+public interface IRefactoringSuggestionService
+{
+    Task<IReadOnlyList<RefactoringSuggestionDto>> SuggestRefactoringsAsync(
+        string workspaceId, string? projectFilter, int limit, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -104,9 +104,9 @@ public static class ServerSurfaceCatalog
         Tool("apply_composite_preview", "orchestration", "experimental", false, true, "Apply a previously previewed orchestration operation."),
         Tool("test_coverage", "validation", "stable", false, false, "Run coverage collection for test execution."),
         Tool("get_syntax_tree", "syntax", "experimental", true, false, "Return a structured syntax tree for a document or range."),
-        Tool("get_code_actions", "code-actions", "experimental", true, false, "List Roslyn code fixes and refactorings at a location or selection range. Selection-range refactorings include introduce parameter and inline temporary variable. Pass endLine/endColumn for selection-range actions."),
-        Tool("preview_code_action", "code-actions", "experimental", true, false, "Preview a Roslyn code action before applying it."),
-        Tool("apply_code_action", "code-actions", "experimental", false, true, "Apply a previously previewed Roslyn code action."),
+        Tool("get_code_actions", "code-actions", "stable", true, false, "List Roslyn code fixes and refactorings at a location or selection range. Selection-range refactorings include introduce parameter and inline temporary variable. Pass endLine/endColumn for selection-range actions."),
+        Tool("preview_code_action", "code-actions", "stable", true, false, "Preview a Roslyn code action before applying it."),
+        Tool("apply_code_action", "code-actions", "stable", false, true, "Apply a previously previewed Roslyn code action."),
 
         Tool("security_diagnostics", "security", "stable", true, false, "Return security-relevant diagnostics with OWASP categorization and fix hints."),
         Tool("security_analyzer_status", "security", "stable", true, false, "Check which security analyzer packages are present and recommend missing ones."),
@@ -126,6 +126,7 @@ public static class ServerSurfaceCatalog
         Tool("extract_type_apply", "refactoring", "experimental", false, true, "Apply a previewed type extraction. Moves members to the new type file and wires composition in the source type."),
 
         Tool("workspace_changes", "workspace", "experimental", true, false, "List all mutations applied to a workspace during this session, with descriptions, affected files, tool names, and timestamps."),
+        Tool("suggest_refactorings", "advanced-analysis", "experimental", true, false, "Analyze the workspace and return ranked refactoring suggestions based on complexity, cohesion (LCOM4), and unused symbol detection. Each suggestion includes severity, target, and recommended tool sequence."),
 
         Tool("extract_method_preview", "refactoring", "experimental", true, false, "Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values."),
         Tool("extract_method_apply", "refactoring", "experimental", false, true, "Apply a previously previewed extract method refactoring."),

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -81,7 +81,7 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **126 tools** (66 stable / 60 experimental), **9 resources**, and **16 prompts**. Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **128 tools** (69 stable / 59 experimental), **9 resources**, and **16 prompts**. Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|

--- a/src/RoslynMcp.Host.Stdio/Tools/SuggestionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SuggestionTools.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class SuggestionTools
+{
+    [McpServerTool(Name = "suggest_refactorings", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
+    [Description("Analyze the workspace and return ranked refactoring suggestions based on complexity metrics, cohesion analysis (LCOM4), and unused symbol detection. Each suggestion includes severity, description, target symbol location, and a recommended tool sequence.")]
+    public static Task<string> SuggestRefactorings(
+        IWorkspaceExecutionGate gate,
+        IRefactoringSuggestionService suggestionService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name")] string? project = null,
+        [Description("Maximum number of suggestions to return (default: 20)")] int limit = 20,
+        CancellationToken ct = default)
+    {
+        return ToolErrorHandler.ExecuteAsync("suggest_refactorings", () =>
+            gate.RunReadAsync(workspaceId, async c =>
+            {
+                var suggestions = await suggestionService.SuggestRefactoringsAsync(
+                    workspaceId, project, limit, c);
+                return JsonSerializer.Serialize(new { count = suggestions.Count, suggestions }, JsonDefaults.Indented);
+            }, ct));
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -91,6 +91,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IEditorConfigService, EditorConfigService>();
         services.AddSingleton<IExtractMethodService, ExtractMethodService>();
         services.AddSingleton<IChangeTracker, ChangeTracker>();
+        services.AddSingleton<IRefactoringSuggestionService, RefactoringSuggestionService>();
         return services;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/OrchestrationService.cs
@@ -15,19 +15,22 @@ public sealed class OrchestrationService : IOrchestrationService
     private readonly IPreviewStore _previewStore;
     private readonly ICrossProjectRefactoringService _crossProjectRefactoringService;
     private readonly IDiRegistrationService _diRegistrationService;
+    private readonly IChangeTracker? _changeTracker;
 
     public OrchestrationService(
         IWorkspaceManager workspace,
         ICompositePreviewStore compositePreviewStore,
         IPreviewStore previewStore,
         ICrossProjectRefactoringService crossProjectRefactoringService,
-        IDiRegistrationService diRegistrationService)
+        IDiRegistrationService diRegistrationService,
+        IChangeTracker? changeTracker = null)
     {
         _workspace = workspace;
         _compositePreviewStore = compositePreviewStore;
         _previewStore = previewStore;
         _crossProjectRefactoringService = crossProjectRefactoringService;
         _diRegistrationService = diRegistrationService;
+        _changeTracker = changeTracker;
     }
 
     public async Task<RefactoringPreviewDto> PreviewMigratePackageAsync(
@@ -371,7 +374,9 @@ public sealed class OrchestrationService : IOrchestrationService
 
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
             _compositePreviewStore.Invalidate(previewToken);
-            return new ApplyResultDto(true, appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList(), null);
+            var distinctFiles = appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            _changeTracker?.RecordChange(workspaceId, $"Composite operation ({distinctFiles.Count} files)", distinctFiles, "apply_composite_preview");
+            return new ApplyResultDto(true, distinctFiles, null);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -26,15 +26,18 @@ public sealed class ProjectMutationService : IProjectMutationService
     private readonly IWorkspaceManager _workspace;
     private readonly IProjectMutationPreviewStore _previewStore;
     private readonly ILogger<ProjectMutationService> _logger;
+    private readonly IChangeTracker? _changeTracker;
 
     public ProjectMutationService(
         IWorkspaceManager workspace,
         IProjectMutationPreviewStore previewStore,
-        ILogger<ProjectMutationService> logger)
+        ILogger<ProjectMutationService> logger,
+        IChangeTracker? changeTracker = null)
     {
         _workspace = workspace;
         _previewStore = previewStore;
         _logger = logger;
+        _changeTracker = changeTracker;
     }
 
     public Task<RefactoringPreviewDto> PreviewAddPackageReferenceAsync(string workspaceId, AddPackageReferenceDto request, CancellationToken ct)
@@ -314,6 +317,7 @@ public sealed class ProjectMutationService : IProjectMutationService
             await File.WriteAllTextAsync(projectFilePath, updatedContent, ct).ConfigureAwait(false);
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
             _previewStore.Invalidate(previewToken);
+            _changeTracker?.RecordChange(workspaceId, $"Project mutation: {Path.GetFileName(projectFilePath)}", [projectFilePath], "apply_project_mutation");
             return new ApplyResultDto(true, [projectFilePath], null);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)

--- a/src/RoslynMcp.Roslyn/Services/RefactoringSuggestionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringSuggestionService.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Aggregates complexity, cohesion, and dead-code metrics into ranked
+/// refactoring suggestions with recommended tool sequences.
+/// </summary>
+public sealed class RefactoringSuggestionService : IRefactoringSuggestionService
+{
+    private readonly ICodeMetricsService _metricsService;
+    private readonly ICohesionAnalysisService _cohesionService;
+    private readonly IUnusedCodeAnalyzer _unusedCodeAnalyzer;
+    private readonly ILogger<RefactoringSuggestionService> _logger;
+
+    public RefactoringSuggestionService(
+        ICodeMetricsService metricsService,
+        ICohesionAnalysisService cohesionService,
+        IUnusedCodeAnalyzer unusedCodeAnalyzer,
+        ILogger<RefactoringSuggestionService> logger)
+    {
+        _metricsService = metricsService;
+        _cohesionService = cohesionService;
+        _unusedCodeAnalyzer = unusedCodeAnalyzer;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<RefactoringSuggestionDto>> SuggestRefactoringsAsync(
+        string workspaceId, string? projectFilter, int limit, CancellationToken ct)
+    {
+        var suggestions = new List<RefactoringSuggestionDto>();
+
+        // Run all analyses in parallel
+        var complexityTask = _metricsService.GetComplexityMetricsAsync(
+            workspaceId, filePath: null, projectFilter, minComplexity: 10, limit: 100, ct);
+        var cohesionTask = _cohesionService.GetCohesionMetricsAsync(
+            workspaceId, filePath: null, projectFilter, minMethods: 3, limit: 100,
+            includeInterfaces: false, excludeTestProjects: true, ct);
+        var unusedTask = _unusedCodeAnalyzer.FindUnusedSymbolsAsync(
+            workspaceId, new UnusedSymbolsAnalysisOptions
+            {
+                ProjectFilter = projectFilter,
+                IncludePublic = false,
+                ExcludeTests = true,
+                ExcludeConventionInvoked = true,
+                Limit = 50
+            }, ct);
+
+        await Task.WhenAll(complexityTask, cohesionTask, unusedTask).ConfigureAwait(false);
+
+        var complexityResults = await complexityTask;
+        var cohesionResults = await cohesionTask;
+        var unusedResults = await unusedTask;
+
+        // High complexity → extract method
+        foreach (var m in complexityResults.Where(m => m.CyclomaticComplexity >= 15))
+        {
+            suggestions.Add(new RefactoringSuggestionDto(
+                Severity: "high",
+                Category: "complexity",
+                Description: $"Method '{m.SymbolName}' has cyclomatic complexity {m.CyclomaticComplexity} (maintainability index {m.MaintainabilityIndex:F0}). Extract cohesive blocks into smaller methods.",
+                TargetSymbol: m.SymbolName,
+                FilePath: m.FilePath,
+                Line: m.Line,
+                RecommendedTools: ["analyze_data_flow", "extract_method_preview", "extract_method_apply", "compile_check"]));
+        }
+
+        // Moderate complexity → flag for review
+        foreach (var m in complexityResults.Where(m => m.CyclomaticComplexity >= 10 && m.CyclomaticComplexity < 15))
+        {
+            suggestions.Add(new RefactoringSuggestionDto(
+                Severity: "medium",
+                Category: "complexity",
+                Description: $"Method '{m.SymbolName}' has cyclomatic complexity {m.CyclomaticComplexity}. Consider extracting complex branches.",
+                TargetSymbol: m.SymbolName,
+                FilePath: m.FilePath,
+                Line: m.Line,
+                RecommendedTools: ["get_complexity_metrics", "analyze_data_flow", "extract_method_preview"]));
+        }
+
+        // High parameter count → introduce parameter object
+        foreach (var m in complexityResults.Where(m => m.ParameterCount >= 7))
+        {
+            suggestions.Add(new RefactoringSuggestionDto(
+                Severity: "medium",
+                Category: "parameter-count",
+                Description: $"Method '{m.SymbolName}' has {m.ParameterCount} parameters. Consider introducing a parameter object.",
+                TargetSymbol: m.SymbolName,
+                FilePath: m.FilePath,
+                Line: m.Line,
+                RecommendedTools: ["extract_type_preview", "extract_type_apply", "compile_check"]));
+        }
+
+        // Low cohesion (LCOM4 >= 2) → extract type or split class
+        foreach (var c in cohesionResults.Where(c => c.Lcom4Score >= 2 && c.FilePath is not null))
+        {
+            suggestions.Add(new RefactoringSuggestionDto(
+                Severity: c.Lcom4Score >= 3 ? "high" : "medium",
+                Category: "cohesion",
+                Description: $"Type '{c.TypeName}' has LCOM4 score {c.Lcom4Score} ({c.Clusters.Count} independent clusters, {c.MethodCount} methods). Split into cohesive types.",
+                TargetSymbol: c.TypeName,
+                FilePath: c.FilePath!,
+                Line: c.Line ?? 0,
+                RecommendedTools: ["get_cohesion_metrics", "find_shared_members", "extract_type_preview", "extract_type_apply", "compile_check"]));
+        }
+
+        // Unused private symbols (high confidence) → remove dead code
+        foreach (var u in unusedResults.Where(u => string.Equals(u.Confidence, "high", StringComparison.OrdinalIgnoreCase)))
+        {
+            suggestions.Add(new RefactoringSuggestionDto(
+                Severity: "low",
+                Category: "dead-code",
+                Description: $"Unused {u.SymbolKind.ToLowerInvariant()} '{u.SymbolName}' in {u.ContainingType ?? "global scope"}.",
+                TargetSymbol: u.SymbolName,
+                FilePath: u.FilePath,
+                Line: u.Line,
+                RecommendedTools: ["find_unused_symbols", "remove_dead_code_preview", "remove_dead_code_apply"]));
+        }
+
+        // Sort: high → medium → low, then by complexity descending
+        var sorted = suggestions
+            .OrderBy(s => s.Severity switch { "high" => 0, "medium" => 1, "low" => 2, _ => 3 })
+            .ThenByDescending(s => s.Category == "complexity" ? 1 : 0)
+            .Take(limit)
+            .ToList();
+
+        _logger.LogDebug("Generated {Count} refactoring suggestions for workspace {WorkspaceId}", sorted.Count, workspaceId);
+
+        return sorted;
+    }
+}

--- a/tests/RoslynMcp.Tests/RefactoringSuggestionTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringSuggestionTests.cs
@@ -1,0 +1,44 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class RefactoringSuggestionTests : SharedWorkspaceTestBase
+{
+    private static string SampleWorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        SampleWorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task SuggestRefactorings_ReturnsResults()
+    {
+        var suggestions = await RefactoringSuggestionService.SuggestRefactoringsAsync(
+            SampleWorkspaceId, projectFilter: null, limit: 50, CancellationToken.None);
+
+        Assert.IsNotNull(suggestions);
+        // Sample solution is small and clean — may or may not have suggestions
+        // but the call should succeed without error
+        foreach (var s in suggestions)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(s.Category));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(s.Severity));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(s.TargetSymbol));
+            Assert.IsTrue(s.RecommendedTools.Count > 0);
+        }
+    }
+
+    [TestMethod]
+    public async Task SuggestRefactorings_RespectLimit()
+    {
+        var suggestions = await RefactoringSuggestionService.SuggestRefactoringsAsync(
+            SampleWorkspaceId, projectFilter: null, limit: 2, CancellationToken.None);
+
+        Assert.IsTrue(suggestions.Count <= 2);
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -67,6 +67,7 @@ public abstract class TestBase
     protected static MsBuildEvaluationService MsBuildEvaluationService { get; private set; } = null!;
     protected static ExtractMethodService ExtractMethodService { get; private set; } = null!;
     protected static ChangeTracker ChangeTracker { get; private set; } = null!;
+    protected static RefactoringSuggestionService RefactoringSuggestionService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -153,6 +154,7 @@ public abstract class TestBase
         MsBuildEvaluationService = services.MsBuildEvaluationService;
         ExtractMethodService = services.ExtractMethodService;
         ChangeTracker = services.ChangeTracker;
+        RefactoringSuggestionService = services.RefactoringSuggestionService;
 
         RepositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
         SampleSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -54,6 +54,7 @@ internal sealed class TestServiceContainer
     public required MsBuildEvaluationService MsBuildEvaluationService { get; init; }
     public required ExtractMethodService ExtractMethodService { get; init; }
     public required ChangeTracker ChangeTracker { get; init; }
+    public required RefactoringSuggestionService RefactoringSuggestionService { get; init; }
 
     public static TestServiceContainer Create(ValidationServiceOptions validationOptions)
     {
@@ -238,7 +239,12 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 previewStore,
                 NullLogger<ExtractMethodService>.Instance),
-            ChangeTracker = changeTracker
+            ChangeTracker = changeTracker,
+            RefactoringSuggestionService = new RefactoringSuggestionService(
+                new CodeMetricsService(workspaceManager, NullLogger<CodeMetricsService>.Instance),
+                new CohesionAnalysisService(workspaceManager, NullLogger<CohesionAnalysisService>.Instance),
+                new UnusedCodeAnalyzer(workspaceManager, compilationCache, NullLogger<UnusedCodeAnalyzer>.Instance),
+                NullLogger<RefactoringSuggestionService>.Instance)
         };
     }
 }


### PR DESCRIPTION
## Summary
- **`suggest_refactorings`** — new read-only tool combining complexity metrics (CC >= 10), LCOM4 cohesion (>= 2 clusters), and high-confidence unused symbols into ranked refactoring suggestions. Each suggestion includes severity, category, target location, and a recommended tool sequence (e.g., `analyze_data_flow` → `extract_method_preview` → `compile_check`).
- **Stable promotions (3 tools):** `get_code_actions`, `preview_code_action`, `apply_code_action` promoted from experimental to stable (69 stable total). Selection-range refactorings verified working in v1.10.0.
- **Change tracker coverage expansion:** `ProjectMutationService.ApplyProjectMutationAsync` and `OrchestrationService.ApplyCompositeAsync` now record changes via `IChangeTracker`, closing blind spots for project mutations and composite operations.
- Version bump 1.10.0 → 1.11.0 across all 5 version files.
- 128 tools (69 stable / 59 experimental), 11 skills, 343 tests.

## Test plan
- [x] `just ci` passes — 343 tests, 0 warnings, 0 vulnerabilities
- [x] `verify-version-drift` confirms all 5 files agree on 1.11.0
- [x] `SuggestRefactorings_ReturnsResults` — service call succeeds, results have valid structure
- [x] `SuggestRefactorings_RespectLimit` — limit parameter is honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)