### PR TITLE
release: v1.27.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn. 159 tools (107 stable / 52 experimental) for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files and get 159 tools (107 stable / 52 experimental) plus 20 MCP prompts; 31 bundled agent skills cover analysis, impact assessment, architecture review, refactor, tests, MSBuild inspection, security hardening, modernization, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+### Changed
+
+### Added
+
+### Maintenance
+
+## [1.27.0] - 2026-04-21
+
+Comprehensive refactor completion — 17 PRs (#303–#319) closing both P3 backlog rows from the 2026-04-20 audit plan. **Workstream 1** (`tools-dispatch-shim-boilerplate-duplication`): 87+ tool-dispatch shims migrated to a shared `ToolDispatch` runtime helper (3 dispatch kinds: `ApplyByTokenAsync`, `PreviewWithWorkspaceIdAsync`, `ReadByWorkspaceIdAsync` + one `Func<string, string?>` peek-delegate overload for non-`IPreviewStore` stores); a source-generator approach was attempted in phase 1.1 but retired in phase 1.7 after phase 1.2 canary discovered an irreconcilable CS0756 conflict with the MCP SDK's `ModelContextProtocol.Analyzers.XmlToDescriptionGenerator` over `public static partial` declarations. **Workstream 2** (`top10-complexity-hotspots-not-yet-extracted`): 15 of 17 enumerated complexity hotspots extracted (all targets met, most cc<10 after); 2 dispositioned as defensible dense-switch-over-closed-kind-set patterns with MI=50. Highest-impact deltas: `BuildAsync` (cc 30→2, MI 27→49), `FindDuplicatedMethodsAsync` (cc 21→1, MI 35→64), `ApplyAddRemoveAsync` (cc 28→1, MI 28→48), `CheckAsync` (cc 28→5; hot-path timing: 15.7s→12.0s wall-clock — faster post-refactor), `PreviewSplitServiceWithDiAsync` (cc 22→3, MI 32→54). Added 5 characterization tests for `CodeMetricsService.VisitChildForNesting` recursion semantics. Critical-path `UndoService.RevertFromSolutionSnapshotAsync` (cc 21→4) verified with 25/25 pre+post test parity. 1 new P3 row filed (`cc-18-to-19-residuals-post-top10-extraction`) surfacing 13 cc=18–19 methods that fell below the original audit's cc=20 anchor line.
+
+### Fixed
+
 - **Fixed:** Deleted dead `SyntaxFormatter` helper at `src/RoslynMcp.Roslyn/Helpers/SyntaxFormatter.cs` — `find_unused_symbols` flagged the type as high-confidence unused and `find_references(metadataName=RoslynMcp.Roslyn.Helpers.SyntaxFormatter)` returned 0 hits solution-wide; the XML-doc "shared helper... centralizes the pattern so every synthesizer gets the same behavior" was aspirational with no call sites. Removes 54 LOC / 2 methods (2026-04-20 refactor audit F1).
 - **Fixed:** Removed dead `BuildSuggestedArgumentList(BaseArgumentListSyntax, NewRecordFieldDto)` overload at `src/RoslynMcp.Roslyn/Services/RecordFieldAdditionService.cs:614` — 0 references solution-wide; body was byte-identical to the still-used `ArgumentListSyntax` overload, whose two call sites at `:260` and `:275` continue to resolve correctly (`ObjectCreationExpressionSyntax.ArgumentList` / `ImplicitObjectCreationExpressionSyntax.ArgumentList` are both `ArgumentListSyntax`, not `BaseArgumentListSyntax`) (2026-04-20 refactor audit F2).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.26.0</Version>
+    <Version>1.27.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

v1.27.0 — comprehensive refactor completion. Closes both P3 backlog rows from the 2026-04-20 audit plan via 17 PRs (#303–#319).

### Workstream 1 — `tools-dispatch-shim-boilerplate-duplication` (CLOSED)

- 87+ tool dispatch shims migrated to a shared `ToolDispatch` runtime helper (`ApplyByTokenAsync`, `PreviewWithWorkspaceIdAsync`, `ReadByWorkspaceIdAsync` + `Func<string, string?>` peek-delegate overload).
- Source-generator approach attempted in phase 1.1 but retired in phase 1.7 — MCP SDK's `ModelContextProtocol.Analyzers.XmlToDescriptionGenerator` already owns the `public static partial` declaration slot for `[McpServerTool]` methods (CS0756 conflict).
- Net ~−300 LOC of dispatch boilerplate; tool wire format + catalog preserved byte-identical.

### Workstream 2 — `top10-complexity-hotspots-not-yet-extracted` (CLOSED)

- 15 of 17 enumerated hotspots extracted; 2 dispositioned as defensible dense-switch-over-closed-kind-set patterns (MI=50 indicates the structure is already clear).
- Highest-impact deltas: `BuildAsync` (cc 30→2), `FindDuplicatedMethodsAsync` (cc 21→1), `ApplyAddRemoveAsync` (cc 28→1), `CheckAsync` (cc 28→5; hot-path faster post-refactor: 15.7s→12.0s wall-clock).
- 5 new characterization tests for `CodeMetricsService.VisitChildForNesting` recursion semantics.
- CRITICAL PATH `UndoService.RevertFromSolutionSnapshotAsync` (cc 21→4) verified with 25/25 pre+post test parity.

### Side cleanups

- 2 dead-code removals: `SyntaxFormatter` (54 LOC) + `BuildSuggestedArgumentList(BaseArgumentListSyntax)` overload (6 LOC).
- 1 new P3 row filed: `cc-18-to-19-residuals-post-top10-extraction` (13 methods that fell below the original audit's cc=20 anchor — follow-on work for a future audit pass).

## Test plan

- [x] Each of 17 child PRs ran `verify-release.ps1 -Configuration Release` clean (779-784 tests across the chain — count grew with the 5 added in session 2.9)
- [x] Hot-path timing for `CheckAsync` measured pre/post (no regression; actually faster)
- [x] Plan doc annotated with shipped status + final-state section (`ai_docs/plans/20260421T123658Z_post-audit-followups.md`)
- [x] `verify-version-drift.ps1` — all 5 version files agree on 1.27.0
- [x] Backlog: 2 rows removed (`tools-dispatch-shim-boilerplate-duplication`, `top10-complexity-hotspots-not-yet-extracted`); 1 added (`cc-18-to-19-residuals-post-top10-extraction`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)