### PR TITLE
chore(ci): fix baseline test drift after PRs #188 and #190

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -79,7 +79,7 @@ public static class ServerSurfaceCatalog
         Tool("restructure_preview", "refactoring", "experimental", true, false, "Preview a syntax-tree pattern-based find-and-replace using __placeholder__ captures."),
         Tool("replace_string_literals_preview", "refactoring", "experimental", true, false, "Preview replacing string literals in argument/initializer position with a constant expression."),
         Tool("symbol_impact_sweep", "analysis", "experimental", true, false, "Sweep downstream impact of a symbol change: references + switch-exhaustiveness diagnostics + mapper-suffix callsites."),
-        Tool("test_reference_map", "validation", "experimental", true, false, "Statically map source symbols to test references; returns covered/uncovered symbol lists and a coverage percentage."),
+        Tool("test_reference_map", "validation", "experimental", true, false, "Statically map source symbols to test references; returns covered/uncovered symbol lists and a coverage percentage. Supports offset/limit pagination and projectName scoping."),
         Tool("get_prompt_text", "prompts", "experimental", true, false, "Render any registered MCP prompt as plain text. Pass the prompt name plus a JSON object of the prompt's parameters; returns { messages: [{role, text}], promptName, parameterCount }."),
         Tool("validate_workspace", "validation", "experimental", true, false, "Composite post-edit validation: compile_check + project_diagnostics (errors) + test_related_files (+ optional test_run)."),
         Tool("change_signature_preview", "refactoring", "experimental", true, false, "Preview adding/removing/renaming a method parameter with all callsites updated atomically."),

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -281,7 +281,9 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     {
         using var catalogDoc = JsonDocument.Parse(ServerResources.GetServerCatalog());
         Assert.AreEqual("local-first", catalogDoc.RootElement.GetProperty("productShape").GetString());
-        Assert.IsTrue(catalogDoc.RootElement.GetProperty("tools").GetArrayLength() > 0);
+        // dr-9-11-payload-exceeds-mcp-tool-result-cap (PR #188): default catalog now returns
+        // a summary with toolCount + toolsResourceTemplate instead of an inline tools array.
+        Assert.IsTrue(catalogDoc.RootElement.GetProperty("toolCount").GetInt32() > 0);
 
         using var templatesDoc = JsonDocument.Parse(ServerResources.GetResourceTemplates());
         Assert.IsTrue(templatesDoc.RootElement.GetProperty("count").GetInt32() >= 1);


### PR DESCRIPTION
## Summary

Two pre-existing regressions in main were blocking verify-release; this PR fixes both.

1. **SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry** — failed for test_reference_map. PR #190 updated the McpToolMetadata attribute summary to mention pagination + projectName scoping but left the matching ServerSurfaceCatalog Tool(...) entry untouched. Drift detector flagged. Synced.

2. **ExpandedSurfaceIntegrationTests.Resources_Return_Machine_Readable_Contracts** — PR #188 replaced the inline tools array with toolCount + toolsResourceTemplate in the default catalog summary, but this test still asserted on tools.GetArrayLength() > 0. Switched to toolCount > 0.

## Test plan
- [x] dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true
- [x] Both previously-failing tests pass locally
- [x] No new test added — both are strictly repairing tests that were already meant to guard these invariants