### PR TITLE
release: v1.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
     {
       "name": "roslyn-mcp",
       "source": "./",
-      "description": "Semantic C# analysis and refactoring powered by Roslyn. 147 tools (104 stable / 43 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.25.0",
+      "description": "Semantic C# analysis and refactoring powered by Roslyn. 159 tools (107 stable / 52 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
+      "version": "1.26.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.25.0",
-  "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 147 tools (104 stable / 43 experimental) plus 20 MCP prompts; 31 bundled agent skills cover analysis, impact assessment, architecture review, refactor, tests, MSBuild inspection, security hardening, modernization, and release workflows.",
+  "version": "1.26.0",
+  "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 159 tools (107 stable / 52 experimental) plus 20 MCP prompts; 31 bundled agent skills cover analysis, impact assessment, architecture review, refactor, tests, MSBuild inspection, security hardening, modernization, and release workflows.",
   "author": {
     "name": "darylmcd",
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+### Changed
+
+### Added
+
+### Maintenance
+
+## [1.26.0] - 2026-04-20
+
+Batches 10, 11, and 12 of backlog-sweep plan `20260419T230057Z_backlog-sweep` — 12 of 15 actionable initiatives merged (80%). Ships `concurrent-mcp-instances-no-tools` startup surface diagnostic + `server_info` `surface.registered` block, a `fetch_mcp_resource` readiness-gate fix via `IWorkspaceExecutionGate.RunReadAsync`, the same-turn `*_preview`→`*_apply` hook accept-case, CI coverage split (PR skip / main collect), CI docs-only skip expansion, `.claude/agents/plan-vetter.md` + `.claude/agents/workspace-health-triage.md` subagents, `/recover-stalled-subagent` skill, `ReadmeSurfaceCountTests.cs` regression (+README count refresh to 159/107/52), and five `ai_docs/`-side process improvements (workflow worktree-cd discipline, backlog-sweep-execute reconciler brief cleanup + Appendix A `dotnet build-server shutdown`, planner anchor-verification sub-step).
+
 ### Added
 
 - **Added:** Startup surface diagnostic — the stdio host now cross-checks SDK-registered vs reflection vs `ServerSurfaceCatalog` counts at `host.Build()` and emits a single `Information`-level log line per process (`Startup surface: pid=… version=… tools=N/N resources=N/N prompts=N/N parity=ok`), flipping to `Error` level with structured mismatch details when any category disagrees. `server_info` gains a `surface.registered` block carrying runtime tool/resource/prompt counts + a `parityOk` flag so clients can distinguish a server-side registration failure (`registered=0`) from a client-side tool-listing issue even when stderr is unreachable. Makes the "N-th concurrent instance has no tools" failure mode observable end-to-end (`concurrent-mcp-instances-no-tools`).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.25.0</Version>
+    <Version>1.26.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.8.x   | Yes       |
-| < 1.8   | No        |
+| 1.26.x  | Yes       |
+| < 1.26  | No        |
 
 ## Reporting a Vulnerability
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Release cut for **v1.26.0** — wraps batches 10, 11, and 12 of backlog-sweep plan `20260419T230057Z_backlog-sweep` into a shipped minor version.

Plan progress at cut time: 12 of 15 actionable initiatives merged (80%).

## Version bump

- `Directory.Build.props`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `manifest.json`: `1.25.0` → `1.26.0`
- `CHANGELOG.md`: `[Unreleased]` promoted to `[1.26.0] - 2026-04-20` with a fresh empty `[Unreleased]` header added above

## Side-edits for release consistency

- **`plugin.json` + `marketplace.json` descriptions**: stale tool count `147 (104/43)` → current `159 (107/52)`. README already had the refreshed count (PR #294) but the plugin-surface metadata strings were missed.
- **`SECURITY.md` supported-versions table**: `1.8.x` → `1.26.x`. Was ~18 minor versions out of date; caught by the publish-preflight gate.

## Preflight results (all pass)

| Step | Result |
|---|---|
| Version drift | 1.26.0 across 5 files |
| AI docs validation | pass |
| Build / test / publish | 775/775 tests, 0 warnings |
| CHANGELOG [1.26.0] header | present (line 17) |
| SECURITY supported versions | 1.26.x listed |
| Consumer README | version-agnostic (pass) |
| `dotnet pack` | `.nupkg` + `.snupkg` produced |

## What's in [1.26.0]

Highlights (full list in `CHANGELOG.md`):

- **Added:** `concurrent-mcp-instances-no-tools` startup surface diagnostic; `.claude/agents/plan-vetter.md`; `.claude/agents/workspace-health-triage.md`; `/recover-stalled-subagent` skill; `ReadmeSurfaceCountTests.cs` regression.
- **Changed:** CI skips coverage on `pull_request` (runs on `push` / scheduled only).
- **Fixed:** `fetch_mcp_resource` readiness-gate via `IWorkspaceExecutionGate.RunReadAsync`; `*_apply` hook accepts same-turn `*_preview` evidence.
- **Maintenance:** 5 `ai_docs/`-side process refinements (workflow worktree-cd discipline, backlog-sweep-execute reconciler-brief cleanup + Appendix A `dotnet build-server shutdown`, backlog-sweep-plan anchor-verification, CI docs-only regex).

Backlog tally shipped under this version: 12 rows closed (P3: 1, P4: 11).

## Test plan

- [x] `eng/verify-release.ps1 -Configuration Release` — green (775/775)
- [x] `eng/verify-version-drift.ps1` — all 5 files agree on 1.26.0
- [x] `eng/verify-ai-docs.ps1` — pass
- [x] `dotnet pack` produces `.nupkg` + `.snupkg`
- [ ] Post-merge: tag `v1.26.0` + push tag + reinstall both layers (`-p:ReinstallTool=true` + `/roslyn-mcp:update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)