### PR TITLE
feat(refactoring): extract_shared_expression_to_helper_preview synthesizes shared helper (extract-shared-expression-to-helper-across-call-sites)

### DIFF
--- a/samples/SampleSolution/SampleLib/SharedExpressionProbe.cs
+++ b/samples/SampleSolution/SampleLib/SharedExpressionProbe.cs
@@ -1,0 +1,28 @@
+namespace SampleLib;
+
+/// <summary>
+/// Fixture class for <c>extract_shared_expression_to_helper_preview</c>. The two public
+/// methods each contain the same normalization expression
+/// <c>System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar)</c>
+/// — the concrete repro case from PR #178 (<c>WorkspaceResources.NormalizeFilePathForResource</c>).
+/// Extracting the shared expression synthesizes a private static helper and rewrites
+/// both call sites, reducing two duplicates to a single canonical definition.
+/// </summary>
+public sealed class SharedExpressionProbe
+{
+    public string Load(string filePath)
+    {
+        // Lines 14-15 hold the candidate expression. Column positions are asserted by the
+        // test at src/RoslynMcp.Tests/ExtractSharedExpressionTests.cs.
+        var normalized =
+            System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar);
+        return normalized;
+    }
+
+    public int LoadLineCount(string filePath)
+    {
+        var normalized =
+            System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar);
+        return normalized.Length;
+    }
+}

--- a/src/RoslynMcp.Core/Services/IExtractMethodService.cs
+++ b/src/RoslynMcp.Core/Services/IExtractMethodService.cs
@@ -8,4 +8,40 @@ public interface IExtractMethodService
         string workspaceId, string filePath,
         int startLine, int startColumn, int endLine, int endColumn,
         string methodName, CancellationToken ct);
+
+    /// <summary>
+    /// Preview extracting a shared sub-expression (at an example span) into a new private
+    /// static helper and rewriting every structurally-identical call site in the scope.
+    /// Complements <see cref="PreviewExtractMethodAsync"/> (statement-block, single-function)
+    /// by handling the "this sub-expression appears in N functions; extract to a shared helper"
+    /// shape.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="exampleFilePath">Absolute path to the source file containing the example.</param>
+    /// <param name="exampleStartLine">1-based start line of the example expression.</param>
+    /// <param name="exampleStartColumn">1-based start column of the example expression.</param>
+    /// <param name="exampleEndLine">1-based end line of the example expression.</param>
+    /// <param name="exampleEndColumn">1-based end column of the example expression.</param>
+    /// <param name="helperName">Name of the synthesized helper method.</param>
+    /// <param name="helperAccessibility">Accessibility modifier (private, internal, or public).
+    /// Defaults to <c>private</c>.</param>
+    /// <param name="allowCrossFile">When true, scans the entire project for structurally-
+    /// identical matches. When false (default), the scan is restricted to the example
+    /// expression's containing type.</param>
+    /// <remarks>
+    /// Guards: (a) refuses when the example span does not resolve to a single
+    /// <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax" />, (b) refuses when
+    /// any candidate site references a variable whose semantic type differs from the
+    /// corresponding variable at the example site, (c) refuses when <paramref name="allowCrossFile"/>
+    /// is false and a hit resides in a different containing type.
+    /// </remarks>
+    Task<RefactoringPreviewDto> PreviewExtractSharedExpressionToHelperAsync(
+        string workspaceId,
+        string exampleFilePath,
+        int exampleStartLine, int exampleStartColumn,
+        int exampleEndLine, int exampleEndColumn,
+        string helperName,
+        string helperAccessibility,
+        bool allowCrossFile,
+        CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -150,6 +150,7 @@ public static class ServerSurfaceCatalog
 
         Tool("extract_method_preview", "refactoring", "stable", true, false, "Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values."),
         Tool("extract_method_apply", "refactoring", "experimental", false, true, "Apply a previously previewed extract method refactoring."),
+        Tool("extract_shared_expression_to_helper_preview", "refactoring", "experimental", true, false, "Preview extracting a shared sub-expression into a synthesized private static helper and rewriting every structurally-identical call site in the scope."),
 
         Tool("revert_last_apply", "undo", "stable", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace."),
         Tool("apply_with_verify", "undo", "experimental", false, true, "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -52,4 +52,33 @@ public static class ExtractMethodTools
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }
+
+    [McpServerTool(Name = "extract_shared_expression_to_helper_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
+    [McpToolMetadata("refactoring", "experimental", true, false,
+        "Preview extracting a shared sub-expression into a synthesized private static helper and rewriting every structurally-identical call site in the scope.")]
+    [Description("Preview extracting a shared sub-expression at an example span into a synthesized static helper, then rewriting every structurally-identical call site in the example's containing type (or entire project when allowCrossFile=true). Refuses when the expression has fewer than 2 occurrences, when a candidate site's free-variable semantic types differ from the example, or when allowCrossFile=false and a hit resides in a different containing type. Complements extract_method_preview (statement-block, single-function) by handling the N-function shape.")]
+    public static Task<string> PreviewExtractSharedExpressionToHelper(
+        IWorkspaceExecutionGate gate,
+        IExtractMethodService extractMethodService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to a source file containing one instance of the expression")] string exampleFilePath,
+        [Description("1-based start line of the example expression")] int exampleStartLine,
+        [Description("1-based start column of the example expression")] int exampleStartColumn,
+        [Description("1-based end line of the example expression")] int exampleEndLine,
+        [Description("1-based end column of the example expression")] int exampleEndColumn,
+        [Description("Name for the synthesized helper method")] string helperName,
+        [Description("Accessibility for the synthesized helper: 'private', 'internal', or 'public'. Defaults to 'private'.")] string helperAccessibility = "private",
+        [Description("When true, scans the entire project for structurally-identical matches. When false (default), the scan is restricted to the example expression's containing type.")] bool allowCrossFile = false,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var result = await extractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+                workspaceId, exampleFilePath,
+                exampleStartLine, exampleStartColumn,
+                exampleEndLine, exampleEndColumn,
+                helperName, helperAccessibility, allowCrossFile, c);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
@@ -430,4 +430,374 @@ public sealed class ExtractMethodService : IExtractMethodService
         IParameterSymbol param => param.Type,
         _ => null
     };
+
+    // ============================================================================
+    // extract_shared_expression_to_helper_preview
+    // ----------------------------------------------------------------------------
+    // Detects the expression at the example span, scans the enclosing type (or
+    // project when allowCrossFile=true) for structurally-identical expressions, and
+    // synthesizes a private static helper that every hit is rewritten to call.
+    // See IExtractMethodService.PreviewExtractSharedExpressionToHelperAsync for the
+    // full contract.
+    // ============================================================================
+
+    public async Task<RefactoringPreviewDto> PreviewExtractSharedExpressionToHelperAsync(
+        string workspaceId,
+        string exampleFilePath,
+        int exampleStartLine, int exampleStartColumn,
+        int exampleEndLine, int exampleEndColumn,
+        string helperName,
+        string helperAccessibility,
+        bool allowCrossFile,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(helperName))
+            throw new ArgumentException("Helper name must not be empty.", nameof(helperName));
+        if (exampleStartLine > exampleEndLine
+            || (exampleStartLine == exampleEndLine && exampleStartColumn > exampleEndColumn))
+            throw new ArgumentException("Start position must be before end position.");
+
+        var accessibilityToken = ParseAccessibility(helperAccessibility);
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var exampleDocument = SymbolResolver.FindDocument(solution, exampleFilePath)
+            ?? throw new InvalidOperationException($"Document not found: {exampleFilePath}");
+
+        var exampleRoot = await exampleDocument.GetSyntaxRootAsync(ct).ConfigureAwait(false) as CompilationUnitSyntax
+            ?? throw new InvalidOperationException("Source document must be a C# compilation unit.");
+        var exampleModel = await exampleDocument.GetSemanticModelAsync(ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Semantic model could not be created for the example document.");
+        var exampleText = await exampleDocument.GetTextAsync(ct).ConfigureAwait(false);
+
+        var exampleSpan = BuildSelectionSpan(
+            exampleText, exampleStartLine, exampleStartColumn, exampleEndLine, exampleEndColumn);
+
+        var exampleExpression = FindContainedExpression(exampleRoot, exampleSpan);
+        var exampleType = exampleExpression.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "Example expression must be inside a type declaration.");
+
+        // Derive the helper signature from free variables (locals + parameters) referenced by
+        // the example expression. Each free variable becomes an ordered parameter; the expression's
+        // inferred type becomes the helper's return type. Order-stable: first appearance wins.
+        var exampleFreeVars = CollectFreeVariables(exampleExpression, exampleModel);
+        var exampleTypeInfo = exampleModel.GetTypeInfo(exampleExpression, ct);
+        var returnType = exampleTypeInfo.ConvertedType ?? exampleTypeInfo.Type
+            ?? throw new InvalidOperationException(
+                "Could not infer the expression's return type. The example span must resolve to a typed expression.");
+        if (returnType.SpecialType == SpecialType.System_Void)
+            throw new InvalidOperationException(
+                "Cannot extract a void expression to a helper. Select a typed sub-expression instead.");
+
+        // Scan candidate documents for structurally-identical expressions. Scope is the example's
+        // containing type unless allowCrossFile=true, in which case we scan the whole project.
+        var scope = allowCrossFile
+            ? exampleDocument.Project.Documents
+            : new[] { exampleDocument };
+        var hits = new List<ExpressionHit>();
+        foreach (var doc in scope)
+        {
+            ct.ThrowIfCancellationRequested();
+            var docRoot = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            if (docRoot is null) continue;
+            var docModel = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+            if (docModel is null) continue;
+
+            foreach (var candidate in docRoot.DescendantNodes().OfType<ExpressionSyntax>())
+            {
+                if (!SyntaxFactory.AreEquivalent(exampleExpression, candidate, topLevel: false))
+                    continue;
+
+                // Apply containing-type guard when allowCrossFile=false. Different containing
+                // types would force the helper to sit across a type boundary that the plan's
+                // guard explicitly forbids.
+                var candidateType = candidate.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+                if (candidateType is null) continue;
+                if (!allowCrossFile && candidateType != exampleType) continue;
+
+                // Semantic-type guard: every free variable must have the same ITypeSymbol as the
+                // example. Matches by position (structural equivalence aligns them 1:1).
+                var candidateFreeVars = CollectFreeVariables(candidate, docModel);
+                if (candidateFreeVars.Count != exampleFreeVars.Count)
+                    throw new InvalidOperationException(
+                        $"Structurally-identical match in '{doc.FilePath ?? doc.Name}' has {candidateFreeVars.Count} free variables; " +
+                        $"the example has {exampleFreeVars.Count}. Cannot extract — the capture sets differ.");
+                for (var i = 0; i < candidateFreeVars.Count; i++)
+                {
+                    var a = exampleFreeVars[i].Type;
+                    var b = candidateFreeVars[i].Type;
+                    if (!SymbolEqualityComparer.Default.Equals(a, b))
+                        throw new InvalidOperationException(
+                            $"Free-variable semantic-type mismatch at match in '{doc.FilePath ?? doc.Name}': " +
+                            $"example variable '{exampleFreeVars[i].Name}' is '{a?.ToDisplayString() ?? "<null>"}' but " +
+                            $"candidate variable '{candidateFreeVars[i].Name}' is '{b?.ToDisplayString() ?? "<null>"}'. " +
+                            "Cannot synthesize a shared helper with different parameter types.");
+                }
+
+                hits.Add(new ExpressionHit(doc, candidate, candidateFreeVars, candidateType));
+            }
+        }
+
+        if (hits.Count == 0)
+            throw new InvalidOperationException(
+                "No structurally-identical expressions found — even the example span did not match. " +
+                "Verify the span covers a complete expression.");
+        if (hits.Count < 2)
+            throw new InvalidOperationException(
+                "Only one occurrence of the expression was found. Use `extract_method_preview` for a single-site extraction; " +
+                "`extract_shared_expression_to_helper_preview` is intended for 2+ call sites.");
+
+        // Build the helper method. Place it on the example's containing type; every hit gets
+        // rewritten to call it via {helperName}(arg1, arg2, ...). When allowCrossFile is true
+        // and hits reside outside the example type, those call sites reach the helper via the
+        // example-type's fully-qualified name.
+        var helperTypeName = exampleType.Identifier.Text;
+        var helperNamespace = exampleType.Ancestors().OfType<BaseNamespaceDeclarationSyntax>()
+            .FirstOrDefault()?.Name.ToString();
+        var helperFullyQualifiedType = string.IsNullOrEmpty(helperNamespace)
+            ? helperTypeName
+            : $"{helperNamespace}.{helperTypeName}";
+
+        var helperMethod = BuildHelperMethod(
+            helperName, accessibilityToken, returnType, exampleFreeVars, exampleExpression);
+
+        // Rewrite hits grouped by document. Each document's edit is independent; the helper
+        // insertion happens on the example doc in a second pass.
+        var hitsByDocument = hits.GroupBy(h => h.Document.Id).ToList();
+        var accumulator = solution;
+        var fileChanges = new List<FileChangeDto>();
+
+        foreach (var group in hitsByDocument)
+        {
+            ct.ThrowIfCancellationRequested();
+            var doc = group.First().Document;
+            var docRoot = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Could not read syntax root for '{doc.FilePath ?? doc.Name}'.");
+            var oldText = docRoot.ToFullString();
+
+            var rewrites = group.ToDictionary(
+                h => (SyntaxNode)h.Expression,
+                h => BuildInvocation(
+                    helperName,
+                    h.FreeVariables,
+                    allowCrossFile && h.ContainingType != exampleType ? helperFullyQualifiedType : null));
+
+            var newDocRoot = docRoot.ReplaceNodes(
+                rewrites.Keys,
+                (original, _) => rewrites[original]
+                    .WithTriviaFrom(original)
+                    .WithAdditionalAnnotations(Formatter.Annotation));
+
+            if (doc.Id == exampleDocument.Id)
+            {
+                newDocRoot = InsertHelperIntoType(newDocRoot, exampleType, helperMethod);
+            }
+
+            // Route the rewritten root through `Formatter.FormatAsync` so the synthesized helper
+            // and the Formatter.Annotation-tagged invocation sites pick up editorconfig-driven
+            // indentation and spacing. Without this, the raw SyntaxFactory output emits
+            // `privatestaticstringHelper(stringarg)` (no whitespace between modifiers/tokens)
+            // and the synthesized helper fails CS1520 at apply time.
+            var documentWithEdit = doc.WithSyntaxRoot(newDocRoot);
+            var formattedDocument = await Formatter.FormatAsync(
+                documentWithEdit,
+                Formatter.Annotation,
+                options: null,
+                cancellationToken: ct).ConfigureAwait(false);
+            var formattedRoot = await formattedDocument.GetSyntaxRootAsync(ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException(
+                    $"Formatter produced no syntax root for '{doc.FilePath ?? doc.Name}'.");
+
+            var newText = formattedRoot.ToFullString();
+            accumulator = accumulator.WithDocumentSyntaxRoot(doc.Id, formattedRoot);
+
+            var docPath = doc.FilePath ?? doc.Name;
+            fileChanges.Add(new FileChangeDto(
+                FilePath: docPath,
+                UnifiedDiff: DiffGenerator.GenerateUnifiedDiff(oldText, newText, docPath)));
+        }
+
+        // If the example doc wasn't among the rewrite groups (can't actually happen since we
+        // always include the example hit — but kept as defense-in-depth), still insert the
+        // helper so the diff is legal.
+        if (!hitsByDocument.Any(g => g.First().Document.Id == exampleDocument.Id))
+        {
+            var docRoot = await exampleDocument.GetSyntaxRootAsync(ct).ConfigureAwait(false) as CompilationUnitSyntax
+                ?? throw new InvalidOperationException("Could not re-read example document root.");
+            var oldText = docRoot.ToFullString();
+            var newDocRoot = InsertHelperIntoType(docRoot, exampleType, helperMethod);
+            var documentWithEdit = exampleDocument.WithSyntaxRoot(newDocRoot);
+            var formattedDocument = await Formatter.FormatAsync(
+                documentWithEdit,
+                Formatter.Annotation,
+                options: null,
+                cancellationToken: ct).ConfigureAwait(false);
+            var formattedRoot = await formattedDocument.GetSyntaxRootAsync(ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Formatter produced no syntax root for the example document.");
+            var newText = formattedRoot.ToFullString();
+            accumulator = accumulator.WithDocumentSyntaxRoot(exampleDocument.Id, formattedRoot);
+            var docPath = exampleDocument.FilePath ?? exampleDocument.Name;
+            fileChanges.Add(new FileChangeDto(
+                FilePath: docPath,
+                UnifiedDiff: DiffGenerator.GenerateUnifiedDiff(oldText, newText, docPath)));
+        }
+
+        var description =
+            $"Extract shared expression into helper '{helperName}' and rewrite {hits.Count} site(s) across {fileChanges.Count} file(s)";
+        var token = _previewStore.Store(
+            workspaceId, accumulator, _workspace.GetCurrentVersion(workspaceId), description);
+
+        _logger.LogDebug("Extract shared expression preview: {Description}", description);
+
+        return new RefactoringPreviewDto(token, description, fileChanges, null);
+    }
+
+    private static SyntaxToken ParseAccessibility(string accessibility)
+    {
+        if (string.IsNullOrWhiteSpace(accessibility))
+            return SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
+
+        return accessibility.Trim().ToLowerInvariant() switch
+        {
+            "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+            "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
+            "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+            _ => throw new ArgumentException(
+                $"Unsupported accessibility '{accessibility}'. Use private, internal, or public.",
+                nameof(accessibility))
+        };
+    }
+
+    private static ExpressionSyntax FindContainedExpression(
+        CompilationUnitSyntax root, Microsoft.CodeAnalysis.Text.TextSpan selectionSpan)
+    {
+        // Prefer the deepest expression fully contained by the selection span; fall back to the
+        // innermost expression touching the span. The caller supplies an example span that
+        // should bracket a complete sub-expression.
+        ExpressionSyntax? best = null;
+        foreach (var expr in root.DescendantNodes().OfType<ExpressionSyntax>())
+        {
+            if (!selectionSpan.Contains(expr.Span)) continue;
+            if (best is null || expr.Span.Length > best.Span.Length) best = expr;
+        }
+
+        if (best is not null) return best;
+
+        // Fall back: find innermost expression overlapping the span.
+        var startNode = root.FindNode(selectionSpan, getInnermostNodeForTie: true);
+        var innermost = startNode.AncestorsAndSelf().OfType<ExpressionSyntax>().FirstOrDefault();
+        return innermost
+            ?? throw new InvalidOperationException(
+                "Example span does not resolve to any C# expression. Select a complete sub-expression.");
+    }
+
+    private static List<FreeVariable> CollectFreeVariables(ExpressionSyntax expression, SemanticModel model)
+    {
+        // A "free variable" is a local/parameter symbol that is REFERENCED by the expression but
+        // is DECLARED OUTSIDE the expression's own lexical boundary. Order-preserving by the
+        // syntactic position of the first reference — matches how invocation arguments will be
+        // emitted at each rewrite site.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var list = new List<FreeVariable>();
+        foreach (var identifier in expression.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            var symbol = model.GetSymbolInfo(identifier).Symbol;
+            if (symbol is not ILocalSymbol and not IParameterSymbol) continue;
+
+            // `this` parameter is implicit; not a free variable the caller should supply.
+            if (symbol is IParameterSymbol p && p.IsThis) continue;
+
+            var name = symbol.Name;
+            if (!seen.Add(name)) continue;
+
+            var type = symbol switch
+            {
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                _ => null
+            };
+            if (type is null) continue;
+            list.Add(new FreeVariable(name, type));
+        }
+        return list;
+    }
+
+    private static MethodDeclarationSyntax BuildHelperMethod(
+        string helperName,
+        SyntaxToken accessibility,
+        ITypeSymbol returnType,
+        IReadOnlyList<FreeVariable> freeVariables,
+        ExpressionSyntax expression)
+    {
+        var returnTypeSyntax = SyntaxFactory.ParseTypeName(
+            returnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+        var parameterList = SyntaxFactory.ParameterList(
+            SyntaxFactory.SeparatedList(
+                freeVariables.Select(v =>
+                    SyntaxFactory.Parameter(SyntaxFactory.Identifier(v.Name))
+                        .WithType(SyntaxFactory.ParseTypeName(
+                            v.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat))))));
+        // Strip trivia from the expression clone: the helper's body sits on its own line and
+        // should not inherit leading/trailing comments or whitespace from its first appearance.
+        var bodyExpression = expression.WithoutTrivia();
+        var body = SyntaxFactory.Block(
+            SyntaxFactory.List<StatementSyntax>(new[]
+            {
+                (StatementSyntax)SyntaxFactory.ReturnStatement(bodyExpression)
+                    .WithAdditionalAnnotations(Formatter.Annotation)
+            }));
+
+        return SyntaxFactory.MethodDeclaration(returnTypeSyntax, SyntaxFactory.Identifier(helperName))
+            .WithModifiers(SyntaxFactory.TokenList(
+                accessibility,
+                SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+            .WithParameterList(parameterList)
+            .WithBody(body)
+            .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    private static InvocationExpressionSyntax BuildInvocation(
+        string helperName,
+        IReadOnlyList<FreeVariable> freeVariables,
+        string? fullyQualifiedTypePrefix)
+    {
+        var argumentList = SyntaxFactory.ArgumentList(
+            SyntaxFactory.SeparatedList(
+                freeVariables.Select(v => SyntaxFactory.Argument(SyntaxFactory.IdentifierName(v.Name)))));
+
+        ExpressionSyntax target = string.IsNullOrEmpty(fullyQualifiedTypePrefix)
+            ? SyntaxFactory.IdentifierName(helperName)
+            : SyntaxFactory.ParseExpression($"{fullyQualifiedTypePrefix}.{helperName}");
+
+        // Formatter.Annotation lets `Formatter.FormatAsync` re-flow spacing around commas,
+        // parentheses, and (when fully-qualified) dotted member-access chains per editorconfig.
+        return SyntaxFactory.InvocationExpression(target, argumentList)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    private static SyntaxNode InsertHelperIntoType(
+        SyntaxNode root, TypeDeclarationSyntax exampleType, MethodDeclarationSyntax helper)
+    {
+        // Locate the type in the possibly-rewritten tree by its identifier+position — the tree
+        // may already have been mutated (expression rewrites). Fall back to identifier-match
+        // when the span shifted.
+        var newType = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == exampleType.Identifier.Text
+                                 && t.SpanStart == exampleType.SpanStart)
+            ?? root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+                .FirstOrDefault(t => t.Identifier.Text == exampleType.Identifier.Text)
+            ?? throw new InvalidOperationException(
+                $"Could not re-locate type '{exampleType.Identifier.Text}' in the rewritten tree.");
+        var updatedType = newType.AddMembers(helper);
+        return root.ReplaceNode(newType, updatedType);
+    }
+
+    private sealed record FreeVariable(string Name, ITypeSymbol Type);
+
+    private sealed record ExpressionHit(
+        Document Document,
+        ExpressionSyntax Expression,
+        IReadOnlyList<FreeVariable> FreeVariables,
+        TypeDeclarationSyntax ContainingType);
 }

--- a/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
@@ -1,0 +1,178 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Integration tests for <c>extract_shared_expression_to_helper_preview</c>. Uses
+/// <c>SharedExpressionProbe.cs</c> — two public methods each contain the same
+/// <c>System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar)</c>
+/// pattern (the concrete PR #178 <c>NormalizeFilePathForResource</c> shape).
+/// </summary>
+[TestClass]
+public sealed class ExtractSharedExpressionTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Primary validation per the plan: two methods share the normalization expression;
+    /// the preview must synthesize a helper and rewrite both call sites so each method
+    /// invokes the new helper.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractSharedExpression_TwoSitesInSameType_SynthesizesHelperAndRewritesBoth()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
+
+        // Line 18, cols 13..104 (1-based, end exclusive) wraps the expression
+        // `System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar)`.
+        var result = await ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+            workspace.WorkspaceId,
+            filePath,
+            exampleStartLine: 18, exampleStartColumn: 13,
+            exampleEndLine: 18, exampleEndColumn: 104,
+            helperName: "NormalizeFilePath",
+            helperAccessibility: "private",
+            allowCrossFile: false,
+            CancellationToken.None);
+
+        Assert.IsNotNull(result.PreviewToken, "Preview should produce a token.");
+        Assert.AreEqual(1, result.Changes.Count,
+            $"Expected exactly one file change (same-type scope). Changes: {result.Changes.Count}");
+
+        var diff = result.Changes[0].UnifiedDiff;
+
+        // The helper must appear in the diff.
+        StringAssert.Contains(diff, "NormalizeFilePath",
+            $"Helper method name should appear in the diff. Diff:\n{diff}");
+        StringAssert.Contains(diff, "private static",
+            $"Helper should be rendered as `private static`. Diff:\n{diff}");
+        StringAssert.Contains(diff, "string filePath",
+            $"Helper should accept the free variable `filePath` as a parameter. Diff:\n{diff}");
+        StringAssert.Contains(diff, "return System.Uri.UnescapeDataString(filePath).Replace('/', System.IO.Path.DirectorySeparatorChar);",
+            $"Helper body should contain the canonical normalization expression. Diff:\n{diff}");
+
+        // Both call sites must be rewritten to invoke the helper.
+        var helperInvocationCount = CountOccurrences(diff, "+            NormalizeFilePath(filePath)");
+        Assert.AreEqual(2, helperInvocationCount,
+            $"Expected two rewritten call sites (one per method). Found {helperInvocationCount}. Diff:\n{diff}");
+    }
+
+    /// <summary>
+    /// Error path — when only one instance of the expression exists, the preview must refuse.
+    /// The tool is specifically for N≥2 call sites; a single-site extraction belongs to
+    /// <c>extract_method_preview</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractSharedExpression_SingleOccurrence_ThrowsInvalidOperation()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        // RefactoringProbe has only one `Math.PI * radius * radius` expression.
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+                workspace.WorkspaceId,
+                filePath,
+                exampleStartLine: 22, exampleStartColumn: 16,
+                exampleEndLine: 22, exampleEndColumn: 39,
+                helperName: "Area",
+                helperAccessibility: "private",
+                allowCrossFile: false,
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "Only one occurrence",
+            $"Error should name the single-occurrence rejection. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// Empty helper name is rejected with <see cref="ArgumentException"/>.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractSharedExpression_EmptyHelperName_Throws()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+                workspace.WorkspaceId,
+                filePath,
+                exampleStartLine: 18, exampleStartColumn: 13,
+                exampleEndLine: 18, exampleEndColumn: 104,
+                helperName: "",
+                helperAccessibility: "private",
+                allowCrossFile: false,
+                CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Unsupported accessibility token is rejected (only private / internal / public are accepted).
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractSharedExpression_InvalidAccessibility_Throws()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+                workspace.WorkspaceId,
+                filePath,
+                exampleStartLine: 18, exampleStartColumn: 13,
+                exampleEndLine: 18, exampleEndColumn: 104,
+                helperName: "NormalizeFilePath",
+                helperAccessibility: "protected",
+                allowCrossFile: false,
+                CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Apply after preview: the synthesized helper and rewritten call sites compile cleanly.
+    /// Guards against parameter-list or return-type inference mistakes that would produce
+    /// CS0103 / CS0029 at the rewrite sites.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractSharedExpression_ApplyAfterPreview_CompilationSucceeds()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
+
+        var preview = await ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
+            workspace.WorkspaceId,
+            filePath,
+            exampleStartLine: 18, exampleStartColumn: 13,
+            exampleEndLine: 18, exampleEndColumn: 104,
+            helperName: "NormalizeFilePath",
+            helperAccessibility: "private",
+            allowCrossFile: false,
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, "Apply should succeed.");
+
+        var compileResult = await CompileCheckService.CheckAsync(
+            workspace.WorkspaceId, new CompileCheckOptions(), CancellationToken.None);
+        Assert.IsTrue(compileResult.Success,
+            "Compilation must succeed after extract-shared-expression apply. Errors: " +
+            $"{string.Join("; ", compileResult.Diagnostics?.Select(d => $"{d.Id}: {d.Message}") ?? [])}");
+    }
+
+    private static int CountOccurrences(string source, string needle)
+    {
+        if (string.IsNullOrEmpty(needle)) return 0;
+        var count = 0;
+        var offset = 0;
+        while ((offset = source.IndexOf(needle, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += needle.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `extract_shared_expression_to_helper_preview` — a new MCP refactoring tool that detects a sub-expression at an example span, scans the containing type (or project with `allowCrossFile=true`) for structurally-identical expressions, synthesizes a private static helper, and rewrites every call site in one preview. Complements `extract_method_preview` (statement-block, single-function) by handling the "this sub-expression appears in N functions; extract to a shared helper" shape.

Concrete repro (PR #178 `WorkspaceResources.NormalizeFilePathForResource`): two methods each containing `Uri.UnescapeDataString(filePath).Replace('/', Path.DirectorySeparatorChar)` collapse to a single private static helper with both sites rewritten to call it.

### Guards

- **Occurrence-count floor:** refuses when only a single occurrence is found (that case belongs to `extract_method_preview`).
- **Capture-set identity:** refuses when a candidate site's free-variable count or semantic types differ from the example.
- **Scope containment:** when `allowCrossFile=false` (default), hits must reside in the example's containing type.

### Flow

1. Resolve the `ExpressionSyntax` at the example span (deepest contained expression wins).
2. Collect free variables (locals / parameters referenced but declared outside the expression) as the helper's parameter list — order-stable on first reference.
3. Infer the helper's return type from `GetTypeInfo(expression).ConvertedType ?? .Type`.
4. Scan same-type (or whole-project) documents for `SyntaxFactory.AreEquivalent` matches.
5. For each hit, verify each free variable's `ITypeSymbol` matches the example by position.
6. Synthesize `{accessibility} static {ReturnType} {helperName}({p1}, ...) { return <expression>; }` on the example's containing type.
7. Rewrite every hit to `{helperName}(arg1, arg2, ...)`; when `allowCrossFile` hits reside outside the example type, use the fully-qualified `{Namespace}.{Type}.{helper}(...)` form.
8. Route each mutated document through `Formatter.FormatAsync` so editorconfig-driven spacing lands on the synthesized helper + rewritten call sites.

### Files

- **`src/RoslynMcp.Core/Services/IExtractMethodService.cs`** — added `PreviewExtractSharedExpressionToHelperAsync` contract.
- **`src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs`** — implementation of the new entry point + supporting helpers (`FindContainedExpression`, `CollectFreeVariables`, `BuildHelperMethod`, `BuildInvocation`, `InsertHelperIntoType`). No changes to the existing `PreviewExtractMethodAsync`.
- **`src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs`** — `PreviewExtractSharedExpressionToHelper` MCP tool binding.
- **`src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs`** — registers `extract_shared_expression_to_helper_preview` under the `refactoring` category, `experimental` stability.
- **`samples/SampleSolution/SampleLib/SharedExpressionProbe.cs`** — fixture with two duplicate `Uri.UnescapeDataString(...).Replace(...)` sites.
- **`tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs`** — 5 tests covering: synthesis+both-site-rewrite (primary validation), single-occurrence refusal, empty-name rejection, invalid-accessibility rejection, and post-apply compile success.

## Validation

- `./eng/verify-release.ps1 -Configuration Release` — **all 700 tests pass**, build 0 warnings 0 errors, publish + hash-manifest generated.
- `./eng/verify-ai-docs.ps1` — **passed**.
- Targeted `dotnet test --filter ~ExtractSharedExpressionTests` — **5/5 pass**.
- Targeted `dotnet test --filter ~ExtractMethod` — **13/13 pass** (5 new + 8 regression).
- Targeted `dotnet test --filter ~Surface|Schema|Tool|Catalog` — **101/101 pass** (verifies catalog parity).

Flake note: during the 4 verify-release runs, one run surfaced a pre-existing timing-related flake in unrelated tests (once `TypeExtractionTests.ExtractType_NonExistentType_ThrowsInvalidOperation`, once `UnresolvedAnalyzerReferenceTests.TypeHierarchy_OnSolutionWithUnresolvedAnalyzerRef_DoesNotCrash`, once `ExtractMethodThisExclusionTests.ExtractMethod_From_Static_Method_Still_Works_Unchanged`). Each passed in isolation and on re-run; the final full pass achieved 700/700 green.

## Test plan

- [x] Two methods with identical normalization expression → preview synthesizes helper and rewrites both sites (primary validation per plan).
- [x] Single-occurrence span raises `InvalidOperationException` referencing "Only one occurrence".
- [x] Empty helper name raises `ArgumentException`.
- [x] Invalid accessibility (`"protected"`) raises `ArgumentException`.
- [x] Apply after preview: solution compiles cleanly (no CS0103 / CS0029 at rewrite sites).

Closes: extract-shared-expression-to-helper-across-call-sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)