### PR TITLE
ci(verify-release): gate coverage collection on main-only, skip on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,23 @@ jobs:
         shell: pwsh
         run: ./eng/verify-ai-docs.ps1
 
-      - name: Verify release build
-        if: steps.detect.outputs.docs_only != 'true'
+      # Coverage collection adds ~60-90s per run via coverlet IL-rewrite on every test
+      # assembly, and CI_POLICY.md treats coverage as informational — not a merge gate.
+      # Pass -NoCoverage on pull_request to skip the collection + HTML summary + upload;
+      # push-to-main, scheduled, and workflow_dispatch keep full collection so the
+      # artifact is still published and trend data continues on main.
+      - name: Verify release build (pull request — no coverage)
+        if: steps.detect.outputs.docs_only != 'true' && github.event_name == 'pull_request'
+        shell: pwsh
+        run: ./eng/verify-release.ps1 -Configuration Release -NoCoverage
+
+      - name: Verify release build (main / dispatch / schedule — with coverage)
+        if: steps.detect.outputs.docs_only != 'true' && github.event_name != 'pull_request'
         shell: pwsh
         run: ./eng/verify-release.ps1 -Configuration Release
 
       - name: Generate coverage HTML summary
-        if: steps.detect.outputs.docs_only != 'true'
+        if: steps.detect.outputs.docs_only != 'true' && github.event_name != 'pull_request'
         shell: pwsh
         run: |
           dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.4.7 --no-cache
@@ -104,7 +114,7 @@ jobs:
           path: artifacts/manifests
 
       - name: Upload code coverage
-        if: steps.detect.outputs.docs_only != 'true'
+        if: steps.detect.outputs.docs_only != 'true' && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage

--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -6,7 +6,7 @@ This document is the single canonical source for validation requirements and mer
 
 - `.github/workflows/ci.yml` runs on pull requests, pushes to `main`, and manual dispatch.
 - CI currently runs `./eng/verify-ai-docs.ps1`.
-- CI currently runs `./eng/verify-release.ps1 -Configuration Release` (includes `dotnet test` with **XPlat Code Coverage** to `artifacts/coverage`, then **ReportGenerator** HTML summary under `artifacts/coverage/report`).
+- CI currently runs `./eng/verify-release.ps1 -Configuration Release`. Coverage collection is gated on event type: pull requests run with `-NoCoverage` (skips `dotnet test --collect:"XPlat Code Coverage"`, the ReportGenerator HTML summary step, and the `code-coverage` artifact upload — coverage is informational, not a merge gate, and the coverlet IL-rewrite cost is ~60–90s per PR). Pushes to `main` and manual dispatches (`workflow_dispatch`) run full coverage collection with **XPlat Code Coverage** to `artifacts/coverage`, then **ReportGenerator** HTML summary under `artifacts/coverage/report`, then upload the `code-coverage` artifact so trend data continues on main. The same gate covers any future non-PR triggers (e.g. `schedule:`) via `github.event_name != 'pull_request'`.
 - CI currently runs `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`.
 - `.github/workflows/codeql.yml` runs the **Analyze C#** CodeQL job on every pull request, push to `main`, weekly schedule, and manual dispatch so the check stays required and always completes. On pull requests, a path filter runs first: if the diff only touches documentation or other non-code paths, CodeQL skips `init`/build/analyze (the job still succeeds). Pull requests that run CodeQL use the `security-extended` query suite; pushes to `main` and scheduled runs use `security-and-quality`. SARIF upload to GitHub Code Scanning is disabled (`upload: never`).
 
@@ -14,7 +14,7 @@ This document is the single canonical source for validation requirements and mer
 
 - For AI-doc changes, run `./eng/verify-ai-docs.ps1`.
 - For release-impacting or code changes, run `./eng/verify-release.ps1`.
-- `eng/verify-release.ps1` performs restore, build, test (with Cobertura coverage under `artifacts/coverage`), publish, and hash-manifest generation.
+- `eng/verify-release.ps1` performs restore, build, test (with Cobertura coverage under `artifacts/coverage`), publish, and hash-manifest generation. Pass `-NoCoverage` to skip the `--collect:"XPlat Code Coverage"` IL-rewrite step for faster iteration when you don't need the coverage artifact (matches the CI pull-request path).
 
 ## Merge Gating Expectations
 

--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$Configuration = "Release",
-    [string]$OutputRoot = "artifacts"
+    [string]$OutputRoot = "artifacts",
+    [switch]$NoCoverage
 )
 
 $ErrorActionPreference = "Stop"
@@ -25,7 +26,9 @@ $hashManifestPath = Join-Path $manifestDir "host-stdio-sha256.txt"
 
 New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
 New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
-New-Item -ItemType Directory -Path $coverageDir -Force | Out-Null
+if (-not $NoCoverage) {
+    New-Item -ItemType Directory -Path $coverageDir -Force | Out-Null
+}
 
 # Version-string drift check across all 5 version files.
 # Runs before build so a drift-only mistake fails fast without waiting for compilation.
@@ -51,10 +54,19 @@ Invoke-DotnetStep "dotnet build"
 
 # Logger verbosity `minimal` emits the run summary and failure details but skips
 # the per-test "Passed X [N ms]" lines that dominated the previous console output.
-dotnet test $solutionPath -c $Configuration --no-build --nologo `
-    --collect:"XPlat Code Coverage" `
-    --results-directory $coverageDir `
-    --logger "console;verbosity=minimal"
+# Coverage collection adds coverlet IL-rewrite latency per test assembly (~60-90s total).
+# CI_POLICY.md treats coverage as informational — not a merge gate — so PR-time collection
+# is pure latency. `-NoCoverage` lets CI skip it on pull_request while push-to-main,
+# scheduled, and workflow_dispatch still collect for the uploaded artifact.
+if ($NoCoverage) {
+    dotnet test $solutionPath -c $Configuration --no-build --nologo `
+        --logger "console;verbosity=minimal"
+} else {
+    dotnet test $solutionPath -c $Configuration --no-build --nologo `
+        --collect:"XPlat Code Coverage" `
+        --results-directory $coverageDir `
+        --logger "console;verbosity=minimal"
+}
 Invoke-DotnetStep "dotnet test"
 
 # PublishReadyToRun (CrossGen) can fail on CI runners when the SDK's crossgen2
@@ -75,4 +87,8 @@ Set-Content -Path $hashManifestPath -Value $hashLines
 
 Write-Host "Publish directory: $publishDir"
 Write-Host "Hash manifest: $hashManifestPath"
-Write-Host "Code coverage (Cobertura): $coverageDir"
+if ($NoCoverage) {
+    Write-Host "Code coverage: skipped (-NoCoverage)"
+} else {
+    Write-Host "Code coverage (Cobertura): $coverageDir"
+}


### PR DESCRIPTION
## Summary

- Add `[switch]$NoCoverage` to `eng/verify-release.ps1`. When set, `dotnet test` runs without `--collect:"XPlat Code Coverage"`, the coverage-dir is not created, and the summary reports "skipped".
- Split `.github/workflows/ci.yml`'s "Verify release build" step into two event-gated branches. Pull requests run `./eng/verify-release.ps1 -Configuration Release -NoCoverage`; push-to-main and `workflow_dispatch` run full coverage collection. "Generate coverage HTML summary" and "Upload code coverage" are gated on the same `github.event_name != 'pull_request'` condition, so the `code-coverage` artifact and trend data continue on main.
- Document the PR-vs-main coverage split in `CI_POLICY.md` § Repository Evidence, and mention `-NoCoverage` in Local Validation for fast-iteration use.

**Why:** `CI_POLICY.md` treats coverage as informational, not a merge gate. PR-time coverlet IL-rewrite costs ~60–90s across all test assemblies for zero gating value.

Closes: ci-verify-release-coverage-on-main-only

## Test plan

- [ ] CI on this PR exercises the new `pull_request` path (runs `-NoCoverage`, skips coverage-summary + upload steps). This is the self-validating check — a green CI run here with the coverage step skipped proves the gate works.
- [ ] Post-merge, the first push-to-main CI run exercises the `github.event_name != 'pull_request'` path and produces the `code-coverage` artifact + HTML summary as before.
- [x] Local: `./eng/verify-release.ps1 -NoCoverage -Configuration Release` restore/build/test/publish all execute, the new flag correctly omits `--collect` (769/770 tests passed in the re-run; the one failure was `CrossProjectRefactoringIntegrationTests.Extract_Interface_Preview_And_Apply_Creates_Interface_File_And_Project_Reference` which passes in isolation — pre-existing test-ordering flake, unrelated to this change, spawned as a separate follow-up task).
- [x] Local: `./eng/verify-ai-docs.ps1` passes.

## Notes

The `if (NoCoverage) { ... } else { ... }` branch in the ps1 duplicates the `dotnet test` call rather than building the argument list conditionally. This is the readable shape for PowerShell param-splat in a script this short — the two branches differ only in three args, and splatting `$testArgs` would obscure the diff at review time. Coverage-on is still the default when the switch is unset, preserving behavior for any existing callers.