### PR TITLE
fix: disable ReadyToRun in verify-release for CI compatibility

### DIFF
--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -27,7 +27,10 @@ dotnet test $solutionPath -c $Configuration --no-build --nologo `
     --collect:"XPlat Code Coverage" `
     --results-directory $coverageDir `
     --logger "console;verbosity=normal"
-dotnet publish $hostProject -c $Configuration --no-build -o $publishDir
+# PublishReadyToRun (CrossGen) can fail on CI runners when the SDK's crossgen2
+# tooling has platform-specific issues. Disable for the verification publish step;
+# the NuGet pack step produces the distributable package independently.
+dotnet publish $hostProject -c $Configuration --no-build -o $publishDir -p:PublishReadyToRun=false
 
 $hashLines = Get-ChildItem -Path $publishDir -File -Recurse |
     Sort-Object FullName |


### PR DESCRIPTION
## Summary
CrossGen2 (`PublishReadyToRun`) fails on ubuntu-latest with .NET 10.0.201 SDK. The verify-release publish step is validation-only — the NuGet `dotnet pack` step produces the distributable package independently.

Adds `-p:PublishReadyToRun=false` to the verify-release publish command.

## Test plan
- [ ] CI passes on ubuntu-latest
- [ ] After merge, retag `v1.12.1` to trigger publish-nuget workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)