### PR TITLE
feat(analysis): get_di_registrations showLifetimeOverrides opt-in (di-lifetime-mismatch-detection)

### DIFF
--- a/src/RoslynMcp.Core/Models/DiRegistrationDto.cs
+++ b/src/RoslynMcp.Core/Models/DiRegistrationDto.cs
@@ -10,3 +10,52 @@ public sealed record DiRegistrationDto(
     string FilePath,
     int Line,
     string RegistrationMethod);
+
+/// <summary>
+/// Per-registration entry inside an override chain. <see cref="EffectiveStatus"/> describes
+/// how MS.DI's descriptor resolution treats this call given the order of all registrations
+/// for the same service type:
+/// <list type="bullet">
+///   <item><description><c>winning</c> — the last <c>Add*</c> descriptor; what
+///   <c>GetService&lt;TService&gt;()</c> returns.</description></item>
+///   <item><description><c>overridden</c> — an earlier <c>Add*</c> descriptor that a later
+///   <c>Add*</c> displaces (last-wins).</description></item>
+///   <item><description><c>shadowed</c> — a <c>TryAdd*</c> call that was a no-op because a
+///   descriptor for the same service type already existed (first-wins variant short-circuited).
+///   </description></item>
+/// </list>
+/// di-lifetime-mismatch-detection.
+/// </summary>
+public sealed record DiRegistrationOverrideEntryDto(
+    string ImplementationType,
+    string Lifetime,
+    string FilePath,
+    int Line,
+    string RegistrationMethod,
+    string EffectiveStatus);
+
+/// <summary>
+/// One service type's full override chain. <see cref="LifetimesDiffer"/> is true when the
+/// chain mixes lifetimes (e.g. <c>Singleton</c> and <c>Scoped</c>) — a captive-dependency or
+/// dead-shadowing risk. <see cref="DeadRegistrationCount"/> is the count of entries whose
+/// <c>EffectiveStatus</c> is <c>overridden</c> or <c>shadowed</c>.
+/// di-lifetime-mismatch-detection.
+/// </summary>
+public sealed record DiRegistrationOverrideChainDto(
+    string ServiceType,
+    IReadOnlyList<DiRegistrationOverrideEntryDto> Registrations,
+    string WinningLifetime,
+    string WinningImplementationType,
+    bool LifetimesDiffer,
+    int DeadRegistrationCount);
+
+/// <summary>
+/// Composite scan result returned when the caller opts in to override-chain analysis. The
+/// <see cref="Registrations"/> list is the same shape returned by the legacy
+/// <c>GetDiRegistrationsAsync</c> path; <see cref="OverrideChains"/> groups any service type
+/// with two or more registrations into a chain entry.
+/// di-lifetime-mismatch-detection.
+/// </summary>
+public sealed record DiRegistrationScanResult(
+    IReadOnlyList<DiRegistrationDto> Registrations,
+    IReadOnlyList<DiRegistrationOverrideChainDto> OverrideChains);

--- a/src/RoslynMcp.Core/Services/IDiRegistrationService.cs
+++ b/src/RoslynMcp.Core/Services/IDiRegistrationService.cs
@@ -11,4 +11,13 @@ public interface IDiRegistrationService
 {
     Task<IReadOnlyList<DiRegistrationDto>> GetDiRegistrationsAsync(
         string workspaceId, string? projectFilter, CancellationToken ct);
+
+    /// <summary>
+    /// di-lifetime-mismatch-detection: extended scan that returns the same flat registration
+    /// list plus a per-service-type override chain. Computed only when the caller opts in via
+    /// the <c>showLifetimeOverrides</c> tool parameter — the default scan path skips the chain
+    /// projection so payload shape stays stable.
+    /// </summary>
+    Task<DiRegistrationScanResult> GetDiRegistrationsWithOverridesAsync(
+        string workspaceId, string? projectFilter, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -51,18 +51,33 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_di_registrations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Inspect DI registration patterns in source."),
-     Description("Scan the solution for dependency injection registrations (AddSingleton, AddScoped, AddTransient) and return the service-to-implementation mappings")]
+     Description("Scan the solution for dependency injection registrations (AddSingleton, AddScoped, AddTransient) and return the service-to-implementation mappings. Pass showLifetimeOverrides=true to additionally emit per-service-type override chains (winning lifetime, lifetime-mismatch flag, dead-registration count) — opt-in to keep the default payload shape stable.")]
     public static Task<string> GetDiRegistrations(
         IWorkspaceExecutionGate gate,
         IDiRegistrationService diRegistrationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name")] string? projectName = null,
+        [Description("When true, also emit overrideChains[] grouping registrations by service type with the winning lifetime, lifetime-mismatch flag (Singleton vs Scoped vs Transient), and dead-registration count. Default: false (legacy shape: count + registrations[]).")] bool showLifetimeOverrides = false,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            var results = await diRegistrationService.GetDiRegistrationsAsync(workspaceId, projectName, c);
-            return JsonSerializer.Serialize(new { count = results.Count, registrations = results }, JsonDefaults.Indented);
+            if (!showLifetimeOverrides)
+            {
+                var results = await diRegistrationService.GetDiRegistrationsAsync(workspaceId, projectName, c);
+                return JsonSerializer.Serialize(new { count = results.Count, registrations = results }, JsonDefaults.Indented);
+            }
+
+            // di-lifetime-mismatch-detection: opt-in path returns the legacy registrations
+            // list (unchanged shape) plus the per-service-type override chains.
+            var scan = await diRegistrationService.GetDiRegistrationsWithOverridesAsync(workspaceId, projectName, c);
+            return JsonSerializer.Serialize(new
+            {
+                count = scan.Registrations.Count,
+                registrations = scan.Registrations,
+                overrideChainCount = scan.OverrideChains.Count,
+                overrideChains = scan.OverrideChains,
+            }, JsonDefaults.Indented);
         }, ct);
     }
 

--- a/src/RoslynMcp.Roslyn/Services/DiRegistrationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiRegistrationService.cs
@@ -25,9 +25,45 @@ public sealed class DiRegistrationService : IDiRegistrationService
     /// callers don't re-walk every syntax tree. Invalidated on workspace close via
     /// <see cref="IWorkspaceManager.WorkspaceClosed"/> and on workspace version bump.
     /// </summary>
+    /// <remarks>
+    /// di-lifetime-mismatch-detection: each snapshot holds the WIDER raw list (including
+    /// <c>TryAdd*</c> entries) plus a memoized legacy view (<c>Add*</c>-only) and lazily-built
+    /// override-chains. The Top10 regression test
+    /// <c>GetDiRegistrations_RepeatCallSameVersion_ReturnsCachedReference</c> asserts reference
+    /// equality on repeat calls — memoizing the legacy view in the snapshot preserves that.
+    /// </remarks>
     private readonly ConcurrentDictionary<string, DiCacheEntry> _scanCache = new(StringComparer.Ordinal);
 
-    private sealed record DiCacheEntry(int Version, ConcurrentDictionary<string, IReadOnlyList<DiRegistrationDto>> ByFilter);
+    private sealed record DiCacheEntry(int Version, ConcurrentDictionary<string, ScanSnapshot> ByFilter);
+
+    /// <summary>
+    /// Per-filter cache snapshot. <see cref="Raw"/> is the full scan (Add* + TryAdd*).
+    /// <see cref="LegacyView"/> is the <c>Add*</c>-only projection returned by
+    /// <see cref="GetDiRegistrationsAsync"/> — cached so repeat callers get the same reference.
+    /// <see cref="OverrideChains"/> is lazily computed on first override-mode call and then
+    /// memoized.
+    /// </summary>
+    private sealed class ScanSnapshot
+    {
+        private IReadOnlyList<DiRegistrationOverrideChainDto>? _overrideChains;
+
+        public ScanSnapshot(IReadOnlyList<DiRegistrationDto> raw, IReadOnlyList<DiRegistrationDto> legacyView)
+        {
+            Raw = raw;
+            LegacyView = legacyView;
+        }
+
+        public IReadOnlyList<DiRegistrationDto> Raw { get; }
+
+        public IReadOnlyList<DiRegistrationDto> LegacyView { get; }
+
+        public IReadOnlyList<DiRegistrationOverrideChainDto> GetOrBuildOverrideChains()
+        {
+            // Volatile single-writer read/write — worst case is two threads each compute once,
+            // both write the same deterministic result, and the last writer wins.
+            return _overrideChains ??= BuildOverrideChains(Raw);
+        }
+    }
 
     private const string UnfilteredKey = "<all>";
     private const int MaxFilterEntriesPerWorkspace = 8;
@@ -48,6 +84,20 @@ public sealed class DiRegistrationService : IDiRegistrationService
     public async Task<IReadOnlyList<DiRegistrationDto>> GetDiRegistrationsAsync(
         string workspaceId, string? projectFilter, CancellationToken ct)
     {
+        var snapshot = await GetOrLoadSnapshotAsync(workspaceId, projectFilter, ct).ConfigureAwait(false);
+        return snapshot.LegacyView;
+    }
+
+    public async Task<DiRegistrationScanResult> GetDiRegistrationsWithOverridesAsync(
+        string workspaceId, string? projectFilter, CancellationToken ct)
+    {
+        var snapshot = await GetOrLoadSnapshotAsync(workspaceId, projectFilter, ct).ConfigureAwait(false);
+        return new DiRegistrationScanResult(snapshot.LegacyView, snapshot.GetOrBuildOverrideChains());
+    }
+
+    private async Task<ScanSnapshot> GetOrLoadSnapshotAsync(
+        string workspaceId, string? projectFilter, CancellationToken ct)
+    {
         // di-registrations-scan-caching: serve from cache if present and the workspace hasn't
         // bumped its version. Cap entries per workspace to avoid unbounded growth on chatty
         // filter combinations.
@@ -56,10 +106,10 @@ public sealed class DiRegistrationService : IDiRegistrationService
 
         var entry = _scanCache.AddOrUpdate(
             workspaceId,
-            _ => new DiCacheEntry(version, new ConcurrentDictionary<string, IReadOnlyList<DiRegistrationDto>>(StringComparer.OrdinalIgnoreCase)),
+            _ => new DiCacheEntry(version, new ConcurrentDictionary<string, ScanSnapshot>(StringComparer.OrdinalIgnoreCase)),
             (_, existing) => existing.Version == version
                 ? existing
-                : new DiCacheEntry(version, new ConcurrentDictionary<string, IReadOnlyList<DiRegistrationDto>>(StringComparer.OrdinalIgnoreCase)));
+                : new DiCacheEntry(version, new ConcurrentDictionary<string, ScanSnapshot>(StringComparer.OrdinalIgnoreCase)));
 
         if (entry.ByFilter.TryGetValue(key, out var cached))
         {
@@ -67,15 +117,22 @@ public sealed class DiRegistrationService : IDiRegistrationService
         }
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var results = await ScanProjectsAsync(workspaceId, solution, projectFilter, ct).ConfigureAwait(false);
+        var raw = await ScanProjectsAsync(workspaceId, solution, projectFilter, ct).ConfigureAwait(false);
+        // di-lifetime-mismatch-detection: derive the legacy view once at cache-population time
+        // so every repeat call returns the same reference (preserves the Top10V2Regression
+        // GetDiRegistrations_RepeatCallSameVersion_ReturnsCachedReference contract).
+        var legacyView = raw.Count == 0
+            ? (IReadOnlyList<DiRegistrationDto>)Array.Empty<DiRegistrationDto>()
+            : raw.Where(r => !IsTryAddMethod(r.RegistrationMethod)).ToList();
+        var snapshot = new ScanSnapshot(raw, legacyView);
 
         if (entry.ByFilter.Count >= MaxFilterEntriesPerWorkspace)
         {
             var someKey = entry.ByFilter.Keys.FirstOrDefault();
             if (someKey is not null) entry.ByFilter.TryRemove(someKey, out _);
         }
-        entry.ByFilter[key] = results;
-        return results;
+        entry.ByFilter[key] = snapshot;
+        return snapshot;
     }
 
     private async Task<IReadOnlyList<DiRegistrationDto>> ScanProjectsAsync(
@@ -205,7 +262,23 @@ public sealed class DiRegistrationService : IDiRegistrationService
         "AddKeyedSingleton" => "Singleton",
         "AddKeyedScoped" => "Scoped",
         "AddKeyedTransient" => "Transient",
+        // di-lifetime-mismatch-detection: include TryAdd* so the override-chain analysis can
+        // model first-wins (TryAdd) vs last-wins (Add) semantics. The legacy
+        // GetDiRegistrationsAsync path filters these back out to preserve its default shape.
+        "TryAddSingleton" => "Singleton",
+        "TryAddScoped" => "Scoped",
+        "TryAddTransient" => "Transient",
+        "TryAddEnumerable" => "Enumerable",
         _ => null
+    };
+
+    private static bool IsTryAddMethod(string methodName) => methodName switch
+    {
+        "TryAddSingleton" => true,
+        "TryAddScoped" => true,
+        "TryAddTransient" => true,
+        "TryAddEnumerable" => true,
+        _ => false
     };
 
     private static bool TryGetDiTypesFromTypeOfArguments(
@@ -282,5 +355,127 @@ public sealed class DiRegistrationService : IDiRegistrationService
             return converted.ToDisplayString();
         }
         return null;
+    }
+
+    /// <summary>
+    /// di-lifetime-mismatch-detection: project the raw scan into per-service-type override
+    /// chains. Models MS.DI's descriptor resolution semantics:
+    /// <list type="bullet">
+    ///   <item><description>Source order is determined by file path then line number across
+    ///   the matched projects. This is a deterministic static approximation of the runtime
+    ///   call order; it cannot model conditional branches that swap composition-root entries
+    ///   at startup.</description></item>
+    ///   <item><description>Each <c>Add*</c> call appends a descriptor; each <c>TryAdd*</c>
+    ///   call appends only if no descriptor exists yet for that service type.</description></item>
+    ///   <item><description>The "winner" returned by <c>GetService&lt;TService&gt;()</c> is the
+    ///   LAST descriptor in the resulting list.</description></item>
+    ///   <item><description>Earlier descriptors are <c>overridden</c>; <c>TryAdd*</c> calls
+    ///   that did not push a descriptor are <c>shadowed</c>.</description></item>
+    ///   <item><description><c>unknown</c> service types (could not resolve generic argument)
+    ///   are skipped — they would group spuriously and produce noise.</description></item>
+    /// </list>
+    /// Service types with only one registration are also skipped from the chain output
+    /// (no override, nothing to flag).
+    /// </summary>
+    private static IReadOnlyList<DiRegistrationOverrideChainDto> BuildOverrideChains(
+        IReadOnlyList<DiRegistrationDto> rawRegistrations)
+    {
+        var chains = new List<DiRegistrationOverrideChainDto>();
+        var groups = rawRegistrations
+            .Where(r => !string.Equals(r.ServiceType, "unknown", StringComparison.Ordinal))
+            .GroupBy(r => r.ServiceType, StringComparer.Ordinal);
+
+        foreach (var group in groups)
+        {
+            var ordered = group
+                .OrderBy(r => r.FilePath ?? string.Empty, StringComparer.Ordinal)
+                .ThenBy(r => r.Line)
+                .ToList();
+
+            if (ordered.Count < 2)
+            {
+                continue;
+            }
+
+            var entries = new List<DiRegistrationOverrideEntryDto>(ordered.Count);
+            var lifetimesSeen = new HashSet<string>(StringComparer.Ordinal);
+            DiRegistrationDto? activeDescriptor = null;
+            DiRegistrationDto? winningDescriptor = null;
+
+            foreach (var registration in ordered)
+            {
+                lifetimesSeen.Add(registration.Lifetime);
+
+                string status;
+                if (IsTryAddMethod(registration.RegistrationMethod))
+                {
+                    if (activeDescriptor is null)
+                    {
+                        // First registration for this service type — TryAdd takes effect.
+                        activeDescriptor = registration;
+                        winningDescriptor = registration;
+                        status = "winning";
+                    }
+                    else
+                    {
+                        // A descriptor already exists; TryAdd is a no-op for GetService.
+                        status = "shadowed";
+                    }
+                }
+                else
+                {
+                    // Unconditional Add*: replaces the prior winner for GetService<T>.
+                    activeDescriptor = registration;
+                    winningDescriptor = registration;
+                    status = "winning";
+                }
+
+                entries.Add(new DiRegistrationOverrideEntryDto(
+                    registration.ImplementationType,
+                    registration.Lifetime,
+                    registration.FilePath,
+                    registration.Line,
+                    registration.RegistrationMethod,
+                    status));
+            }
+
+            // Mark every prior "winning" entry as overridden — only the last winning entry
+            // actually wins. Walk the list once from the end, demoting earlier winners.
+            var seenFinalWinner = false;
+            for (var i = entries.Count - 1; i >= 0; i--)
+            {
+                if (entries[i].EffectiveStatus != "winning")
+                {
+                    continue;
+                }
+
+                if (!seenFinalWinner)
+                {
+                    seenFinalWinner = true;
+                    continue;
+                }
+
+                entries[i] = entries[i] with { EffectiveStatus = "overridden" };
+            }
+
+            var deadCount = entries.Count(e => e.EffectiveStatus is "overridden" or "shadowed");
+            var lifetimesDiffer = lifetimesSeen.Count > 1;
+            // winningDescriptor is non-null because Count >= 2 guarantees at least one entry
+            // and the loop always promotes the first call to winning (Add or first-TryAdd).
+            var winner = winningDescriptor!;
+
+            chains.Add(new DiRegistrationOverrideChainDto(
+                group.Key,
+                entries,
+                winner.Lifetime,
+                winner.ImplementationType,
+                lifetimesDiffer,
+                deadCount));
+        }
+
+        // Stable ordering for callers: alphabetical by service type.
+        return chains
+            .OrderBy(c => c.ServiceType, StringComparer.Ordinal)
+            .ToList();
     }
 }

--- a/tests/RoslynMcp.Tests/DiLifetimeOverrideTests.cs
+++ b/tests/RoslynMcp.Tests/DiLifetimeOverrideTests.cs
@@ -1,0 +1,197 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// di-lifetime-mismatch-detection: covers the override-chain analysis added to
+/// <c>get_di_registrations</c>. Tests use a self-contained shim of <c>IServiceCollection</c> +
+/// <c>ServiceCollectionExtensions</c> written into the isolated workspace, so the analyzer
+/// detects registrations purely by name-shape (containing-type name contains
+/// "ServiceCollection") without requiring a real Microsoft.Extensions.DependencyInjection
+/// package reference. This keeps the test independent of fixture-csproj package churn.
+/// </summary>
+[TestClass]
+public sealed class DiLifetimeOverrideTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        InitializeServices();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task ShowLifetimeOverrides_Off_Default_Result_Matches_Legacy_Shape()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await WriteServiceCollectionShimAsync(workspace, CancellationToken.None);
+        await WriteRegistrationFileAsync(
+            workspace,
+            "RegistrationsAlpha.cs",
+            "namespace SampleLib;\n\npublic static class RegistrationsAlpha\n{\n    public static void Configure(IServiceCollection services)\n    {\n        services.AddSingleton<IFoo, FooSingleton>();\n        services.AddScoped<IFoo, FooScoped>();\n    }\n}\n",
+            CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var legacyResults = await DiRegistrationService.GetDiRegistrationsAsync(
+            workspace.WorkspaceId, projectFilter: "SampleLib", CancellationToken.None);
+
+        var iFooEntries = legacyResults.Where(r => r.ServiceType.EndsWith("IFoo", StringComparison.Ordinal)).ToList();
+        Assert.AreEqual(2, iFooEntries.Count, "Legacy view must surface both Add* registrations.");
+        Assert.IsTrue(
+            iFooEntries.All(r => r.RegistrationMethod is "AddSingleton" or "AddScoped"),
+            "Legacy view must NOT include TryAdd* methods (they are filtered out to keep the default shape stable).");
+    }
+
+    [TestMethod]
+    public async Task Last_Wins_Add_Then_Add_Marks_Earlier_Singleton_As_Overridden_With_Scoped_Winner()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await WriteServiceCollectionShimAsync(workspace, CancellationToken.None);
+
+        // Two separate composition-root files — first registers IFoo as Singleton, second as Scoped.
+        // Validation per plan: winning lifetime = Scoped, overridden = [Singleton], deadCount = 1.
+        await WriteRegistrationFileAsync(
+            workspace,
+            "RegistrationsAlpha.cs",
+            "namespace SampleLib;\n\npublic static class RegistrationsAlpha\n{\n    public static void Configure(IServiceCollection services)\n    {\n        services.AddSingleton<IFoo, FooSingleton>();\n    }\n}\n",
+            CancellationToken.None);
+        await WriteRegistrationFileAsync(
+            workspace,
+            "RegistrationsBeta.cs",
+            "namespace SampleLib;\n\npublic static class RegistrationsBeta\n{\n    public static void Configure(IServiceCollection services)\n    {\n        services.AddScoped<IFoo, FooScoped>();\n    }\n}\n",
+            CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var scan = await DiRegistrationService.GetDiRegistrationsWithOverridesAsync(
+            workspace.WorkspaceId, projectFilter: "SampleLib", CancellationToken.None);
+
+        var chain = scan.OverrideChains.SingleOrDefault(c => c.ServiceType.EndsWith("IFoo", StringComparison.Ordinal));
+        Assert.IsNotNull(chain, "Expected an override chain for IFoo.");
+        Assert.AreEqual("Scoped", chain.WinningLifetime,
+            "Last Add* call wins per MS.DI descriptor resolution semantics.");
+        Assert.AreEqual("FooScoped", ImplementationLeaf(chain.WinningImplementationType));
+        Assert.IsTrue(chain.LifetimesDiffer, "Mixed Singleton + Scoped registrations must flag lifetime mismatch.");
+        Assert.AreEqual(1, chain.DeadRegistrationCount, "Earlier Singleton registration is dead.");
+        Assert.AreEqual(2, chain.Registrations.Count);
+
+        var singletonEntry = chain.Registrations.Single(e => e.Lifetime == "Singleton");
+        Assert.AreEqual("overridden", singletonEntry.EffectiveStatus,
+            "Earlier Singleton must be marked overridden (last-wins semantics).");
+
+        var scopedEntry = chain.Registrations.Single(e => e.Lifetime == "Scoped");
+        Assert.AreEqual("winning", scopedEntry.EffectiveStatus,
+            "Final Scoped registration is the winner.");
+    }
+
+    [TestMethod]
+    public async Task TryAdd_First_Wins_Subsequent_TryAdd_Is_Shadowed()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await WriteServiceCollectionShimAsync(workspace, CancellationToken.None);
+
+        // First TryAdd takes effect; second TryAdd is a no-op because a descriptor exists.
+        await WriteRegistrationFileAsync(
+            workspace,
+            "RegistrationsAlpha.cs",
+            "namespace SampleLib;\n\npublic static class RegistrationsAlpha\n{\n    public static void Configure(IServiceCollection services)\n    {\n        services.TryAddSingleton<IBar, BarFirst>();\n        services.TryAddSingleton<IBar, BarSecond>();\n    }\n}\n",
+            CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var scan = await DiRegistrationService.GetDiRegistrationsWithOverridesAsync(
+            workspace.WorkspaceId, projectFilter: "SampleLib", CancellationToken.None);
+
+        var chain = scan.OverrideChains.SingleOrDefault(c => c.ServiceType.EndsWith("IBar", StringComparison.Ordinal));
+        Assert.IsNotNull(chain, "Expected an override chain for IBar.");
+        Assert.AreEqual("BarFirst", ImplementationLeaf(chain.WinningImplementationType),
+            "First TryAddSingleton wins; subsequent TryAdds are no-ops.");
+        Assert.AreEqual("Singleton", chain.WinningLifetime);
+        Assert.IsFalse(chain.LifetimesDiffer, "Both registrations are Singleton — no mismatch.");
+        Assert.AreEqual(1, chain.DeadRegistrationCount, "Second TryAdd contributes nothing.");
+        Assert.AreEqual(2, chain.Registrations.Count);
+
+        var statuses = chain.Registrations.Select(e => e.EffectiveStatus).ToList();
+        CollectionAssert.AreEqual(new[] { "winning", "shadowed" }, statuses,
+            "Source-order: first TryAdd is the winner; second is shadowed.");
+    }
+
+    [TestMethod]
+    public async Task Single_Registration_Service_Type_Is_Excluded_From_Override_Chains()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await WriteServiceCollectionShimAsync(workspace, CancellationToken.None);
+        await WriteRegistrationFileAsync(
+            workspace,
+            "RegistrationsAlpha.cs",
+            "namespace SampleLib;\n\npublic static class RegistrationsAlpha\n{\n    public static void Configure(IServiceCollection services)\n    {\n        services.AddSingleton<IBaz, BazOnly>();\n    }\n}\n",
+            CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var scan = await DiRegistrationService.GetDiRegistrationsWithOverridesAsync(
+            workspace.WorkspaceId, projectFilter: "SampleLib", CancellationToken.None);
+
+        Assert.IsFalse(
+            scan.OverrideChains.Any(c => c.ServiceType.EndsWith("IBaz", StringComparison.Ordinal)),
+            "A service registered exactly once is not an override and must be omitted from the chain output.");
+    }
+
+    /// <summary>
+    /// Writes a self-contained shim of <c>IServiceCollection</c> + extension methods to
+    /// SampleLib. The DI registration walker matches by containing-type name shape
+    /// ("ServiceCollection") and method-name lifetime mapping, so this gives full semantic
+    /// binding without dragging in Microsoft.Extensions.DependencyInjection.
+    /// </summary>
+    private static async Task WriteServiceCollectionShimAsync(IsolatedWorkspaceScope workspace, CancellationToken ct)
+    {
+        var shim = """
+namespace SampleLib;
+
+public interface IServiceCollection { }
+
+public sealed class FakeServiceCollection : IServiceCollection { }
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddSingleton<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+    public static IServiceCollection AddScoped<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+    public static IServiceCollection AddTransient<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+    public static IServiceCollection TryAddSingleton<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+    public static IServiceCollection TryAddScoped<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+    public static IServiceCollection TryAddTransient<TService, TImpl>(this IServiceCollection services)
+        where TImpl : TService => services;
+}
+
+public interface IFoo { }
+public sealed class FooSingleton : IFoo { }
+public sealed class FooScoped : IFoo { }
+
+public interface IBar { }
+public sealed class BarFirst : IBar { }
+public sealed class BarSecond : IBar { }
+
+public interface IBaz { }
+public sealed class BazOnly : IBaz { }
+""";
+        await File.WriteAllTextAsync(workspace.GetPath("SampleLib", "DiShim.cs"), shim, ct).ConfigureAwait(false);
+    }
+
+    private static async Task WriteRegistrationFileAsync(IsolatedWorkspaceScope workspace, string fileName, string contents, CancellationToken ct)
+    {
+        await File.WriteAllTextAsync(workspace.GetPath("SampleLib", fileName), contents, ct).ConfigureAwait(false);
+    }
+
+    private static string ImplementationLeaf(string fullyQualifiedTypeName)
+    {
+        var lastDot = fullyQualifiedTypeName.LastIndexOf('.');
+        return lastDot >= 0 ? fullyQualifiedTypeName[(lastDot + 1)..] : fullyQualifiedTypeName;
+    }
+}


### PR DESCRIPTION
## Summary

Extends `get_di_registrations` with an opt-in `showLifetimeOverrides=true`
parameter that emits per-service-type override chains alongside the legacy
flat registration list. Helps surface dead registrations + captive-dependency
risk without loading a full-audit workflow.

Output per chain:

- `serviceType`
- `registrations[]` — every registration in source order with
  `effectiveStatus: winning | overridden | shadowed`
- `winningLifetime` / `winningImplementationType`
- `lifetimesDiffer` (true when chain mixes Singleton/Scoped/Transient —
  captive-dependency or dead-shadowing signal)
- `deadRegistrationCount` — count of overridden + shadowed entries

Default output shape unchanged — opt-in keeps legacy callers untouched.

## Behavior modeled

Matches Microsoft.Extensions.DependencyInjection descriptor resolution:

- `Add*` — unconditionally appends a descriptor; last `Add*` wins for
  `GetService<T>()`.
- `TryAdd*` — appends only if no descriptor exists yet (first-wins).

Cache extended to a per-filter snapshot holding both the raw scan (with
`TryAdd*`) and a memoized `Add*`-only legacy view, preserving the
`Top10V2RegressionTests.GetDiRegistrations_RepeatCallSameVersion_ReturnsCachedReference`
reference-equality contract for repeat default-shape calls.

## Scope

| File | Change |
|---|---|
| `src/RoslynMcp.Core/Models/DiRegistrationDto.cs` | Add `DiRegistrationOverrideEntryDto`, `DiRegistrationOverrideChainDto`, `DiRegistrationScanResult` records. |
| `src/RoslynMcp.Core/Services/IDiRegistrationService.cs` | Add `GetDiRegistrationsWithOverridesAsync`. |
| `src/RoslynMcp.Roslyn/Services/DiRegistrationService.cs` | Implement override-chain analysis, `TryAdd*` lifetime mapping (filtered out of the legacy view), cache snapshot refactor. |
| `src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs` | Add `showLifetimeOverrides: bool = false` tool parameter. |
| `tests/RoslynMcp.Tests/DiLifetimeOverrideTests.cs` | 4 new regression tests (legacy-shape stability, last-wins, TryAdd first-wins/shadowed, single-registration exclusion). |

Two additional prod files beyond plan Scope (IDiRegistrationService.cs +
AdvancedAnalysisTools.cs) — strictly required to expose the new analysis
through the public service contract and the MCP tool surface.

## Validation

- `eng/verify-ai-docs.ps1`: passes.
- 4 new tests in `DiLifetimeOverrideTests`: all pass.
- 8-test DI-adjacent regression battery (legacy shape, cache reference
  equality, existing `CompositeSplitServiceDi*`, repo-wide DI analysis,
  `ServiceCollectionExtensionsTests`): all pass.
- `eng/verify-release.ps1 -Configuration Release` run 3×; each run surfaces
  1–9 flakes from a rotating set of tests unrelated to DI scanning
  (Kitten/OrganizeUsings/AddPackageReference/EditUndoCohesion/CreateFileRevert
  etc.). Each flake passes when run in isolation. Matches the pre-existing
  `ci-test-parallelization-audit` backlog row (shared-state concurrency in
  the assembly-level `DoNotParallelize` gate). No DI-related test fails.

## Test plan

- [ ] CI green (ignoring known flakes tracked in `ci-test-parallelization-audit`).
- [ ] Smoke: `get_di_registrations` without the new param returns the same
      `{ count, registrations }` shape as before.
- [ ] Smoke: `get_di_registrations workspaceId=... showLifetimeOverrides=true`
      returns `{ count, registrations, overrideChainCount, overrideChains }`.

Closes: di-lifetime-mismatch-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)