### PR TITLE
chore(plan): mark mcp-connection-session-resilience merged (PR #218)

### DIFF
--- a/ai_docs/plans/20260417T120000Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260417T120000Z_backlog-sweep/plan.md
@@ -40,7 +40,7 @@ Within each correctness class, initiatives are sorted by estimated context cost 
 
 ### 1. `mcp-connection-session-resilience` — Enrich server_info with connection readiness and add heartbeat
 
-**Status:** in-review (branch: remediation/mcp-connection-session-resilience, worktree: .worktrees/mcp-connection-session-resilience) · **Order:** 1 · **Correctness class:** P3-correctness · **Schedule hint:** — · **Estimated context:** 45000 tokens · **CHANGELOG category:** Fixed
+**Status:** merged (PR #218, 2026-04-17) · **Order:** 1 · **Correctness class:** P3-correctness · **Schedule hint:** — · **Estimated context:** 45000 tokens · **CHANGELOG category:** Fixed
 
 | Field | Content |
 |---|---|

--- a/ai_docs/plans/20260417T120000Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260417T120000Z_backlog-sweep/state.json
@@ -15,14 +15,14 @@
       "estimatedContextTokens": 45000,
       "productionFilesTouched": 3,
       "testFilesAdded": 1,
-      "status": "in-review",
+      "status": "merged",
       "correctnessClass": "P3-correctness",
       "scheduleHint": null,
       "changelogCategory": "Fixed",
       "branch": "remediation/mcp-connection-session-resilience",
       "worktreePath": ".worktrees/mcp-connection-session-resilience",
-      "prUrl": null,
-      "mergedAt": null,
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/218",
+      "mergedAt": "2026-04-17T13:05:19Z",
       "notes": ""
     },
     {


### PR DESCRIPTION
Step 9 reconciliation for the backlog-sweep executor. Flips state.json `status` → `merged` with `prUrl` + `mergedAt`, and bumps plan.md Status row to `merged (PR #218, 2026-04-17)` so the next backlog-sweep executor's Step 1b reconciliation is a no-op for this row.

Pure metadata — no code or docs touched. Follows PR #218 (`fix(server): add connection readiness + server_heartbeat tool (mcp-connection-session-resilience)`).

Generated with [Claude Code](https://claude.com/claude-code)