### PR TITLE
chore(release): bump to 1.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 142 tools (102 stable / 40 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 142 tools (102 stable / 40 experimental) plus 20 MCP prompts; 20 bundled agent skills cover analysis, refactor, tests, MSBuild inspection, session undo, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-04-18
+
+Backlog sweep `20260417T120000Z` execution passes 2 + 3 — 7 initiatives shipped across 14 PRs (features #234, #237, #238, #239, #244, #245, #247, #248, #249; reconciles #240, #242, #246, #250, #251) closing **7 backlog rows** (P3: 3, P4: 4). Adds four new MCP tools (`trace_exception_flow`, `find_duplicated_methods`, `change_type_namespace_preview`, `validate_recent_git_changes`) and `scaffold_test_preview` sibling-test pattern inference; extends `get_cohesion_metrics` with action-triad lifecycle-pattern detection; adds a `server_info` connectivity precheck to the four most-run `roslyn-mcp` skills (`analyze`, `review`, `complexity`, `test-coverage`). Breaking: PostToolUse `*_apply` verification-reminder batching; two DTO field additions (`Warnings` on `WorkspaceValidationDto`, `LifecyclePattern` + `Recommendation` on `CohesionMetricsDto`). Internal: planner prompt refactored to v3 (per-initiative `toolPolicy` + new-MCP-tool structural-unit exemption) and executor prompt to v4 (concurrent-session safety + subagent result-protocol hardening); PreToolUse hook widened to accept composite-preview-redeemed evidence; `discover_capabilities` parameter-name drift fixed.
+
 ### Fixed
 
 - **Fixed:** `roslyn-mcp:analyze`/`review`/`complexity`/`test-coverage` now include a `server_info` connectivity precheck and bail with a clear message when the server is disconnected, replacing silent-loop failures (`dr-9-2-medium-and-related-skills-have-no-graceful-degra`).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.22.0</Version>
+    <Version>1.23.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Release cut for the 2026-04-17 backlog sweep (execution passes 2 + 3).

- **7 initiatives shipped** across [#234](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/234), [#237](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/237), [#238](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/238), [#239](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/239), [#244](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/244), [#245](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/245), [#247](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/247), [#248](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/248), [#249](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/249) (reconciles: [#240](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/240), [#242](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/242), [#246](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/246), [#250](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/250), [#251](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/251)).
- **7 backlog rows closed** (P3: 3, P4: 4).
- **4 new MCP tools:** `trace_exception_flow`, `find_duplicated_methods`, `change_type_namespace_preview`, `validate_recent_git_changes`.
- **Other changes:** sibling-test pattern inference in `scaffold_test_preview`, action-triad lifecycle detection in `get_cohesion_metrics`, skill connectivity prechecks (4 skills).
- **Breaking:** PostToolUse `*_apply` verification-reminder batching; DTO field additions on `WorkspaceValidationDto` + `CohesionMetricsDto`.
- **Internal:** planner v3 + executor v4 sweep-prompt refactors; PreToolUse hook widened.

Version bump `1.22.0` → `1.23.0` across 5 files (`Directory.Build.props`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `manifest.json`, `CHANGELOG.md`).

## Test plan
- [x] `pwsh ./eng/verify-version-drift.ps1` — all 5 files agree on 1.23.0.
- [x] `pwsh ./eng/verify-release.ps1 -Configuration Release` — 678/678 tests green (5.8 min). Publish to `artifacts/publish/host-stdio/` successful.
- [x] `pwsh ./eng/verify-ai-docs.ps1` — passed.

Tag `v1.23.0` + global-tool reinstall land after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)