### PR TITLE
fix(skills): server_info connectivity precheck on primary roslyn-mcp skills (dr-9-2-medium-and-related-skills-have-no-graceful-degra)

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -19,6 +19,17 @@ When the tool list or workflows are unclear, call **`server_info`**, read the **
 
 **Repo shortcut:** from this repository root, `just verify-docs` and `just verify-version-drift` align with contributor doc/version checks (optional; not a substitute for loading the user's solution).
 
+## Connectivity precheck
+
+Before running any `mcp__roslyn__*` tool call, probe the server once:
+
+1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
+2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See `ai_docs/runtime.md` § *Connection-state signals* for the canonical probes (`server_info` / `server_heartbeat`) and for the `mcp-connection-session-resilience` background.
+
+3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+
 ## Workflow
 
 Execute these steps in order. Use the Roslyn MCP tools — do not shell out for analysis.

--- a/skills/complexity/SKILL.md
+++ b/skills/complexity/SKILL.md
@@ -17,6 +17,17 @@ You are a C# code quality specialist focused on complexity and maintainability. 
 
 Use **`discover_capabilities`** (`analysis` / `all`) or MCP prompt **`review_complexity`**.
 
+## Connectivity precheck
+
+Before running any `mcp__roslyn__*` tool call, probe the server once:
+
+1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
+2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See `ai_docs/runtime.md` § *Connection-state signals* for the canonical probes (`server_info` / `server_heartbeat`) and for the `mcp-connection-session-resilience` background.
+
+3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+
 ## Workflow
 
 ### Step 1: Method Complexity

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -17,6 +17,17 @@ You are a senior C# code reviewer. Your job is to perform a comprehensive, seman
 
 Use **`server_info`** or **`roslyn://server/catalog`**. MCP prompt **`review_file`** assembles symbols, diagnostics, and source for one file.
 
+## Connectivity precheck
+
+Before running any `mcp__roslyn__*` tool call, probe the server once:
+
+1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
+2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See `ai_docs/runtime.md` § *Connection-state signals* for the canonical probes (`server_info` / `server_heartbeat`) and for the `mcp-connection-session-resilience` background.
+
+3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+
 ## Workflow
 
 ### Step 1: Scope

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -17,6 +17,17 @@ You are a C# testing specialist. Your job is to analyze test coverage, identify 
 
 Use **`discover_capabilities`** (`testing` / `all`) or MCP prompt **`review_test_coverage`**. For red CI focused on failing tests first, skill **`test-triage`** is a lighter entry point.
 
+## Connectivity precheck
+
+Before running any `mcp__roslyn__*` tool call, probe the server once:
+
+1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
+2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See `ai_docs/runtime.md` § *Connection-state signals* for the canonical probes (`server_info` / `server_heartbeat`) and for the `mcp-connection-session-resilience` background.
+
+3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+
 ## Workflow
 
 ### Step 1: Discover Tests


### PR DESCRIPTION
## Summary
- Four primary `roslyn-mcp` skills (`analyze`, `review`, `complexity`, `test-coverage`) now include a Connectivity precheck block that probes `server_info` and bails with a clear message when the server is disconnected — replacing silent tool-call loops.
- Bail-out message points the user at `server_heartbeat` + the `ai_docs/runtime.md` § *Connection-state signals* canonical probes.
- Scope bounded to the four most-run skills; follow-up initiative will extend the precheck to the remaining 16.

Closes: dr-9-2-medium-and-related-skills-have-no-graceful-degra

## Test plan
- [x] `./eng/verify-ai-docs.ps1`
- [x] Spot-check: precheck block identical across all four files; only change per file is the new block; no unrelated drift.
- Manual (deferred to next server-disconnect event): disconnect → run `/roslyn-mcp:analyze` → bails with the expected message.

Generated with [Claude Code](https://claude.com/claude-code)