### PR TITLE
chore(release): bump version to 1.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 147 tools (104 stable / 43 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 147 tools (104 stable / 43 experimental) plus 20 MCP prompts; 31 bundled agent skills cover analysis, impact assessment, architecture review, refactor, tests, MSBuild inspection, security hardening, modernization, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.25.0] - 2026-04-19
+
+Batch-9 backlog sweep — ships the final non-heroic initiative from plan `20260417T120000Z_backlog-sweep` (`record-field-add-satellite-member-sync`), bringing the plan to 34/37 merged (2 heroic-last + 1 deferred remaining). Rolls up the multi-batch Unreleased accumulation: 13 new MCP tools (`split_service_with_di_preview`, `scaffold_first_test_file_preview`, `get_di_registrations` lifetime-overrides, `apply_text_edit`/`apply_multi_file_edit` verify hooks, `extract_shared_expression_to_helper_preview`, `probe_position`, external-edit stale tracking, `verify_pragma_suppresses` + `pragma_scope_widen`, `get_coupling_metrics`, `find_duplicate_helpers`, `replace_invocation_preview`, `find_dead_locals`, `preview_record_field_addition`, `record_field_add_with_satellites_preview`), one workspace-load restore-race fix, and +86 regression tests across 15 new files.
+
+### Added
+
 - **Added:** `split_service_with_di_preview` composite preview splits a DI-consumed service type into N partition implementations + a forwarding facade and emits DI-registration deltas against the existing host registration (Transient/Scoped/Singleton inferred from the current `services.Add*` call). Built on top of v1.18 `symbol_refactor_preview` primitives (`restructure` + `edit` ops); when the host registration file is null or the registration is missing, the preview falls back to a warning rather than crashing (`composite-split-service-di-registration`). Includes `SplitServicePartition` DTO on `ISymbolRefactorService`.
 - **Added:** `scaffold_first_test_file_preview` inspects a target service's constructor + public methods and emits a new `<Service>Tests.cs` fixture with `ClassInitialize` + service instantiation + one smoke-test method per public method. Derives the boilerplate shape from the 2-3 most-recently-modified sibling test fixtures in the target test project, falling back to repo-convention defaults for projects with zero existing fixtures. Hardened with three type-resolution fallbacks (`GetTypeByMetadataName` → `GetSymbolsWithName` → `ClassDeclarationSyntax` walk) against fresh-load + immediate-query timing gaps in MSBuildWorkspace (`first-test-for-new-service-scaffold`).
 - **Added:** `get_di_registrations` gains a `showLifetimeOverrides: true` opt-in that emits per-interface override chains, the winning registration's lifetime, whether lifetimes differ across overrides (Singleton→Scoped etc.), and a dead-registration count for registrations overridden by a later-wins composition-root call. `DiRegistrationDto` grows a `LifetimeOverrides` section; default output shape unchanged (`di-lifetime-mismatch-detection`).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.24.0</Version>
+    <Version>1.25.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary
- Promote multi-batch `[Unreleased]` accumulation into `## [1.25.0] - 2026-04-19` section.
- Bump all 5 version files 1.24.0 → 1.25.0 (`Directory.Build.props`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `manifest.json`, `CHANGELOG.md` header).
- Fresh empty `## [Unreleased]` block at top.
- `verify-version-drift` green (all 5 files agree on 1.25.0).

## Release contents (1.25.0)
- 13 new MCP tools: `split_service_with_di_preview`, `scaffold_first_test_file_preview`, `get_di_registrations` lifetime-overrides, `apply_text_edit`/`apply_multi_file_edit` verify hooks, `extract_shared_expression_to_helper_preview`, `probe_position`, external-edit stale tracking, `verify_pragma_suppresses` + `pragma_scope_widen`, `get_coupling_metrics`, `find_duplicate_helpers`, `replace_invocation_preview`, `find_dead_locals`, `preview_record_field_addition`, `record_field_add_with_satellites_preview`
- 1 workspace-load restore-race fix (`dr-9-10-initial-does-not-wait-for-concurrent-to-finaliz`)
- +86 regression tests across 15 new test files (678 → 764)
- 15 backlog rows closed (P3: 1, P4: 14)

## Plan state
34/37 initiatives merged in `20260417T120000Z_backlog-sweep` (92%). Remaining: 2 heroic-last (#36, #37 — human-judgment investigation) + 1 deferred (#5).

## Test plan
- [x] `verify-version-drift.ps1` green
- [ ] CI `validate` job (runs full 764-test suite + verify-release)
- [ ] After merge: tag `v1.25.0` on the squash-merged commit
- [ ] After tag: confirm release workflow publishes NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)