### PR TITLE
feat(analysis): preview_record_field_addition — audit positional, deconstruction, pattern, with-expression sites (breaking-change-impact-preview-for-positional-records)

### DIFF
--- a/src/RoslynMcp.Core/Models/RecordFieldAdditionImpactDto.cs
+++ b/src/RoslynMcp.Core/Models/RecordFieldAdditionImpactDto.cs
@@ -1,0 +1,124 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Result of <c>preview_record_field_addition</c>: every site impacted by adding a positional
+/// field to a positional record. Each bucket represents a structurally distinct breakage that
+/// the C# compiler would NOT catch on its own (positional ctors are caught — pattern-match,
+/// deconstruction, and <c>with</c>-shape sites are NOT, beyond the trivial cases).
+/// </summary>
+/// <param name="TargetRecordDisplay">Fully qualified display name of the analyzed record.</param>
+/// <param name="IsPositionalRecord">
+/// <c>true</c> when the record has a primary constructor (positional fields). When <c>false</c>,
+/// only <see cref="WithExpressionSites"/> are populated — adding a property to a non-positional
+/// record only breaks <c>with { ... }</c> consumers that explicitly omit the new property when
+/// the property is required.
+/// </param>
+/// <param name="NewField">The proposed added field (name, type, optional default expression).</param>
+/// <param name="ExistingPositionalParameters">
+/// The current positional parameter list of the target record, in declaration order. Empty when
+/// <see cref="IsPositionalRecord"/> is <c>false</c>.
+/// </param>
+/// <param name="PositionalConstructionSites">
+/// Every <c>new TargetRecord(arg1, arg2, ...)</c> call site whose argument count matches the
+/// existing positional ctor (these will fail to compile after the field is added unless an
+/// extra argument is passed). Each entry includes a suggested rewritten argument list.
+/// </param>
+/// <param name="DeconstructionSites">
+/// Every <c>var (a, b) = record;</c> deconstruction call site (and corresponding switch /
+/// is-pattern positional-deconstruction sites). Each entry includes a suggested rewritten
+/// pattern with a placeholder for the new field.
+/// </param>
+/// <param name="PropertyPatternSites">
+/// Every <c>record is { Foo: x, Bar: y }</c> property-pattern site that references the target
+/// record. Flagged with <c>MissedCorrelation</c> when the pattern is exhaustive in spirit
+/// (uses every existing field) but does not yet name the new field — these are the high-signal
+/// correlations a reviewer should audit.
+/// </param>
+/// <param name="WithExpressionSites">
+/// Every <c>existing with { ... }</c> site. Always populated regardless of
+/// <see cref="IsPositionalRecord"/> because <c>with</c>-expressions work on every record kind
+/// and are sensitive to required-property changes.
+/// </param>
+/// <param name="TestFilesConstructing">
+/// Distinct test file paths (under any <c>*.Tests</c> project, or files matching <c>*Tests.cs</c>
+/// / <c>*Spec.cs</c>) that mention the target record. Test sites are typically the densest
+/// remediation cluster and benefit from being grouped separately so reviewers can plan a
+/// single test-fixture sweep.
+/// </param>
+/// <param name="SuggestedTasks">
+/// Human-readable remediation hints derived from the populated buckets — e.g. how many sites
+/// need an updated argument list, how many patterns may be missing the new field.
+/// </param>
+public sealed record RecordFieldAdditionImpactDto(
+    string TargetRecordDisplay,
+    bool IsPositionalRecord,
+    NewRecordFieldDto NewField,
+    IReadOnlyList<ExistingPositionalParameterDto> ExistingPositionalParameters,
+    IReadOnlyList<RecordPositionalConstructionSiteDto> PositionalConstructionSites,
+    IReadOnlyList<RecordDeconstructionSiteDto> DeconstructionSites,
+    IReadOnlyList<RecordPropertyPatternSiteDto> PropertyPatternSites,
+    IReadOnlyList<RecordWithExpressionSiteDto> WithExpressionSites,
+    IReadOnlyList<string> TestFilesConstructing,
+    IReadOnlyList<string> SuggestedTasks);
+
+/// <summary>The proposed new positional field on the target record.</summary>
+/// <param name="Name">The new field/property name (PascalCase, valid C# identifier).</param>
+/// <param name="Type">The new field/property type (display string, e.g. <c>bool</c>, <c>System.Guid</c>).</param>
+/// <param name="DefaultValueExpression">
+/// Optional default-value expression to splice into rewritten construction sites
+/// (e.g. <c>false</c>, <c>null</c>, <c>Guid.Empty</c>). When <c>null</c>, the rewritten
+/// argument list uses the placeholder <c>/* TODO: NewField */</c>.
+/// </param>
+public sealed record NewRecordFieldDto(string Name, string Type, string? DefaultValueExpression);
+
+/// <summary>One existing positional parameter on the target record.</summary>
+/// <param name="Name">The parameter name (matches the auto-generated property name).</param>
+/// <param name="Type">The parameter type display string.</param>
+public sealed record ExistingPositionalParameterDto(string Name, string Type);
+
+/// <summary>
+/// One <c>new TargetRecord(...)</c> construction site whose argument count matches the existing
+/// positional constructor. Carries a suggested rewritten argument list with the new field
+/// inserted at the end.
+/// </summary>
+/// <param name="Location">Source location of the construction expression.</param>
+/// <param name="OriginalArgumentList">The original argument list as written, e.g. <c>(1, "x")</c>.</param>
+/// <param name="SuggestedArgumentList">The suggested rewritten argument list, e.g. <c>(1, "x", false)</c>.</param>
+public sealed record RecordPositionalConstructionSiteDto(
+    LocationDto Location,
+    string OriginalArgumentList,
+    string SuggestedArgumentList);
+
+/// <summary>
+/// One deconstruction site of the form <c>var (a, b) = record;</c>, including
+/// positional patterns inside <c>switch</c> / <c>is</c>.
+/// </summary>
+/// <param name="Location">Source location of the deconstruction expression / pattern.</param>
+/// <param name="OriginalPattern">The original deconstruction shape, e.g. <c>(a, b)</c>.</param>
+/// <param name="SuggestedPattern">The suggested rewritten shape with the new field, e.g. <c>(a, b, _)</c>.</param>
+public sealed record RecordDeconstructionSiteDto(
+    LocationDto Location,
+    string OriginalPattern,
+    string SuggestedPattern);
+
+/// <summary>
+/// One property-pattern site of the form <c>record is { Foo: x, Bar: y }</c>.
+/// </summary>
+/// <param name="Location">Source location of the property pattern.</param>
+/// <param name="OriginalPattern">The original property-pattern shape (e.g. <c>{ Foo: x, Bar: y }</c>).</param>
+/// <param name="MissedCorrelation">
+/// <c>true</c> when the pattern names every existing positional field (suggesting it was meant
+/// to be exhaustive) but does not yet name the new field. These are the highest-signal sites
+/// for reviewer attention.
+/// </param>
+public sealed record RecordPropertyPatternSiteDto(
+    LocationDto Location,
+    string OriginalPattern,
+    bool MissedCorrelation);
+
+/// <summary>One <c>existing with { ... }</c> site.</summary>
+/// <param name="Location">Source location of the <c>with</c> expression.</param>
+/// <param name="OriginalExpression">The original <c>with</c> initializer block (e.g. <c>{ Foo = 1 }</c>).</param>
+public sealed record RecordWithExpressionSiteDto(
+    LocationDto Location,
+    string OriginalExpression);

--- a/src/RoslynMcp.Core/Services/IRecordFieldAdditionService.cs
+++ b/src/RoslynMcp.Core/Services/IRecordFieldAdditionService.cs
@@ -1,0 +1,40 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Pre-flight audit for adding a positional field to a record. Positional record changes are a
+/// canonical source of silent breakage: the C# compiler catches positional-ctor argument mismatches
+/// but not deconstruction shape, property-pattern coverage, or <c>with</c>-expression assumptions.
+/// This service classifies every reachable site so a reviewer can plan the change before applying it.
+/// </summary>
+public interface IRecordFieldAdditionService
+{
+    /// <summary>
+    /// Computes a <see cref="RecordFieldAdditionImpactDto"/> for the named record. Resolves the
+    /// record by metadata name, walks the cross-solution references, and classifies each one
+    /// into the five impact buckets.
+    /// </summary>
+    /// <param name="workspaceId">Workspace session identifier from <c>workspace_load</c>.</param>
+    /// <param name="recordMetadataName">Fully qualified metadata name of the target record (e.g. <c>SampleLib.MyRecord</c>).</param>
+    /// <param name="newFieldName">The proposed new positional field name (PascalCase, valid C# identifier).</param>
+    /// <param name="newFieldType">The proposed new field type (display string, e.g. <c>bool</c>, <c>System.Guid</c>).</param>
+    /// <param name="defaultValueExpression">
+    /// Optional default-value expression. When provided, suggested rewrites splice this in;
+    /// otherwise rewrites use a <c>/* TODO */</c> placeholder.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="System.Collections.Generic.KeyNotFoundException">
+    /// Thrown when no type can be resolved for <paramref name="recordMetadataName"/> in the workspace.
+    /// </exception>
+    /// <exception cref="System.ArgumentException">
+    /// Thrown when the resolved type is not a record (record class or record struct).
+    /// </exception>
+    Task<RecordFieldAdditionImpactDto> PreviewAdditionAsync(
+        string workspaceId,
+        string recordMetadataName,
+        string newFieldName,
+        string newFieldType,
+        string? defaultValueExpression,
+        CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -136,6 +136,7 @@ public static class ServerSurfaceCatalog
         Tool("find_consumers", "analysis", "stable", true, false, "Find all types that depend on a given type or interface, classified by dependency kind."),
         Tool("get_cohesion_metrics", "analysis", "stable", true, false, "Measure type cohesion via LCOM4 metrics, identifying independent method clusters."),
         Tool("get_coupling_metrics", "analysis", "stable", true, false, "Measure per-type afferent/efferent coupling + Martin's instability index."),
+        Tool("preview_record_field_addition", "analysis", "experimental", true, false, "Pre-flight audit: every site impacted by adding a positional field to a record."),
         Tool("find_shared_members", "analysis", "stable", true, false, "Find private members used by multiple public methods to inform type extractions."),
 
         Tool("move_type_to_file_preview", "refactoring", "stable", true, false, "Preview moving a type declaration into its own file."),

--- a/src/RoslynMcp.Host.Stdio/Tools/RecordImpactTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RecordImpactTools.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// Tools that audit record-shape changes (positional field addition, etc.). Distinct from
+/// <see cref="ImpactSweepTools"/> (which handles general symbol-impact sweeps) because record-shape
+/// breakage has its own structural categories — pattern matches, deconstructions, <c>with</c>
+/// expressions — that need separate buckets in the response.
+/// </summary>
+[McpServerToolType]
+public static class RecordImpactTools
+{
+    [McpServerTool(Name = "preview_record_field_addition", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("analysis", "experimental", true, false,
+        "Pre-flight audit: every site impacted by adding a positional field to a record."),
+     Description("Pre-flight audit for adding a positional field to a record. Returns positional construction sites (with rewritten arg lists), deconstruction sites (with rewritten patterns), property-pattern sites (flagged when exhaustive-in-spirit but missing the new field), `with`-expression sites, and test files that mention the record. Catches the breaking-change shapes the C# compiler does NOT flag: pattern coverage, deconstruction shape, with-expression assumptions.")]
+    public static Task<string> PreviewRecordFieldAddition(
+        IWorkspaceExecutionGate gate,
+        IRecordFieldAdditionService recordFieldAdditionService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Fully qualified metadata name of the target record (e.g. 'SampleLib.MyRecord')")] string recordMetadataName,
+        [Description("The proposed new positional field name (PascalCase, valid C# identifier)")] string newFieldName,
+        [Description("The proposed new field type display string (e.g. 'bool', 'System.Guid', 'string?')")] string newFieldType,
+        [Description("Optional default-value expression to splice into rewritten construction sites (e.g. 'false', 'Guid.Empty'). When null, rewrites use a /* TODO */ placeholder.")] string? defaultValue = null,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var dto = await recordFieldAdditionService.PreviewAdditionAsync(
+                workspaceId, recordMetadataName, newFieldName, newFieldType, defaultValue, c).ConfigureAwait(false);
+            return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
+        }, ct);
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IConsumerAnalysisService, ConsumerAnalysisService>();
         services.AddSingleton<ICohesionAnalysisService, CohesionAnalysisService>();
         services.AddSingleton<ICouplingAnalysisService, CouplingAnalysisService>();
+        services.AddSingleton<IRecordFieldAdditionService, RecordFieldAdditionService>();
         services.AddSingleton<ITypeMoveService, TypeMoveService>();
         services.AddSingleton<INamespaceRelocationService, NamespaceRelocationService>();
         services.AddSingleton<IInterfaceExtractionService, InterfaceExtractionService>();

--- a/src/RoslynMcp.Roslyn/Services/RecordFieldAdditionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RecordFieldAdditionService.cs
@@ -1,0 +1,697 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Implements <see cref="IRecordFieldAdditionService"/>. Walks the cross-solution references for the
+/// target record and classifies each reference site into one of five buckets:
+/// <list type="number">
+///   <item><description>Positional-construction sites (<c>new R(a, b)</c>) whose arity matches the existing primary ctor.</description></item>
+///   <item><description>Deconstruction sites (<c>var (a, b) = r</c>, plus <c>switch</c> / <c>is</c> positional patterns).</description></item>
+///   <item><description>Property-pattern sites (<c>r is { Foo: x, Bar: y }</c>) — flagged as a missed correlation when the pattern is in-spirit-exhaustive over the existing positional fields.</description></item>
+///   <item><description><c>with</c>-expression sites (<c>existing with { ... }</c>).</description></item>
+///   <item><description>Test-file paths that mention the record (deduped, sorted).</description></item>
+/// </list>
+/// Construction-site rewrites splice the new field into the argument list; deconstruction-site
+/// rewrites splice <c>_</c> as the new positional discard. The compiler natively catches the
+/// construction case (CS7036), but every other bucket compiles silently, which is what makes the
+/// pre-flight audit useful.
+/// </summary>
+public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<RecordFieldAdditionService> _logger;
+
+    public RecordFieldAdditionService(IWorkspaceManager workspace, ILogger<RecordFieldAdditionService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<RecordFieldAdditionImpactDto> PreviewAdditionAsync(
+        string workspaceId,
+        string recordMetadataName,
+        string newFieldName,
+        string newFieldType,
+        string? defaultValueExpression,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(recordMetadataName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newFieldName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newFieldType);
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveByMetadataNameAsync(solution, recordMetadataName, ct).ConfigureAwait(false);
+        if (symbol is not INamedTypeSymbol typeSymbol)
+        {
+            throw new KeyNotFoundException($"No type resolved for metadata name '{recordMetadataName}'.");
+        }
+        if (!typeSymbol.IsRecord)
+        {
+            throw new ArgumentException(
+                $"Type '{recordMetadataName}' is not a record. preview_record_field_addition only " +
+                "supports record class / record struct types.",
+                nameof(recordMetadataName));
+        }
+
+        var newField = new NewRecordFieldDto(newFieldName, newFieldType, defaultValueExpression);
+        var existingPositionalParameters = ExtractPositionalParameters(typeSymbol);
+        var isPositional = existingPositionalParameters.Count > 0;
+
+        // Cross-solution reference walk. SymbolFinder collapses partial declarations, generic
+        // instantiations, and projects into one stream. We use it to (a) drive the per-location
+        // classification for type-name references (ObjectCreation, RecursivePattern) AND (b)
+        // identify the set of documents that mention the record, so we can do a second
+        // SyntaxWalker pass over those documents to catch sites that don't directly reference
+        // the type symbol — most notably `var (a, b) = r;` (references the local only) and
+        // `x with { ... }` (references the local whose type is the target). Without the
+        // document-level walk those sites would be silently missed.
+        var references = await SymbolFinder.FindReferencesAsync(typeSymbol, solution, ct).ConfigureAwait(false);
+        var refLocations = references
+            .SelectMany(r => r.Locations)
+            .Where(l => !l.IsImplicit)
+            .ToList();
+
+        var materialized = await ReferenceLocationMaterializer.MaterializeAsync(refLocations, ct).ConfigureAwait(false);
+
+        var constructionSites = new List<RecordPositionalConstructionSiteDto>();
+        var deconstructionSites = new List<RecordDeconstructionSiteDto>();
+        var propertyPatternSites = new List<RecordPropertyPatternSiteDto>();
+        var withExpressionSites = new List<RecordWithExpressionSiteDto>();
+        var testFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var dedupeSpans = new HashSet<(string Path, int Line, int Col, string Kind)>();
+
+        // Pass A: per-reference-location classification (catches type-token uses like
+        // ObjectCreation, RecursivePattern-with-type).
+        foreach (var rich in materialized)
+        {
+            if (ct.IsCancellationRequested) break;
+            if (rich.SyntaxRoot is null || rich.SemanticModel is null) continue;
+
+            var sourceSpan = rich.Source.Location.SourceSpan;
+            var node = rich.SyntaxRoot.FindNode(sourceSpan, getInnermostNodeForTie: true);
+            if (node is null) continue;
+
+            if (IsTestDocument(rich.Source.Document))
+            {
+                var path = rich.Source.Document.FilePath;
+                if (!string.IsNullOrEmpty(path)) testFiles.Add(path);
+            }
+
+            ClassifySite(
+                node,
+                rich.Dto,
+                rich.SemanticModel,
+                typeSymbol,
+                existingPositionalParameters,
+                newField,
+                constructionSites,
+                deconstructionSites,
+                propertyPatternSites,
+                withExpressionSites,
+                dedupeSpans,
+                ct);
+        }
+
+        // Pass B: document-level walk — catches deconstruction & with-expressions on variables
+        // whose inferred type is the target (these don't show up as type-name references). We
+        // only walk documents that already mentioned the type in pass A, so this is bounded by
+        // the same reference-density constant as pass A.
+        var documentsToWalk = materialized
+            .Where(m => m.Source.Document is not null)
+            .Select(m => m.Source.Document)
+            .Distinct()
+            .ToList();
+
+        foreach (var doc in documentsToWalk)
+        {
+            if (ct.IsCancellationRequested) break;
+            var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            var semanticModel = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+            if (root is null || semanticModel is null) continue;
+
+            foreach (var node in root.DescendantNodes())
+            {
+                if (ct.IsCancellationRequested) break;
+                switch (node)
+                {
+                    case WithExpressionSyntax we when ResolvesToTargetExpression(we.Expression, semanticModel, typeSymbol, ct):
+                        AddUniqueWithSite(we, doc, withExpressionSites, dedupeSpans);
+                        break;
+                    case DeclarationExpressionSyntax decl when decl.Designation is ParenthesizedVariableDesignationSyntax pvd
+                                                                && InferredDeconstructionTargetMatches(decl, semanticModel, typeSymbol, ct):
+                        AddUniqueDeconstructionFromDesignation(decl, pvd, doc, existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
+                        break;
+                    case AssignmentExpressionSyntax asn when asn.Left is TupleExpressionSyntax tuple
+                                                              && AssignmentTargetMatches(asn, semanticModel, typeSymbol, ct):
+                        AddUniqueDeconstructionFromTuple(asn, tuple, doc, existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
+                        break;
+                    case RecursivePatternSyntax rp when PatternMatchesTarget(rp, semanticModel, typeSymbol, ct):
+                        AddUniqueRecursivePattern(rp, doc, existingPositionalParameters, newField, deconstructionSites, propertyPatternSites, dedupeSpans);
+                        break;
+                }
+            }
+        }
+
+        // Stable order: by file path then start line. Helps reviewers diff output across runs.
+        constructionSites.Sort(CompareByLocation);
+        deconstructionSites.Sort(CompareByLocation);
+        propertyPatternSites.Sort(CompareByLocation);
+        withExpressionSites.Sort(CompareByLocation);
+        var testFileList = testFiles.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var suggestedTasks = BuildSuggestedTasks(
+            isPositional,
+            constructionSites.Count,
+            deconstructionSites.Count,
+            propertyPatternSites.Count,
+            withExpressionSites.Count,
+            testFileList.Count);
+
+        return new RecordFieldAdditionImpactDto(
+            TargetRecordDisplay: typeSymbol.ToDisplayString(),
+            IsPositionalRecord: isPositional,
+            NewField: newField,
+            ExistingPositionalParameters: existingPositionalParameters,
+            PositionalConstructionSites: constructionSites,
+            DeconstructionSites: deconstructionSites,
+            PropertyPatternSites: propertyPatternSites,
+            WithExpressionSites: withExpressionSites,
+            TestFilesConstructing: testFileList,
+            SuggestedTasks: suggestedTasks);
+    }
+
+    /// <summary>
+    /// Returns the primary-constructor parameter list for a positional record, or an empty list
+    /// when the record is not positional. Positional records always have a non-null
+    /// <see cref="IMethodSymbol.IsImplicitlyDeclared"/> = <c>false</c> primary constructor with at
+    /// least one parameter; non-positional record classes have only the implicit parameterless ctor.
+    /// </summary>
+    private static IReadOnlyList<ExistingPositionalParameterDto> ExtractPositionalParameters(INamedTypeSymbol typeSymbol)
+    {
+        // Find the constructor matching the primary record constructor signature: it is the only
+        // ctor whose syntax is a RecordDeclarationSyntax with a non-null ParameterList.
+        foreach (var ctor in typeSymbol.InstanceConstructors)
+        {
+            foreach (var declRef in ctor.DeclaringSyntaxReferences)
+            {
+                if (declRef.GetSyntax() is RecordDeclarationSyntax recordDecl && recordDecl.ParameterList is not null)
+                {
+                    var parameters = ctor.Parameters
+                        .Select(p => new ExistingPositionalParameterDto(p.Name, p.Type.ToDisplayString()))
+                        .ToList();
+                    return parameters;
+                }
+            }
+        }
+        return Array.Empty<ExistingPositionalParameterDto>();
+    }
+
+    private static void ClassifySite(
+        SyntaxNode node,
+        LocationDto baseDto,
+        SemanticModel semanticModel,
+        INamedTypeSymbol targetType,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordPositionalConstructionSiteDto> constructionSites,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        List<RecordPropertyPatternSiteDto> propertyPatternSites,
+        List<RecordWithExpressionSiteDto> withExpressionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans,
+        CancellationToken ct)
+    {
+        // Walk up the node ancestry looking for the syntactic shape that classifies the site.
+        // We bound the walk because most matches are within 3-4 hops of the IdentifierNameSyntax
+        // ref, and a runaway walk on a deeply-nested expression would do useless work.
+        var current = node;
+        var depth = 0;
+        const int maxDepth = 8;
+
+        while (current is not null && depth < maxDepth)
+        {
+            ct.ThrowIfCancellationRequested();
+            depth++;
+
+            switch (current)
+            {
+                case ObjectCreationExpressionSyntax oc when ResolvesToTarget(oc.Type, semanticModel, targetType, ct):
+                {
+                    var argList = oc.ArgumentList;
+                    // Only flag when arity matches the existing positional-ctor count. A `new R()`
+                    // with zero args isn't an arity-match for a positional record with parameters
+                    // (so the compiler would already catch it). We focus on the "looks valid today,
+                    // breaks tomorrow" cases.
+                    if (argList is not null && existingParameters.Count > 0 &&
+                        argList.Arguments.Count == existingParameters.Count)
+                    {
+                        var loc = UpdateDtoSpan(baseDto, oc);
+                        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, nameof(ObjectCreationExpressionSyntax))))
+                        {
+                            var original = argList.ToString();
+                            var suggested = BuildSuggestedArgumentList(argList, newField);
+                            constructionSites.Add(new RecordPositionalConstructionSiteDto(loc, original, suggested));
+                        }
+                    }
+                    return;
+                }
+                case ImplicitObjectCreationExpressionSyntax ioc when InferredImplicitTargetMatches(ioc, semanticModel, targetType, ct):
+                {
+                    var argList = ioc.ArgumentList;
+                    if (existingParameters.Count > 0 && argList.Arguments.Count == existingParameters.Count)
+                    {
+                        var loc = UpdateDtoSpan(baseDto, ioc);
+                        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, nameof(ImplicitObjectCreationExpressionSyntax))))
+                        {
+                            var original = argList.ToString();
+                            var suggested = BuildSuggestedArgumentList(argList, newField);
+                            constructionSites.Add(new RecordPositionalConstructionSiteDto(loc, original, suggested));
+                        }
+                    }
+                    return;
+                }
+                case WithExpressionSyntax we when ResolvesToTargetExpression(we.Expression, semanticModel, targetType, ct):
+                {
+                    var loc = UpdateDtoSpan(baseDto, we);
+                    if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, nameof(WithExpressionSyntax))))
+                    {
+                        var initializer = we.Initializer.ToString();
+                        withExpressionSites.Add(new RecordWithExpressionSiteDto(loc, initializer));
+                    }
+                    return;
+                }
+                case RecursivePatternSyntax rp when PatternMatchesTarget(rp, semanticModel, targetType, ct):
+                {
+                    var loc = UpdateDtoSpan(baseDto, rp);
+                    // A recursive pattern can carry both a positional sub-pattern AND a property
+                    // sub-pattern. We classify each independently (a single ref can yield two
+                    // entries) so callers see the full impact.
+                    if (rp.PositionalPatternClause is { } positional && existingParameters.Count > 0 &&
+                        positional.Subpatterns.Count == existingParameters.Count)
+                    {
+                        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Deconstruct:" + nameof(RecursivePatternSyntax))))
+                        {
+                            var original = positional.ToString();
+                            var suggested = BuildSuggestedDeconstructionPattern(positional, newField);
+                            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+                        }
+                    }
+                    if (rp.PropertyPatternClause is { } property)
+                    {
+                        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Property:" + nameof(RecursivePatternSyntax))))
+                        {
+                            var original = property.ToString();
+                            var missed = IsExhaustiveInSpirit(property, existingParameters, newField);
+                            propertyPatternSites.Add(new RecordPropertyPatternSiteDto(loc, original, missed));
+                        }
+                    }
+                    return;
+                }
+                case DeclarationExpressionSyntax decl when decl.Designation is ParenthesizedVariableDesignationSyntax pvd
+                                                          && InferredDeconstructionTargetMatches(decl, semanticModel, targetType, ct):
+                {
+                    AddUniqueDeconstructionFromDesignation(decl, pvd, baseDto, existingParameters, newField, deconstructionSites, dedupeSpans);
+                    return;
+                }
+                case AssignmentExpressionSyntax asn when asn.Left is TupleExpressionSyntax tuple
+                                                          && AssignmentTargetMatches(asn, semanticModel, targetType, ct):
+                {
+                    AddUniqueDeconstructionFromTuple(asn, tuple, baseDto, existingParameters, newField, deconstructionSites, dedupeSpans);
+                    return;
+                }
+            }
+
+            current = current.Parent;
+        }
+    }
+
+    /// <summary>
+    /// Builds a minimal <see cref="LocationDto"/> directly from a <see cref="SyntaxNode"/> —
+    /// used by the pass-B document walker where we don't have a preceding
+    /// <see cref="ReferenceLocation"/> to start from.
+    /// </summary>
+    private static LocationDto BuildLocationDto(SyntaxNode node, Document document)
+    {
+        var lineSpan = node.GetLocation().GetLineSpan();
+        return new LocationDto(
+            FilePath: document.FilePath ?? string.Empty,
+            StartLine: lineSpan.StartLinePosition.Line + 1,
+            StartColumn: lineSpan.StartLinePosition.Character + 1,
+            EndLine: lineSpan.EndLinePosition.Line + 1,
+            EndColumn: lineSpan.EndLinePosition.Character + 1,
+            ContainingMember: null,
+            PreviewText: null);
+    }
+
+    private static void AddUniqueWithSite(
+        WithExpressionSyntax we,
+        Document document,
+        List<RecordWithExpressionSiteDto> withExpressionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        var loc = BuildLocationDto(we, document);
+        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, nameof(WithExpressionSyntax))))
+        {
+            withExpressionSites.Add(new RecordWithExpressionSiteDto(loc, we.Initializer.ToString()));
+        }
+    }
+
+    private static void AddUniqueDeconstructionFromDesignation(
+        DeclarationExpressionSyntax decl,
+        ParenthesizedVariableDesignationSyntax pvd,
+        LocationDto baseDto,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        if (existingParameters.Count == 0 || pvd.Variables.Count != existingParameters.Count) return;
+        var loc = UpdateDtoSpan(baseDto, decl);
+        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Designation:" + nameof(DeclarationExpressionSyntax))))
+        {
+            var original = pvd.ToString();
+            var suggested = BuildSuggestedDesignationPattern(pvd, newField);
+            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+        }
+    }
+
+    private static void AddUniqueDeconstructionFromDesignation(
+        DeclarationExpressionSyntax decl,
+        ParenthesizedVariableDesignationSyntax pvd,
+        Document document,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        if (existingParameters.Count == 0 || pvd.Variables.Count != existingParameters.Count) return;
+        var loc = BuildLocationDto(decl, document);
+        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Designation:" + nameof(DeclarationExpressionSyntax))))
+        {
+            var original = pvd.ToString();
+            var suggested = BuildSuggestedDesignationPattern(pvd, newField);
+            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+        }
+    }
+
+    private static void AddUniqueDeconstructionFromTuple(
+        AssignmentExpressionSyntax asn,
+        TupleExpressionSyntax tuple,
+        LocationDto baseDto,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        if (existingParameters.Count == 0 || tuple.Arguments.Count != existingParameters.Count) return;
+        var loc = UpdateDtoSpan(baseDto, asn);
+        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Tuple:" + nameof(AssignmentExpressionSyntax))))
+        {
+            var original = tuple.ToString();
+            var suggested = BuildSuggestedTuplePattern(tuple, newField);
+            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+        }
+    }
+
+    private static void AddUniqueDeconstructionFromTuple(
+        AssignmentExpressionSyntax asn,
+        TupleExpressionSyntax tuple,
+        Document document,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        if (existingParameters.Count == 0 || tuple.Arguments.Count != existingParameters.Count) return;
+        var loc = BuildLocationDto(asn, document);
+        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Tuple:" + nameof(AssignmentExpressionSyntax))))
+        {
+            var original = tuple.ToString();
+            var suggested = BuildSuggestedTuplePattern(tuple, newField);
+            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+        }
+    }
+
+    private static void AddUniqueRecursivePattern(
+        RecursivePatternSyntax rp,
+        Document document,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField,
+        List<RecordDeconstructionSiteDto> deconstructionSites,
+        List<RecordPropertyPatternSiteDto> propertyPatternSites,
+        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
+    {
+        var loc = BuildLocationDto(rp, document);
+
+        if (rp.PositionalPatternClause is { } positional && existingParameters.Count > 0 &&
+            positional.Subpatterns.Count == existingParameters.Count)
+        {
+            if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Deconstruct:" + nameof(RecursivePatternSyntax))))
+            {
+                var original = positional.ToString();
+                var suggested = BuildSuggestedDeconstructionPattern(positional, newField);
+                deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
+            }
+        }
+        if (rp.PropertyPatternClause is { } property)
+        {
+            if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Property:" + nameof(RecursivePatternSyntax))))
+            {
+                var original = property.ToString();
+                var missed = IsExhaustiveInSpirit(property, existingParameters, newField);
+                propertyPatternSites.Add(new RecordPropertyPatternSiteDto(loc, original, missed));
+            }
+        }
+    }
+
+    private static bool ResolvesToTarget(TypeSyntax typeSyntax, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+    {
+        var info = model.GetSymbolInfo(typeSyntax, ct);
+        var symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
+        return SymbolEqualityComparer.Default.Equals(UnwrapNamedType(symbol), target);
+    }
+
+    private static bool ResolvesToTargetExpression(ExpressionSyntax expr, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+    {
+        var typeInfo = model.GetTypeInfo(expr, ct);
+        var t = typeInfo.Type ?? typeInfo.ConvertedType;
+        return SymbolEqualityComparer.Default.Equals(UnwrapNamedType(t), target);
+    }
+
+    private static bool InferredImplicitTargetMatches(ImplicitObjectCreationExpressionSyntax ioc, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+    {
+        var typeInfo = model.GetTypeInfo(ioc, ct);
+        var t = typeInfo.Type ?? typeInfo.ConvertedType;
+        return SymbolEqualityComparer.Default.Equals(UnwrapNamedType(t), target);
+    }
+
+    private static bool PatternMatchesTarget(RecursivePatternSyntax rp, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+    {
+        // The pattern's "target type" comes either from the explicit type token (`record is Foo {...}`)
+        // or from the inferred type of the expression being matched. The semantic model exposes both
+        // via GetTypeInfo on the pattern node itself.
+        if (rp.Type is { } typeRef && ResolvesToTarget(typeRef, model, target, ct))
+        {
+            return true;
+        }
+        // Walk up to find the IsPatternExpression / SwitchExpressionArm to get the input type.
+        SyntaxNode? n = rp.Parent;
+        while (n is not null)
+        {
+            if (n is IsPatternExpressionSyntax ipe)
+            {
+                return ResolvesToTargetExpression(ipe.Expression, model, target, ct);
+            }
+            if (n is SwitchExpressionSyntax se)
+            {
+                return ResolvesToTargetExpression(se.GoverningExpression, model, target, ct);
+            }
+            if (n is SwitchStatementSyntax ss)
+            {
+                return ResolvesToTargetExpression(ss.Expression, model, target, ct);
+            }
+            n = n.Parent;
+        }
+        return false;
+    }
+
+    private static bool InferredDeconstructionTargetMatches(DeclarationExpressionSyntax decl, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+    {
+        // The right-hand side of the assignment containing this declaration is the deconstruction
+        // source. Find the enclosing assignment and check its right-hand type.
+        SyntaxNode? n = decl.Parent;
+        while (n is not null)
+        {
+            if (n is AssignmentExpressionSyntax asn && asn.Left == decl)
+            {
+                return ResolvesToTargetExpression(asn.Right, model, target, ct);
+            }
+            // foreach (var (a, b) in src) — ForEachVariableStatement is a separate shape.
+            if (n is ForEachVariableStatementSyntax fevs)
+            {
+                var typeInfo = model.GetTypeInfo(fevs.Expression, ct);
+                var elem = (typeInfo.Type ?? typeInfo.ConvertedType) is INamedTypeSymbol nt
+                    ? nt.TypeArguments.FirstOrDefault() as INamedTypeSymbol
+                    : null;
+                return SymbolEqualityComparer.Default.Equals(elem, target);
+            }
+            n = n.Parent;
+        }
+        return false;
+    }
+
+    private static bool AssignmentTargetMatches(AssignmentExpressionSyntax asn, SemanticModel model, INamedTypeSymbol target, CancellationToken ct)
+        => ResolvesToTargetExpression(asn.Right, model, target, ct);
+
+    private static INamedTypeSymbol? UnwrapNamedType(ISymbol? symbol) => symbol switch
+    {
+        INamedTypeSymbol named when named.IsGenericType => named.OriginalDefinition,
+        INamedTypeSymbol named => named,
+        _ => null,
+    };
+
+    private static INamedTypeSymbol? UnwrapNamedType(ITypeSymbol? type) => type switch
+    {
+        INamedTypeSymbol named when named.IsGenericType => named.OriginalDefinition,
+        INamedTypeSymbol named => named,
+        _ => null,
+    };
+
+    private static bool IsTestDocument(Document document)
+    {
+        // Heuristic: same one CouplingAnalysis / ImpactSweep use — IsTestProject metadata flag
+        // wins, otherwise file name heuristic. The metadata check requires reading the project's
+        // XML so we cache via IsTestProject(Project).
+        if (ProjectMetadataParser.IsTestProject(document.Project)) return true;
+        var name = Path.GetFileNameWithoutExtension(document.FilePath);
+        if (string.IsNullOrEmpty(name)) return false;
+        return name.EndsWith("Tests", StringComparison.Ordinal)
+            || name.EndsWith("Test", StringComparison.Ordinal)
+            || name.EndsWith("Spec", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// "Exhaustive in spirit" = the property pattern explicitly names every existing positional
+    /// parameter of the record but does NOT name the new field. These are the patterns most likely
+    /// to need an explicit update — the author has shown intent to be thorough about every field.
+    /// A pattern that names only one field is a deliberate partial match and not flagged.
+    /// </summary>
+    private static bool IsExhaustiveInSpirit(
+        PropertyPatternClauseSyntax property,
+        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
+        NewRecordFieldDto newField)
+    {
+        if (existingParameters.Count == 0) return false;
+
+        var named = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var sub in property.Subpatterns)
+        {
+            if (sub.NameColon?.Name.Identifier.ValueText is { } n1) named.Add(n1);
+            else if (sub.ExpressionColon?.Expression is IdentifierNameSyntax ins) named.Add(ins.Identifier.ValueText);
+        }
+
+        // Every existing parameter named, AND the new field is NOT named.
+        var allExistingNamed = existingParameters.All(p => named.Contains(p.Name));
+        var newFieldNotNamed = !named.Contains(newField.Name);
+        return allExistingNamed && newFieldNotNamed;
+    }
+
+    private static string BuildSuggestedArgumentList(ArgumentListSyntax original, NewRecordFieldDto newField)
+    {
+        var args = original.Arguments.Select(a => a.ToString()).ToList();
+        args.Add(newField.DefaultValueExpression ?? $"/* TODO: {newField.Name} ({newField.Type}) */");
+        return "(" + string.Join(", ", args) + ")";
+    }
+
+    private static string BuildSuggestedArgumentList(BaseArgumentListSyntax original, NewRecordFieldDto newField)
+    {
+        var args = original.Arguments.Select(a => a.ToString()).ToList();
+        args.Add(newField.DefaultValueExpression ?? $"/* TODO: {newField.Name} ({newField.Type}) */");
+        return "(" + string.Join(", ", args) + ")";
+    }
+
+    private static string BuildSuggestedDeconstructionPattern(PositionalPatternClauseSyntax original, NewRecordFieldDto newField)
+    {
+        var parts = original.Subpatterns.Select(s => s.ToString()).ToList();
+        parts.Add("_");
+        return "(" + string.Join(", ", parts) + ")";
+    }
+
+    private static string BuildSuggestedDesignationPattern(ParenthesizedVariableDesignationSyntax original, NewRecordFieldDto newField)
+    {
+        var parts = original.Variables.Select(v => v.ToString()).ToList();
+        parts.Add("_");
+        return "(" + string.Join(", ", parts) + ")";
+    }
+
+    private static string BuildSuggestedTuplePattern(TupleExpressionSyntax original, NewRecordFieldDto newField)
+    {
+        var parts = original.Arguments.Select(a => a.ToString()).ToList();
+        parts.Add("_");
+        return "(" + string.Join(", ", parts) + ")";
+    }
+
+    /// <summary>
+    /// Promotes the base reference DTO span to cover the wider classified expression
+    /// (e.g. the entire <c>new Foo(a, b)</c>, not just the type identifier inside it).
+    /// </summary>
+    private static LocationDto UpdateDtoSpan(LocationDto baseDto, SyntaxNode wider)
+    {
+        var lineSpan = wider.GetLocation().GetLineSpan();
+        return baseDto with
+        {
+            StartLine = lineSpan.StartLinePosition.Line + 1,
+            StartColumn = lineSpan.StartLinePosition.Character + 1,
+            EndLine = lineSpan.EndLinePosition.Line + 1,
+            EndColumn = lineSpan.EndLinePosition.Character + 1,
+        };
+    }
+
+    private static int CompareByLocation<T>(T a, T b) where T : class
+    {
+        var la = GetLocation(a);
+        var lb = GetLocation(b);
+        var fileCmp = string.Compare(la.FilePath, lb.FilePath, StringComparison.OrdinalIgnoreCase);
+        return fileCmp != 0 ? fileCmp : la.StartLine.CompareTo(lb.StartLine);
+    }
+
+    private static LocationDto GetLocation(object site) => site switch
+    {
+        RecordPositionalConstructionSiteDto c => c.Location,
+        RecordDeconstructionSiteDto d => d.Location,
+        RecordPropertyPatternSiteDto p => p.Location,
+        RecordWithExpressionSiteDto w => w.Location,
+        _ => throw new InvalidOperationException($"Unexpected site type {site.GetType().Name}."),
+    };
+
+    private static IReadOnlyList<string> BuildSuggestedTasks(
+        bool isPositional, int construction, int deconstruction, int propertyPattern, int with, int testFiles)
+    {
+        var tasks = new List<string>();
+        if (!isPositional)
+        {
+            tasks.Add("Target is NOT a positional record — only `with { ... }` consumers and explicit property writes are affected. Construction / deconstruction / positional-pattern lists will be empty.");
+        }
+        if (construction > 0)
+            tasks.Add($"Update {construction} positional construction site(s) to pass the new field as the trailing argument.");
+        if (deconstruction > 0)
+            tasks.Add($"Update {deconstruction} deconstruction site(s) — add a trailing `_` (or named variable) for the new positional element.");
+        if (propertyPattern > 0)
+            tasks.Add($"Audit {propertyPattern} property-pattern site(s) — sites flagged with `MissedCorrelation: true` named every prior field and likely need the new field added.");
+        if (with > 0)
+            tasks.Add($"Audit {with} `with`-expression site(s) — confirm the new field's default is correct or add an explicit `{{ NewField = ... }}` assignment.");
+        if (testFiles > 0)
+            tasks.Add($"Sweep {testFiles} test file(s) that mention the record — fixture builders are typically the densest cluster of construction sites.");
+        if (tasks.Count == 0)
+            tasks.Add("No impact detected. The record is unreferenced beyond its declaration.");
+        return tasks;
+    }
+}

--- a/tests/RoslynMcp.Tests/RecordFieldAdditionImpactTests.cs
+++ b/tests/RoslynMcp.Tests/RecordFieldAdditionImpactTests.cs
@@ -1,0 +1,250 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class RecordFieldAdditionImpactTests : SharedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task PreviewAddition_ClassifiesAllCategoriesOfImpact_ForPositionalRecord()
+    {
+        // Plan validation fixture: add `bool NewFlag` to `TestRecord(int A, string B)`.
+        // Impact output must list every `new TestRecord(x, y)` construction site, every
+        // `var (a, b) = testRecord` deconstruction, and flag the property patterns that
+        // omit `NewFlag`. We write a self-contained fixture file so the test is fully
+        // reproducible and the signal isn't noisy from unrelated sample types.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var libPath = Path.Combine(copiedRoot, "SampleLib", "TestRecordFixture.cs");
+            var testPath = Path.Combine(copiedRoot, "SampleLib.Tests", "TestRecordConsumerTests.cs");
+            var consumerPath = Path.Combine(copiedRoot, "SampleApp", "TestRecordConsumer.cs");
+
+            await File.WriteAllTextAsync(libPath, """
+namespace SampleLib.Records;
+
+public record TestRecord(int A, string B);
+""", CancellationToken.None);
+
+            // Consumer file in SampleApp — production construction + with + property-pattern sites.
+            await File.WriteAllTextAsync(consumerPath, """
+using SampleLib.Records;
+
+namespace SampleApp.RecordImpactConsumers;
+
+public static class TestRecordConsumer
+{
+    public static TestRecord MakeOne() => new TestRecord(1, "first");
+
+    public static TestRecord CopyWith(TestRecord original) => original with { A = original.A + 1 };
+
+    public static string Describe(TestRecord r) => r switch
+    {
+        { A: 0, B: "" } => "empty",
+        { A: var a, B: var b } => $"{a}/{b}",
+    };
+
+    public static string Deconstruct(TestRecord r)
+    {
+        var (a, b) = r;
+        return a + "/" + b;
+    }
+}
+""", CancellationToken.None);
+
+            // Test file — production construction in test fixtures. The service should route this
+            // into TestFilesConstructing because the project is an MSBuild test project.
+            await File.WriteAllTextAsync(testPath, """
+using SampleLib.Records;
+
+namespace SampleLib.Tests.RecordImpactFixtures;
+
+public static class TestRecordConsumerTests
+{
+    public static TestRecord Fixture() => new TestRecord(42, "fixture");
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var result = await RecordFieldAdditionService.PreviewAdditionAsync(
+                workspaceId,
+                recordMetadataName: "SampleLib.Records.TestRecord",
+                newFieldName: "NewFlag",
+                newFieldType: "bool",
+                defaultValueExpression: "false",
+                CancellationToken.None);
+
+            // Shape assertions.
+            Assert.AreEqual("SampleLib.Records.TestRecord", result.TargetRecordDisplay);
+            Assert.IsTrue(result.IsPositionalRecord, "TestRecord has a primary ctor so it must be positional.");
+            Assert.AreEqual(2, result.ExistingPositionalParameters.Count);
+            Assert.AreEqual("A", result.ExistingPositionalParameters[0].Name);
+            Assert.AreEqual("int", result.ExistingPositionalParameters[0].Type);
+            Assert.AreEqual("B", result.ExistingPositionalParameters[1].Name);
+            Assert.AreEqual("string", result.ExistingPositionalParameters[1].Type);
+
+            // Construction sites: the production consumer + the test file both construct with 2 args.
+            Assert.IsTrue(result.PositionalConstructionSites.Count >= 2,
+                $"Expected at least 2 construction sites (consumer + test fixture), got {result.PositionalConstructionSites.Count}.");
+            var prodConstruction = result.PositionalConstructionSites
+                .FirstOrDefault(c => c.Location.FilePath.EndsWith("TestRecordConsumer.cs", StringComparison.OrdinalIgnoreCase));
+            Assert.IsNotNull(prodConstruction, "Production construction site (TestRecordConsumer.cs) must be present.");
+            Assert.AreEqual("(1, \"first\")", prodConstruction.OriginalArgumentList);
+            Assert.AreEqual("(1, \"first\", false)", prodConstruction.SuggestedArgumentList);
+
+            // Deconstruction site from `var (a, b) = r;`.
+            Assert.IsTrue(result.DeconstructionSites.Count >= 1,
+                $"Expected at least 1 deconstruction site, got {result.DeconstructionSites.Count}.");
+            var decon = result.DeconstructionSites[0];
+            Assert.AreEqual("(a, b)", decon.OriginalPattern);
+            Assert.AreEqual("(a, b, _)", decon.SuggestedPattern);
+
+            // Property-pattern sites: the `{ A: 0, B: "" }` and `{ A: var a, B: var b }` patterns
+            // name every existing positional field but not NewFlag — both must be flagged as
+            // missed correlations, which is the entire point of the tool.
+            Assert.IsTrue(result.PropertyPatternSites.Count >= 2,
+                $"Expected at least 2 property-pattern sites, got {result.PropertyPatternSites.Count}.");
+            Assert.IsTrue(result.PropertyPatternSites.All(p => p.MissedCorrelation),
+                "All property patterns name every existing field but not NewFlag — every entry must carry MissedCorrelation=true.");
+
+            // `with { ... }` site from CopyWith.
+            Assert.IsTrue(result.WithExpressionSites.Count >= 1,
+                $"Expected at least 1 with-expression site, got {result.WithExpressionSites.Count}.");
+
+            // Test-file routing: the file under SampleLib.Tests must be routed into
+            // TestFilesConstructing because its containing project is a test project.
+            Assert.IsTrue(result.TestFilesConstructing.Any(p => p.EndsWith("TestRecordConsumerTests.cs", StringComparison.OrdinalIgnoreCase)),
+                "Test-project consumers must be routed into TestFilesConstructing for dedicated fixture sweep.");
+
+            // Suggested tasks should non-vacuously describe the remediation plan.
+            Assert.IsTrue(result.SuggestedTasks.Count >= 2,
+                $"Expected at least 2 suggested tasks for a non-empty impact, got {result.SuggestedTasks.Count}.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task PreviewAddition_ForNonPositionalRecord_ReportsOnlyWithExpressionSites()
+    {
+        // A record declared without a primary constructor (only explicit property declarations)
+        // is NOT positional — construction and deconstruction shape are irrelevant, only
+        // `with { ... }` consumers are affected by a required new property. This is a critical
+        // distinction for reviewers: non-positional adds are lower risk than positional adds.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var libPath = Path.Combine(copiedRoot, "SampleLib", "NonPositionalRecordFixture.cs");
+            await File.WriteAllTextAsync(libPath, """
+namespace SampleLib.Records;
+
+public record NonPositionalRecord
+{
+    public int A { get; init; }
+    public string B { get; init; } = "";
+}
+""", CancellationToken.None);
+
+            var consumerPath = Path.Combine(copiedRoot, "SampleApp", "NonPositionalRecordConsumer.cs");
+            await File.WriteAllTextAsync(consumerPath, """
+using SampleLib.Records;
+
+namespace SampleApp.RecordImpactConsumers;
+
+public static class NonPositionalRecordConsumer
+{
+    public static NonPositionalRecord MakeOne() => new NonPositionalRecord { A = 1, B = "x" };
+
+    public static NonPositionalRecord CopyWith(NonPositionalRecord original) => original with { A = 2 };
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var result = await RecordFieldAdditionService.PreviewAdditionAsync(
+                workspaceId,
+                recordMetadataName: "SampleLib.Records.NonPositionalRecord",
+                newFieldName: "NewField",
+                newFieldType: "string",
+                defaultValueExpression: "\"default\"",
+                CancellationToken.None);
+
+            Assert.IsFalse(result.IsPositionalRecord,
+                "A record without a primary constructor must be reported as non-positional.");
+            Assert.AreEqual(0, result.ExistingPositionalParameters.Count);
+            Assert.AreEqual(0, result.PositionalConstructionSites.Count,
+                "Non-positional records cannot have positional construction-site impact.");
+            Assert.AreEqual(0, result.DeconstructionSites.Count,
+                "Non-positional records cannot have positional-deconstruction impact.");
+
+            // `with { ... }` still applies — it's the only breaking-change shape for non-positional.
+            Assert.IsTrue(result.WithExpressionSites.Count >= 1,
+                $"Expected at least 1 with-expression site for non-positional record, got {result.WithExpressionSites.Count}.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task PreviewAddition_ThrowsWhenTargetIsNotRecord()
+    {
+        // Non-record types (ordinary classes/structs) are out of scope. The service must fail
+        // fast with ArgumentException rather than silently returning an empty DTO — callers
+        // should know they invoked the wrong tool.
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await RecordFieldAdditionService.PreviewAdditionAsync(
+                workspaceId,
+                recordMetadataName: "SampleLib.Dog",
+                newFieldName: "NewFlag",
+                newFieldType: "bool",
+                defaultValueExpression: null,
+                CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task PreviewAddition_ThrowsWhenRecordIsNotFound()
+    {
+        // Missing metadata-name resolution must produce a structured KeyNotFoundException, which
+        // the tool-error handler maps to the NotFound envelope. Silent empty returns would hide
+        // typos.
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await RecordFieldAdditionService.PreviewAdditionAsync(
+                workspaceId,
+                recordMetadataName: "SampleLib.NoSuchRecordType",
+                newFieldName: "NewFlag",
+                newFieldType: "bool",
+                defaultValueExpression: null,
+                CancellationToken.None));
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -57,6 +57,7 @@ public abstract class TestBase
     protected static BulkRefactoringService BulkRefactoringService { get; private set; } = null!;
     protected static CohesionAnalysisService CohesionAnalysisService { get; private set; } = null!;
     protected static CouplingAnalysisService CouplingAnalysisService { get; private set; } = null!;
+    protected static RecordFieldAdditionService RecordFieldAdditionService { get; private set; } = null!;
     protected static ConsumerAnalysisService ConsumerAnalysisService { get; private set; } = null!;
     protected static TypeExtractionService TypeExtractionService { get; private set; } = null!;
     protected static TypeMoveService TypeMoveService { get; private set; } = null!;
@@ -152,6 +153,7 @@ public abstract class TestBase
         BulkRefactoringService = services.BulkRefactoringService;
         CohesionAnalysisService = services.CohesionAnalysisService;
         CouplingAnalysisService = services.CouplingAnalysisService;
+        RecordFieldAdditionService = services.RecordFieldAdditionService;
         ConsumerAnalysisService = services.ConsumerAnalysisService;
         TypeExtractionService = services.TypeExtractionService;
         TypeMoveService = services.TypeMoveService;

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -44,6 +44,7 @@ internal sealed class TestServiceContainer
     public required BulkRefactoringService BulkRefactoringService { get; init; }
     public required CohesionAnalysisService CohesionAnalysisService { get; init; }
     public required CouplingAnalysisService CouplingAnalysisService { get; init; }
+    public required RecordFieldAdditionService RecordFieldAdditionService { get; init; }
     public required ConsumerAnalysisService ConsumerAnalysisService { get; init; }
     public required TypeExtractionService TypeExtractionService { get; init; }
     public required TypeMoveService TypeMoveService { get; init; }
@@ -227,6 +228,9 @@ internal sealed class TestServiceContainer
             CouplingAnalysisService = new CouplingAnalysisService(
                 workspaceManager,
                 NullLogger<CouplingAnalysisService>.Instance),
+            RecordFieldAdditionService = new RecordFieldAdditionService(
+                workspaceManager,
+                NullLogger<RecordFieldAdditionService>.Instance),
             ConsumerAnalysisService = new ConsumerAnalysisService(
                 workspaceManager,
                 NullLogger<ConsumerAnalysisService>.Instance),


### PR DESCRIPTION
## Summary

- New `preview_record_field_addition(workspaceId, recordMetadataName, newFieldName, newFieldType, defaultValue?)` MCP tool returns a structured `RecordFieldAdditionImpactDto` classifying every site impacted by adding a positional field to a record: positional construction (with suggested rewritten arg lists), deconstruction (with suggested rewritten patterns), property-pattern matches (flagged with `MissedCorrelation: true` when the pattern names every existing field but not the new one), `with { ... }` expressions, and test-file paths that construct the record.
- Closes the gap between what the C# compiler flags (positional-ctor arg mismatches) and what silently breaks (pattern coverage, deconstruction shape, with-expression assumptions).
- Two-pass walk: SymbolFinder references + document-wide descendants so sites that only reference a variable whose type is the target (e.g. `var (a, b) = r;`, `r with { ... }`) are still caught. Spans are deduped across passes.

## Implementation notes

- Service: `RecordFieldAdditionService` under `RoslynMcp.Roslyn.Services` — one per-reference classification pass for type-token sites (ObjectCreation, RecursivePattern-with-type-token) and one per-document descendant pass for inferred-type sites (WithExpression, DeclarationExpression+ParenthesizedDesignation, tuple-LHS assignments, RecursivePattern on inferred input).
- DTO family: `RecordFieldAdditionImpactDto` with five per-bucket site records under `RoslynMcp.Core.Models`. A separate file because the shape is structurally distinct from `ImpactAnalysisDto` (which is for symbol impact, not record-shape impact).
- Tool host file: `RecordImpactTools.cs` — new file per recent precedent (`CouplingAnalysisTools.cs` vs `CohesionAnalysisTools.cs`) so record-shape impact has its own semantic home distinct from the general `symbol_impact_sweep`.
- Structural wiring only: `ServiceCollectionExtensions` (+1 DI line), `ServerSurfaceCatalog` (+1 tool entry), `TestBase` / `TestServiceContainer` (+1 service property each). No shims, no backwards-compat ctors.

## Test plan

- [x] `RecordFieldAdditionImpactTests.PreviewAddition_ClassifiesAllCategoriesOfImpact_ForPositionalRecord` — fixture adds `bool NewFlag` to `TestRecord(int A, string B)` and verifies every construction / deconstruction / property-pattern / with-expression / test-file bucket populates correctly with the suggested rewrites and `MissedCorrelation: true` on patterns that name every existing field.
- [x] `RecordFieldAdditionImpactTests.PreviewAddition_ForNonPositionalRecord_ReportsOnlyWithExpressionSites` — a record declared without a primary ctor reports `IsPositionalRecord: false` and empty construction / deconstruction lists; only `with { ... }` sites remain.
- [x] `PreviewAddition_ThrowsWhenTargetIsNotRecord` — a non-record type throws `ArgumentException` rather than silently returning empty.
- [x] `PreviewAddition_ThrowsWhenRecordIsNotFound` — an unresolvable metadata name throws `KeyNotFoundException` mapped to the tool's NotFound envelope.
- [x] `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry` passes — catalog entry + `[McpToolMetadata]` attribute agree on category/tier/summary/flags.
- [x] Full `./eng/verify-release.ps1 -Configuration Release` — 747/747 passed on the clean run (an initial run hit the known rotating shared-workspace flakes `DiLifetimeOverrideTests.Single_Registration_Service_Type_Is_Excluded_From_Override_Chains` and `ExceptionFlowServiceTests.TraceExceptionFlow_FindsTypedCatch_WithRethrowAsAndBodyExcerpt`; both passed in isolation and in the subsequent full run).
- [x] `./eng/verify-ai-docs.ps1` passed.

Closes: breaking-change-impact-preview-for-positional-records

---
Generated with Claude Code