### PR TITLE
fix(cohesion): detect action-triad lifecycle pattern (lcom4-lifecycle-pattern-false-positive)

### DIFF
--- a/src/RoslynMcp.Core/Models/CohesionMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/CohesionMetricsDto.cs
@@ -15,6 +15,22 @@ public sealed record CohesionMetricsDto(
 {
     /// <summary>The kind of type: Class, Struct, Interface, Enum, etc.</summary>
     public string TypeKind { get; init; } = "Class";
+
+    /// <summary>
+    /// Well-known lifecycle pattern detected on the type, or <c>null</c> if none.
+    /// Types matching a known lifecycle pattern are expected to have high LCOM4 by design
+    /// (their public methods are orthogonal on fields), so the split recommendation is downgraded.
+    /// Current values: <c>"action-triad"</c> (type name ending in Action/Handler/Command/Stage
+    /// with a Describe + Validate* + Execute* method triad). Reserved for future patterns.
+    /// </summary>
+    public string? LifecyclePattern { get; init; }
+
+    /// <summary>
+    /// Human-readable recommendation for the LCOM4 score. When a lifecycle pattern is detected,
+    /// this is softened to explain that a high LCOM4 is expected by design. <c>null</c> when no
+    /// special-case guidance applies (callers should fall back to the default "split" suggestion).
+    /// </summary>
+    public string? Recommendation { get; init; }
 }
 
 /// <summary>

--- a/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
@@ -119,6 +119,9 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
         var (methodFieldMap, methodCallMap) = BuildMethodAccessMaps(instanceMethods, typeSymbol, typeDecl, semanticModel, ct);
         var clusters = ComputeClusters(methodFieldMap, methodCallMap);
 
+        var lifecyclePattern = DetectLifecyclePattern(typeSymbol);
+        var recommendation = BuildRecommendation(lifecyclePattern);
+
         return new CohesionMetricsDto(
             TypeName: typeSymbol.Name,
             FullyQualifiedName: typeSymbol.ToDisplayString(),
@@ -128,8 +131,67 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
             FieldCount: instanceFields.Count,
             Lcom4Score: clusters.Count,
             Clusters: clusters)
-        { TypeKind = typeSymbol.TypeKind.ToString() };
+        {
+            TypeKind = typeSymbol.TypeKind.ToString(),
+            LifecyclePattern = lifecyclePattern,
+            Recommendation = recommendation,
+        };
     }
+
+    /// <summary>
+    /// Detects well-known lifecycle patterns on a type whose public methods are orthogonal on
+    /// fields by design. When matched, the caller should expect a high LCOM4 score and should
+    /// NOT treat it as a code smell.
+    ///
+    /// Returns <c>"action-triad"</c> when ALL of the following hold (conservative, strict AND):
+    /// <list type="bullet">
+    ///   <item><description>Type name ends in <c>Action</c>, <c>Handler</c>, <c>Command</c>, or <c>Stage</c> (suffix match).</description></item>
+    ///   <item><description>Has a public method exactly named <c>Describe</c> (case-sensitive).</description></item>
+    ///   <item><description>Has at least one public method whose name is <c>Validate</c> or starts with <c>Validate</c>.</description></item>
+    ///   <item><description>Has at least one public method whose name is <c>Execute</c> or starts with <c>Execute</c>.</description></item>
+    /// </list>
+    /// Returns <c>null</c> otherwise. The conservative predicate avoids false-negatives where
+    /// real low-cohesion types happen to loosely match a lifecycle-style naming.
+    /// </summary>
+    private static string? DetectLifecyclePattern(INamedTypeSymbol typeSymbol)
+    {
+        var name = typeSymbol.Name;
+        var suffixMatch =
+            name.EndsWith("Action", StringComparison.Ordinal) ||
+            name.EndsWith("Handler", StringComparison.Ordinal) ||
+            name.EndsWith("Command", StringComparison.Ordinal) ||
+            name.EndsWith("Stage", StringComparison.Ordinal);
+        if (!suffixMatch) return null;
+
+        var publicMethods = typeSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(m => m.MethodKind == MethodKind.Ordinary
+                        && m.DeclaredAccessibility == Accessibility.Public
+                        && !m.IsImplicitlyDeclared)
+            .ToList();
+
+        var hasDescribe = publicMethods.Any(m => string.Equals(m.Name, "Describe", StringComparison.Ordinal));
+        if (!hasDescribe) return null;
+
+        var hasValidate = publicMethods.Any(m => m.Name.StartsWith("Validate", StringComparison.Ordinal));
+        if (!hasValidate) return null;
+
+        var hasExecute = publicMethods.Any(m => m.Name.StartsWith("Execute", StringComparison.Ordinal));
+        if (!hasExecute) return null;
+
+        return "action-triad";
+    }
+
+    /// <summary>
+    /// Builds the softened LCOM4 recommendation text for a detected lifecycle pattern. Returns
+    /// <c>null</c> when no pattern applies, leaving consumers free to emit their default
+    /// "split into cohesive types" guidance.
+    /// </summary>
+    private static string? BuildRecommendation(string? lifecyclePattern) => lifecyclePattern switch
+    {
+        "action-triad" => "Lifecycle pattern: action-triad — LCOM4 is expected to be high by design because Describe/Validate*/Execute* are orthogonal on fields. Do not split.",
+        _ => null,
+    };
 
     /// <summary>
     /// For each method, build two maps:

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -243,6 +243,142 @@ public class AdapterUnderTest
     }
 
     [TestMethod]
+    public async Task GetCohesionMetrics_ActionTriadPattern_ClassifiesAsActionTriad_AndDowngradesRecommendation()
+    {
+        // lcom4-lifecycle-pattern-false-positive: A type ending in `Action`/`Handler`/`Command`/`Stage`
+        // with the exact Describe + Validate* + Execute* triad is a lifecycle pattern whose
+        // public methods are orthogonal on fields by design. LCOM4 should still report the
+        // real cluster count, but the DTO carries LifecyclePattern="action-triad" and a
+        // softened Recommendation so callers can suppress the "split" suggestion.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "FooAction.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public class FooAction
+{
+    private readonly string _name;
+    private readonly int _limit;
+    private readonly bool _strict;
+
+    public FooAction(string name, int limit, bool strict)
+    {
+        _name = name;
+        _limit = limit;
+        _strict = strict;
+    }
+
+    public string Describe() => _name;
+
+    public bool Validate() => _limit > 0;
+
+    public int Execute() => _strict ? 1 : 0;
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+            var action = metrics.FirstOrDefault(m => m.TypeName == "FooAction");
+            Assert.IsNotNull(action, "FooAction should appear in cohesion metrics.");
+            Assert.AreEqual("action-triad", action.LifecyclePattern,
+                "FooAction with Describe/Validate/Execute triad should be classified as action-triad.");
+            Assert.IsNotNull(action.Recommendation,
+                "Recommendation should be populated for a detected lifecycle pattern.");
+            StringAssert.Contains(action.Recommendation, "action-triad",
+                "Recommendation should mention the action-triad pattern so callers can downgrade the split suggestion.");
+            // Triad methods are orthogonal on fields — each uses a different private field and
+            // forms its own LCOM4 cluster. Lcom4Score = 3 confirms this is exactly the shape the
+            // detector is designed to de-emphasize (without suppressing the raw score itself).
+            Assert.AreEqual(3, action.Lcom4Score,
+                "Describe/_name, Validate/_limit, Execute/_strict are orthogonal → expect Lcom4Score=3.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCohesionMetrics_ActionSuffixWithoutTriad_DoesNotClassifyAsActionTriad()
+    {
+        // lcom4-lifecycle-pattern-false-positive: A type whose name ends in `Action` but whose
+        // methods are NOT the Describe/Validate*/Execute* triad should still report a regular
+        // LCOM4 score with no LifecyclePattern and no softened Recommendation — ensuring the
+        // detector is conservative and does not suppress real low-cohesion signals.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "NotATriadAction.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public class NotATriadAction
+{
+    private readonly string _a;
+    private readonly int _b;
+    private readonly bool _c;
+
+    public NotATriadAction(string a, int b, bool c)
+    {
+        _a = a;
+        _b = b;
+        _c = c;
+    }
+
+    public string Describe() => _a;
+
+    public int Foo() => _b;
+
+    public bool Bar() => _c;
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+            var notTriad = metrics.FirstOrDefault(m => m.TypeName == "NotATriadAction");
+            Assert.IsNotNull(notTriad, "NotATriadAction should appear in cohesion metrics.");
+            Assert.IsNull(notTriad.LifecyclePattern,
+                "LifecyclePattern must be null when the Describe/Validate/Execute triad is incomplete (only Describe + Foo + Bar).");
+            Assert.IsNull(notTriad.Recommendation,
+                "Recommendation must be null when no lifecycle pattern applies, so callers fall back to the default split suggestion.");
+            Assert.AreEqual(3, notTriad.Lcom4Score,
+                "Three orthogonal methods with no shared fields should yield Lcom4Score=3 (default message applies).");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
     public async Task FindSharedMembers_Supports_StaticClasses()
     {
         var copiedSolutionPath = CreateSampleSolutionCopy();


### PR DESCRIPTION
## Summary
- `get_cohesion_metrics` recognizes the action/handler lifecycle triad (`Describe` + `Validate*` + `Execute*` with type name ending in `Action`/`Handler`/`Command`/`Stage`).
- New `lifecyclePattern: "action-triad" | null` field in `CohesionMetricsDto`, plus a paired `recommendation` string.
- When the triad is detected, the LCOM4 split recommendation is downgraded (methods are orthogonal on fields by design).
- Conservative detection: all four conditions must hold.

Closes: lcom4-lifecycle-pattern-false-positive

## Test plan
- [x] `./eng/verify-release.ps1 -Configuration Release`
- [x] `./eng/verify-ai-docs.ps1`
- [x] New test cases in `CohesionAnalysisTests`: `FooAction { Describe, Validate, Execute }` classifies as action-triad with downgraded recommendation; `NotATriadAction { Describe, Foo, Bar }` still reports LCOM4=3 with default (null) recommendation.

Note: `verify-release.ps1` surfaces known pre-existing parallel-run flaky tests (varies per run, all pass in isolation); unrelated to this change (matches prior-sweep precedent noted in plan `state.json`).

Generated with [Claude Code](https://claude.com/claude-code)