### PR TITLE
chore(release): bump to v1.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 142 tools (102 stable / 40 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.18.2",
+      "version": "1.19.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 142 tools (102 stable / 40 experimental) plus 20 MCP prompts; 20 bundled agent skills cover analysis, refactor, tests, MSBuild inspection, session undo, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-04-16
+
 Top-10 remediation pass v6 — ten correctness and safety fixes targeting the classes of bugs flagged across the 2026-04-15 experimental-promotion audits (firewall-analyzer, IT-Chat-Bot, NetworkDocumentation, SampleSolution) and the v1.18.2 Jellyfin stress test. Closes **19 backlog rows** (7 P2 · 6 P3 · 6 P4). Shipped as PR #162 — one commit per item, plus a baseline plan commit and a final backlog-sync commit.
 
-Backlog sweep 2026-04-16 (plan: `ai_docs/plans/20260416T054040Z_backlog-sweep/plan.md`) — additional initiatives shipped one PR each, listed below.
+Backlog sweep 2026-04-16 (plan: `ai_docs/plans/20260416T054040Z_backlog-sweep/plan.md`) — 14 additional initiatives shipped one PR each (PRs #165–#178), closing 17 more backlog rows (11 P3 · 6 P4). Summary-mode additions across 4 high-fan-out tools, tighter readiness contract, structured parameter-binding errors, and Windows-path resource normalization dominate the feature surface.
 
 ### Fixed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.18.2</Version>
+    <Version>1.19.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Release v1.19.0 — closes the 2026-04-16 backlog sweep session (14 PRs merged #165–#178 + retro #179, 17 backlog rows closed: 11 P3 + 6 P4).

## Highlights

- **Added**: Summary-mode across 4 high-fan-out tools (`find_references`, `get_nuget_dependencies`, `symbol_impact_sweep`, `validate_workspace`). `maxNodes` + `maxTotalBytes` budgets on `get_syntax_tree`.
- **Changed — BREAKING**: `WorkspaceStatusSummaryDto` gains `AnalyzersReady` field; `isReady` contract tightened (requires `AnalyzersReady && IsLoaded && !IsStale && errors == 0`).
- **Fixed**: `format_range_preview` empty-diff bug, `change_signature_preview` brace-concat + interface-callsite enumeration, `extract_type_preview` refuses when external consumers exist, parameter-binding structured errors, `server_info.update.latest` inversion, stdin-EOF flush, Windows path resource normalization.

## Version files (all 5 agree)

- `Directory.Build.props`: 1.18.2 → 1.19.0
- `.claude-plugin/plugin.json`: 1.18.2 → 1.19.0
- `.claude-plugin/marketplace.json` (plugins[0]): 1.18.2 → 1.19.0
- `manifest.json`: 1.18.2 → 1.19.0
- `CHANGELOG.md`: `[Unreleased]` → `[1.19.0] - 2026-04-16`

## Validation

- `eng/verify-version-drift.ps1` → All 5 version files agree on 1.19.0
- `eng/verify-ai-docs.ps1` → AI docs validation passed
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors
- Full test suite: 564 / 564 passing (from session — no code changes in this PR)

## Post-merge actions

1. Tag `v1.19.0` at the merge commit
2. Create GitHub release with CHANGELOG section as body
3. NuGet publish (if CI pipeline handles it) or manual `roslyn-mcp:publish-preflight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)