### PR TITLE
feat: symbol handle propagation + rename post-apply rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,37 @@ claude --plugin-dir /path/to/Roslyn-Backed-MCP
 
 ### Available Skills
 
+The plugin bundles **31 skills**. The most commonly used ones:
+
 | Skill | Description |
 |-------|-------------|
 | `/roslyn-mcp:analyze` | Solution health check — diagnostics, complexity, cohesion, vulnerabilities |
 | `/roslyn-mcp:refactor` | Guided semantic refactoring — rename, extract, move, split |
+| `/roslyn-mcp:refactor-loop` | Guided preview → apply-with-verify → validate loop for non-trivial refactors |
 | `/roslyn-mcp:review` | Semantic code review — diagnostics, dead code, complexity, security |
+| `/roslyn-mcp:impact-assessment` | Pre-change blast-radius report for a rename, signature change, or deletion |
+| `/roslyn-mcp:architecture-review` | Layering and Dependency-Inversion-Principle audit |
 | `/roslyn-mcp:document` | XML documentation generator for public APIs |
 | `/roslyn-mcp:security` | Security audit — OWASP diagnostics, CVE scan, reflection, DI |
 | `/roslyn-mcp:dead-code` | Dead code detection and safe cleanup |
 | `/roslyn-mcp:test-coverage` | Test coverage analysis and test scaffolding |
+| `/roslyn-mcp:test-triage` | Test discovery and failure triage when CI is red |
+| `/roslyn-mcp:generate-tests` | Batch-scaffold test stubs for untested public APIs |
 | `/roslyn-mcp:migrate-package` | NuGet package migration across projects |
+| `/roslyn-mcp:modernize` | Staged codebase modernization toward a natural-language goal |
 | `/roslyn-mcp:explain-error` | Diagnostic explanation with auto-fix |
 | `/roslyn-mcp:extract-method` | Extract statements into a new method with parameter inference |
+| `/roslyn-mcp:code-actions` | IDE-style fixes and refactorings at a position or selection |
 | `/roslyn-mcp:complexity` | Complexity hotspot and god class analysis |
+| `/roslyn-mcp:di-audit` | Audit dependency-injection registrations and lifetime mismatches |
+| `/roslyn-mcp:trace-flow` | Walk a value through control, data, and exception flow |
+| `/roslyn-mcp:inheritance-explorer` | Walk the inheritance and member-override graph for a type or member |
+| `/roslyn-mcp:exception-audit` | Repo-wide classification of exception-handling patterns |
+| `/roslyn-mcp:format-sweep` | Whole-solution formatting compliance pass |
+| `/roslyn-mcp:workspace-health` | One-shot status report on the server and loaded workspaces |
+| `/roslyn-mcp:session-undo` | Session history and undo of recent applies |
+
+Plus `project-inspection`, `snippet-eval`, `semantic-find`, `nuget-preflight`, `version-bump`, `update`, and release-workflow helpers. Browse [`skills/`](skills/) for the full catalogue.
 
 ### Plugin Hooks
 

--- a/skills/extract-method/SKILL.md
+++ b/skills/extract-method/SKILL.md
@@ -32,7 +32,7 @@ Use **`discover_capabilities`** (`refactoring`) or **`roslyn://server/catalog`**
 
 ### Step 1: Find the Code Region
 
-1. Use `symbol_search` to locate the containing type or method.
+1. Use `symbol_search` to locate the containing type or method. Capture the match's `symbolHandle` so downstream tools (`symbol_info`, `callers_callees`, `get_complexity_metrics`) can resolve the method without re-passing file/line.
 2. Use `get_source_text` to read the file and identify the exact line range.
 3. Identify which statements to extract — look for:
    - Blocks that do a distinct subtask (validation, calculation, I/O)

--- a/skills/impact-assessment/SKILL.md
+++ b/skills/impact-assessment/SKILL.md
@@ -47,16 +47,16 @@ Execute these steps in order. Use Roslyn MCP tools throughout — do not shell o
 
 ### Step 2: Locate the Symbol
 
-1. Call `symbol_search` with the provided name.
+1. Call `symbol_search` with the provided name. Each result includes a `symbolHandle` — **capture the chosen match's handle** for every downstream sweep call.
 2. If multiple candidates come back, list them (kind, containing type, file:line) and ask the user to disambiguate. Do not guess.
-3. Once resolved, call `symbol_info` to capture:
+3. Once resolved, call `symbol_info` with `symbolHandle:` (not file/line) to capture:
    - `kind` (Method, Property, Field, Event, NamedType, Parameter, ...)
    - `accessibility` (Public / Internal / Private)
    - `isVirtual`, `isAbstract`, `isOverride`, `isInterfaceMember`
    - declaring file and line
    - signature and containing type
 
-The `kind` + virtuality flags determine which tools the impact sweep runs next (see Impact Tier Table).
+The `kind` + virtuality flags determine which tools the impact sweep runs next (see Impact Tier Table). **Propagate `symbolHandle`** (rather than re-passing file/line) to every Step 4 tool that accepts it — `find_references`, `find_consumers`, `impact_analysis`, `symbol_impact_sweep`, `find_property_writes`, `callers_callees`. Handles disambiguate overloads, partial classes, and tuple-deconstruction lines.
 
 ### Step 3: Determine Change Type and Tier
 

--- a/skills/inheritance-explorer/SKILL.md
+++ b/skills/inheritance-explorer/SKILL.md
@@ -42,9 +42,9 @@ Execute these steps in order. Use the Roslyn MCP tools — do not shell out for 
 
 ### Step 2: Resolve Target
 
-1. Call `symbol_search` with the user-supplied name.
-2. Call `symbol_info` on the best candidate to get full details (`kind`, `containingType`, `isAbstract`, `isVirtual`, `isSealed`, `isOverride`, declaring file and line).
-3. If ambiguous (multiple candidates with the same short name), present the candidates and ask the user to disambiguate by fully-qualified name before continuing.
+1. Call `symbol_search` with the user-supplied name. **Capture the chosen candidate's `symbolHandle`** — every downstream traversal tool that accepts `symbolHandle` (`symbol_info`, `find_overrides`, `find_implementations`, `find_base_members`, `find_references`) should receive it instead of file/line.
+2. Call `symbol_info` with `symbolHandle:` to get full details (`kind`, `containingType`, `isAbstract`, `isVirtual`, `isSealed`, `isOverride`, declaring file and line).
+3. If ambiguous (multiple candidates with the same short name), present the candidates and ask the user to disambiguate by fully-qualified name before continuing. Keep only the chosen handle.
 4. Optionally call `goto_type_definition` when the input refers to a variable or parameter whose type is the real target.
 
 ### Step 3: Route by Kind

--- a/skills/refactor-loop/SKILL.md
+++ b/skills/refactor-loop/SKILL.md
@@ -17,11 +17,13 @@ If no workspace is loaded, ask for the solution path and call `workspace_load` f
 
 ## Stage 1 — Pick the primitive
 
+When the intent targets a named symbol, resolve it with `symbol_search` first and **capture the returned `symbolHandle`**. Pass the handle to every `*_preview` primitive that accepts one (`rename_preview`, `symbol_refactor_preview`, etc.) instead of file/line — it survives busy lines where coordinate lookups can drift onto an adjacent symbol.
+
 Inspect the intent and select **one** primitive as the entry point:
 
 | Intent shape | Primitive | Notes |
 |---|---|---|
-| Rename a symbol | `rename_preview` | Single-symbol rename; `prepare_rename` first if uncertain. |
+| Rename a symbol | `rename_preview` | Single-symbol rename; pass `symbolHandle` captured above; `prepare_rename` first if uncertain. |
 | Extract a method | `extract_method_preview` | Selection-based; pass start/end positions. |
 | Mechanical pattern rewrite | `restructure_preview` | Use `__name__` placeholders to capture sub-expressions. |
 | Magic-string centralization | `replace_string_literals_preview` | Position-aware (arg/initializer only). |

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -50,16 +50,17 @@ Parse the user's request to determine the refactoring type:
 - **Dependency inversion / DI wiring**: `dependency_inversion_preview`, `extract_and_wire_interface_preview` (orchestrated previews)
 - **Format a range**: `format_range_preview` / `format_range_apply` (when whole-document format is too broad)
 
-### Step 2: Find the Target
+### Step 2: Find the Target and capture its handle
 
-1. Use `symbol_search` to locate the symbol by name.
-2. Use `symbol_info` to get full details (file, line, kind, containing type).
-3. If ambiguous, show candidates and ask the user to pick.
+1. Use `symbol_search` to locate the symbol by name. Each result includes a `symbolHandle` — **capture it from the chosen match** and keep it for every downstream step.
+2. Use `symbol_info` with `symbolHandle:` (not file/line) to confirm full details.
+3. If ambiguous, show candidates and ask the user to pick. Keep only the chosen handle — discard the rest.
+4. **Propagate `symbolHandle` to every downstream tool** (`find_references`, `impact_analysis`, `rename_preview`, etc.) instead of re-passing file/line. Handles disambiguate overloads, partial classes, and tuple-deconstruction lines where coordinate lookups can drift to an adjacent symbol on busy lines.
 
 ### Step 3: Assess Impact
 
-1. Call `find_references` to understand usage scope.
-2. Call `impact_analysis` to get affected files and declarations.
+1. Call `find_references` with the captured `symbolHandle`.
+2. Call `impact_analysis` with the same `symbolHandle`.
 3. Summarize: "{N} references across {M} files in {P} projects."
 4. If the impact is large (>10 files), warn the user and ask for confirmation.
 
@@ -69,7 +70,7 @@ Call the appropriate preview tool based on refactoring type:
 
 | Type | Preview Tool |
 |------|-------------|
-| Rename | `rename_preview` with `newName` |
+| Rename | `rename_preview` with `symbolHandle` + `newName` (prefer handle over file/line per the tool's docstring) |
 | Extract Interface | `extract_interface_preview` with `typeName`, `interfaceName` |
 | Extract Type | `extract_type_preview` with `typeName`, `memberNames`, `newTypeName` |
 | Move to File | `move_type_to_file_preview` with `typeName` |
@@ -96,6 +97,7 @@ After user confirmation:
 1. Call the corresponding `*_apply` tool with the preview token.
 2. Immediately call `compile_check` to verify no errors.
 3. If errors are introduced, report them and offer to revert with `revert_last_apply`.
+4. **Handle rotation**: after a rename / signature-change / type-move, the captured `symbolHandle` from Step 2 points at the *pre-mutation* symbol and may no longer resolve in the current solution. Re-resolve via `symbol_search` (with the new name) or `symbol_info` (by file/line of an applied file) before issuing follow-up calls on the same symbol.
 
 ### Step 6: Report
 

--- a/skills/trace-flow/SKILL.md
+++ b/skills/trace-flow/SKILL.md
@@ -59,7 +59,7 @@ Parse `$ARGUMENTS` and resolve to a concrete declaration:
 - **`file:line` (or `file:line:column`)**: call `enclosing_symbol` to find the nearest declaration (method, property, parameter, local) that contains the span. If the line lands inside a method body but names no symbol, treat the enclosing method as the target and record the specific line for span-scoped analysis.
 - **Exception type**: resolve via `symbol_search` (kind: `NamedType`); skip data/control flow unless the user also named a containing method.
 
-Once resolved, call `symbol_info` to capture full details (file, line, `SymbolKind`, containing type, parameter list, return type). Record this as the **target descriptor** — every downstream step references it.
+Once resolved, call `symbol_info` to capture full details (file, line, `SymbolKind`, containing type, parameter list, return type). **Capture the `symbolHandle`** from the resolver (search result or `enclosing_symbol` handle) — downstream flow tools that accept it (`callers_callees`, `find_references`, `find_property_writes`, `find_type_mutations`) should receive the handle instead of re-resolving by file/line. Record the handle + descriptor as the **target descriptor**; every downstream step references it.
 
 ### Step 3: Detect Symbol Kind and Pick Analyses
 

--- a/src/RoslynMcp.Core/Models/ApplyResultDto.cs
+++ b/src/RoslynMcp.Core/Models/ApplyResultDto.cs
@@ -3,7 +3,17 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents the result of applying a previewed workspace mutation.
 /// </summary>
+/// <param name="Success">Whether the apply succeeded.</param>
+/// <param name="AppliedFiles">Files whose on-disk content was changed.</param>
+/// <param name="Error">Human-readable error description when <paramref name="Success"/> is false.</param>
+/// <param name="MutatedSymbol">
+/// When a rename apply changes a symbol's identity, carries a fresh <see cref="SymbolDto"/> for the
+/// renamed symbol (new name, new symbol handle) so downstream tools can keep chaining without
+/// re-resolving by the new name. Null for all other apply kinds (the existing handle still resolves
+/// after move-type, change-signature, format, code-fix, etc.).
+/// </param>
 public sealed record ApplyResultDto(
     bool Success,
     IReadOnlyList<string> AppliedFiles,
-    string? Error);
+    string? Error,
+    SymbolDto? MutatedSymbol = null);

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -65,7 +65,7 @@ Claude Code also supports installing this server as a **plugin** with curated sk
 
 No further configuration is required; the server starts with the defaults listed in [Configuration](#configuration). To tune any `ROSLYNMCP_*` value, drop a project-scope `.mcp.json` at your repo root with literal `env` values — see [`docs/mcp-json-examples/`](https://github.com/darylmcd/Roslyn-Backed-MCP/tree/main/docs/mcp-json-examples) for copy-ready templates.
 
-The plugin adds 10 guided slash commands (`/roslyn-mcp:analyze`, `/roslyn-mcp:refactor`, `/roslyn-mcp:review`, `/roslyn-mcp:security`, `/roslyn-mcp:dead-code`, `/roslyn-mcp:test-coverage`, `/roslyn-mcp:migrate-package`, `/roslyn-mcp:explain-error`, `/roslyn-mcp:complexity`, `/roslyn-mcp:document`) and pre-apply safety hooks that block `*_apply` calls without a matching `*_preview`. See the [GitHub README](https://github.com/darylmcd/Roslyn-Backed-MCP#claude-code-plugin-installation) for the full skill documentation.
+The plugin adds **31 bundled agent skills** — including `/roslyn-mcp:analyze`, `/roslyn-mcp:refactor`, `/roslyn-mcp:review`, `/roslyn-mcp:security`, `/roslyn-mcp:dead-code`, `/roslyn-mcp:test-coverage`, `/roslyn-mcp:migrate-package`, `/roslyn-mcp:explain-error`, `/roslyn-mcp:complexity`, `/roslyn-mcp:document`, `/roslyn-mcp:impact-assessment`, `/roslyn-mcp:refactor-loop`, `/roslyn-mcp:modernize`, `/roslyn-mcp:trace-flow`, `/roslyn-mcp:inheritance-explorer`, and more — plus pre-apply safety hooks that block `*_apply` calls without a matching `*_preview`. See the [GitHub README](https://github.com/darylmcd/Roslyn-Backed-MCP#claude-code-plugin-installation) for the full skill catalogue.
 
 ### VS Code (and other stdio MCP clients)
 
@@ -83,12 +83,12 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **128 tools** (69 stable / 59 experimental), **9 resources**, and **19 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **159 tools** (107 stable / 52 experimental), **9 resources**, and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|
 | **Workspace** | `workspace_load`, `workspace_status`, `workspace_list`, `project_graph`, source-generated documents — workspace tools default to a lean **summary** payload (~500 bytes) and offer `verbose=true` opt-in for the full per-project tree. |
-| **Symbol navigation** | `find_references`, `find_implementations`, `find_overrides`, `goto_definition`, `symbol_search`, `find_consumers`, `find_type_usages`, `type_hierarchy`, `callers_callees`, `impact_analysis`. |
+| **Symbol navigation** | `find_references`, `find_implementations`, `find_overrides`, `goto_definition`, `symbol_search`, `find_consumers`, `find_type_usages`, `type_hierarchy`, `callers_callees`, `impact_analysis`. Major semantic tools accept a `symbolHandle` from prior search/info calls — pass it instead of file/line to disambiguate overloads and partial classes. |
 | **Diagnostics** | `project_diagnostics`, `compile_check` (in-memory, with optional emit validation), `diagnostic_details`, `security_diagnostics`, `nuget_vulnerability_scan`, `list_analyzers`. |
 | **Refactoring (preview / apply)** | `rename_*`, `extract_interface_*`, `extract_type_*`, `move_type_to_file_*`, `bulk_replace_type_*`, `code_fix_*`, `fix_all_*`, `format_document_*`, `organize_usings_*`, `split_class_*`, dead-code removal. |
 | **Build / test** | `build_workspace`, `build_project`, `test_discover`, `test_run`, `test_related`, `test_related_files`, `test_coverage`. |

--- a/src/RoslynMcp.Roslyn/Contracts/IPostApplySymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IPostApplySymbolResolver.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Roslyn.Contracts;
+
+/// <summary>
+/// Registry for post-apply symbol-rotation hints, keyed by preview token.
+/// </summary>
+/// <remarks>
+/// When a refactor that changes a symbol's identity (e.g. rename) is previewed, the preview
+/// service registers a hint so the generic apply path can rebuild a fresh
+/// <see cref="SymbolDto"/> for the mutated symbol and return it on
+/// <see cref="ApplyResultDto.MutatedSymbol"/>. Hints are consumed on the first successful
+/// <see cref="ConsumeAsync"/> and can be invalidated explicitly when an apply fails.
+/// </remarks>
+public interface IPostApplySymbolResolver
+{
+    /// <summary>
+    /// Registers a rename hint against a preview token. Overwrites any prior hint for the token.
+    /// </summary>
+    void RegisterRename(string previewToken, PostApplyRenameHint hint);
+
+    /// <summary>
+    /// Removes any hint registered for <paramref name="previewToken"/> without attempting resolution.
+    /// Call on failed applies or token expiry to avoid leaking entries.
+    /// </summary>
+    void Invalidate(string previewToken);
+
+    /// <summary>
+    /// Consumes the hint registered for <paramref name="previewToken"/> and returns a fresh
+    /// <see cref="SymbolDto"/> for the post-apply symbol, or null if no hint was registered or the
+    /// symbol could not be resolved in <paramref name="appliedSolution"/>.
+    /// </summary>
+    Task<SymbolDto?> ConsumeAsync(string previewToken, Solution appliedSolution, CancellationToken ct);
+}
+
+/// <summary>
+/// Hint for rotating a handle after a rename apply — stores the declaration position (stable across
+/// renames) plus the expected new name so the resolver can re-resolve the renamed symbol and
+/// verify it landed where expected.
+/// </summary>
+public sealed record PostApplyRenameHint(
+    string DeclarationFilePath,
+    int DeclarationLine,
+    int DeclarationColumn,
+    string ExpectedNewName);

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -120,6 +120,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IChangeSignatureService, ChangeSignatureService>();
         services.AddSingleton<ISymbolRefactorService, SymbolRefactorService>();
         services.AddSingleton<IExceptionFlowService, ExceptionFlowService>();
+        services.AddSingleton<IPostApplySymbolResolver, PostApplySymbolResolver>();
         return services;
     }
 

--- a/src/RoslynMcp.Roslyn/Services/PostApplySymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Services/PostApplySymbolResolver.cs
@@ -1,0 +1,43 @@
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <inheritdoc />
+public sealed class PostApplySymbolResolver : IPostApplySymbolResolver
+{
+    private readonly ConcurrentDictionary<string, PostApplyRenameHint> _hints = new(StringComparer.Ordinal);
+
+    public void RegisterRename(string previewToken, PostApplyRenameHint hint)
+        => _hints[previewToken] = hint;
+
+    public void Invalidate(string previewToken)
+        => _hints.TryRemove(previewToken, out _);
+
+    public async Task<SymbolDto?> ConsumeAsync(string previewToken, Solution appliedSolution, CancellationToken ct)
+    {
+        if (!_hints.TryRemove(previewToken, out var hint))
+            return null;
+
+        var symbol = await SymbolResolver.ResolveAtPositionAsync(
+            appliedSolution,
+            hint.DeclarationFilePath,
+            hint.DeclarationLine,
+            hint.DeclarationColumn,
+            ct).ConfigureAwait(false);
+
+        if (symbol is null)
+            return null;
+
+        // The declaration position is stable across renames, so the symbol at the stashed
+        // position should now carry the new name. If it doesn't, something else mutated the
+        // position — return null rather than emit a misleading rotated handle.
+        if (!string.Equals(symbol.Name, hint.ExpectedNewName, StringComparison.Ordinal))
+            return null;
+
+        return SymbolMapper.ToDto(symbol, appliedSolution);
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -27,15 +28,17 @@ public sealed class RefactoringService : IRefactoringService
     private readonly IUndoService? _undoService;
     private readonly IChangeTracker? _changeTracker;
     private readonly ICodeFixProviderRegistry? _codeFixRegistry;
+    private readonly IPostApplySymbolResolver? _postApplyResolver;
     private readonly ILogger<RefactoringService> _logger;
 
-    public RefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<RefactoringService> logger, IUndoService? undoService = null, IChangeTracker? changeTracker = null, ICodeFixProviderRegistry? codeFixRegistry = null)
+    public RefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<RefactoringService> logger, IUndoService? undoService = null, IChangeTracker? changeTracker = null, ICodeFixProviderRegistry? codeFixRegistry = null, IPostApplySymbolResolver? postApplyResolver = null)
     {
         _workspace = workspace;
         _previewStore = previewStore;
         _undoService = undoService;
         _changeTracker = changeTracker;
         _codeFixRegistry = codeFixRegistry;
+        _postApplyResolver = postApplyResolver;
         _logger = logger;
     }
 
@@ -85,6 +88,25 @@ public sealed class RefactoringService : IRefactoringService
 
         var description = $"Rename '{symbol.Name}' to '{newName}'";
         var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+
+        // Register a post-apply rename hint so ApplyRefactoringAsync can rotate the handle
+        // and return ApplyResult.MutatedSymbol with the new name. Declaration position is
+        // stable across renames, so stashing it plus the expected new name is sufficient.
+        if (_postApplyResolver is not null)
+        {
+            var declLocation = symbol.Locations.FirstOrDefault(static l => l.IsInSource);
+            if (declLocation is not null)
+            {
+                var declLineSpan = declLocation.GetLineSpan();
+                _postApplyResolver.RegisterRename(
+                    token,
+                    new PostApplyRenameHint(
+                        declLineSpan.Path,
+                        declLineSpan.StartLinePosition.Line + 1,
+                        declLineSpan.StartLinePosition.Character + 1,
+                        newName));
+            }
+        }
 
         // No-op warning: caller asked to rename a symbol to its own current name. C# identifiers
         // are case-sensitive, so a Foo→foo rename is real and must NOT be flagged.
@@ -284,6 +306,7 @@ public sealed class RefactoringService : IRefactoringService
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
                     _logger.LogWarning(ex, "Failed to persist changed documents to disk for workspace {WorkspaceId}", workspaceId);
+                    _postApplyResolver?.Invalidate(previewToken);
                     return new ApplyResultDto(false, [], "Failed to persist applied changes to disk.");
                 }
             }
@@ -293,12 +316,23 @@ public sealed class RefactoringService : IRefactoringService
 
         if (!success)
         {
+            _postApplyResolver?.Invalidate(previewToken);
             return new ApplyResultDto(false, [], "Failed to apply changes to the workspace.");
         }
 
         _changeTracker?.RecordChange(workspaceId, description, appliedFiles, "refactoring_apply");
         _logger.LogInformation("Applied refactoring '{Description}' to {Count} file(s)", description, appliedFiles.Count);
-        return new ApplyResultDto(true, appliedFiles, null);
+
+        // Rotate the symbol handle for refactors that change symbol identity (rename).
+        // Null for every other apply kind — the pre-apply handle still resolves on move-type,
+        // change-signature, format, code-fix, etc.
+        SymbolDto? mutatedSymbol = null;
+        if (_postApplyResolver is not null)
+        {
+            var appliedSolution = _workspace.GetCurrentSolution(workspaceId);
+            mutatedSymbol = await _postApplyResolver.ConsumeAsync(previewToken, appliedSolution, ct).ConfigureAwait(false);
+        }
+        return new ApplyResultDto(true, appliedFiles, null, mutatedSymbol);
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/PostApplySymbolRotationTests.cs
+++ b/tests/RoslynMcp.Tests/PostApplySymbolRotationTests.cs
@@ -1,0 +1,100 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for <see cref="ApplyResultDto.MutatedSymbol"/> handle rotation on rename.
+/// After a rename apply, the old <c>symbolHandle</c> captured by the agent at preview time no
+/// longer resolves (MetadataName and DisplayName both change). The apply response rotates the
+/// handle so agents can keep chaining without re-issuing <c>symbol_search</c> with the new name.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class PostApplySymbolRotationTests : SharedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task RenameApply_Returns_MutatedSymbol_With_New_Name_And_Fresh_Handle()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var animalServicePath = Path.Combine(solutionDir, "SampleLib", "AnimalService.cs");
+            var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals");
+
+            var preview = await RefactoringService.PreviewRenameAsync(
+                workspaceId, locator, "GetAllAnimalsRotated", CancellationToken.None);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
+
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+
+            Assert.IsTrue(apply.Success, apply.Error);
+            Assert.IsNotNull(apply.MutatedSymbol, "Rename apply must return a rotated handle in MutatedSymbol.");
+            Assert.AreEqual("GetAllAnimalsRotated", apply.MutatedSymbol!.Name);
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(apply.MutatedSymbol.SymbolHandle),
+                "Rotated SymbolDto must carry a fresh SymbolHandle resolvable against the post-apply solution.");
+            StringAssert.Contains(
+                apply.MutatedSymbol.FullyQualifiedName,
+                "GetAllAnimalsRotated",
+                "FullyQualifiedName on the rotated symbol must reflect the new name.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task OrganizeUsingsApply_Does_Not_Set_MutatedSymbol()
+    {
+        // Non-rename applies leave MutatedSymbol null — the existing handle (if the agent captured
+        // one) still resolves because neither MetadataName nor DisplayName changed.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var targetFile = Path.Combine(solutionDir, "SampleLib", "AnimalService.cs");
+            var preview = await RefactoringService.PreviewOrganizeUsingsAsync(
+                workspaceId, targetFile, CancellationToken.None);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
+
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+
+            Assert.IsTrue(apply.Success, apply.Error);
+            Assert.IsNull(
+                apply.MutatedSymbol,
+                "Non-rename applies must leave MutatedSymbol null — only rename changes symbol identity.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -153,7 +153,8 @@ internal sealed class TestServiceContainer
                 NullLogger<RefactoringService>.Instance,
                 undoService,
                 changeTracker,
-                new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance)),
+                new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance),
+                new PostApplySymbolResolver()),
             BuildService = new BuildService(
                 workspaceManager,
                 gatedCommandExecutor,

--- a/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
@@ -30,9 +30,9 @@ public sealed class WorkspaceWarmServiceTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(
             result.ProjectsWarmed.Count > 0,
             $"Expected projectsWarmed.Count > 0; got {result.ProjectsWarmed.Count}.");
-        Assert.IsTrue(
-            result.ElapsedMs > 100,
-            $"Expected first-call elapsedMs > 100 (cold-start cost); got {result.ElapsedMs}ms.");
+        // Wall-clock elapsedMs is too brittle for a correctness assertion — a fast CI runner
+        // can complete cold compilations well under 100ms (observed: 23ms). The semantic
+        // signal that real work happened is ColdCompilationCount > 0.
         Assert.IsTrue(
             result.ColdCompilationCount > 0,
             $"Expected coldCompilationCount > 0 on a fresh workspace; got {result.ColdCompilationCount}.");


### PR DESCRIPTION
## Summary

Teaches agents to propagate `symbolHandle` through chained semantic tools and rotates the handle after a rename apply so downstream calls don't re-search by the new name.

**Docs (6 skills)** — `refactor`, `impact-assessment`, `extract-method`, `refactor-loop`, `inheritance-explorer`, `trace-flow`: capture `symbolHandle` at resolve time and pass it to every downstream tool instead of file/line (disambiguates overloads and partial classes).

**Phase 2b rotation (rename-only correct scope):**
- `ApplyResultDto.MutatedSymbol`: additive nullable field (4th positional, defaults null — every 3-arg callsite unchanged).
- New `IPostApplySymbolResolver` + `PostApplySymbolResolver`: side-channel registry keyed on preview token. Avoids touching `IPreviewStore`'s interface.
- `RefactoringService`: `PreviewRenameAsync` registers a hint; `ApplyRefactoringAsync` consumes and re-resolves the post-apply symbol. Failure paths invalidate defensively.
- Rename is the only refactor where both `MetadataName` *and* `DisplayName` change; move-type / change-signature existing handles still resolve via `SymbolHandleSerializer`.

**READMEs:** NuGet README counts synced (128 → **159 tools**, 19 → **20 prompts**, 10 slash commands → **31 bundled skills**); root README skill table expanded 11 → 25.

## Test plan

- [x] `dotnet build RoslynMcp.slnx` — 0 warnings, 0 errors
- [x] New `PostApplySymbolRotationTests` — 2/2 pass
- [x] Rename / refactoring integration suite — 26/26 pass
- [x] Undo / apply / change-tracker / apply-with-verify — 75/75 pass
- [x] `just verify-skills` — 31/31 generic

🤖 Generated with [Claude Code](https://claude.com/claude-code)