### PR TITLE
feat(refactoring): probe_position returns lexical + containing-symbol state for caret-pinned test authoring (position-probe-for-test-fixture-authoring)

### DIFF
--- a/src/RoslynMcp.Core/Models/PositionProbeDto.cs
+++ b/src/RoslynMcp.Core/Models/PositionProbeDto.cs
@@ -1,0 +1,60 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// position-probe-for-test-fixture-authoring: raw lexical + containing-symbol state at a source
+/// position. Intended for test-fixture authoring and caret diagnostics — eliminates the off-by-one
+/// column-counting friction encountered when hard-coding <c>SymbolLocator.BySource(path, line, column)</c>
+/// anchors. Shape is deterministic and trivia-aware so callers can distinguish "caret on identifier"
+/// from "caret inside whitespace between tokens" without re-implementing Roslyn's token-boundary rules.
+/// </summary>
+/// <param name="FilePath">Absolute source-file path of the probed position (normalized by Roslyn).</param>
+/// <param name="Line">1-based line the caret lands on.</param>
+/// <param name="Column">1-based column the caret lands on.</param>
+/// <param name="TokenKind">
+/// Logical classification of what the caret sits on:
+/// <c>Identifier</c>, <c>Keyword</c>, <c>Punctuation</c>, <c>Literal</c>, <c>Whitespace</c>, <c>Comment</c>,
+/// <c>EndOfLine</c>, <c>EndOfFile</c>, or <c>Other</c>. Whitespace / comment / end-of-line are only
+/// reported when the caret sits inside that trivia — a caret on the token itself always returns the
+/// token's own classification regardless of surrounding trivia.
+/// </param>
+/// <param name="SyntaxKind">
+/// Raw Roslyn <see cref="Microsoft.CodeAnalysis.CSharp.SyntaxKind"/> name for the underlying token or
+/// trivia node (e.g. <c>IdentifierToken</c>, <c>WhitespaceTrivia</c>, <c>EndOfLineTrivia</c>). Useful
+/// for fixture authors who need to assert on the exact lexical shape the compiler sees.
+/// </param>
+/// <param name="TokenText">
+/// Literal text of the token (or trivia) the caret is on, verbatim as it appears in source. Empty
+/// string when the caret is at end-of-file.
+/// </param>
+/// <param name="ContainingSymbol">
+/// Fully-qualified display name of the nearest enclosing member, type, or local function — the same
+/// resolution <see cref="ISymbolNavigationService.GetEnclosingSymbolAsync"/> returns. <see langword="null"/>
+/// only when the position is outside any declaration (e.g. top-level-statement host files with only
+/// file-scoped usings).
+/// </param>
+/// <param name="ContainingSymbolKind">
+/// Kind of the containing symbol as a friendly string (<c>Method</c>, <c>Property</c>, <c>Class</c>,
+/// <c>LocalFunction</c>, etc.), or <see langword="null"/> when <paramref name="ContainingSymbol"/> is null.
+/// </param>
+/// <param name="LeadingTriviaBefore">
+/// <see langword="true"/> when the caret sits inside the leading trivia of the token returned by
+/// <see cref="Microsoft.CodeAnalysis.SyntaxNode.FindToken"/> — i.e. the caret is positioned BEFORE
+/// the token's <see cref="Microsoft.CodeAnalysis.SyntaxToken.SpanStart"/> but inside its full span
+/// (leading whitespace, comments, and blank lines attached to the NEXT token). When the caret
+/// instead lands in trailing trivia (whitespace / end-of-line attached to the PREVIOUS token per
+/// Roslyn's trivia-attachment rules) <paramref name="TokenKind"/> still reports Whitespace /
+/// EndOfLine / Comment, but this flag stays <see langword="false"/>. Callers that only care
+/// "is the caret inside any trivia at all?" should check <c>TokenKind</c> against
+/// <c>Whitespace</c>/<c>EndOfLine</c>/<c>Comment</c>; those who want to distinguish the two
+/// directions use this flag.
+/// </param>
+public sealed record PositionProbeDto(
+    string FilePath,
+    int Line,
+    int Column,
+    string TokenKind,
+    string SyntaxKind,
+    string TokenText,
+    string? ContainingSymbol,
+    string? ContainingSymbolKind,
+    bool LeadingTriviaBefore);

--- a/src/RoslynMcp.Core/Services/ISymbolNavigationService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolNavigationService.cs
@@ -11,4 +11,16 @@ public interface ISymbolNavigationService
     Task<IReadOnlyList<LocationDto>> GoToDefinitionAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
     Task<IReadOnlyList<LocationDto>> GoToTypeDefinitionAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
     Task<SymbolDto?> GetEnclosingSymbolAsync(string workspaceId, string filePath, int line, int column, CancellationToken ct);
+
+    /// <summary>
+    /// position-probe-for-test-fixture-authoring: returns the raw lexical token + containing
+    /// symbol at the given 1-based source position without applying the lenient
+    /// adjacent-identifier fallback used by <see cref="GoToDefinitionAsync"/> or symbol resolution.
+    /// Intended for test-fixture authoring — a caret on whitespace returns a
+    /// <c>Whitespace</c> token classification instead of silently resolving to the next
+    /// identifier, so callers can nail down exact caret anchors before pinning them into a
+    /// <see cref="SymbolLocator.BySource"/> call.
+    /// </summary>
+    /// <returns>The probe result, or <see langword="null"/> when the file is not part of the loaded workspace.</returns>
+    Task<PositionProbeDto?> ProbePositionAsync(string workspaceId, string filePath, int line, int column, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -36,6 +36,7 @@ public static class ServerSurfaceCatalog
         Tool("symbol_relationships", "symbols", "stable", true, false, "Combine definition, reference, base, and implementation relationships."),
         Tool("find_references_bulk", "symbols", "stable", true, false, "Resolve references for multiple symbols in one request."),
         Tool("find_property_writes", "symbols", "stable", true, false, "Find property write sites and classify object-initializer writes."),
+        Tool("probe_position", "symbols", "experimental", true, false, "Probe the raw lexical token and containing symbol at a source position."),
         Tool("enclosing_symbol", "symbols", "stable", true, false, "Return the enclosing symbol for a source position."),
         Tool("goto_type_definition", "symbols", "stable", true, false, "Navigate from a symbol usage to its type definition."),
         Tool("get_completions", "symbols", "stable", true, false, "Return IntelliSense-style completion items at a position."),

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -353,6 +353,28 @@ public static class SymbolTools
         }, ct);
     }
 
+    [McpServerTool(Name = "probe_position", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("position-probe-for-test-fixture-authoring: return the raw lexical + containing-symbol state at a source position without applying the lenient adjacent-identifier fallback used by symbol resolvers. Intended for test-fixture authoring — a caret on whitespace returns tokenKind='Whitespace' + leadingTriviaBefore=true instead of silently resolving to the next identifier. Response shape: { filePath, line, column, tokenKind, syntaxKind, tokenText, containingSymbol, containingSymbolKind, leadingTriviaBefore }.")]
+    [McpToolMetadata("symbols", "experimental", true, false,
+        "Probe the raw lexical token and containing symbol at a source position.")]
+    public static Task<string> ProbePosition(
+        McpServer server,
+        IWorkspaceExecutionGate gate,
+        ISymbolNavigationService symbolNavigationService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        [Description("1-based line number")] int line,
+        [Description("1-based column number")] int column,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+            var result = await symbolNavigationService.ProbePositionAsync(workspaceId, filePath, line, column, c);
+            if (result is null) throw new KeyNotFoundException($"File '{filePath}' is not part of the loaded workspace.");
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
+
     [McpServerTool(Name = "enclosing_symbol", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the enclosing symbol (method, property, type) at a given file position — useful for understanding the context of a cursor position")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Return the enclosing symbol for a source position.")]

--- a/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs
@@ -164,4 +164,189 @@ public sealed class SymbolNavigationService : ISymbolNavigationService
 
         return null;
     }
+
+    /// <summary>
+    /// position-probe-for-test-fixture-authoring: returns a trivia-aware snapshot of the token at
+    /// the caret. Distinguishes "caret on the token" from "caret inside the leading trivia of the
+    /// next token" via <see cref="PositionProbeDto.LeadingTriviaBefore"/> so test-fixture authors can
+    /// verify their hard-coded line/column anchors without re-implementing Roslyn's token-boundary
+    /// rules. Never applies the adjacent-identifier fallback used by
+    /// <see cref="SymbolResolver.ResolveAtPositionAsync"/> in lenient mode — whitespace stays
+    /// whitespace.
+    /// </summary>
+    public async Task<PositionProbeDto?> ProbePositionAsync(string workspaceId, string filePath, int line, int column, CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var document = SymbolResolver.FindDocument(solution, filePath);
+        if (document is null) return null;
+
+        var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
+        if (semanticModel is null) return null;
+
+        var syntaxTree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
+        if (syntaxTree is null) return null;
+
+        var text = await syntaxTree.GetTextAsync(ct).ConfigureAwait(false);
+        if (line < 1 || line > text.Lines.Count)
+        {
+            throw new ArgumentException(
+                $"Line {line} is out of range. The file has {text.Lines.Count} line(s).",
+                nameof(line));
+        }
+
+        var lineInfo = text.Lines[line - 1];
+        // Column 1-based; clamp to line-end so callers probing past the last column on a line fall
+        // on the end-of-line trivia (deterministic) instead of silently advancing to the next line's
+        // first token — this is the end-of-line risk called out in the plan's Risks field.
+        var maxColumn = lineInfo.EndIncludingLineBreak - lineInfo.Start + 1;
+        if (column < 1 || column > maxColumn)
+        {
+            throw new ArgumentException(
+                $"Column {column} is out of range for line {line} (valid range: 1..{maxColumn}).",
+                nameof(column));
+        }
+
+        var position = lineInfo.Start + (column - 1);
+        var root = await syntaxTree.GetRootAsync(ct).ConfigureAwait(false);
+
+        // FindToken returns the token whose FullSpan encloses `position`. That FullSpan covers:
+        //   [leading-trivia...][token.Span][trailing-trivia...]
+        // Roslyn's convention attaches trailing whitespace (up to and including the terminating
+        // end-of-line trivia) to the preceding token, NOT the following token's leading trivia.
+        // So for a caret in "    public void MakeThemSpeak(    IEnumerable…" at column 32 (inside
+        // the 4-space run between '(' and 'IEnumerable'), FindToken returns '(' and position is
+        // inside '(''s trailing trivia, not 'IEnumerable''s leading trivia.
+        var token = root.FindToken(position);
+
+        // End-of-file edge case: FindToken returns the EndOfFileToken with empty text; classify
+        // explicitly so callers see a stable shape instead of an Other+empty-text combo.
+        if (token.IsKind(SyntaxKind.EndOfFileToken))
+        {
+            var eofContaining = ResolveContainingSymbol(semanticModel, token, ct);
+            return new PositionProbeDto(
+                FilePath: filePath,
+                Line: line,
+                Column: column,
+                TokenKind: "EndOfFile",
+                SyntaxKind: nameof(SyntaxKind.EndOfFileToken),
+                TokenText: string.Empty,
+                ContainingSymbol: eofContaining.Display,
+                ContainingSymbolKind: eofContaining.Kind,
+                LeadingTriviaBefore: false);
+        }
+
+        // Trivia classification:
+        //   position < token.SpanStart        → inside the token's LEADING trivia
+        //   position >= token.Span.End        → inside the token's TRAILING trivia
+        //   otherwise                          → on the token proper
+        // leadingTriviaBefore reports ONLY the first case — trailing trivia is its own bucket
+        // reported via tokenKind/syntaxKind but not via the leading-trivia flag. This lets callers
+        // distinguish "caret is before the next token (no token seen yet)" from "caret is after
+        // the previous token (already consumed it)" which matters for certain fixture patterns
+        // (e.g., testing that a refactoring preserves trailing whitespace of the preceding token).
+        var inLeadingTrivia = position < token.SpanStart;
+        var inTrailingTrivia = position >= token.Span.End;
+
+        string tokenKind;
+        string syntaxKind;
+        string tokenText;
+
+        if (inLeadingTrivia || inTrailingTrivia)
+        {
+            // Walk the correct trivia list and find the specific trivia span the caret is inside.
+            // This gives a finer classification (WhitespaceTrivia vs SingleLineCommentTrivia vs
+            // EndOfLineTrivia) than just reporting "trivia".
+            var triviaList = inLeadingTrivia ? token.LeadingTrivia : token.TrailingTrivia;
+            var trivia = triviaList.FirstOrDefault(t => t.FullSpan.Contains(position));
+            var triviaIsNone = trivia.IsKind(SyntaxKind.None);
+            syntaxKind = triviaIsNone
+                ? (inLeadingTrivia ? "LeadingTrivia" : "TrailingTrivia")
+                : trivia.Kind().ToString();
+            tokenKind = ClassifyTrivia(trivia);
+            tokenText = triviaIsNone ? string.Empty : trivia.ToFullString();
+        }
+        else
+        {
+            syntaxKind = token.Kind().ToString();
+            tokenKind = ClassifyToken(token);
+            tokenText = token.Text;
+        }
+
+        var containing = ResolveContainingSymbol(semanticModel, token, ct);
+        return new PositionProbeDto(
+            FilePath: filePath,
+            Line: line,
+            Column: column,
+            TokenKind: tokenKind,
+            SyntaxKind: syntaxKind,
+            TokenText: tokenText,
+            ContainingSymbol: containing.Display,
+            ContainingSymbolKind: containing.Kind,
+            LeadingTriviaBefore: inLeadingTrivia);
+    }
+
+    /// <summary>
+    /// Classifies a <see cref="SyntaxToken"/> into a stable friendly bucket: Identifier, Keyword,
+    /// Punctuation, Literal, or Other. Kept separate from trivia classification so the two never
+    /// cross-pollute.
+    /// </summary>
+    private static string ClassifyToken(SyntaxToken token)
+    {
+        if (token.IsKind(SyntaxKind.IdentifierToken)) return "Identifier";
+        if (SyntaxFacts.IsKeywordKind(token.Kind()) || SyntaxFacts.IsContextualKeyword(token.Kind())) return "Keyword";
+        if (SyntaxFacts.IsPunctuation(token.Kind())) return "Punctuation";
+        if (SyntaxFacts.IsAnyToken(token.Kind()) && IsLiteralKind(token.Kind())) return "Literal";
+        return "Other";
+    }
+
+    private static bool IsLiteralKind(SyntaxKind kind) => kind is
+        SyntaxKind.NumericLiteralToken or
+        SyntaxKind.StringLiteralToken or
+        SyntaxKind.CharacterLiteralToken or
+        SyntaxKind.InterpolatedStringTextToken or
+        SyntaxKind.SingleLineRawStringLiteralToken or
+        SyntaxKind.MultiLineRawStringLiteralToken or
+        SyntaxKind.Utf8StringLiteralToken or
+        SyntaxKind.Utf8SingleLineRawStringLiteralToken or
+        SyntaxKind.Utf8MultiLineRawStringLiteralToken;
+
+    /// <summary>
+    /// Classifies a <see cref="SyntaxTrivia"/> into a stable friendly bucket: Whitespace, Comment,
+    /// EndOfLine, or Other. Documentation-comment trivia is bucketed as Comment alongside regular
+    /// comments — fine-grained distinction is still available via the raw SyntaxKind field.
+    /// </summary>
+    private static string ClassifyTrivia(SyntaxTrivia trivia) => trivia.Kind() switch
+    {
+        SyntaxKind.WhitespaceTrivia => "Whitespace",
+        SyntaxKind.EndOfLineTrivia => "EndOfLine",
+        SyntaxKind.SingleLineCommentTrivia => "Comment",
+        SyntaxKind.MultiLineCommentTrivia => "Comment",
+        SyntaxKind.SingleLineDocumentationCommentTrivia => "Comment",
+        SyntaxKind.MultiLineDocumentationCommentTrivia => "Comment",
+        SyntaxKind.DocumentationCommentExteriorTrivia => "Comment",
+        SyntaxKind.None => "Other",
+        _ => "Other"
+    };
+
+    /// <summary>
+    /// Walks the token's ancestor chain looking for the nearest enclosing member, local function,
+    /// or type declaration — matches the resolution used by <see cref="GetEnclosingSymbolAsync"/>
+    /// so <c>probe_position</c> and <c>enclosing_symbol</c> stay consistent.
+    /// </summary>
+    private static (string? Display, string? Kind) ResolveContainingSymbol(SemanticModel semanticModel, SyntaxToken token, CancellationToken ct)
+    {
+        for (var node = token.Parent; node is not null; node = node.Parent)
+        {
+            if (node is MemberDeclarationSyntax or LocalFunctionStatementSyntax or BaseTypeDeclarationSyntax)
+            {
+                var declared = semanticModel.GetDeclaredSymbol(node, ct);
+                if (declared is not null)
+                {
+                    return (declared.ToDisplayString(), declared.Kind.ToString());
+                }
+            }
+        }
+
+        return (null, null);
+    }
 }

--- a/tests/RoslynMcp.Tests/PositionProbeTests.cs
+++ b/tests/RoslynMcp.Tests/PositionProbeTests.cs
@@ -1,0 +1,191 @@
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// position-probe-for-test-fixture-authoring: verifies <c>SymbolNavigationService.ProbePositionAsync</c>
+/// returns deterministic, trivia-aware lexical snapshots so fixture authors can pin 1-based
+/// line/column anchors without re-implementing Roslyn's token-boundary rules.
+/// </summary>
+[TestClass]
+public sealed class PositionProbeTests : SharedWorkspaceTestBase
+{
+    private static string _workspaceId = string.Empty;
+    private static string _animalServicePath = string.Empty;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        _workspaceId = await LoadSharedSampleWorkspaceAsync();
+        var sampleSolutionRoot = Path.GetDirectoryName(SampleSolutionPath)!;
+        _animalServicePath = Path.Combine(sampleSolutionRoot, "SampleLib", "AnimalService.cs");
+    }
+
+    /// <summary>
+    /// Validation row from plan: caret on identifier returns tokenKind=Identifier plus the
+    /// enclosing containing symbol (the method the identifier lives in). Uses AnimalService.cs
+    /// line 16 "public void MakeThemSpeak(    IEnumerable&lt;IAnimal&gt;     animals   )" —
+    /// column 21 lands inside 'MakeThemSpeak' (cols 17-29).
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnIdentifier_ReturnsIdentifierAndContainingSymbol()
+    {
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 21, CancellationToken.None);
+
+        Assert.IsNotNull(probe, "Probe must not return null for a file inside the loaded workspace.");
+        Assert.AreEqual("Identifier", probe.TokenKind, "Caret inside 'MakeThemSpeak' identifier should classify as Identifier.");
+        Assert.AreEqual("IdentifierToken", probe.SyntaxKind);
+        Assert.AreEqual("MakeThemSpeak", probe.TokenText);
+        Assert.IsFalse(probe.LeadingTriviaBefore, "Caret on the identifier token itself must not report leading-trivia-before.");
+        Assert.IsNotNull(probe.ContainingSymbol, "A method declaration identifier has the method itself as its containing symbol.");
+        StringAssert.Contains(probe.ContainingSymbol!, "MakeThemSpeak",
+            $"Expected containingSymbol to reference MakeThemSpeak; got '{probe.ContainingSymbol}'.");
+        Assert.AreEqual("Method", probe.ContainingSymbolKind);
+    }
+
+    /// <summary>
+    /// Validation row from plan: caret on whitespace returns tokenKind=Whitespace plus the
+    /// enclosing containing symbol. AnimalService.cs line 16 parens hold "    " between '(' and
+    /// 'IEnumerable' — column 32 lands on whitespace (cols 31-34). The lenient adjacent-identifier
+    /// fallback MUST NOT fire: a Whitespace classification here is the whole point of the probe.
+    /// Per Roslyn's trivia-attachment rules this whitespace is TRAILING trivia of '(' (not leading
+    /// trivia of 'IEnumerable'), so <c>LeadingTriviaBefore</c> is false while <c>TokenKind</c>
+    /// still surfaces the Whitespace classification.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnWhitespace_ReturnsWhitespaceAndContainingSymbol()
+    {
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 32, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.AreEqual("Whitespace", probe.TokenKind,
+            $"Caret on whitespace between '(' and 'IEnumerable' must classify as Whitespace, not as the adjacent identifier. Got tokenText='{probe.TokenText}', syntaxKind='{probe.SyntaxKind}'.");
+        Assert.AreEqual("WhitespaceTrivia", probe.SyntaxKind);
+        Assert.IsFalse(probe.LeadingTriviaBefore,
+            "Trailing whitespace attached to '(' per Roslyn's trivia-attachment rules — not leading trivia of the next token.");
+        // Whitespace inside a method declaration's parameter list still resolves to the method as
+        // the containing symbol — the probe reports the nearest enclosing member, not a synthesized
+        // "none" placeholder.
+        Assert.IsNotNull(probe.ContainingSymbol,
+            "Whitespace inside a method signature should still report the enclosing method as its containing symbol.");
+        StringAssert.Contains(probe.ContainingSymbol!, "MakeThemSpeak");
+        Assert.AreEqual("Method", probe.ContainingSymbolKind);
+    }
+
+    /// <summary>
+    /// Risk row from plan: positions near end-of-line must not accidentally resolve to the next
+    /// line's first token. Line 16 ends at column 70 (the closing paren); column 71 is the
+    /// newline. Confirm the probe classifies this as <c>EndOfLine</c> trivia — it must NOT leak
+    /// forward into line 17's opening brace. Roslyn attaches this EOL trivia to ')' as trailing
+    /// trivia, so the containing method is still reported via the enclosing-symbol walk.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnEndOfLine_DoesNotLeakToNextLineToken()
+    {
+        // Column 71 is the '\n' immediately after ')' on line 16. Roslyn attaches this as
+        // EndOfLineTrivia to the ')' token's TRAILING trivia, not the '{' of line 17's leading
+        // trivia — the probe must NOT report the next line's token.
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 71, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.AreEqual("EndOfLine", probe.TokenKind,
+            $"Caret on line-end whitespace/newline must classify as EndOfLine, not leak forward to the next token. Got tokenKind='{probe.TokenKind}', syntaxKind='{probe.SyntaxKind}', tokenText='{probe.TokenText}'.");
+        Assert.AreEqual("EndOfLineTrivia", probe.SyntaxKind);
+        Assert.IsFalse(probe.LeadingTriviaBefore,
+            "End-of-line trivia terminating a source line is trailing trivia of the preceding token.");
+        // Leak check: containing symbol should still be MakeThemSpeak (line 16's declaring method),
+        // not MakeThemSpeak's body (which would be resolved if the caret leaked to line 17's '{').
+        StringAssert.Contains(probe.ContainingSymbol!, "MakeThemSpeak");
+    }
+
+    /// <summary>
+    /// Trivia-boundary determinism check: caret EXACTLY on a token boundary (SpanStart of the
+    /// identifier, not inside preceding whitespace) must classify as the token — not as the
+    /// trailing trivia of the preceding token. This is the primary caret-off-by-one case the
+    /// probe is designed to eliminate.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnTokenSpanStart_ClassifiesAsTokenNotTrivia()
+    {
+        // Line 16, column 35 == SpanStart of 'IEnumerable' (preceded by the 4-space whitespace
+        // gap). Roslyn's FindToken returns 'IEnumerable' and position == token.SpanStart means
+        // we're on the token, not in its leading trivia.
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 35, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.AreEqual("Identifier", probe.TokenKind,
+            $"Caret EXACTLY on a token's start must classify as that token, not as preceding trivia. Got tokenKind='{probe.TokenKind}', tokenText='{probe.TokenText}'.");
+        Assert.AreEqual("IEnumerable", probe.TokenText);
+        Assert.IsFalse(probe.LeadingTriviaBefore,
+            "Caret at token.SpanStart is on the token, not in its leading trivia.");
+    }
+
+    /// <summary>
+    /// Caret on a keyword token (public) returns <c>Keyword</c> classification. Anchors on
+    /// line 16 col 5 — the 'public' modifier of MakeThemSpeak.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnKeyword_ReturnsKeyword()
+    {
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 5, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.AreEqual("Keyword", probe.TokenKind);
+        Assert.AreEqual("public", probe.TokenText);
+        Assert.IsFalse(probe.LeadingTriviaBefore);
+    }
+
+    /// <summary>
+    /// Leading-trivia detection: caret on the 4-space indent of line 16 (col 1) lands inside the
+    /// leading trivia of the 'public' keyword — because the blank line 15 and preceding end-of-line
+    /// trivia push this whitespace into the next token's leading-trivia slot. Confirms the probe
+    /// distinguishes leading trivia (attached to the following token) from trailing trivia
+    /// (attached to the preceding token) via the <c>LeadingTriviaBefore</c> flag.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_CaretOnLineIndent_ReportsLeadingTriviaBeforeFlag()
+    {
+        // Column 1 on line 16 — start of "    public". The blank line 15 forces the preceding '}'
+        // of line 14 to NOT own this whitespace as trailing trivia; instead Roslyn attaches it
+        // (plus line 15's EOL) as LEADING trivia of line 16's 'public' keyword.
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, _animalServicePath, line: 16, column: 1, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.AreEqual("Whitespace", probe.TokenKind,
+            $"Caret on line-16 indent should classify as Whitespace. Got tokenKind='{probe.TokenKind}', syntaxKind='{probe.SyntaxKind}', tokenText='{probe.TokenText}'.");
+        Assert.IsTrue(probe.LeadingTriviaBefore,
+            "Indent whitespace after a blank line is leading trivia of the next non-whitespace token.");
+    }
+
+    /// <summary>
+    /// Out-of-range line surfaces an informative ArgumentException. Keeps the error shape
+    /// consistent with <c>GetEnclosingSymbolAsync</c> so clients can share validation logic.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_LineOutOfRange_Throws()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            SymbolNavigationService.ProbePositionAsync(
+                _workspaceId, _animalServicePath, line: 99_999, column: 1, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// File not in the loaded workspace returns null — consistent with the rest of the
+    /// ISymbolNavigationService surface for missing-document cases.
+    /// </summary>
+    [TestMethod]
+    public async Task ProbePosition_UnknownFile_ReturnsNull()
+    {
+        var bogusPath = Path.Combine(Path.GetTempPath(), "definitely-not-in-the-workspace.cs");
+
+        var probe = await SymbolNavigationService.ProbePositionAsync(
+            _workspaceId, bogusPath, line: 1, column: 1, CancellationToken.None);
+
+        Assert.IsNull(probe);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new read-only MCP tool **`probe_position(workspaceId, filePath, line, column)`** → `{ tokenKind, syntaxKind, tokenText, containingSymbol, containingSymbolKind, leadingTriviaBefore }` — intended for test-fixture authoring to eliminate caret off-by-one mistakes when hard-coding `SymbolLocator.BySource(path, line, column)` anchors.
- Trivia-aware: a caret on whitespace returns `tokenKind='Whitespace'` instead of silently resolving to the adjacent identifier. Distinguishes leading trivia (before next token) from trailing trivia (after previous token) via the `leadingTriviaBefore` flag per Roslyn's trivia-attachment rules.
- Thin wrapper over `SyntaxTree.FindToken` plus the same enclosing-member walk `enclosing_symbol` already uses, so the two tools stay consistent.

## Scope touched (per plan)

- **Prod (2 files extended):** `src/RoslynMcp.Roslyn/Services/SymbolNavigationService.cs` (+`ProbePositionAsync` and classification helpers), `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs` (+`ProbePosition` tool).
- **Tests (+1 file):** `tests/RoslynMcp.Tests/PositionProbeTests.cs` with 8 cases — identifier, keyword, whitespace (trailing-trivia), whitespace (leading-trivia indent), end-of-line, exact span-start boundary, line-out-of-range, unknown-file.
- **Structural-unit exemption invoked** for the new MCP tool surface: `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` + `src/RoslynMcp.Core/Services/ISymbolNavigationService.cs` + `src/RoslynMcp.Core/Models/PositionProbeDto.cs` — same pattern as prior tool additions (`scaffold_first_test_file_preview`, `extract_shared_expression_to_helper_preview`). DI registration unchanged because the probe reuses the existing `ISymbolNavigationService` registration.

## Validation

- `compile_check` clean on `RoslynMcp.Core`, `RoslynMcp.Roslyn`, `RoslynMcp.Host.Stdio`, `RoslynMcp.Tests`.
- Targeted tests pass: 8/8 PositionProbeTests, plus 4 ServerSurfaceCatalogAnalyzer + 1 SurfaceCatalog parity + 1 SecurityDiagnostic catalog workflow.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1 -Configuration Release` — **706/711 passed, 5 pre-existing cross-class flakes.**

### Pre-existing flake caveat

Full-suite `verify-release.ps1` runs showed 2–5 failures that are unrelated to this change and **are known flakes from shared-workspace state across test classes** (not new regressions from this PR):

- Run 1: `ApplyTextEdit_OverlappingSpans_ThrowsArgumentException` + `ApplyTextEdit_SnapshotOverwritesPreviousRefactoring`.
- Run 2 (different set): `TraceExceptionFlow_MatchesBaseClassCatches_AndUntypedCatch`, `ExtractType_EmptyMemberList_ThrowsArgument`, `Dependency_Inversion_Preview_Preserves_Source_File_Formatting`, `Dependency_Inversion_Preview_*`, `ApplyTextEdit_OverlappingSpans_*`.

Each failure:
1. Passes in isolation (verified individually).
2. Touches code I did not modify (EditService, RefactoringService, TypeExtractionService, ExceptionFlowService, CrossProjectRefactoringService).
3. Varies between runs (same build, different failures) — classic non-deterministic cross-class workspace-state contamination.

CI should run on this PR to capture its own isolated snapshot.

Closes: position-probe-for-test-fixture-authoring

## Test plan

- [x] New probe returns deterministic `Identifier` classification on `MakeThemSpeak` caret
- [x] Whitespace between `(` and `IEnumerable` classifies as `Whitespace` (not falling through to the next identifier)
- [x] End-of-line position stays on line 16 — does not leak forward to line 17's opening brace
- [x] Caret on exact token SpanStart classifies as the token (not preceding trivia)
- [x] Indent whitespace after blank line classifies as leading trivia of next token (`leadingTriviaBefore=true`)
- [x] Out-of-range line throws `ArgumentException`
- [x] Unknown file path returns `null`
- [x] Keyword classification (`public`) works
- [x] `ServerSurfaceCatalog` parity tests still pass (new `probe_position` entry)

Generated with Claude Code.