### PR TITLE
docs: correct v1.18.0 surface counts (144→142, +6→+4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "roslyn-mcp",
       "source": "./",
-      "description": "Semantic C# analysis and refactoring powered by Roslyn. 144 tools (102 stable / 42 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
+      "description": "Semantic C# analysis and refactoring powered by Roslyn. 142 tools (102 stable / 40 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
       "version": "1.18.0",
       "author": {
         "name": "darylmcd"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "1.18.0",
-  "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 144 tools (102 stable / 42 experimental) plus 20 MCP prompts; 20 bundled agent skills cover analysis, refactor, tests, MSBuild inspection, session undo, and release workflows.",
+  "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 142 tools (102 stable / 40 experimental) plus 20 MCP prompts; 20 bundled agent skills cover analysis, refactor, tests, MSBuild inspection, session undo, and release workflows.",
   "author": {
     "name": "darylmcd",
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [1.18.0] - 2026-04-14
 
-Top-10 backlog remediation pass v5 — **six new tools**, one new prompt, one new skill, two service extensions, a security-analyzer cleanup, and the full v1.17 catalog-attribute migration. Stable surface unchanged at 102; experimental lifts from 36 → 42.
+Top-10 backlog remediation pass v5 — **four new tools**, one new prompt, one new skill, two service extensions, a security-analyzer cleanup, and the full v1.17 catalog-attribute migration. Stable surface unchanged at 102; experimental lifts from 36 → 40 (live `server_info` confirms 142 tools post-ship; CHANGELOG initially miscounted as 144).
 
 ### Removed
 
@@ -29,14 +29,14 @@ Top-10 backlog remediation pass v5 — **six new tools**, one new prompt, one ne
 - **`symbol_impact_sweep` persistence-layer findings (`mapper-snapshot-dto-symmetry-check`):** When the swept symbol is a property, the response gains a `persistenceLayerFindings` array. Each entry pairs the domain property with its sibling DTO record (matched by `JsonPropertyName` / `DataMember` attribute or by property name), then checks mapper-suffixed types for `To*` + `From*` symmetry. Asymmetric pairs — e.g. `ToSnapshot` writes the property but `FromSnapshot` never reads it — are flagged.
 - **Composite preview token disk persistence (`preview-token-cross-process-handoff`):** New env var `ROSLYNMCP_PREVIEW_PERSIST_DIR` activates opt-in on-disk storage for `CompositePreviewStore` tokens under `{dir}/{workspaceVersion}/{token}.json` with atomic-write + TTL-by-mtime semantics. When unset (default), behavior is in-memory only as before. Only composite preview tokens are portable cross-process — full Roslyn-`Solution` previews stored in `IPreviewStore` remain single-process.
 - **`IEditService` / `IChangeTracker` consumption:** `WorkspaceValidationService` reads `IChangeTracker.GetChanges()` when the caller doesn't pass an explicit `changedFilePaths` list, so the post-edit validation bundle auto-scopes to the session's tracked mutations.
-- **Surface counts:** catalog bumps from 138 → 144 tools (102 stable / 42 experimental, +6 experimental). Prompts bump from 19 → 20 (new `refactor_loop`). Skills bump from 19 → 20 (new `refactor-loop`).
+- **Surface counts:** catalog bumps from 138 → 142 tools (102 stable / 40 experimental, +4 experimental). The 4 new tools: `get_prompt_text`, `validate_workspace`, `change_signature_preview`, `symbol_refactor_preview`. `preview-token-cross-process-handoff` shipped as an env var (no new tool surface) and `roslyn-mcp-guided-refactor-flow` shipped as a prompt + skill. Prompts bump from 19 → 20 (new `refactor_loop`). Skills bump from 19 → 20 (new `refactor-loop`). (CHANGELOG originally claimed 144/+6; corrected post-ship after `server_info` reported the live count.)
 
 ### Maintenance
 
 - **Backlog:** Closed 10 rows in this pass plus the `securitycodescan-currency` sidecar (`roslyn-mcp-workspace-staleness`… wait, those closed in v1.17). v1.18 closes: `securitycodescan-currency`, `tool-catalog-full-attribute-migration`, `change-signature-add-parameter-cross-callsite`, `prompt-tools-exposable-to-agents`, `roslyn-mcp-post-edit-validation-bundle`, `preview-token-cross-process-handoff`, `agent-symbol-refactor-unified-preview`, `roslyn-mcp-guided-refactor-flow`, `test-mock-drift-new-interface-usage`, `mapper-snapshot-dto-symmetry-check`. The `composite-split-service-di-registration` P3 row is not closed but is now implementable on top of `symbol_refactor_preview` — deferred to a future pass.
 - **Tests:** 491 passed, 0 failed. `SecurityDiagnosticIntegrationTests.AnalyzerStatus_AfterSecurityCodeScanRemoval_ReportsAbsence` replaces the pre-v1.18 `AnalyzerStatus_Reports_SecurityCodeScan_Present` to match the removal. `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry` now enforces the attribute across all 144 tools.
 - **Docs:** `ai_docs/runtime.md` env-var table adds `ROSLYNMCP_PREVIEW_PERSIST_DIR`. `ai_docs/backlog.md` synced per the workflow contract.
-- **CHANGELOG correction:** v1.17.0 prose originally claimed 140 tools / +9 experimental; actual live count was 138 / +7. v1.17.0 entry rewritten in this PR to match reality; v1.18.0 count (138 → 144) is derived from the corrected baseline.
+- **CHANGELOG correction:** v1.17.0 prose originally claimed 140 tools / +9 experimental; actual live count was 138 / +7. v1.17.0 entry rewritten in this PR to match reality; v1.18.0 count is 138 → 142 (+4) derived from the corrected baseline, after a second post-ship correction when `server_info` revealed a similar over-count.
 
 ## [1.17.0] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/i
 
 ## Supported Surface
 
-Catalog **`2026.04`** ships **131 tools** (102 stable / 29 experimental), **10 resources** (9 stable / 1 experimental), and **19 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
+Catalog **`2026.04`** ships **142 tools** (102 stable / 40 experimental), **10 resources** (9 stable / 1 experimental), and **20 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
 
 ### Stable tool families
 


### PR DESCRIPTION
## Summary

v1.18.0 ship prose over-counted by 2 tools. Live `server_info` (post-reinstall, commit 435ffb3) reports:

- **Tools:** 142 (102 stable / 40 experimental, +4 from v1.17)
- **Prompts:** 20 (new: `refactor_loop`)

The 4 tools that actually shipped:
1. `get_prompt_text`
2. `validate_workspace`
3. `change_signature_preview`
4. `symbol_refactor_preview`

Two items shipped as **non-tools** but were counted in the prose:
- `preview-token-cross-process-handoff` → env var (`ROSLYNMCP_PREVIEW_PERSIST_DIR`), no new tool
- `roslyn-mcp-guided-refactor-flow` → prompt (`refactor_loop`) + skill (`refactor-loop/`), not a tool

## Files corrected

- `CHANGELOG.md` — v1.18.0 entry header + Surface counts line + CHANGELOG correction note
- `.claude-plugin/plugin.json` — description string
- `.claude-plugin/marketplace.json` — description string
- `README.md` — Supported Surface section (was still showing pre-v1.17 counts: 131 / 29 / 19)

## Test plan

- [x] `eng/verify-version-drift.ps1` passes
- [x] `eng/verify-ai-docs.ps1` passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)