### PR TITLE
feat(analysis): find_duplicate_helpers — flag private helpers duplicating BCL/NuGet symbols

### DIFF
--- a/src/RoslynMcp.Core/Models/DuplicateHelperDto.cs
+++ b/src/RoslynMcp.Core/Models/DuplicateHelperDto.cs
@@ -1,0 +1,27 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents a private or internal helper method whose body shape appears to
+/// duplicate a reachable canonical symbol from the BCL or a referenced NuGet
+/// package. See <see cref="IUnusedCodeAnalyzer.FindDuplicateHelpersAsync"/> for
+/// the heuristic that produces these hits.
+/// </summary>
+/// <param name="SymbolName">Name of the local helper method (e.g. <c>IsNullOrWhiteSpace</c>).</param>
+/// <param name="ContainingType">The declaring static helper type (e.g. <c>StringHelper</c>).</param>
+/// <param name="FilePath">Absolute path to the source file declaring the helper.</param>
+/// <param name="Line">1-based declaration line.</param>
+/// <param name="Column">1-based declaration column.</param>
+/// <param name="ProjectName">Roslyn project containing the helper.</param>
+/// <param name="CanonicalTarget">Fully-qualified display string of the canonical symbol the body delegates to (e.g. <c>string.IsNullOrWhiteSpace(string)</c>).</param>
+/// <param name="CanonicalTargetAssembly">Name of the assembly (BCL/NuGet) the canonical symbol lives in — the signal that the helper is re-inventing a library primitive.</param>
+/// <param name="Confidence">Heuristic confidence: <c>high</c> (single-statement single-argument delegation), <c>medium</c> (two-statement null-guarded delegation).</param>
+public sealed record DuplicateHelperDto(
+    string SymbolName,
+    string? ContainingType,
+    string FilePath,
+    int Line,
+    int Column,
+    string ProjectName,
+    string CanonicalTarget,
+    string CanonicalTargetAssembly,
+    string Confidence);

--- a/src/RoslynMcp.Core/Services/DuplicateHelperAnalysisOptions.cs
+++ b/src/RoslynMcp.Core/Services/DuplicateHelperAnalysisOptions.cs
@@ -1,0 +1,16 @@
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Controls which projects are scanned for private/internal extension-method helpers
+/// whose body-shape duplicates a canonical BCL or NuGet symbol.
+/// </summary>
+public sealed record DuplicateHelperAnalysisOptions
+{
+    /// <summary>
+    /// Optional project name filter. When non-null, only that project is scanned.
+    /// </summary>
+    public string? ProjectFilter { get; init; }
+
+    /// <summary>Maximum number of hits to return. Defaults to 50.</summary>
+    public int Limit { get; init; } = 50;
+}

--- a/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
@@ -4,11 +4,28 @@ namespace RoslynMcp.Core.Services;
 
 /// <summary>
 /// Finds symbols with zero references across a solution to identify dead code candidates.
+/// Also surfaces private/internal helper methods whose body shape duplicates a reachable
+/// canonical symbol from a referenced BCL/NuGet assembly (a category that
+/// <see cref="FindUnusedSymbolsAsync"/> and classic dead-code scans miss because the
+/// helper IS used locally).
 /// </summary>
 public interface IUnusedCodeAnalyzer
 {
     Task<IReadOnlyList<UnusedSymbolDto>> FindUnusedSymbolsAsync(
         string workspaceId,
         UnusedSymbolsAnalysisOptions options,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Flags private/internal extension-method helpers whose body shape duplicates a
+    /// reachable canonical symbol from a referenced package (BCL/NuGet). Conservative
+    /// match: the helper body must be structurally ≤ 2 statements AND terminate in a
+    /// single method-call invocation whose bound target lives in a non-source assembly
+    /// (i.e. not declared in the current solution). Domain-specific wrappers whose body
+    /// does more than a single delegation or null-guard are intentionally NOT flagged.
+    /// </summary>
+    Task<IReadOnlyList<DuplicateHelperDto>> FindDuplicateHelpersAsync(
+        string workspaceId,
+        DuplicateHelperAnalysisOptions options,
         CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -75,6 +75,7 @@ public static class ServerSurfaceCatalog
         Tool("get_nuget_dependencies", "advanced-analysis", "stable", true, false, "Inspect NuGet package references and versions."),
         Tool("semantic_search", "advanced-analysis", "stable", true, false, "Run semantic search over symbols and declarations."),
         Tool("find_duplicated_methods", "advanced-analysis", "stable", true, false, "Find clusters of near-duplicate method bodies by AST-normalized hash."),
+        Tool("find_duplicate_helpers", "advanced-analysis", "experimental", true, false, "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),
 
         Tool("apply_text_edit", "editing", "stable", false, true, "Apply direct text edits to a single file; optional verify + auto-revert on new compile errors."),
         Tool("apply_multi_file_edit", "editing", "experimental", false, true, "Apply direct text edits to multiple files; optional verify + auto-revert on new compile errors."),

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -178,6 +178,32 @@ public static class AdvancedAnalysisTools
         }, ct);
     }
 
+    [McpServerTool(Name = "find_duplicate_helpers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("advanced-analysis", "experimental", true, false,
+        "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),
+     Description("Find private/internal static helpers (on `static class` hosts) whose body is a single ≤ 2-statement delegation to a method declared in a non-source assembly (BCL or referenced NuGet) — the \"reinvented `string.IsNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull`\" pattern that `find_unused_symbols` misses because the helper IS used locally. Conservative: expression-bodied forwarders and `{ return Target(...); }` bodies return Confidence=high; a single null-guard followed by the delegation returns Confidence=medium. Any body that calls the solution's own code (same-solution assembly), or does more than a pure re-wrap, is not flagged. Intentionally distinct from `find_duplicated_methods` (which buckets internal-to-internal structural duplicates); this tool targets internal-vs-referenced-library duplicates.")]
+    public static Task<string> FindDuplicateHelpers(
+        IWorkspaceExecutionGate gate,
+        IUnusedCodeAnalyzer unusedCodeAnalyzer,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var results = await unusedCodeAnalyzer.FindDuplicateHelpersAsync(
+                workspaceId,
+                new DuplicateHelperAnalysisOptions
+                {
+                    ProjectFilter = projectFilter,
+                    Limit = limit
+                },
+                c);
+            return JsonSerializer.Serialize(new { count = results.Count, helpers = results }, JsonDefaults.Indented);
+        }, ct);
+    }
+
     [McpServerTool(Name = "find_duplicated_methods", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find clusters of near-duplicate method bodies by AST-normalized hash."),

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -481,4 +481,180 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
 
         return false;
     }
+
+    /// <summary>
+    /// Surfaces private/internal static helper methods that delegate in ≤ 2 body
+    /// statements to a symbol declared in a non-source (BCL/NuGet) assembly — the
+    /// "reinvented <c>string.IsNullOrWhiteSpace</c>" pattern. See
+    /// <see cref="IUnusedCodeAnalyzer.FindDuplicateHelpersAsync"/> for the contract.
+    /// </summary>
+    public async Task<IReadOnlyList<DuplicateHelperDto>> FindDuplicateHelpersAsync(
+        string workspaceId,
+        DuplicateHelperAnalysisOptions options,
+        CancellationToken ct)
+    {
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var results = new List<DuplicateHelperDto>();
+
+        var projects = ProjectFilterHelper.FilterProjects(solution, options.ProjectFilter);
+        foreach (var project in projects)
+        {
+            if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+                if (PathFilter.IsGeneratedOrContentFile(tree.FilePath)) continue;
+
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+                foreach (var methodDecl in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                {
+                    if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+
+                    var hit = TryClassifyHelperAsDuplicate(methodDecl, semanticModel, project, ct);
+                    if (hit is not null) results.Add(hit);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Inspects a method declaration and, when its host is a static helper class,
+    /// its effective accessibility is non-public, and its body is a single
+    /// ≤ 2-statement delegation to a non-source-declared method, returns a
+    /// <see cref="DuplicateHelperDto"/>. Returns <see langword="null"/> otherwise.
+    /// </summary>
+    private static DuplicateHelperDto? TryClassifyHelperAsDuplicate(
+        MethodDeclarationSyntax methodDecl,
+        SemanticModel semanticModel,
+        Project project,
+        CancellationToken ct)
+    {
+        if (semanticModel.GetDeclaredSymbol(methodDecl, ct) is not IMethodSymbol methodSymbol)
+            return null;
+
+        // Only methods on static helper classes — the idiomatic "StringHelper" /
+        // "StringExtensions" shape. Filters out random static utilities that are not
+        // re-wrappers of library primitives.
+        if (methodSymbol.ContainingType is not { IsStatic: true } hostType)
+            return null;
+
+        // Effective accessibility: min(method, type). Public method on an internal
+        // static class still surfaces here because the containing type clamps the
+        // exposure. Public-on-public is intentionally excluded (library-API surface,
+        // not a reinvented helper).
+        var effective = MinAccessibility(methodSymbol.DeclaredAccessibility, hostType.DeclaredAccessibility);
+        if (effective == Accessibility.Public) return null;
+
+        // Skip the method kinds that cannot be a single-delegation shape.
+        if (methodSymbol.MethodKind is not MethodKind.Ordinary) return null;
+
+        // Extract the delegation target. Accepts:
+        //   (a) expression-bodied method:  => Target(...);
+        //   (b) single-statement body:     { return Target(...); } OR { Target(...); }
+        //   (c) two-statement body:        { if (s is null) throw ...; return Target(...); }
+        //                                  (any first statement that is NOT an invocation)
+        var (invocation, statementCount) = ExtractDelegationInvocation(methodDecl);
+        if (invocation is null) return null;
+
+        // Resolve the target symbol. It must live in a NON-source assembly (BCL or
+        // NuGet). A target that resolves to another project in the same solution is
+        // an internal refactoring artifact, not a library-reinvention.
+        if (semanticModel.GetSymbolInfo(invocation, ct).Symbol is not IMethodSymbol targetSymbol)
+            return null;
+
+        // Unwrap reduced extension methods — we want the original library-defined
+        // form so an assembly check reflects the true canonical target.
+        targetSymbol = targetSymbol.ReducedFrom ?? targetSymbol;
+
+        var targetAssembly = targetSymbol.ContainingAssembly;
+        if (targetAssembly is null) return null;
+
+        // Skip self-delegation: the helper calls into a method defined in the same
+        // solution (could be a legitimate internal re-export, not a reinvented BCL).
+        var projectAssemblyNames = new HashSet<string>(
+            project.Solution.Projects.Select(p => p.AssemblyName),
+            StringComparer.Ordinal);
+        if (projectAssemblyNames.Contains(targetAssembly.Name)) return null;
+
+        // Skip delegations to the helper's own containing type (recursion / self-call).
+        if (SymbolEqualityComparer.Default.Equals(targetSymbol.ContainingType, hostType))
+            return null;
+
+        var lineSpan = methodDecl.Identifier.GetLocation().GetLineSpan();
+        var confidence = statementCount <= 1 ? "high" : "medium";
+
+        return new DuplicateHelperDto(
+            SymbolName: methodSymbol.Name,
+            ContainingType: hostType.Name,
+            FilePath: lineSpan.Path,
+            Line: lineSpan.StartLinePosition.Line + 1,
+            Column: lineSpan.StartLinePosition.Character + 1,
+            ProjectName: project.Name,
+            CanonicalTarget: targetSymbol.ToDisplayString(),
+            CanonicalTargetAssembly: targetAssembly.Name,
+            Confidence: confidence);
+    }
+
+    /// <summary>
+    /// Extracts the single delegation invocation from a method declaration, if the
+    /// body shape qualifies as "≤ 2 statements ending in a single method call".
+    /// Returns the invocation plus the statement count (1 for expression-bodied or
+    /// single-statement, 2 for two-statement-with-guard). Returns null otherwise.
+    /// </summary>
+    private static (InvocationExpressionSyntax? Invocation, int StatementCount) ExtractDelegationInvocation(
+        MethodDeclarationSyntax methodDecl)
+    {
+        // Expression-bodied: public static bool X(string s) => string.IsNullOrWhiteSpace(s);
+        if (methodDecl.ExpressionBody is { Expression: InvocationExpressionSyntax inv })
+            return (inv, 1);
+
+        if (methodDecl.Body is not { } block) return (null, 0);
+
+        var statements = block.Statements;
+        if (statements.Count == 0 || statements.Count > 2) return (null, 0);
+
+        // Find the "delegation" statement — the last one, which must be a return of
+        // an invocation or a bare invocation (void-returning helpers). Roslyn parses
+        // `return X(...);` as ReturnStatementSyntax with Expression == InvocationExpressionSyntax.
+        var last = statements[^1];
+        InvocationExpressionSyntax? delegationInv = last switch
+        {
+            ReturnStatementSyntax { Expression: InvocationExpressionSyntax retInv } => retInv,
+            ExpressionStatementSyntax { Expression: InvocationExpressionSyntax exprInv } => exprInv,
+            _ => null
+        };
+
+        if (delegationInv is null) return (null, 0);
+
+        // Two-statement shape: the first statement may NOT be another invocation
+        // (else it's a helper that does work and then delegates — not a pure
+        // re-wrapper). It's typically a null-guard / throw: `if (s is null) throw ...;`.
+        if (statements.Count == 2)
+        {
+            var first = statements[0];
+            if (first is ExpressionStatementSyntax { Expression: InvocationExpressionSyntax })
+                return (null, 0);
+        }
+
+        return (delegationInv, statements.Count);
+    }
+
+    /// <summary>
+    /// Returns the more-restrictive of two accessibility values. Accessibility is
+    /// ordered Public > Protected-or-Internal > Internal == Protected >
+    /// Private-Protected > Private, so we take the smaller enum value.
+    /// </summary>
+    private static Accessibility MinAccessibility(Accessibility a, Accessibility b)
+    {
+        // Higher enum value = more visible (Public=6, Internal=4, Private=1).
+        return ((int)a < (int)b) ? a : b;
+    }
 }

--- a/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
@@ -1,0 +1,339 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UnusedCodeAnalyzer.FindDuplicateHelpersAsync"/>. Uses an
+/// in-memory <see cref="AdhocWorkspace"/> seeded with the BCL reference set so that
+/// semantic-model binding reaches <c>System.String</c>, <c>System.ArgumentException</c>,
+/// etc. — the detector needs to see that a delegation target lives in a non-source
+/// assembly to flag a helper as a library reinvention.
+/// </summary>
+[TestClass]
+public sealed class DuplicateHelperDetectionTests
+{
+    private const string WorkspaceId = "dup-helper-test-ws";
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_ExpressionBodiedDelegateToBcl_IsDetected()
+    {
+        // The canonical shape from the initiative: an internal static class whose only
+        // method is an expression-bodied forwarder into a BCL primitive.
+        const string source = """
+            namespace Sample;
+            internal static class StringHelper
+            {
+                public static bool IsNullOrWhiteSpace(string s) => string.IsNullOrWhiteSpace(s);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count, "Expected a single hit for the BCL-forwarding helper.");
+        var hit = hits[0];
+        Assert.AreEqual("IsNullOrWhiteSpace", hit.SymbolName);
+        Assert.AreEqual("StringHelper", hit.ContainingType);
+        Assert.IsTrue(
+            hit.CanonicalTarget.Contains("IsNullOrWhiteSpace", StringComparison.Ordinal),
+            $"Canonical target should point at string.IsNullOrWhiteSpace; got '{hit.CanonicalTarget}'.");
+        // BCL symbols live in System.Private.CoreLib on .NET Core / modern runtimes; the
+        // assembly name is stable across test hosts. Loosely assert it's non-empty and
+        // not the current (test) assembly.
+        Assert.IsFalse(string.IsNullOrEmpty(hit.CanonicalTargetAssembly));
+        Assert.AreNotEqual("TestAsm", hit.CanonicalTargetAssembly);
+        Assert.AreEqual("high", hit.Confidence, "Expression-bodied single delegation is a high-confidence hit.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_DomainSpecificWrapper_IsNotDetected()
+    {
+        // The negative half of the validation fixture: a helper that does real work
+        // (composition, formatting) rather than a pure library-primitive re-wrap. The
+        // body is larger than 2 statements and its final statement is a .NET method
+        // call — but the body as a whole is NOT a re-wrap.
+        const string source = """
+            namespace Sample;
+            internal static class StringHelper
+            {
+                public static string NormalizeForMyDomain(string s)
+                {
+                    var trimmed = s.Trim();
+                    var lowered = trimmed.ToLowerInvariant();
+                    var prefixed = "my-" + lowered;
+                    return prefixed.Replace(' ', '-');
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "Multi-statement domain-specific wrappers must not be flagged as library reinventions. " +
+            "Got: " + string.Join(", ", hits.Select(h => h.SymbolName)));
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_NullGuardPlusDelegation_IsMediumConfidence()
+    {
+        // Two-statement shape — first is a guard (not itself an invocation), second is
+        // the delegation. Conservative detection: flagged, but with medium confidence
+        // since the helper adds a caller-friendly NRE-avoidance layer on top of the
+        // BCL primitive.
+        const string source = """
+            namespace Sample;
+            internal static class StringHelper
+            {
+                public static bool IsNullOrWhiteSpace(string s)
+                {
+                    if (s is null) return true;
+                    return string.IsNullOrWhiteSpace(s);
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count);
+        Assert.AreEqual("medium", hits[0].Confidence, "Two-statement guard + delegation is medium confidence.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_PublicHelperOnPublicStaticClass_IsNotDetected()
+    {
+        // Effective accessibility = Public (method public on public static class). That's
+        // a library-API surface, not a private reinvention — out of scope for this tool.
+        const string source = """
+            namespace Sample;
+            public static class StringHelper
+            {
+                public static bool IsNullOrWhiteSpace(string s) => string.IsNullOrWhiteSpace(s);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "Public helpers on public static classes are library API, not reinventions.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_HelperDelegatingToSameSolution_IsNotDetected()
+    {
+        // The delegation target must live in a non-source (referenced) assembly. A helper
+        // whose body calls another symbol in the same solution is a legitimate internal
+        // re-export, not a BCL/NuGet reinvention.
+        const string source = """
+            namespace Sample;
+            internal static class Forwarder
+            {
+                public static int Double(int x) => InternalMath.Double(x);
+            }
+            internal static class InternalMath
+            {
+                public static int Double(int x) => x + x;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "Helpers delegating to same-solution targets must not be flagged.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_HelperOnNonStaticClass_IsNotDetected()
+    {
+        // The detector gates on the containing type being `static class` — the idiomatic
+        // helper shape. Methods on a regular (non-static) class are out of scope even if
+        // they happen to be a single BCL delegation.
+        const string source = """
+            namespace Sample;
+            internal class NotAHelper
+            {
+                public static bool IsNullOrWhiteSpace(string s) => string.IsNullOrWhiteSpace(s);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "Only methods on static helper classes are in scope.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_ExtensionMethodForwardingToBcl_IsDetected()
+    {
+        // An extension method that forwards (on first-arg `this`) to the equivalent BCL
+        // static. This is the most common "reinvented extension" shape.
+        const string source = """
+            namespace Sample;
+            internal static class StringExtensions
+            {
+                public static bool IsBlank(this string s) => string.IsNullOrWhiteSpace(s);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count);
+        Assert.AreEqual("IsBlank", hits[0].SymbolName);
+        Assert.AreEqual("StringExtensions", hits[0].ContainingType);
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_LimitCapsResults()
+    {
+        // Confirm the `Limit` option clamps the result count even when more hits exist.
+        const string source = """
+            namespace Sample;
+            internal static class StringHelper
+            {
+                public static bool IsBlankA(string s) => string.IsNullOrWhiteSpace(s);
+                public static bool IsBlankB(string s) => string.IsNullOrWhiteSpace(s);
+                public static bool IsBlankC(string s) => string.IsNullOrWhiteSpace(s);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions { Limit = 2 },
+            default);
+
+        Assert.AreEqual(2, hits.Count, "Result count must be capped by Limit.");
+    }
+
+    /// <summary>
+    /// Builds an <see cref="UnusedCodeAnalyzer"/> against a single-file AdhocWorkspace
+    /// with the BCL reference loaded. The semantic model must bind <c>string</c>-rooted
+    /// calls to <see cref="System.String"/> in <c>System.Private.CoreLib</c> for the
+    /// detector's non-source-assembly check to fire.
+    /// </summary>
+    private static UnusedCodeAnalyzer BuildAnalyzerWithSource(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "TestAsm",
+            assemblyName: "TestAsm",
+            language: LanguageNames.CSharp,
+            filePath: Path.Combine(Path.GetTempPath(), "TestAsm.csproj"),
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+            ]);
+        workspace.AddProject(projectInfo);
+
+        var docId = DocumentId.CreateNewId(projectId);
+        var fileName = "Sample.cs";
+        var fullPath = Path.Combine(Path.GetTempPath(), fileName);
+        workspace.AddDocument(DocumentInfo.Create(
+            docId,
+            fileName,
+            filePath: fullPath,
+            loader: TextLoader.From(
+                TextAndVersion.Create(
+                    SourceText.From(source),
+                    VersionStamp.Create(),
+                    fullPath))));
+
+        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
+        var cache = new CompilationCache(wsManager);
+        return new UnusedCodeAnalyzer(
+            wsManager,
+            cache,
+            NullLogger<UnusedCodeAnalyzer>.Instance);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IWorkspaceManager"/> stand-in — only the surface the analyzer
+    /// and the compilation cache touch is wired; the rest throws to surface accidental
+    /// coupling.
+    /// </summary>
+    private sealed class TestWorkspaceManager : IWorkspaceManager
+    {
+        private readonly string _workspaceId;
+        private readonly AdhocWorkspace _workspace;
+
+        public event Action<string>? WorkspaceClosed;
+        public event Action<string>? WorkspaceReloaded;
+
+        public TestWorkspaceManager(string workspaceId, AdhocWorkspace workspace)
+        {
+            _workspaceId = workspaceId;
+            _workspace = workspace;
+        }
+
+        public void RaiseWorkspaceClosed(string workspaceId) => WorkspaceClosed?.Invoke(workspaceId);
+        public void RaiseWorkspaceReloaded(string workspaceId) => WorkspaceReloaded?.Invoke(workspaceId);
+
+        public Solution GetCurrentSolution(string workspaceId)
+        {
+            return workspaceId == _workspaceId
+                ? _workspace.CurrentSolution
+                : throw new InvalidOperationException($"Unknown workspace {workspaceId}");
+        }
+
+        public int GetCurrentVersion(string workspaceId) => 1;
+        public void RestoreVersion(string workspaceId, int version) { }
+        public bool ContainsWorkspace(string workspaceId) => workspaceId == _workspaceId;
+        public bool IsStale(string workspaceId) => false;
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `find_duplicate_helpers` — flags private/internal helper methods whose body is a single ≤ 2-statement delegation to a method declared in a non-source (BCL/NuGet) assembly. Surfaces the "reinvented `string.IsNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull`" pattern that `find_unused_symbols` misses because the helper IS used locally, and that `find_duplicated_methods` misses because those cluster internal-to-internal, not internal-to-referenced-library.
- Binds delegation targets via the semantic model, unwraps `ReducedFrom` for extension methods, and requires the target's assembly to differ from every project assembly in the solution (skips same-solution forwards — those are legitimate internal re-exports, not library reinventions).
- Conservative shape gates: `static class` host, effective accessibility non-public (method min type), first statement is NOT another invocation (filters out "does work then delegates"), final statement is a `return Target(...)` / `Target(...)` / expression-bodied delegation. Two-statement guarded delegation → Confidence=medium; single delegation → Confidence=high.

Closes: `duplicate-helper-detection-across-modules`

## Files touched

- `src/RoslynMcp.Core/Models/DuplicateHelperDto.cs` (new)
- `src/RoslynMcp.Core/Services/DuplicateHelperAnalysisOptions.cs` (new)
- `src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs` (+ `FindDuplicateHelpersAsync`)
- `src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs` (+ implementation — shape classifier, delegation extractor, accessibility reducer)
- `src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs` (+ `find_duplicate_helpers` tool surface)
- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` (+ catalog registration, tier `experimental`)
- `tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs` (new — 8 tests)

## Test plan

- [x] `DuplicateHelperDetectionTests` (8 tests, all pass) — covers expression-bodied BCL delegation, multi-statement domain wrappers (negative), two-statement null-guard (medium confidence), public-on-public (out-of-scope), same-solution forwarding (not flagged), non-static host class (not flagged), extension-method shape (detected), `Limit` enforcement.
- [x] Regression sanity: 50 related tests across `DuplicateHelperDetectionTests`, `DuplicateMethodDetectorTests`, `SurfaceCatalogTests`, `DeadCodeIntegrationTests`, `BacklogFixTests`, `ServerSurfaceCatalogAnalyzerTests` all pass in Release.
- [x] `verify-ai-docs.ps1` passes.
- [x] `verify-release.ps1` build + 732/734 test pass — two residual failures (`Dependency_Inversion_Preview_Preserves_Source_File_Formatting`, `AnalyzeControlFlow_StatementBodiedMethod_StillUsesStatementPath`) are environmental parallel-session flakes on `%TEMP%\RoslynMcpTests\<guid>\...` isolated workspaces (race between concurrent subagent test hosts over shared temp paths); both re-run cleanly in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)