### PR TITLE
feat(suppression): verify_pragma_suppresses + pragma_scope_widen tool pair (pragma-directive-scope-manipulation)

### DIFF
--- a/src/RoslynMcp.Core/Models/PragmaVerifyResultDto.cs
+++ b/src/RoslynMcp.Core/Models/PragmaVerifyResultDto.cs
@@ -1,0 +1,38 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Result of checking whether an existing <c>#pragma warning disable/restore</c> pair
+/// actually covers a diagnostic's fire site.
+/// </summary>
+/// <param name="Suppresses">
+/// <c>true</c> when the fire line lies strictly inside a matching
+/// <c>disable</c>/<c>restore</c> span for <paramref name="DiagnosticId"/>. <c>false</c>
+/// when no matching pair exists, the fire line is outside the span, or the pair
+/// is inverted/malformed.
+/// </param>
+/// <param name="FilePath">Absolute path of the file that was inspected.</param>
+/// <param name="Line">The 1-based line that the caller wanted covered (the diagnostic fire site).</param>
+/// <param name="DiagnosticId">The diagnostic id whose suppression was checked (e.g. <c>CA2025</c>).</param>
+/// <param name="DisableLine">1-based line of the most-relevant <c>#pragma warning disable &lt;id&gt;</c>, or <c>null</c> if none was found.</param>
+/// <param name="RestoreLine">
+/// 1-based line of the matching <c>#pragma warning restore &lt;id&gt;</c>, or <c>null</c> if the
+/// disable has no matching restore (dangling / file-end). A dangling disable is considered
+/// to cover every line after it up to the end of file.
+/// </param>
+/// <param name="Reason">Human-readable diagnosis suitable for a terse tool response (why it does / does not cover).</param>
+/// <param name="DiagnosticFiresAtLine">
+/// <c>true</c> when the current in-memory compilation reports an actual diagnostic with the
+/// given id at <paramref name="Line"/>, confirming the fire site is real. <c>false</c> when
+/// the diagnostic does not fire there (either because it is already suppressed by the pair or
+/// because the caller gave a stale line). <c>null</c> when the workspace lookup was skipped
+/// or failed — in which case the caller has only the structural answer in <paramref name="Suppresses"/>.
+/// </param>
+public sealed record PragmaVerifyResultDto(
+    bool Suppresses,
+    string FilePath,
+    int Line,
+    string DiagnosticId,
+    int? DisableLine,
+    int? RestoreLine,
+    string Reason,
+    bool? DiagnosticFiresAtLine = null);

--- a/src/RoslynMcp.Core/Models/PragmaWidenResultDto.cs
+++ b/src/RoslynMcp.Core/Models/PragmaWidenResultDto.cs
@@ -1,0 +1,43 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Result of extending an existing <c>#pragma warning restore &lt;id&gt;</c> further down so
+/// the matching disable/restore span covers a previously-uncovered fire site.
+/// </summary>
+/// <param name="Success">
+/// <c>true</c> when the restore directive was relocated (or was already in place) such that
+/// <paramref name="TargetLine"/> is inside the disable/restore span and no safety invariants
+/// were violated. <c>false</c> when the widen was refused — see <paramref name="Reason"/>.
+/// </param>
+/// <param name="FilePath">Absolute path of the file that was inspected or modified.</param>
+/// <param name="TargetLine">1-based line the caller wanted covered (typically the diagnostic fire site).</param>
+/// <param name="DiagnosticId">The diagnostic id whose <c>restore</c> was extended.</param>
+/// <param name="DisableLine">1-based line of the matched <c>#pragma warning disable &lt;id&gt;</c>, or <c>null</c> when no pair was located.</param>
+/// <param name="OriginalRestoreLine">
+/// 1-based line of the <c>#pragma warning restore &lt;id&gt;</c> as it existed before this call,
+/// or <c>null</c> when the disable had no matching restore (dangling / file-end).
+/// </param>
+/// <param name="NewRestoreLine">
+/// 1-based line of the <c>#pragma warning restore &lt;id&gt;</c> after this call. Strictly greater
+/// than <paramref name="TargetLine"/> on success. Equal to <paramref name="OriginalRestoreLine"/>
+/// on the no-op path (the pair already covers the target). <c>null</c> on failure.
+/// </param>
+/// <param name="AlreadyCovered">
+/// <c>true</c> when the existing pair already covered <paramref name="TargetLine"/> — no edit
+/// was made and no undo snapshot was captured. The caller can treat this as an idempotent success.
+/// </param>
+/// <param name="Reason">
+/// Human-readable explanation — on success, a short confirmation; on refusal, the specific
+/// safety invariant that blocked the widen (e.g. "would cross #region boundary",
+/// "would nest into another pragma disable for the same id").
+/// </param>
+public sealed record PragmaWidenResultDto(
+    bool Success,
+    string FilePath,
+    int TargetLine,
+    string DiagnosticId,
+    int? DisableLine,
+    int? OriginalRestoreLine,
+    int? NewRestoreLine,
+    bool AlreadyCovered,
+    string Reason);

--- a/src/RoslynMcp.Core/Services/ISuppressionService.cs
+++ b/src/RoslynMcp.Core/Services/ISuppressionService.cs
@@ -18,4 +18,33 @@ public interface ISuppressionService
     /// </summary>
     Task<TextEditResultDto> AddPragmaWarningDisableAsync(
         string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct);
+
+    /// <summary>
+    /// Checks whether the <c>#pragma warning disable/restore</c> pair for the given diagnostic id
+    /// actually covers the specified 1-based line. Used to detect "cosmetic pragma" bugs where the
+    /// pragma pair wraps the wrong span — e.g. pair wraps line 68 but the diagnostic actually fires
+    /// at line 78 (IT-Chat-Bot RetrievalExecutor CA2025 regression).
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="filePath">Absolute path to the C# source file to inspect.</param>
+    /// <param name="line">1-based line number that should be covered by the pragma pair (typically the diagnostic fire site).</param>
+    /// <param name="diagnosticId">The diagnostic id whose suppression to check (e.g. <c>CA2025</c>).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<PragmaVerifyResultDto> VerifyPragmaSuppressesAsync(
+        string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct);
+
+    /// <summary>
+    /// Extends the matching <c>#pragma warning restore &lt;id&gt;</c> past the given 1-based line,
+    /// so the pair covers a previously-uncovered fire site. Refuses the edit when relocating the
+    /// restore would cross a <c>#region</c>/<c>#endregion</c> boundary or nest into another
+    /// <c>#pragma warning disable &lt;id&gt;</c> for the same id (both would silently change the
+    /// effective scope of other suppressions).
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="filePath">Absolute path to the C# source file to modify.</param>
+    /// <param name="line">1-based line that must be covered after the widen (typically the diagnostic fire site).</param>
+    /// <param name="diagnosticId">The diagnostic id whose <c>restore</c> is being moved.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<PragmaWidenResultDto> WidenPragmaScopeAsync(
+        string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -173,7 +173,9 @@ public static class ServerSurfaceCatalog
         Tool("evaluate_msbuild_items", "project-mutation", "stable", true, false, "List MSBuild items of a type with evaluated includes and metadata."),
         Tool("get_msbuild_properties", "project-mutation", "stable", true, false, "Dump evaluated MSBuild properties for a project."),
         Tool("set_diagnostic_severity", "configuration", "stable", false, false, "Set dotnet_diagnostic severity in .editorconfig."),
-        Tool("add_pragma_suppression", "editing", "stable", false, false, "Insert a #pragma warning disable before a line.")
+        Tool("add_pragma_suppression", "editing", "stable", false, false, "Insert a #pragma warning disable before a line."),
+        Tool("verify_pragma_suppresses", "validation", "stable", true, false, "Verify an existing #pragma warning disable/restore pair covers a fire line."),
+        Tool("pragma_scope_widen", "editing", "stable", false, false, "Extend an existing #pragma warning restore past a target line.")
     ];
 
     public static IReadOnlyList<SurfaceEntry> Resources { get; } =

--- a/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
@@ -50,4 +50,46 @@ public static class SuppressionTools
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }
+
+    [McpServerTool(Name = "verify_pragma_suppresses", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("validation", "stable", true, false,
+        "Verify an existing #pragma warning disable/restore pair covers a fire line."),
+     Description("Check whether a '#pragma warning disable/restore' pair for the given diagnostic id actually covers the specified 1-based line. Detects 'cosmetic pragma' bugs where the pragma pair wraps the wrong span (e.g. pair wraps line 68 but the diagnostic actually fires at line 78). Read-only — no edits.")]
+    public static Task<string> VerifyPragmaSuppresses(
+        IWorkspaceExecutionGate gate,
+        ISuppressionService suppressionService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the C# source file to inspect")] string filePath,
+        [Description("1-based line number that should be covered (the diagnostic fire site)")] int line,
+        [Description("Diagnostic id whose suppression to check (e.g. CA2025)")] string diagnosticId,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var result = await suppressionService.VerifyPragmaSuppressesAsync(
+                workspaceId, filePath, line, diagnosticId, c);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
+
+    [McpServerTool(Name = "pragma_scope_widen", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
+     McpToolMetadata("editing", "stable", false, false,
+        "Extend an existing #pragma warning restore past a target line."),
+     Description("Extend a matching '#pragma warning restore &lt;id&gt;' down to cover a previously-uncovered fire site. Refuses the edit when relocating the restore would cross a #region/#endregion boundary or nest into another '#pragma warning disable &lt;id&gt;' for the same id (both would silently change the effective scope of other suppressions). Idempotent no-op when the existing pair already covers the target.")]
+    public static Task<string> PragmaScopeWiden(
+        IWorkspaceExecutionGate gate,
+        ISuppressionService suppressionService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the C# source file to modify")] string filePath,
+        [Description("1-based line number that must be covered after the widen (the diagnostic fire site)")] int line,
+        [Description("Diagnostic id whose 'restore' is being moved (e.g. CA2025)")] string diagnosticId,
+        CancellationToken ct = default)
+    {
+        return gate.RunWriteAsync(workspaceId, async c =>
+        {
+            var result = await suppressionService.WidenPragmaScopeAsync(
+                workspaceId, filePath, line, diagnosticId, c);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
 }

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -68,7 +68,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDiRegistrationService, DiRegistrationService>();
         services.AddSingleton<INuGetDependencyService, NuGetDependencyService>();
         services.AddSingleton<IMsBuildEvaluationService, MsBuildEvaluationService>();
-        services.AddSingleton<ISuppressionService, SuppressionService>();
+        services.AddSingleton<ISuppressionService>(sp => new SuppressionService(
+            sp.GetRequiredService<IEditorConfigService>(),
+            sp.GetRequiredService<IEditService>(),
+            sp.GetRequiredService<IWorkspaceManager>(),
+            sp.GetRequiredService<ICompileCheckService>()));
         services.AddSingleton<ICodePatternAnalyzer, CodePatternAnalyzer>();
         services.AddSingleton<IEditService, EditService>();
         services.AddSingleton<IFileOperationService, FileOperationService>();

--- a/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
@@ -1,5 +1,9 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -7,11 +11,32 @@ public sealed class SuppressionService : ISuppressionService
 {
     private readonly IEditorConfigService _editorConfig;
     private readonly IEditService _editService;
+    private readonly IWorkspaceManager? _workspace;
+    private readonly ICompileCheckService? _compileCheck;
 
+    /// <summary>
+    /// Legacy constructor preserved for stub-based unit tests in
+    /// <see cref="RoslynMcp.Tests.SuppressionServiceTests"/>. Production DI wires the
+    /// overload that also takes <see cref="IWorkspaceManager"/> and
+    /// <see cref="ICompileCheckService"/>; without those the structural pragma-scope
+    /// operations still work but the fire-site confirmation in
+    /// <c>VerifyPragmaSuppressesAsync</c> reports <c>null</c>.
+    /// </summary>
     public SuppressionService(IEditorConfigService editorConfig, IEditService editService)
+        : this(editorConfig, editService, workspace: null, compileCheck: null)
+    {
+    }
+
+    public SuppressionService(
+        IEditorConfigService editorConfig,
+        IEditService editService,
+        IWorkspaceManager? workspace,
+        ICompileCheckService? compileCheck)
     {
         _editorConfig = editorConfig;
         _editService = editService;
+        _workspace = workspace;
+        _compileCheck = compileCheck;
     }
 
     public Task<EditorConfigWriteResultDto> SetDiagnosticSeverityAsync(
@@ -43,4 +68,513 @@ public sealed class SuppressionService : ISuppressionService
         var edit = new TextEditDto(line, 1, line, 1, pragma);
         return _editService.ApplyTextEditsAsync(workspaceId, filePath, [edit], ct);
     }
+
+    public async Task<PragmaVerifyResultDto> VerifyPragmaSuppressesAsync(
+        string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct)
+    {
+        ValidateVerifyWidenArgs(filePath, line, diagnosticId);
+        var normalizedId = diagnosticId.Trim();
+        var sourceText = await ReadSourceTextAsync(filePath, ct).ConfigureAwait(false);
+        var tree = CSharpSyntaxTree.ParseText(sourceText, path: filePath, cancellationToken: ct);
+        var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+        var pair = FindEnclosingPragmaPair(root, normalizedId, line);
+
+        // Structural answer first — does a disable/restore pair cover this line?
+        bool suppresses;
+        string reason;
+        int? disableLine = pair.DisableLine;
+        int? restoreLine = pair.RestoreLine;
+
+        if (pair.DisableLine is null)
+        {
+            suppresses = false;
+            reason = $"No '#pragma warning disable {normalizedId}' found at or before line {line}.";
+        }
+        else if (pair.RestoreLine is null)
+        {
+            // Dangling disable — Roslyn treats this as "disabled until end of file".
+            suppresses = line > pair.DisableLine.Value;
+            reason = suppresses
+                ? $"Dangling '#pragma warning disable {normalizedId}' at line {pair.DisableLine} covers all subsequent lines including {line}."
+                : $"Line {line} precedes the disable at line {pair.DisableLine}.";
+        }
+        else if (line > pair.DisableLine.Value && line < pair.RestoreLine.Value)
+        {
+            suppresses = true;
+            reason = $"Line {line} lies inside the '#pragma warning disable {normalizedId}' span (disable {pair.DisableLine} → restore {pair.RestoreLine}).";
+        }
+        else if (line <= pair.DisableLine.Value)
+        {
+            suppresses = false;
+            reason = $"Line {line} precedes the disable at line {pair.DisableLine}.";
+        }
+        else
+        {
+            // line >= restoreLine
+            suppresses = false;
+            reason = $"Line {line} is at or past the restore at line {pair.RestoreLine}; the pragma pair (disable {pair.DisableLine} → restore {pair.RestoreLine}) does not cover it.";
+        }
+
+        // Optional fire-site confirmation via the live compilation.
+        bool? firesAtLine = null;
+        if (_workspace is not null && _compileCheck is not null)
+        {
+            firesAtLine = await TryConfirmDiagnosticFiresAsync(workspaceId, filePath, line, normalizedId, ct).ConfigureAwait(false);
+        }
+
+        return new PragmaVerifyResultDto(
+            Suppresses: suppresses,
+            FilePath: Path.GetFullPath(filePath),
+            Line: line,
+            DiagnosticId: normalizedId,
+            DisableLine: disableLine,
+            RestoreLine: restoreLine,
+            Reason: reason,
+            DiagnosticFiresAtLine: firesAtLine);
+    }
+
+    public async Task<PragmaWidenResultDto> WidenPragmaScopeAsync(
+        string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct)
+    {
+        ValidateVerifyWidenArgs(filePath, line, diagnosticId);
+        var normalizedId = diagnosticId.Trim();
+        var fullPath = Path.GetFullPath(filePath);
+        var sourceText = await ReadSourceTextAsync(filePath, ct).ConfigureAwait(false);
+        var tree = CSharpSyntaxTree.ParseText(sourceText, path: filePath, cancellationToken: ct);
+        var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+        var pair = FindEnclosingPragmaPair(root, normalizedId, line);
+
+        if (pair.DisableLine is null)
+        {
+            return new PragmaWidenResultDto(
+                Success: false,
+                FilePath: fullPath,
+                TargetLine: line,
+                DiagnosticId: normalizedId,
+                DisableLine: null,
+                OriginalRestoreLine: null,
+                NewRestoreLine: null,
+                AlreadyCovered: false,
+                Reason: $"No '#pragma warning disable {normalizedId}' found at or before line {line}; nothing to widen.");
+        }
+
+        // Already-covered: the restore is null (dangling) or strictly past the target line.
+        if (pair.RestoreLine is null)
+        {
+            return new PragmaWidenResultDto(
+                Success: true,
+                FilePath: fullPath,
+                TargetLine: line,
+                DiagnosticId: normalizedId,
+                DisableLine: pair.DisableLine,
+                OriginalRestoreLine: null,
+                NewRestoreLine: null,
+                AlreadyCovered: true,
+                Reason: $"Dangling '#pragma warning disable {normalizedId}' at line {pair.DisableLine} already covers all subsequent lines; no edit needed.");
+        }
+
+        if (line < pair.RestoreLine.Value)
+        {
+            return new PragmaWidenResultDto(
+                Success: true,
+                FilePath: fullPath,
+                TargetLine: line,
+                DiagnosticId: normalizedId,
+                DisableLine: pair.DisableLine,
+                OriginalRestoreLine: pair.RestoreLine,
+                NewRestoreLine: pair.RestoreLine,
+                AlreadyCovered: true,
+                Reason: $"Line {line} already lies inside the pragma span (disable {pair.DisableLine} → restore {pair.RestoreLine}); no edit needed.");
+        }
+
+        // Safety invariant: moving the restore from its current line down past `line` must not
+        // cross a #region/#endregion boundary or enter another pragma disable for the same id.
+        // The scan window is (pair.RestoreLine, line] in ORIGINAL coordinates — any forbidden
+        // directive inside that window blocks the widen.
+        var safetyBlocker = FindSafetyBlocker(root, normalizedId, pair.RestoreLine.Value, line, pair.RestoreTrivia);
+        if (safetyBlocker is not null)
+        {
+            return new PragmaWidenResultDto(
+                Success: false,
+                FilePath: fullPath,
+                TargetLine: line,
+                DiagnosticId: normalizedId,
+                DisableLine: pair.DisableLine,
+                OriginalRestoreLine: pair.RestoreLine,
+                NewRestoreLine: null,
+                AlreadyCovered: false,
+                Reason: safetyBlocker);
+        }
+
+        // Emit two independent edits (delete old restore line, insert new restore at anchor)
+        // against ORIGINAL coordinates. EditService.ApplyTextEditsAsync hands them to
+        // SourceText.WithChanges in one call, so the spans do not interfere with each other —
+        // see BuildRelocateRestoreEdits for the anchor-math rationale.
+        var (edits, newRestoreLineInFinalFile) = BuildRelocateRestoreEdits(
+            sourceText, pair.RestoreTrivia!, pair.RestoreLine.Value, line, normalizedId);
+
+        var applyResult = await _editService.ApplyTextEditsAsync(
+            workspaceId,
+            filePath,
+            edits,
+            ct,
+            skipSyntaxCheck: false,
+            verify: false,
+            autoRevertOnError: false).ConfigureAwait(false);
+
+        if (!applyResult.Success)
+        {
+            return new PragmaWidenResultDto(
+                Success: false,
+                FilePath: fullPath,
+                TargetLine: line,
+                DiagnosticId: normalizedId,
+                DisableLine: pair.DisableLine,
+                OriginalRestoreLine: pair.RestoreLine,
+                NewRestoreLine: null,
+                AlreadyCovered: false,
+                Reason: "Underlying text edit failed — see apply_text_edit logs for details.");
+        }
+
+        return new PragmaWidenResultDto(
+            Success: true,
+            FilePath: fullPath,
+            TargetLine: line,
+            DiagnosticId: normalizedId,
+            DisableLine: pair.DisableLine,
+            OriginalRestoreLine: pair.RestoreLine,
+            NewRestoreLine: newRestoreLineInFinalFile,
+            AlreadyCovered: false,
+            Reason: $"Moved '#pragma warning restore {normalizedId}' from line {pair.RestoreLine} to line {newRestoreLineInFinalFile}; span now covers target line {line}.");
+    }
+
+    // ----- helpers -----
+
+    private static void ValidateVerifyWidenArgs(string filePath, int line, string diagnosticId)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException("File path is required.", nameof(filePath));
+        }
+        if (line < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(line), "Line must be 1-based and positive.");
+        }
+        if (string.IsNullOrWhiteSpace(diagnosticId))
+        {
+            throw new ArgumentException("Diagnostic id is required.", nameof(diagnosticId));
+        }
+    }
+
+    private static Task<string> ReadSourceTextAsync(string filePath, CancellationToken ct) =>
+        File.ReadAllTextAsync(filePath, ct);
+
+    /// <summary>
+    /// Walks the directive trivia list for the file, collects all <c>#pragma warning</c>
+    /// directives that mention <paramref name="diagnosticId"/>, and finds the enclosing
+    /// pair (most-recent <c>disable</c> at or before <paramref name="line"/>, matching
+    /// <c>restore</c> after it). A dangling disable (no matching restore) returns
+    /// <see cref="PragmaPair.RestoreLine"/> <c>null</c>.
+    /// </summary>
+    private static PragmaPair FindEnclosingPragmaPair(SyntaxNode root, string diagnosticId, int line)
+    {
+        var directives = CollectPragmaDirectives(root, diagnosticId);
+
+        // Find the most-recent disable at or before `line`, then the first restore strictly after it.
+        PragmaWarningDirectiveTriviaSyntax? disable = null;
+        int disableLine = -1;
+        foreach (var d in directives)
+        {
+            var dLine = d.Directive.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+            if (d.Kind == PragmaKind.Disable && dLine <= line && dLine > disableLine)
+            {
+                disable = d.Directive;
+                disableLine = dLine;
+            }
+        }
+
+        if (disable is null)
+        {
+            return new PragmaPair(null, null, null, null);
+        }
+
+        // Find the first matching restore whose line is > disableLine.
+        PragmaWarningDirectiveTriviaSyntax? restore = null;
+        int restoreLine = int.MaxValue;
+        foreach (var d in directives)
+        {
+            if (d.Kind != PragmaKind.Restore) continue;
+            var rLine = d.Directive.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+            if (rLine > disableLine && rLine < restoreLine)
+            {
+                restore = d.Directive;
+                restoreLine = rLine;
+            }
+        }
+
+        return new PragmaPair(
+            DisableLine: disableLine,
+            RestoreLine: restore is null ? null : restoreLine,
+            DisableTrivia: disable,
+            RestoreTrivia: restore);
+    }
+
+    private static List<(PragmaWarningDirectiveTriviaSyntax Directive, PragmaKind Kind)> CollectPragmaDirectives(
+        SyntaxNode root, string diagnosticId)
+    {
+        var results = new List<(PragmaWarningDirectiveTriviaSyntax, PragmaKind)>();
+        foreach (var directive in root.DescendantTrivia(descendIntoTrivia: true)
+                                      .Where(t => t.HasStructure)
+                                      .Select(t => t.GetStructure())
+                                      .OfType<PragmaWarningDirectiveTriviaSyntax>())
+        {
+            if (!DirectiveMentionsId(directive, diagnosticId))
+            {
+                continue;
+            }
+            var kind = directive.DisableOrRestoreKeyword.IsKind(SyntaxKind.DisableKeyword)
+                ? PragmaKind.Disable
+                : PragmaKind.Restore;
+            results.Add((directive, kind));
+        }
+        return results;
+    }
+
+    private static bool DirectiveMentionsId(PragmaWarningDirectiveTriviaSyntax directive, string diagnosticId)
+    {
+        // The directive can list multiple ids; match if any of them equal the target id.
+        // Tokens can be identifiers (CS0168) or numeric (168) — compare on the textual form.
+        foreach (var token in directive.ErrorCodes)
+        {
+            var text = token.ToString().Trim();
+            if (string.Equals(text, diagnosticId, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Checks that relocating the <c>restore</c> from <paramref name="oldRestoreLine"/> so the
+    /// pair covers <paramref name="targetLine"/> does not cross a <c>#region</c>/<c>#endregion</c>
+    /// boundary or nest into another <c>#pragma warning disable &lt;id&gt;</c> for the same id.
+    /// The scan window is <c>(oldRestoreLine .. targetLine + 1]</c> in ORIGINAL line numbers —
+    /// lines 1..oldRestoreLine are already inside the pair, and we must also inspect line
+    /// <c>targetLine + 1</c> because the new restore will land on that line and colliding with
+    /// an existing disable there ("adjacent nesting") is still a scope hazard. Returns a
+    /// human-readable reason when the widen is unsafe; <c>null</c> when it is safe.
+    /// </summary>
+    private static string? FindSafetyBlocker(
+        SyntaxNode root,
+        string diagnosticId,
+        int oldRestoreLine,
+        int targetLine,
+        PragmaWarningDirectiveTriviaSyntax? existingRestore)
+    {
+        var windowEnd = targetLine + 1;
+        if (oldRestoreLine >= windowEnd)
+        {
+            return null;
+        }
+
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (!trivia.HasStructure) continue;
+            var structure = trivia.GetStructure();
+            if (structure is null) continue;
+
+            var line = structure.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+            if (line <= oldRestoreLine || line > windowEnd) continue;
+
+            switch (structure)
+            {
+                case RegionDirectiveTriviaSyntax:
+                    return $"Widening would cross a '#region' boundary at line {line}.";
+                case EndRegionDirectiveTriviaSyntax:
+                    return $"Widening would cross an '#endregion' boundary at line {line}.";
+                case PragmaWarningDirectiveTriviaSyntax pragma when ReferenceEquals(pragma, existingRestore):
+                    // This is the restore we are about to relocate — ignore.
+                    continue;
+                case PragmaWarningDirectiveTriviaSyntax pragma
+                    when pragma.DisableOrRestoreKeyword.IsKind(SyntaxKind.DisableKeyword)
+                         && DirectiveMentionsId(pragma, diagnosticId):
+                    return $"Widening would nest into another '#pragma warning disable {diagnosticId}' at line {line}.";
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Produces the edits that move the <c>#pragma warning restore &lt;id&gt;</c> from
+    /// <paramref name="oldRestoreLine"/> so the span covers <paramref name="targetLine"/>.
+    /// Returns both the edit list (to be applied against the ORIGINAL document by
+    /// <see cref="EditService.ApplyTextEditsAsync"/>) and the FINAL-file line number where
+    /// the relocated restore ends up, so the caller can round-trip that number through the
+    /// <see cref="PragmaWidenResultDto"/>.
+    /// </summary>
+    /// <remarks>
+    /// Implementation note: two independent edits (delete old line + insert at anchor line)
+    /// are emitted. Both spans use ORIGINAL coordinates; <see cref="EditService"/> applies
+    /// them as a single <see cref="Microsoft.CodeAnalysis.Text.SourceText.WithChanges"/> call
+    /// so the two spans do not interfere with each other. Because deleting the old line
+    /// removes one line from the file ABOVE the insert anchor, the new restore ends up at
+    /// line <c>targetLine + 1</c> of the FINAL file when the anchor is placed at original
+    /// line <c>targetLine + 2</c>.
+    ///
+    /// <para>
+    /// Edge case — when the file has no original line at <c>targetLine + 2</c> (e.g. target
+    /// is the penultimate line and there is no trailing line after the closing brace), the
+    /// insert anchor falls back to the end of the file. The restore is appended.
+    /// </para>
+    /// </remarks>
+    private static (IReadOnlyList<TextEditDto> Edits, int NewRestoreLineInFinalFile) BuildRelocateRestoreEdits(
+        string sourceText,
+        PragmaWarningDirectiveTriviaSyntax oldRestore,
+        int oldRestoreLine,
+        int targetLine,
+        string diagnosticId)
+    {
+        _ = oldRestore; // retained for symmetry with the pair type; anchor is computed from line number
+
+        // Delete the ENTIRE original restore line including its trailing newline: span is
+        // [(oldRestoreLine, col1) .. (oldRestoreLine + 1, col1)).
+        var deleteEdit = new TextEditDto(oldRestoreLine, 1, oldRestoreLine + 1, 1, string.Empty);
+
+        // Anchor for the insert. We want the new restore at FINAL line targetLine + 1. Since
+        // the delete removes one line above the anchor, picking original line targetLine + 2
+        // places the insert at FINAL line targetLine + 1.
+        var (anchorLine, anchorColumn, needsLeadingNewline) = ResolveInsertAnchor(sourceText, targetLine + 2);
+
+        // Carry over the indentation of the line the insert sits next to so the pragma is
+        // neither wildly out of alignment nor trailing a half-line.
+        var indentation = GetIndentationForLine(sourceText, needsLeadingNewline ? targetLine + 1 : targetLine + 2);
+        var directiveText = needsLeadingNewline
+            ? $"{Environment.NewLine}{indentation}#pragma warning restore {diagnosticId}"
+            : $"{indentation}#pragma warning restore {diagnosticId}{Environment.NewLine}";
+
+        var insertEdit = new TextEditDto(anchorLine, anchorColumn, anchorLine, anchorColumn, directiveText);
+
+        // FINAL-file line number of the new restore: the insert falls at FINAL line
+        // (anchorLine - 1) when the anchor is past oldRestoreLine. When the anchor falls at
+        // end-of-file with a leading newline, the new restore sits one line past the last
+        // original line minus the one we deleted.
+        int finalRestoreLine;
+        if (needsLeadingNewline)
+        {
+            var totalLinesOriginal = CountLines(sourceText);
+            finalRestoreLine = totalLinesOriginal; // after delete (-1) then leading-newline insert (+1) = totalLinesOriginal
+        }
+        else
+        {
+            finalRestoreLine = anchorLine - 1;
+        }
+
+        return (new TextEditDto[] { deleteEdit, insertEdit }, finalRestoreLine);
+    }
+
+    /// <summary>
+    /// Computes the <see cref="TextEditDto"/> anchor for an insert that conceptually belongs
+    /// at the <b>start</b> of original line <paramref name="desiredLine"/>. When the file has
+    /// that many lines, the anchor is <c>(desiredLine, col 1)</c> and the inserted text
+    /// carries its own trailing newline. When the file has fewer lines — i.e. the desired
+    /// line is past EOF — the anchor is end-of-last-line and the caller is told to prepend a
+    /// newline so the inserted directive does not fuse onto the previous line.
+    /// </summary>
+    private static (int Line, int Column, bool NeedsLeadingNewline) ResolveInsertAnchor(
+        string sourceText, int desiredLine)
+    {
+        var totalLines = CountLines(sourceText);
+        if (desiredLine <= totalLines)
+        {
+            return (desiredLine, 1, NeedsLeadingNewline: false);
+        }
+        // Desired line is past the last line — anchor at end of the last line, inject a
+        // leading newline so the restore sits on its own line.
+        var lines = sourceText.Split('\n');
+        var lastLine = lines[^1];
+        var lastLineEndColumn = lastLine.Length + 1;
+        // If the file's trailing char is already '\n' (empty lines[^1]), the anchor is on
+        // the phantom last line with column 1. Accept that — Roslyn treats end-of-file as
+        // a valid position.
+        return (totalLines, lastLineEndColumn, NeedsLeadingNewline: true);
+    }
+
+    private static int CountLines(string sourceText)
+    {
+        if (string.IsNullOrEmpty(sourceText)) return 1;
+        var lineCount = 1;
+        foreach (var ch in sourceText)
+        {
+            if (ch == '\n') lineCount++;
+        }
+        // If the file ends with '\n' the last Split('\n') entry is empty — Roslyn counts the
+        // position after the trailing newline as its own line, so keep this behaviour.
+        return lineCount;
+    }
+
+    private static string GetIndentationForLine(string sourceText, int lineNumber)
+    {
+        var lines = sourceText.Split('\n');
+        if (lineNumber < 1 || lineNumber > lines.Length)
+        {
+            return string.Empty;
+        }
+        var line = lines[lineNumber - 1];
+        int i = 0;
+        while (i < line.Length && (line[i] == ' ' || line[i] == '\t'))
+        {
+            i++;
+        }
+        return line.Substring(0, i);
+    }
+
+    private async Task<bool?> TryConfirmDiagnosticFiresAsync(
+        string workspaceId, string filePath, int line, string diagnosticId, CancellationToken ct)
+    {
+        if (_workspace is null || _compileCheck is null)
+        {
+            return null;
+        }
+
+        // Guard against missing/closed workspace — return null rather than throwing so the
+        // structural answer still makes it back to the caller.
+        if (!_workspace.ContainsWorkspace(workspaceId))
+        {
+            return null;
+        }
+
+        try
+        {
+            var options = new CompileCheckOptions(FileFilter: filePath, SeverityFilter: null, Limit: 200);
+            var result = await _compileCheck.CheckAsync(workspaceId, options, ct).ConfigureAwait(false);
+            foreach (var diag in result.Diagnostics)
+            {
+                if (!string.Equals(diag.Id, diagnosticId, StringComparison.OrdinalIgnoreCase)) continue;
+                if (diag.StartLine == line) return true;
+                // Allow multi-line spans — treat "line in range" as a hit.
+                if (diag.StartLine is int s && diag.EndLine is int e && line >= s && line <= e) return true;
+            }
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Best-effort confirmation — never let this probe mask the structural answer.
+            return null;
+        }
+    }
+
+    private enum PragmaKind { Disable, Restore }
+
+    private readonly record struct PragmaPair(
+        int? DisableLine,
+        int? RestoreLine,
+        PragmaWarningDirectiveTriviaSyntax? DisableTrivia,
+        PragmaWarningDirectiveTriviaSyntax? RestoreTrivia);
 }

--- a/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
@@ -15,23 +15,22 @@ public sealed class SuppressionService : ISuppressionService
     private readonly ICompileCheckService? _compileCheck;
 
     /// <summary>
-    /// Legacy constructor preserved for stub-based unit tests in
-    /// <see cref="RoslynMcp.Tests.SuppressionServiceTests"/>. Production DI wires the
-    /// overload that also takes <see cref="IWorkspaceManager"/> and
-    /// <see cref="ICompileCheckService"/>; without those the structural pragma-scope
-    /// operations still work but the fire-site confirmation in
-    /// <c>VerifyPragmaSuppressesAsync</c> reports <c>null</c>.
+    /// Constructs a <see cref="SuppressionService"/>. The <paramref name="workspace"/> and
+    /// <paramref name="compileCheck"/> dependencies are optional: when either is <c>null</c>
+    /// the structural pragma-scope operations (<c>AddPragmaWarningDisableAsync</c>,
+    /// <c>WidenPragmaScopeAsync</c>, and the directive-scan portion of
+    /// <c>VerifyPragmaSuppressesAsync</c>) continue to work, but the fire-site confirmation
+    /// inside <c>VerifyPragmaSuppressesAsync</c> — which replays the live compilation to
+    /// confirm the target diagnostic is actually reported at the target line — degrades to
+    /// <c>null</c> in the <see cref="PragmaVerifyResultDto.DiagnosticFiresAtLine"/> field.
+    /// Production DI supplies all four dependencies; stub-driven unit tests that exercise
+    /// only the editorconfig and edit-service wiring can omit the workspace pair.
     /// </summary>
-    public SuppressionService(IEditorConfigService editorConfig, IEditService editService)
-        : this(editorConfig, editService, workspace: null, compileCheck: null)
-    {
-    }
-
     public SuppressionService(
         IEditorConfigService editorConfig,
         IEditService editService,
-        IWorkspaceManager? workspace,
-        ICompileCheckService? compileCheck)
+        IWorkspaceManager? workspace = null,
+        ICompileCheckService? compileCheck = null)
     {
         _editorConfig = editorConfig;
         _editService = editService;

--- a/tests/RoslynMcp.Tests/PragmaScopeManipulationTests.cs
+++ b/tests/RoslynMcp.Tests/PragmaScopeManipulationTests.cs
@@ -1,0 +1,416 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Integration coverage for the <c>verify_pragma_suppresses</c> / <c>pragma_scope_widen</c>
+/// tool pair (initiative <c>pragma-directive-scope-manipulation</c>). The canonical scenario
+/// mirrors the IT-Chat-Bot RetrievalExecutor CA2025 bug: a pragma pair wraps the wrong span
+/// while the diagnostic actually fires further down. Verify must report the mismatch; widen
+/// must move the restore so the subsequent verify passes.
+/// </summary>
+[TestClass]
+public sealed class PragmaScopeManipulationTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    private static SuppressionService CreateService() =>
+        new SuppressionService(EditorConfigService, EditService, WorkspaceManager, CompileCheckService);
+
+    // ------------------------------------------------------------------
+    // Canonical misaligned-pair scenario. The fixture is deliberately CS0219-rich (unused
+    // local vars) so the live compilation reports the diagnostic at the fire line, giving
+    // us end-to-end coverage of both the structural and the fire-site branches in one test.
+    //
+    // Line layout in the original file (1-based):
+    //   1: namespace SampleLib.PragmaFixture;
+    //   2: (blank)
+    //   3: public class Misaligned
+    //   4: {
+    //   5:     public void M()
+    //   6:     {
+    //   7: #pragma warning disable CS0219
+    //   8:         int wrapped = 1;                         <-- covered
+    //   9: #pragma warning restore CS0219
+    //  10:         int leaked = 2;                          <-- fire site, NOT covered
+    //  11:     }
+    //  12: }
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Verify_ThenWiden_ThenVerify_CoversFireSite()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var filePath = workspace.GetPath("SampleLib", "Pragma_MisalignedPair.cs");
+        var fixtureText = """
+            namespace SampleLib.PragmaFixture;
+
+            public class Misaligned
+            {
+                public void M()
+                {
+            #pragma warning disable CS0219
+                    int wrapped = 1;
+            #pragma warning restore CS0219
+                    int leaked = 2;
+                }
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, fixtureText, CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+
+        // Step 1 — verify at line 10 (the leaked declaration, OUTSIDE the pair):
+        // Structurally NOT suppressed, and the compiler reports CS0219 there.
+        var verifyBefore = await sut.VerifyPragmaSuppressesAsync(
+            workspace.WorkspaceId, filePath, line: 10, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(verifyBefore.Suppresses,
+            $"Verify should report the pair does NOT cover line 10. Reason: {verifyBefore.Reason}");
+        Assert.AreEqual(7, verifyBefore.DisableLine);
+        Assert.AreEqual(9, verifyBefore.RestoreLine);
+        Assert.IsTrue(verifyBefore.DiagnosticFiresAtLine == true,
+            $"Compiler should confirm CS0219 fires at line 10. DiagnosticFiresAtLine={verifyBefore.DiagnosticFiresAtLine}");
+
+        // Step 2 — widen the restore past line 10.
+        var widen = await sut.WidenPragmaScopeAsync(
+            workspace.WorkspaceId, filePath, line: 10, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsTrue(widen.Success, $"Widen must succeed. Reason: {widen.Reason}");
+        Assert.IsFalse(widen.AlreadyCovered, "The original pair did not cover line 10, so this is a real widen.");
+        Assert.AreEqual(7, widen.DisableLine);
+        Assert.AreEqual(9, widen.OriginalRestoreLine);
+        Assert.IsNotNull(widen.NewRestoreLine);
+        Assert.IsTrue(widen.NewRestoreLine.Value > 10,
+            $"NewRestoreLine ({widen.NewRestoreLine}) must be strictly past line 10 so the span covers it.");
+
+        // Reload so the post-edit source text is what verify observes.
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // Step 3 — verify again. The pair now covers line 10.
+        var verifyAfter = await sut.VerifyPragmaSuppressesAsync(
+            workspace.WorkspaceId, filePath, line: 10, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsTrue(verifyAfter.Suppresses,
+            $"Verify should now report the pair covers line 10. Reason: {verifyAfter.Reason}");
+        Assert.AreEqual(7, verifyAfter.DisableLine);
+        Assert.AreEqual(widen.NewRestoreLine, verifyAfter.RestoreLine);
+        // Fire-site confirmation should now be false — the compiler no longer reports CS0219
+        // at line 10 because the widened pair suppresses it.
+        Assert.IsTrue(verifyAfter.DiagnosticFiresAtLine == false,
+            $"After widen the compiler should no longer fire CS0219 at line 10. DiagnosticFiresAtLine={verifyAfter.DiagnosticFiresAtLine}");
+    }
+
+    // ------------------------------------------------------------------
+    // No pragma pair at all → verify returns Suppresses=false with a clear reason.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Verify_NoPragmaPair_ReturnsFalse()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_NoPair.cs");
+        await File.WriteAllTextAsync(
+            filePath,
+            """
+            namespace SampleLib.PragmaFixture;
+
+            public class NoPair
+            {
+                public void M()
+                {
+                    int unused = 1;
+                }
+            }
+            """,
+            CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        var result = await sut.VerifyPragmaSuppressesAsync(
+            workspace.WorkspaceId, filePath, line: 7, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(result.Suppresses);
+        Assert.IsNull(result.DisableLine);
+        Assert.IsNull(result.RestoreLine);
+        StringAssert.Contains(result.Reason, "No '#pragma warning disable CS0219' found");
+    }
+
+    // ------------------------------------------------------------------
+    // Widen with no disable anywhere → fails with a clear reason.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Widen_NoPragmaPair_ReturnsFailureUntouched()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_WidenNoPair.cs");
+        var originalText = """
+            namespace SampleLib.PragmaFixture;
+
+            public class NoPair
+            {
+                public void M()
+                {
+                    int unused = 1;
+                }
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, originalText, CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        var result = await sut.WidenPragmaScopeAsync(
+            workspace.WorkspaceId, filePath, line: 7, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(result.Success);
+        StringAssert.Contains(result.Reason, "No '#pragma warning disable CS0219' found");
+
+        // The file must be unchanged since widen refused to act.
+        var afterText = await File.ReadAllTextAsync(filePath, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(originalText.Replace("\r\n", "\n"), afterText.Replace("\r\n", "\n"),
+            "Widen must not modify the file when it refuses to act.");
+    }
+
+    // ------------------------------------------------------------------
+    // Already-covered: widen is a no-op when the existing pair already wraps the target.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Widen_AlreadyCovered_IsNoOp()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_AlreadyCovered.cs");
+        var originalText = """
+            namespace SampleLib.PragmaFixture;
+
+            public class AlreadyCovered
+            {
+                public void M()
+                {
+            #pragma warning disable CS0219
+                    int a = 1;
+                    int b = 2;
+                    int c = 3;
+            #pragma warning restore CS0219
+                }
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, originalText, CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        // Target line 9 (int b = 2) is inside the pair (disable=7, restore=11).
+        var result = await sut.WidenPragmaScopeAsync(
+            workspace.WorkspaceId, filePath, line: 9, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.AlreadyCovered, "Widen should short-circuit when the pair already covers the target.");
+        Assert.AreEqual(7, result.DisableLine);
+        Assert.AreEqual(11, result.OriginalRestoreLine);
+
+        // File contents must be unchanged.
+        var afterText = await File.ReadAllTextAsync(filePath, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(originalText.Replace("\r\n", "\n"), afterText.Replace("\r\n", "\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // Safety invariant: widening must refuse when the new restore would cross a '#region'
+    // or '#endregion' boundary. The file stays untouched.
+    //
+    //   1: namespace ...
+    //   2: blank
+    //   3: public class CrossingRegion
+    //   4: {
+    //   5:   public void M()
+    //   6:   {
+    //   7: #pragma warning disable CS0219
+    //   8:       int wrapped = 1;
+    //   9: #pragma warning restore CS0219
+    //  10: #region Tail
+    //  11:       int tailed = 2;
+    //  12: #endregion
+    //  13:   }
+    //  14: }
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Widen_CrossingRegionBoundary_IsRefused()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_CrossingRegion.cs");
+        var originalText = """
+            namespace SampleLib.PragmaFixture;
+
+            public class CrossingRegion
+            {
+                public void M()
+                {
+            #pragma warning disable CS0219
+                    int wrapped = 1;
+            #pragma warning restore CS0219
+            #region Tail
+                    int tailed = 2;
+            #endregion
+                }
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, originalText, CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        // Target line 11 (int tailed = 2) is inside the #region Tail / #endregion block.
+        // Widening pair (7..9) to cover line 11 would cross the #region boundary at line 10.
+        var result = await sut.WidenPragmaScopeAsync(
+            workspace.WorkspaceId, filePath, line: 11, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(result.Success, $"Widen must refuse to cross a #region boundary. Reason: {result.Reason}");
+        StringAssert.Contains(result.Reason, "region");
+        Assert.IsNull(result.NewRestoreLine);
+
+        var afterText = await File.ReadAllTextAsync(filePath, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(originalText.Replace("\r\n", "\n"), afterText.Replace("\r\n", "\n"),
+            "Widen must not modify the file when it refuses to act.");
+    }
+
+    // ------------------------------------------------------------------
+    // Safety invariant: widening must refuse when the target line falls BETWEEN two
+    // pragma pairs for the same id, i.e. the new restore would land right on (or past)
+    // a subsequent disable directive for the same id.
+    //
+    //   1: namespace ...
+    //   2: blank
+    //   3: public class NestedDisable
+    //   4: {
+    //   5:   public void M()
+    //   6:   {
+    //   7: #pragma warning disable CS0219
+    //   8:       int wrapped = 1;
+    //   9: #pragma warning restore CS0219
+    //  10:       int between = 2;       <-- target, between the two pairs
+    //  11: #pragma warning disable CS0219
+    //  12:       int later = 3;
+    //  13: #pragma warning restore CS0219
+    //  14:   }
+    //  15: }
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Widen_NestingIntoAnotherDisable_IsRefused()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_NestedDisable.cs");
+        var originalText = """
+            namespace SampleLib.PragmaFixture;
+
+            public class NestedDisable
+            {
+                public void M()
+                {
+            #pragma warning disable CS0219
+                    int wrapped = 1;
+            #pragma warning restore CS0219
+                    int between = 2;
+            #pragma warning disable CS0219
+                    int later = 3;
+            #pragma warning restore CS0219
+                }
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, originalText, CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        // Target line 10 (int between = 2) is NOT covered by either pair (first ends at
+        // line 9, second starts at line 11). Widening the first pair past line 10 would
+        // put the new restore at line 11 — the same line as the second disable → refuse.
+        var result = await sut.WidenPragmaScopeAsync(
+            workspace.WorkspaceId, filePath, line: 10, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(result.Success, $"Widen must refuse to nest into another disable. Reason: {result.Reason}");
+        StringAssert.Contains(result.Reason, "nest");
+
+        var afterText = await File.ReadAllTextAsync(filePath, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(originalText.Replace("\r\n", "\n"), afterText.Replace("\r\n", "\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // Fire-site confirmation: verify surfaces DiagnosticFiresAtLine=true when the live
+    // compilation reports the diagnostic at the given line.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Verify_DiagnosticFiresAtLine_IsTrue_WhenCompilerReportsIt()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var filePath = workspace.GetPath("SampleLib", "Pragma_FireSite.cs");
+        // CS0219 fires on the unused local at line 7.
+        await File.WriteAllTextAsync(
+            filePath,
+            """
+            namespace SampleLib.PragmaFixture;
+
+            public class FireSite
+            {
+                public void M()
+                {
+                    int unused = 1;
+                }
+            }
+            """,
+            CancellationToken.None).ConfigureAwait(false);
+        await workspace.ReloadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var sut = CreateService();
+        var result = await sut.VerifyPragmaSuppressesAsync(
+            workspace.WorkspaceId, filePath, line: 7, diagnosticId: "CS0219", CancellationToken.None)
+            .ConfigureAwait(false);
+
+        Assert.IsFalse(result.Suppresses, "No pair → structurally not suppressing.");
+        Assert.IsTrue(result.DiagnosticFiresAtLine == true,
+            $"Compiler should report CS0219 at line 7. DiagnosticFiresAtLine={result.DiagnosticFiresAtLine}");
+    }
+
+    // ------------------------------------------------------------------
+    // Argument validation.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task VerifyPragmaSuppresses_Throws_OnBadArgs()
+    {
+        var sut = CreateService();
+        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+            sut.VerifyPragmaSuppressesAsync("ws", "/tmp/a.cs", 0, "CS0219", CancellationToken.None));
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            sut.VerifyPragmaSuppressesAsync("ws", "/tmp/a.cs", 1, " ", CancellationToken.None));
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            sut.VerifyPragmaSuppressesAsync("ws", " ", 1, "CS0219", CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task PragmaScopeWiden_Throws_OnBadArgs()
+    {
+        var sut = CreateService();
+        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+            sut.WidenPragmaScopeAsync("ws", "/tmp/a.cs", 0, "CS0219", CancellationToken.None));
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            sut.WidenPragmaScopeAsync("ws", "/tmp/a.cs", 1, " ", CancellationToken.None));
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            sut.WidenPragmaScopeAsync("ws", " ", 1, "CS0219", CancellationToken.None));
+    }
+}


### PR DESCRIPTION
## Summary

Adds two companion MCP tools for the `pragma-directive-scope-manipulation` initiative:

- **`verify_pragma_suppresses(filePath, line, diagnosticId)`** — read-only check of whether an existing `#pragma warning disable/restore` pair for `diagnosticId` actually covers the specified 1-based line. Combines a structural parse answer (is the line inside a matching pair?) with a live compile-check confirmation (`DiagnosticFiresAtLine`) so the caller sees both what the directive text says AND what the compiler actually reports.

- **`pragma_scope_widen(filePath, line, diagnosticId)`** — extend the matching `restore` past a specified line so the pair covers a previously-uncovered fire site. Safety invariants: refuses to cross `#region`/`#endregion` boundaries or nest into another `#pragma warning disable <id>` for the same id (both would silently change the effective scope of other suppressions). Idempotent no-op when the existing pair already covers the target.

Together this pair eliminates the "cosmetic pragma" class of bugs where a pair wraps the wrong span — e.g. the IT-Chat-Bot RetrievalExecutor regression where the pragma wrapped line 68 but CA2025 actually fires at line 78.

## Scope

- **prod (2 modified + 2 new)**
  - `src/RoslynMcp.Roslyn/Services/SuppressionService.cs` — extended with `VerifyPragmaSuppressesAsync` + `WidenPragmaScopeAsync`, backed by a `#pragma warning` directive-trivia walker and a 2-edit relocate (delete old restore + insert at computed anchor line).
  - `src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs` — two new `[McpServerTool]` entries wired through the existing `IWorkspaceExecutionGate` read/write pattern.
  - `src/RoslynMcp.Core/Models/PragmaVerifyResultDto.cs` (new), `src/RoslynMcp.Core/Models/PragmaWidenResultDto.cs` (new) — result records.
  - `src/RoslynMcp.Core/Services/ISuppressionService.cs` — two interface additions.
  - `src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs` — DI now constructs `SuppressionService` with the additional `IWorkspaceManager` + `ICompileCheckService` dependencies so the fire-site confirmation branch is live in production. A legacy single-ctor path stays for the existing stub-based unit tests.
  - `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` — catalog entries (structural-unit exemption per plan).

- **tests (+1)**
  - `tests/RoslynMcp.Tests/PragmaScopeManipulationTests.cs` — 9 tests covering the canonical verify → widen → re-verify flow, no-pair / already-covered / no-disable-to-widen branches, both safety refusals (region crossing and nested disable), fire-site confirmation, and argument validation.

## Validation

- **New tests:** 9/9 passing locally.
- **`./eng/verify-release.ps1 -Configuration Release`** (CI-parity Release build + full test suite + publish + hash manifest) → **712/712 passing**, Release build 0 warnings / 0 errors.
- **`./eng/verify-ai-docs.ps1`** → passed.
- **`./eng/verify-skills-are-generic.ps1`** → passed (31 SKILL.md checked).

## Test plan

- [x] Canonical misaligned-pair scenario: pair wraps lines 7-9, target=10 → verify reports Suppresses=false; widen moves restore past 10; re-verify reports Suppresses=true and the compiler no longer fires.
- [x] Fire-site confirmation: compiler-reported CS0219 surfaces as `DiagnosticFiresAtLine=true`.
- [x] Safety refusals: `#region` crossing and nested-disable both produce `Success=false` with a descriptive reason and leave the file byte-for-byte unchanged.
- [x] Idempotent no-op: widen with a target already inside the pair returns `AlreadyCovered=true` with no edit.
- [x] Argument validation: empty path / non-positive line / blank diagnostic id all throw the appropriate `ArgumentException` / `ArgumentOutOfRangeException`.

Closes: `pragma-directive-scope-manipulation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)