### PR TITLE
feat(analysis): get_coupling_metrics — Martin stability (coupling-metrics-tool)

### DIFF
--- a/src/RoslynMcp.Core/Models/CouplingMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/CouplingMetricsDto.cs
@@ -1,0 +1,42 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Coupling metrics for a single type, computed per Robert C. Martin's stability formula.
+/// </summary>
+/// <param name="TypeName">Short name of the analyzed type.</param>
+/// <param name="FullyQualifiedName">Fully qualified name for disambiguation.</param>
+/// <param name="FilePath">Absolute path to the declaring file, or <c>null</c> when not in source.</param>
+/// <param name="Line">1-based line number of the declaration, or <c>null</c> when not in source.</param>
+/// <param name="ProjectName">The containing project's name.</param>
+/// <param name="AfferentCoupling">
+/// Ca — the number of distinct types OUTSIDE this type that reference it (incoming dependencies).
+/// High Ca means many consumers rely on this type; changes here have broad blast radius.
+/// </param>
+/// <param name="EfferentCoupling">
+/// Ce — the number of distinct types OUTSIDE this type that THIS type references (outgoing dependencies).
+/// High Ce means this type knows about many other types; it is sensitive to upstream changes.
+/// </param>
+/// <param name="Instability">
+/// I = Ce / (Ca + Ce). 0.0 = maximally stable (all incoming, no outgoing — a sink/leaf).
+/// 1.0 = maximally unstable (all outgoing, no incoming — a root/entrypoint).
+/// Returns 0.0 when both Ca and Ce are zero (no coupling at all).
+/// </param>
+/// <param name="Classification">
+/// Human-readable bucket derived from <paramref name="Instability"/>:
+/// "stable" (I &lt; 0.3), "unstable" (I &gt; 0.7), "balanced" otherwise.
+/// Types with Ca + Ce == 0 are reported as "isolated".
+/// </param>
+public sealed record CouplingMetricsDto(
+    string TypeName,
+    string FullyQualifiedName,
+    string? FilePath,
+    int? Line,
+    string ProjectName,
+    int AfferentCoupling,
+    int EfferentCoupling,
+    double Instability,
+    string Classification)
+{
+    /// <summary>The kind of type: Class, Struct, Interface, Enum, etc.</summary>
+    public string TypeKind { get; init; } = "Class";
+}

--- a/src/RoslynMcp.Core/Services/ICouplingAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/ICouplingAnalysisService.cs
@@ -1,0 +1,28 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Computes per-type afferent (Ca) / efferent (Ce) coupling plus Martin's instability index (I).
+/// Companion to <see cref="ICohesionAnalysisService"/> — cohesion looks inward (how tightly a type
+/// holds together), coupling looks outward (how the type relates to the rest of the codebase).
+/// </summary>
+public interface ICouplingAnalysisService
+{
+    /// <summary>
+    /// Computes coupling metrics for types in the workspace.
+    /// </summary>
+    /// <param name="workspaceId">Workspace session identifier from <c>workspace_load</c>.</param>
+    /// <param name="projectFilter">Optional project name filter (case-insensitive exact match).</param>
+    /// <param name="limit">Maximum number of results to return.</param>
+    /// <param name="excludeTestProjects">When true, skip MSBuild test projects from analysis.</param>
+    /// <param name="includeInterfaces">When true, include interfaces alongside classes/structs/records.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<CouplingMetricsDto>> GetCouplingMetricsAsync(
+        string workspaceId,
+        string? projectFilter,
+        int limit,
+        bool excludeTestProjects,
+        bool includeInterfaces,
+        CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -134,6 +134,7 @@ public static class ServerSurfaceCatalog
 
         Tool("find_consumers", "analysis", "stable", true, false, "Find all types that depend on a given type or interface, classified by dependency kind."),
         Tool("get_cohesion_metrics", "analysis", "stable", true, false, "Measure type cohesion via LCOM4 metrics, identifying independent method clusters."),
+        Tool("get_coupling_metrics", "analysis", "stable", true, false, "Measure per-type afferent/efferent coupling + Martin's instability index."),
         Tool("find_shared_members", "analysis", "stable", true, false, "Find private members used by multiple public methods to inform type extractions."),
 
         Tool("move_type_to_file_preview", "refactoring", "stable", true, false, "Preview moving a type declaration into its own file."),

--- a/src/RoslynMcp.Host.Stdio/Tools/CouplingAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CouplingAnalysisTools.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+[McpServerToolType]
+public static class CouplingAnalysisTools
+{
+    [McpServerTool(Name = "get_coupling_metrics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("analysis", "stable", true, false,
+        "Measure per-type afferent/efferent coupling + Martin's instability index."),
+     Description("Compute per-type coupling metrics (Martin): AfferentCoupling Ca (incoming refs), EfferentCoupling Ce (outgoing refs), Instability I = Ce / (Ca + Ce). Classifies types as stable / balanced / unstable / isolated. Companion to get_cohesion_metrics — cohesion looks inward, coupling looks outward.")]
+    public static Task<string> GetCouplingMetrics(
+        IWorkspaceExecutionGate gate,
+        ICouplingAnalysisService couplingAnalysisService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name (case-insensitive exact match)")] string? projectName = null,
+        [Description("Maximum number of results to return (default: 100)")] int limit = 100,
+        [Description("When true, exclude MSBuild test projects (IsTestProject / test framework packages) from analysis")] bool excludeTestProjects = false,
+        [Description("When true, include interface types alongside classes/structs/records")] bool includeInterfaces = false,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var results = await couplingAnalysisService.GetCouplingMetricsAsync(
+                workspaceId, projectName, limit, excludeTestProjects, includeInterfaces, c);
+
+            return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonDefaults.Indented);
+        }, ct);
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISecurityDiagnosticService, SecurityDiagnosticService>();
         services.AddSingleton<IConsumerAnalysisService, ConsumerAnalysisService>();
         services.AddSingleton<ICohesionAnalysisService, CohesionAnalysisService>();
+        services.AddSingleton<ICouplingAnalysisService, CouplingAnalysisService>();
         services.AddSingleton<ITypeMoveService, TypeMoveService>();
         services.AddSingleton<INamespaceRelocationService, NamespaceRelocationService>();
         services.AddSingleton<IInterfaceExtractionService, InterfaceExtractionService>();

--- a/src/RoslynMcp.Roslyn/Services/CouplingAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CouplingAnalysisService.cs
@@ -1,0 +1,334 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Computes Robert C. Martin's afferent / efferent coupling and instability for each type in
+/// the workspace. Afferent coupling (Ca) is derived from <see cref="SymbolFinder"/> reference
+/// walks so we stay consistent with <c>find_references</c> / <c>find_consumers</c>; efferent
+/// coupling (Ce) is computed from a syntax+semantic pass over the type's own declaration trees.
+/// </summary>
+public sealed class CouplingAnalysisService : ICouplingAnalysisService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<CouplingAnalysisService> _logger;
+
+    public CouplingAnalysisService(IWorkspaceManager workspace, ILogger<CouplingAnalysisService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<CouplingMetricsDto>> GetCouplingMetricsAsync(
+        string workspaceId,
+        string? projectFilter,
+        int limit,
+        bool excludeTestProjects,
+        bool includeInterfaces,
+        CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter)
+            .Where(p => !excludeTestProjects || !ProjectMetadataParser.IsTestProject(p))
+            .ToList();
+
+        // Enumerate every candidate top-level type across the filtered projects. The tuple carries
+        // the compilation so the Ce pass downstream can build semantic models without a second
+        // GetCompilationAsync call per type.
+        var candidates = new List<(INamedTypeSymbol Type, Project Project, Compilation Compilation)>();
+        foreach (var project in projects)
+        {
+            if (ct.IsCancellationRequested) break;
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            foreach (var symbol in EnumerateDeclaredTypes(compilation.Assembly.GlobalNamespace))
+            {
+                if (ct.IsCancellationRequested) break;
+                if (!ShouldAnalyze(symbol, includeInterfaces)) continue;
+                candidates.Add((symbol, project, compilation));
+            }
+        }
+
+        var results = new List<CouplingMetricsDto>(candidates.Count);
+        foreach (var (type, project, compilation) in candidates)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                var metrics = await ComputeMetricsAsync(type, project, compilation, solution, ct).ConfigureAwait(false);
+                results.Add(metrics);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to compute coupling metrics for type '{TypeName}', skipping",
+                    type.ToDisplayString());
+            }
+        }
+
+        // Order: highest instability first (the "unstable" types most at risk of upstream churn),
+        // then Ce desc as a stable tiebreaker so the heavy outgoing-dependency types bubble up.
+        return results
+            .OrderByDescending(r => r.Instability)
+            .ThenByDescending(r => r.EfferentCoupling)
+            .ThenBy(r => r.FullyQualifiedName, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList();
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateDeclaredTypes(INamespaceSymbol ns)
+    {
+        foreach (var member in ns.GetMembers())
+        {
+            if (member is INamespaceSymbol child)
+            {
+                foreach (var t in EnumerateDeclaredTypes(child))
+                    yield return t;
+            }
+            else if (member is INamedTypeSymbol type)
+            {
+                yield return type;
+                // Nested types count too — they own their own afferent/efferent graph.
+                foreach (var nested in EnumerateNestedTypes(type))
+                    yield return nested;
+            }
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (var nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (var deeper in EnumerateNestedTypes(nested))
+                yield return deeper;
+        }
+    }
+
+    private static bool ShouldAnalyze(INamedTypeSymbol type, bool includeInterfaces)
+    {
+        // Only types declared in source in this compilation.
+        if (!type.Locations.Any(l => l.IsInSource)) return false;
+
+        // Skip compiler-generated types (anonymous types, display classes, etc.).
+        if (type.IsImplicitlyDeclared) return false;
+
+        return type.TypeKind switch
+        {
+            TypeKind.Class or TypeKind.Struct => true,
+            TypeKind.Interface => includeInterfaces,
+            _ => false,
+        };
+    }
+
+    private async Task<CouplingMetricsDto> ComputeMetricsAsync(
+        INamedTypeSymbol type, Project project, Compilation compilation, Solution solution, CancellationToken ct)
+    {
+        var afferent = await ComputeAfferentCouplingAsync(type, solution, ct).ConfigureAwait(false);
+        var efferent = await ComputeEfferentCouplingAsync(type, compilation, ct).ConfigureAwait(false);
+
+        var instability = ComputeInstability(afferent, efferent);
+        var classification = Classify(afferent, efferent, instability);
+
+        var sourceLoc = type.Locations.FirstOrDefault(l => l.IsInSource);
+        var lineSpan = sourceLoc?.GetLineSpan();
+
+        return new CouplingMetricsDto(
+            TypeName: type.Name,
+            FullyQualifiedName: type.ToDisplayString(),
+            FilePath: lineSpan?.Path,
+            Line: (lineSpan?.StartLinePosition.Line ?? 0) + 1,
+            ProjectName: project.Name,
+            AfferentCoupling: afferent,
+            EfferentCoupling: efferent,
+            Instability: instability,
+            Classification: classification)
+        {
+            TypeKind = type.TypeKind.ToString(),
+        };
+    }
+
+    /// <summary>
+    /// Counts DISTINCT external types that reference the target type. "External" = containing
+    /// type of the reference is not the same named type (partial declarations collapse into
+    /// one entity via <see cref="SymbolEqualityComparer"/>).
+    /// </summary>
+    private static async Task<int> ComputeAfferentCouplingAsync(
+        INamedTypeSymbol type, Solution solution, CancellationToken ct)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(type, solution, ct).ConfigureAwait(false);
+        var externalConsumers = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var referenced in references)
+        {
+            foreach (var loc in referenced.Locations)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                var doc = loc.Document;
+                var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                var semanticModel = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+                if (root is null || semanticModel is null) continue;
+
+                var node = root.FindNode(loc.Location.SourceSpan);
+                var containing = FindContainingTopLevelType(node, semanticModel, ct);
+                if (containing is null) continue;
+
+                if (SymbolEqualityComparer.Default.Equals(containing, type)) continue;
+                externalConsumers.Add(containing);
+            }
+        }
+
+        return externalConsumers.Count;
+    }
+
+    /// <summary>
+    /// Counts DISTINCT external types that THIS type references. Walks every identifier /
+    /// member-access / type reference inside every declaration (partials included) and
+    /// aggregates the distinct outbound named-type symbols via <see cref="SymbolEqualityComparer"/>.
+    /// Built-in primitive types from the BCL (<c>System</c> / <c>System.Collections.Generic</c>)
+    /// are excluded — counting them would drown the signal for every type.
+    /// </summary>
+    private static async Task<int> ComputeEfferentCouplingAsync(
+        INamedTypeSymbol type, Compilation compilation, CancellationToken ct)
+    {
+        var outbound = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var reference in type.DeclaringSyntaxReferences)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            var syntax = await reference.GetSyntaxAsync(ct).ConfigureAwait(false);
+            if (syntax is not TypeDeclarationSyntax typeDecl) continue;
+
+            var tree = syntax.SyntaxTree;
+            // The tree must belong to this compilation (the partials of a type always live in the
+            // same project, which is the compilation we were passed). Guard against a divergent
+            // snapshot just in case.
+            if (!compilation.SyntaxTrees.Contains(tree)) continue;
+
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            foreach (var descendant in typeDecl.DescendantNodes())
+            {
+                if (ct.IsCancellationRequested) break;
+
+                var symbolInfo = semanticModel.GetSymbolInfo(descendant, ct);
+                var referenced = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+                if (referenced is null) continue;
+
+                var namedType = ExtractNamedType(referenced);
+                if (namedType is null) continue;
+                if (!IsCountableEfferent(namedType, type)) continue;
+
+                outbound.Add(namedType);
+            }
+
+            // Also include the explicit base type + implemented interfaces. These appear in
+            // DescendantNodes as IdentifierNameSyntax nodes too, but pulling them off the
+            // semantic model directly guarantees we never miss a base-list entry regardless
+            // of how the syntax is shaped (simple identifier vs qualified vs generic).
+            if (semanticModel.GetDeclaredSymbol(typeDecl, ct) is INamedTypeSymbol declaredSymbol)
+            {
+                if (declaredSymbol.BaseType is { } baseType && IsCountableEfferent(baseType, type))
+                    outbound.Add(baseType);
+                foreach (var iface in declaredSymbol.Interfaces)
+                {
+                    if (IsCountableEfferent(iface, type))
+                        outbound.Add(iface);
+                }
+            }
+        }
+
+        return outbound.Count;
+    }
+
+    private static INamedTypeSymbol? ExtractNamedType(ISymbol symbol) => symbol switch
+    {
+        INamedTypeSymbol named => UnwrapConstructed(named),
+        IMethodSymbol method => UnwrapConstructed(method.ContainingType),
+        IFieldSymbol field => UnwrapConstructed(field.ContainingType),
+        IPropertySymbol prop => UnwrapConstructed(prop.ContainingType),
+        IEventSymbol evt => UnwrapConstructed(evt.ContainingType),
+        _ => null,
+    };
+
+    private static INamedTypeSymbol? UnwrapConstructed(INamedTypeSymbol? type)
+    {
+        if (type is null) return null;
+        // Map constructed generics (List<Foo>) back to their definition (List<T>) so every
+        // instantiation of the same generic counts as one outbound edge, not N.
+        return type.IsGenericType ? type.OriginalDefinition : type;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="candidate"/> is a real outbound dependency of
+    /// <paramref name="self"/> — i.e. a distinct, source-declared type that isn't a primitive.
+    /// </summary>
+    private static bool IsCountableEfferent(INamedTypeSymbol candidate, INamedTypeSymbol self)
+    {
+        if (candidate.IsImplicitlyDeclared) return false;
+        if (candidate.SpecialType != SpecialType.None) return false;
+
+        // Skip self (including nested-type-on-self chains).
+        if (SymbolEqualityComparer.Default.Equals(candidate, self)) return false;
+
+        // Skip nested types owned by self — they are part of the same outer type.
+        var outer = candidate.ContainingType;
+        while (outer is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(outer, self)) return false;
+            outer = outer.ContainingType;
+        }
+
+        // Only count types that have at least one source location. Pure metadata references
+        // (BCL, NuGet packages) are noise for coupling — Martin's metric is about module
+        // boundaries within the SUT, not transitive library usage.
+        return candidate.Locations.Any(l => l.IsInSource);
+    }
+
+    /// <summary>
+    /// Walks up the syntax tree from <paramref name="node"/> to find the enclosing top-level
+    /// named type (or nested type) and returns its symbol. Returns <c>null</c> when the
+    /// reference is outside any type (top-level statements, file-scoped using, etc.).
+    /// </summary>
+    private static INamedTypeSymbol? FindContainingTopLevelType(
+        SyntaxNode node, SemanticModel semanticModel, CancellationToken ct)
+    {
+        var current = node;
+        while (current is not null)
+        {
+            if (current is TypeDeclarationSyntax typeDecl)
+            {
+                return semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol;
+            }
+            current = current.Parent;
+        }
+        return null;
+    }
+
+    private static double ComputeInstability(int afferent, int efferent)
+    {
+        var total = afferent + efferent;
+        if (total == 0) return 0.0;
+        return (double)efferent / total;
+    }
+
+    private static string Classify(int afferent, int efferent, double instability)
+    {
+        if (afferent == 0 && efferent == 0) return "isolated";
+        if (instability < 0.3) return "stable";
+        if (instability > 0.7) return "unstable";
+        return "balanced";
+    }
+}

--- a/tests/RoslynMcp.Tests/CouplingAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CouplingAnalysisTests.cs
@@ -1,0 +1,240 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class CouplingAnalysisTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task GetCouplingMetrics_ReturnsMetrics_ForSampleWorkspace()
+    {
+        var result = await CouplingAnalysisService.GetCouplingMetricsAsync(
+            WorkspaceId, projectFilter: "SampleLib", limit: 100,
+            excludeTestProjects: false, includeInterfaces: false, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Count > 0, "Expected at least one type with coupling metrics.");
+
+        foreach (var m in result)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(m.TypeName));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(m.FullyQualifiedName));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(m.Classification));
+            Assert.IsTrue(m.AfferentCoupling >= 0, $"Ca must be non-negative for {m.TypeName}.");
+            Assert.IsTrue(m.EfferentCoupling >= 0, $"Ce must be non-negative for {m.TypeName}.");
+            Assert.IsTrue(m.Instability is >= 0.0 and <= 1.0,
+                $"Instability must be in [0,1] for {m.TypeName}, got {m.Instability}.");
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCouplingMetrics_WhenExcludeTestProjects_OmitsTestProjectTypes()
+    {
+        var result = await CouplingAnalysisService.GetCouplingMetricsAsync(
+            WorkspaceId, projectFilter: null, limit: 500,
+            excludeTestProjects: true, includeInterfaces: false, CancellationToken.None);
+
+        Assert.IsTrue(
+            result.All(m => m.FilePath is null ||
+                !m.FilePath.Contains("SampleLib.Tests", StringComparison.OrdinalIgnoreCase)),
+            "Types from MSBuild test projects should be omitted when excludeTestProjects is true.");
+    }
+
+    [TestMethod]
+    public async Task GetCouplingMetrics_AbcDependencyChain_MatchesMartinStabilityFormula()
+    {
+        // Plan validation fixture: A -> B -> C dependency chain.
+        //   A.Ce = 1 (references B), A.Ca = 0 -> I = 1 / (0+1) = 1.0 (unstable)
+        //   B.Ce = 1 (references C), B.Ca = 1 (A references B) -> I = 1 / (1+1) = 0.5 (balanced)
+        //   C.Ce = 0, C.Ca = 1 (B references C) -> I = 0 / (1+0) = 0.0 (stable)
+        // This is the canonical Martin-stability example and proves the service's Ca/Ce numbers
+        // are accurate (not just non-negative).
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "AbcChain.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib.CouplingFixture;
+
+public class TypeA
+{
+    private readonly TypeB _b = new TypeB();
+
+    public int DoWork() => _b.DoWork();
+}
+
+public class TypeB
+{
+    private readonly TypeC _c = new TypeC();
+
+    public int DoWork() => _c.Value;
+}
+
+public class TypeC
+{
+    public int Value => 42;
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CouplingAnalysisService.GetCouplingMetricsAsync(
+                workspaceId, projectFilter: "SampleLib", limit: 500,
+                excludeTestProjects: false, includeInterfaces: false, CancellationToken.None);
+
+            var a = metrics.FirstOrDefault(m => m.FullyQualifiedName == "SampleLib.CouplingFixture.TypeA");
+            var b = metrics.FirstOrDefault(m => m.FullyQualifiedName == "SampleLib.CouplingFixture.TypeB");
+            var c = metrics.FirstOrDefault(m => m.FullyQualifiedName == "SampleLib.CouplingFixture.TypeC");
+
+            Assert.IsNotNull(a, "TypeA should be in the metrics output.");
+            Assert.IsNotNull(b, "TypeB should be in the metrics output.");
+            Assert.IsNotNull(c, "TypeC should be in the metrics output.");
+
+            // A: Ce=1 (depends on B), Ca=0, I=1.0
+            Assert.AreEqual(0, a.AfferentCoupling, "TypeA has no incoming consumers — Ca must be 0.");
+            Assert.AreEqual(1, a.EfferentCoupling, "TypeA depends on TypeB — Ce must be 1.");
+            Assert.AreEqual(1.0, a.Instability, 1e-9, "TypeA I = Ce/(Ca+Ce) = 1/1 = 1.0 (maximally unstable).");
+            Assert.AreEqual("unstable", a.Classification);
+
+            // B: Ce=1 (depends on C), Ca=1 (A depends on B), I=0.5
+            Assert.AreEqual(1, b.AfferentCoupling, "TypeB is consumed by TypeA — Ca must be 1.");
+            Assert.AreEqual(1, b.EfferentCoupling, "TypeB depends on TypeC — Ce must be 1.");
+            Assert.AreEqual(0.5, b.Instability, 1e-9, "TypeB I = 1/(1+1) = 0.5 (balanced).");
+            Assert.AreEqual("balanced", b.Classification);
+
+            // C: Ce=0, Ca=1 (B depends on C), I=0.0
+            Assert.AreEqual(1, c.AfferentCoupling, "TypeC is consumed by TypeB — Ca must be 1.");
+            Assert.AreEqual(0, c.EfferentCoupling, "TypeC has no outbound deps — Ce must be 0.");
+            Assert.AreEqual(0.0, c.Instability, 1e-9, "TypeC I = 0/(1+0) = 0.0 (maximally stable).");
+            Assert.AreEqual("stable", c.Classification);
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCouplingMetrics_IsolatedType_ClassifiesAsIsolated()
+    {
+        // A type with no incoming and no outgoing references should be reported as "isolated"
+        // rather than "stable" — this avoids the misleading I=0 verdict for a class that simply
+        // nothing consumes and that consumes nothing (a dead-code candidate, not a stable one).
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "OrphanType.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib.CouplingFixture;
+
+public class OrphanType
+{
+    public int Value { get; set; }
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CouplingAnalysisService.GetCouplingMetricsAsync(
+                workspaceId, projectFilter: "SampleLib", limit: 500,
+                excludeTestProjects: false, includeInterfaces: false, CancellationToken.None);
+
+            var orphan = metrics.FirstOrDefault(m => m.FullyQualifiedName == "SampleLib.CouplingFixture.OrphanType");
+            Assert.IsNotNull(orphan, "OrphanType should be in the metrics output.");
+            Assert.AreEqual(0, orphan.AfferentCoupling);
+            Assert.AreEqual(0, orphan.EfferentCoupling);
+            Assert.AreEqual("isolated", orphan.Classification,
+                "A type with Ca=0 and Ce=0 should be reported as 'isolated', not 'stable'.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCouplingMetrics_BaseTypeAndInterface_CountTowardEfferent()
+    {
+        // Base-class + interface declarations in the base list are real outbound dependencies
+        // — they must show up in Ce regardless of whether the implementing class references
+        // the base via code inside its body.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "BaseAndIface.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib.CouplingFixture;
+
+public interface IThing
+{
+    int Get();
+}
+
+public abstract class ThingBase
+{
+    public abstract int Get();
+}
+
+public class ConcreteThing : ThingBase, IThing
+{
+    public override int Get() => 7;
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CouplingAnalysisService.GetCouplingMetricsAsync(
+                workspaceId, projectFilter: "SampleLib", limit: 500,
+                excludeTestProjects: false, includeInterfaces: true, CancellationToken.None);
+
+            var concrete = metrics.FirstOrDefault(m => m.FullyQualifiedName == "SampleLib.CouplingFixture.ConcreteThing");
+            Assert.IsNotNull(concrete, "ConcreteThing should be in the metrics output.");
+            // Ce should include ThingBase AND IThing (2 outbound types).
+            Assert.IsTrue(concrete.EfferentCoupling >= 2,
+                $"ConcreteThing Ce should include base class + interface (>= 2). Actual: {concrete.EfferentCoupling}.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -56,6 +56,7 @@ public abstract class TestBase
     protected static GatedCommandExecutor GatedCommandExecutor { get; private set; } = null!;
     protected static BulkRefactoringService BulkRefactoringService { get; private set; } = null!;
     protected static CohesionAnalysisService CohesionAnalysisService { get; private set; } = null!;
+    protected static CouplingAnalysisService CouplingAnalysisService { get; private set; } = null!;
     protected static ConsumerAnalysisService ConsumerAnalysisService { get; private set; } = null!;
     protected static TypeExtractionService TypeExtractionService { get; private set; } = null!;
     protected static TypeMoveService TypeMoveService { get; private set; } = null!;
@@ -150,6 +151,7 @@ public abstract class TestBase
         GatedCommandExecutor = services.GatedCommandExecutor;
         BulkRefactoringService = services.BulkRefactoringService;
         CohesionAnalysisService = services.CohesionAnalysisService;
+        CouplingAnalysisService = services.CouplingAnalysisService;
         ConsumerAnalysisService = services.ConsumerAnalysisService;
         TypeExtractionService = services.TypeExtractionService;
         TypeMoveService = services.TypeMoveService;

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -43,6 +43,7 @@ internal sealed class TestServiceContainer
     public required GatedCommandExecutor GatedCommandExecutor { get; init; }
     public required BulkRefactoringService BulkRefactoringService { get; init; }
     public required CohesionAnalysisService CohesionAnalysisService { get; init; }
+    public required CouplingAnalysisService CouplingAnalysisService { get; init; }
     public required ConsumerAnalysisService ConsumerAnalysisService { get; init; }
     public required TypeExtractionService TypeExtractionService { get; init; }
     public required TypeMoveService TypeMoveService { get; init; }
@@ -223,6 +224,9 @@ internal sealed class TestServiceContainer
             CohesionAnalysisService = new CohesionAnalysisService(
                 workspaceManager,
                 NullLogger<CohesionAnalysisService>.Instance),
+            CouplingAnalysisService = new CouplingAnalysisService(
+                workspaceManager,
+                NullLogger<CouplingAnalysisService>.Instance),
             ConsumerAnalysisService = new ConsumerAnalysisService(
                 workspaceManager,
                 NullLogger<ConsumerAnalysisService>.Instance),


### PR DESCRIPTION
## Summary

- New MCP tool `get_coupling_metrics(workspaceId, projectName?, limit, excludeTestProjects, includeInterfaces)` returns per-type afferent coupling (Ca), efferent coupling (Ce), Martin's instability index I = Ce/(Ca+Ce), and a stable / balanced / unstable / isolated classification. Companion to the existing `get_cohesion_metrics` — cohesion looks inward, coupling looks outward.
- Implementation uses `SymbolFinder.FindReferencesAsync` for Ca (reuses the same path as `find_consumers`) and a syntax+semantic walk over the type's own declaration trees for Ce. Outbound types are aggregated via `SymbolEqualityComparer` so each external named type counts once regardless of how many times it is referenced. Constructed generics are unwrapped to their definition so `List<Foo>` and `List<Bar>` don't both inflate the score. Metadata-only types (BCL, NuGet) are excluded — Martin's metric is about module boundaries within the SUT, not transitive library usage. Base classes and implemented interfaces are pulled off the semantic model directly to guarantee the base list always shows up in Ce.

## Scope

- **prod (3 non-exempt):** `CouplingMetricsDto`, `CouplingAnalysisService`, `CouplingAnalysisTools`.
- **structural units (Rule 3 exempt):** `ICouplingAnalysisService` interface, one-line DI registration in `ServiceCollectionExtensions`, one-line entry in `ServerSurfaceCatalog`, parallel wiring in `TestBase` + `TestServiceContainer`.
- **tests (+1):** `CouplingAnalysisTests` — 5 tests: sample-workspace smoke, test-project exclusion, the plan-validation A->B->C Martin fixture, isolated-type classification, base+interface Ce attribution.

## Test plan

- [x] A->B->C fixture: A.Ce=1 / A.Ca=0 / I=1.0 (unstable); B.Ce=1 / B.Ca=1 / I=0.5 (balanced); C.Ce=0 / C.Ca=1 / I=0.0 (stable) — matches Martin's formula exactly.
- [x] `dotnet build RoslynMcp.slnx --configuration Release` — 0 warnings, 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName~CouplingAnalysisTests"` — 5/5 passed.
- [x] `./eng/verify-ai-docs.ps1` — passed.
- [x] `./eng/verify-release.ps1 -Configuration Release` — 728 passed, 3 pre-existing flaky tests failed under full-suite MSBuild file-lock contention (`ApplyTextEdit_PreservesLineBreak_WhenSpanEndsAtColumn1`, `ExtractMethod_From_InstanceMethod_Reading_Field_Does_Not_Add_This_Parameter`, `DeleteFile_Then_Revert_Restores_File_With_Original_Content`). Each passes individually and also fails the same way when run against untouched `main` (verified via `git stash`). Unrelated to this change.

Closes: coupling-metrics-tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)