### PR TITLE
feat(skills): changelog.d fragment-file pattern for conflict-free CHANGELOG updates (parallel-pr-changelog-append-friction)

### DIFF
--- a/.claude/skills/bump/SKILL.md
+++ b/.claude/skills/bump/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: bump
-description: "Version bump. Use when: bumping the version for a release, preparing a version increment (major/minor/patch), or when code changes require a new version. Takes bump type as input: 'major', 'minor', or 'patch'. Edits all 5 version files and prepends a CHANGELOG.md section."
+description: "Version bump. Use when: bumping the version for a release, preparing a version increment (major/minor/patch), or when code changes require a new version. Takes bump type as input: 'major', 'minor', or 'patch'. Edits all 5 version files, consumes `changelog.d/*.md` fragments into a new `## [X.Y.Z]` section grouped by category, and `git rm`s the consumed fragments."
 user-invocable: true
 argument-hint: "patch | minor | major"
 ---
 
 # Version Bump
 
-You are a release engineer. Your job is to increment the project version across all 5 version files and prepare a changelog section.
+You are a release engineer. Your job is to increment the project version across all 5 version files, consume accumulated `changelog.d/` fragments into the new `## [X.Y.Z]` section of `CHANGELOG.md`, and delete the consumed fragments in the same commit-ready change set.
 
 ## Server discovery
 
@@ -30,7 +30,11 @@ All 5 files must carry the same version string. See `docs/release-policy.md` § 
 | 2 | `.claude-plugin/plugin.json` | `"version": "X.Y.Z"` |
 | 3 | `.claude-plugin/marketplace.json` | `plugins[0].version` (NOT `metadata.version`) |
 | 4 | `manifest.json` | `"version": "X.Y.Z"` |
-| 5 | `CHANGELOG.md` | New `## [X.Y.Z] - YYYY-MM-DD` header at top of entries |
+| 5 | `CHANGELOG.md` | New `## [X.Y.Z] - YYYY-MM-DD` header populated from `changelog.d/*.md` fragments, grouped by category |
+
+## Fragment-file migration
+
+`CHANGELOG.md`'s `## [Unreleased]` section is a structural anchor and stays empty between releases. Per-PR changelog entries are written as fragment files at `changelog.d/<row-id>.md` with YAML frontmatter carrying the category (see `changelog.d/README.md` for the full pattern). At release-cut time this skill consumes those fragments.
 
 ## Workflow
 
@@ -47,23 +51,91 @@ Parse the current version as `major.minor.patch`. Apply the bump type:
 
 Display the new version and confirm with the user before proceeding.
 
-### Step 3: Edit All 5 Files
+### Step 3: Edit Version Files 1-4
 
-Edit each file using the Edit tool, replacing the old version with the new version:
+Edit each of the first four version files using the Edit tool, replacing the old version with the new version:
 
 1. **`Directory.Build.props`**: Replace `<Version>OLD</Version>` with `<Version>NEW</Version>`
 2. **`.claude-plugin/plugin.json`**: Replace `"version": "OLD"` with `"version": "NEW"` (the first occurrence)
 3. **`.claude-plugin/marketplace.json`**: Replace `"version": "OLD"` in the `plugins[0]` entry (NOT the `metadata.version` on line 9)
 4. **`manifest.json`**: Replace `"version": "OLD"` with `"version": "NEW"`
-5. **`CHANGELOG.md`**: Insert a new section header `## [NEW] - YYYY-MM-DD` (today's date) with empty `### Fixed`, `### Changed`, `### Added` subsections above the previous top entry. Do NOT remove or edit existing entries.
 
-### Step 4: Verify
+### Step 4: Consume `changelog.d/` fragments into `CHANGELOG.md`
+
+Scan `changelog.d/*.md` (exclude `README.md` — the directory explainer is NOT a fragment):
+
+```bash
+ls changelog.d/*.md | grep -v README.md
+```
+
+For each fragment, parse YAML frontmatter and extract:
+
+- `category` — must be one of: `Fixed`, `Changed`, `Changed — BREAKING`, `Added`, `Maintenance` (em-dash is U+2014). Unknown values fail the bump loudly — see *Refusal conditions* below.
+- Body — everything after the closing `---`. Expected to be a single bullet in the shipping `**<Category>:**` prose style (one per fragment).
+
+Group the fragments by `category` in the canonical emit order: `Fixed` → `Changed — BREAKING` → `Changed` → `Added` → `Maintenance`.
+
+Insert a new section into `CHANGELOG.md` immediately above the most recent `## [X.Y.Z]` block:
+
+```
+## [NEW] - YYYY-MM-DD
+
+### Fixed
+
+<bullets from Fixed fragments in the order fragments were read>
+
+### Changed — BREAKING
+
+<bullets from Changed — BREAKING fragments>
+
+### Changed
+
+<bullets from Changed fragments>
+
+### Added
+
+<bullets from Added fragments>
+
+### Maintenance
+
+<bullets from Maintenance fragments>
+```
+
+Omit any subsection that has zero fragments (do NOT emit an empty `### Fixed` header if no Fixed fragments were present). Do NOT remove or edit `## [Unreleased]` — it stays as a structural anchor with its empty subsection headers.
+
+If no fragments were present at all, emit a `## [NEW] - YYYY-MM-DD` section with a single `_No user-visible changes in this release._` line and proceed — some patch bumps legitimately ship with no fragments (e.g. version-file drift repair).
+
+Delete each consumed fragment from disk after the `CHANGELOG.md` edit lands:
+
+```bash
+rm changelog.d/<row-id>.md
+```
+
+The intent is that `git add -- CHANGELOG.md changelog.d/` then `git status` shows a single atomic change set: one `CHANGELOG.md` edit + N `changelog.d/*.md` deletions. This is what `/ship` (or a manual `git commit`) will commit.
+
+### Refusal conditions (fragment consumption)
+
+Refuse loudly — abort the bump before any `CHANGELOG.md` write — if any of the following hold:
+
+| Condition | Message |
+|---|---|
+| A fragment has missing or unparseable YAML frontmatter | `"Refusing: changelog.d/<file> is missing its YAML frontmatter or the frontmatter did not parse. Fix the fragment and re-run."` |
+| A fragment's `category` key is missing | `"Refusing: changelog.d/<file> has no 'category' key in its frontmatter. Fix the fragment and re-run."` |
+| A fragment's `category` value is not one of the five canonical values | `"Refusing: changelog.d/<file> has category '<value>'; expected one of Fixed / Changed — BREAKING / Changed / Added / Maintenance. Fix the fragment and re-run."` |
+| A fragment has no body (frontmatter-only) | `"Refusing: changelog.d/<file> has no bullet body. Fix the fragment and re-run."` |
+
+Do NOT silently skip malformed fragments — a silent skip would lose the release note.
+
+### Step 5: Verify
 
 Run `eng/verify-version-drift.ps1` via Bash to confirm all 5 files agree on the new version. If it fails, fix the discrepancy and re-run.
 
-### Step 5: Report
+Also confirm `changelog.d/` now contains only `README.md` — every fragment that was present at Step 4 start should have been consumed and deleted.
+
+### Step 6: Report
 
 Display a summary:
 - Previous version → New version
-- Files modified (list all 5)
-- Reminder: "Fill in the CHANGELOG.md section before shipping. Run `/roslyn-mcp:publish-preflight` when ready to validate the full release."
+- Files modified (list all 5 version files + `CHANGELOG.md`)
+- Fragments consumed (count + list of `changelog.d/` filenames deleted)
+- Reminder: "Review the `## [NEW]` section in `CHANGELOG.md` — the grouped bullets came directly from the fragments. Edit the prose if a fragment was under-specified. Run `/roslyn-mcp:publish-preflight` when ready to validate the full release."

--- a/.claude/skills/draft-changelog-entry/SKILL.md
+++ b/.claude/skills/draft-changelog-entry/SKILL.md
@@ -1,37 +1,40 @@
 ---
 name: draft-changelog-entry
-description: "Drafts one CHANGELOG.md bullet from PR/commit metadata and atomically updates Maintenance tallies. Use when: preparing a PR for ship, writing a CHANGELOG entry for a merged or about-to-merge change, or filling `## [Unreleased]` subsections from an initiative in a backlog-sweep `state.json`. Takes initiative id + commit SHA (or branch name) + backlog row id(s) closed. Non-destructive — emits a diff for review, never auto-commits."
+description: "Drafts one changelog fragment file under `changelog.d/<row-id>.md` from PR/commit metadata. Use when: preparing a PR for ship, writing a CHANGELOG entry for a merged or about-to-merge change, or filling `changelog.d/` from an initiative in a backlog-sweep `state.json`. Takes initiative id + commit SHA (or branch name) + backlog row id(s) closed. Non-destructive — emits the fragment file contents for review, never auto-commits, never touches `CHANGELOG.md` directly."
 user-invocable: true
 argument-hint: "<initiative-id> <commit-sha-or-branch> <row-id-1>[,<row-id-2>,...]"
 ---
 
 # Draft Changelog Entry
 
-You are a release-notes drafter. Your job is to emit exactly ONE CHANGELOG.md bullet under `## [Unreleased]` from (a) the initiative's `changelogCategory` in the active backlog-sweep `state.json`, (b) the commit-message body on the named SHA/branch, and (c) the backlog row id(s) the change closes. If the initiative's `### Maintenance` contributions are observable (tests added, rows closed), you additionally update the Maintenance subsection tallies atomically with the bullet insertion. You do NOT commit, push, or touch git in any way — the user reviews the diff and commits themselves (typically via `/ship`).
+You are a release-notes drafter. Your job is to write exactly ONE changelog fragment file at `changelog.d/<row-id>.md` from (a) the initiative's `changelogCategory` in the active backlog-sweep `state.json`, (b) the commit-message body on the named SHA/branch, and (c) the backlog row id(s) the change closes. You do NOT edit `CHANGELOG.md` — that file is consumed at release-cut time by `/bump`, which groups the fragments by category into the new `## [X.Y.Z]` section and `git rm`s them in the same commit. You do NOT commit, push, or touch git in any way — the user reviews the fragment file and commits themselves (typically via `/ship`).
+
+See `changelog.d/README.md` for the fragment-file pattern rationale (parallel-PR merge-conflict avoidance) and the exact on-disk shape.
 
 ## Inputs
 
 `$ARGUMENTS` must contain three space-separated tokens:
 
-1. **Initiative id** — the `id` field in the active backlog-sweep `state.json`'s `initiatives[]` array (e.g. `mcp-connection-session-resilience`, `changelog-entry-draft-from-pr-metadata`). Used to look up `changelogCategory`, `testFilesAdded`, and `rowsClosedCount`.
-2. **Commit SHA or branch name** — source-of-truth for the prose. The skill reads the commit message body (not subject line) via `gh` or `git` and adapts it into the bullet's body. Examples: `remediation/changelog-entry-draft-from-pr-metadata`, `abc1234`.
-3. **Comma-separated backlog row id(s) closed** — e.g. `changelog-entry-draft-from-pr-metadata` or `dr-9-1,dr-9-2` when an initiative bundles rows. Appears as the bold closing parenthesis at the end of the bullet.
+1. **Initiative id** — the `id` field in the active backlog-sweep `state.json`'s `initiatives[]` array (e.g. `mcp-connection-session-resilience`, `parallel-pr-changelog-append-friction`). Used to look up `changelogCategory`.
+2. **Commit SHA or branch name** — source-of-truth for the prose. The skill reads the commit message body (not subject line) via `gh` or `git` and adapts it into the bullet's body. Examples: `remediation/parallel-pr-changelog-append-friction`, `abc1234`.
+3. **Comma-separated backlog row id(s) closed** — e.g. `parallel-pr-changelog-append-friction` or `dr-9-1,dr-9-2` when an initiative bundles rows. Appears as the bold closing parenthesis at the end of the bullet. The FIRST id in the list also becomes the fragment filename.
 
 If any of the three are missing, ask the user to supply them with a one-line example.
 
 ## Refusal conditions (check these FIRST, before any file edits)
 
-Refuse and report cleanly — do NOT produce a partial diff — if any of the following hold:
+Refuse and report cleanly — do NOT produce a partial fragment — if any of the following hold:
 
 | Condition | Message |
 |---|---|
 | Active `state.json` cannot be located OR `schemaVersion != 2` | `"Refusing: unsupported backlog-sweep state schema. This skill requires schemaVersion == 2. Found: <value> at <path>."` |
 | `gh` CLI is not on PATH (`command -v gh` fails) | `"Refusing: the 'gh' CLI is required to read commit metadata but was not found on PATH."` |
-| An existing bullet under `## [Unreleased]` already contains one of the supplied row ids (simple substring scan for the backlog id in backticks, e.g. `` `changelog-entry-draft-from-pr-metadata` ``) | `"Refusing: an Unreleased entry for row '<id>' is already present on line <N>. This skill never clobbers existing entries — edit the existing bullet by hand if it needs an update, or remove it first."` |
+| A fragment file `changelog.d/<first-row-id>.md` already exists | `"Refusing: a fragment for row '<id>' already exists at changelog.d/<id>.md. This skill never clobbers existing fragments — edit the existing file by hand if it needs an update, or remove it first."` |
 | The initiative id is not found in `state.json` OR its `changelogCategory` is null | `"Refusing: initiative '<id>' not found in <state.json path>, or its changelogCategory is null. Backfill changelogCategory in state.json first."` |
 | The commit cannot be resolved (`git show <ref>` returns non-zero) | `"Refusing: cannot resolve commit / branch '<ref>'."` |
+| `changelog.d/` directory does not exist at the repo root | `"Refusing: changelog.d/ directory not found at repo root. See changelog.d/README.md for the expected layout; ensure the parallel-pr-changelog-append-friction initiative has shipped."` |
 
-Refusals must be emitted BEFORE any file is touched. Never emit a partial CHANGELOG edit.
+Refusals must be emitted BEFORE any file is touched. Never emit a partial fragment.
 
 ## Workflow
 
@@ -45,9 +48,7 @@ ls -t ai_docs/plans/*_backlog-sweep/state.json | head -1
 
 Read it. Confirm `schemaVersion == 2`. Locate the initiative whose `id` matches the first argument. Capture:
 
-- `changelogCategory` — one of `"Fixed"`, `"Added"`, `"Changed"`, `"Changed — BREAKING"`, `"Maintenance"`.
-- `testFilesAdded` (int, may be 0).
-- `rowsClosedCount` (int).
+- `changelogCategory` — one of `"Fixed"`, `"Added"`, `"Changed"`, `"Changed — BREAKING"`, `"Maintenance"`. Must exactly match one of the five values in `changelog.d/README.md` (including the em-dash in `Changed — BREAKING`).
 
 ### Step 2: Read the commit body
 
@@ -57,76 +58,59 @@ Via `gh` (preferred, pulls trailers and merged-PR context) or `git` fallback:
 git show -s --format=%B <commit-sha-or-branch>
 ```
 
-The **subject line** is the commit title (e.g. `feat(skills): add /draft-changelog-entry skill (changelog-entry-draft-from-pr-metadata)`). The **body** starts after the first blank line and carries the explanatory prose + row-id citations. Adapt the body into 1-3 sentences that mirror the format of existing `## [Unreleased]` bullets (see Step 4 for the format). Keep proper-nouns, tool names, and file paths verbatim; compress rationale prose.
+The **subject line** is the commit title (e.g. `feat(skills): changelog.d fragment-file pattern (parallel-pr-changelog-append-friction)`). The **body** starts after the first blank line and carries the explanatory prose + row-id citations. Adapt the body into 1-3 sentences that mirror the format of existing shipped bullets under `CHANGELOG.md`'s most recent released `## [X.Y.Z]` section. Keep proper-nouns, tool names, and file paths verbatim; compress rationale prose.
 
-### Step 3: Scan for duplicates under `## [Unreleased]`
+### Step 3: Check for fragment collision
 
-Before emitting any diff, confirm that **none** of the supplied row ids already appear in backticks under the `## [Unreleased]` block. If any match, refuse per the table above.
+Before emitting, confirm that `changelog.d/<first-row-id>.md` does not already exist. If it does, refuse per the table above. (Don't scan `CHANGELOG.md` for the row id — `CHANGELOG.md` is source-of-truth for released versions only; the fragment directory is the only write-target for `[Unreleased]`-equivalent content.)
 
-### Step 4: Draft the bullet
+### Step 4: Draft the fragment contents
 
-Format (mirrors existing entries in `CHANGELOG.md`):
+Format (see `changelog.d/README.md` for the reference example):
 
 ```
+---
+category: <Category>
+---
+
 - **<Category>:** <one-sentence summary of the change> (`<row-id-1>`[, `<row-id-2>`, ...]).
 ```
 
-When the commit body has multiple paragraphs of rationale (common for non-trivial fixes), include the second sentence only if it carries load-bearing context (root cause, observable symptom, regression-test name). Do NOT dump the whole commit body — the CHANGELOG is a summary, not an archive. The commit history is the archive.
+- `<Category>` in the frontmatter value AND the bold prefix must match exactly: `Fixed`, `Changed`, `Changed — BREAKING`, `Added`, or `Maintenance` (em-dash is U+2014, not two hyphens).
+- When the commit body has multiple paragraphs of rationale (common for non-trivial fixes), include a second sentence only if it carries load-bearing context (root cause, observable symptom, regression-test name). Do NOT dump the whole commit body — the CHANGELOG is a summary, not an archive. The commit history is the archive.
 
-- Category maps from `changelogCategory`: `"Fixed"` → `### Fixed`, `"Added"` → `### Added`, `"Changed"` → `### Changed`, `"Changed — BREAKING"` → `### Changed — BREAKING`, `"Maintenance"` → `### Maintenance`.
-- The bold `**<Category>:**` prefix matches the in-repo convention even inside the `### Maintenance` subsection (e.g. `**Backlog:** 6 rows closed`).
+### Step 5: Write the fragment file
 
-### Step 5: Insert under the right subsection
+Write the drafted contents to `changelog.d/<first-row-id>.md`. This is the ONLY file the skill creates or edits. Do NOT touch `CHANGELOG.md`. Do NOT run `git add`, `git commit`, or any other mutating git command.
 
-Locate `## [Unreleased]` in `CHANGELOG.md`. Under it, find the subsection that matches the category (`### Fixed` / `### Added` / `### Changed` / `### Changed — BREAKING` / `### Maintenance`). Insert the new bullet as the FIRST item under that subsection (newest-first, matching existing in-file ordering).
+If the filename collides with an unrelated existing fragment (rare — bundled-work case), disambiguate by reading `changelog.d/` first and appending `-2`, `-3` suffixes; cite the collision in the final report.
 
-If the target subsection does not yet exist (it sometimes happens that `### Changed — BREAKING` is absent when no breaking changes have accumulated), insert the subsection header in the canonical order: `### Fixed` → `### Changed — BREAKING` → `### Changed` → `### Added` → `### Maintenance`.
+### Step 6: Emit the fragment contents and stop
 
-### Step 6: Update Maintenance tallies (only if `### Maintenance` already exists under `## [Unreleased]`)
+Print the new fragment file contents to the transcript for the user's review. Report:
 
-If a `### Maintenance` subsection is already present AND either `testFilesAdded > 0` or `rowsClosedCount > 0`, amend the existing `**Backlog:** N rows closed` / tests-added tally bullets atomically with the insertion above:
-
-- `**Backlog:** N rows closed under the <date> sweep ...` — sum `N` += `rowsClosedCount` and append each new row id to the comma-separated list of closed row ids at the end of that bullet (preserving existing citations).
-- `**Tests:** N tests added` (if present) — sum += `testFilesAdded`.
-
-If the `### Maintenance` subsection exists but the specific tally bullet you need to update does not yet appear, leave it alone — only adjust existing bullets, never synthesize new Maintenance bullets (a human picks the wording).
-
-If the category is `"Maintenance"` itself (i.e. the current change IS a maintenance entry), emit the new bullet under `### Maintenance` per Step 5 and do NOT also recount — the bullet you inserted already carries its own tally.
-
-### Step 7: Emit the diff and stop
-
-Print the `CHANGELOG.md` diff (unified, 3 lines of context) to the transcript for the user's review. Do NOT run `git add`, `git commit`, or any other mutating git command. Report:
-
-- Which `## [Unreleased]` subsection the bullet landed under.
-- Whether Maintenance tallies were updated (and by how much).
-- Next step: `"Review the diff. When ready, run /ship (or git commit) to ship."`
+- Fragment path: `changelog.d/<first-row-id>.md`
+- Category captured: `<Category>` (matches one of the five valid frontmatter values).
+- Next step: `"Review the fragment. When ready, run /ship (or git add + git commit) to ship. The fragment will be consumed and deleted at the next /bump."`
 
 ## Example output
 
-**Input:** `/draft-changelog-entry changelog-entry-draft-from-pr-metadata remediation/changelog-entry-draft-from-pr-metadata changelog-entry-draft-from-pr-metadata`
+**Input:** `/draft-changelog-entry parallel-pr-changelog-append-friction remediation/parallel-pr-changelog-append-friction parallel-pr-changelog-append-friction`
 
-**Lookup from `state.json`:** `changelogCategory = "Added"`, `rowsClosedCount = 1`, `testFilesAdded = 0`.
+**Lookup from `state.json`:** `changelogCategory = "Changed"`.
 
 **Commit body (abbreviated):**
-> Add `skills/draft-changelog-entry/SKILL.md` — a prompt document that takes (initiative id, commit SHA, backlog row id(s)) and emits one `## [Unreleased]` CHANGELOG bullet plus atomically updates Maintenance tallies. Non-destructive: prints a diff, does not commit. Refuses on schemaVersion != 2, missing gh, or duplicate row-id.
+> Add `changelog.d/` fragment-file directory + update `draft-changelog-entry` and `bump` skills so every PR writes `changelog.d/<row-id>.md` instead of editing `CHANGELOG.md` under `## [Unreleased]`. Eliminates the merge-conflict hotspot that bit 50% of parallel subagents in 2026-04-17 pass-1. Release-cut (`/bump`) consumes fragments and groups them into the new `## [X.Y.Z]` section, then `git rm`s them in the same commit.
 
-**Emitted diff:**
+**Written file — `changelog.d/parallel-pr-changelog-append-friction.md`:**
 
-```diff
- ## [Unreleased]
+```
+---
+category: Changed
+---
 
- ### Fixed
-
- ...
-
-+### Added
-+
-+- **Added:** `/draft-changelog-entry` skill takes an initiative id + commit SHA and emits the CHANGELOG bullet + Maintenance tallies atomically (`changelog-entry-draft-from-pr-metadata`).
-+
- ### Maintenance
-
- - **Backlog:** 6 rows closed under the 2026-04-17 sweep ...
+- **Changed:** Changelog workflow moves to a `changelog.d/` fragment-file pattern (towncrier-style) — every PR writes `changelog.d/<row-id>.md` instead of appending to `CHANGELOG.md`, eliminating the merge-conflict hotspot that bit 50% of parallel subagents in 2026-04-17 pass-1. Release-cut consumes and groups fragments into `## [X.Y.Z]` at bump time. `draft-changelog-entry` and `bump` skills updated accordingly (`parallel-pr-changelog-append-friction`).
 ```
 
 **Report:**
-> Inserted bullet under `## [Unreleased]` → `### Added`. Maintenance tallies unchanged (rowsClosedCount=1 but the change itself is in `### Added`, not `### Maintenance`). Review the diff. When ready, run /ship.
+> Wrote `changelog.d/parallel-pr-changelog-append-friction.md` with category `Changed`. Review the fragment. When ready, run /ship to commit + push. Fragment will be consumed + deleted at the next /bump release-cut.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,56 @@
+# changelog.d — Changelog fragments
+
+Every initiative (or standalone PR) that would historically have appended a bullet to `CHANGELOG.md` under `## [Unreleased]` now writes a single fragment file here instead. At release-cut time the `/bump` skill consumes all fragment files, groups them by category, emits them into the new `## [X.Y.Z]` section of `CHANGELOG.md`, and deletes the consumed files in the same commit.
+
+## Why
+
+Parallel-subagent backlog-sweeps routinely hit `CHANGELOG.md` merge conflicts because every PR appends to the same `## [Unreleased]` subsection. The 2026-04-17 pass-1 session showed 50% of parallel subagents paying a serial-rebase tax on this one file — each rebase cost 1–3 minutes of conflict resolution plus a destructive-resolution risk (`"accept ours"` silently drops a sibling entry).
+
+Per-PR-per-file fragments are merge-safe by construction: no two PRs ever touch the same file.
+
+## File shape
+
+- **Filename:** `<backlog-row-id>.md` — kebab-case, matches the backlog row the change closes. If a single PR closes multiple rows, pick one id as the filename; cite all closed rows in the bullet body.
+- **Format:** YAML frontmatter carrying the CHANGELOG category; body is a single bullet in the shipping `**<Category>:**` prose style.
+
+Example fragment, filename `changelog.d/release-cut-atomic-skill-bump-ship-tag-reinstall.md`:
+
+    ---
+    category: Added
+    ---
+
+    - **Added:** `/release-cut` skill at `.claude/skills/release-cut/SKILL.md` — single-invocation release pipeline (bump → verify → ship → tag → reinstall-both-layers). Closes `release-cut-atomic-skill-bump-ship-tag-reinstall`.
+
+Note: the example above is indented by four spaces to render as a literal block in this README. Actual fragment files are not indented — they are plain YAML frontmatter + a markdown bullet at column 0.
+
+## Valid categories
+
+- `Fixed`
+- `Changed`
+- `Changed — BREAKING`
+- `Added`
+- `Maintenance`
+
+Categories must match exactly (case-sensitive, including the em-dash `—` in `Changed — BREAKING`) — the `/bump` skill's fragment consumer groups by this field and refuses unknown values.
+
+## Bump-time behavior
+
+At release-cut (`/bump <type>`):
+
+1. Scan `changelog.d/*.md` (excluding this README).
+2. Group fragments by `category` frontmatter.
+3. Emit under the new `## [X.Y.Z] - YYYY-MM-DD` section, one subsection per category, canonical order: `Fixed` → `Changed — BREAKING` → `Changed` → `Added` → `Maintenance`.
+4. `git rm` every consumed fragment in the same commit that creates the `[X.Y.Z]` section — so after a bump, `changelog.d/` holds only this README again.
+
+Malformed fragments fail the bump skill loudly — no silent skip. Failure modes:
+
+- Missing or unparseable YAML frontmatter.
+- Missing `category` key in frontmatter.
+- Unknown category value (not one of the five listed above).
+- Empty body (frontmatter-only file).
+
+Two initiatives colliding on the same filename is rare (usually a bundled-work case) — the bump skill disambiguates by appending `-2`, `-3` suffixes at emit time; the filename-on-disk precedent wins and the second writer's `-2` file ships alongside.
+
+## Migration note
+
+This directory is the new home for Unreleased-section bullets. `## [Unreleased]` in `CHANGELOG.md` remains as a structural anchor but will stay empty between releases — bump-time consumption is what populates the new `## [X.Y.Z]` block. The `/draft-changelog-entry` skill writes directly into `changelog.d/` and does not touch `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

Closes: `parallel-pr-changelog-append-friction`

Adds `changelog.d/` fragment-file directory (towncrier-style) so every PR writes a per-row-id file instead of appending to `CHANGELOG.md` under `## [Unreleased]`. Eliminates the merge-conflict hotspot that bit 50% of parallel subagents in 2026-04-17 pass-1.

## Changes

- **NEW** `changelog.d/README.md` — documents the fragment pattern: filename = `<row-id>.md`, YAML frontmatter with `category` (one of Fixed / Changed — BREAKING / Changed / Added / Maintenance), body = one bullet. Merge-safe by construction.
- **UPDATE** `.claude/skills/draft-changelog-entry/SKILL.md` — now writes `changelog.d/<first-row-id>.md` instead of editing `CHANGELOG.md`. Refusal swapped from "duplicate row id under Unreleased" to "fragment file already exists". Drops Step 6 Maintenance-tally logic (recomputed at release-cut).
- **UPDATE** `.claude/skills/bump/SKILL.md` — Step 4 scans `changelog.d/*.md`, parses YAML frontmatter, groups by category in canonical order, emits the new `## [X.Y.Z]` section, and `rm`s the consumed fragments. Malformed fragments fail loudly. `## [Unreleased]` stays as a structural anchor with empty subsections.

## Scope discipline

3 prod files — under the Rule 3 ≤ 4 cap. The `CHANGELOG.md` pointer note (4th file in plan §14 scope) is deferred to the orchestrator's batch-reconcile PR because `CHANGELOG.md` is orchestrator-owned per backlog-sweep-execute.md shared-file discipline.

## Migration note

`## [Unreleased]` in `CHANGELOG.md` stays empty between releases from this merge forward. New entries land in `changelog.d/` and get consumed + grouped into `## [X.Y.Z]` at the next release-cut.

## Test plan

- [x] `pwsh -File ./eng/verify-ai-docs.ps1` — passes (AI docs validation + 31 shipped SKILL.md genericity check).
- [x] Manual readthrough of both updated SKILL.md files — workflow steps are coherent end-to-end; refusal conditions are symmetric; example inputs/outputs match the new file-shape.
- [ ] Next parallel-sweep wave: 3+ subagents each add a `changelog.d/<row>.md` fragment; zero `CHANGELOG.md` merge conflicts.
- [ ] Next release cut: `/bump` consumes all fragments into a single `## [X.Y.Z]` section and deletes them.

Part of the 2026-04-19 backlog sweep (plan at `ai_docs/plans/20260419T230057Z_backlog-sweep/plan.md`, initiative §14).