### PR TITLE
docs(workflow): document worktree + gh pr merge discipline

### DIFF
--- a/ai_docs/workflow.md
+++ b/ai_docs/workflow.md
@@ -37,6 +37,17 @@ This document is the single owner for branch, worktree, pull-request, and merge-
 - Remove temporary worktrees created for the task.
 - Start follow-up work on a new branch.
 
+### Worktree `gh pr merge` discipline
+
+`gh pr merge` fails inside a worktree with `fatal: '<branch>' is already used by
+worktree at <primary-path>` because `gh` tries to update / delete a local
+branch checked out in the primary repo. Run merge commands from the primary
+repo root:
+
+    cd "$(git rev-parse --git-common-dir)/.." && gh pr merge <n> --squash --delete-branch
+
+See `prompts/backlog-sweep-execute.md` § Step 8 for the subagent-flow wording.
+
 ## Ownership
 
 - Validation and merge gating belong to `../CI_POLICY.md`.


### PR DESCRIPTION
## Summary

- Add `### Worktree \`gh pr merge\` discipline` subsection to `ai_docs/workflow.md` under § Post-Merge Cleanup.
- Captures the failure mode (`fatal: '<branch>' is already used by worktree at <primary-path>`), the `cd "$(git rev-parse --git-common-dir)/.."` preamble, and a cross-reference to `prompts/backlog-sweep-execute.md` § Step 8.
- Doc-only change; 1 file / +11 lines; heading slug `#worktree-gh-pr-merge-discipline` is linkable.

## Test plan

- [x] `./eng/verify-ai-docs.ps1` — passes (link + stale-reference scan).
- [x] Note body is 8 non-heading lines (plan cap: ≤ 8); file is 54 lines (plan cap: ≤ 60).
- [x] `/ship`-style external callers still work — the in-repo doc is descriptive, not a hook.

Closes: gh-pr-merge-from-worktree-fails-uses-local-main

Generated with Claude Code