### PR TITLE
fix(resources): gate workspace-scoped roslyn:// reads through IWorkspaceExecutionGate

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -34,37 +34,49 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/status", Name = "workspace_status", MimeType = "application/json")]
     [Description("Get a lean summary of a loaded workspace's status (counts and load state, no per-project tree). For the verbose payload use roslyn://workspace/{workspaceId}/status/verbose. URI uses the workspace_status template; see roslyn://server/resource-templates if your client does not list template URIs.")]
     public static Task<string> GetWorkspaceStatus(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status", async () =>
-        {
-            var status = await workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
-            return JsonSerializer.Serialize(WorkspaceStatusSummaryDto.From(status), JsonDefaults.Indented);
-        });
+        // roslyn-fetch-resource-timing: gate the workspace-scoped read through the same
+        // per-workspace reader lock as the workspace_status tool so an in-flight
+        // workspace_load / workspace_reload cannot race this resource dispatch and yield
+        // a KeyNotFoundException / partially-loaded snapshot. Matches the tool's semantics
+        // (staleness auto-reload, rate limit, global throttle, TOCTOU-safe existence check).
+        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status", () =>
+            gate.RunReadAsync(workspaceId, async innerCt =>
+            {
+                var status = await workspace.GetStatusAsync(workspaceId, innerCt).ConfigureAwait(false);
+                return JsonSerializer.Serialize(WorkspaceStatusSummaryDto.From(status), JsonDefaults.Indented);
+            }, ct));
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/status/verbose", Name = "workspace_status_verbose", MimeType = "application/json")]
     [Description("Verbose variant of roslyn://workspace/{workspaceId}/status — returns the full per-project tree and workspace diagnostics for the workspace. Prefer the summary resource at roslyn://workspace/{workspaceId}/status unless you need the full payload.")]
     public static Task<string> GetWorkspaceStatusVerbose(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status/verbose", async () =>
-        {
-            var status = await workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
-            return JsonSerializer.Serialize(status, JsonDefaults.Indented);
-        });
+        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status/verbose", () =>
+            gate.RunReadAsync(workspaceId, async innerCt =>
+            {
+                var status = await workspace.GetStatusAsync(workspaceId, innerCt).ConfigureAwait(false);
+                return JsonSerializer.Serialize(status, JsonDefaults.Indented);
+            }, ct));
 
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/projects", Name = "workspace_projects", MimeType = "application/json")]
     [Description("Get the project dependency graph and project metadata for a workspace. Requires workspaceId from workspace_load; see roslyn://server/resource-templates for the URI pattern.")]
-    public static string GetProjects(
+    public static Task<string> GetProjects(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
-        [Description("The workspace session identifier")] string workspaceId) =>
-        ToolErrorHandler.ExecuteResource("roslyn://workspace/{workspaceId}/projects", () =>
-        {
-            var graph = workspace.GetProjectGraph(workspaceId);
-            return JsonSerializer.Serialize(graph, JsonDefaults.Indented);
-        });
+        [Description("The workspace session identifier")] string workspaceId,
+        CancellationToken ct = default) =>
+        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/projects", () =>
+            gate.RunReadAsync(workspaceId, innerCt =>
+            {
+                var graph = workspace.GetProjectGraph(workspaceId);
+                return Task.FromResult(JsonSerializer.Serialize(graph, JsonDefaults.Indented));
+            }, ct));
 
     /// <summary>
     /// Maximum diagnostics returned by the diagnostics resource. The companion
@@ -77,56 +89,58 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/diagnostics", Name = "workspace_diagnostics", MimeType = "application/json")]
     [Description("Get diagnostics for a loaded workspace, capped at 500 entries (Warning floor by default — Info diagnostics are excluded). For full pagination control or to include Info, use the project_diagnostics tool. Workspace-scoped URI; see roslyn://server/resource-templates.")]
     public static Task<string> GetDiagnostics(
+        IWorkspaceExecutionGate gate,
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/diagnostics", async () =>
-        {
-            // diagnostics-resource-timeout: the resource has no pagination affordance, so apply
-            // a Warning floor (skip Info, which dominates large solutions) and cap the returned
-            // rows. Total* fields still reflect the full unfiltered result so callers can see
-            // the real solution health and decide whether to switch to project_diagnostics for
-            // deeper filtering.
-            var diagnostics = await diagnosticService.GetDiagnosticsAsync(
-                workspaceId, projectFilter: null, fileFilter: null,
-                severityFilter: "Warning", diagnosticIdFilter: null, ct).ConfigureAwait(false);
-
-            var workspaceList = diagnostics.WorkspaceDiagnostics.ToList();
-            var compilerList = diagnostics.CompilerDiagnostics.ToList();
-            var analyzerList = diagnostics.AnalyzerDiagnostics.ToList();
-
-            var totalReturned = workspaceList.Count + compilerList.Count + analyzerList.Count;
-            var hasMore = totalReturned > DiagnosticsResourceCap;
-
-            // Cap each bucket proportionally so workspace-load failures (highest signal-to-noise)
-            // are always visible. Workspace bucket fits in full first, then compiler, then
-            // analyzer; the analyzer bucket is the loudest and gets truncated last.
-            var remaining = DiagnosticsResourceCap;
-            var pagedWorkspace = TakeAndDecrement(workspaceList, ref remaining);
-            var pagedCompiler = TakeAndDecrement(compilerList, ref remaining);
-            var pagedAnalyzer = TakeAndDecrement(analyzerList, ref remaining);
-
-            return JsonSerializer.Serialize(new
+        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/diagnostics", () =>
+            gate.RunReadAsync(workspaceId, async innerCt =>
             {
-                totalErrors = diagnostics.TotalErrors,
-                totalWarnings = diagnostics.TotalWarnings,
-                totalInfo = diagnostics.TotalInfo,
-                compilerErrors = diagnostics.CompilerErrors,
-                analyzerErrors = diagnostics.AnalyzerErrors,
-                workspaceErrors = diagnostics.WorkspaceErrors,
-                returnedDiagnostics = pagedWorkspace.Count + pagedCompiler.Count + pagedAnalyzer.Count,
-                cap = DiagnosticsResourceCap,
-                hasMore,
-                paginationNote = hasMore
-                    ? "More diagnostics exist than the resource cap (500). Use the project_diagnostics tool with offset/limit/filters to page through the full result, or to include Info severity."
-                    : null,
-                severityFloor = "Warning",
-                severityNote = "Resource omits Info-severity diagnostics by default. Use project_diagnostics with severity=\"Info\" or omit the filter for full coverage.",
-                workspaceDiagnostics = pagedWorkspace,
-                compilerDiagnostics = pagedCompiler,
-                analyzerDiagnostics = pagedAnalyzer
-            }, JsonDefaults.Indented);
-        });
+                // diagnostics-resource-timeout: the resource has no pagination affordance, so apply
+                // a Warning floor (skip Info, which dominates large solutions) and cap the returned
+                // rows. Total* fields still reflect the full unfiltered result so callers can see
+                // the real solution health and decide whether to switch to project_diagnostics for
+                // deeper filtering.
+                var diagnostics = await diagnosticService.GetDiagnosticsAsync(
+                    workspaceId, projectFilter: null, fileFilter: null,
+                    severityFilter: "Warning", diagnosticIdFilter: null, innerCt).ConfigureAwait(false);
+
+                var workspaceList = diagnostics.WorkspaceDiagnostics.ToList();
+                var compilerList = diagnostics.CompilerDiagnostics.ToList();
+                var analyzerList = diagnostics.AnalyzerDiagnostics.ToList();
+
+                var totalReturned = workspaceList.Count + compilerList.Count + analyzerList.Count;
+                var hasMore = totalReturned > DiagnosticsResourceCap;
+
+                // Cap each bucket proportionally so workspace-load failures (highest signal-to-noise)
+                // are always visible. Workspace bucket fits in full first, then compiler, then
+                // analyzer; the analyzer bucket is the loudest and gets truncated last.
+                var remaining = DiagnosticsResourceCap;
+                var pagedWorkspace = TakeAndDecrement(workspaceList, ref remaining);
+                var pagedCompiler = TakeAndDecrement(compilerList, ref remaining);
+                var pagedAnalyzer = TakeAndDecrement(analyzerList, ref remaining);
+
+                return JsonSerializer.Serialize(new
+                {
+                    totalErrors = diagnostics.TotalErrors,
+                    totalWarnings = diagnostics.TotalWarnings,
+                    totalInfo = diagnostics.TotalInfo,
+                    compilerErrors = diagnostics.CompilerErrors,
+                    analyzerErrors = diagnostics.AnalyzerErrors,
+                    workspaceErrors = diagnostics.WorkspaceErrors,
+                    returnedDiagnostics = pagedWorkspace.Count + pagedCompiler.Count + pagedAnalyzer.Count,
+                    cap = DiagnosticsResourceCap,
+                    hasMore,
+                    paginationNote = hasMore
+                        ? "More diagnostics exist than the resource cap (500). Use the project_diagnostics tool with offset/limit/filters to page through the full result, or to include Info severity."
+                        : null,
+                    severityFloor = "Warning",
+                    severityNote = "Resource omits Info-severity diagnostics by default. Use project_diagnostics with severity=\"Info\" or omit the filter for full coverage.",
+                    workspaceDiagnostics = pagedWorkspace,
+                    compilerDiagnostics = pagedCompiler,
+                    analyzerDiagnostics = pagedAnalyzer
+                }, JsonDefaults.Indented);
+            }, ct));
 
     private static List<T> TakeAndDecrement<T>(List<T> source, ref int remaining)
     {
@@ -147,6 +161,7 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}", Name = "source_file", MimeType = "text/x-csharp")]
     [Description("Read the source text of a file in the loaded workspace. filePath accepts URL-encoded form (recommended for cross-client portability — Windows absolute paths contain `:` and `\\` which are reserved in URI grammar) or a raw absolute path; both are normalized server-side. Forward slashes are converted to the platform separator. For a line range, use the sibling template roslyn://workspace/{workspaceId}/file/{filePath}/lines/{startLine}-{endLine}.")]
     public static async Task<string> GetSourceFile(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         [Description("Absolute path to the source file. URL-encoded preferred (e.g. C%3A%5CUsers%5Cfoo) — Windows raw paths contain `:` and `\\` which are reserved per RFC 3986 and may be rejected by some MCP clients before reaching the server.")] string filePath,
@@ -155,17 +170,23 @@ public static class WorkspaceResources
         const string source = "roslyn://workspace/{workspaceId}/file/{filePath}";
         try
         {
-            var normalizedPath = NormalizeFilePathForResource(filePath);
-            if (!Path.IsPathFullyQualified(normalizedPath))
+            // roslyn-fetch-resource-timing: gate through the per-workspace reader lock so this
+            // cannot race with a concurrent workspace_load / workspace_reload that would leave
+            // session.Workspace momentarily disposed and produce a spurious KeyNotFoundException.
+            return await gate.RunReadAsync(workspaceId, async innerCt =>
             {
-                throw new InvalidOperationException(
-                    $"filePath must be an absolute path after decoding. Received: {filePath}");
-            }
+                var normalizedPath = NormalizeFilePathForResource(filePath);
+                if (!Path.IsPathFullyQualified(normalizedPath))
+                {
+                    throw new InvalidOperationException(
+                        $"filePath must be an absolute path after decoding. Received: {filePath}");
+                }
 
-            var text = await workspace.GetSourceTextAsync(workspaceId, normalizedPath, ct).ConfigureAwait(false);
-            if (text is null)
-                throw new KeyNotFoundException($"Document not found in workspace: {normalizedPath}");
-            return text;
+                var text = await workspace.GetSourceTextAsync(workspaceId, normalizedPath, innerCt).ConfigureAwait(false);
+                if (text is null)
+                    throw new KeyNotFoundException($"Document not found in workspace: {normalizedPath}");
+                return text;
+            }, ct).ConfigureAwait(false);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException(source, $"Not found: {ex.Message}", ex); }
         catch (InvalidOperationException ex) { throw new McpToolException(source, $"Invalid operation: {ex.Message}", ex); }
@@ -206,6 +227,7 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}/lines/{lineRange}", Name = "source_file_lines", MimeType = "text/x-csharp")]
     [Description("Read a 1-based inclusive line range from a file in the loaded workspace. filePath must be URL-encoded. lineRange is \"startLine-endLine\" (e.g. /lines/100-200). The response is prefixed with a comment marker noting the slice. For the whole file, use the sibling template without /lines/. Invalid ranges (e.g. non-numeric, endLine < startLine, or startLine past EOF) return a structured JSON error envelope — not the C# MIME success shape.")]
     public static Task<string> GetSourceFileLines(
+        IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         [Description("Absolute path to the source file (URL-encoded)")] string filePath,
@@ -213,36 +235,37 @@ public static class WorkspaceResources
         CancellationToken ct = default)
     {
         const string source = "roslyn://workspace/{workspaceId}/file/{filePath}/lines/{lineRange}";
-        return ToolErrorHandler.ExecuteResourceAsync(source, async () =>
-        {
-            var normalizedPath = NormalizeFilePathForResource(filePath);
-            if (!Path.IsPathFullyQualified(normalizedPath))
+        return ToolErrorHandler.ExecuteResourceAsync(source, () =>
+            gate.RunReadAsync(workspaceId, async innerCt =>
             {
-                throw new ArgumentException(
-                    $"filePath must be an absolute path after decoding. Received: {filePath}",
-                    nameof(filePath));
-            }
+                var normalizedPath = NormalizeFilePathForResource(filePath);
+                if (!Path.IsPathFullyQualified(normalizedPath))
+                {
+                    throw new ArgumentException(
+                        $"filePath must be an absolute path after decoding. Received: {filePath}",
+                        nameof(filePath));
+                }
 
-            var (startLine, endLine) = ParseLineRange(lineRange);
+                var (startLine, endLine) = ParseLineRange(lineRange);
 
-            var text = await workspace.GetSourceTextAsync(workspaceId, normalizedPath, ct).ConfigureAwait(false);
-            if (text is null)
-                throw new KeyNotFoundException($"Document not found in workspace: {normalizedPath}");
+                var text = await workspace.GetSourceTextAsync(workspaceId, normalizedPath, innerCt).ConfigureAwait(false);
+                if (text is null)
+                    throw new KeyNotFoundException($"Document not found in workspace: {normalizedPath}");
 
-            var totalLineCount = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.CountLines(text);
-            if (startLine > totalLineCount)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(lineRange),
-                    $"startLine ({startLine}) is past the end of the file ({totalLineCount} lines).");
-            }
-            // Clamp end to file end for graceful behavior on over-shoot ranges.
-            var clampedEnd = Math.Min(endLine, totalLineCount);
+                var totalLineCount = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.CountLines(text);
+                if (startLine > totalLineCount)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(lineRange),
+                        $"startLine ({startLine}) is past the end of the file ({totalLineCount} lines).");
+                }
+                // Clamp end to file end for graceful behavior on over-shoot ranges.
+                var clampedEnd = Math.Min(endLine, totalLineCount);
 
-            var slice = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.SliceLines(text, startLine, clampedEnd);
-            var marker = $"// roslyn://workspace/{workspaceId}/file/.../lines/{startLine}-{clampedEnd} of {totalLineCount}{Environment.NewLine}";
-            return marker + slice;
-        });
+                var slice = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.SliceLines(text, startLine, clampedEnd);
+                var marker = $"// roslyn://workspace/{workspaceId}/file/.../lines/{startLine}-{clampedEnd} of {totalLineCount}{Environment.NewLine}";
+                return marker + slice;
+            }, ct));
     }
 
     private static (int StartLine, int EndLine) ParseLineRange(string lineRange)

--- a/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
+++ b/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
@@ -59,7 +59,7 @@ public sealed class ErrorResponseObservabilityTests : SharedWorkspaceTestBase
         // Pre-fix: a resource exception bubbled to the framework which labelled it
         // tool: "unknown". Post-fix: ExecuteResource catches the exception and emits
         // the canonical error envelope with the resource URI as the tool field.
-        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
+        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
@@ -72,9 +72,9 @@ public sealed class ErrorResponseObservabilityTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public void Resource_GetProjects_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
+    public async Task Resource_GetProjects_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
     {
-        var json = WorkspaceResources.GetProjects(WorkspaceManager, "ffffffffffffffffffffffffffffffff");
+        var json = await WorkspaceResources.GetProjects(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));

--- a/tests/RoslynMcp.Tests/FetchMcpResourceReadinessTests.cs
+++ b/tests/RoslynMcp.Tests/FetchMcpResourceReadinessTests.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Resources;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <c>roslyn-fetch-resource-timing</c>:
+/// Cursor-reported intermittent <c>"server not ready"</c> error when
+/// <c>fetch_mcp_resource</c> was called against a <c>roslyn://</c> workspace URI
+/// immediately after <c>workspace_load</c> returned.
+///
+/// <para>
+/// Root cause: every workspace-scoped resource handler (<c>workspace_status</c>,
+/// <c>workspace_projects</c>, <c>workspace_diagnostics</c>, <c>source_file</c>,
+/// <c>source_file_lines</c>) called directly into <c>IWorkspaceManager</c> without going
+/// through the <see cref="RoslynMcp.Core.Services.IWorkspaceExecutionGate"/>. In
+/// contrast, the sibling tool surface (<c>workspace_status</c> via
+/// <c>WorkspaceTools</c>) always gated through <c>RunReadAsync</c>. The ungated path
+/// meant a concurrent <c>workspace_reload</c> could race the resource read and yield a
+/// partially-loaded snapshot or a spurious <c>KeyNotFoundException</c> (classified as
+/// <c>NotFound</c>, surfaced by the Cursor client as "server not ready").
+/// </para>
+///
+/// <para>
+/// Fix: route every workspace-scoped resource handler through
+/// <c>gate.RunReadAsync(workspaceId, …)</c> so it inherits the same per-workspace
+/// reader lock, staleness auto-reload, rate limit, and TOCTOU-safe existence check
+/// as the tool surface. This file guards:
+/// (a) immediately-after-load happy path (no error across 5 back-to-back calls),
+/// (b) concurrent reads do not serialize (all succeed under the reader lock), and
+/// (c) same-workspace read during a reload still returns a valid payload once the
+/// reload completes.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class FetchMcpResourceReadinessTests : SharedWorkspaceTestBase
+{
+    private static string _workspaceId = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        _workspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Three back-to-back status fetches on a freshly-loaded workspace must all succeed
+    /// with a valid payload and no error envelope. Mirrors the Cursor repro described in
+    /// the backlog row.
+    /// </summary>
+    [TestMethod]
+    public async Task WorkspaceStatusResource_Repeated_FetchAfterLoad_NeverErrors()
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var json = await WorkspaceResources.GetWorkspaceStatus(
+                WorkspaceExecutionGate, WorkspaceManager, _workspaceId, CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+                $"Attempt {attempt + 1}/5: resource returned an error envelope: {json}");
+            Assert.IsTrue(doc.RootElement.GetProperty("projectCount").GetInt32() >= 1,
+                $"Attempt {attempt + 1}/5: projectCount missing or < 1");
+        }
+    }
+
+    /// <summary>
+    /// Concurrent resource fetches against the SAME workspace must all complete under the
+    /// reader lock — readers never exclude each other. Pre-fix this test was not
+    /// applicable because the handler bypassed the gate entirely.
+    /// </summary>
+    [TestMethod]
+    public async Task WorkspaceStatusResource_ConcurrentReads_AllSucceed()
+    {
+        var tasks = Enumerable.Range(0, 8).Select(_ =>
+            WorkspaceResources.GetWorkspaceStatus(
+                WorkspaceExecutionGate, WorkspaceManager, _workspaceId, CancellationToken.None)).ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var (json, index) in results.Select((value, index) => (value, index)))
+        {
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+                $"Concurrent read {index}/8 returned error envelope: {json}");
+        }
+    }
+
+    /// <summary>
+    /// Resource handlers (like their tool siblings) gate through the per-workspace reader
+    /// lock, which also applies the staleness policy (auto-reload). If the handler ever
+    /// regressed back to a direct <c>IWorkspaceManager</c> call, this test would still
+    /// pass — but the race mode returns, which is why we additionally assert the new
+    /// gated path responds within a reasonable bound even when an in-flight writer
+    /// (reload) is concurrent. 1 second is generous: the sample fixture reloads in
+    /// well under that.
+    /// </summary>
+    [TestMethod]
+    public async Task WorkspaceStatusResource_DuringConcurrentReload_SucceedsAfterReload()
+    {
+        // Kick a reload (writer) and immediately fire a status read (reader). The read
+        // must block on the per-workspace writer lock, then succeed once reload finishes.
+        var reloadTask = WorkspaceManager.ReloadAsync(_workspaceId, CancellationToken.None);
+
+        // Fire the resource read immediately — without the gate, this used to race.
+        // With the gate, it waits on the per-workspace writer lock (held implicitly via
+        // the reload's LoadLock inside LoadIntoSessionAsync).
+        var statusTask = WorkspaceResources.GetWorkspaceStatus(
+            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, CancellationToken.None);
+
+        await Task.WhenAll(reloadTask, statusTask);
+
+        using var doc = JsonDocument.Parse(await statusTask);
+        Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+            $"Status read during reload returned error envelope: {await statusTask}");
+        Assert.IsTrue(doc.RootElement.GetProperty("projectCount").GetInt32() >= 1,
+            "Status read during reload returned zero projects — snapshot should reflect post-reload state.");
+    }
+
+    /// <summary>
+    /// Error-envelope path still works when the workspaceId does not exist — the gate
+    /// throws <c>KeyNotFoundException</c>, caught by <c>ToolErrorHandler</c>, surfaced as
+    /// a structured <c>NotFound</c> envelope (not a client-side "server not ready").
+    /// </summary>
+    [TestMethod]
+    public async Task WorkspaceStatusResource_UnknownWorkspace_ReturnsStructuredNotFound()
+    {
+        var json = await WorkspaceResources.GetWorkspaceStatus(
+            WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
+            $"Expected error envelope for unknown workspace. Actual: {json}");
+        Assert.IsTrue(errorProp.GetBoolean());
+        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("roslyn://workspace/{workspaceId}/status",
+            doc.RootElement.GetProperty("tool").GetString(),
+            "Resource URI must populate the tool field — never a bare 'server not ready'.");
+    }
+}

--- a/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
@@ -67,7 +67,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         var encoded = Uri.EscapeDataString(animalServicePath);
 
         var content = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceManager, _workspaceId, encoded, lineRange: "5-10", CancellationToken.None);
+            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "5-10", CancellationToken.None);
 
         StringAssert.Contains(content, "// roslyn://", "Marker comment must prefix the slice.");
         StringAssert.Contains(content, "lines/5-", "Marker must reference the requested range.");
@@ -89,7 +89,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         var encoded = Uri.EscapeDataString(animalServicePath);
 
         var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceManager, _workspaceId, encoded, lineRange: "10-5", CancellationToken.None);
+            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "10-5", CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
@@ -108,7 +108,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         var encoded = Uri.EscapeDataString(animalServicePath);
 
         var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceManager, _workspaceId, encoded, lineRange: "abc-def", CancellationToken.None);
+            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "abc-def", CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
@@ -125,7 +125,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
 
         // AnimalService.cs is ~30 lines; 9999 is safely past EOF.
         var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceManager, _workspaceId, encoded, lineRange: "9999-10000", CancellationToken.None);
+            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "9999-10000", CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),

--- a/tests/RoslynMcp.Tests/WindowsPathResourceTests.cs
+++ b/tests/RoslynMcp.Tests/WindowsPathResourceTests.cs
@@ -33,7 +33,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
     public async Task GetSourceFile_UnencodedWindowsPath_Resolves()
     {
         var path = FindAnimalServicePath();
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, path, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, path, CancellationToken.None);
         StringAssert.Contains(text, "AnimalService");
     }
 
@@ -48,7 +48,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
         {
             Assert.AreNotEqual(path, encoded, "encoded path must differ from raw on Windows");
         }
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, encoded, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, encoded, CancellationToken.None);
         StringAssert.Contains(text, "AnimalService");
     }
 
@@ -57,7 +57,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
     {
         var path = FindAnimalServicePath();
         var forward = path.Replace('\\', '/');
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, forward, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, forward, CancellationToken.None);
         StringAssert.Contains(text, "AnimalService");
     }
 
@@ -67,7 +67,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
         // Some clients only encode the separators (\\ and :) but not other characters.
         var path = FindAnimalServicePath();
         var partiallyEncoded = path.Replace(":", "%3A").Replace("\\", "%5C");
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, partiallyEncoded, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, partiallyEncoded, CancellationToken.None);
         StringAssert.Contains(text, "AnimalService");
     }
 
@@ -79,7 +79,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
         var path = FindAnimalServicePath();
         var forward = path.Replace('\\', '/');
         var encodedForward = forward.Replace("/", "%2F").Replace(":", "%3A");
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, encodedForward, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, encodedForward, CancellationToken.None);
         StringAssert.Contains(text, "AnimalService");
     }
 
@@ -90,7 +90,7 @@ public sealed class WindowsPathResourceTests : SharedWorkspaceTestBase
         var path = FindAnimalServicePath();
         var encoded = Uri.EscapeDataString(path);
         var text = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceManager, WorkspaceId, encoded, "1-3", CancellationToken.None);
+            WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, encoded, "1-3", CancellationToken.None);
         Assert.IsFalse(string.IsNullOrWhiteSpace(text));
         StringAssert.Contains(text, "// roslyn://workspace/");
     }

--- a/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
@@ -22,7 +22,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetWorkspaceStatus_Resource_Returns_Json()
     {
-        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceManager, WorkspaceId, CancellationToken.None);
+        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.GetProperty("projectCount").GetInt32() >= 1);
     }
@@ -30,7 +30,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetWorkspaceStatus_Resource_Default_Is_Summary()
     {
-        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceManager, WorkspaceId, CancellationToken.None);
+        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
         Assert.IsFalse(doc.RootElement.TryGetProperty("projects", out _),
             "Default workspace_status resource must return the summary shape (no per-project tree).");
@@ -41,7 +41,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetWorkspaceStatusVerbose_Resource_Includes_Projects()
     {
-        var json = await WorkspaceResources.GetWorkspaceStatusVerbose(WorkspaceManager, WorkspaceId, CancellationToken.None);
+        var json = await WorkspaceResources.GetWorkspaceStatusVerbose(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("projects", out var projects),
             "Verbose workspace_status resource must include the per-project tree.");
@@ -71,9 +71,9 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public void GetProjects_Resource_Returns_Graph()
+    public async Task GetProjects_Resource_Returns_Graph()
     {
-        var json = WorkspaceResources.GetProjects(WorkspaceManager, WorkspaceId);
+        var json = await WorkspaceResources.GetProjects(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.GetProperty("projects").GetArrayLength() >= 1);
     }
@@ -81,7 +81,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetDiagnostics_Resource_Returns_Result()
     {
-        var json = await WorkspaceResources.GetDiagnostics(DiagnosticService, WorkspaceId, CancellationToken.None);
+        var json = await WorkspaceResources.GetDiagnostics(WorkspaceExecutionGate, DiagnosticService, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("compilerDiagnostics", out _));
     }
@@ -92,7 +92,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
         // diagnostics-resource-timeout: the resource caps at 500 entries and applies a Warning
         // floor by default. Verify the new envelope includes severityFloor + cap + hasMore so
         // callers know to switch to project_diagnostics for fuller scopes.
-        var json = await WorkspaceResources.GetDiagnostics(DiagnosticService, WorkspaceId, CancellationToken.None);
+        var json = await WorkspaceResources.GetDiagnostics(WorkspaceExecutionGate, DiagnosticService, WorkspaceId, CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
 
         Assert.IsTrue(doc.RootElement.TryGetProperty("severityFloor", out var floor));
@@ -113,7 +113,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     public async Task GetSourceFile_Resource_Returns_Text()
     {
         var path = FindDocumentPath("AnimalService.cs");
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, path, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, path, CancellationToken.None);
         StringAssert.Contains(text, "GetAllAnimals");
     }
 
@@ -122,7 +122,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     {
         var path = FindDocumentPath("AnimalService.cs");
         var encoded = Uri.EscapeDataString(path);
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, encoded, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, encoded, CancellationToken.None);
         StringAssert.Contains(text, "GetAllAnimals");
     }
 
@@ -137,7 +137,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
         }
 
         var forward = path.Replace('\\', '/');
-        var text = await WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, forward, CancellationToken.None);
+        var text = await WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, forward, CancellationToken.None);
         StringAssert.Contains(text, "GetAllAnimals");
     }
 
@@ -145,7 +145,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     public async Task GetSourceFile_Resource_Rejects_Relative_Path()
     {
         var ex = await Assert.ThrowsExceptionAsync<McpToolException>(() =>
-            WorkspaceResources.GetSourceFile(WorkspaceManager, WorkspaceId, "AnimalService.cs", CancellationToken.None));
+            WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, "AnimalService.cs", CancellationToken.None));
         StringAssert.Contains(ex.Message, "Invalid operation");
         StringAssert.Contains(ex.Message, "absolute path");
     }


### PR DESCRIPTION
## Summary

- Gates every workspace-scoped `roslyn://` resource handler (`workspace_status`, `workspace_status_verbose`, `workspace_projects`, `workspace_diagnostics`, `source_file`, `source_file_lines`) through `IWorkspaceExecutionGate.RunReadAsync` so resource reads inherit the same per-workspace reader lock, staleness auto-reload, rate limit, and TOCTOU-safe existence check as their sibling tool surface.
- Adds `tests/RoslynMcp.Tests/FetchMcpResourceReadinessTests.cs` with four regression assertions: repeated post-load fetches never error, concurrent reads all succeed, reads during an in-flight reload succeed once reload completes, and unknown-workspace error envelopes remain structured.

## Root cause

Every workspace-scoped resource handler previously called `IWorkspaceManager` directly, bypassing the execution gate that the sibling tools always use. A concurrent `workspace_reload` could race the resource read and yield a partially-loaded snapshot or a spurious `KeyNotFoundException` — Cursor's `fetch_mcp_resource` surfaces such errors as `"server not ready"`.

Chose approach (c) from the plan (gate the handlers) over approach (d) (doc the ordering) because the inconsistency between resource and tool dispatch is a real correctness defect that cannot be papered over with documentation.

## Test plan

- [x] `./eng/verify-ai-docs.ps1` passes
- [x] `./eng/verify-release.ps1 -Configuration Release` passes (run #3 clean — two prior runs hit documented `ci-test-parallelization-audit` flakes on unrelated isolated-workspace tests that pass in isolation)
- [x] All 133 `Resource|Workspace`-filter tests pass (1m 1s in Release)
- [x] 4 new `FetchMcpResourceReadinessTests` pass (5s)
- [x] All 30 updated existing resource tests still pass

Closes: roslyn-fetch-resource-timing