### PR TITLE
docs(workflow): prepend dotnet build-server shutdown to worktree cleanup (windows-testhost-file-lock-blocks-worktree-cleanup)

### DIFF
--- a/ai_docs/prompts/backlog-sweep-execute.md
+++ b/ai_docs/prompts/backlog-sweep-execute.md
@@ -584,6 +584,17 @@ initiatives are taken. **Therefore:**
 7. After all batch PRs merge: open ONE reconcile PR per Step 7 parallel variant,
    merge it, run the post-merge main-sync idiom.
 8. Worktree cleanup:
+   - `dotnet build-server shutdown` **before** any worktree-removal command.
+     This releases `testhost.exe` / `VBCSCompiler.exe` file locks on
+     `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/` that verify-release.ps1
+     leaves behind on Windows. The command is a no-op when no servers are
+     running, so it is always safe to prepend unconditionally. It prints one
+     informational line to stdout (e.g. `Build server didn't shut down due to an
+     error or it wasn't running.`) — this is not an error; do not let cleanup
+     scripts treat non-zero-length stdout as failure. Without this step,
+     `git worktree remove --force` / `rm -rf .worktrees/<id>` fail with
+     `Device or resource busy` on Windows and leave stale `.worktrees/*`
+     directories (hit twice in the 2026-04-18 pass-3 retrospective).
    - `git worktree remove --force .worktrees/<id>` for each.
    - `git push origin --delete remediation/<id>` for each merged branch.
    - `git remote prune origin`.


### PR DESCRIPTION
## Summary

- Appendix A step 8 in `ai_docs/prompts/backlog-sweep-execute.md` now runs `dotnet build-server shutdown` **before** any `git worktree remove --force` / `rm -rf .worktrees/<id>` command.
- Eliminates the Windows `testhost.exe` / `VBCSCompiler.exe` file-lock residue that left stale `.worktrees/*` directories after every verify-release run (hit twice in the 2026-04-18 pass-3 retrospective).
- The SDK command is a no-op when no servers are running, so it is always safe to prepend unconditionally. The note also flags that the command prints one informational line to stdout that cleanup scripts must not treat as an error.

## Scope

Doc-only change. One file, +11 lines.

- `ai_docs/prompts/backlog-sweep-execute.md` — Appendix A step 8

No code, no tests. `verify-release.ps1` is not required for doc-only PRs per CI's `detect-docs-only` gate.

## Validation

- `./eng/verify-ai-docs.ps1` → passed.

## Test plan

- [x] `verify-ai-docs.ps1` passes.
- [ ] Next backlog-sweep session runs verify-release in a worktree and the cleanup phase removes the worktree directory without residue (check `tasklist /FI "IMAGENAME eq testhost.exe"` returns no processes after cleanup).

Closes: windows-testhost-file-lock-blocks-worktree-cleanup