### PR TITLE
docs: sync deep-review prompt and checklist with v1.11.0 surface (#137)

### DIFF
--- a/ai_docs/audit-reports/deep-review-session-checklist.md
+++ b/ai_docs/audit-reports/deep-review-session-checklist.md
@@ -154,6 +154,7 @@ Report section 11. One row per live skill (2026.04 snapshot: 11 skills). Mark `b
 | `dead-code` | | | | |
 | `document` | | | | |
 | `explain-error` | | | | |
+| `extract-method` | | | | |
 | `migrate-package` | | | | |
 | `refactor` | | | | |
 | `review` | | | | na |

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -6,7 +6,7 @@
      with the project's actual tool, resource, prompt, and plugin-skill surface at all times.
      When tools, resources, prompts, or skills are added, removed, or renamed,
      update the Tools Reference appendix (tier + category) and re-run `./eng/verify-ai-docs.ps1`.
-   Last surface audit: 2026-04-08 (catalog 2026.04; 123 tools = 62 stable / 61 experimental, 9 resources (all stable), 16 prompts (all experimental), 10 plugin skills). -->
+   Last surface audit: 2026-04-13 (catalog 2026.04; 128 tools = 69 stable / 59 experimental, 9 resources (all stable), 16 prompts (all experimental), 11 plugin skills). -->
 
 > Use this prompt with an AI coding agent that has access to the Roslyn MCP server.
 > **Primary purpose:** produce an MCP server audit (bugs, incorrect results, gaps) **plus** an experimental-tier promotion scorecard and a plugin-skill health report. **Mechanism:** real refactoring plus tool calls that exercise the full surface.
@@ -90,7 +90,7 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 12. From the loaded repo, record the repo-shape constraints that affect later phases (projects, tests, analyzers, DI, source generators, Central Package Management, multi-targeting, network limits).
 13. **Restore precheck (mandatory for any C# repo).** Before running any Phase-1 semantic-analysis tool, run `dotnet restore <entrypoint>` from the host shell. Unrestored package references put `UnresolvedAnalyzerReference` entries into `Project.AnalyzerReferences`, which historically crashed `find_unused_symbols`, `type_hierarchy`, `callers_callees`, and `impact_analysis` (FLAG-A). Server v1.7+ filters that subtype out, but the precheck remains a precondition discipline — without restore, `compile_check` and `project_diagnostics` flood with hundreds of CS0246 errors from missing types in unrestored packages, which alone is enough to push a single-turn tool result over the output budget (cross-cutting principle #12). If the host has no shell access, mark this step `blocked` and continue — note in the report header that semantic-analysis tools may degrade or surface package-not-restored errors.
 14. Seed or update the coverage ledger so every live tool/resource/prompt already has a planned phase or a provisional skip reason. Ledger columns: `kind`, `name`, `tier`, `category` (live catalog value), `status`, `phase`, `lastElapsedMs`, `notes`.
-15. Seed the **Experimental promotion scorecard** with one row per experimental tool, resource, and prompt. Pre-fill `tier=experimental`; leave `recommendation` blank until the Final surface closure step. Count: 61 experimental tools + 0 experimental resources + 16 experimental prompts = **77 rows** against the 2026-04-08 catalog. Use the live catalog count if different.
+15. Seed the **Experimental promotion scorecard** with one row per experimental tool, resource, and prompt. Pre-fill `tier=experimental`; leave `recommendation` blank until the Final surface closure step. Count: 59 experimental tools + 0 experimental resources + 16 experimental prompts = **75 rows** against the 2026-04-13 catalog. Use the live catalog count if different.
 16. Seed the **Performance baseline** table. Every exercised read/reader surface contributes one row; writer surfaces contribute a row in Phase 8b.5. The table is machine-readable (see Output Format → Performance baseline).
 
 **MCP audit checkpoint:** Did `server_info` and `roslyn://server/catalog` agree on live counts and tiers? Did `workspace_load` succeed on the chosen entrypoint? Does `workspace_list` show the new session? Did `workspace_status` report any stale documents or missing projects? Did `dotnet restore` complete cleanly (or did you mark step 13 `blocked` with a reason)? Did you explicitly record the disposable isolation path / conservative rationale, the repo shape, the **debug log channel availability**, the initial coverage ledger with no silent omissions, the seeded promotion scorecard row count, and the seeded performance baseline table? If every candidate entrypoint failed to load, did you mark workspace-scoped rows `blocked` and continue only with workspace-independent families?
@@ -122,8 +122,9 @@ These standing rules apply to **every** tool call across all phases. Do not wait
 4. Call `find_unused_symbols` with `includePublic=true` and compare — are there public APIs with zero internal references?
 5. Call `get_namespace_dependencies` to check for circular namespace dependencies.
 6. Call `get_nuget_dependencies` to audit package references across projects.
+7. Call `suggest_refactorings` to get aggregated ranked suggestions based on the complexity, cohesion, and dead-code data above. Compare the suggestions against your own observations — does the ranking make sense? Do the recommended tool sequences match the actual tools for the suggested category? This exercises the v1.11.0 aggregation tool.
 
-**MCP audit checkpoint:** Do complexity metrics make sense for the methods shown? Are LCOM4 scores reasonable (do types with score=1 actually look cohesive when you read them)? After v1.8+, are source-gen partial methods correctly excluded from the cluster count, and are `SharedFields` lists free of private-helper-method names? Does `find_unused_symbols` miss any obviously dead code or falsely flag used symbols?
+**MCP audit checkpoint:** Do complexity metrics make sense for the methods shown? Are LCOM4 scores reasonable (do types with score=1 actually look cohesive when you read them)? After v1.8+, are source-gen partial methods correctly excluded from the cluster count, and are `SharedFields` lists free of private-helper-method names? Does `find_unused_symbols` miss any obviously dead code or falsely flag used symbols? Does `suggest_refactorings` produce suggestions consistent with the raw metrics? Are severity rankings reasonable (high complexity before medium; dead code as low)?
 
 ---
 
@@ -262,9 +263,22 @@ For each method with high complexity:
 3. Call `remove_dead_code_apply`.
 4. Call `compile_check`.
 
-**MCP audit checkpoint:** Does `fix_all_preview` find ALL instances? Does it crash or timeout on large scopes? Does `rename_preview` catch references in comments or strings? Does `extract_interface_preview` generate valid C# syntax? Does `bulk_replace_type_preview` miss any usages? Does `extract_type_preview` handle shared private members correctly? Does `format_range_preview` format only the specified range or does it bleed? Does `remove_dead_code_preview` correctly remove only the targeted symbols? Does `set_diagnostic_severity` correctly update or create the `.editorconfig` entry? Does `add_pragma_suppression` insert the pragma at the correct line without breaking surrounding code? After each apply, does `compile_check` pass?
+#### 6j. Extract Method
+1. Call `suggest_refactorings` to get ranked suggestions. If any complexity suggestions appear, use them to pick an extraction target. If none, pick a method with complexity >= 10 from Phase 2's `get_complexity_metrics` results.
+2. Call `analyze_data_flow` on the target statement range to understand parameters and return values.
+3. Call `extract_method_preview` with the selected line range and a descriptive method name.
+4. Verify the preview shows: extracted method with correct parameters, return type, and call site replacement.
+5. Call `extract_method_apply`.
+6. Call `compile_check`.
 
-**Cross-tool chain validation (Phase 6):** After `rename_apply`, call `find_references` on the new name — does the count match the preview? After `extract_interface_apply`, call `type_hierarchy` on the new interface — does it show the implementor? After `fix_all_apply`, call `project_diagnostics` with the same diagnostic ID — did the count drop to zero? After `organize_usings_apply`, call `get_source_text` — are usings actually sorted? These chains verify that workspace state stays consistent across mutations.
+#### 6k. Session Change Tracking
+1. After all Phase 6 mutations, call `workspace_changes` to list all changes applied during the session.
+2. Verify each applied refactoring appears with correct descriptions, affected files, tool names, and timestamps.
+3. Verify ordering matches the sequence of applies.
+
+**MCP audit checkpoint:** Does `fix_all_preview` find ALL instances? Does it crash or timeout on large scopes? Does `rename_preview` catch references in comments or strings? Does `extract_interface_preview` generate valid C# syntax? Does `bulk_replace_type_preview` miss any usages? Does `extract_type_preview` handle shared private members correctly? Does `format_range_preview` format only the specified range or does it bleed? Does `remove_dead_code_preview` correctly remove only the targeted symbols? Does `set_diagnostic_severity` correctly update or create the `.editorconfig` entry? Does `add_pragma_suppression` insert the pragma at the correct line without breaking surrounding code? Does `extract_method_preview` infer correct parameters from DataFlowsIn and return value from DataFlowsOut? Does `suggest_refactorings` produce ranked suggestions that match the metrics data? Does `workspace_changes` accurately reflect all applies with correct ordering? After each apply, does `compile_check` pass?
+
+**Cross-tool chain validation (Phase 6):** After `rename_apply`, call `find_references` on the new name — does the count match the preview? After `extract_interface_apply`, call `type_hierarchy` on the new interface — does it show the implementor? After `fix_all_apply`, call `project_diagnostics` with the same diagnostic ID — did the count drop to zero? After `organize_usings_apply`, call `get_source_text` — are usings actually sorted? After `extract_method_apply`, call `find_references` on the new method name — does it show at least one call site? After all applies, does `workspace_changes` list the correct number of entries? These chains verify that workspace state stays consistent across mutations.
 
 **Mutation-family coverage note:** By the end of Phase 6 plus the later file/scaffolding/project-mutation phases, every write-capable family exposed by the live catalog must be either exercised end-to-end or explicitly marked `skipped-safety` / `skipped-repo-shape`. Do not assume a preview-only call covers an apply sibling unless the catalog exposes no separate apply tool.
 
@@ -978,9 +992,9 @@ The file must exist at the canonical path above (or the documented fallback). Cr
 > **Maintenance note:** This appendix **mirrors** the live catalog categories (`Category`) and tier (`SupportTier`) values emitted by `roslyn://server/catalog`. The live catalog from Phase 0 is authoritative. Treat this appendix as a convenience snapshot; if it drifts from the running server, record prompt drift in *Improvement suggestions* and trust the live catalog.
 > When tools, resources, prompts, or skills change, update this section **and** `eng/verify-ai-docs.ps1` passes.
 > Client limitations do **not** change appendix counts. If a client cannot invoke prompts or resources, record those entries as `blocked` in the audit ledger rather than editing them out.
-> Last verified: 2026-04-08 against catalog version 2026.04 — **123 tools (62 stable / 61 experimental) | 9 resources (all stable) | 16 prompts (all experimental) | 10 plugin skills**.
+> Last verified: 2026-04-13 against catalog version 2026.04 — **128 tools (69 stable / 59 experimental) | 9 resources (all stable) | 16 prompts (all experimental) | 11 plugin skills**.
 
-### Tools by live catalog category (123 total)
+### Tools by live catalog category (128 total)
 
 The `Category` column below is the exact value emitted by `roslyn://server/catalog` — use these strings in the coverage summary, not the legacy convenience groupings. Tools with a preview/apply pairing are kept together and their pair is noted in the *Pair* column.
 
@@ -991,7 +1005,7 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 |------|------|------|-------|
 | `server_info` | S | RO | Surface inventory, tiers, runtime. |
 
-#### `workspace` (8 stable, 0 experimental)
+#### `workspace` (8 stable, 1 experimental)
 | Tool | Tier | RO/D | Notes |
 |------|------|------|-------|
 | `workspace_load` | S | RO | Lean summary default; `verbose=true` for project tree. |
@@ -1002,6 +1016,7 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | `project_graph` | S | RO | Project dependency graph. |
 | `source_generated_documents` | S | RO | Lists source-gen outputs. |
 | `get_source_text` | S | RO | Read a file from workspace. |
+| `workspace_changes` | E | RO | Session mutation history (v1.10.0+). |
 
 #### `symbols` (16 stable, 0 experimental)
 | Tool | Tier | RO/D | Notes |
@@ -1039,7 +1054,7 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | `list_analyzers` | S | RO | Paginated rules. |
 | `analyze_snippet` | S | RO | Ephemeral workspace; wrapper-relative positions fixed v1.7+ (FLAG-C). |
 
-#### `advanced-analysis` (6 stable, 4 experimental)
+#### `advanced-analysis` (9 stable, 2 experimental)
 | Tool | Tier | RO/D | Notes |
 |------|------|------|-------|
 | `find_unused_symbols` | S | RO | |
@@ -1048,10 +1063,11 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | `find_reflection_usages` | S | RO | |
 | `get_namespace_dependencies` | S | RO | Large output — page carefully. |
 | `get_nuget_dependencies` | S | RO | |
-| `semantic_search` | E | RO | Modifier-sensitive matching; backlog items `semantic-search-*`. |
-| `analyze_data_flow` | E | RO | Expression-bodied members supported v1.8+. |
-| `analyze_control_flow` | E | RO | Expression-body synthesis v1.8+. |
+| `semantic_search` | S | RO | Promoted v1.9.0; verbose-query fallback + exact-match predicate. |
+| `analyze_data_flow` | S | RO | Promoted v1.9.0; expression-bodied members supported. |
+| `analyze_control_flow` | S | RO | Promoted v1.9.0; expression-body synthesis. |
 | `get_operations` | E | RO | Column must point at syntax token (UX-003). |
+| `suggest_refactorings` | E | RO | Ranked suggestions from complexity, cohesion (LCOM4), and unused symbols (v1.11.0+). |
 
 #### `security` (3 stable, 0 experimental)
 | Tool | Tier | RO/D | Notes |
@@ -1072,7 +1088,7 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | `test_coverage` | S | RO | Requires coverlet.collector. |
 | `compile_check` | S | RO | Paginated v1.7+; `emitValidation=true` forces PE emit. |
 
-#### `refactoring` (8 stable, 12 experimental)
+#### `refactoring` (8 stable, 14 experimental)
 | Tool | Tier | RO/D | Pair | Notes |
 |------|------|------|------|-------|
 | `rename_preview` | S | RO | — | |
@@ -1095,6 +1111,8 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | `move_type_to_file_apply` | E | D | `move_type_to_file_preview` | Revertible. |
 | `bulk_replace_type_preview` | E | RO | — | |
 | `bulk_replace_type_apply` | E | D | `bulk_replace_type_preview` | Revertible. |
+| `extract_method_preview` | E | RO | — | Custom DataFlowAnalysis-based extraction (v1.10.0+). |
+| `extract_method_apply` | E | D | `extract_method_preview` | Revertible. |
 
 #### `cross-project-refactoring` (0 stable, 3 experimental)
 | Tool | Tier | RO/D | Notes |
@@ -1164,20 +1182,20 @@ The `Category` column below is the exact value emitted by `roslyn://server/catal
 | Tool | Tier | RO/D | Notes |
 |------|------|------|-------|
 | `get_editorconfig_options` | E | RO | |
-| `set_editorconfig_option` | E | RO+D | ⚠ DIRECT-APPLY, **not** registered with `revert_last_apply` (UX-006). |
+| `set_editorconfig_option` | E | RO+D | Revertible via `revert_last_apply` (undo retrofit v1.8.2). |
 | `set_diagnostic_severity` | E | RO+D | Writes `.editorconfig`; not undoable via `revert_last_apply`. |
 
-#### `code-actions` (0 stable, 3 experimental)
+#### `code-actions` (3 stable, 0 experimental)
 | Tool | Tier | RO/D | Pair | Notes |
 |------|------|------|------|-------|
-| `get_code_actions` | E | RO | — | |
-| `preview_code_action` | E | RO | — | |
-| `apply_code_action` | E | D | `preview_code_action` | Revertible. |
+| `get_code_actions` | S | RO | — | Promoted v1.11.0; supports selection-range refactorings (introduce parameter, inline temporary). |
+| `preview_code_action` | S | RO | — | Promoted v1.11.0. |
+| `apply_code_action` | S | D | `preview_code_action` | Promoted v1.11.0; revertible. |
 
-#### `scripting` (0 stable, 1 experimental)
+#### `scripting` (1 stable, 0 experimental)
 | Tool | Tier | RO/D | Notes |
 |------|------|------|-------|
-| `evaluate_csharp` | E | RO | Hard-budget via `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS`; cross-cutting principle #9 for stalls. |
+| `evaluate_csharp` | S | RO | Promoted v1.9.0; hard-budget via `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS`; cross-cutting principle #9 for stalls. |
 
 #### `syntax` (0 stable, 1 experimental)
 | Tool | Tier | RO/D | Notes |


### PR DESCRIPTION
## Summary
Synced the living deep-review prompt (`ai_docs/prompts/deep-review-and-refactor.md`) and session checklist with the current v1.11.0 surface (128 tools, 69 stable, 59 experimental, 11 skills).

### Appendix updates
- Promoted 7 tools to `S` tier in the reference tables
- Added 5 new tools: `extract_method_preview/apply`, `workspace_changes`, `suggest_refactorings`
- Updated all category header counts (workspace, advanced-analysis, refactoring, code-actions, scripting)
- Fixed stale `set_editorconfig_option` undo note
- Updated skill count from 10 → 11, experimental scorecard seed from 77 → 75 rows

### Phase coverage for new tools
- Phase 2 step 7: `suggest_refactorings` call after metrics gathering
- Phase 6j: Extract Method workflow (`suggest_refactorings` → `analyze_data_flow` → `extract_method_preview` → apply → compile_check)
- Phase 6k: Session change tracking (`workspace_changes` verification)
- Updated cross-tool chain validations and audit checkpoints

### Session checklist
- Added `extract-method` skill row to Phase 16b table

## Test plan
- [x] `verify-ai-docs.ps1` passes
- [x] No stale counts remain (grep for old 62/61/123/10-skills returns empty)
- [x] All 5 new tools appear in appendix tables and at least one phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)