### PR TITLE
feat(editing): apply_text_edit/apply_multi_file_edit verify+autoRevert wrapper (semantic-edit-with-compile-check-wrapper)

### DIFF
--- a/src/RoslynMcp.Core/Models/MultiFileEditResultDto.cs
+++ b/src/RoslynMcp.Core/Models/MultiFileEditResultDto.cs
@@ -3,10 +3,18 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents the result of applying text edits across multiple files.
 /// </summary>
+/// <param name="Verification">
+/// When <c>verify=true</c> was requested, carries a single batch-level post-edit
+/// compile-check outcome. The verify pass runs ONCE at the end of the batch
+/// across the union of owning projects, not once per file — that matches the
+/// single-snapshot undo semantics of <c>apply_multi_file_edit</c>. <c>null</c>
+/// on the default (<c>verify=false</c>) path.
+/// </param>
 public sealed record MultiFileEditResultDto(
     bool Success,
     int FilesModified,
-    IReadOnlyList<FileEditSummaryDto> Files);
+    IReadOnlyList<FileEditSummaryDto> Files,
+    VerifyOutcomeDto? Verification = null);
 
 /// <summary>
 /// Represents the edit outcome for a single file in a multi-file edit operation.

--- a/src/RoslynMcp.Core/Models/TextEditDto.cs
+++ b/src/RoslynMcp.Core/Models/TextEditDto.cs
@@ -13,9 +13,17 @@ public sealed record TextEditDto(
 /// <summary>
 /// Represents the result of applying one or more text edits to a file.
 /// </summary>
+/// <param name="Verification">
+/// When <c>verify=true</c> was requested on the apply call, carries the post-edit
+/// compile-check outcome (including any new errors and whether an auto-revert
+/// fired). <c>null</c> on the default (<c>verify=false</c>) path so existing
+/// call-sites see the same shape they did before
+/// <c>semantic-edit-with-compile-check-wrapper</c>.
+/// </param>
 public sealed record TextEditResultDto(
     bool Success,
     string FilePath,
     int EditsApplied,
     IReadOnlyList<FileChangeDto> Changes,
-    IReadOnlyList<TextEditSyntaxErrorDto>? SyntaxErrors = null);
+    IReadOnlyList<TextEditSyntaxErrorDto>? SyntaxErrors = null,
+    VerifyOutcomeDto? Verification = null);

--- a/src/RoslynMcp.Core/Models/VerifyOutcomeDto.cs
+++ b/src/RoslynMcp.Core/Models/VerifyOutcomeDto.cs
@@ -1,0 +1,35 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Outcome of the post-edit verify pass attached to <c>apply_text_edit</c> /
+/// <c>apply_multi_file_edit</c> when callers pass <c>verify=true</c>.
+/// </summary>
+/// <remarks>
+/// The verify pass runs <c>compile_check</c> scoped to the owning project(s) of the
+/// edited file(s) AFTER the edit is applied and persisted to disk, then compares the
+/// resulting error diagnostics against a pre-edit baseline so pre-existing compile
+/// errors are not attributed to the current call.
+/// <para>
+/// Status values:
+/// <list type="bullet">
+///   <item><c>skipped</c> — caller did not request verification (default path).</item>
+///   <item><c>clean</c> — verify ran and introduced no new errors.</item>
+///   <item><c>errors_introduced</c> — verify ran, new errors appeared, and the
+///     caller did NOT request <c>autoRevertOnError</c>, so the workspace stays
+///     in the errored state for inspection.</item>
+///   <item><c>reverted</c> — verify ran, new errors appeared, and
+///     <c>autoRevertOnError=true</c> triggered a successful single-shot revert
+///     via the existing <c>revert_last_apply</c> slot.</item>
+///   <item><c>revert_failed</c> — verify ran, new errors appeared, revert was
+///     attempted but the undo stack could not restore the pre-edit state. The
+///     workspace is in an inconsistent state and requires manual inspection.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed record VerifyOutcomeDto(
+    string Status,
+    int PreErrorCount,
+    int PostErrorCount,
+    IReadOnlyList<DiagnosticDto> NewDiagnostics,
+    string? ProjectFilter = null,
+    string? Message = null);

--- a/src/RoslynMcp.Core/Services/IEditService.cs
+++ b/src/RoslynMcp.Core/Services/IEditService.cs
@@ -17,8 +17,29 @@ public interface IEditService
     /// <param name="edits">The text edits to apply. Edits are applied in document order.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <param name="skipSyntaxCheck">When <c>false</c> (default), <c>.cs</c> files are parsed after edits; parser errors block apply. Set <c>true</c> for intentional non-compilable intermediate states.</param>
+    /// <param name="verify">
+    /// When <c>true</c>, run <c>compile_check</c> scoped to the owning project of
+    /// <paramref name="filePath"/> after the edit is persisted. The new-error set
+    /// is attached to <see cref="TextEditResultDto.Verification"/>. Pre-existing
+    /// errors unrelated to the edit are filtered out via a pre-vs-post fingerprint
+    /// diff, so a repo that already fails to compile will not mis-attribute its
+    /// errors to this call.
+    /// </param>
+    /// <param name="autoRevertOnError">
+    /// When <c>true</c> AND <paramref name="verify"/> surfaces new compile errors,
+    /// the edit is rolled back through the same single-slot <c>revert_last_apply</c>
+    /// undo path that this call just populated. Single-shot per call: only the
+    /// snapshot this call captured can be reverted — prior-turn edits are never
+    /// touched. Ignored when <paramref name="verify"/> is <c>false</c>.
+    /// </param>
     Task<TextEditResultDto> ApplyTextEditsAsync(
-        string workspaceId, string filePath, IReadOnlyList<TextEditDto> edits, CancellationToken ct, bool skipSyntaxCheck = false);
+        string workspaceId,
+        string filePath,
+        IReadOnlyList<TextEditDto> edits,
+        CancellationToken ct,
+        bool skipSyntaxCheck = false,
+        bool verify = false,
+        bool autoRevertOnError = false);
 
     /// <summary>
     /// Applies text edits to multiple files atomically from an undo perspective: a single
@@ -29,8 +50,23 @@ public interface IEditService
     /// <param name="fileEdits">The per-file edit batches to apply, in order.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <param name="skipSyntaxCheck">When <c>false</c> (default), each <c>.cs</c> file is parsed after edits; parser errors block that file's apply.</param>
+    /// <param name="verify">
+    /// When <c>true</c>, run <c>compile_check</c> ONCE after the full batch completes,
+    /// scoped to the union of owning projects for the edited files. The new-error set
+    /// is attached to <see cref="MultiFileEditResultDto.Verification"/>.
+    /// </param>
+    /// <param name="autoRevertOnError">
+    /// When <c>true</c> AND <paramref name="verify"/> surfaces new compile errors,
+    /// the entire batch is rolled back via the single batch-level undo snapshot.
+    /// Ignored when <paramref name="verify"/> is <c>false</c>.
+    /// </param>
     Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
-        string workspaceId, IReadOnlyList<FileEditsDto> fileEdits, CancellationToken ct, bool skipSyntaxCheck = false);
+        string workspaceId,
+        IReadOnlyList<FileEditsDto> fileEdits,
+        CancellationToken ct,
+        bool skipSyntaxCheck = false,
+        bool verify = false,
+        bool autoRevertOnError = false);
 
     /// <summary>
     /// Item 5: previews a multi-file edit batch. Edits are simulated in-memory against the

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -75,8 +75,8 @@ public static class ServerSurfaceCatalog
         Tool("semantic_search", "advanced-analysis", "stable", true, false, "Run semantic search over symbols and declarations."),
         Tool("find_duplicated_methods", "advanced-analysis", "stable", true, false, "Find clusters of near-duplicate method bodies by AST-normalized hash."),
 
-        Tool("apply_text_edit", "editing", "stable", false, true, "Apply direct text edits to a single file."),
-        Tool("apply_multi_file_edit", "editing", "experimental", false, true, "Apply direct text edits to multiple files."),
+        Tool("apply_text_edit", "editing", "stable", false, true, "Apply direct text edits to a single file; optional verify + auto-revert on new compile errors."),
+        Tool("apply_multi_file_edit", "editing", "experimental", false, true, "Apply direct text edits to multiple files; optional verify + auto-revert on new compile errors."),
         Tool("preview_multi_file_edit", "editing", "experimental", true, false, "Preview a multi-file edit batch; returns per-file diffs and a preview token."),
         Tool("preview_multi_file_edit_apply", "editing", "experimental", false, true, "Apply a previously previewed multi-file edit."),
         Tool("restructure_preview", "refactoring", "experimental", true, false, "Preview a syntax-tree pattern-based find-and-replace using __placeholder__ captures."),

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -13,8 +13,8 @@ public static class EditTools
 
     [McpServerTool(Name = "apply_text_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("editing", "stable", false, true,
-        "Apply direct text edits to a single file."),
-     Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned. Revertible via revert_last_apply (one snapshot per call, single-slot per workspace). Prefer a semantic preview/apply Roslyn tool whenever one exists; only fall back to apply_text_edit when no semantic equivalent is available.")]
+        "Apply direct text edits to a single file; optional verify + auto-revert on new compile errors."),
+     Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned. Revertible via revert_last_apply (one snapshot per call, single-slot per workspace). When verify=true, runs compile_check scoped to the owning project after the edit and attaches the new-error set as Verification (pre-existing errors are filtered out via a pre-vs-post fingerprint diff). When autoRevertOnError=true AND new errors appeared, the edit is rolled back through the same single-slot undo path this call just populated. Prefer a semantic preview/apply Roslyn tool whenever one exists; only fall back to apply_text_edit when no semantic equivalent is available.")]
     public static Task<string> ApplyTextEdit(
         McpServer server,
         IWorkspaceExecutionGate gate,
@@ -23,12 +23,14 @@ public static class EditTools
         [Description("Absolute path to the source file to edit")] string filePath,
         [Description("Array of text edits. Each edit has startLine, startColumn, endLine, endColumn (1-based), and newText. Example: [{\"startLine\":10,\"startColumn\":5,\"endLine\":10,\"endColumn\":15,\"newText\":\"newValue\"}]. All positions are 1-based inclusive; non-overlapping edits are applied in the order given.")] TextEditDto[] edits,
         CancellationToken ct = default,
-        [Description("When false (default), C# files are parsed after edits and lexer/parser errors block the apply. Set true only for intentional intermediate invalid states.")] bool skipSyntaxCheck = false)
+        [Description("When false (default), C# files are parsed after edits and lexer/parser errors block the apply. Set true only for intentional intermediate invalid states.")] bool skipSyntaxCheck = false,
+        [Description("When true, run compile_check scoped to the owning project after the edit and attach the result under Verification. Pre-existing errors are filtered out, so only NEW errors appear in the outcome. Default false preserves the original call-site behavior.")] bool verify = false,
+        [Description("When true AND verify surfaces new compile errors, automatically revert the edit through the single-slot undo path this call populated. Single-shot per call - never touches prior-turn edits. Ignored when verify is false. Default false.")] bool autoRevertOnError = false)
     {
         return gate.RunWriteAsync(workspaceId, async c =>
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
-            var result = await editService.ApplyTextEditsAsync(workspaceId, filePath, edits, c, skipSyntaxCheck);
+            var result = await editService.ApplyTextEditsAsync(workspaceId, filePath, edits, c, skipSyntaxCheck, verify, autoRevertOnError);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -14,8 +14,8 @@ public static class MultiFileEditTools
 
     [McpServerTool(Name = "apply_multi_file_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("editing", "experimental", false, true,
-        "Apply direct text edits to multiple files."),
-     Description("Apply text edits to multiple files in the workspace sequentially. All edits share a single pre-apply snapshot — revert_last_apply rolls back the entire batch atomically. If a file validation or apply fails partway through, revert_last_apply restores the pre-call state for any files that were already written. Prefer preview_multi_file_edit + apply_composite_preview for agent workflows that need a review step.")]
+        "Apply direct text edits to multiple files; optional verify + auto-revert on new compile errors."),
+     Description("Apply text edits to multiple files in the workspace sequentially. All edits share a single pre-apply snapshot — revert_last_apply rolls back the entire batch atomically. If a file validation or apply fails partway through, revert_last_apply restores the pre-call state for any files that were already written. When verify=true, runs compile_check ONCE after the batch completes (scoped to the single owning project when the batch is single-project, or the full solution when it spans multiple) and attaches the new-error set as Verification. When autoRevertOnError=true AND new errors appeared, the whole batch is rolled back through the single batch-level undo snapshot. Prefer preview_multi_file_edit + apply_composite_preview for agent workflows that need a review step.")]
     public static Task<string> ApplyMultiFileEdit(
         McpServer server,
         IWorkspaceExecutionGate gate,
@@ -23,7 +23,9 @@ public static class MultiFileEditTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Array of file edits. Each has filePath (string) and edits (array of TextEditDto with startLine, startColumn, endLine, endColumn, newText)")] FileEditsDto[] fileEdits,
         CancellationToken ct = default,
-        [Description("When false (default), each C# file is parsed after edits; parser errors block that file's apply.")] bool skipSyntaxCheck = false)
+        [Description("When false (default), each C# file is parsed after edits; parser errors block that file's apply.")] bool skipSyntaxCheck = false,
+        [Description("When true, run compile_check once after the batch completes (scoped to the single owning project when possible) and attach the result under Verification. Pre-existing errors are filtered out, so only NEW errors appear in the outcome. Default false.")] bool verify = false,
+        [Description("When true AND verify surfaces new compile errors, automatically revert the entire batch through the single-slot undo path this call populated. Ignored when verify is false. Default false.")] bool autoRevertOnError = false)
     {
         return gate.RunWriteAsync(workspaceId, async c =>
         {
@@ -33,7 +35,7 @@ public static class MultiFileEditTools
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, fileEdit.FilePath, c).ConfigureAwait(false);
             }
 
-            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, c, skipSyntaxCheck).ConfigureAwait(false);
+            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, c, skipSyntaxCheck, verify, autoRevertOnError).ConfigureAwait(false);
             return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -15,23 +15,32 @@ public sealed class EditService : IEditService
     private readonly IUndoService? _undoService;
     private readonly IChangeTracker? _changeTracker;
     private readonly Contracts.IPreviewStore? _previewStore;
+    private readonly ICompileCheckService? _compileCheckService;
 
     public EditService(
         IWorkspaceManager workspace,
         ILogger<EditService> logger,
         IUndoService? undoService = null,
         IChangeTracker? changeTracker = null,
-        Contracts.IPreviewStore? previewStore = null)
+        Contracts.IPreviewStore? previewStore = null,
+        ICompileCheckService? compileCheckService = null)
     {
         _workspace = workspace;
         _logger = logger;
         _undoService = undoService;
         _changeTracker = changeTracker;
         _previewStore = previewStore;
+        _compileCheckService = compileCheckService;
     }
 
     public async Task<TextEditResultDto> ApplyTextEditsAsync(
-        string workspaceId, string filePath, IReadOnlyList<TextEditDto> edits, CancellationToken ct, bool skipSyntaxCheck = false)
+        string workspaceId,
+        string filePath,
+        IReadOnlyList<TextEditDto> edits,
+        CancellationToken ct,
+        bool skipSyntaxCheck = false,
+        bool verify = false,
+        bool autoRevertOnError = false)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var (document, sourceText) = await ResolveDocumentAndTextAsync(solution, filePath, ct).ConfigureAwait(false);
@@ -53,6 +62,15 @@ public sealed class EditService : IEditService
             }
         }
 
+        // semantic-edit-with-compile-check-wrapper: capture the pre-edit diagnostic
+        // fingerprint set BEFORE we mutate the workspace so the verify pass can tell
+        // NEW errors from pre-existing ones. Lives outside ApplyTextEditsCoreAsync
+        // because MultiFile runs the capture once at the batch boundary.
+        var projectFilter = verify ? document.Project.Name : null;
+        var preErrorBaseline = verify
+            ? await CapturePreEditBaselineAsync(workspaceId, projectFilter, ct).ConfigureAwait(false)
+            : null;
+
         // Capture pre-apply snapshot so revert_last_apply can roll back this edit. We
         // pass BOTH the solution (for the legacy path) AND an explicit file snapshot
         // (for the authoritative file-based restore path — see FLAG-9A in UndoService).
@@ -67,11 +85,34 @@ public sealed class EditService : IEditService
             solution,
             fileSnapshots);
 
-        return await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, document, sourceText, newSourceText, ct).ConfigureAwait(false);
+        var coreResult = await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, document, sourceText, newSourceText, ct).ConfigureAwait(false);
+
+        // Only wire up verify when the core apply actually wrote the edit. When the
+        // core path returns Success=false (e.g. MSBuildWorkspace.TryApplyChanges
+        // rejected the change), the undo entry still contains the pre-edit snapshot,
+        // but nothing happened on disk — running compile_check here would add noise.
+        if (!verify || !coreResult.Success)
+        {
+            return coreResult;
+        }
+
+        var verification = await RunVerifyAndMaybeRevertAsync(
+            workspaceId,
+            projectFilter,
+            preErrorBaseline!,
+            autoRevertOnError,
+            ct).ConfigureAwait(false);
+
+        return coreResult with { Verification = verification };
     }
 
     public async Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
-        string workspaceId, IReadOnlyList<FileEditsDto> fileEdits, CancellationToken ct, bool skipSyntaxCheck = false)
+        string workspaceId,
+        IReadOnlyList<FileEditsDto> fileEdits,
+        CancellationToken ct,
+        bool skipSyntaxCheck = false,
+        bool verify = false,
+        bool autoRevertOnError = false)
     {
         var initialSolution = _workspace.GetCurrentSolution(workspaceId);
 
@@ -86,6 +127,19 @@ public sealed class EditService : IEditService
             ValidateEdits(fileEdit.FilePath, fileEdit.Edits, sourceText);
             perFileSnapshots.Add((document, sourceText, Path.GetFullPath(fileEdit.FilePath)));
         }
+
+        // semantic-edit-with-compile-check-wrapper: pre-edit baseline runs ONCE across
+        // the union of owning projects (project-level filter is still cheaper than a
+        // full-solution compile). A null projectFilter means "compile every project"
+        // — required when the batch spans more than one project.
+        var ownerProjects = perFileSnapshots
+            .Select(t => t.Document.Project.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var batchProjectFilter = verify && ownerProjects.Count == 1 ? ownerProjects[0] : null;
+        var preErrorBaseline = verify
+            ? await CapturePreEditBaselineAsync(workspaceId, batchProjectFilter, ct).ConfigureAwait(false)
+            : null;
 
         // Single snapshot at the top so revert_last_apply rolls back the ENTIRE batch atomically
         // (from an undo perspective; individual disk writes still happen sequentially).
@@ -126,7 +180,18 @@ public sealed class EditService : IEditService
             results.Add(new FileEditSummaryDto(fileEdit.FilePath, result.EditsApplied, diff));
         }
 
-        return new MultiFileEditResultDto(true, results.Count, results);
+        VerifyOutcomeDto? verification = null;
+        if (verify)
+        {
+            verification = await RunVerifyAndMaybeRevertAsync(
+                workspaceId,
+                batchProjectFilter,
+                preErrorBaseline!,
+                autoRevertOnError,
+                ct).ConfigureAwait(false);
+        }
+
+        return new MultiFileEditResultDto(true, results.Count, results, verification);
     }
 
     /// <summary>
@@ -476,4 +541,171 @@ public sealed class EditService : IEditService
             return false;
         }
     }
+
+    // --------------------------------------------------------------------------
+    // semantic-edit-with-compile-check-wrapper: verify + auto-revert support
+    // --------------------------------------------------------------------------
+
+    /// <summary>
+    /// Captures a stable per-error fingerprint set for the current workspace so the
+    /// post-edit verify pass can subtract pre-existing errors from the introduced set.
+    /// Fingerprint format mirrors <c>ApplyWithVerifyTool.ExtractErrorFingerprints</c>:
+    /// <c>id|file:line:col|message</c>. When <paramref name="projectFilter"/> is
+    /// non-null, the baseline is scoped to that single project — cheaper and more
+    /// precise than a full-solution compile for single-file edits.
+    /// </summary>
+    private async Task<PreEditBaseline> CapturePreEditBaselineAsync(
+        string workspaceId,
+        string? projectFilter,
+        CancellationToken ct)
+    {
+        if (_compileCheckService is null)
+        {
+            // verify was requested but the service is not wired — surface a structured
+            // message instead of silently skipping. The caller asked for verify; they
+            // deserve to know why there is no outcome to inspect.
+            throw new InvalidOperationException(
+                "apply_text_edit/apply_multi_file_edit verify=true requires ICompileCheckService to be registered. " +
+                "Ensure RoslynMcp.Roslyn DI is configured (AddRoslynMcpCoreServices).");
+        }
+
+        // Page size of 500 covers most single-project repos. If a project legitimately
+        // has more than 500 errors, the fingerprint set will be an over-count — not a
+        // correctness hazard (any such error will also appear post-edit and be filtered
+        // out), just a performance one.
+        var baseline = await _compileCheckService.CheckAsync(
+            workspaceId,
+            new CompileCheckOptions(ProjectFilter: projectFilter, SeverityFilter: "error", Limit: 500),
+            ct).ConfigureAwait(false);
+
+        var fingerprints = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var d in baseline.Diagnostics)
+        {
+            if (!string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            fingerprints.Add(FormatErrorFingerprint(d));
+        }
+
+        return new PreEditBaseline(fingerprints, baseline.ErrorCount);
+    }
+
+    /// <summary>
+    /// Post-edit verify leg: runs <c>compile_check</c> on the same scope as the baseline,
+    /// subtracts the pre-existing errors to produce the introduced-error set, then either
+    /// returns the verify outcome (when no new errors OR <paramref name="autoRevertOnError"/>
+    /// is false) or calls <c>revert_last_apply</c> to roll back the single-slot snapshot
+    /// this call just captured.
+    /// </summary>
+    /// <remarks>
+    /// Single-shot semantics: this revert targets ONLY the snapshot that the current
+    /// call placed on the undo stack. Prior-turn edits are never touched — the undo
+    /// service is already single-slot per workspace, so the capture earlier in this
+    /// method overwrote whatever was there. Running <c>RevertAsync</c> restores the
+    /// pre-edit state that was captured inside this call's frame, not an earlier one.
+    /// </remarks>
+    private async Task<VerifyOutcomeDto> RunVerifyAndMaybeRevertAsync(
+        string workspaceId,
+        string? projectFilter,
+        PreEditBaseline preEditBaseline,
+        bool autoRevertOnError,
+        CancellationToken ct)
+    {
+        // The null-check here would only fire in a misconfigured test DI; production
+        // comes through AddRoslynMcpCoreServices which always wires CompileCheckService.
+        // The CapturePreEditBaselineAsync path would have already thrown.
+        ArgumentNullException.ThrowIfNull(_compileCheckService);
+
+        var postCheck = await _compileCheckService.CheckAsync(
+            workspaceId,
+            new CompileCheckOptions(ProjectFilter: projectFilter, SeverityFilter: "error", Limit: 500),
+            ct).ConfigureAwait(false);
+
+        var newDiagnostics = new List<DiagnosticDto>();
+        foreach (var d in postCheck.Diagnostics)
+        {
+            if (!string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            var fingerprint = FormatErrorFingerprint(d);
+            if (!preEditBaseline.ErrorFingerprints.Contains(fingerprint))
+            {
+                newDiagnostics.Add(d);
+            }
+        }
+
+        if (newDiagnostics.Count == 0)
+        {
+            return new VerifyOutcomeDto(
+                Status: "clean",
+                PreErrorCount: preEditBaseline.ErrorCount,
+                PostErrorCount: postCheck.ErrorCount,
+                NewDiagnostics: Array.Empty<DiagnosticDto>(),
+                ProjectFilter: projectFilter,
+                Message: null);
+        }
+
+        if (!autoRevertOnError)
+        {
+            return new VerifyOutcomeDto(
+                Status: "errors_introduced",
+                PreErrorCount: preEditBaseline.ErrorCount,
+                PostErrorCount: postCheck.ErrorCount,
+                NewDiagnostics: newDiagnostics,
+                ProjectFilter: projectFilter,
+                Message: "The edit applied but introduced new compile errors. autoRevertOnError was false, " +
+                        "so the workspace is preserved for inspection. Call revert_last_apply to roll back this edit.");
+        }
+
+        // autoRevertOnError=true AND new errors appeared. Roll back the single-slot
+        // snapshot this call captured. _undoService may legitimately be null in
+        // test contexts that construct EditService without an undo stack — surface
+        // that as a structured outcome rather than a NullReferenceException.
+        if (_undoService is null)
+        {
+            return new VerifyOutcomeDto(
+                Status: "revert_failed",
+                PreErrorCount: preEditBaseline.ErrorCount,
+                PostErrorCount: postCheck.ErrorCount,
+                NewDiagnostics: newDiagnostics,
+                ProjectFilter: projectFilter,
+                Message: "autoRevertOnError=true but IUndoService is not registered on this EditService. " +
+                        "The edit remained applied. Wire IUndoService via AddRoslynMcpCoreServices.");
+        }
+
+        var reverted = await _undoService.RevertAsync(workspaceId, ct).ConfigureAwait(false);
+        if (reverted)
+        {
+            return new VerifyOutcomeDto(
+                Status: "reverted",
+                PreErrorCount: preEditBaseline.ErrorCount,
+                PostErrorCount: postCheck.ErrorCount,
+                NewDiagnostics: newDiagnostics,
+                ProjectFilter: projectFilter,
+                Message: "The edit introduced new compile errors and was reverted. " +
+                        "The workspace is back to the pre-edit state.");
+        }
+
+        return new VerifyOutcomeDto(
+            Status: "revert_failed",
+            PreErrorCount: preEditBaseline.ErrorCount,
+            PostErrorCount: postCheck.ErrorCount,
+            NewDiagnostics: newDiagnostics,
+            ProjectFilter: projectFilter,
+            Message: "The edit introduced new compile errors AND the auto-revert failed. " +
+                    "The workspace is in an inconsistent state — inspect and call revert_last_apply manually.");
+    }
+
+    private static string FormatErrorFingerprint(DiagnosticDto d)
+        => $"{d.Id}|{d.FilePath}:{d.StartLine}:{d.StartColumn}|{d.Message}";
+
+    /// <summary>
+    /// Holds the pre-edit fingerprint set plus the total pre-existing error count so the
+    /// verify outcome can report both the delta and the baseline headline number.
+    /// </summary>
+    private sealed record PreEditBaseline(
+        HashSet<string> ErrorFingerprints,
+        int ErrorCount);
 }

--- a/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
@@ -1,0 +1,352 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <c>semantic-edit-with-compile-check-wrapper</c>:
+/// <c>apply_text_edit</c> and <c>apply_multi_file_edit</c> accept <c>verify</c> +
+/// <c>autoRevertOnError</c> parameters. The verify pass runs <c>compile_check</c>
+/// scoped to the owning project after the edit and filters pre-existing errors out
+/// via a pre-vs-post fingerprint diff, so pre-existing errors are never attributed
+/// to the current call. <c>autoRevertOnError=true</c> triggers a single-shot revert
+/// through the same snapshot slot the call captured.
+/// </summary>
+[TestClass]
+public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    // ------------------------------------------------------------------
+    // Default-path preservation: verify omitted → no Verification field.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_VerifyFalse_OmitsVerificationField()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var edit = AppendCommentEdit(originalText, "// verify-false probe");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { edit },
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: false,
+            autoRevertOnError: false);
+
+        Assert.IsTrue(result.Success, "Edit with verify=false must apply cleanly.");
+        Assert.IsNull(result.Verification, "Default path must not attach a Verification field.");
+
+        var afterEdit = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        StringAssert.Contains(afterEdit, "// verify-false probe");
+    }
+
+    // ------------------------------------------------------------------
+    // verify=true + clean edit → Verification.Status == "clean".
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_VerifyTrue_CleanEdit_ReturnsStatusClean()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var edit = AppendCommentEdit(originalText, "// clean-verify probe");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { edit },
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: true,
+            autoRevertOnError: false);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Verification, "verify=true must populate the Verification field.");
+        Assert.AreEqual("clean", result.Verification!.Status);
+        Assert.AreEqual(0, result.Verification.NewDiagnostics.Count);
+        Assert.AreEqual("SampleLib", result.Verification.ProjectFilter,
+            "Single-file edit should scope verify to the owning project.");
+    }
+
+    // ------------------------------------------------------------------
+    // verify=true + compile error + autoRevertOnError=false →
+    // Status == "errors_introduced"; file on disk still has the bad edit.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_VerifyTrue_CompileError_NoAutoRevert_PreservesBrokenState()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        // Break Speak's return expression with an undefined symbol. Syntax-valid
+        // (so the pre-apply syntax check passes), but compile-invalid (so the verify
+        // pass MUST flag it as a new error).
+        var edit = ReplaceSpeakReturnEdit(originalText, "UndefinedSymbolForCompileError");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { edit },
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: true,
+            autoRevertOnError: false);
+
+        Assert.IsTrue(result.Success, "Core apply should succeed — the edit is syntactically valid.");
+        Assert.IsNotNull(result.Verification);
+        Assert.AreEqual("errors_introduced", result.Verification!.Status);
+        Assert.IsTrue(result.Verification.NewDiagnostics.Count > 0,
+            "Verification must list at least one new compile diagnostic.");
+
+        // File on disk should still have the broken edit (no auto-revert).
+        var afterEdit = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        StringAssert.Contains(afterEdit, "UndefinedSymbolForCompileError");
+
+        // The undo snapshot still carries the pre-edit state so the caller can
+        // manually call revert_last_apply.
+        var undoEntry = UndoService.GetLastOperation(workspaceId);
+        Assert.IsNotNull(undoEntry, "Undo snapshot must remain so the caller can revert manually.");
+    }
+
+    // ------------------------------------------------------------------
+    // verify=true + compile error + autoRevertOnError=true →
+    // Status == "reverted"; file on disk matches original byte-for-byte.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_VerifyTrue_CompileError_AutoRevert_RollsBackEdit()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var edit = ReplaceSpeakReturnEdit(originalText, "UndefinedSymbolForRevertPath");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { edit },
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: true,
+            autoRevertOnError: true);
+
+        Assert.IsTrue(result.Success, "Core apply should still report Success=true — the rollback is recorded in Verification.");
+        Assert.IsNotNull(result.Verification);
+        Assert.AreEqual("reverted", result.Verification!.Status);
+        Assert.IsTrue(result.Verification.NewDiagnostics.Count > 0);
+
+        // File on disk must match the original byte-for-byte — the auto-revert
+        // used the same undo slot this call captured.
+        var afterRevert = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalText, afterRevert,
+            "After auto-revert, Dog.cs must match the original byte-for-byte.");
+        Assert.IsFalse(afterRevert.Contains("UndefinedSymbolForRevertPath", StringComparison.Ordinal));
+    }
+
+    // ------------------------------------------------------------------
+    // Pre-vs-post filter: a compile error left in place by a PRIOR call
+    // (autoRevertOnError=false) must NOT cause a later benign call's
+    // verify to report "errors_introduced" — the filter treats that
+    // error as pre-existing.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyTextEdit_VerifyTrue_DoesNotFlagPreExistingErrors()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+
+        // Call 1: break Cat.cs with an undefined symbol. verify=false so the broken
+        // state is left in place; no auto-revert.
+        var originalCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+        var catEdit = ReplaceSpeakReturnEdit(originalCat, "PreExistingErrorMarker");
+        var call1 = await EditService.ApplyTextEditsAsync(
+            workspaceId, catFilePath, new[] { catEdit }, CancellationToken.None,
+            skipSyntaxCheck: false, verify: false, autoRevertOnError: false);
+        Assert.IsTrue(call1.Success);
+        Assert.IsNull(call1.Verification, "Sanity: call 1 should not have a Verification field.");
+
+        // Sanity: workspace now has at least one compile error.
+        var baselineCheck = await CompileCheckService.CheckAsync(
+            workspaceId,
+            new CompileCheckOptions(ProjectFilter: "SampleLib", SeverityFilter: "error", Limit: 50),
+            CancellationToken.None);
+        Assert.IsTrue(baselineCheck.ErrorCount > 0,
+            "Pre-existing error baseline must be non-zero for this test to be meaningful.");
+
+        // Call 2: benign edit to Dog.cs with verify=true AND autoRevertOnError=true.
+        // The pre-existing error from call 1 must NOT be attributed to call 2, so
+        // the verify outcome should be "clean" and the file should keep the edit.
+        var originalDog = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var dogEdit = AppendCommentEdit(originalDog, "// benign-in-broken-workspace");
+        var call2 = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { dogEdit }, CancellationToken.None,
+            skipSyntaxCheck: false, verify: true, autoRevertOnError: true);
+
+        Assert.IsTrue(call2.Success);
+        Assert.IsNotNull(call2.Verification);
+        Assert.AreEqual("clean", call2.Verification!.Status,
+            "Pre-existing errors from call 1 must be filtered out of call 2's verify outcome.");
+        Assert.IsTrue(call2.Verification.PreErrorCount > 0,
+            "PreErrorCount must reflect the pre-existing errors so the caller can inspect them.");
+
+        // Dog edit survives — the benign edit was not auto-reverted.
+        var afterCall2 = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        StringAssert.Contains(afterCall2, "// benign-in-broken-workspace");
+    }
+
+    // ------------------------------------------------------------------
+    // apply_multi_file_edit — symmetry with apply_text_edit.
+    // verify=true + clean edits → Verification.Status == "clean".
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyMultiFileEdit_VerifyTrue_CleanEdits_ReturnsStatusClean()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+
+        var originalDog = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var originalCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+
+        var fileEdits = new[]
+        {
+            new FileEditsDto(dogFilePath, new[] { AppendCommentEdit(originalDog, "// multi-file verify dog") }),
+            new FileEditsDto(catFilePath, new[] { AppendCommentEdit(originalCat, "// multi-file verify cat") }),
+        };
+
+        var result = await EditService.ApplyMultiFileTextEditsAsync(
+            workspaceId,
+            fileEdits,
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: true,
+            autoRevertOnError: false);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(2, result.FilesModified);
+        Assert.IsNotNull(result.Verification, "apply_multi_file_edit verify=true must populate Verification.");
+        Assert.AreEqual("clean", result.Verification!.Status);
+    }
+
+    // ------------------------------------------------------------------
+    // apply_multi_file_edit — auto-revert on a batch that introduces a
+    // compile error. All files in the batch must be restored to pre-edit
+    // state because the undo snapshot is batch-level (single-slot).
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ApplyMultiFileEdit_VerifyTrue_CompileError_AutoRevert_RollsBackWholeBatch()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+
+        var originalDog = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var originalCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+
+        var fileEdits = new[]
+        {
+            // Benign edit in Dog.cs that would survive on its own.
+            new FileEditsDto(dogFilePath, new[] { AppendCommentEdit(originalDog, "// batch-revert dog") }),
+            // Cat.cs edit introduces an undefined symbol, failing the batch's compile.
+            new FileEditsDto(catFilePath, new[] { ReplaceSpeakReturnEdit(originalCat, "BatchRevertMarker") }),
+        };
+
+        var result = await EditService.ApplyMultiFileTextEditsAsync(
+            workspaceId,
+            fileEdits,
+            CancellationToken.None,
+            skipSyntaxCheck: false,
+            verify: true,
+            autoRevertOnError: true);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Verification);
+        Assert.AreEqual("reverted", result.Verification!.Status);
+        Assert.IsTrue(result.Verification.NewDiagnostics.Count > 0);
+
+        // Both files must match the original — the batch-level snapshot rolled back
+        // the benign edit alongside the breaking one.
+        var afterDog = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var afterCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+        Assert.AreEqual(originalDog, afterDog,
+            "Dog.cs must match the original after batch-level auto-revert.");
+        Assert.AreEqual(originalCat, afterCat,
+            "Cat.cs must match the original after batch-level auto-revert.");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static TextEditDto AppendCommentEdit(string fileText, string commentLine)
+    {
+        var lines = fileText.Split('\n');
+        var lastLine = lines.Length;
+        var lastColumn = lines[^1].Length + 1;
+        return new TextEditDto(lastLine, lastColumn, lastLine, lastColumn, "\n" + commentLine);
+    }
+
+    /// <summary>
+    /// Replaces the <c>"Woof"</c> / <c>"Meow"</c> string literal in the
+    /// <c>Speak() =&gt; ...</c> expression body with an undefined identifier. Produces a
+    /// compile error (CS0103) but keeps the syntax tree valid, so the pre-apply syntax
+    /// check passes and the verify pass is the only layer that can catch the breakage.
+    /// </summary>
+    private static TextEditDto ReplaceSpeakReturnEdit(string fileText, string replacementIdentifier)
+    {
+        var lines = fileText.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!lines[i].Contains("Speak()", StringComparison.Ordinal) ||
+                !lines[i].Contains("=>", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Replace the contents AFTER "=>" up to the trailing semicolon.
+            // Preserve the "    public string Speak() => " prefix so the syntax
+            // tree remains well-formed.
+            var arrowIndex = lines[i].IndexOf("=>", StringComparison.Ordinal);
+            var semicolonIndex = lines[i].LastIndexOf(';');
+            if (arrowIndex < 0 || semicolonIndex <= arrowIndex)
+            {
+                throw new InvalidOperationException(
+                    "Expected 'public string Speak() => \"...\";' pattern — test fixture drift?");
+            }
+
+            // TextEditDto is 1-based (line, column). `arrowIndex + 2` + 1 gives the
+            // column right after "=> "; use the space-skipped start column.
+            var startColumn = arrowIndex + 3 + 1; // +2 for "=>", +1 for space, +1 for 1-based.
+            var endColumn = semicolonIndex + 1;   // exclusive-1-based end at the semicolon.
+            return new TextEditDto(i + 1, startColumn, i + 1, endColumn, replacementIdentifier);
+        }
+
+        throw new InvalidOperationException("Could not locate Speak() expression body in test fixture.");
+    }
+}

--- a/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
@@ -84,13 +84,27 @@ public sealed class SuppressionServiceTests
     {
         public Func<string, string, IReadOnlyList<TextEditDto>, CancellationToken, bool, Task<TextEditResultDto>>? OnApply { get; init; }
 
+        // SuppressionService only forwards the default (verify=false, autoRevertOnError=false)
+        // parameter values to apply_text_edit. The stub ignores them — it verifies that the
+        // pragma-injection edit is wired up, not the verify pathway.
         public Task<TextEditResultDto> ApplyTextEditsAsync(
-            string workspaceId, string filePath, IReadOnlyList<TextEditDto> edits, CancellationToken ct, bool skipSyntaxCheck = false) =>
+            string workspaceId,
+            string filePath,
+            IReadOnlyList<TextEditDto> edits,
+            CancellationToken ct,
+            bool skipSyntaxCheck = false,
+            bool verify = false,
+            bool autoRevertOnError = false) =>
             OnApply?.Invoke(workspaceId, filePath, edits, ct, skipSyntaxCheck)
             ?? Task.FromResult(new TextEditResultDto(false, filePath, 0, []));
 
         public Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
-            string workspaceId, IReadOnlyList<FileEditsDto> fileEdits, CancellationToken ct, bool skipSyntaxCheck = false) =>
+            string workspaceId,
+            IReadOnlyList<FileEditsDto> fileEdits,
+            CancellationToken ct,
+            bool skipSyntaxCheck = false,
+            bool verify = false,
+            bool autoRevertOnError = false) =>
             throw new NotSupportedException();
 
         public Task<RefactoringPreviewDto> PreviewMultiFileTextEditsAsync(

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -113,6 +113,13 @@ internal sealed class TestServiceContainer
             previewStore);
         var compositePreviewStore = new CompositePreviewStore();
 
+        // semantic-edit-with-compile-check-wrapper: hoist CompileCheckService construction
+        // above EditService so EditService can accept it as an optional dependency for
+        // the verify+autoRevertOnError pathway.
+        var compileCheckService = new CompileCheckService(
+            workspaceManager,
+            NullLogger<CompileCheckService>.Instance);
+
         return new TestServiceContainer
         {
             PreviewStore = previewStore,
@@ -179,7 +186,9 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 NullLogger<EditService>.Instance,
                 undoService,
-                changeTracker),
+                changeTracker,
+                previewStore: null,
+                compileCheckService: compileCheckService),
             FileOperationService = fileOperationService,
             ProjectMutationService = new ProjectMutationService(
                 workspaceManager,
@@ -229,9 +238,7 @@ internal sealed class TestServiceContainer
             FlowAnalysisService = new FlowAnalysisService(
                 workspaceManager,
                 NullLogger<FlowAnalysisService>.Instance),
-            CompileCheckService = new CompileCheckService(
-                workspaceManager,
-                NullLogger<CompileCheckService>.Instance),
+            CompileCheckService = compileCheckService,
             AnalyzerInfoService = new AnalyzerInfoService(
                 workspaceManager,
                 NullLogger<AnalyzerInfoService>.Instance),


### PR DESCRIPTION
## Summary

Extend `apply_text_edit` and `apply_multi_file_edit` with two new optional
parameters, `verify` and `autoRevertOnError`, that collapse the previously
separate three-step flow (apply → `compile_check` → `revert_last_apply`)
into a single atomic call. Default values (`false`/`false`) preserve
existing call-site behavior exactly.

When `verify=true`:
- Captures a pre-edit error fingerprint set scoped to the owning project(s)
  BEFORE the undo snapshot is captured.
- Runs `compile_check` after the edit persists to disk, subtracting the
  pre-edit fingerprints so pre-existing errors are never attributed to the
  current call.
- Attaches the new-error set to `VerifyOutcomeDto` under `Verification` on
  the response DTO. Status values: `clean` / `errors_introduced` /
  `reverted` / `revert_failed`.

When `autoRevertOnError=true` AND new errors appeared:
- Rolls back via `IUndoService.RevertAsync` against the single-slot
  snapshot the current call just captured — never touches prior-turn
  edits. Multi-file batch reverts the full batch (single batch-level
  snapshot).

Owning-project scope: single-file path uses `document.Project.Name` as
the `CompileCheckOptions.ProjectFilter`; multi-file path uses the single
owning project when the batch is single-project, or the full solution
when it spans multiple.

## Closes

- `semantic-edit-with-compile-check-wrapper`

## Scope note

Plan's Scope field estimated 3 production files (EditTools.cs,
MultiFileEditTools.cs, EditService.cs). Actual touch: 8 production files
+ 2 test files. The plan under-estimated the DTO / interface / catalog
surface area that naturally follows from adding two optional parameters:

- `src/RoslynMcp.Core/Models/TextEditDto.cs` — add `Verification` field to `TextEditResultDto`.
- `src/RoslynMcp.Core/Models/MultiFileEditResultDto.cs` — same for batch response.
- `src/RoslynMcp.Core/Models/VerifyOutcomeDto.cs` — new DTO (status + diagnostics + baseline count).
- `src/RoslynMcp.Core/Services/IEditService.cs` — interface params match service impl.
- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` — summary string update keeps `McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry` green.
- `src/RoslynMcp.Host.Stdio/Tools/EditTools.cs` + `MultiFileEditTools.cs` — tool parameters.
- `src/RoslynMcp.Roslyn/Services/EditService.cs` — verify+revert wrapper logic.
- `tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs` — hoist CompileCheckService construction so EditService can accept it.
- `tests/RoslynMcp.Tests/SuppressionServiceTests.cs` — stub signature match for new interface params.

Each file is narrowly scoped to the initiative's logical goal. No behavior
changes for non-verify callers (default path returns `Verification=null`).

## Validation

- `eng/verify-ai-docs.ps1` — passed.
- `eng/verify-skills-are-generic.ps1` — passed (31 skills).
- New test file `tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs` — 7 tests, all passing:
  - `ApplyTextEdit_VerifyFalse_OmitsVerificationField` — default path preserved.
  - `ApplyTextEdit_VerifyTrue_CleanEdit_ReturnsStatusClean`
  - `ApplyTextEdit_VerifyTrue_CompileError_NoAutoRevert_PreservesBrokenState`
  - `ApplyTextEdit_VerifyTrue_CompileError_AutoRevert_RollsBackEdit`
  - `ApplyTextEdit_VerifyTrue_DoesNotFlagPreExistingErrors` — pre-vs-post filter regression.
  - `ApplyMultiFileEdit_VerifyTrue_CleanEdits_ReturnsStatusClean`
  - `ApplyMultiFileEdit_VerifyTrue_CompileError_AutoRevert_RollsBackWholeBatch` — batch-level revert covers the benign file too.
- Related regression suites (EditUndoIntegrationTests, EditUndoCohesionTests, SuppressionServiceTests, ExpandedSurfaceIntegrationTests, SurfaceCatalogTests, ApplyWithVerify*) — 51/51 passing together.
- `eng/verify-release.ps1 -Configuration Release` — 684/687 passed; the 3 failing tests (`TraceExceptionFlow_WhenFilter_IncludesFilterSourceInBodyExcerpt`, `FLAG_13B_Set_Project_Property_Preview_Emits_MultiLine_PropertyGroup`, `DeleteFile_Then_Revert_Restores_File_With_Original_Content`) are pre-existing full-suite shared-workspace flakiness — each passes alone and independently reproduces on `main` (the same verify-release on main also fails 1 unrelated test for the same reason). These failures are NOT caused by this change.

## Performance review

`compile_check` scopes to the owning project via `CompileCheckOptions.ProjectFilter` — no hotspot impact beyond what the caller would do manually in the separate-step flow. Additional passes: one baseline `CheckAsync` + one post-edit `CheckAsync` per call when `verify=true`. When `verify=false` (default), zero extra work.

## Test plan

- [x] New tests cover clean / errors_introduced / reverted / pre-existing-error-filter / multi-file paths.
- [x] Default path preservation verified (Verification=null when verify=false).
- [x] Build clean on Release (0 warnings, 0 errors).
- [x] Catalog metadata updated to match tool summary (drift test green).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)