### PR TITLE
chore(docs): drop dead planPath/initiativeId from reconciler brief (pr-reconciler-plan-md-commit-is-write-only-dead-code)

### DIFF
--- a/ai_docs/prompts/backlog-sweep-execute.md
+++ b/ai_docs/prompts/backlog-sweep-execute.md
@@ -412,9 +412,25 @@ Use the `ship` skill if available, otherwise `Bash: gh pr create ...` and
 **For the merge + cleanup leg specifically:** once the PR is open, invoke the
 `pr-reconciler` subagent (`.claude/agents/pr-reconciler.md`). It polls `gh pr view`
 for green checks, squash-merges from the primary repo root (the
-worktree-cd discipline is handled inside the subagent), cleans up the worktree +
-remote branch, and updates plan.md's Status row — all in isolated context.
-Falls through to manual `gh pr merge` if unavailable.
+worktree-cd discipline is handled inside the subagent), and cleans up the worktree +
+remote branch — all in isolated context. Falls through to manual `gh pr merge` if
+unavailable.
+
+**Reconciler brief — minimal fields only:** pass exactly these three fields and
+NOTHING ELSE:
+
+- `prNumberOrUrl` — PR number or full URL
+- `branch` — `remediation/<initiative.id>`
+- `worktreePath` — `.worktrees/<initiative.id>` (or `null` if branch-only)
+
+The reconciler does NOT touch `plan.md` or `state.json` — the orchestrator handles
+those in the batch-boundary reconcile PR (Step 7 parallel variant) or in Step 9
+(serial). Do NOT emit `planPath` or `initiativeId` in the brief: the reconciler's
+input contract lists them as "accepted but ignored for backwards compatibility,"
+but emitting them encourages the reconciler to try `plan.md` edits that cannot be
+pushed (main is branch-protected) and that the next reconciler's `git reset --hard
+origin/main` would wipe anyway. The 2026-04-18 pass-4 retrospective confirmed 5/5
+such commits were silently discarded.
 
 ### Worktree-cd discipline (both modes)
 


### PR DESCRIPTION
## Summary

Step 8 of `ai_docs/prompts/backlog-sweep-execute.md` had two related problems this PR fixes:

1. **Stale capability claim.** Step 8 said the pr-reconciler subagent "updates plan.md's Status row — all in isolated context." Per the reconciler's own Step 4 (`/.claude/agents/pr-reconciler.md`), it explicitly does NOT edit `plan.md` or `state.json` — the orchestrator owns those in the batch-boundary reconcile PR (parallel) or at Step 9 (serial). The 2026-04-18 pass-4 retrospective confirmed 5/5 such reconciler plan.md commits were silently discarded by the next reconciler's `git reset --hard origin/main`.

2. **No explicit brief template.** Step 8 didn't document the minimal reconciler brief, which allowed orchestrators to bundle `planPath` / `initiativeId`. Those fields are listed in the reconciler's input contract as "accepted but ignored for backwards compatibility" — but emitting them nudges the reconciler toward plan.md edits that cannot be pushed (main is branch-protected) and will be wiped anyway.

## Change

- Corrected Step 8's description to drop the misleading "updates plan.md's Status row" claim.
- Added an explicit "Reconciler brief — minimal fields only" paragraph documenting the exact three-field contract: `prNumberOrUrl`, `branch`, `worktreePath`.
- Kept the Appendix B `initiative-executor` brief untouched (it still needs `initiative.id` and `plan path` — those are load-bearing for the executor).

## Audit (b) — other `.claude/agents/*.md` for the "commit to local main without push" anti-pattern

Per the plan's Approach (b), grepped `initiative-executor.md` and `changelog-and-backlog-sync.md` for `git commit` / `git push` / `main`:

- `initiative-executor.md`: commits/pushes go to `remediation/<id>` only — clean.
- `changelog-and-backlog-sync.md`: commits only when `autoCommit: true`, on whatever branch the orchestrator put it on (typically a short-lived branch + PR for main edits). Never commits to local main.

No follow-up row needed.

## Test plan

- [x] `./eng/verify-ai-docs.ps1` passes.
- [x] Diff is doc-only; verify-release is not required to pass for doc-only changes (CI's `detect-docs-only` gate will exercise this in the PR check).
- [x] `backlog-sweep-execute.md` renders cleanly; Step 8 is still coherent end-to-end.

Closes: pr-reconciler-plan-md-commit-is-write-only-dead-code