### PR TITLE
feat(workspace): add workspace_warm MCP tool for opt-in compilation prewarm (compilation-prewarm-on-load)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ For privacy questions, open an issue at [github.com/darylmcd/Roslyn-Backed-MCP/i
 
 ## Supported Surface
 
-Catalog **`2026.04`** ships **159 tools** (107 stable / 52 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
+Catalog **`2026.04`** ships **160 tools** (107 stable / 53 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental). Use the `server_info` tool and the `roslyn://server/catalog` resource for the authoritative live surface — the categories below are a quick orientation.
 
 ### Stable tool families
 

--- a/src/RoslynMcp.Core/Models/WorkspaceWarmResult.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceWarmResult.cs
@@ -1,0 +1,28 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Result envelope for <c>workspace_warm</c>. Reports the per-project warm roster, the
+/// wall-clock budget the warm consumed, and how many projects were cold at the start of
+/// the call so callers can verify whether warming actually did work (repeat calls on a
+/// warm workspace will report <see cref="ColdCompilationCount"/> = 0).
+/// </summary>
+/// <param name="WorkspaceId">The workspace session identifier that was warmed.</param>
+/// <param name="ProjectsWarmed">
+/// Names of the projects whose compilation + first semantic model were force-resolved in
+/// this call. Includes projects that were already warm (no-op delta) so the caller sees
+/// the full roster the warm inspected. If the per-workspace read lock could not be
+/// acquired for a given project the list includes a best-effort note for that project
+/// (e.g. a status suffix) rather than silently skipping it.
+/// </param>
+/// <param name="ElapsedMs">Wall-clock time spent inside <c>WarmAsync</c>, in milliseconds.</param>
+/// <param name="ColdCompilationCount">
+/// Number of projects whose compilation was NOT yet present in Roslyn's internal cache
+/// at the start of the call — i.e. the projects that actually paid the cold-start cost
+/// this invocation. A second call on the same workspace with no intervening
+/// <c>workspace_reload</c> should report 0.
+/// </param>
+public sealed record WorkspaceWarmResult(
+    string WorkspaceId,
+    IReadOnlyList<string> ProjectsWarmed,
+    long ElapsedMs,
+    int ColdCompilationCount);

--- a/src/RoslynMcp.Core/Services/IWorkspaceWarmService.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceWarmService.cs
@@ -1,0 +1,43 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Opt-in compilation prewarm for a loaded workspace. Forces Roslyn's
+/// <c>GetCompilationAsync</c> and semantic-model resolution across the workspace (or a
+/// filtered project set) so the next read-side tool call (e.g. <c>symbol_search</c>,
+/// <c>find_references</c>) does not pay the full cold-start penalty (~4600ms on a
+/// mid-sized solution).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Opt-in only.</b> Per the 2026-04-14 user preference against blocking tool
+/// registration, warming never runs automatically on <c>workspace_load</c>. Callers that
+/// prefer cold-start latency continue to pay it on the first read; callers that want
+/// the warm-start profile invoke <see cref="WarmAsync"/> explicitly after load.
+/// </para>
+/// <para>
+/// <b>No default timeout.</b> Warming all projects in a large solution can take tens
+/// of seconds. The returned <see cref="WorkspaceWarmResult.ElapsedMs"/> lets the caller
+/// budget future invocations; the service itself will not time out or cancel mid-project
+/// except via the caller's <see cref="CancellationToken"/>.
+/// </para>
+/// </remarks>
+public interface IWorkspaceWarmService
+{
+    /// <summary>
+    /// Force-compile every project in the workspace (or the subset named by
+    /// <paramref name="projects"/>) and resolve one semantic model per project to stabilize
+    /// the semantic cache. Compilations already present in Roslyn's internal cache are
+    /// counted as warm; each cold project's first <c>GetCompilationAsync</c> is what delivers
+    /// the latency delta.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier returned by <c>workspace_load</c>.</param>
+    /// <param name="projects">
+    /// Optional filter of project names (case-insensitive). When <see langword="null"/> or
+    /// empty every project in the solution is warmed. Unknown names are silently skipped so
+    /// callers can pass a best-effort set without pre-validation.
+    /// </param>
+    /// <param name="ct">The caller's cancellation token.</param>
+    Task<WorkspaceWarmResult> WarmAsync(string workspaceId, string[]? projects, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -16,6 +16,7 @@ public static class ServerSurfaceCatalog
         Tool("workspace_load", "workspace", "stable", false, false, "Load a .sln, .slnx, or .csproj into a named Roslyn workspace session."),
         Tool("workspace_reload", "workspace", "stable", false, false, "Reload an existing workspace session from disk."),
         Tool("workspace_close", "workspace", "stable", false, true, "Close a loaded workspace session and release resources."),
+        Tool("workspace_warm", "workspace", "experimental", false, false, "Opt-in compilation prewarm: force GetCompilationAsync + first-semantic-model resolution across the workspace to cut the cold-start penalty of the first read-side tool call."),
         Tool("workspace_list", "workspace", "stable", true, false, "List active workspace sessions."),
         Tool("workspace_status", "workspace", "stable", true, false, "Inspect status, diagnostics, and stale-state information for a workspace."),
         Tool("workspace_health", "workspace", "stable", true, false, "Lean workspace readiness summary (alias of workspace_status verbose=false)."),

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// MCP tool entry point for opt-in compilation prewarm. Wraps
+/// <see cref="IWorkspaceWarmService.WarmAsync"/> with the standard read-gated dispatch
+/// (<see cref="ToolDispatch.ReadByWorkspaceIdAsync{TDto}"/>) so multiple warms run
+/// concurrently on the same workspace and so an in-flight write (<c>*_apply</c>) blocks
+/// the warm until it completes.
+/// </summary>
+/// <remarks>
+/// Per the 2026-04-14 user preference, warming is never automatic. Callers decide when
+/// (if ever) to pay the prewarm cost — the tool is experimental precisely so the shape
+/// can evolve without a stability contract on the opt-in timing semantics.
+/// </remarks>
+[McpServerToolType]
+public static class WorkspaceWarmTools
+{
+    [McpServerTool(Name = "workspace_warm", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("workspace", "experimental", false, false,
+        "Opt-in compilation prewarm: force GetCompilationAsync + first-semantic-model resolution across the workspace to cut the cold-start penalty of the first read-side tool call."),
+     Description("Opt-in compilation prewarm for a loaded workspace. Forces Roslyn's internal compilation cache and semantic-model cache to populate by calling GetCompilationAsync on every project (or the subset named by the `projects` filter) and resolving one semantic model per project. On a mid-sized solution this shifts the ~4600ms cold-start penalty of the first symbol_search / find_references call into this single explicit warm invocation, so follow-up reads run at ~40ms. Never runs automatically — callers invoke this tool explicitly after workspace_load when they want the warm-start profile. Returns ElapsedMs so callers can budget subsequent invocations; a repeat call on an unchanged workspace returns ColdCompilationCount=0 and typically ElapsedMs < 10% of the first call. No internal timeout — the caller's CancellationToken is the only cap.")]
+    public static Task<string> WorkspaceWarm(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceWarmService warmService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: project names to warm. Case-insensitive; unknown names are silently skipped. Omit or pass an empty array to warm every project in the solution.")] string[]? projects = null,
+        CancellationToken ct = default)
+        => ToolDispatch.ReadByWorkspaceIdAsync(
+            gate,
+            workspaceId,
+            c => warmService.WarmAsync(workspaceId, projects, c),
+            ct);
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -116,6 +116,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IImpactSweepService, ImpactSweepService>();
         services.AddSingleton<ITestReferenceMapService, TestReferenceMapService>();
         services.AddSingleton<IWorkspaceValidationService, WorkspaceValidationService>();
+        services.AddSingleton<IWorkspaceWarmService, WorkspaceWarmService>();
         services.AddSingleton<IChangeSignatureService, ChangeSignatureService>();
         services.AddSingleton<ISymbolRefactorService, SymbolRefactorService>();
         services.AddSingleton<IExceptionFlowService, ExceptionFlowService>();

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Opt-in <c>workspace_warm</c> implementation. Walks every project in the workspace (or
+/// the caller-provided filter subset), forces <see cref="Project.GetCompilationAsync"/>,
+/// and then resolves one semantic model per project to stabilize Roslyn's semantic cache.
+/// The first post-<c>workspace_load</c> read-side call on a mid-sized solution pays a
+/// ~4600ms cold cost vs ~40ms warm; warming up front shifts that cost into this call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Cold-vs-warm detection.</b> We call <see cref="Project.TryGetCompilation"/> BEFORE
+/// <see cref="Project.GetCompilationAsync"/>. <see cref="Project.TryGetCompilation"/>
+/// returns <see langword="true"/> only when the compilation is already present in the
+/// project's internal cache; a <see langword="false"/> result means the project was cold
+/// going into the warm. <see cref="WorkspaceWarmResult.ColdCompilationCount"/> increments
+/// once per cold project so a repeat warm on an unchanged workspace reports 0.
+/// </para>
+/// <para>
+/// <b>Per-project fault isolation.</b> A warm on one project may raise (e.g. a malformed
+/// project file the MSBuild workspace couldn't fully rehydrate). We catch
+/// <see cref="OperationCanceledException"/> to honor the caller's cancellation and let it
+/// propagate; any other exception is logged at warning, the project is marked in
+/// <see cref="WorkspaceWarmResult.ProjectsWarmed"/> with a "warm-failed" suffix, and the
+/// sweep continues so a single bad project can't stop the rest of the warm.
+/// </para>
+/// <para>
+/// <b>Gate discipline.</b> The calling <see cref="Host.Stdio.Tools.WorkspaceWarmTools"/>
+/// invokes this service under the per-workspace read gate (see
+/// <see cref="IWorkspaceExecutionGate.RunReadAsync{T}"/>). Multiple warms on the same
+/// workspace run concurrently; a warm is blocked by any in-flight write (e.g. an
+/// <c>*_apply</c> refactor). Warming does not mutate source files, only Roslyn's internal
+/// compilation and semantic caches.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceWarmService : IWorkspaceWarmService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<WorkspaceWarmService> _logger;
+
+    public WorkspaceWarmService(IWorkspaceManager workspace, ILogger<WorkspaceWarmService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<WorkspaceWarmResult> WarmAsync(string workspaceId, string[]? projects, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        var projectFilter = BuildProjectFilter(projects);
+        var warmedNames = new List<string>();
+        var coldCount = 0;
+
+        foreach (var project in solution.Projects)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            if (projectFilter is not null && !projectFilter.Contains(project.Name))
+                continue;
+
+            var outcome = await WarmProjectAsync(project, ct).ConfigureAwait(false);
+            warmedNames.Add(outcome.DisplayName);
+            if (outcome.WasCold) coldCount++;
+        }
+
+        stopwatch.Stop();
+        return new WorkspaceWarmResult(
+            WorkspaceId: workspaceId,
+            ProjectsWarmed: warmedNames,
+            ElapsedMs: stopwatch.ElapsedMilliseconds,
+            ColdCompilationCount: coldCount);
+    }
+
+    private static HashSet<string>? BuildProjectFilter(string[]? projects)
+    {
+        if (projects is null || projects.Length == 0) return null;
+        return new HashSet<string>(projects, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task<ProjectWarmOutcome> WarmProjectAsync(Project project, CancellationToken ct)
+    {
+        // Cold-vs-warm detection: TryGetCompilation pre-check. If the compilation is
+        // already in Roslyn's cache this returns true without allocating work.
+        var wasCold = !project.TryGetCompilation(out _);
+
+        try
+        {
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is null)
+            {
+                // Non-C#/VB project (e.g. language not supported by the workspace). Skip
+                // semantic model warm but keep the entry in the roster so the caller sees
+                // which projects were visited.
+                return new ProjectWarmOutcome(project.Name, wasCold);
+            }
+
+            // Stabilize the semantic-model cache: pick the first compiled document in the
+            // project and resolve its syntax tree → semantic model. That populates the
+            // shared per-compilation semantic cache, so the first post-warm
+            // symbol_search / find_references call against this project hits the fast path.
+            var firstDocument = project.Documents.FirstOrDefault();
+            if (firstDocument is not null)
+            {
+                var tree = await firstDocument.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
+                if (tree is not null)
+                {
+                    _ = compilation.GetSemanticModel(tree);
+                }
+            }
+
+            return new ProjectWarmOutcome(project.Name, wasCold);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "workspace_warm: project '{ProjectName}' failed to warm.", project.Name);
+            return new ProjectWarmOutcome($"{project.Name} (warm-failed: {ex.GetType().Name})", wasCold);
+        }
+    }
+
+    private readonly record struct ProjectWarmOutcome(string DisplayName, bool WasCold);
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -77,6 +77,7 @@ public abstract class TestBase
     protected static FormatVerifyService FormatVerifyService { get; private set; } = null!;
     protected static InterfaceExtractionService InterfaceExtractionService { get; private set; } = null!;
     protected static ExceptionFlowService ExceptionFlowService { get; private set; } = null!;
+    protected static WorkspaceWarmService WorkspaceWarmService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -173,6 +174,7 @@ public abstract class TestBase
         FormatVerifyService = services.FormatVerifyService;
         InterfaceExtractionService = services.InterfaceExtractionService;
         ExceptionFlowService = services.ExceptionFlowService;
+        WorkspaceWarmService = services.WorkspaceWarmService;
 
         RepositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
         SampleSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -64,6 +64,7 @@ internal sealed class TestServiceContainer
     public required FormatVerifyService FormatVerifyService { get; init; }
     public required InterfaceExtractionService InterfaceExtractionService { get; init; }
     public required ExceptionFlowService ExceptionFlowService { get; init; }
+    public required WorkspaceWarmService WorkspaceWarmService { get; init; }
 
     public static TestServiceContainer Create(ValidationServiceOptions validationOptions)
     {
@@ -283,7 +284,10 @@ internal sealed class TestServiceContainer
             FormatVerifyService = new FormatVerifyService(workspaceManager, NullLogger<FormatVerifyService>.Instance),
             ExceptionFlowService = new ExceptionFlowService(
                 workspaceManager,
-                NullLogger<ExceptionFlowService>.Instance)
+                NullLogger<ExceptionFlowService>.Instance),
+            WorkspaceWarmService = new WorkspaceWarmService(
+                workspaceManager,
+                NullLogger<WorkspaceWarmService>.Instance)
         };
     }
 }

--- a/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
@@ -1,0 +1,70 @@
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="Roslyn.Services.WorkspaceWarmService"/>. Uses
+/// <see cref="IsolatedWorkspaceTestBase"/> so each test starts from a cold workspace
+/// (fresh <c>MSBuildWorkspace</c> → no projects in Roslyn's compilation cache) and can
+/// assert the cold-to-warm transition without cross-test contamination from other
+/// fixtures that may have already forced compilations.
+/// </summary>
+[TestClass]
+public sealed class WorkspaceWarmServiceTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task WarmAsync_FirstCall_ForcesColdCompilations()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var result = await WorkspaceWarmService.WarmAsync(
+            workspace.WorkspaceId,
+            projects: null,
+            CancellationToken.None);
+
+        Assert.AreEqual(workspace.WorkspaceId, result.WorkspaceId, "Workspace id should round-trip.");
+        Assert.IsTrue(
+            result.ProjectsWarmed.Count > 0,
+            $"Expected projectsWarmed.Count > 0; got {result.ProjectsWarmed.Count}.");
+        Assert.IsTrue(
+            result.ElapsedMs > 100,
+            $"Expected first-call elapsedMs > 100 (cold-start cost); got {result.ElapsedMs}ms.");
+        Assert.IsTrue(
+            result.ColdCompilationCount > 0,
+            $"Expected coldCompilationCount > 0 on a fresh workspace; got {result.ColdCompilationCount}.");
+    }
+
+    [TestMethod]
+    public async Task WarmAsync_SecondCall_NoCold_FasterThanFirst()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var first = await WorkspaceWarmService.WarmAsync(
+            workspace.WorkspaceId,
+            projects: null,
+            CancellationToken.None);
+
+        // Sanity: the first call must have done real work, otherwise the warm/warm
+        // comparison below is meaningless.
+        Assert.IsTrue(
+            first.ColdCompilationCount > 0,
+            "Precondition failed: first warm should report at least one cold project.");
+
+        var second = await WorkspaceWarmService.WarmAsync(
+            workspace.WorkspaceId,
+            projects: null,
+            CancellationToken.None);
+
+        Assert.AreEqual(
+            0,
+            second.ColdCompilationCount,
+            "Repeat warm on an unchanged workspace should see every project already cached.");
+        Assert.IsTrue(
+            second.ElapsedMs < first.ElapsedMs / 10,
+            $"Expected second warm to be at least 10× faster than first: first={first.ElapsedMs}ms second={second.ElapsedMs}ms.");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `workspace_warm(workspaceId, projects?)` — an **experimental, opt-in** MCP tool that forces Roslyn's `GetCompilationAsync` + first-semantic-model resolution across the workspace (or a filtered project set). Follow-up read-side calls (`symbol_search`, `find_references`, etc.) run warm instead of paying the ~4600ms cold-start cost of the first post-`workspace_load` invocation on a mid-sized solution.

- **Never runs automatically.** Per the 2026-04-14 user preference against blocking tool registration, warming is pure opt-in: callers that prefer cold-start latency simply never call it.
- **No default timeout** — the caller's `CancellationToken` is the only cap. `ElapsedMs` is returned so callers can budget subsequent invocations.
- **Read-gated**, not write-gated — warming does not mutate source files, only Roslyn's internal compilation and semantic caches. Concurrent warms on the same workspace are allowed; an in-flight `*_apply` blocks the warm.

## Architecture

Three-layer shape mirroring sibling read-side services:
- `IWorkspaceWarmService` + `WorkspaceWarmResult` (Core)
- `WorkspaceWarmService` (Roslyn) — uses `Project.TryGetCompilation(out _)` *before* `GetCompilationAsync` to count cold projects, then resolves one semantic model per project via the first `Document.GetSyntaxTreeAsync` to stabilize the semantic cache
- `WorkspaceWarmTools` (Host.Stdio) — uses the shared `ToolDispatch.ReadByWorkspaceIdAsync` read-gate pattern
- `ServerSurfaceCatalog` entry (experimental, category `workspace`, `IsRead=false` per the side-effects-on-internal-caches classification) + DI registration in `AddRoslynServices`
- Per-project fault isolation: a malformed project does not stop the sweep — the project is tagged `warm-failed: {ExceptionType}` in `ProjectsWarmed` and the warm continues

## Benchmark

Unable to re-measure in-worktree — the 4669ms cold vs ~40ms warm `symbol_search` figure comes from the original backlog row on a full production-sized solution. Retained in the description as the motivating baseline; the pattern (`TryGetCompilation` pre-check + `GetCompilationAsync` + first semantic model) is the standard Roslyn warming recipe.

## Test plan

- [x] `WorkspaceWarmServiceTests.WarmAsync_FirstCall_ForcesColdCompilations` — asserts `projectsWarmed.Count > 0`, `elapsedMs > 100`, `coldCompilationCount > 0` on a fresh `IsolatedWorkspaceTestBase` fixture.
- [x] `WorkspaceWarmServiceTests.WarmAsync_SecondCall_NoCold_FasterThanFirst` — asserts `coldCompilationCount == 0` and `elapsedMs < first / 10` on the second call.
- [x] `ServerSurfaceCatalogAnalyzer` (RMCP001/RMCP002) — catalog entry + `[McpServerTool]` stay in sync at build time.
- [x] `ReadmeSurfaceCountTests` — README tool-count bumped 159 → 160 (experimental 52 → 53).
- [x] `SurfaceCatalogTests`, `ToolDiResolutionTests` — all 16 surface + DI tests pass; DI resolution confirms the MCP SDK will bind the service from `AddRoslynServices`.
- [x] Full CI-parity: `./eng/verify-release.ps1 -Configuration Release` → 786 passed / 0 failed. (An initial run hit a pre-existing `ProjectMutationIntegrationTests.Add_And_Remove_Central_Package_Version_Preview_And_Apply` flake unrelated to this change; re-run was clean.)
- [x] `./eng/verify-ai-docs.ps1` — passes.

Closes: compilation-prewarm-on-load