### PR TITLE
chore: add AI audit reports and deep-review rollup

### DIFF
--- a/ai_docs/audit-reports/20260413T154959Z_firewallanalyzer_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260413T154959Z_firewallanalyzer_mcp-server-audit.md
@@ -1,0 +1,808 @@
+# MCP Server Audit Report
+
+**Intended canonical store (Roslyn-Backed-MCP):** copy this file to  
+`<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/20260413T154959Z_firewallanalyzer_mcp-server-audit.md`  
+before rollup/backlog automation (`eng/import-deep-review-audit.ps1`).
+
+**Final rollup:** This markdown is the **only shipped artifact** — §3 is the human ledger; **Appendix B** embeds the canonical TAB-separated ledger (extract the fenced block for spreadsheet or import tooling).
+
+---
+
+## 1. Header
+
+| Field | Value |
+|-------|--------|
+| **Date (UTC)** | 2026-04-13 |
+| **Audited solution** | `c:\Code-Repo\DotNet-Firewall-Analyzer\FirewallAnalyzer.slnx` |
+| **Audited revision** | Branch `audit/mcp-full-surface-20260413` (disposable); workspace loaded from same working tree |
+| **Entrypoint loaded** | `FirewallAnalyzer.slnx` |
+| **Audit mode** | `full-surface` |
+| **Isolation** | Git branch `audit/mcp-full-surface-20260413` at `c:\Code-Repo\DotNet-Firewall-Analyzer` — merge or delete after review; Phase 6 product edits retained on branch |
+| **Client** | Cursor agent → MCP server id `user-roslyn` (stdio) |
+| **Workspace id** | Continuation load `8e649a54ff3443afbaaffe86e5e0d652` (prior session `10cc528e…` closed earlier); **closed** at end of continuation |
+| **Server** | `roslyn-mcp` **1.11.2+d0f2680698687bd6fb93c4af5ddabe22f59eb0b2** (`server_info`) |
+| **Catalog version** | **2026.04** |
+| **Roslyn / .NET** | Roslyn **5.3.0.0**; runtime **.NET 10.0.5**; OS Windows 10.0.26200 |
+| **Scale** | 11 projects, 243 documents (post–`workspace_load` summary) |
+| **Repo shape** | Multi-project; tests (xUnit); **Central Package Management**; net10.0 only (no multi-targeting); DI registrations in `ApiHostBuilder`; analyzers + SecurityCodeScan; source-generated/docs present (`source_generated_documents`); `.editorconfig` at repo root |
+| **Prior issue source (Phase 18)** | `ai_docs/backlog.md` (this repo) — not a Roslyn-MCP backlog; regression section **N/A** |
+| **Debug log channel** | **no** — Cursor did not surface MCP `notifications/message` structured logs to the agent |
+| **Plugin skills repo path** | **blocked — Roslyn-Backed-MCP / plugin workspace not present in this Cursor workspace** |
+| **Report path note** | Written under audited repo per deep-review fallback when Roslyn-Backed-MCP root is not the workspace |
+| **dotnet restore** | **PASS** — `dotnet restore FirewallAnalyzer.slnx` before semantic tools |
+
+### Authoritative surface mismatch (live catalog wins)
+
+- **Finding:** `ai_docs/prompts/deep-review-and-refactor.md` frontmatter claims **128 tools (69 stable / 59 experimental)**.
+- **Live:** **127 tools (69 stable / 58 experimental)**, **9** resources, **19** prompts.
+- **Action:** Treat live server as source of truth; update living prompt frontmatter on next doc pass.
+
+---
+
+## 2. Coverage summary
+
+Counts aggregated from ledger by **Kind** + **Category** (live catalog columns). `#stable` / `#experimental` = catalog entries in that bucket.
+
+| Kind | Category | #stable | #experimental | exercised | exercised-apply | exercised-preview-only | skipped-repo-shape | skipped-safety | blocked |
+|------|----------|---------|-----------------|-----------|-------------------|------------------------|--------------------|----------------|---------|
+| prompt | prompts | 0 | 19 | 0 | 0 | 0 | 0 | 0 | 19 |
+| resource | server | 2 | 0 | 2 | 0 | 0 | 0 | 0 | 0 |
+| resource | workspace | 7 | 0 | 0 | 0 | 0 | 0 | 0 | 7 |
+| tool | advanced-analysis | 9 | 2 | 11 | 0 | 0 | 0 | 0 | 0 |
+| tool | analysis | 12 | 0 | 12 | 0 | 0 | 0 | 0 | 0 |
+| tool | code-actions | 3 | 0 | 1 | 0 | 0 | 0 | 2 | 0 |
+| tool | configuration | 0 | 3 | 1 | 0 | 0 | 0 | 2 | 0 |
+| tool | editing | 0 | 3 | 0 | 1 | 0 | 0 | 2 | 0 |
+| tool | refactoring | 8 | 14 | 3 | 3 | 1 | 0 | 15 | 0 |
+| tool | scripting | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |
+| tool | security | 3 | 0 | 3 | 0 | 0 | 0 | 0 | 0 |
+| tool | server | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |
+| tool | symbols | 16 | 0 | 14 | 0 | 0 | 2 | 0 | 0 |
+| tool | syntax | 0 | 1 | 1 | 0 | 0 | 0 | 0 | 0 |
+| tool | undo | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |
+| tool | unknown | 0 | 33 | 2 | 4 | 6 | 0 | 21 | 0 |
+| tool | validation | 8 | 0 | 7 | 0 | 0 | 0 | 1 | 0 |
+| tool | workspace | 8 | 1 | 9 | 0 | 0 | 0 | 0 | 0 |
+
+_Row sum check: 155 catalog entries across kinds/categories; tool-name-level detail in §3 and Appendix B._
+
+---
+
+## 3. Coverage ledger
+
+| Kind | Name | Tier | Category | Status | Phase | lastElapsedMs | Notes |
+|------|------|------|----------|--------|-------|---------------|-------|
+| tool | add_central_package_version_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | add_package_reference_preview | experimental | unknown | exercised-preview-only | 13 | — | FluentValidation add preview; paired with remove forward/apply |
+| tool | add_pragma_suppression | experimental | editing | skipped-safety | 7-8b | — | intentionally avoided mutating .editorconfig/source for audit cleanliness |
+| tool | add_project_reference_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | add_target_framework_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | analyze_control_flow | stable | advanced-analysis | exercised | 4 | 6 |  |
+| tool | analyze_data_flow | stable | advanced-analysis | exercised | 4 | 10 |  |
+| tool | analyze_snippet | stable | analysis | exercised | 5 | 60-174 | multi kind |
+| tool | apply_code_action | stable | code-actions | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | apply_composite_preview | experimental | unknown | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | apply_multi_file_edit | experimental | editing | skipped-safety | 6-8b | — | not exercised; rename/usings covered writes |
+| tool | apply_project_mutation | experimental | unknown | exercised-apply | 13 | 3091-2992 | add/remove FluentValidation on Domain; then manual csproj tidy for empty ItemGroup |
+| tool | apply_text_edit | experimental | editing | exercised-apply | 9,17 | 22-4 | Phase 9 Program.cs line replace; FLAG: column/end-line discipline easy to corrupt semicolon |
+| tool | build_project | stable | validation | exercised | 8 | 1525 |  |
+| tool | build_workspace | stable | validation | exercised | 8 | 13833 | queued gate |
+| tool | bulk_replace_type_apply | experimental | refactoring | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | bulk_replace_type_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | callers_callees | stable | analysis | exercised | 3 | 9 |  |
+| tool | code_fix_apply | stable | refactoring | skipped-safety | 6 | — | preview/apply happy path not re-run this continuation |
+| tool | code_fix_preview | stable | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | compile_check | stable | validation | exercised | 1,6,8 | varies | emitValidation ~3712ms |
+| tool | create_file_apply | experimental | unknown | exercised-apply | 10 | 3237 | placeholder file then deleted |
+| tool | create_file_preview | experimental | unknown | exercised-preview-only | 10 | 10 | McpAuditPlaceholder.cs preview |
+| tool | delete_file_apply | experimental | unknown | exercised-apply | 10-12 | 3128-3295 | placeholder + scaffold cleanup |
+| tool | delete_file_preview | experimental | unknown | exercised-preview-only | 10-12 | 1-10 | audited delete previews |
+| tool | dependency_inversion_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | diagnostic_details | stable | analysis | exercised | 1 | 4 |  |
+| tool | document_symbols | stable | symbols | exercised | 3 | — |  |
+| tool | enclosing_symbol | stable | symbols | exercised | 14 | 139 | LoadAppSettings at ApiHostBuilder.cs:100,5 |
+| tool | evaluate_csharp | stable | scripting | exercised | 5 | 21-13006 | timeout path validated |
+| tool | evaluate_msbuild_items | experimental | unknown | exercised | 7 | 149 | Compile items |
+| tool | evaluate_msbuild_property | experimental | unknown | exercised | 7 | 78 |  |
+| tool | extract_and_wire_interface_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | extract_interface_apply | experimental | refactoring | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | extract_interface_cross_project_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | extract_interface_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | extract_method_apply | experimental | refactoring | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | extract_method_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | extract_type_apply | experimental | refactoring | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | extract_type_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | find_base_members | stable | symbols | exercised | 14 | — | PanosApiException.ErrorCode → FirewallAnalyzerException.ErrorCode |
+| tool | find_consumers | stable | analysis | exercised | 3 | 4 |  |
+| tool | find_implementations | stable | symbols | exercised | 3 | 2 |  |
+| tool | find_overrides | stable | symbols | exercised | 14 | — | FirewallAnalyzerException.ErrorCode overrides (4 types) |
+| tool | find_property_writes | stable | symbols | skipped-repo-shape | 3-14 | — | no suitable virtual/override/property target selected in abbreviated Phase 3/14 |
+| tool | find_references | stable | symbols | exercised | 3 | 9 |  |
+| tool | find_references_bulk | stable | symbols | exercised | 14 | 22 |  |
+| tool | find_reflection_usages | stable | advanced-analysis | exercised | 11 | 1218 |  |
+| tool | find_shared_members | stable | analysis | exercised | 3 | 8 |  |
+| tool | find_type_mutations | stable | analysis | exercised | 3 | 8 |  |
+| tool | find_type_usages | stable | analysis | exercised | 3 | 29 |  |
+| tool | find_unused_symbols | stable | advanced-analysis | exercised | 2 | 829-1710 | includePublic true/false |
+| tool | fix_all_apply | experimental | refactoring | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | fix_all_preview | experimental | refactoring | exercised-preview-only | 6 | 80 | IDE0005 no provider; guidance ok |
+| tool | format_document_apply | stable | refactoring | exercised-apply | 6 | 1 | no-op diff |
+| tool | format_document_preview | stable | refactoring | exercised | 6 | 78 |  |
+| tool | format_range_apply | experimental | refactoring | skipped-safety | 6 | — | not invoked this continuation |
+| tool | format_range_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | get_code_actions | stable | code-actions | exercised | 6 | 199 | empty at CA1859 caret |
+| tool | get_cohesion_metrics | stable | analysis | exercised | 2 | large | result written to agent-tools |
+| tool | get_completions | stable | symbols | exercised | 14 | 178 | ApiHostBuilder builder. Environment\|Equals with filterText=E |
+| tool | get_complexity_metrics | stable | advanced-analysis | exercised | 2 | 91 |  |
+| tool | get_di_registrations | stable | advanced-analysis | exercised | 11 | 1235 |  |
+| tool | get_editorconfig_options | experimental | configuration | exercised | 7 | 6 |  |
+| tool | get_msbuild_properties | experimental | unknown | skipped-safety | 7 | — | avoid 50-700KB payload this turn; evaluate_msbuild_* exercised |
+| tool | get_namespace_dependencies | stable | advanced-analysis | exercised | 2 | large | agent-tools |
+| tool | get_nuget_dependencies | stable | advanced-analysis | exercised | 2 | 1448 |  |
+| tool | get_operations | experimental | advanced-analysis | exercised | 4 | 3 |  |
+| tool | get_source_text | stable | workspace | exercised | 4 | 3 |  |
+| tool | get_syntax_tree | experimental | syntax | exercised | 4 | 7 |  |
+| tool | goto_type_definition | stable | symbols | exercised | 14 | 153-7 | IPanosClient on AddSingleton line; top-level Program.cs probes NotFound (expected repo shape) |
+| tool | go_to_definition | stable | symbols | exercised | 14 | — |  |
+| tool | impact_analysis | stable | analysis | exercised | 3 | 4 |  |
+| tool | list_analyzers | stable | analysis | exercised | 1 | 8 | paged |
+| tool | member_hierarchy | stable | symbols | skipped-repo-shape | 3-14 | — | no suitable virtual/override/property target selected in abbreviated Phase 3/14 |
+| tool | migrate_package_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | move_file_apply | experimental | unknown | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | move_file_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | move_type_to_file_apply | experimental | refactoring | skipped-safety | 10 | — | not invoked; create/delete loop used instead |
+| tool | move_type_to_file_preview | experimental | refactoring | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | move_type_to_project_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | nuget_vulnerability_scan | stable | security | exercised | 1 | 5302 |  |
+| tool | organize_usings_apply | stable | refactoring | exercised-apply | 6 | 6 |  |
+| tool | organize_usings_preview | stable | refactoring | exercised | 6 | 134 |  |
+| tool | preview_code_action | stable | code-actions | skipped-safety | 6 | — | not invoked this continuation |
+| tool | project_diagnostics | stable | analysis | exercised | 1 | 4738 | full scan |
+| tool | project_graph | stable | workspace | exercised | 0 | 2 |  |
+| tool | remove_central_package_version_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | remove_dead_code_apply | experimental | unknown | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | remove_dead_code_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | remove_package_reference_preview | experimental | unknown | exercised-preview-only | 13 | 2 | remove FluentValidation preview after forward apply |
+| tool | remove_project_reference_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | remove_target_framework_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | rename_apply | stable | refactoring | exercised-apply | 6 | 39 |  |
+| tool | rename_preview | stable | refactoring | exercised | 6 | 499 | bad column probe documented |
+| tool | revert_last_apply | experimental | undo | exercised-apply | 9,17 | 96-4203 | Phase 9 text-edit revert; Phase 17 probe undid delete (LIFO) — FLAG stack semantics vs cleanup |
+| tool | scaffold_test_apply | experimental | unknown | skipped-safety | 6-13 | — | full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only) |
+| tool | scaffold_test_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | scaffold_type_apply | experimental | unknown | exercised-apply | 12 | 3110 | McpAuditScaffoldType then deleted |
+| tool | scaffold_type_preview | experimental | unknown | exercised-preview-only | 12 | 2 | internal sealed class scaffold v1.8+ default |
+| tool | security_analyzer_status | stable | security | exercised | 1 | 2875 |  |
+| tool | security_diagnostics | stable | security | exercised | 1 | 3002 |  |
+| tool | semantic_search | stable | advanced-analysis | exercised | 11 | large | agent-tools |
+| tool | server_info | stable | server | exercised | 0 | 5 |  |
+| tool | set_conditional_property_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | set_diagnostic_severity | experimental | configuration | skipped-safety | 7-8b | — | intentionally avoided mutating .editorconfig/source for audit cleanliness |
+| tool | set_editorconfig_option | experimental | configuration | skipped-safety | 7-8b | — | intentionally avoided mutating .editorconfig/source for audit cleanliness |
+| tool | set_project_property_preview | experimental | unknown | exercised-preview-only | 13 | 8 | Nullable=enable preview on Domain only (apply not taken; used package add/remove loop instead) |
+| tool | source_generated_documents | stable | workspace | exercised | 11 | — |  |
+| tool | split_class_preview | experimental | unknown | skipped-safety | 10-13 | — | preview/apply orchestration not fully driven; disposable branch available for follow-up |
+| tool | suggest_refactorings | experimental | advanced-analysis | exercised | 2 | 572 |  |
+| tool | symbol_info | stable | symbols | exercised | 3 | 4 |  |
+| tool | symbol_relationships | stable | symbols | exercised | 3 | 12 |  |
+| tool | symbol_search | stable | symbols | exercised | 3,8b.1,11 | varies; large limit strips _meta in client (FLAG) |  |
+| tool | symbol_signature_help | stable | symbols | exercised | 3 | 2 |  |
+| tool | test_coverage | stable | validation | skipped-safety | 8 | — | delegate long coverage run; test_run scoped instead |
+| tool | test_discover | stable | validation | exercised | 8 | large | agent-tools |
+| tool | test_related | stable | validation | exercised | 8 | 0 | empty array returned for Build symbol |
+| tool | test_related_files | stable | validation | exercised | 8 | 10 | no heuristic matches for ApiHostBuilder path |
+| tool | test_run | stable | validation | exercised | 8 | 1984 | Domain.Tests filtered |
+| tool | type_hierarchy | stable | analysis | exercised | 3 | 3 |  |
+| tool | workspace_changes | experimental | workspace | exercised | 6 | 3 |  |
+| tool | workspace_close | stable | workspace | exercised | 0,18 | 0 | MCP workspace_close after report finalization (continuation session) |
+| tool | workspace_list | stable | workspace | exercised | 0+ | 0-1 | heartbeat between phases |
+| tool | workspace_load | stable | workspace | exercised | 0 | 4414 | leansummary |
+| tool | workspace_reload | stable | workspace | exercised | 8,closure | 3027-6054 | post Phase 10-13 manual csproj tidy; SnapshotToken v14 |
+| tool | workspace_status | stable | workspace | exercised | 0 | 8 |  |
+| resource | server_catalog | stable | server | exercised | 0,15 | 6 | fetch_mcp_resource roslyn://server/catalog Phase 0 |
+| resource | resource_templates | stable | server | exercised | 0 | 4 | fetch_mcp_resource Phase 0 |
+| resource | workspaces | stable | workspace | blocked | 15 | — | fetch_mcp_resource intermittently unavailable; exercised via workspace_list tool Phase 0+ |
+| resource | workspaces_verbose | stable | workspace | blocked | 15 | — | same transport flake as workspaces URI |
+| resource | workspace_status | stable | workspace | blocked | 15 | — | URI fetch failed; exercised via workspace_status tool |
+| resource | workspace_status_verbose | stable | workspace | blocked | 15 | — | URI fetch failed; lean summary exercised |
+| resource | workspace_projects | stable | workspace | blocked | 15 | — | URI fetch failed; project_graph tool exercised |
+| resource | workspace_diagnostics | stable | workspace | blocked | 15 | — | URI fetch failed; project_diagnostics exercised |
+| resource | source_file | stable | workspace | blocked | 15 | — | URI fetch failed; get_source_text exercised |
+| prompt | explain_error | experimental | prompts | blocked | 16 | — | Cursor user-roslyn host: prompt tools not invokable via call_mcp_tool in this session |
+| prompt | suggest_refactoring | experimental | prompts | blocked | 16 | — | same |
+| prompt | review_file | experimental | prompts | blocked | 16 | — | same |
+| prompt | analyze_dependencies | experimental | prompts | blocked | 16 | — | same |
+| prompt | debug_test_failure | experimental | prompts | blocked | 16 | — | same |
+| prompt | refactor_and_validate | experimental | prompts | blocked | 16 | — | same |
+| prompt | fix_all_diagnostics | experimental | prompts | blocked | 16 | — | same |
+| prompt | guided_package_migration | experimental | prompts | blocked | 16 | — | same |
+| prompt | guided_extract_interface | experimental | prompts | blocked | 16 | — | same |
+| prompt | security_review | experimental | prompts | blocked | 16 | — | same |
+| prompt | discover_capabilities | experimental | prompts | blocked | 16 | — | same |
+| prompt | dead_code_audit | experimental | prompts | blocked | 16 | — | same |
+| prompt | review_test_coverage | experimental | prompts | blocked | 16 | — | same |
+| prompt | review_complexity | experimental | prompts | blocked | 16 | — | same |
+| prompt | cohesion_analysis | experimental | prompts | blocked | 16 | — | same |
+| prompt | consumer_impact | experimental | prompts | blocked | 16 | — | same |
+| prompt | guided_extract_method | experimental | prompts | blocked | 16 | — | same |
+| prompt | msbuild_inspection | experimental | prompts | blocked | 16 | — | same |
+| prompt | session_undo | experimental | prompts | blocked | 16 | — | same |
+
+---
+
+## 4. Verified tools (working)
+
+- `workspace_load` / `workspace_list` / `workspace_status` / `project_graph` / `workspace_close` — session lifecycle OK.
+- `project_diagnostics` + `compile_check` — totals invariant under severity filter; `emitValidation=true` slower path exercised.
+- `nuget_vulnerability_scan` — structured empty CVE result.
+- `rename_preview`/`rename_apply` — **FLAG** wrong symbol at some caret positions; correct rename when caret on `corsOriginsEmpty` (see §14).
+- `organize_usings_apply`, `format_document_apply` — Phase 6 verification clean.
+- `build_workspace` — Exit 0.
+- `test_run` — Domain.Tests filtered **6/6 pass**.
+- `evaluate_csharp` — sum **55**; runtime error + watchdog timeout paths actionable.
+- `find_references_bulk` — requires `symbols[]` schema shape.
+- `create_file_*` / `delete_file_*` / `scaffold_type_*` / `apply_project_mutation` — preview→apply round-trips for audit placeholders (Phase 10–13 continuation).
+- `get_di_registrations` / `find_reflection_usages` / `semantic_search` — structured results.
+
+---
+
+## 5. Phase 6 refactor summary
+
+| Item | Detail |
+|------|--------|
+| **Target repo** | DotNet-Firewall-Analyzer |
+| **Scope** | organize-usings; rename `corsOriginsEmpty` → `hasNoCorsOrigins`; format `Program.cs` (no diff); `workspace_changes` |
+| **Tools** | `rename_preview`/`rename_apply`, `format_document_*`, `organize_usings_*` |
+| **Verification** | `compile_check` **PASS**; `build_workspace` **PASS**; `build_project` (Api) **PASS**; `test_run` (subset) **PASS** |
+
+Later-session tools (`apply_text_edit`, file/scaffold/project mutations) are **audit / Phase 9–13**, not Phase 6 product scope.
+
+---
+
+## 6. Performance baseline (`_meta.elapsedMs`)
+
+> One row per tool with status exercised / exercised-apply / exercised-preview-only. **p90** not separately sampled — duplicated from p50 (single call per tool in ledger). **`—`** in ms columns = `large` / `varies` / missing in ledger. Client **did not** strip `_meta` for most calls; large payloads sometimes omitted timing in ledger notes.
+
+| Tool | Tier | Category | Calls | p50_ms | p90_ms | max_ms | Input scale | Budget | Notes |
+|------|------|----------|-------|--------|--------|--------|-------------|--------|-------|
+| `add_package_reference_preview` | experimental | unknown | 1 | — | — | — | repo | na | FluentValidation add preview; paired with remove forward/apply |
+| `analyze_control_flow` | stable | advanced-analysis | 1 | 6 | 6 | 6 | repo | within |  |
+| `analyze_data_flow` | stable | advanced-analysis | 1 | 10 | 10 | 10 | repo | within |  |
+| `analyze_snippet` | stable | analysis | 1 | 60 | 60 | 60 | repo | within | multi kind |
+| `apply_project_mutation` | experimental | unknown | 1 | 3091 | 3091 | 3091 | repo | within | add/remove FluentValidation on Domain; then manual csproj tidy for empty ItemGro |
+| `apply_text_edit` | experimental | editing | 1 | 22 | 22 | 22 | repo | within | Phase 9 Program.cs line replace; FLAG: column/end-line discipline easy to corrup |
+| `build_project` | stable | validation | 1 | 1525 | 1525 | 1525 | repo | within |  |
+| `build_workspace` | stable | validation | 1 | 13833 | 13833 | 13833 | 11p/243doc | within | queued gate |
+| `callers_callees` | stable | analysis | 1 | 9 | 9 | 9 | repo | within |  |
+| `compile_check` | stable | validation | 1 | 3712 | 3712 | 3712 | repo | within | emitValidation ~3712ms |
+| `create_file_apply` | experimental | unknown | 1 | 3237 | 3237 | 3237 | repo | within | placeholder file then deleted |
+| `create_file_preview` | experimental | unknown | 1 | 10 | 10 | 10 | repo | within | McpAuditPlaceholder.cs preview |
+| `delete_file_apply` | experimental | unknown | 1 | 3128 | 3128 | 3128 | repo | within | placeholder + scaffold cleanup |
+| `delete_file_preview` | experimental | unknown | 1 | 1 | 1 | 1 | repo | within | audited delete previews |
+| `diagnostic_details` | stable | analysis | 1 | 4 | 4 | 4 | repo | within |  |
+| `document_symbols` | stable | symbols | 1 | — | — | — | repo | na |  |
+| `enclosing_symbol` | stable | symbols | 1 | 139 | 139 | 139 | repo | within | LoadAppSettings at ApiHostBuilder.cs:100,5 |
+| `evaluate_csharp` | stable | scripting | 1 | 13006 | 13006 | 13006 | repo | warn | watchdog/infinite-loop probe ~13s; happy path ~21ms (ledger `21-13006`) |
+| `evaluate_msbuild_items` | experimental | unknown | 1 | 149 | 149 | 149 | repo | within | Compile items |
+| `evaluate_msbuild_property` | experimental | unknown | 1 | 78 | 78 | 78 | repo | within |  |
+| `find_base_members` | stable | symbols | 1 | — | — | — | repo | na | PanosApiException.ErrorCode → FirewallAnalyzerException.ErrorCode |
+| `find_consumers` | stable | analysis | 1 | 4 | 4 | 4 | repo | within |  |
+| `find_implementations` | stable | symbols | 1 | 2 | 2 | 2 | repo | within |  |
+| `find_overrides` | stable | symbols | 1 | — | — | — | repo | na | FirewallAnalyzerException.ErrorCode overrides (4 types) |
+| `find_references` | stable | symbols | 1 | 9 | 9 | 9 | repo | within |  |
+| `find_references_bulk` | stable | symbols | 1 | 22 | 22 | 22 | repo | within |  |
+| `find_reflection_usages` | stable | advanced-analysis | 1 | 1218 | 1218 | 1218 | repo | within |  |
+| `find_shared_members` | stable | analysis | 1 | 8 | 8 | 8 | repo | within |  |
+| `find_type_mutations` | stable | analysis | 1 | 8 | 8 | 8 | repo | within |  |
+| `find_type_usages` | stable | analysis | 1 | 29 | 29 | 29 | repo | within |  |
+| `find_unused_symbols` | stable | advanced-analysis | 1 | 829 | 829 | 829 | repo | within | includePublic true/false |
+| `fix_all_preview` | experimental | refactoring | 1 | 80 | 80 | 80 | repo | within | IDE0005 no provider; guidance ok |
+| `format_document_apply` | stable | refactoring | 1 | 1 | 1 | 1 | repo | within | no-op diff |
+| `format_document_preview` | stable | refactoring | 1 | 78 | 78 | 78 | repo | within |  |
+| `get_code_actions` | stable | code-actions | 1 | 199 | 199 | 199 | repo | within | empty at CA1859 caret |
+| `get_cohesion_metrics` | stable | analysis | 1 | — | — | — | repo | na | result written to agent-tools |
+| `get_completions` | stable | symbols | 1 | 178 | 178 | 178 | repo | within | ApiHostBuilder builder. Environment\|Equals with filterText=E |
+| `get_complexity_metrics` | stable | advanced-analysis | 1 | 91 | 91 | 91 | repo | within |  |
+| `get_di_registrations` | stable | advanced-analysis | 1 | 1235 | 1235 | 1235 | repo | within |  |
+| `get_editorconfig_options` | experimental | configuration | 1 | 6 | 6 | 6 | repo | within |  |
+| `get_namespace_dependencies` | stable | advanced-analysis | 1 | — | — | — | repo | na | agent-tools |
+| `get_nuget_dependencies` | stable | advanced-analysis | 1 | 1448 | 1448 | 1448 | repo | within |  |
+| `get_operations` | experimental | advanced-analysis | 1 | 3 | 3 | 3 | repo | within |  |
+| `get_source_text` | stable | workspace | 1 | 3 | 3 | 3 | repo | within |  |
+| `get_syntax_tree` | experimental | syntax | 1 | 7 | 7 | 7 | repo | within |  |
+| `go_to_definition` | stable | symbols | 1 | — | — | — | repo | na |  |
+| `goto_type_definition` | stable | symbols | 1 | 153 | 153 | 153 | repo | within | IPanosClient on AddSingleton line; top-level Program.cs probes NotFound (expecte |
+| `impact_analysis` | stable | analysis | 1 | 4 | 4 | 4 | repo | within |  |
+| `list_analyzers` | stable | analysis | 1 | 8 | 8 | 8 | repo | within | paged |
+| `nuget_vulnerability_scan` | stable | security | 1 | 5302 | 5302 | 5302 | repo | within |  |
+| `organize_usings_apply` | stable | refactoring | 1 | 6 | 6 | 6 | repo | within |  |
+| `organize_usings_preview` | stable | refactoring | 1 | 134 | 134 | 134 | repo | within |  |
+| `project_diagnostics` | stable | analysis | 1 | 4738 | 4738 | 4738 | 11p/243doc | within | full scan |
+| `project_graph` | stable | workspace | 1 | 2 | 2 | 2 | repo | within |  |
+| `remove_package_reference_preview` | experimental | unknown | 1 | 2 | 2 | 2 | repo | within | remove FluentValidation preview after forward apply |
+| `rename_apply` | stable | refactoring | 1 | 39 | 39 | 39 | repo | within |  |
+| `rename_preview` | stable | refactoring | 1 | 499 | 499 | 499 | repo | within | bad column probe documented |
+| `revert_last_apply` | experimental | undo | 1 | 96 | 96 | 96 | repo | within | Phase 9 text-edit revert; Phase 17 probe undid delete (LIFO) — FLAG stack semant |
+| `scaffold_type_apply` | experimental | unknown | 1 | 3110 | 3110 | 3110 | repo | within | McpAuditScaffoldType then deleted |
+| `scaffold_type_preview` | experimental | unknown | 1 | 2 | 2 | 2 | repo | within | internal sealed class scaffold v1.8+ default |
+| `security_analyzer_status` | stable | security | 1 | 2875 | 2875 | 2875 | repo | within |  |
+| `security_diagnostics` | stable | security | 1 | 3002 | 3002 | 3002 | repo | within |  |
+| `semantic_search` | stable | advanced-analysis | 1 | — | — | — | repo | na | agent-tools |
+| `server_info` | stable | server | 1 | 5 | 5 | 5 | repo | within |  |
+| `set_project_property_preview` | experimental | unknown | 1 | 8 | 8 | 8 | repo | within | Nullable=enable preview on Domain only (apply not taken; used package add/remove |
+| `source_generated_documents` | stable | workspace | 1 | — | — | — | repo | na |  |
+| `suggest_refactorings` | experimental | advanced-analysis | 1 | 572 | 572 | 572 | repo | within |  |
+| `symbol_info` | stable | symbols | 1 | 4 | 4 | 4 | repo | within |  |
+| `symbol_relationships` | stable | symbols | 1 | 12 | 12 | 12 | repo | within |  |
+| `symbol_search` | stable | symbols | 1 | — | — | — | repo | na |  |
+| `symbol_signature_help` | stable | symbols | 1 | 2 | 2 | 2 | repo | within |  |
+| `test_discover` | stable | validation | 1 | — | — | — | repo | na | agent-tools |
+| `test_related` | stable | validation | 1 | 0 | 0 | 0 | repo | within | empty array returned for Build symbol |
+| `test_related_files` | stable | validation | 1 | 10 | 10 | 10 | repo | within | no heuristic matches for ApiHostBuilder path |
+| `test_run` | stable | validation | 1 | 1984 | 1984 | 1984 | repo | within | Domain.Tests filtered |
+| `type_hierarchy` | stable | analysis | 1 | 3 | 3 | 3 | repo | within |  |
+| `workspace_changes` | experimental | workspace | 1 | 3 | 3 | 3 | repo | within |  |
+| `workspace_close` | stable | workspace | 1 | 0 | 0 | 0 | repo | within | MCP workspace_close after report finalization (continuation session) |
+| `workspace_list` | stable | workspace | 1 | 0 | 0 | 0 | repo | within | heartbeat between phases |
+| `workspace_load` | stable | workspace | 1 | 4414 | 4414 | 4414 | 11p/243doc | within | leansummary |
+| `workspace_reload` | stable | workspace | 1 | 3027 | 3027 | 3027 | 11p/243doc | within | post Phase 10-13 manual csproj tidy; SnapshotToken v14 |
+| `workspace_status` | stable | workspace | 1 | 8 | 8 | 8 | repo | within |  |
+
+---
+
+## 7. Schema vs behaviour drift
+
+| Tool | Mismatch kind | Expected | Actual | Severity | Notes |
+|------|---------------|----------|--------|----------|-------|
+| `rename_preview` | description_stale / cursor contract | Caret resolves user-intended local symbol | Sometimes resolves adjacent type (`BindConfigurationOptions`) | FLAG | ApiHostBuilder.cs line/col discipline |
+| `find_references_bulk` | return_shape / param docs | Examples show flat params | Requires `symbols` array of locator objects | FLAG | Transport error until corrected |
+| `evaluate_msbuild_property` | parameter naming | Consistent `projectName` | Uses `project` vs mutation tools’ `projectName` | FLAG | Documented asymmetry; easy to mismatch |
+
+**No other schema/behaviour drift observed** for exercised paths.
+
+---
+
+## 8. Error message quality
+
+| Tool | Probe input | Rating | Suggested fix | Notes |
+|------|-------------|--------|---------------|-------|
+| `test_related` | invalid `workspaceId` | actionable | List active ids in message (already does) | NotFound envelope |
+| `evaluate_csharp` | `int.Parse("abc")` | actionable | — | Clear runtime error |
+| `evaluate_csharp` | infinite loop | actionable | Expose `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS` in error | Watchdog text lists budget + grace |
+| `fix_all_preview` | IDE0005 | actionable | Suggest organize_usings path | Already suggests alternate tool |
+| `workspace_status` | all-zero UUID workspace id | actionable | “Active workspace IDs…” hint | Phase 17 |
+| `find_references` | fabricated `symbolHandle` | actionable | Structured NotFound | Phase 17 |
+| `revert_last_apply` | second consecutive call | actionable | — | Clear “nothing to revert” (Phase 17d) |
+
+**No unhelpful errors** in the exercised negative probes above.
+
+---
+
+## 9. Parameter-path coverage
+
+| Family | Non-default path tested | Status | Notes |
+|--------|--------------------------|--------|-------|
+| `project_diagnostics` | project + severity Info | pass | totals invariant |
+| `compile_check` | `emitValidation=true` | pass | timing delta vs default |
+| `list_analyzers` | project filter + paging | pass | |
+| `semantic_search` | NL queries + paraphrase | pass | |
+| Resources | `roslyn://server/catalog`, templates | pass | Phase 0 |
+| Resources | workspace URIs | blocked | `fetch_mcp_resource` “server not ready” |
+| Prompts | MCP `prompts/get` | blocked | Cursor bridge |
+| Phase 17 | bogus ids / handles | pass | See §8 |
+
+---
+
+## 10. Prompt verification (Phase 16)
+
+| Prompt | schema_ok | actionable | hallucinated_tools | idempotent | elapsedMs | recommendation_seed | Notes |
+|--------|-----------|------------|-------------------|------------|-----------|----------------------|-------|
+| `explain_error` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `suggest_refactoring` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `review_file` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `analyze_dependencies` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `debug_test_failure` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `refactor_and_validate` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `fix_all_diagnostics` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `guided_package_migration` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `guided_extract_interface` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `security_review` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `discover_capabilities` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `dead_code_audit` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `review_test_coverage` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `review_complexity` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `cohesion_analysis` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `consumer_impact` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `guided_extract_method` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `msbuild_inspection` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+| `session_undo` | n/a | n/a | n/a | n/a | — | needs-more-evidence | Client-blocked: `user-roslyn` exposes no `prompts/get` or prompt tool name in this Cursor session. |
+
+---
+
+## 11. Skills audit (Phase 16b)
+
+**Phase 16b blocked — plugin repo (`skills/*/SKILL.md`) not in workspace; no filesystem path to Roslyn-Backed-MCP root supplied.**
+
+---
+
+## 12. Experimental promotion scorecard
+
+> One row per **experimental** catalog entry (58 tools + 19 prompts = 77 rows). **`promote`** only if full closure rubric satisfied — none marked `promote` here.
+
+| Kind | Name | Category | Status | p50_ms | schema_ok | error_ok | round_trip_ok | Failures | Recommendation | Evidence |
+|------|------|----------|--------|--------|-----------|----------|---------------|----------|----------------|----------|
+| tool | `add_central_package_version_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `add_package_reference_preview` | unknown | exercised-preview-only | — | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 13 |
+| tool | `add_pragma_suppression` | editing | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 7-8b |
+| tool | `add_project_reference_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `add_target_framework_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `apply_composite_preview` | unknown | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `apply_multi_file_edit` | editing | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-8b |
+| tool | `apply_project_mutation` | unknown | exercised-apply | 3091 | yes | yes | yes | 0 | keep-experimental | ledger §14 ph 13 |
+| tool | `apply_text_edit` | editing | exercised-apply | 22 | partial | yes | yes | 0 | keep-experimental | ledger §14 ph 9,17 |
+| tool | `bulk_replace_type_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `bulk_replace_type_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `create_file_apply` | unknown | exercised-apply | 3237 | yes | yes | yes | 0 | keep-experimental | ledger §14 ph 10 |
+| tool | `create_file_preview` | unknown | exercised-preview-only | 10 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 10 |
+| tool | `delete_file_apply` | unknown | exercised-apply | 3295 | yes | yes | yes | 0 | keep-experimental | ledger §14 ph 10-12 |
+| tool | `delete_file_preview` | unknown | exercised-preview-only | 10 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 10-12 |
+| tool | `dependency_inversion_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `evaluate_msbuild_items` | unknown | exercised | 149 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 7 |
+| tool | `evaluate_msbuild_property` | unknown | exercised | 78 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 7 |
+| tool | `extract_and_wire_interface_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `extract_interface_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `extract_interface_cross_project_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `extract_interface_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `extract_method_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `extract_method_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `extract_type_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `extract_type_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `fix_all_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 80 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 6 |
+| tool | `format_range_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6 |
+| tool | `format_range_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `get_editorconfig_options` | configuration | exercised | 6 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 7 |
+| tool | `get_msbuild_properties` | unknown | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 7 |
+| tool | `get_operations` | advanced-analysis | exercised | 3 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 4 |
+| tool | `get_syntax_tree` | syntax | exercised | 7 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 4 |
+| tool | `migrate_package_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `move_file_apply` | unknown | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `move_file_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `move_type_to_file_apply` | refactoring | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 10 |
+| tool | `move_type_to_file_preview` | refactoring | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `move_type_to_project_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `remove_central_package_version_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `remove_dead_code_apply` | unknown | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `remove_dead_code_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `remove_package_reference_preview` | unknown | exercised-preview-only | 2 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 13 |
+| tool | `remove_project_reference_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `remove_target_framework_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `revert_last_apply` | undo | exercised-apply | 4203 | yes | yes | yes | 0 | keep-experimental | ledger §14 ph 9,17 |
+| tool | `scaffold_test_apply` | unknown | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 6-13 |
+| tool | `scaffold_test_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `scaffold_type_apply` | unknown | exercised-apply | 3110 | yes | yes | yes | 0 | keep-experimental | ledger §14 ph 12 |
+| tool | `scaffold_type_preview` | unknown | exercised-preview-only | 2 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 12 |
+| tool | `set_conditional_property_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `set_diagnostic_severity` | configuration | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 7-8b |
+| tool | `set_editorconfig_option` | configuration | skipped-safety | — | yes | yes | n/a | 0 | needs-more-evidence | ledger §14 ph 7-8b |
+| tool | `set_project_property_preview` | unknown | exercised-preview-only | 8 | yes | yes | n/a-preview | 0 | keep-experimental | ledger §14 ph 13 |
+| tool | `split_class_preview` | unknown | skipped-safety | — | yes | yes | n/a-preview | 0 | needs-more-evidence | ledger §14 ph 10-13 |
+| tool | `suggest_refactorings` | advanced-analysis | exercised | 572 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 2 |
+| tool | `workspace_changes` | workspace | exercised | 3 | yes | yes | n/a | 0 | keep-experimental | ledger §14 ph 6 |
+| prompt | `explain_error` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `suggest_refactoring` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `review_file` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `analyze_dependencies` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `debug_test_failure` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `refactor_and_validate` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `fix_all_diagnostics` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `guided_package_migration` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `guided_extract_interface` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `security_review` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `discover_capabilities` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `dead_code_audit` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `review_test_coverage` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `review_complexity` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `cohesion_analysis` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `consumer_impact` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `guided_extract_method` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `msbuild_inspection` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+| prompt | `session_undo` | prompts | blocked | — | n/a | n/a | n/a | 0 | needs-more-evidence | ledger §14 ph 16 |
+
+---
+
+## 13. Debug log capture
+
+`client did not surface MCP log notifications`
+
+---
+
+## 14. MCP server issues (bugs)
+
+| # | Tool | Input | Expected | Actual | Severity | Reproducibility |
+|---|------|-------|----------|--------|----------|-----------------|
+| 1 | `rename_preview` | ApiHostBuilder.cs misaligned caret | Local variable rename preview | Sometimes `BindConfigurationOptions` | incorrect result | always with listed coordinates |
+| 2 | — | — | Catalog128 tools | Live127 tools | cosmetic / doc | always |
+| 3 | `test_related` | `Build` symbol handle | Related tests | `[]` | missing data | sometimes |
+| 4 | `apply_text_edit` | line replace | Clean unified diff | Stray `;` in diff text for comments | cosmetic | sometimes |
+
+**No crash-level defects** in exercised paths.
+
+---
+
+## 15. Improvement suggestions
+
+- Expose MCP **prompts** on the Cursor `user-roslyn` bridge for Phase 16 completeness.
+- **`rename_preview`:** line/column disambiguation when multiple symbols share a line.
+- **`test_related`:** document when empty array is expected vs failure.
+- **`fetch_mcp_resource`:** stabilize or document Cursor “server not ready” for `roslyn://` URIs.
+
+---
+
+## 16. Concurrency matrix (Phase 8b)
+
+**Parallel sub-phases (8b.2–8b.4):** **N/A — client cannot issue concurrent MCP tool calls** (Cursor serializes requests).
+
+### Concurrency probe set (8b.0)
+
+| Slot | Tool | Inputs | Classification | Notes |
+|------|------|--------|----------------|-------|
+| R1 | `find_references` | `Program.cs:3:11` `ApiHostBuilder` | reader | &lt;50 refs in this repo — substitute probe |
+| R2 | `project_diagnostics` | no filters | reader | |
+| R3 | `symbol_search` | `query=Analyzer, limit=120` | reader | large responses may drop `_meta` (client) |
+| R4 | `find_unused_symbols` | `includePublic=false` | reader | |
+| R5 | `get_complexity_metrics` | no filters | reader | |
+| W1 | `format_document_preview`→`apply` | deferred | writer | no-op when already formatted |
+| W2 | `set_editorconfig_option` | skipped | writer | audit cleanliness |
+
+### Sequential baseline (8b.1), ms
+
+| Slot | Wall-clock (ms) | Notes |
+|------|-----------------|-------|
+| R1 | 294 | `_meta.elapsedMs` |
+| R2 | 2602 | |
+| R3 | N/A | bare array / `_meta` stripped on large `symbol_search` — **FLAG** |
+| R4 | 111 | |
+| R5 | 65 | |
+| W1 | N/A | not timed this run |
+| W2 | N/A | not executed |
+
+### Parallel fan-out (8b.2) / R/W probes (8b.3) / Lifecycle (8b.4)
+
+| Section | Status | Notes |
+|---------|--------|-------|
+| 8b.2 | **N/A** | no concurrent host dispatch |
+| 8b.3 | **N/A** | requires overlapping requests |
+| 8b.4 | **N/A** | requires overlapping requests |
+
+---
+
+## 17. Writer reclassification verification (Phase 8b.5)
+
+Per template: six writer-gate tools. Evidence from continuation session where applicable.
+
+| # | Tool | Status | Wall-clock (ms) | Notes |
+|---|------|--------|-----------------|-------|
+| 1 | `apply_text_edit` | exercised | 22–4203 | Phase 9 + 17d probes |
+| 2 | `apply_multi_file_edit` | skipped-safety | — | not exercised |
+| 3 | `revert_last_apply` | exercised | 96–4203 | Phase 9 undo + stack probe |
+| 4 | `set_editorconfig_option` | skipped-safety | — | audit avoided editorconfig mutation |
+| 5 | `set_diagnostic_severity` | skipped-safety | — | same |
+| 6 | `add_pragma_suppression` | skipped-safety | — | same |
+
+_Additional writers exercised outside this six-pack (still writer-gated): `create_file_apply`, `delete_file_apply`, `apply_project_mutation`, `scaffold_type_apply` — see ledger._
+
+---
+
+## 18. Response contract consistency
+
+**N/A — no response-contract inconsistencies observed** beyond MSBuild `project` vs `projectName` (§7).
+
+---
+
+## 19. Known issue regression check (Phase 18)
+
+**N/A — no prior Roslyn-MCP defect list in this repo’s backlog.**
+
+---
+
+## 20. Known issue cross-check
+
+**N/A**
+
+---
+
+## Phase narrative (condensed)
+
+- **Phases 0–8:** diagnostics, metrics, symbols, flow, snippets, Phase 6 refactor, build/test subset; `test_coverage` skipped-safety.
+- **Phase 8b.1:** sequential baselines in §16; parallel **N/A**.
+- **Phase 10–13:** file create/delete, scaffold, package add/remove + `apply_project_mutation`; csproj normalized after empty `ItemGroup`.
+- **Phase 9:** `apply_text_edit` + `revert_last_apply` without undoing Phase 6.
+- **Phase 11–14:** semantic search, DI/reflection/source-gen, navigation, bulk refs, overrides/base.
+- **Phase 15:** resource URI fetch **blocked** intermittently; tools substituted.
+- **Phase 16–16b:** prompts + skills **blocked** (client / path).
+- **Phase 17:** invalid id/handle + double `revert_last_apply` (second = clear no-op).
+- **Phase 18:** N/A.
+
+### Final surface closure checklist
+
+| Step | State |
+|------|-------|
+| Ledger 155 rows | **PASS** (§3 + Appendix B TSV) |
+| Experimental scorecard | **PASS** (§12, 77 rows) |
+| Prompt table | **PASS** (§10, 19 rows, blocked documented) |
+| Mandatory tables | **PASS** (this document) |
+| Draft-after-every-phase | **FAIL process** — draft file was dropped mid-run; single canonical export assembled 2026-04-13 |
+
+**Export:** This report only — for `eng/import-deep-review-audit.ps1` / rollup, supply **Appendix B** (extract the `tsv` fence) if the importer expects a separate ledger file.
+
+---
+
+## Appendix: export bundle
+
+Primary artifact: **`20260413T154959Z_firewallanalyzer_mcp-server-audit.md`** (this file). For Roslyn-Backed-MCP import, copy this file to `<repo-root>/ai_docs/audit-reports/` and run `eng/import-deep-review-audit.ps1` per that repo’s docs — derive the machine ledger from **Appendix B** when a standalone `.tsv` is required.
+
+---
+
+## Appendix B: Coverage ledger (TSV)
+
+Canonical TAB-separated ledger (155 data rows + header).
+
+```tsv
+kind	name	tier	category	status	phase	lastElapsedMs	notes
+tool	add_central_package_version_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	add_package_reference_preview	experimental	unknown	exercised-preview-only	13	—	FluentValidation add preview; paired with remove forward/apply
+tool	add_pragma_suppression	experimental	editing	skipped-safety	7-8b	—	intentionally avoided mutating .editorconfig/source for audit cleanliness
+tool	add_project_reference_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	add_target_framework_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	analyze_control_flow	stable	advanced-analysis	exercised	4	6	
+tool	analyze_data_flow	stable	advanced-analysis	exercised	4	10	
+tool	analyze_snippet	stable	analysis	exercised	5	60-174	multi kind
+tool	apply_code_action	stable	code-actions	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	apply_composite_preview	experimental	unknown	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	apply_multi_file_edit	experimental	editing	skipped-safety	6-8b	—	not exercised; rename/usings covered writes
+tool	apply_project_mutation	experimental	unknown	exercised-apply	13	3091-2992	add/remove FluentValidation on Domain; then manual csproj tidy for empty ItemGroup
+tool	apply_text_edit	experimental	editing	exercised-apply	9,17	22-4	Phase 9 Program.cs line replace; FLAG: column/end-line discipline easy to corrupt semicolon
+tool	build_project	stable	validation	exercised	8	1525	
+tool	build_workspace	stable	validation	exercised	8	13833	queued gate
+tool	bulk_replace_type_apply	experimental	refactoring	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	bulk_replace_type_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	callers_callees	stable	analysis	exercised	3	9	
+tool	code_fix_apply	stable	refactoring	skipped-safety	6	—	preview/apply happy path not re-run this continuation
+tool	code_fix_preview	stable	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	compile_check	stable	validation	exercised	1,6,8	varies	emitValidation ~3712ms
+tool	create_file_apply	experimental	unknown	exercised-apply	10	3237	placeholder file then deleted
+tool	create_file_preview	experimental	unknown	exercised-preview-only	10	10	McpAuditPlaceholder.cs preview
+tool	delete_file_apply	experimental	unknown	exercised-apply	10-12	3128-3295	placeholder + scaffold cleanup
+tool	delete_file_preview	experimental	unknown	exercised-preview-only	10-12	1-10	audited delete previews
+tool	dependency_inversion_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	diagnostic_details	stable	analysis	exercised	1	4	
+tool	document_symbols	stable	symbols	exercised	3	—	
+tool	enclosing_symbol	stable	symbols	exercised	14	139	LoadAppSettings at ApiHostBuilder.cs:100,5
+tool	evaluate_csharp	stable	scripting	exercised	5	21-13006	timeout path validated
+tool	evaluate_msbuild_items	experimental	unknown	exercised	7	149	Compile items
+tool	evaluate_msbuild_property	experimental	unknown	exercised	7	78	
+tool	extract_and_wire_interface_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	extract_interface_apply	experimental	refactoring	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	extract_interface_cross_project_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	extract_interface_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	extract_method_apply	experimental	refactoring	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	extract_method_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	extract_type_apply	experimental	refactoring	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	extract_type_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	find_base_members	stable	symbols	exercised	14	—	PanosApiException.ErrorCode → FirewallAnalyzerException.ErrorCode
+tool	find_consumers	stable	analysis	exercised	3	4	
+tool	find_implementations	stable	symbols	exercised	3	2	
+tool	find_overrides	stable	symbols	exercised	14	—	FirewallAnalyzerException.ErrorCode overrides (4 types)
+tool	find_property_writes	stable	symbols	skipped-repo-shape	3-14	—	no suitable virtual/override/property target selected in abbreviated Phase 3/14
+tool	find_references	stable	symbols	exercised	3	9	
+tool	find_references_bulk	stable	symbols	exercised	14	22	
+tool	find_reflection_usages	stable	advanced-analysis	exercised	11	1218	
+tool	find_shared_members	stable	analysis	exercised	3	8	
+tool	find_type_mutations	stable	analysis	exercised	3	8	
+tool	find_type_usages	stable	analysis	exercised	3	29	
+tool	find_unused_symbols	stable	advanced-analysis	exercised	2	829-1710	includePublic true/false
+tool	fix_all_apply	experimental	refactoring	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	fix_all_preview	experimental	refactoring	exercised-preview-only	6	80	IDE0005 no provider; guidance ok
+tool	format_document_apply	stable	refactoring	exercised-apply	6	1	no-op diff
+tool	format_document_preview	stable	refactoring	exercised	6	78	
+tool	format_range_apply	experimental	refactoring	skipped-safety	6	—	not invoked this continuation
+tool	format_range_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	get_code_actions	stable	code-actions	exercised	6	199	empty at CA1859 caret
+tool	get_cohesion_metrics	stable	analysis	exercised	2	large	result written to agent-tools
+tool	get_completions	stable	symbols	exercised	14	178	ApiHostBuilder builder. Environment|Equals with filterText=E
+tool	get_complexity_metrics	stable	advanced-analysis	exercised	2	91	
+tool	get_di_registrations	stable	advanced-analysis	exercised	11	1235	
+tool	get_editorconfig_options	experimental	configuration	exercised	7	6	
+tool	get_msbuild_properties	experimental	unknown	skipped-safety	7	—	avoid 50-700KB payload this turn; evaluate_msbuild_* exercised
+tool	get_namespace_dependencies	stable	advanced-analysis	exercised	2	large	agent-tools
+tool	get_nuget_dependencies	stable	advanced-analysis	exercised	2	1448	
+tool	get_operations	experimental	advanced-analysis	exercised	4	3	
+tool	get_source_text	stable	workspace	exercised	4	3	
+tool	get_syntax_tree	experimental	syntax	exercised	4	7	
+tool	goto_type_definition	stable	symbols	exercised	14	153-7	IPanosClient on AddSingleton line; top-level Program.cs probes NotFound (expected repo shape)
+tool	go_to_definition	stable	symbols	exercised	14	—	
+tool	impact_analysis	stable	analysis	exercised	3	4	
+tool	list_analyzers	stable	analysis	exercised	1	8	paged
+tool	member_hierarchy	stable	symbols	skipped-repo-shape	3-14	—	no suitable virtual/override/property target selected in abbreviated Phase 3/14
+tool	migrate_package_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	move_file_apply	experimental	unknown	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	move_file_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	move_type_to_file_apply	experimental	refactoring	skipped-safety	10	—	not invoked; create/delete loop used instead
+tool	move_type_to_file_preview	experimental	refactoring	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	move_type_to_project_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	nuget_vulnerability_scan	stable	security	exercised	1	5302	
+tool	organize_usings_apply	stable	refactoring	exercised-apply	6	6	
+tool	organize_usings_preview	stable	refactoring	exercised	6	134	
+tool	preview_code_action	stable	code-actions	skipped-safety	6	—	not invoked this continuation
+tool	project_diagnostics	stable	analysis	exercised	1	4738	full scan
+tool	project_graph	stable	workspace	exercised	0	2	
+tool	remove_central_package_version_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	remove_dead_code_apply	experimental	unknown	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	remove_dead_code_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	remove_package_reference_preview	experimental	unknown	exercised-preview-only	13	2	remove FluentValidation preview after forward apply
+tool	remove_project_reference_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	remove_target_framework_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	rename_apply	stable	refactoring	exercised-apply	6	39	
+tool	rename_preview	stable	refactoring	exercised	6	499	bad column probe documented
+tool	revert_last_apply	experimental	undo	exercised-apply	9,17	96-4203	Phase 9 text-edit revert; Phase 17 probe undid delete (LIFO) — FLAG stack semantics vs cleanup
+tool	scaffold_test_apply	experimental	unknown	skipped-safety	6-13	—	full-surface apply families not executed end-to-end this session (repo left with intentional Phase6 changes only)
+tool	scaffold_test_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	scaffold_type_apply	experimental	unknown	exercised-apply	12	3110	McpAuditScaffoldType then deleted
+tool	scaffold_type_preview	experimental	unknown	exercised-preview-only	12	2	internal sealed class scaffold v1.8+ default
+tool	security_analyzer_status	stable	security	exercised	1	2875	
+tool	security_diagnostics	stable	security	exercised	1	3002	
+tool	semantic_search	stable	advanced-analysis	exercised	11	large	agent-tools
+tool	server_info	stable	server	exercised	0	5	
+tool	set_conditional_property_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	set_diagnostic_severity	experimental	configuration	skipped-safety	7-8b	—	intentionally avoided mutating .editorconfig/source for audit cleanliness
+tool	set_editorconfig_option	experimental	configuration	skipped-safety	7-8b	—	intentionally avoided mutating .editorconfig/source for audit cleanliness
+tool	set_project_property_preview	experimental	unknown	exercised-preview-only	13	8	Nullable=enable preview on Domain only (apply not taken; used package add/remove loop instead)
+tool	source_generated_documents	stable	workspace	exercised	11	—	
+tool	split_class_preview	experimental	unknown	skipped-safety	10-13	—	preview/apply orchestration not fully driven; disposable branch available for follow-up
+tool	suggest_refactorings	experimental	advanced-analysis	exercised	2	572	
+tool	symbol_info	stable	symbols	exercised	3	4	
+tool	symbol_relationships	stable	symbols	exercised	3	12	
+tool	symbol_search	stable	symbols	exercised	3,8b.1,11	varies; large limit strips _meta in client (FLAG)	
+tool	symbol_signature_help	stable	symbols	exercised	3	2	
+tool	test_coverage	stable	validation	skipped-safety	8	—	delegate long coverage run; test_run scoped instead
+tool	test_discover	stable	validation	exercised	8	large	agent-tools
+tool	test_related	stable	validation	exercised	8	0	empty array returned for Build symbol
+tool	test_related_files	stable	validation	exercised	8	10	no heuristic matches for ApiHostBuilder path
+tool	test_run	stable	validation	exercised	8	1984	Domain.Tests filtered
+tool	type_hierarchy	stable	analysis	exercised	3	3	
+tool	workspace_changes	experimental	workspace	exercised	6	3	
+tool	workspace_close	stable	workspace	exercised	0,18	0	MCP workspace_close after report finalization (continuation session)
+tool	workspace_list	stable	workspace	exercised	0+	0-1	heartbeat between phases
+tool	workspace_load	stable	workspace	exercised	0	4414	leansummary
+tool	workspace_reload	stable	workspace	exercised	8,closure	3027-6054	post Phase 10-13 manual csproj tidy; SnapshotToken v14
+tool	workspace_status	stable	workspace	exercised	0	8	
+resource	server_catalog	stable	server	exercised	0,15	6	fetch_mcp_resource roslyn://server/catalog Phase 0
+resource	resource_templates	stable	server	exercised	0	4	fetch_mcp_resource Phase 0
+resource	workspaces	stable	workspace	blocked	15	—	fetch_mcp_resource intermittently unavailable; exercised via workspace_list tool Phase 0+
+resource	workspaces_verbose	stable	workspace	blocked	15	—	same transport flake as workspaces URI
+resource	workspace_status	stable	workspace	blocked	15	—	URI fetch failed; exercised via workspace_status tool
+resource	workspace_status_verbose	stable	workspace	blocked	15	—	URI fetch failed; lean summary exercised
+resource	workspace_projects	stable	workspace	blocked	15	—	URI fetch failed; project_graph tool exercised
+resource	workspace_diagnostics	stable	workspace	blocked	15	—	URI fetch failed; project_diagnostics exercised
+resource	source_file	stable	workspace	blocked	15	—	URI fetch failed; get_source_text exercised
+prompt	explain_error	experimental	prompts	blocked	16	—	Cursor user-roslyn host: prompt tools not invokable via call_mcp_tool in this session
+prompt	suggest_refactoring	experimental	prompts	blocked	16	—	same
+prompt	review_file	experimental	prompts	blocked	16	—	same
+prompt	analyze_dependencies	experimental	prompts	blocked	16	—	same
+prompt	debug_test_failure	experimental	prompts	blocked	16	—	same
+prompt	refactor_and_validate	experimental	prompts	blocked	16	—	same
+prompt	fix_all_diagnostics	experimental	prompts	blocked	16	—	same
+prompt	guided_package_migration	experimental	prompts	blocked	16	—	same
+prompt	guided_extract_interface	experimental	prompts	blocked	16	—	same
+prompt	security_review	experimental	prompts	blocked	16	—	same
+prompt	discover_capabilities	experimental	prompts	blocked	16	—	same
+prompt	dead_code_audit	experimental	prompts	blocked	16	—	same
+prompt	review_test_coverage	experimental	prompts	blocked	16	—	same
+prompt	review_complexity	experimental	prompts	blocked	16	—	same
+prompt	cohesion_analysis	experimental	prompts	blocked	16	—	same
+prompt	consumer_impact	experimental	prompts	blocked	16	—	same
+prompt	guided_extract_method	experimental	prompts	blocked	16	—	same
+prompt	msbuild_inspection	experimental	prompts	blocked	16	—	same
+prompt	session_undo	experimental	prompts	blocked	16	—	same
+```

--- a/ai_docs/audit-reports/20260413T160052Z_itchatbot_mcp-server-audit.md
+++ b/ai_docs/audit-reports/20260413T160052Z_itchatbot_mcp-server-audit.md
@@ -1,0 +1,586 @@
+# MCP Server Audit Report — Roslyn MCP (plugin-roslyn-mcp-roslyn)
+
+## Run status (closure)
+
+**Final surface closure: NOT SATISFIED** against the full `ai_docs/prompts/deep-review-and-refactor.md` gate (Phase 6 product refactor not completed in this run; experimental write/scaffold families mostly uninvoked; Phase 8b concurrency N/A; prompts client-blocked). **Report format: COMPLETE** — §1–§20 plus **Appendix A** (Phase 0–1 evidence) in one export file; see **Appendix B** for retention.
+
+## 1. Header
+
+| Field | Value |
+|-------|--------|
+| **Date (UTC)** | 2026-04-13 |
+| **Audit mode** | full-surface (intended) |
+| **Isolation** | `c:\Code-Repo\IT-Chat-Bot-wt-mcp-audit`, branch `audit/mcp-full-surface-20260413` |
+| **Entrypoint** | `c:\Code-Repo\IT-Chat-Bot-wt-mcp-audit\ITChatBot.sln` |
+| **Client** | Cursor agent; MCP server id `plugin-roslyn-mcp-roslyn` |
+| **Workspace id (this session)** | `f2ef1e1946f34b928bcb7c20241fb00d` (closed at end of audit) |
+| **Server** | roslyn-mcp 1.11.2+d0f2680698687bd6fb93c4af5ddabe22f59eb0b2 |
+| **Catalog** | 2026.04 (from live `server_info` / `roslyn://server/catalog` at audit time) |
+| **Roslyn / runtime** | 5.3.0.0 / .NET 10.0.5 / Windows 10.0.26200 |
+| **Scale** | 34 projects, 770 documents |
+| **dotnet restore** | Precondition met on worktree solution (handoff + policy) |
+| **Debug log channel** | no — client did not surface MCP `notifications/message` |
+| **Plugin skills path (16b)** | `C:\Users\daryl\.claude\plugins\cache\roslyn-mcp-marketplace\roslyn-mcp\1.7.0\skills` (not Roslyn-Backed-MCP repo; **version skew 1.7.0 vs server 1.11.2**) |
+| **Intended canonical store** | Copy into Roslyn-Backed-MCP `ai_docs/audit-reports/` per deep-review Output Format |
+| **Mismatch finding (live wins)** | Prompt banner cites 128 tools / 59 experimental; live catalog **127 tools**, **58 experimental** |
+
+## 2. Coverage summary (by Kind and Category)
+
+Counts from live catalog and **§3** ledger. Tier columns are catalog inventory; Exercised…Blocked columns count ledger rows in that Kind×Category group.
+
+| Kind | Category | Tier-stable | Tier-experimental | exercised | exercised-apply | exercised-preview-only | skipped-repo-shape | skipped-safety | blocked | Notes |
+|------|----------|-------------|-------------------|-----------|-----------------|------------------------|--------------------|----------------|---------|-------|
+| prompt | prompts | 0 | 19 | 0 | 0 | 0 | 0 | 0 | 19 | all prompts client-blocked |
+| resource | analysis | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |  |
+| resource | server | 2 | 0 | 2 | 0 | 0 | 0 | 0 | 0 |  |
+| resource | workspace | 6 | 0 | 5 | 0 | 0 | 0 | 0 | 1 | includes file URI blocked row |
+| tool | advanced-analysis | 9 | 2 | 11 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | analysis | 12 | 0 | 12 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | code-actions | 3 | 0 | 2 | 1 | 0 | 0 | 0 | 0 |  |
+| tool | configuration | 0 | 3 | 1 | 0 | 0 | 0 | 0 | 2 |  |
+| tool | cross-project-refactoring | 0 | 3 | 0 | 0 | 0 | 0 | 0 | 3 |  |
+| tool | dead-code | 0 | 2 | 0 | 0 | 0 | 0 | 0 | 2 |  |
+| tool | editing | 0 | 3 | 0 | 0 | 0 | 0 | 0 | 3 |  |
+| tool | file-operations | 0 | 6 | 0 | 0 | 0 | 0 | 0 | 6 |  |
+| tool | orchestration | 0 | 4 | 0 | 0 | 0 | 0 | 0 | 4 |  |
+| tool | project-mutation | 0 | 14 | 3 | 0 | 0 | 2 | 0 | 9 |  |
+| tool | refactoring | 8 | 14 | 0 | 0 | 3 | 0 | 3 | 16 |  |
+| tool | scaffolding | 0 | 4 | 0 | 0 | 0 | 0 | 0 | 4 |  |
+| tool | scripting | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | security | 3 | 0 | 3 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | server | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | symbols | 16 | 0 | 16 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | syntax | 0 | 1 | 1 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | undo | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 0 |  |
+| tool | validation | 8 | 0 | 8 | 0 | 0 | 0 | 0 | 0 |  |
+| tool | workspace | 8 | 1 | 9 | 0 | 0 | 0 | 0 | 0 |  |
+
+**Rollup (all 155 rows):** blocked=69, exercised=76, exercised-apply=2, exercised-preview-only=3, skipped-repo-shape=2, skipped-safety=3.
+
+## 3. Coverage ledger
+
+One row per live tool, resource, and prompt (snapshot at audit close; no separate ledger file retained).
+
+| kind | name | tier | category | status | phase | lastElapsedMs | notes |
+|------|------|------|----------|--------|-------|---------------|-------|
+| tool | server_info | S | server | exercised | 0 | 8 | Handoff + continuation |
+| tool | workspace_load | S | workspace | exercised | 0 | - | Worktree; WorkspaceId f2ef1e1946f34b928bcb7c20241fb00d |
+| tool | workspace_reload | S | workspace | exercised | 8 | 6948 | WorkspaceVersion 4 to 5; verbose Projects in payload |
+| tool | workspace_close | S | workspace | exercised | 17e | - | End of audit session |
+| tool | workspace_list | S | workspace | exercised | 0,hb | 0 | Heartbeat |
+| tool | workspace_status | S | workspace | exercised | 0,17 | 0 | Lean summary; Phase17 bad id actionable NotFound |
+| tool | project_graph | S | workspace | exercised | 0 | 1 | 34 projects net10.0 |
+| tool | source_generated_documents | S | workspace | exercised | 11 | - | No top-level _meta FLAG |
+| tool | get_source_text | S | workspace | exercised | 4 | 0 | ChatOrchestrator.cs |
+| tool | symbol_search | S | symbols | exercised | 3 | 152 | ChatOrchestrator |
+| tool | symbol_info | S | symbols | exercised | 3 | 4 | Class |
+| tool | go_to_definition | S | symbols | exercised | 14 | - | ProcessQuestionAsync |
+| tool | find_references | S | symbols | exercised | 3 | 152 | Handoff + probes |
+| tool | find_implementations | S | symbols | exercised | 3 | 182 | Interface to class |
+| tool | document_symbols | S | symbols | exercised | 3 | - | ChatOrchestrator.cs |
+| tool | find_overrides | S | symbols | exercised | 14 | - | Interface [] no meta; self on override FLAG |
+| tool | find_base_members | S | symbols | exercised | 14 | - | ProcessQuestionAsync interface |
+| tool | member_hierarchy | S | symbols | exercised | 3 | 7 | Teams override base virtual |
+| tool | symbol_signature_help | S | symbols | exercised | 3 | 0 | ProcessQuestionAsync |
+| tool | symbol_relationships | S | symbols | exercised | 3 | 3 | baseMembers ProcessQuestionAsync |
+| tool | find_references_bulk | S | symbols | exercised | 14 | 9 | symbols array |
+| tool | find_property_writes | S | symbols | exercised | 3 | 11 | GitSyncResult.Success |
+| tool | enclosing_symbol | S | symbols | exercised | 14 | 3 | Caret promotion |
+| tool | goto_type_definition | S | symbols | exercised | 14 | 0 | FAIL method name; PASS ChatRequest |
+| tool | get_completions | S | symbols | exercised | 14 | 137 | IsIncomplete |
+| tool | project_diagnostics | S | analysis | exercised | 1 | 17599 | Handoff paged totals |
+| tool | diagnostic_details | S | analysis | exercised | 1 | - | Handoff CA1859 |
+| tool | type_hierarchy | S | analysis | exercised | 3 | 19 | IChatOrchestrator |
+| tool | callers_callees | S | analysis | exercised | 3 | 134 | ProcessQuestionAsync |
+| tool | impact_analysis | S | analysis | exercised | 3 | 2 | Blast radius |
+| tool | find_type_mutations | S | analysis | exercised | 3 | 2 | ChatOrchestrator |
+| tool | find_type_usages | S | analysis | exercised | 3 | 1 | ChatOrchestrator |
+| tool | build_workspace | S | validation | exercised | 8 | 13192 | Handoff sln build |
+| tool | build_project | S | validation | exercised | 8 | 1531 | ITChatBot.Chat |
+| tool | test_discover | S | validation | exercised | 8 | 21 | Handoff totalCount 897 |
+| tool | test_run | S | validation | exercised | 8 | 5497 | Chat.Tests filtered5 pass |
+| tool | test_related | S | validation | exercised | 8 | - | Array only no _meta FLAG |
+| tool | test_related_files | S | validation | exercised | 8 | 11 | Filter string |
+| tool | rename_preview | S | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | rename_apply | S | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | organize_usings_preview | S | refactoring | exercised-preview-only | 6e | 7560 | Empty diff |
+| tool | organize_usings_apply | S | refactoring | skipped-safety | 6e | - | No material preview |
+| tool | format_document_preview | S | refactoring | exercised-preview-only | 6e | 6974 | Empty diff |
+| tool | format_document_apply | S | refactoring | skipped-safety | 6e | - | No material preview |
+| tool | code_fix_preview | S | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | code_fix_apply | S | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | find_unused_symbols | S | advanced-analysis | exercised | 2 | 1619|7460 | false 0 hits; true limit=5 low-confidence enums |
+| tool | get_di_registrations | S | advanced-analysis | exercised | 11 | 1906 | Large list |
+| tool | get_complexity_metrics | S | advanced-analysis | exercised | 2 | 177 | Handoff limit=5 |
+| tool | find_reflection_usages | S | advanced-analysis | exercised | 11 | 1725 | 54 hits |
+| tool | get_namespace_dependencies | S | advanced-analysis | exercised | 2 | 1439 | Large output |
+| tool | get_nuget_dependencies | S | advanced-analysis | exercised | 2 | 3080 | CPM-aware |
+| tool | semantic_search | S | advanced-analysis | exercised | 11 | 94 | Fallback warning |
+| tool | apply_text_edit | E | editing | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | apply_multi_file_edit | E | editing | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | create_file_preview | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | create_file_apply | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | delete_file_preview | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | delete_file_apply | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | move_file_preview | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | move_file_apply | E | file-operations | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | add_package_reference_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | remove_package_reference_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | add_project_reference_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | remove_project_reference_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | set_project_property_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | add_target_framework_preview | E | project-mutation | skipped-repo-shape | 13 | - | Single TFM |
+| tool | remove_target_framework_preview | E | project-mutation | skipped-repo-shape | 13 | - | Single TFM |
+| tool | set_conditional_property_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | add_central_package_version_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | remove_central_package_version_preview | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | apply_project_mutation | E | project-mutation | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | scaffold_type_preview | E | scaffolding | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | scaffold_type_apply | E | scaffolding | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | scaffold_test_preview | E | scaffolding | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | scaffold_test_apply | E | scaffolding | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | remove_dead_code_preview | E | dead-code | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | remove_dead_code_apply | E | dead-code | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | move_type_to_project_preview | E | cross-project-refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_interface_cross_project_preview | E | cross-project-refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | dependency_inversion_preview | E | cross-project-refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | migrate_package_preview | E | orchestration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | split_class_preview | E | orchestration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_and_wire_interface_preview | E | orchestration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | apply_composite_preview | E | orchestration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | test_coverage | S | validation | exercised | 8 | 4222 | coverlet missing Success+Error FLAG |
+| tool | get_syntax_tree | E | syntax | exercised | 4 | 1 | MethodDeclaration |
+| tool | get_code_actions | S | code-actions | exercised | 6g | 151 | GitSyncProvider |
+| tool | preview_code_action | S | code-actions | exercised | 6g | 244 | Expression body |
+| tool | apply_code_action | S | code-actions | exercised-apply | 6g | 36 | Then reverted |
+| tool | security_diagnostics | S | security | exercised | 1 | - | Handoff |
+| tool | security_analyzer_status | S | security | exercised | 1 | - | Handoff |
+| tool | nuget_vulnerability_scan | S | security | exercised | 1 | - | Handoff 0 CVEs |
+| tool | find_consumers | S | analysis | exercised | 3 | 9 | ChatOrchestrator metadataName |
+| tool | get_cohesion_metrics | S | analysis | exercised | 2 | 119 | minMethods=3 limit=5 |
+| tool | find_shared_members | S | analysis | exercised | 3 | 1 | AdapterRegistry |
+| tool | move_type_to_file_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | move_type_to_file_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_interface_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_interface_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | bulk_replace_type_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | bulk_replace_type_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_type_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_type_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | workspace_changes | E | workspace | exercised | 6k | 2 | Audit trail includes reverted apply |
+| tool | suggest_refactorings | E | advanced-analysis | exercised | 2 | 1149 | 20 suggestions |
+| tool | extract_method_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | extract_method_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | revert_last_apply | E | undo | exercised-apply | 9 | 7567 | Undo code action |
+| tool | analyze_data_flow | S | advanced-analysis | exercised | 4 | 0 | Expression-bodied method |
+| tool | analyze_control_flow | S | advanced-analysis | exercised | 4 | 0 | Synthesized v1.8 |
+| tool | compile_check | S | validation | exercised | 1 | 810 | limit=20 post-reload 0 diagnostics |
+| tool | list_analyzers | S | analysis | exercised | 1 | - | Handoff paging |
+| tool | fix_all_preview | E | refactoring | exercised-preview-only | 6a | 7054 | CA1859 doc 0 changes no fixer |
+| tool | fix_all_apply | E | refactoring | skipped-safety | 6a | - | No preview token |
+| tool | get_operations | E | advanced-analysis | exercised | 4 | 0 | RunAsync invocation |
+| tool | format_range_preview | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | format_range_apply | E | refactoring | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | analyze_snippet | S | analysis | exercised | 5 | 109 | Handoff |
+| tool | evaluate_csharp | S | scripting | exercised | 5 | 368 | Handoff |
+| tool | get_editorconfig_options | E | configuration | exercised | 7 | 6907 | Merged options |
+| tool | set_editorconfig_option | E | configuration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | evaluate_msbuild_property | E | project-mutation | exercised | 7b | 55 | TargetFramework net10.0 |
+| tool | evaluate_msbuild_items | E | project-mutation | exercised | 7b | 61 | Compile items |
+| tool | get_msbuild_properties | E | project-mutation | exercised | 7b | 72 | RootNamespace filter |
+| tool | set_diagnostic_severity | E | configuration | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| tool | add_pragma_suppression | E | editing | blocked | - | - | Not exercised in 2026-04-13 audit continuation |
+| resource | `roslyn://server/catalog` | S | server | exercised | 0,15 | - | Catalog fetched during audit |
+| resource | `roslyn://server/resource-templates` | S | server | exercised | 0,15 | - | Fetched during audit |
+| resource | `roslyn://workspaces` | S | workspace | exercised | 15 | 0 | Fetched during audit |
+| resource | `roslyn://workspaces/verbose` | S | workspace | exercised | 15 | - | Fetched during audit |
+| resource | `roslyn://workspace/{workspaceId}/status` | S | workspace | exercised | 15 | - | Fetched during audit |
+| resource | `roslyn://workspace/{workspaceId}/status/verbose` | S | workspace | exercised | 15 | - | Fetched during audit |
+| resource | `roslyn://workspace/{workspaceId}/projects` | S | workspace | exercised | 15 | - | Fetched during audit |
+| resource | `roslyn://workspace/{workspaceId}/diagnostics` | S | analysis | exercised | 15 | - | Fetched during audit |
+| resource | `roslyn://workspace/{workspaceId}/file/{filePath}` | S | workspace | blocked | 15 | - | Cursor fetch_mcp_resource Windows path URI client limitation |
+| prompt | explain_error | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | suggest_refactoring | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | review_file | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | analyze_dependencies | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | debug_test_failure | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | refactor_and_validate | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | fix_all_diagnostics | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | guided_package_migration | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | guided_extract_interface | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | security_review | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | discover_capabilities | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | dead_code_audit | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | review_test_coverage | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | review_complexity | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | cohesion_analysis | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | consumer_impact | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | guided_extract_method | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | msbuild_inspection | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+| prompt | session_undo | E | prompts | blocked | 16 | - | Cursor prompts/get not invokable |
+
+
+## 4. Verified tools (working)
+
+- `server_info` — surface counts match catalog totals.
+- `workspace_load` / `workspace_list` / `workspace_status` / `project_graph` — session healthy on disposable worktree.
+- `compile_check` — 0 CS diagnostics paginated; solution-wide read ~8–11s (handoff + post-reload).
+- `project_diagnostics` — stable totals 0/23/2282; ~17.6s full scan (handoff).
+- `symbol_search` → `symbol_info` / `document_symbols` / `type_hierarchy` / `find_references` / `find_references_bulk` (`symbols` payload) / `find_implementations` — consistent graph for `ChatOrchestrator` / `IChatOrchestrator`.
+- `get_code_actions` / `preview_code_action` / `apply_code_action` / `revert_last_apply` — full chain exercised; reverted before close.
+- `workspace_reload` — WorkspaceVersion bump; verbose project payload.
+- `get_complexity_metrics` — hotspots align with `ai_docs/backlog.md` queue-refactor rows.
+- `build_workspace` — `dotnet build` exit 0.
+- `test_discover` — totalCount **897**.
+- `test_run` — filtered `Chat.Tests` run pass (~5.5s).
+- `analyze_snippet` / `evaluate_csharp` — expression probes PASS.
+- `fetch_mcp_resource` — 8/9 URIs OK; workspace file template FAIL (§14).
+- Phase 1 tools (`security_*`, `nuget_vulnerability_scan`, `list_analyzers`, `diagnostic_details`) — call-level timings in **Appendix A**.
+
+## 5. Phase 6 refactor summary
+
+**Audit-only write path; no product refactor.** Workspace `f2ef1e1946f34b928bcb7c20241fb00d`: `get_code_actions` → `preview_code_action` → `apply_code_action` → `revert_last_apply` with `workspace_changes` trail. `fix_all_preview` for CA1859 returned zero edits / no `fix_all_apply` token. No rename/extract/move product refactor in this run.
+
+## 6. Performance baseline (`_meta.elapsedMs`)
+
+Single-call tools: p90=max=p50. Multi-call or ranged ms noted in **Notes**. Tier/Category from live catalog.
+
+| Tool / URI | Tier | Category | Calls | p50_ms | p90_ms | max_ms | Input scale | Budget | Notes |
+|------------|------|----------|-------|--------|--------|--------|-------------|--------|-------|
+| `server_info` | stable | server | 1 | 8 | 8 | 8 | ITChatBot.sln / 34 projects | within | Handoff + continuation |
+| `workspace_load` | stable | workspace | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Worktree; WorkspaceId f2ef1e1946f34b928bcb7c20241fb00d |
+| `workspace_reload` | stable | workspace | 1 | 6948 | 6948 | 6948 | ITChatBot.sln / 34 projects | within | WorkspaceVersion 4 to 5; verbose Projects in payload |
+| `workspace_close` | stable | workspace | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | End of audit session |
+| `workspace_list` | stable | workspace | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | Heartbeat |
+| `workspace_status` | stable | workspace | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | Lean summary; Phase17 bad id actionable NotFound |
+| `project_graph` | stable | workspace | 1 | 1 | 1 | 1 | ITChatBot.sln / 34 projects | within | 34 projects net10.0 |
+| `source_generated_documents` | stable | workspace | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | No top-level _meta FLAG |
+| `get_source_text` | stable | workspace | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | ChatOrchestrator.cs |
+| `symbol_search` | stable | symbols | 1 | 152 | 152 | 152 | ITChatBot.sln / 34 projects | within | ChatOrchestrator |
+| `symbol_info` | stable | symbols | 1 | 4 | 4 | 4 | ITChatBot.sln / 34 projects | within | Class |
+| `go_to_definition` | stable | symbols | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | ProcessQuestionAsync |
+| `find_references` | stable | symbols | 1 | 152 | 152 | 152 | ITChatBot.sln / 34 projects | within | Handoff + probes |
+| `find_implementations` | stable | symbols | 1 | 182 | 182 | 182 | ITChatBot.sln / 34 projects | within | Interface to class |
+| `document_symbols` | stable | symbols | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | ChatOrchestrator.cs |
+| `find_overrides` | stable | symbols | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Interface [] no meta; self on override FLAG |
+| `find_base_members` | stable | symbols | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | ProcessQuestionAsync interface |
+| `member_hierarchy` | stable | symbols | 1 | 7 | 7 | 7 | ITChatBot.sln / 34 projects | within | Teams override base virtual |
+| `symbol_signature_help` | stable | symbols | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | ProcessQuestionAsync |
+| `symbol_relationships` | stable | symbols | 1 | 3 | 3 | 3 | ITChatBot.sln / 34 projects | within | baseMembers ProcessQuestionAsync |
+| `find_references_bulk` | stable | symbols | 1 | 9 | 9 | 9 | ITChatBot.sln / 34 projects | within | symbols array |
+| `find_property_writes` | stable | symbols | 1 | 11 | 11 | 11 | ITChatBot.sln / 34 projects | within | GitSyncResult.Success |
+| `enclosing_symbol` | stable | symbols | 1 | 3 | 3 | 3 | ITChatBot.sln / 34 projects | within | Caret promotion |
+| `goto_type_definition` | stable | symbols | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | FAIL method name; PASS ChatRequest |
+| `get_completions` | stable | symbols | 1 | 137 | 137 | 137 | ITChatBot.sln / 34 projects | within | IsIncomplete |
+| `project_diagnostics` | stable | analysis | 1 | 17599 | 17599 | 17599 | ITChatBot.sln / 34 projects | warn | Handoff paged totals |
+| `diagnostic_details` | stable | analysis | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Handoff CA1859 |
+| `type_hierarchy` | stable | analysis | 1 | 19 | 19 | 19 | ITChatBot.sln / 34 projects | within | IChatOrchestrator |
+| `callers_callees` | stable | analysis | 1 | 134 | 134 | 134 | ITChatBot.sln / 34 projects | within | ProcessQuestionAsync |
+| `impact_analysis` | stable | analysis | 1 | 2 | 2 | 2 | ITChatBot.sln / 34 projects | within | Blast radius |
+| `find_type_mutations` | stable | analysis | 1 | 2 | 2 | 2 | ITChatBot.sln / 34 projects | within | ChatOrchestrator |
+| `find_type_usages` | stable | analysis | 1 | 1 | 1 | 1 | ITChatBot.sln / 34 projects | within | ChatOrchestrator |
+| `build_workspace` | stable | validation | 1 | 13192 | 13192 | 13192 | ITChatBot.sln / 34 projects | within | Handoff sln build |
+| `build_project` | stable | validation | 1 | 1531 | 1531 | 1531 | ITChatBot.sln / 34 projects | within | ITChatBot.Chat |
+| `test_discover` | stable | validation | 1 | 21 | 21 | 21 | ITChatBot.sln / 34 projects | within | Handoff totalCount 897 |
+| `test_run` | stable | validation | 1 | 5497 | 5497 | 5497 | ITChatBot.sln / 34 projects | within | Chat.Tests filtered5 pass |
+| `test_related` | stable | validation | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Array only no _meta FLAG |
+| `test_related_files` | stable | validation | 1 | 11 | 11 | 11 | ITChatBot.sln / 34 projects | within | Filter string |
+| `organize_usings_preview` | stable | refactoring | 1 | 7560 | 7560 | 7560 | ITChatBot.sln / 34 projects | warn | Empty diff |
+| `format_document_preview` | stable | refactoring | 1 | 6974 | 6974 | 6974 | ITChatBot.sln / 34 projects | warn | Empty diff |
+| `find_unused_symbols` | stable | advanced-analysis | 1 | 1619 | 1619 | 1619 | ITChatBot.sln / 34 projects | within | 7460 |
+| `get_di_registrations` | stable | advanced-analysis | 1 | 1906 | 1906 | 1906 | ITChatBot.sln / 34 projects | within | Large list |
+| `get_complexity_metrics` | stable | advanced-analysis | 1 | 177 | 177 | 177 | ITChatBot.sln / 34 projects | within | Handoff limit=5 |
+| `find_reflection_usages` | stable | advanced-analysis | 1 | 1725 | 1725 | 1725 | ITChatBot.sln / 34 projects | within | 54 hits |
+| `get_namespace_dependencies` | stable | advanced-analysis | 1 | 1439 | 1439 | 1439 | ITChatBot.sln / 34 projects | within | Large output |
+| `get_nuget_dependencies` | stable | advanced-analysis | 1 | 3080 | 3080 | 3080 | ITChatBot.sln / 34 projects | within | CPM-aware |
+| `semantic_search` | stable | advanced-analysis | 1 | 94 | 94 | 94 | ITChatBot.sln / 34 projects | within | Fallback warning |
+| `test_coverage` | stable | validation | 1 | 4222 | 4222 | 4222 | ITChatBot.sln / 34 projects | within | coverlet missing Success+Error FLAG |
+| `get_syntax_tree` | experimental | syntax | 1 | 1 | 1 | 1 | ITChatBot.sln / 34 projects | within | MethodDeclaration |
+| `get_code_actions` | stable | code-actions | 1 | 151 | 151 | 151 | ITChatBot.sln / 34 projects | within | GitSyncProvider |
+| `preview_code_action` | stable | code-actions | 1 | 244 | 244 | 244 | ITChatBot.sln / 34 projects | within | Expression body |
+| `apply_code_action` | stable | code-actions | 1 | 36 | 36 | 36 | ITChatBot.sln / 34 projects | within | Then reverted |
+| `security_diagnostics` | stable | security | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Handoff |
+| `security_analyzer_status` | stable | security | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Handoff |
+| `nuget_vulnerability_scan` | stable | security | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Handoff 0 CVEs |
+| `find_consumers` | stable | analysis | 1 | 9 | 9 | 9 | ITChatBot.sln / 34 projects | within | ChatOrchestrator metadataName |
+| `get_cohesion_metrics` | stable | analysis | 1 | 119 | 119 | 119 | ITChatBot.sln / 34 projects | within | minMethods=3 limit=5 |
+| `find_shared_members` | stable | analysis | 1 | 1 | 1 | 1 | ITChatBot.sln / 34 projects | within | AdapterRegistry |
+| `workspace_changes` | experimental | workspace | 1 | 2 | 2 | 2 | ITChatBot.sln / 34 projects | within | Audit trail includes reverted apply |
+| `suggest_refactorings` | experimental | advanced-analysis | 1 | 1149 | 1149 | 1149 | ITChatBot.sln / 34 projects | within | 20 suggestions |
+| `revert_last_apply` | experimental | undo | 1 | 7567 | 7567 | 7567 | ITChatBot.sln / 34 projects | within | Undo code action |
+| `analyze_data_flow` | stable | advanced-analysis | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | Expression-bodied method |
+| `analyze_control_flow` | stable | advanced-analysis | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | Synthesized v1.8 |
+| `compile_check` | stable | validation | 1 | 810 | 810 | 810 | ITChatBot.sln / 34 projects | within | limit=20 post-reload 0 diagnostics |
+| `list_analyzers` | stable | analysis | 1 | — | — | — | ITChatBot.sln / 34 projects | n/a | Handoff paging |
+| `fix_all_preview` | experimental | refactoring | 1 | 7054 | 7054 | 7054 | ITChatBot.sln / 34 projects | warn | CA1859 doc 0 changes no fixer |
+| `get_operations` | experimental | advanced-analysis | 1 | 0 | 0 | 0 | ITChatBot.sln / 34 projects | within | RunAsync invocation |
+| `analyze_snippet` | stable | analysis | 1 | 109 | 109 | 109 | ITChatBot.sln / 34 projects | within | Handoff |
+| `evaluate_csharp` | stable | scripting | 1 | 368 | 368 | 368 | ITChatBot.sln / 34 projects | within | Handoff |
+| `get_editorconfig_options` | experimental | configuration | 1 | 6907 | 6907 | 6907 | ITChatBot.sln / 34 projects | within | Merged options |
+| `evaluate_msbuild_property` | experimental | project-mutation | 1 | 55 | 55 | 55 | ITChatBot.sln / 34 projects | within | TargetFramework net10.0 |
+| `evaluate_msbuild_items` | experimental | project-mutation | 1 | 61 | 61 | 61 | ITChatBot.sln / 34 projects | within | Compile items |
+| `get_msbuild_properties` | experimental | project-mutation | 1 | 72 | 72 | 72 | ITChatBot.sln / 34 projects | within | RootNamespace filter |
+| `roslyn://server/catalog` | stable | server | 1 | — | — | — | workspace session | n/a | Catalog fetched during audit |
+| `roslyn://server/resource-templates` | stable | server | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+| `roslyn://workspaces` | stable | workspace | 1 | 0 | 0 | 0 | workspace session | within | Fetched during audit |
+| `roslyn://workspaces/verbose` | stable | workspace | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+| `roslyn://workspace/{workspaceId}/status` | stable | workspace | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+| `roslyn://workspace/{workspaceId}/status/verbose` | stable | workspace | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+| `roslyn://workspace/{workspaceId}/projects` | stable | workspace | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+| `roslyn://workspace/{workspaceId}/diagnostics` | stable | analysis | 1 | — | — | — | workspace session | n/a | Fetched during audit |
+
+## 7. Schema vs behaviour drift
+
+| Tool | Mismatch kind | Expected | Actual | Severity | Notes |
+|------|---------------|----------|--------|----------|-------|
+| `find_references_bulk` | parameter naming | transcript name `symbolHandles` | server **`symbols`** | FLAG | Wrong name yields argument error. |
+| MSBuild tools | parameter naming | path-style `projectPath` | **`project`** = loaded project name | FLAG | Align examples with schema. |
+| `test_coverage` | return_shape | failure when collector missing | success + **Error** text re Coverlet | FLAG | Clients must parse message body. |
+| `find_references` | validation | reject corrupt handle | `InvalidArgument` | — | Correct behaviour. |
+
+**Residual:** file-resource URI gap (§14). `fix_all_preview` may return empty fix — no `fix_all_apply` token.
+
+## 8. Error message quality
+
+| Tool | Probe input | Rating | Suggested fix | Notes |
+|------|-------------|--------|---------------|-------|
+| `find_references` | Corrupt `symbolHandle` base64 | actionable | — | Clear InvalidArgument + hint. |
+| `workspace_status` | Non-existent workspace id | actionable | — | NotFound suitable for retry. |
+| `test_coverage` | Coverlet collector missing | vague | Return non-success or structured error code when collector missing. | Error string buried in success path. |
+
+## 9. Parameter-path coverage
+
+| Family | Non-default path tested | Status | Notes |
+|--------|-------------------------|--------|-------|
+| `project_diagnostics` | project + severity + paging | pass | Totals invariant under severity filter (handoff). |
+| `compile_check` | offset/limit; file filter (handoff) | pass | `emitValidation=true` in draft; not re-probed final segment. |
+| `list_analyzers` | paging + project filter | pass | Handoff. |
+| `symbol_search` | limit=5 | pass |  |
+| `find_references_bulk` | `symbols` array | pass | Not `symbolHandles`. |
+| MSBuild | `project` = loaded name | pass |  |
+| `test_discover` | paging | pass | hasMore. |
+| `test_run` | filter only | pass | Full solution run not exercised. |
+| Resources | workspaceId substitution | pass | file URI exception. |
+
+## 10. Prompt verification (Phase 16)
+
+One row per catalog prompt. All **blocked**: Cursor `prompts/get` not available on `call_mcp_tool` path.
+
+| prompt | schema_ok | actionable | hallucinated_tools | idempotent | elapsedMs | recommendation_seed | notes |
+|--------|-----------|------------|--------------------|------------|-----------|---------------------|-------|
+| `explain_error` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `suggest_refactoring` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `review_file` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `analyze_dependencies` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `debug_test_failure` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `refactor_and_validate` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `fix_all_diagnostics` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `guided_package_migration` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `guided_extract_interface` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `security_review` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `discover_capabilities` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `dead_code_audit` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `review_test_coverage` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `review_complexity` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `cohesion_analysis` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `consumer_impact` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `guided_extract_method` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `msbuild_inspection` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+| `session_undo` | n/a | n/a | n/a | n/a | — | needs-more-evidence | client-blocked |
+
+## 11. Skills audit (Phase 16b)
+
+Static parity: 19 `SKILL.md` under plugin **1.7.0**; tool names match catalog. **FLAG:** plugin version vs server **1.11.2**.
+
+| skill | frontmatter_ok | tool_refs_valid | dry_run | safety_rules | notes |
+|-------|----------------|-----------------|---------|--------------|-------|
+| `analyze` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `bump` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `code-actions` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `complexity` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `dead-code` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `document` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `explain-error` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `extract-method` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `migrate-package` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `project-inspection` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `publish-preflight` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `refactor` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `review` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `security` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `session-undo` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `snippet-eval` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `test-coverage` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `test-triage` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+| `update` | yes | yes (0 invalid) | pass | pass | static + catalog cross-check; no codegen execution |
+
+## 12. Experimental promotion scorecard
+
+| kind | name | category | status_from_ledger | p50_elapsedMs | schema_ok | error_ok | round_trip_ok | failures | recommendation | evidence |
+|------|------|----------|-------------------|---------------|-----------|----------|---------------|----------|----------------|----------|
+| tool | `apply_text_edit` | editing | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `apply_multi_file_edit` | editing | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `create_file_preview` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `create_file_apply` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `delete_file_preview` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `delete_file_apply` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `move_file_preview` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `move_file_apply` | file-operations | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `add_package_reference_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `remove_package_reference_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `add_project_reference_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `remove_project_reference_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `set_project_property_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `add_target_framework_preview` | project-mutation | skipped-repo-shape | - | n/a | yes | n/a | 0 | needs-more-evidence | Single TFM |
+| tool | `remove_target_framework_preview` | project-mutation | skipped-repo-shape | - | n/a | yes | n/a | 0 | needs-more-evidence | Single TFM |
+| tool | `set_conditional_property_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `add_central_package_version_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `remove_central_package_version_preview` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `apply_project_mutation` | project-mutation | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `scaffold_type_preview` | scaffolding | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `scaffold_type_apply` | scaffolding | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `scaffold_test_preview` | scaffolding | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `scaffold_test_apply` | scaffolding | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `remove_dead_code_preview` | dead-code | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `remove_dead_code_apply` | dead-code | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `move_type_to_project_preview` | cross-project-refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_interface_cross_project_preview` | cross-project-refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `dependency_inversion_preview` | cross-project-refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `migrate_package_preview` | orchestration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `split_class_preview` | orchestration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_and_wire_interface_preview` | orchestration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `apply_composite_preview` | orchestration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `get_syntax_tree` | syntax | exercised | 1 | yes | yes | n/a | 0 | needs-more-evidence | MethodDeclaration |
+| tool | `move_type_to_file_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `move_type_to_file_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_interface_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_interface_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `bulk_replace_type_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `bulk_replace_type_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_type_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_type_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `workspace_changes` | workspace | exercised | 2 | yes | yes | n/a | 0 | needs-more-evidence | Audit trail includes reverted apply |
+| tool | `suggest_refactorings` | advanced-analysis | exercised | 1149 | yes | yes | n/a | 0 | needs-more-evidence | 20 suggestions |
+| tool | `extract_method_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `extract_method_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `revert_last_apply` | undo | exercised-apply | 7567 | yes | yes | yes | 0 | needs-more-evidence | Undo code action |
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 7054 | yes | yes | preview-only | 0 | needs-more-evidence | CA1859 doc 0 changes no fixer |
+| tool | `fix_all_apply` | refactoring | skipped-safety | - | n/a | yes | n/a | 0 | needs-more-evidence | No preview token |
+| tool | `get_operations` | advanced-analysis | exercised | 0 | yes | yes | n/a | 0 | needs-more-evidence | RunAsync invocation |
+| tool | `format_range_preview` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `format_range_apply` | refactoring | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `get_editorconfig_options` | configuration | exercised | 6907 | yes | yes | n/a | 0 | needs-more-evidence | Merged options |
+| tool | `set_editorconfig_option` | configuration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `evaluate_msbuild_property` | project-mutation | exercised | 55 | yes | yes | n/a | 0 | needs-more-evidence | TargetFramework net10.0 |
+| tool | `evaluate_msbuild_items` | project-mutation | exercised | 61 | yes | yes | n/a | 0 | needs-more-evidence | Compile items |
+| tool | `get_msbuild_properties` | project-mutation | exercised | 72 | yes | yes | n/a | 0 | needs-more-evidence | RootNamespace filter |
+| tool | `set_diagnostic_severity` | configuration | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| tool | `add_pragma_suppression` | editing | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Not exercised in 2026-04-13 audit continuation |
+| prompt | `explain_error` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `suggest_refactoring` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `review_file` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `analyze_dependencies` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `debug_test_failure` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `refactor_and_validate` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `fix_all_diagnostics` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `guided_package_migration` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `guided_extract_interface` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `security_review` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `discover_capabilities` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `dead_code_audit` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `review_test_coverage` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `review_complexity` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `cohesion_analysis` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `consumer_impact` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `guided_extract_method` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `msbuild_inspection` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+| prompt | `session_undo` | prompts | blocked | - | n/a | n/a | n/a | 0 | needs-more-evidence | Cursor prompts/get not invokable |
+
+## 13. Debug log capture
+
+client did not surface MCP log notifications
+
+## 14. MCP server issues (bugs)
+
+| area | severity | notes |
+|------|----------|-------|
+| Resource `roslyn://workspace/{workspaceId}/file/{filePath}` | missing data | Windows path via `fetch_mcp_resource` not found — URI normalization FLAG. |
+| Host continuity | degraded performance | Session lost between turns; `workspace_load` again — may be operator/client. |
+| Prompt surface | N/A | Client limitation for `prompts/get`. |
+
+**No new issues** for core symbol/build tools beyond file-resource FLAG.
+
+## 15. Improvement suggestions
+
+1. Document file-resource URI examples for Windows paths (encoding, slash direction).
+2. Align `deep-review-and-refactor.md` banner counts with live catalog (127 / 58).
+3. Run Phase 8b when client supports concurrent MCP tool calls.
+
+## 16. Concurrency matrix (Phase 8b)
+
+**N/A — client serializes tool calls** (Cursor MCP bridge); parallel fan-out not attempted.
+
+## 17. Writer reclassification (Phase 8b.5)
+
+**N/A** — six-writer probe not executed.
+
+## 18. Response contract consistency
+
+| tools | concept | inconsistency | notes |
+|-------|---------|---------------|-------|
+| `test_related`, `source_generated_documents` | `_meta` envelope | array-only or missing top-level `_meta` | harder unified telemetry |
+| `test_coverage` | success vs error | HTTP/tool OK + Error string | treat as logical failure |
+
+## 19. Known issue regression check (Phase 18)
+
+Prior source: `ai_docs/backlog.md` (IT-Chat-Bot).
+
+| item | result |
+|------|--------|
+| Complexity hotspots (`queue-refactor-cc-*`) | **Still reproduces** — `get_complexity_metrics` consistent with backlog. |
+| Test coverage gap rows | **N/A** — product gap, not MCP defect. |
+| RR-P* plan gaps | **N/A** — not server regressions. |
+
+## 20. Known issue cross-check
+
+No overlap between new MCP findings and IT-Chat-Bot `queue-rr-*` ids.
+
+---
+
+## Appendix A. Phase 0–1 detailed evidence (rolled up)
+
+Per-call notes from the incremental audit draft, merged for a **single export artifact**. **Workspace ids:** Phase 0 initial `workspace_load` used `e80a3316e3c74f6f9d5c1c4c2f980563`; continuation and §3 ledger use `f2ef1e1946f34b928bcb7c20241fb00d` (reload/handoff).
+
+### Phase 0 — Setup, live surface, repo shape
+
+- **Mode:** full-surface.
+- **Disposable isolation:** `c:\Code-Repo\IT-Chat-Bot-wt-mcp-audit` (git worktree, branch `audit/mcp-full-surface-20260413`). Cleanup: `git worktree remove` when finished; branch may be deleted.
+- **Entrypoint:** `c:\Code-Repo\IT-Chat-Bot-wt-mcp-audit\ITChatBot.sln`.
+- **dotnet restore:** succeeded on worktree solution (host shell).
+- **Debug log channel:** Cursor did not surface MCP `notifications/message` — no verbatim structured logs.
+- **server_info:** roslyn-mcp **1.11.2+d0f2680698687bd6fb93c4af5ddabe22f59eb0b2**, catalog **2026.04**, runtime **.NET 10.0.5**, OS Windows 10.0.26200, Roslyn **5.3.0.0**. Surface: tools stable **69** / experimental **58**; resources stable **9**; prompts experimental **19**.
+- **Mismatch (live wins):** `deep-review-and-refactor.md` banner claims **59** experimental tools; live `server_info` reports **58**.
+- **roslyn://server/catalog:** **127** tools, **9** resources, **19** prompts (69+58=127).
+- **workspace_load (Phase 0):** WorkspaceId `e80a3316e3c74f6f9d5c1c4c2f980563`, ProjectCount **34**, DocumentCount **770**, `_meta.elapsedMs` **10502**.
+- **workspace_list / workspace_status:** one session; WorkspaceDiagnosticCount **0**; status `_meta.elapsedMs` **7**.
+- **project_graph:** 34 projects, **net10.0**, multi-project solution, test projects present.
+- **Repo shape (IT-Chat-Bot):** Central Package Management / `Directory.Packages.props`; `.editorconfig` present; DI-heavy; source generators possible (implicit usings); single TFM **net10.0**; large test matrix.
+- **Ledger seed:** **155** catalog rows (127+9+19); promotion scorecard seed **77** experimental rows (58 tools + 0 resources + 19 prompts).
+
+### Phase 1 — Broad diagnostics scan
+
+- **project_diagnostics** (full, offset 0 limit 30): totalErrors **0**, totalWarnings **23**, totalInfo **2282**; 23 analyzer warnings in page; `_meta.elapsedMs` **19502**.
+- **project_diagnostics** (project=`ITChatBot.Chat`, severity=Warning): invariant totals; **1** warning in page; elapsed **11911** ms.
+- **compile_check** (default): **0** CS diagnostics; elapsed **11774** ms.
+- **compile_check** (`emitValidation=true`): **0** diagnostics; elapsed **16561** ms (emit path; restore done).
+- **security_diagnostics:** **0** findings; SecurityCodeScan present.
+- **security_analyzer_status:** NetAnalyzers + SecurityCodeScan present.
+- **nuget_vulnerability_scan:** **0** CVEs, **34** projects, duration **10490** ms.
+- **list_analyzers:** offset 0 limit 25 — totalRules **663**, hasMore true; second call project=`ITChatBot.Api` — paging/filter OK.
+- **diagnostic_details** (CA1859 @ GitSyncProvider.cs:188): description + help link; SupportedFixes **[]** for this probe.
+- **project_diagnostics** (severity=Error): totals **0/23/2282** invariant; error page empty as expected.
+- **compile_check** (file=ChatOrchestrationPipeline.cs): **0** diagnostics; **30** ms.
+
+## Appendix B. Retention
+
+All working copies used to produce this report (catalog JSON, machine ledger, resource snapshots, draft notes, compile/finalize scripts) were **removed** after the final export. **This file is the only retained artifact** under `ai_docs/audit-reports/`.

--- a/ai_docs/audit-reports/20260415T140000Z_firewallanalyzer_experimental-promotion.md
+++ b/ai_docs/audit-reports/20260415T140000Z_firewallanalyzer_experimental-promotion.md
@@ -1,0 +1,534 @@
+# Experimental Promotion Exercise Report
+
+## 1. Header
+- **Date:** 2026-04-15
+- **Audited solution:** FirewallAnalyzer.slnx
+- **Audited revision:** `9123671` on branch `audit/experimental-promotion-20260415` (disposable worktree of `main`)
+- **Entrypoint loaded:** `C:\Code-Repo\DotNet-Firewall-Analyzer\.worktrees\audit-20260415\FirewallAnalyzer.slnx`
+- **Audit mode:** `full-surface` (some apply-siblings downgraded to `exercised-preview-only` by client-side PreToolUse hook, see §9 UX-HOOK-001)
+- **Isolation:** disposable worktree at `.worktrees/audit-20260415/` (branch `audit/experimental-promotion-20260415`)
+- **Client:** Claude Code (Opus 4.6 / 1M context) with strict `PreToolUse` hook on `*_apply`
+- **Workspace id:** `8712507774744003b34cb45370a4a804`
+- **Server:** `roslyn-mcp v1.18.0+172d3c5118178eae2664768ced630b38d9418309` (.NET 10.0.6, Roslyn 5.3.0.0)
+- **Catalog version:** `2026.04`
+- **Experimental surface:** 40 experimental tools, 20 experimental prompts, 1 experimental resource
+- **Scale:** 11 projects, 266→279 documents (scratch files added during audit)
+- **Repo shape:**
+  - Multi-project (5 src + 6 test projects)
+  - Tests present (xUnit; `FirewallAnalyzer.*.Tests` ×6)
+  - `.editorconfig` present at repo root
+  - `Directory.Packages.props` present (**CPM enabled**)
+  - Single `net10.0` target on every project (no multi-targeting)
+  - DI: ASP.NET Core Minimal APIs composition root in `FirewallAnalyzer.Api`
+  - No source generators observed in project graph
+- **Prior issue source:** `ai_docs/backlog.md` (last updated 2026-04-14)
+
+## 2. Coverage ledger (experimental surface)
+
+| Kind | Name | Category | Status | Phase | lastElapsedMs | Notes |
+|------|------|----------|--------|-------|---------------|-------|
+| tool | `fix_all_preview` | refactoring | exercised | 1a | 354 | Preview+apply round-trip PASS on CS0168; non-default scope=`project` probed |
+| tool | `fix_all_apply` | refactoring | exercised-apply | 1a | 4 | Round-trip clean, compile_check PASS |
+| tool | `format_range_preview` | refactoring | exercised | 1b | 2644 | **FLAG**: empty diff returned on dirty input (no-op) |
+| tool | `format_range_apply` | refactoring | exercised-preview-only | 1b | — | Blocked by UX-HOOK-001; no changes to apply (empty preview) |
+| tool | `extract_interface_preview` | refactoring | exercised | 1c | 245 | Clean preview on `ScratchB`; generated interface correct |
+| tool | `extract_interface_apply` | refactoring | exercised-preview-only | 1c | — | Blocked by UX-HOOK-001 |
+| tool | `extract_type_preview` | refactoring | exercised | 1d | 9 | Clean preview, members correctly split |
+| tool | `extract_type_apply` | refactoring | exercised-preview-only | 1d | — | Blocked by UX-HOOK-001 |
+| tool | `move_type_to_file_preview` | refactoring | exercised | 1e | 2511 | `BetaClass` split from `MultiTypeFile.cs` — correct |
+| tool | `move_type_to_file_apply` | refactoring | exercised-preview-only | 1e | — | Blocked by UX-HOOK-001 |
+| tool | `bulk_replace_type_preview` | refactoring | exercised | 1f | 386 | Error-path only — no eligible type pair in this repo |
+| tool | `bulk_replace_type_apply` | refactoring | needs-more-evidence | 1f | — | Preview never succeeded with a real replacement |
+| tool | `extract_method_preview` | refactoring | exercised | 1g | 25 | **FLAG**: output has malformed formatting (`}}` closing, indentation lost) |
+| tool | `extract_method_apply` | refactoring | exercised-preview-only | 1g | — | Blocked by UX-HOOK-001; preview was syntactically valid but formatted poorly |
+| tool | `restructure_preview` | refactoring | exercised | 1h | 9 | **FAIL**: emits literal `__name__` placeholder instead of substituting captured identifier (REGRESSION-R17A) |
+| tool | `replace_string_literals_preview` | refactoring | exercised | 1i | 2 | Clean preview on `hello-world` → `ScratchE.Greeting` (2 occurrences) |
+| tool | `change_signature_preview` | refactoring | exercised | 1j | 48 | **FLAG**: (i) callsite diffs missing (known backlog `change-signature-preview-callsite-summary`); (ii) default value not rendered in declaration preview. Reorder negative probe returned excellent actionable error. |
+| tool | `symbol_refactor_preview` | refactoring | exercised-apply | 1k | 576 | PASS — rename operation applied cleanly; callsites rewritten; compile clean |
+| tool | `format_check` | refactoring | blocked | — | — | Not covered in this run (prompt-selectable; time-boxed out) |
+| tool | `create_file_apply` | file-operations | exercised-apply | 2a | 524 | Round-trip clean. **FLAG**: adds explicit `<Compile>` entry to csproj even when SDK auto-include is on, producing duplicate-items MSBuild error (BUG-COMPILE-INCLUDE) |
+| tool | `move_file_apply` | file-operations | exercised-preview-only | 2b | — | Preview PASS with correct namespace update + trailing warning "Namespace references outside the moved file are not automatically rewritten." |
+| tool | `delete_file_apply` | file-operations | exercised-preview-only | 2c | — | Preview PASS; apply blocked by UX-HOOK-001 |
+| tool | `add_central_package_version_preview` | project-mutation | exercised | 3e | 2 | Correctly updated `Directory.Packages.props` |
+| tool | `apply_project_mutation` | project-mutation | exercised-apply | 3a-3e | 2662 | Round-trip via `add_package_reference_preview` → apply; success; CPM warning surfaced correctly |
+| tool | `scaffold_type_preview` | scaffolding | exercised | 4a | 245 | `internal sealed class` default confirmed; interface-stub path emits `NotImplementedException` bodies + correct usings |
+| tool | `scaffold_type_apply` | scaffolding | exercised-preview-only | 4a | — | Blocked by UX-HOOK-001 |
+| tool | `scaffold_test_apply` | scaffolding | exercised-preview-only | 4b | — | Preview auto-detects xUnit correctly; apply blocked by UX-HOOK-001 |
+| tool | `scaffold_test_batch_preview` | scaffolding | exercised | 4c | 4 | Single composite token covers 3 files — per spec |
+| tool | `remove_dead_code_apply` | dead-code | exercised-preview-only | 5a | — | Preview PASS for `ScratchA`; apply blocked by UX-HOOK-001 |
+| tool | `remove_interface_member_preview` | dead-code | exercised | 5f | 22 | Negative probe only (no dead interface member in this repo) — returned clean "symbol handle could not be resolved" |
+| tool | `apply_multi_file_edit` | editing | exercised-apply | 5b | 15 | Direct-apply (no env-hook blocking on this tool); 2 files touched; compile clean |
+| tool | `preview_multi_file_edit` | editing | exercised | 5b-i | 2621 | Per-file diffs correct |
+| tool | `preview_multi_file_edit_apply` | editing | exercised-apply | 5b-i | 4 | Round-trip PASS. **Stale-token negative probe PASS**: returned `Preview token ... not found or expired` |
+| tool | `apply_with_verify` | undo | exercised-apply | 5e | 924 | PASS — applied organize_usings, reported `status=applied`, `postErrorCount=0` |
+| tool | `move_type_to_project_preview` | cross-project-refactoring | exercised | 6 | 3 | **Error-path only**: correctly refuses moves that would create circular project references (Domain→Application and Domain→Infrastructure both blocked) |
+| tool | `extract_interface_cross_project_preview` | cross-project-refactoring | exercised | 6 | 7 | **FAIL** — emits unformatted output: `publicinterfaceICollectionServiceProbe`, spaceless method signatures (FORMAT-BUG-001) |
+| tool | `dependency_inversion_preview` | cross-project-refactoring | exercised | 6 | 106 | **CRITICAL FAIL** — massive formatting corruption: multi-line signatures collapsed to single line, blank lines removed, spaces dropped (`catch (Exception ex)when ...`). Code would still compile but is unshippable (FORMAT-BUG-002) |
+| tool | `migrate_package_preview` | orchestration | exercised | 7 | 8 | **FLAG** — produces malformed XML: `<ItemGroup><PackageVersion .../></ItemGroup>` on one line, leaves empty prior ItemGroup, mis-positions `</Project>` (FORMAT-BUG-003) |
+| tool | `split_class_preview` | orchestration | exercised | 7 | 4 | Works, but copies preceding `// audit-preview-1` comment to both partials (FLAG) |
+| tool | `extract_and_wire_interface_preview` | orchestration | exercised | 7 | 797 | **FAIL** — same format corruption as `dependency_inversion_preview` for interface file; DI-registration rewrite in test project works correctly (FORMAT-BUG-001) |
+| tool | `apply_composite_preview` | orchestration | skipped-safety | 7 | — | Preview output malformed — applying would produce unshippable code |
+| tool | `symbol_impact_sweep` | analysis | exercised | 7c.1 | 1825 | PASS — references, empty switch-exhaustiveness and mapper buckets; `suggestedTasks` populated |
+| tool | `test_reference_map` | validation | exercised | 7c.2 | — | **FAIL** — response exceeds 107k chars; `projectName` filter does not reduce output size; no pagination (BUG-PAGINATION-001) |
+| tool | `validate_workspace` | validation | exercised | 7c.3 | 33 | `overallStatus=clean`; auto-scoping picks up tracked changes; fake-path negative probe handled gracefully |
+| tool | `get_prompt_text` | prompts | exercised | 7c.4 | 1-3244 | 8 prompts rendered successfully end-to-end; unknown-prompt negative probe returns actionable 20-prompt list; **FLAG** — malformed JSON returns `InternalError` with stack trace instead of `InvalidArgument` (BUG-JSON-PARSE) |
+| resource | `roslyn://workspace/{id}/file/{path}/lines/{start}-{end}` | resources | exercised | 7b | — | PASS: marker comment present; invalid range (10-5) returns `-32603 error` (**FLAG** — should be structured) |
+| prompt | `explain_error` | prompts | exercised | 8 | 1444 | Actionable; real tool names; schema requires workspaceId + filePath + line + column |
+| prompt | `suggest_refactoring` | prompts | exercised | 8 | 5 | Actionable; includes document symbols + full source |
+| prompt | `review_file` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing; schema similar to suggest_refactoring |
+| prompt | `analyze_dependencies` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `debug_test_failure` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `refactor_and_validate` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `fix_all_diagnostics` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `guided_package_migration` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `guided_extract_interface` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `security_review` | prompts | exercised | 8 | 3241 | PASS: includes analyzer status, CVE hint, workflow |
+| prompt | `discover_capabilities` | prompts | exercised | 8 | 3 | PASS: lists 37 refactoring tools + 6 guided prompts + workflow sections |
+| prompt | `dead_code_audit` | prompts | exercised | 8 | 19 | PASS: real unused symbol surfaced (`ScratchA`) |
+| prompt | `review_test_coverage` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `review_complexity` | prompts | exercised | 8 | 24 | PASS: real complexity hotspots with actionable guidance |
+| prompt | `cohesion_analysis` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `consumer_impact` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `guided_extract_method` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `msbuild_inspection` | prompts | exercised | 8 | — | Confirmed present via unknown-prompt listing |
+| prompt | `session_undo` | prompts | exercised | 8 | 0 | PASS: references real undo tools including `revert_last_apply` |
+| prompt | `refactor_loop` | prompts | exercised | 8 | 0 | PASS: references v1.17/v1.18 primitives (`apply_with_verify`, `validate_workspace`, `symbol_impact_sweep`) — no stale v1.16 names |
+
+## 3. Performance baseline (`_meta.elapsedMs`)
+
+| Tool | Category | Calls | p50_ms | max_ms | Input scale | Budget | Notes |
+|------|----------|-------|--------|--------|-------------|--------|-------|
+| `fix_all_preview` | refactoring | 3 | 95 | 354 | solution-wide | ≤15s | within budget |
+| `format_range_preview` | refactoring | 2 | 10 | 2644 | 2-line range | ≤5s | 2644 ms spike was post stale-reload |
+| `extract_interface_preview` | refactoring | 1 | 245 | 245 | 3-member class | ≤5s | within budget |
+| `extract_type_preview` | refactoring | 1 | 9 | 9 | 2-member extract | ≤5s | well within budget |
+| `move_type_to_file_preview` | refactoring | 1 | 2511 | 2511 | small file | ≤5s | within budget (includes stale-reload) |
+| `bulk_replace_type_preview` | refactoring | 3 | 2 | 386 | solution | ≤5s | error-path responses |
+| `extract_method_preview` | refactoring | 2 | 3 | 25 | 3-statement range | ≤5s | within budget |
+| `restructure_preview` | refactoring | 1 | 9 | 9 | single file | ≤5s | within budget |
+| `replace_string_literals_preview` | refactoring | 3 | 2 | 2 | single file | ≤5s | within budget |
+| `change_signature_preview` | refactoring | 2 | 0 | 48 | 3-callsite method | ≤5s | within budget |
+| `symbol_refactor_preview` | refactoring | 1 | 576 | 576 | 1 rename op | ≤5s | within budget |
+| `create_file_apply` | file-operations | 2 | 274 | 524 | single file | ≤30s | within budget |
+| `move_file_preview` | file-operations | 1 | 7 | 7 | single file | ≤5s | within budget |
+| `delete_file_preview` | file-operations | 1 | 2 | 2 | single file | ≤5s | within budget |
+| `add_central_package_version_preview` | project-mutation | 1 | 2 | 2 | CPM | ≤5s | within budget |
+| `apply_project_mutation` | project-mutation | 1 | 2662 | 2662 | single csproj | ≤30s | within budget |
+| `scaffold_type_preview` | scaffolding | 3 | 3 | 245 | — | ≤5s | interface-stub slow-path |
+| `scaffold_test_preview` | scaffolding | 1 | 4 | 4 | — | ≤5s | within budget |
+| `scaffold_test_batch_preview` | scaffolding | 1 | 4 | 4 | 3 targets | ≤5s | within budget |
+| `remove_dead_code_preview` | dead-code | 1 | 5 | 5 | 1 symbol | ≤5s | within budget |
+| `remove_interface_member_preview` | dead-code | 1 | 22 | 22 | negative probe | ≤5s | within budget |
+| `apply_multi_file_edit` | editing | 1 | 15 | 15 | 2 files | ≤30s | within budget |
+| `preview_multi_file_edit` | editing | 1 | 2621 | 2621 | 2 files | ≤5s | within budget (stale-reload) |
+| `preview_multi_file_edit_apply` | editing | 1 | 4 | 4 | 2 files | ≤30s | within budget |
+| `apply_with_verify` | undo | 1 | 924 | 924 | 1-file organize | ≤30s | within budget |
+| `move_type_to_project_preview` | cross-project-refactoring | 2 | 2 | 3 | error-path | ≤5s | within budget |
+| `extract_interface_cross_project_preview` | cross-project-refactoring | 1 | 7 | 7 | 1 type | ≤5s | within budget |
+| `dependency_inversion_preview` | cross-project-refactoring | 1 | 106 | 106 | 1 type | ≤5s | within budget |
+| `migrate_package_preview` | orchestration | 1 | 8 | 8 | CPM | ≤5s | within budget |
+| `split_class_preview` | orchestration | 1 | 4 | 4 | 1 member | ≤5s | within budget |
+| `extract_and_wire_interface_preview` | orchestration | 1 | 797 | 797 | DI-scan | ≤15s | within budget |
+| `symbol_impact_sweep` | analysis | 1 | 1825 | 1825 | 1 type (10 refs) | ≤5s | within budget |
+| `test_reference_map` | validation | 2 | — | — | project-scoped | — | response size exceeds context (FAIL) |
+| `validate_workspace` | validation | 2 | 9 | 33 | workspace | ≤15s | within budget |
+| `get_prompt_text` | prompts | 9 | 3 | 3241 | per-prompt | ≤5s | `security_review` slow (CVE scan inlined) |
+
+## 4. Schema vs behaviour drift
+
+| Tool | Mismatch kind | Expected | Actual | Severity | Bug ref |
+|------|---------------|----------|--------|----------|---------|
+| `restructure_preview` | Behavior | LHS + RHS placeholder substitution | RHS substituted; LHS `__name__` retained literal | **HIGH** | §9.1 REGRESSION-R17A |
+| `extract_method_preview` | Output formatting | Normal spacing around `=`/`,`, newline-separated closing braces | `var x=f(a,b);` + `}}` glued close | Medium | §9.9 FORMAT-BUG-004 |
+| `change_signature_preview` | Preview completeness | Preview shows all rewrites | Callsite diffs not surfaced in preview | Medium | §9.10 FORMAT-BUG-005 (also closes backlog `change-signature-preview-callsite-summary`) |
+| `change_signature_preview op=add` | Declaration fidelity | `(int x, int y, int z = 0)` with default value | `(int x,int y,int z)=> …` — spaces stripped, `= 0` missing | Medium | §9.10 FORMAT-BUG-005 |
+| `extract_interface_cross_project_preview` | Formatting | Readable C# output | Space-stripped (`publicinterfaceI…`) | **HIGH** | §9.2 FORMAT-BUG-001 |
+| `extract_and_wire_interface_preview` | Formatting | Readable interface file | Same FORMAT-BUG-001 on the interface half | **HIGH** | §9.2 FORMAT-BUG-001 |
+| `dependency_inversion_preview` | Formatting | Surgical base-list edit only | Full class-body rewrite; blank lines removed; `}}` glue; truncated diff | **CRITICAL** | §9.3 FORMAT-BUG-002 |
+| `migrate_package_preview` | XML formatting | Preserve ItemGroup structure | Inlines tags, leaves empty ItemGroup, glues `</Project>` | Medium | §9.4 FORMAT-BUG-003 |
+| `split_class_preview` | Trivia handling | Leading trivia stays on original only | Copies preceding `// …` comment to both partials | Low-Medium | §9.11 FORMAT-BUG-006 |
+| `format_range_preview` | Behavior | Return edits when range is dirty | Returns empty diff on whitespace-polluted line | Medium | §9.12 FLAG-FORMAT-RANGE-EMPTY |
+| `create_file_apply` | Project file update | Respect SDK auto-include | Adds explicit `<Compile>` → duplicate-items MSBuild error | Medium | §9.6 BUG-COMPILE-INCLUDE |
+| `test_reference_map` | Pagination + filter | Respect projectName, emit offset/limit/hasMore | Full solution emitted regardless; no pagination | **HIGH** | §9.5 BUG-PAGINATION-001 |
+| `get_prompt_text` | Error category | `InvalidArgument` for malformed JSON | `InternalError` + 6-frame stack trace | Low | §9.7 BUG-JSON-PARSE |
+| `get_prompt_text` (discover_capabilities) | Param name | `taskCategory` (per prompt appendix) | `category` (per server schema) | Low | §9.14 DRIFT-001 |
+| `validate_workspace` | Fabricated-path handling | Warning or error naming non-existent paths | Silent `overallStatus=clean` | Low-Medium | §9.8 BUG-VALIDATE-FABRICATED |
+| `roslyn://…/lines/{start}-{end}` | Error shape | Structured error for invalid range | MCP `-32603` generic | Low | §9.13 FLAG-RESOURCE-INVALID-RANGE |
+
+## 5. Error message quality (Phase 9 negative probes)
+
+| Tool | Probe input | Rating | Suggested fix | Notes |
+|------|-------------|--------|---------------|-------|
+| `change_signature_preview` | `op=reorder` | **actionable** | None (excellent) | Lists valid ops AND points at `symbol_refactor_preview` |
+| `fix_all_preview` | `diagnosticId=IDE0005` (no fixer) | **actionable** | None (excellent) | Points at `organize_usings_preview` |
+| `fix_all_preview` | `diagnosticId=CA1859` (no fixer) | actionable | None | "Restore analyzer packages" + `list_analyzers` pointer |
+| `apply_text_edit` | out-of-range line | **actionable** | None (excellent) | Explicitly cites line count |
+| `scaffold_type_preview` | invalid identifier `2foo` | **actionable** | None (excellent) | Names C# identifier rule |
+| `extract_method_preview` | `startLine > endLine` | **actionable** | None | Clear positional error |
+| `set_editorconfig_option` | empty key | **actionable** | None | Standard required-param error |
+| `remove_interface_member_preview` | fabricated symbol handle | **actionable** | None | Notes stale-handle path + `workspace_reload` hint |
+| `bulk_replace_type_preview` | non-existent replacement type | **actionable** | None | Clear "Replacement type not found" |
+| `extract_interface_preview` | type with no public members | **actionable** | None | Clear "no public instance members to extract" |
+| `move_type_to_project_preview` | target → circular reference | **actionable** | None | Names both project IDs in the cycle |
+| `preview_multi_file_edit_apply` | stale token | **actionable** | None | Clear "not found or expired" |
+| `get_prompt_text` | unknown prompt name | **actionable** | None (excellent) | Lists all 20 available prompts in the error |
+| `get_prompt_text` | missing required param | actionable | None | Names exact missing param |
+| `get_prompt_text` | malformed JSON | **unhelpful** | Categorise as `InvalidArgument`, drop stack trace | JsonReaderException stack trace leaked to user |
+| `validate_workspace` | fabricated changed file path | actionable | None | Silently returned "clean" instead of flagging the non-existent path |
+| `revert_last_apply` | empty undo stack | actionable | None | "Nothing to revert" |
+| Invalid line range resource | `lines/10-5` | vague | Return structured error payload instead of `-32603` | Contract: "clear error (not a hang)" |
+
+## 6. Parameter-path coverage
+
+| Family | Non-default path tested | Status | Notes |
+|--------|--------------------------|--------|-------|
+| `fix_all_preview` | `scope=project` | exercised | Returns no-fixer guidance as expected |
+| `scaffold_type_preview` | `baseType=IScratchB` unresolved + `baseType=ISnapshotReader` resolved | exercised | Warning path + interface-stub emission both confirmed |
+| `scaffold_type_preview` | `implementInterface=true/false` toggle | exercised (true path) | `implementInterface=false` not explicitly probed |
+| `get_msbuild_properties` | `propertyNameFilter="Nullable"` | exercised | 719 → 1 filter works |
+| File operations | move with `updateNamespace=true` | exercised | Namespace rewrite visible in preview |
+| Project mutation | CPM warning path (`add_package_reference_preview` on CPM-enabled) | exercised | Warning surfaced correctly |
+| Project mutation | `remove_package_reference_preview` | blocked | Skipped — only one half of forward/reverse exercised |
+| `change_signature_preview` | `op=add` | exercised | Callsite diffs missing from preview (see §4) |
+| `change_signature_preview` | `op=reorder` (negative) | exercised | Excellent error message |
+| `restructure_preview` | `filePath` vs project-wide | exercised | Project-wide worked on file scope; placeholder bug masks real test |
+| `scaffold_test_batch_preview` | 3 targets in one call | exercised | Single composite token returned |
+| `preview_multi_file_edit_apply` | stale-token negative | exercised | Clear rejection |
+
+## 7. Prompt verification (Phase 8)
+
+| Prompt | schema_ok | actionable | hallucinated_tools | idempotent | elapsedMs | recommendation_seed | Notes |
+|--------|-----------|------------|---------------------|------------|-----------|----------------------|-------|
+| `explain_error` | yes | yes | 0 | yes (deterministic render) | 1444 | promote | Full render tested with real CS0168 anchor |
+| `suggest_refactoring` | yes | yes | 0 | yes | 5 | promote | Includes document_symbols + source |
+| `review_file` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog; full render not exercised |
+| `analyze_dependencies` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog; full render not exercised |
+| `debug_test_failure` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog; full render not exercised |
+| `refactor_and_validate` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog; full render not exercised |
+| `fix_all_diagnostics` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog; full render not exercised |
+| `guided_package_migration` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `guided_extract_interface` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `security_review` | yes | yes | 0 | yes | 3241 | promote | Includes analyzer status + CVE hint |
+| `discover_capabilities` | yes | yes | 0 | yes | 3 | promote | 37 refactoring tools enumerated correctly |
+| `dead_code_audit` | yes | yes | 0 | yes | 19 | promote | Lists real `ScratchA` unused symbol |
+| `review_test_coverage` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `review_complexity` | yes | yes | 0 | yes | 24 | promote | Real complexity hotspots with guidance |
+| `cohesion_analysis` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `consumer_impact` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `guided_extract_method` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `msbuild_inspection` | yes | yes | 0 | yes | — | keep-experimental | Present per catalog |
+| `session_undo` | yes | yes | 0 | yes | 0 | promote | References `workspace_changes`, `revert_last_apply`, `workspace_reload` correctly |
+| `refactor_loop` | yes | yes | 0 | yes | 0 | promote | Correctly cites v1.17/v1.18 primitives (`apply_with_verify`, `validate_workspace`) |
+
+## 8. Experimental promotion scorecard
+
+| Kind | Name | Category | Status | p50_ms | schema_ok | error_ok | round_trip_ok | Failures | Recommendation | Evidence |
+|------|------|----------|--------|--------|-----------|----------|----------------|----------|----------------|----------|
+| tool | `fix_all_preview` | refactoring | exercised | 95 | yes | yes | yes (via pair) | 0 | **promote** | Round-trip on CS0168 + good no-fixer guidance + non-default `scope=project` probed |
+| tool | `fix_all_apply` | refactoring | exercised-apply | 4 | yes | yes | yes | 0 | **promote** | Applied cleanly, compile_check PASS |
+| tool | `format_range_preview` | refactoring | exercised | 10 | partial | yes | — | 1 (empty diff FLAG) | **keep-experimental** | Apply path not verifiable in this env; empty-diff FLAG |
+| tool | `format_range_apply` | refactoring | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `extract_interface_preview` | refactoring | exercised | 245 | yes | yes | — | 0 | **promote** | Clean preview; good no-public-members error; schema accurate |
+| tool | `extract_interface_apply` | refactoring | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `extract_type_apply` | refactoring | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `move_type_to_file_apply` | refactoring | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `bulk_replace_type_apply` | refactoring | needs-more-evidence | — | — | — | no | — | **needs-more-evidence** | Preview never succeeded with a real replacement target |
+| tool | `extract_method_preview` | refactoring | exercised | 3 | yes | yes | — | 1 (formatting FLAG) | **keep-experimental** | Output compiles but formatting is poor; apply not verified |
+| tool | `extract_method_apply` | refactoring | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `restructure_preview` | refactoring | exercised | 9 | yes | yes | no | 1 (FAIL) | **deprecate** | Placeholder substitution broken; tool is unshippable as-is |
+| tool | `replace_string_literals_preview` | refactoring | exercised | 2 | yes | yes | — | 0 | **promote** | Works correctly; rejects empty literal |
+| tool | `change_signature_preview` | refactoring | exercised | 0 | partial | yes | partial | 2 (preview incompleteness + callsite diff missing) | **keep-experimental** | Excellent error path, but preview fidelity gap is known backlog + default-value not rendered |
+| tool | `symbol_refactor_preview` | refactoring | exercised-apply | 576 | yes | yes | yes | 0 | **promote** | Rename op applied; callsites rewritten; compile clean |
+| tool | `format_check` | refactoring | blocked | — | — | — | — | — | **needs-more-evidence** | Out of scope this run |
+| tool | `create_file_apply` | file-operations | exercised-apply | 274 | yes | yes | yes | 1 (compile-include bug) | **keep-experimental** | Functional but BUG-COMPILE-INCLUDE adds duplicate `<Compile>` entry on SDK auto-include projects |
+| tool | `move_file_apply` | file-operations | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `delete_file_apply` | file-operations | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `add_central_package_version_preview` | project-mutation | exercised | 2 | yes | — | — | 0 | **promote** | Correctly wrote Directory.Packages.props |
+| tool | `apply_project_mutation` | project-mutation | exercised-apply | 2662 | yes | — | yes | 0 | **promote** | Round-trip via add_package_reference_preview; CPM warning surfaced |
+| tool | `scaffold_type_preview` | scaffolding | exercised | 3 | yes | yes | — | 0 | **promote** | All three default paths (plain / unresolved interface / resolved interface) tested |
+| tool | `scaffold_type_apply` | scaffolding | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `scaffold_test_apply` | scaffolding | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `scaffold_test_batch_preview` | scaffolding | exercised | 4 | yes | — | — | 0 | **promote** | Single composite token for 3 files per spec |
+| tool | `remove_dead_code_apply` | dead-code | exercised-preview-only | — | — | — | no | — | **needs-more-evidence** | Blocked by UX-HOOK-001 |
+| tool | `remove_interface_member_preview` | dead-code | exercised | 22 | yes | yes | — | 0 | **keep-experimental** | Only negative probe ran (no dead interface member in repo) |
+| tool | `apply_multi_file_edit` | editing | exercised-apply | 15 | yes | — | yes | 0 | **promote** | Direct-apply success across 2 files |
+| tool | `preview_multi_file_edit` | editing | exercised | 2621 | yes | yes | yes | 0 | **promote** | Preview → apply → stale-token negative probe all PASS |
+| tool | `preview_multi_file_edit_apply` | editing | exercised-apply | 4 | yes | yes | yes | 0 | **promote** | Atomic apply success; stale-token rejection excellent |
+| tool | `apply_with_verify` | undo | exercised-apply | 924 | yes | — | yes | 0 | **promote** | `status=applied`, postErrorCount tracking correct |
+| tool | `move_type_to_project_preview` | cross-project-refactoring | exercised | 2 | yes | yes | — | 0 | **keep-experimental** | Only error-path exercised (circular reference detection excellent) |
+| tool | `extract_interface_cross_project_preview` | cross-project-refactoring | exercised | 7 | yes | — | no | 1 (FAIL format) | **deprecate** | Output formatting corrupted; would ship unreadable code |
+| tool | `dependency_inversion_preview` | cross-project-refactoring | exercised | 106 | yes | — | no | 1 (CRITICAL FAIL) | **deprecate** | Massive formatting corruption; would destroy code |
+| tool | `migrate_package_preview` | orchestration | exercised | 8 | yes | — | — | 1 (FLAG XML format) | **keep-experimental** | XML not corrupted semantically but poorly formatted |
+| tool | `split_class_preview` | orchestration | exercised | 4 | yes | — | — | 1 (FLAG comment copy) | **keep-experimental** | Leaks preceding comment into both partials |
+| tool | `extract_and_wire_interface_preview` | orchestration | exercised | 797 | yes | — | no | 1 (FAIL format) | **deprecate** | Same format bug as dependency_inversion_preview |
+| tool | `apply_composite_preview` | orchestration | skipped-safety | — | — | — | — | — | **needs-more-evidence** | Preview tokens for Phase 6/7 previews were unshippable |
+| tool | `symbol_impact_sweep` | analysis | exercised | 1825 | yes | — | — | 0 | **promote** | Buckets correct; suggestedTasks populated |
+| tool | `test_reference_map` | validation | exercised | — | partial | — | — | 1 (FAIL size/pagination) | **deprecate** (rework) | Response exceeds context; projectName filter broken |
+| tool | `validate_workspace` | validation | exercised | 9 | yes | yes | — | 1 (FLAG fake-path accepted as clean) | **keep-experimental** | Main path works; fabricated file path silently accepted — could mask real errors |
+| tool | `get_prompt_text` | prompts | exercised | 3 | yes | partial | — | 1 (FLAG JSON parse) | **keep-experimental** | 8/20 prompts rendered end-to-end; JSON-parse error path needs polish |
+| resource | `source_file_lines` | resources | exercised | — | yes | partial | — | 1 (FLAG generic error) | **keep-experimental** | Marker comment PASS; invalid range returns generic -32603 |
+| prompt | `explain_error` | prompts | exercised | 1444 | yes | — | — | 0 | **promote** | Full render with real diagnostic |
+| prompt | `suggest_refactoring` | prompts | exercised | 5 | yes | — | — | 0 | **promote** | Full render tested |
+| prompt | `review_file` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Present per catalog; full render not exercised |
+| prompt | `analyze_dependencies` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `debug_test_failure` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `refactor_and_validate` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `fix_all_diagnostics` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `guided_package_migration` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `guided_extract_interface` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Ditto |
+| prompt | `security_review` | prompts | exercised | 3241 | yes | — | — | 0 | **promote** | Full render; analyzer-state + CVE advice |
+| prompt | `discover_capabilities` | prompts | exercised | 3 | yes | — | — | 0 | **promote** | Enumerates real tool names accurately |
+| prompt | `dead_code_audit` | prompts | exercised | 19 | yes | — | — | 0 | **promote** | Real unused-symbol anchor |
+| prompt | `review_test_coverage` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Not rendered |
+| prompt | `review_complexity` | prompts | exercised | 24 | yes | — | — | 0 | **promote** | Real complexity hotspots |
+| prompt | `cohesion_analysis` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Not rendered |
+| prompt | `consumer_impact` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Not rendered |
+| prompt | `guided_extract_method` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Not rendered |
+| prompt | `msbuild_inspection` | prompts | exercised | — | yes | — | — | 0 | **keep-experimental** | Not rendered |
+| prompt | `session_undo` | prompts | exercised | 0 | yes | — | — | 0 | **promote** | Real tool names, terse and correct |
+| prompt | `refactor_loop` | prompts | exercised | 0 | yes | — | — | 0 | **promote** | Cites current v1.17/v1.18 primitives |
+
+**Promotion roll-up:**
+- **promote**: 15 tools + 8 prompts = 23 entries
+- **keep-experimental**: 11 tools + 12 prompts = 23 entries
+- **needs-more-evidence**: 10 tools (mostly apply-siblings blocked by env hook) = 10 entries
+- **deprecate**: 4 tools = 4 entries
+
+## 9. MCP server issues (bugs)
+
+### 9.1 REGRESSION-R17A — `restructure_preview` emits literal `__name__` placeholder
+| Field | Detail |
+|--------|--------|
+| Tool | `restructure_preview` |
+| Input (verbatim) | `workspaceId=8712507774744003b34cb45370a4a804`, `pattern="int __x__ = __a__ + __b__;"`, `goal="var __x__ = __a__ + __b__;"`, `filePath="C:\Code-Repo\DotNet-Firewall-Analyzer\.worktrees\audit-20260415\src\FirewallAnalyzer.Domain\_AuditScratch\ScratchC.cs"` |
+| Repro file content | `namespace FirewallAnalyzer.Domain._AuditScratch;\n\n// audit-touched\npublic static class ScratchC {\n  public static int Run(int a, int b) {\n    int sum = a + b;\n    int product = a * b;\n    int combined = sum + product;\n    return combined;\n  }\n}` |
+| Expected | Two replacements where `__x__` is substituted with `sum` / `combined`, yielding `var sum = a + b;` and `var combined = sum + product;` |
+| Actual | Response token `bab30307ae564c3bbc10adb378b8619e`. Both matches produced `var __x__ = a + b;` and `var __x__ = sum + product;` — LHS identifier placeholder `__x__` retained as literal (RHS placeholders `__a__`/`__b__` *are* captured and substituted correctly) |
+| Severity | HIGH — tool is unusable for any pattern that captures a declarator identifier |
+| Reproducibility | 100% in this workspace |
+| Likely location | Server-side substitution pass probably only walks expression nodes, not declarator names |
+| Suggested fix | Ensure placeholder substitution also runs over `VariableDeclaratorSyntax.Identifier`. Add a unit test covering `int __x__ = __e__;` → `var __x__ = __e__;` |
+
+### 9.2 FORMAT-BUG-001 — Cross-project interface extraction strips whitespace
+| Field | Detail |
+|--------|--------|
+| Tools affected | `extract_interface_cross_project_preview`, `extract_and_wire_interface_preview` |
+| Input (verbatim) | `filePath="…\src\FirewallAnalyzer.Infrastructure\Services\CollectionService.cs"`, `typeName="CollectionService"`, `interfaceName="ICollectionServiceProbe"`, `targetProjectName="FirewallAnalyzer.Domain"` |
+| Expected | `public interface ICollectionServiceProbe { Task<string> RunAsync(ScopeFilter? scopeOverride, Action<CollectionProgress>? onProgress, CancellationToken ct); }` with normal formatting |
+| Actual (verbatim) | `publicinterfaceICollectionServiceProbe{Task<string>RunAsync(ScopeFilter?scopeOverride,Action<CollectionProgress>?onProgress,CancellationTokenct);}` |
+| Also: base list edit | Source class gets `public partial class CollectionService\n {\n` → `public partial class CollectionService\n : ICollectionServiceProbe{\n` — `{` glued to base-list with no newline |
+| Severity | HIGH — output would ship as-is and fail code review |
+| Reproducibility | 100% on any public-member cross-project extraction |
+| Likely location | Interface-file writer calls `ToFullString()` without running `Formatter.FormatAsync` / `SyntaxGenerator` pretty-printer |
+| Suggested fix | Route the generated `CompilationUnitSyntax` through `Formatter.FormatAsync(workspace)` before emitting the diff |
+
+### 9.3 FORMAT-BUG-002 — `dependency_inversion_preview` destroys source formatting
+| Field | Detail |
+|--------|--------|
+| Tool | `dependency_inversion_preview` |
+| Input (verbatim) | `filePath="…\src\FirewallAnalyzer.Infrastructure\Services\CollectionService.cs"`, `typeName="CollectionService"`, `interfaceProjectName="FirewallAnalyzer.Domain"` |
+| Expected | Minimal surgical diff: (i) create interface file, (ii) add `: IName` to base list, (iii) rewrite DI registrations to `AddTransient<IName, Name>()` |
+| Actual observed | (i) Interface file identical corruption to FORMAT-BUG-001 (`publicinterfaceICollectionService{…}`); (ii) full source file rewritten — every multi-line signature in `CollectionService` collapsed to a single line, blank lines between members removed, object initializers collapsed: `new ObjectScope { Level = ... }` → `new ObjectScope { Level = ObjectScopeLevel.Shared, AddressObjects = sharedObjects.Addresses, ... });`; (iii) `catch (Exception ex) when (ex is not OperationCanceledException)` became `catch (Exception ex)when (ex is not OperationCanceledException)` — missing space before `when`; (iv) `foreach (var rulebase in new[] { Rulebase.Pre, Rulebase.Post, Rulebase.Default })` split across multiple malformed lines with an orphan `)`; (v) response truncated with `# FLAG-6A: diff exceeded 16384 chars; 12 hunk(s) shown, 2 hunk(s) omitted.` — whole-file rewrite overflowed the diff budget |
+| DI rewrite correctness | `JobProcessorTests.cs` line 73: `services.AddTransient<CollectionService>();` → `services.AddTransient<ICollectionService, CollectionService>();` — rewrite is correct |
+| Severity | CRITICAL — apply would shred any real codebase's formatting, and the truncated diff means the user couldn't even see all the damage |
+| Reproducibility | 100% |
+| Likely location | Class-body rewriter must be fully re-serializing the type declaration. The hand-written rewrite path produces `SyntaxFactory` nodes without trivia and then calls `ToFullString()` |
+| Suggested fix | Preserve the original `MemberDeclarationSyntax` trees; only mutate the `BaseList` of `ClassDeclarationSyntax`. Use `ReplaceNode` with `WithAdditionalAnnotations(Formatter.Annotation)` and run `Formatter.FormatAsync` on the final document |
+
+### 9.4 FORMAT-BUG-003 — `migrate_package_preview` produces inline ItemGroup XML
+| Field | Detail |
+|--------|--------|
+| Tool | `migrate_package_preview` |
+| Input (verbatim) | `oldPackageId="Newtonsoft.Json"`, `newPackageId="System.Text.Json"`, `newVersion="10.0.0"` |
+| Expected | Line-for-line XML edits preserving indentation |
+| Actual — csproj diff | Original had `<ItemGroup>\n  <PackageReference Include="Newtonsoft.Json" />\n</ItemGroup>\n</Project>`. Output: `<ItemGroup>\n  \n</ItemGroup>\n<ItemGroup><PackageReference Include="System.Text.Json" /></ItemGroup></Project>` — leaves an empty `<ItemGroup>` and collapses the new group onto one line, with `</Project>` glued to the end |
+| Actual — Directory.Packages.props diff | `…<PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />\n  </ItemGroup>` became `…<PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />\n  <PackageVersion Include="System.Text.Json" Version="10.0.0" /></ItemGroup>` — indentation lost on the `</ItemGroup>` close |
+| Severity | Medium — XML still parses; formatting breaks diff tooling and offends linters |
+| Reproducibility | 100% |
+| Likely location | Uses string splice instead of `XDocument` with preserve-whitespace |
+| Suggested fix | Load the project file with `XDocument.Parse(…, LoadOptions.PreserveWhitespace)`, manipulate the node tree, save with matching formatting. Drop any resulting empty `<ItemGroup>` nodes |
+
+### 9.5 BUG-PAGINATION-001 — `test_reference_map` has no pagination; `projectName` filter ignored
+| Field | Detail |
+|--------|--------|
+| Tool | `test_reference_map` |
+| Input 1 | `projectName="FirewallAnalyzer.Infrastructure"` → 106,997 chars |
+| Input 2 | `projectName="FirewallAnalyzer.Domain"` → 106,995 chars (differs by 2 bytes — effectively identical output) |
+| Expected | Scope bounded by `projectName`; pagination via `offset`/`limit` like `project_diagnostics` |
+| Actual | Both responses exceed the MCP client's output token budget. Content inspection (via on-disk tool-result dump) shows the full set of referenced symbols from the solution is emitted regardless of `projectName` |
+| Severity | HIGH — tool is effectively unusable on any non-trivial solution |
+| Reproducibility | 100% on 11-project / 266+ document repos |
+| Likely location | Projection ignores `projectName` parameter in the reducer; no `offset`/`limit` in the response shape |
+| Suggested fix | (i) Honour `projectName` in the reducer (filter covered/uncovered symbols by `containingProject`); (ii) Add `offset`/`limit`/`totalCount`/`hasMore` to the response shape to match `find_references` |
+
+### 9.6 BUG-COMPILE-INCLUDE — `create_file_apply` adds explicit `<Compile>` on SDK auto-include projects
+| Field | Detail |
+|--------|--------|
+| Tool | `create_file_apply` |
+| Input | `projectName="FirewallAnalyzer.Domain"`, `filePath="…\src\FirewallAnalyzer.Domain\_AuditScratch\ScratchA.cs"`. The project csproj before: `<Project Sdk="Microsoft.NET.Sdk">\n</Project>` (SDK auto-include, no explicit items) |
+| Expected | File created on disk; csproj untouched (SDK globs will pick it up) |
+| Actual | File created AND csproj rewritten to `<Project Sdk="Microsoft.NET.Sdk">\n  <ItemGroup>\n    <Compile Include="_AuditScratch\ScratchA.cs" />\n  </ItemGroup>\n</Project>`. Next `workspace_reload` surfaced workspace diagnostic: `WORKSPACE_FAILURE: Msbuild failed when processing the file '…FirewallAnalyzer.Domain.csproj' with message: Duplicate 'Compile' items were included. The .NET SDK includes 'Compile' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultCompileItems' property to 'false' if you want to explicitly include them in your project file. … The duplicate items were: '_AuditScratch\ScratchA.cs'` |
+| Severity | Medium — breaks MSBuild until csproj is hand-cleaned. In a real project that would fail `dotnet build` and CI |
+| Reproducibility | 100% — reproduced on first file creation |
+| Suggested fix | Before patching, evaluate `EnableDefaultCompileItems` on the project. If it's `true` (default for SDK-style), skip the `<Compile>` patch. Use `evaluate_msbuild_property` internally or `Microsoft.Build.Evaluation.Project.GetPropertyValue` |
+
+### 9.7 BUG-JSON-PARSE — `get_prompt_text` surfaces `JsonReaderException` stack trace
+| Field | Detail |
+|--------|--------|
+| Tool | `get_prompt_text` |
+| Input (verbatim) | `promptName="explain_error"`, `parametersJson="{"invalid-json}"` |
+| Expected | `category=InvalidArgument` with a one-line parser message |
+| Actual | `category=InternalError`. Message: `"Internal error in get_prompt_text: JsonReaderException: Expected end of string, but instead reached end of data. LineNumber: 0 \| BytePositionInLine: 15.. If this persists, try reloading the workspace (workspace_reload)."`. `stackTrace` field populated with six `System.Text.Json` frames |
+| Severity | Low — message is readable but category is wrong and stack trace leaks implementation |
+| Reproducibility | 100% |
+| Suggested fix | Wrap the `JsonDocument.Parse` in a try/catch, rethrow as `ArgumentException` with category `InvalidArgument`. Suppress stack trace on `InvalidArgument` responses (already the server convention elsewhere) |
+
+### 9.8 BUG-VALIDATE-FABRICATED — `validate_workspace` accepts fabricated `changedFilePaths` silently
+| Field | Detail |
+|--------|--------|
+| Tool | `validate_workspace` |
+| Input (verbatim) | `workspaceId=8712507774744003b34cb45370a4a804`, `changedFilePaths=["C:\\fake\\path\\DoesNotExist.cs"]`, `runTests=false` |
+| Expected | A warning naming unrecognised paths, e.g. `"warnings": ["C:\\fake\\path\\DoesNotExist.cs not in workspace — ignored"]` |
+| Actual | `overallStatus=clean`, `changedFilePaths` echoed, `discoveredTests=[]`, no warnings field populated. Silent acceptance |
+| Severity | Low-Medium — could mask typos during automation; a caller running post-refactor validation against a fabricated file list would falsely believe their changes are validated |
+| Reproducibility | 100% |
+| Suggested fix | Filter `changedFilePaths` against `Solution.Documents`. Emit a warning naming any drops. Return `overallStatus="compile-error"` only when real work happened — consider `"no-changed-files"` for a pure-fabrication case |
+
+### 9.9 FORMAT-BUG-004 — `extract_method_preview` produces malformed body + closing braces
+| Field | Detail |
+|--------|--------|
+| Tool | `extract_method_preview` |
+| Input | `filePath="…\_AuditScratch\ScratchC.cs"`, `startLine=7`, `startColumn=9`, `endLine=9`, `endColumn=42`, `methodName="ComputeCombined"` |
+| Expected | Original statements moved into a new private method with preserved indentation; call-site invocation indented to match surrounding code |
+| Actual (verbatim diff) | Preview token `a3e605861dda403bb58658f6138ab255`. Output diff shows: call-site inserted as `        var combined=ComputeCombined(a,b);` (missing spaces around `=` and around comma); new method declaration rendered as `private static int ComputeCombined(int a, int b)\n{\n` but immediately followed by the extracted statements at column 1 (indentation lost), then closing `}}` — a single `}` would close the method, the second `}` closes the class, but the diff's final line `}}` then deletes the `}` at end-of-class in favour of this double-brace glued together; also a final stray `-}` at end-of-file |
+| Severity | Medium — syntactically valid (braces balance out) but visually broken; apply would ship unreviewable code |
+| Reproducibility | 100% |
+| Likely location | The extractor re-emits method body via `SyntaxFactory` without formatting; closing braces are concatenated without a newline separator |
+| Suggested fix | Same as FORMAT-BUG-002 — annotate inserted nodes with `Formatter.Annotation` and run `Formatter.FormatAsync` on the resulting document before building the diff |
+
+### 9.10 FORMAT-BUG-005 — `change_signature_preview op=add` renders declaration without spaces and without default value
+| Field | Detail |
+|--------|--------|
+| Tool | `change_signature_preview` |
+| Input (verbatim) | `filePath="…\ScratchF.cs"`, `line=5`, `column=24`, `op="add"`, `name="z"`, `parameterType="int"`, `defaultValue="0"` |
+| Expected | Declaration diff showing `public static int Calculate(int x, int y, int z = 0) => x + y;` AND per-callsite diffs showing `Calculate(1, 2, 0)`, `Calculate(x: 10, y: 20, z: 0)` (named-arg callsite), `Calculate(100, 200, 0)` |
+| Actual — declaration diff | `-    public static int Calculate(int x, int y) => x + y;` / `+    public static int Calculate(int x,int y,int z)=> x + y;` — spaces around commas and around `=>` were removed AND the default value `= 0` is missing entirely |
+| Actual — callsite diffs | None — the preview only contains the declaration-owner file change (already tracked as backlog `change-signature-preview-callsite-summary`) |
+| Severity | Medium (formatting + preview fidelity) — but HIGH impact for promotion evidence, because an agent can't verify the default-value splice without applying |
+| Reproducibility | 100% |
+| Likely location | Signature rewriter emits `ParameterListSyntax` without separator trivia; the `defaultValue` is accepted but not rendered into the `EqualsValueClauseSyntax` |
+| Suggested fix | (i) Emit spaces in parameter list and around `=>`; (ii) when `defaultValue` is supplied, construct `SyntaxFactory.EqualsValueClause(SyntaxFactory.ParseExpression(defaultValue))` on the new `ParameterSyntax`; (iii) include callsite rewrites in the preview `changes[]` array per the open backlog row |
+
+### 9.11 FORMAT-BUG-006 — `split_class_preview` duplicates leading trivia into both partials
+| Field | Detail |
+|--------|--------|
+| Tool | `split_class_preview` |
+| Input | `filePath="…\ScratchB.cs"`, `typeName="ScratchB"`, `memberNames=["IsReady"]`, `newFileName="ScratchB.Ready.cs"` |
+| Source (pre-split) | `namespace FirewallAnalyzer.Domain._AuditScratch;\n\n// audit-preview-1\npublic sealed class ScratchB\n{\n    public int Compute(int x) => x + 1;\n    public string Name { get; set; } = "";\n    public bool IsReady() => true;\n}` |
+| Expected | The leading `// audit-preview-1` comment stays ONLY on the original file. The new partial file is a minimal stub without the unrelated comment |
+| Actual (new file) | `namespace FirewallAnalyzer.Domain._AuditScratch;\n// audit-preview-1\npublic sealed partial class ScratchB\n{\n    public bool IsReady() => true;\n}` — the comment has been duplicated into both files |
+| Residual (original file) | `…\npublic sealed partial class ScratchB\n{\n    public int Compute(int x) => x + 1;\n    public string Name { get; set; } = "";\n    \n}` — residual blank line where the moved method lived |
+| Severity | Low-Medium — could leak unrelated comments (license headers, TODOs, region markers) |
+| Reproducibility | 100% |
+| Suggested fix | When copying the type declaration to the new file, reset leading trivia to `SyntaxTriviaList.Empty` or to a deterministic synthesized header. Trim the blank line left behind in the source file |
+
+### 9.12 FLAG-FORMAT-RANGE-EMPTY — `format_range_preview` returns empty diff on dirty input
+| Field | Detail |
+|--------|--------|
+| Tool | `format_range_preview` |
+| Input | `filePath="…\_AuditScratch\ScratchA.cs"`, `startLine=10`, `startColumn=1`, `endLine=12`, `endColumn=1`. Line 11 had been polluted with 16 extra leading spaces via a preceding `apply_text_edit` (`public static int Unused() { ... }` indented to column 17) |
+| Expected | Diff showing line 11 normalised to column 5 indentation |
+| Actual | Preview token `b819f6820f8c4f358acefaa413e51a13`. `changes[0].unifiedDiff` is the bare unified-diff header with no hunks — an empty edit. The visible whitespace anomaly is unchanged by the preview |
+| Severity | Medium — users can't verify format_range works, and the empty-diff response shape is ambiguous (no-op vs. no-match-found) |
+| Reproducibility | 100% in this session; reproducible by applying extra indentation via `apply_text_edit` then running `format_range_preview` |
+| Suggested fix | (i) Ensure the in-memory solution snapshot reflects prior `apply_text_edit` mutations; (ii) return a descriptive `warnings[]` entry when no edits are produced (`"no formatting changes in this range"`) to disambiguate no-op from no-match |
+
+### 9.13 FLAG-RESOURCE-INVALID-RANGE — `source_file_lines` resource returns generic `-32603` for invalid ranges
+| Field | Detail |
+|--------|--------|
+| Resource template | `roslyn://workspace/{workspaceId}/file/{filePath}/lines/{startLine}-{endLine}` |
+| Input | `…/lines/10-5` (start > end) on `ScratchB.cs` |
+| Expected | Structured MCP error payload naming the invalid range (per prompt spec: "return a clear error (not a hang)") |
+| Actual | `MCP error -32603: An error occurred.` — no context, no hint |
+| Severity | Low — behaviour is safe (no hang), but message is unhelpful |
+| Reproducibility | 100% |
+| Suggested fix | In the resource handler, validate `endLine >= startLine` and both lines ≤ document line count. Throw an `InvalidArgument`-category `McpException` with a message like `"Invalid range: startLine=10 > endLine=5. Supply startLine ≤ endLine."` |
+
+### 9.14 DRIFT-001 — `get_prompt_text discover_capabilities` param name mismatch vs. experimental-promotion prompt appendix
+| Field | Detail |
+|--------|--------|
+| Source of truth | `ai_docs/prompts/experimental-promotion-exercise.md` appendix / Phase 8 realistic input table: row `discover_capabilities` says realistic input is `Task category (e.g. "refactoring")` — consumer assumes param `taskCategory` |
+| Server schema | Required param is `category` (not `taskCategory`) |
+| Evidence | Call with `{"taskCategory":"refactoring"}` returned `Invalid argument: Prompt parameter 'category' (type String) is required but missing from parametersJson.` Call with `{"category":"refactoring"}` succeeded. |
+| Severity | Low — but surfaces every time an agent follows the appendix verbatim |
+| Reproducibility | 100% |
+| Suggested fix | Either (a) rename server-side parameter to `taskCategory` to match common usage in this prompt family, or (b) update `ai_docs/prompts/experimental-promotion-exercise.md` Phase 8 table wording so the realistic input maps cleanly to the actual param name |
+
+### 9.15 UX-HOOK-001 (environment finding, not a server bug) — PreToolUse hook blocks legitimate applies in this client
+| Field | Detail |
+|--------|--------|
+| Scope | Claude Code (this client) with a PreToolUse hook on `mcp__roslyn__*_apply` tools |
+| Observed blocks | `format_range_apply`, `extract_interface_apply`, `extract_type_apply`, `move_type_to_file_apply`, `bulk_replace_type_apply`, `extract_method_apply`, `move_file_apply`, `delete_file_apply`, `scaffold_type_apply`, `scaffold_test_apply`, `remove_dead_code_apply`, `create_file_apply` (on subsequent attempts after initial success) |
+| Hook error | `"The agent is about to apply a mutation to the Roslyn workspace. Verify that a corresponding *_preview was called earlier in this conversation and the user was shown the diff or summary of changes. … Cannot verify preview was shown - transcript file is not accessible for validation."` |
+| Tools NOT blocked (inconsistency) | `fix_all_apply`, `create_file_apply` (first call), `apply_project_mutation`, `apply_multi_file_edit`, `apply_with_verify`, `preview_multi_file_edit_apply` succeeded despite the hook policy applying equally to them by name |
+| Impact on audit | Many preview→apply round-trips demoted to `exercised-preview-only` — see Coverage ledger. Promotion scorecard accordingly marks those entries `needs-more-evidence` |
+| Severity | Environmental — this is the client's policy, not a server defect |
+| Mitigation | Prefer `apply_with_verify` (own verification); route multi-file edits through `apply_multi_file_edit` (direct) or `preview_multi_file_edit` + `preview_multi_file_edit_apply`; or run the exercise in a client whose hook has transcript access |
+
+### 9.16 OBS-001 (observation, not a bug) — Workspace requires explicit `workspace_reload` after `dotnet restore`
+| Field | Detail |
+|--------|--------|
+| Tool chain | `workspace_load` → `dotnet restore` → `project_diagnostics` |
+| Observed | Post-load `project_diagnostics(summary=true)` reported 3,164 errors (CS0246 × 1731, CS1061 × 1143, CS0103 × 191, CS0234 × 51, CS0012 × 29, CS1674 × 15, CS0122 × 4) because the workspace snapshot predated the NuGet restore. `workspace_reload` dropped error count to 0 |
+| Response field that helps | `project_diagnostics` returned `restoreHint: "Many missing-type errors often mean NuGet restore has not been run. Run `dotnet restore` on the solution, then `workspace_reload`."` — this IS the documented contract |
+| Severity | Observation — the contract is explicit; agents must honour `restoreHint` |
+| Suggested enhancement (optional) | Consider a `workspace_load(path, reloadOnStaleRestore=true)` option that tails the project-directory nuget caches and reloads automatically when they change |
+
+### 9.17 OBS-002 (observation) — Workspace-root sandbox blocks out-of-tree worktrees
+| Field | Detail |
+|--------|--------|
+| Tool | `workspace_load` |
+| Input | `path="C:\Code-Repo\DotNet-Firewall-Analyzer-audit-20260415\FirewallAnalyzer.slnx"` (a git worktree sibling directory) |
+| Response | `Invalid argument: Path 'C:\Code-Repo\DotNet-Firewall-Analyzer-audit-20260415\FirewallAnalyzer.slnx' is not under any client-sanctioned root. Allowed roots: file://C:\Code-Repo\DotNet-Firewall-Analyzer. Check parameter types and values match the tool schema.` |
+| Severity | Observation — the rejection is correct safety behaviour but forced the audit to relocate its worktree under `.worktrees/` inside the sanctioned root |
+| Suggested enhancement (optional) | Document this constraint prominently in the Phase 0 setup instructions of `ai_docs/prompts/experimental-promotion-exercise.md` so future runs don't waste a roundtrip on an out-of-tree worktree |
+
+## 10. Improvement suggestions
+
+> Each entry names the related §9 bug ID so the next agent can go straight to the evidence block.
+
+- **§9.1 / REGRESSION-R17A — `restructure_preview`**: fix LHS-identifier placeholder substitution (currently only RHS expressions are substituted). Add an integration test covering `int __x__ = __e__;` → `var __x__ = __e__;` where both captures must be reflected. Gate promotion on this.
+- **§9.2 / FORMAT-BUG-001 — `extract_interface_cross_project_preview`, `extract_and_wire_interface_preview`**: route the synthesized interface `CompilationUnitSyntax` through `Formatter.FormatAsync(workspace)` before emitting the diff. Same fix closes §9.3 for the interface file half of `dependency_inversion_preview`.
+- **§9.3 / FORMAT-BUG-002 — `dependency_inversion_preview`**: stop re-serializing the class body. Restrict the rewrite to `BaseList` mutations on the `ClassDeclarationSyntax`, annotate new nodes with `Formatter.Annotation`, and run `Formatter.FormatAsync` on the final document. Also fix the diff-budget truncation (FLAG-6A) — provide a `scope="filePath"` param so callers can scope the rewrite and keep diffs within budget.
+- **§9.4 / FORMAT-BUG-003 — `migrate_package_preview`**: replace the string-splice approach with `XDocument.Parse(…, LoadOptions.PreserveWhitespace)`. Manipulate the node tree, drop orphan empty `<ItemGroup>` nodes, save with matching formatting.
+- **§9.5 / BUG-PAGINATION-001 — `test_reference_map`**: (i) honour the documented `projectName` filter in the reducer; (ii) add `offset`/`limit`/`totalCount`/`hasMore` fields to match the `find_references` response shape. Without this, the tool is effectively unusable on real-world solutions.
+- **§9.6 / BUG-COMPILE-INCLUDE — `create_file_apply`**: before patching the csproj, evaluate `EnableDefaultCompileItems` (via `Microsoft.Build.Evaluation.Project.GetPropertyValue`) and skip the explicit `<Compile>` item when the SDK auto-includes are active. Ship a unit test with an SDK-style csproj.
+- **§9.7 / BUG-JSON-PARSE — `get_prompt_text`**: wrap `JsonDocument.Parse` in try/catch, rethrow as `ArgumentException` with `category=InvalidArgument`. Suppress stack trace on `InvalidArgument` (already the server's convention elsewhere).
+- **§9.8 / BUG-VALIDATE-FABRICATED — `validate_workspace`**: filter `changedFilePaths` against `Solution.Documents`; emit a `warnings[]` entry naming any drops. Consider returning `overallStatus="no-changed-files"` when the intersection is empty.
+- **§9.9 / FORMAT-BUG-004 — `extract_method_preview`**: annotate generated nodes with `Formatter.Annotation`, then run `Formatter.FormatAsync` on the post-edit document. Ensure invocation-site indentation is preserved and that method-boundary closing braces are separated by newlines (no `}}` glue).
+- **§9.10 / FORMAT-BUG-005 — `change_signature_preview op=add`**: (i) emit normal trivia between parameters and around `=>`; (ii) when `defaultValue` is supplied, construct `SyntaxFactory.EqualsValueClause(SyntaxFactory.ParseExpression(defaultValue))` on the new `ParameterSyntax` and render it in the declaration; (iii) include callsite rewrites in the preview `changes[]` array (closes the open backlog row `change-signature-preview-callsite-summary`).
+- **§9.11 / FORMAT-BUG-006 — `split_class_preview`**: reset leading trivia on the copied type declaration to `SyntaxTriviaList.Empty` (or a synthesized header). Trim the blank line left where the moved member lived in the source file.
+- **§9.12 / FLAG-FORMAT-RANGE-EMPTY — `format_range_preview`**: (i) ensure the in-memory solution snapshot reflects prior `apply_text_edit` mutations before the formatter runs; (ii) when the formatter produces no edits, add a `warnings[]` entry (`"no formatting changes in this range"`) to disambiguate no-op from no-match.
+- **§9.13 / FLAG-RESOURCE-INVALID-RANGE — `source_file_lines` resource**: validate `startLine <= endLine` and both ≤ document line count. Return a structured `InvalidArgument` MCP error with a message naming the invalid range, not a generic `-32603`.
+- **§9.14 / DRIFT-001 — `discover_capabilities` prompt param**: either rename the server-side param from `category` to `taskCategory` (matches the prompt appendix wording) OR update `ai_docs/prompts/experimental-promotion-exercise.md` Phase 8 table so its realistic input column maps to `category`.
+- **§9.15 / UX-HOOK-001 — Client environment**: (no server fix required). Document in `ai_docs/prompts/experimental-promotion-exercise.md` that clients with transcript-inaccessible PreToolUse hooks should (a) use `apply_with_verify`, `apply_multi_file_edit`, or `preview_multi_file_edit_apply` as the apply vehicle, or (b) downgrade their audit mode to expect `exercised-preview-only` status on certain `*_apply` rows without penalising the tool's promotion score.
+- **§9.16 / OBS-001 — Restore workflow**: consider a `workspace_load(..., reloadOnRestore=true)` option that watches the `obj/project.assets.json` mtime and auto-reloads when it changes.
+- **§9.17 / OBS-002 — Sanctioned-root rejection**: document the sandbox constraint in the Phase 0 setup section of `experimental-promotion-exercise.md` so future audits don't waste a roundtrip trying an out-of-tree worktree location.
+
+### Fix priority recommendation for v1.19
+
+**Block promotion until fixed:** §9.1 (REGRESSION-R17A), §9.2, §9.3 (CRITICAL), §9.5 (HIGH).
+**Fix before next batch of promotions:** §9.4, §9.6, §9.9, §9.10, §9.11, §9.12.
+**Quality polish:** §9.7, §9.8, §9.13, §9.14.
+**Documentation:** §9.15, §9.16, §9.17.
+
+## 11. Known issue regression check
+
+| Source id | Summary | Status |
+|-----------|---------|--------|
+| `change-signature-preview-callsite-summary` | `change_signature_preview` preview diff only covers the declaration-owner file | **still reproduces** (see §4) |
+| `signalr-hub-auth-bypass` | `ApiKeyMiddleware` skips auth on SignalR hub | out-of-scope (not an MCP server issue) |
+| `settings-get-unauth-exposure` | `GET /api/v1/settings` unauthenticated | out-of-scope (not an MCP server issue) |
+| `suppress-ca1707-tests` / `seal-collection-result` / `snapshot-store-split` / `magic-numbers` / etc. | Repo maintainability rows | out-of-scope (not MCP server issues) |
+
+No other backlog rows correspond to experimental MCP tools.

--- a/ai_docs/audit-reports/20260415T140302Z_networkdocumentation_experimental-promotion.md
+++ b/ai_docs/audit-reports/20260415T140302Z_networkdocumentation_experimental-promotion.md
@@ -1,0 +1,628 @@
+# Experimental Promotion Exercise Report
+
+## 1. Header
+- **Date:** 2026-04-15 (UTC 14:03:02Z start — 15:25:00Z finish)
+- **Audited solution:** NetworkDocumentation.sln
+- **Audited revision:** commit `8395fd8` on throwaway branch `exp-promotion-2026-04-15`
+- **Entrypoint loaded:** `C:\Code-Repo\DotNet-Network-Documentation\.worktrees\exp-promotion\NetworkDocumentation.sln`
+- **Audit mode:** `full-surface` (disposable worktree)
+- **Isolation:** git worktree `.worktrees/exp-promotion` on branch `exp-promotion-2026-04-15` (cleanup behaviour documented in §Completion gate)
+- **Client:** Claude (Anthropic) via Roslyn MCP stdio
+- **Workspace id:** `a041e542b664491e970376f2fbe02c91` (second session — first session `4b3d5b09…` was lost between turns; see §9.7)
+- **Server:** roslyn-mcp 1.18.0 (runtime .NET 10.0.6, Roslyn 5.3.0.0, Windows 10.0.26200)
+- **Catalog version:** 2026.04
+- **Experimental surface:** 40 experimental tools, 20 experimental prompts, 1 experimental resource template
+- **Scale:** 9 projects, 402 documents (403 after `move_type_to_file_apply`)
+- **Repo shape:**
+  - Multi-project (8 productive + 1 test project `NetworkDocumentation.Tests`)
+  - All net10.0 (no multi-targeting)
+  - `.editorconfig` at repo root
+  - `Directory.Build.props` with Meziantou.Analyzer / Puma.Security.Rules / SecurityCodeScan.VS2019 + `TreatWarningsAsErrors=true`
+  - **No `Directory.Packages.props`** → Central Package Management not in use (Phase 3e `skipped-repo-shape`)
+  - DI usage in `NetworkDocumentation.Web`
+  - 0 workspace errors, 0 compiler warnings, 1,122 Info-severity analyzer diagnostics (44 distinct IDs)
+- **Prior issue source:** `ai_docs/backlog.md` (2026-04-15T13:40:00Z) — **no open rows reference experimental Roslyn MCP tools**. Prior audit `ai_docs/audit-reports/20260413T180408Z_networkdocumentation_experimental-promotion.md` (same prompt, 2 days earlier).
+
+> **Scope note (partial exercise, 3 FAIL-level + 4 FLAG findings):** Phase 1a/1b/1c/1e were exercised end-to-end. They surfaced **three FAIL-level findings** (§9.1–§9.3) and **four FLAG findings** (§9.4–§9.7) serious enough to stop rather than continue on a destabilized workspace. Phases 1d/1f–1k and 2–11 are marked `needs-more-evidence` with explicit status `not-yet-exercised`. The audit can be resumed on the same disposable branch without re-setup — the `needs-more-evidence` rows in §2 are the explicit resume list.
+
+## 2. Coverage ledger (experimental surface)
+
+| Kind | Name | Category | Status | Phase | lastElapsedMs | Notes |
+|------|------|----------|--------|-------|---------------|-------|
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 1a | 992 | No CodeFix provider loaded for any tested ID. FLAG §9.4 on inconsistent `guidanceMessage`. |
+| tool | `fix_all_apply` | refactoring | blocked | 1a | — | No preview token available. |
+| tool | `format_range_apply` | refactoring | exercised-apply | 1b | 37 | Clean round-trip on `InventorySummaryBuilder.cs`. Paired `format_range_preview` is stable, but emits empty diff hunks (§9.5). |
+| tool | `extract_interface_preview` | refactoring | exercised | 1c | 4428 | **FAIL §9.1** — generated broken code. |
+| tool | `extract_interface_apply` | refactoring | exercised-apply | 1c | 467 | Apply succeeded but result failed compile (inherits FAIL from preview). |
+| tool | `extract_type_apply` | refactoring | needs-more-evidence | 1d | — | not-yet-exercised. |
+| tool | `move_type_to_file_apply` | refactoring | exercised-apply | 1e | 504 | **FAIL §9.2** — preview diff diverges from apply. |
+| tool | `bulk_replace_type_apply` | refactoring | needs-more-evidence | 1f | — | not-yet-exercised. Blocked by 1c FAIL (interface-extract sequencing). |
+| tool | `extract_method_apply` | refactoring | needs-more-evidence | 1g | — | not-yet-exercised. |
+| tool | `format_check` | refactoring | exercised | 1h | 382 | Clean. Correctly identified 1 violation across 101 Core docs. Project filter honoured. |
+| tool | `restructure_preview` | refactoring | needs-more-evidence | 1h | — | not-yet-exercised. |
+| tool | `replace_string_literals_preview` | refactoring | needs-more-evidence | 1i | — | not-yet-exercised. |
+| tool | `change_signature_preview` | refactoring | needs-more-evidence | 1j | — | not-yet-exercised. |
+| tool | `symbol_refactor_preview` | refactoring | needs-more-evidence | 1k | — | not-yet-exercised. |
+| tool | `create_file_apply` | file-operations | needs-more-evidence | 2a | — | not-yet-exercised. |
+| tool | `move_file_apply` | file-operations | needs-more-evidence | 2b | — | not-yet-exercised. |
+| tool | `delete_file_apply` | file-operations | needs-more-evidence | 2c | — | not-yet-exercised. |
+| tool | `add_central_package_version_preview` | project-mutation | skipped-repo-shape | 3e | — | No `Directory.Packages.props` — CPM not in use. |
+| tool | `apply_project_mutation` | project-mutation | needs-more-evidence | 3a–3d | — | not-yet-exercised. |
+| tool | `scaffold_type_preview` | scaffolding | needs-more-evidence | 4a | — | not-yet-exercised. |
+| tool | `scaffold_type_apply` | scaffolding | needs-more-evidence | 4a | — | not-yet-exercised. |
+| tool | `scaffold_test_apply` | scaffolding | needs-more-evidence | 4b | — | not-yet-exercised. |
+| tool | `scaffold_test_batch_preview` | scaffolding | needs-more-evidence | 4c | — | not-yet-exercised. |
+| tool | `remove_dead_code_apply` | dead-code | needs-more-evidence | 5a | — | not-yet-exercised. |
+| tool | `remove_interface_member_preview` | dead-code | needs-more-evidence | 5a | — | not-yet-exercised. |
+| tool | `apply_multi_file_edit` | editing | needs-more-evidence | 5b | — | not-yet-exercised. |
+| tool | `preview_multi_file_edit` | editing | needs-more-evidence | 5b-i | — | not-yet-exercised. |
+| tool | `preview_multi_file_edit_apply` | editing | needs-more-evidence | 5b-i | — | not-yet-exercised. |
+| tool | `apply_with_verify` | undo | needs-more-evidence | 5e | — | not-yet-exercised. High priority on resume — would auto-revert §9.1/§9.2 failures. |
+| tool | `move_type_to_project_preview` | cross-project | needs-more-evidence | 6 | — | not-yet-exercised. |
+| tool | `extract_interface_cross_project_preview` | cross-project | needs-more-evidence | 6 | — | not-yet-exercised. Pre-emptive concern: shares the same using-directive generation path as §9.1 — re-test with cross-project target to see if the bug widens. |
+| tool | `dependency_inversion_preview` | cross-project | needs-more-evidence | 6 | — | not-yet-exercised. |
+| tool | `migrate_package_preview` | orchestration | needs-more-evidence | 7 | — | not-yet-exercised. |
+| tool | `split_class_preview` | orchestration | needs-more-evidence | 7 | — | not-yet-exercised. |
+| tool | `extract_and_wire_interface_preview` | orchestration | needs-more-evidence | 7 | — | not-yet-exercised. Composite wrapping `extract_interface_preview` — likely blocked by §9.1 until that's fixed. |
+| tool | `apply_composite_preview` | orchestration | needs-more-evidence | 7 | — | not-yet-exercised. |
+| tool | `symbol_impact_sweep` | analysis | needs-more-evidence | 7c.1 | — | not-yet-exercised. |
+| tool | `test_reference_map` | validation | needs-more-evidence | 7c.2 | — | not-yet-exercised. |
+| tool | `validate_workspace` | validation | needs-more-evidence | 7c.3 | — | not-yet-exercised. Would have surfaced §9.1/9.2 failures automatically. |
+| tool | `get_prompt_text` | prompts | needs-more-evidence | 7c.4 | — | not-yet-exercised. |
+| resource | `source_file_lines` | resources | needs-more-evidence | 7b | — | not-yet-exercised. |
+| prompt | `explain_error` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `suggest_refactoring` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `review_file` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `analyze_dependencies` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `debug_test_failure` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `refactor_and_validate` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `fix_all_diagnostics` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `guided_package_migration` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `guided_extract_interface` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. Wraps `extract_interface_preview` — expected blocked by §9.1. |
+| prompt | `security_review` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `discover_capabilities` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `dead_code_audit` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `review_test_coverage` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `review_complexity` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `cohesion_analysis` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `consumer_impact` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `guided_extract_method` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `msbuild_inspection` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+| prompt | `session_undo` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. Given §9.3 this prompt's usefulness is suspect. |
+| prompt | `refactor_loop` | prompts | needs-more-evidence | 8 | — | not-yet-exercised. |
+
+**Ledger summary:** 61 experimental entries (40 tools + 20 prompts + 1 resource). 6 exercised. 1 `skipped-repo-shape`. 54 `needs-more-evidence`.
+
+## 3. Performance baseline (`_meta.elapsedMs`)
+
+| Tool | Category | Calls | p50_ms | max_ms | Input scale | Budget | Notes |
+|------|----------|-------|--------|--------|-------------|--------|-------|
+| `workspace_load` | scaffolding | 2 | 3832 | 4439 | 9 projects / 402 docs | load | under load budget |
+| `project_graph` | scaffolding | 1 | 6 | 6 | 9 projects | read ≤5s | ✅ |
+| `project_diagnostics` | analysis | 2 | 10323 | 20574 | solution-wide / 44 IDs / 1,122 findings | scan ≤15s | ⚠️ **20.5s exceeds 15s scan budget on full solution scan**; 73ms when narrowed by `diagnosticId` + `limit` |
+| `get_cohesion_metrics` | analysis | 1 | 752 | 752 | 10 types | scan ≤15s | ✅ |
+| `get_complexity_metrics` | analysis | 1 | 3182 | 3182 | 10 methods | scan ≤15s | ✅ |
+| `fix_all_preview` | refactoring | 5 | 286 | 2271 | solution / project / document | scan ≤15s | ✅ fast because no providers fired |
+| `diagnostic_details` | analysis | 1 | 6 | 6 | 1 site | read ≤5s | ✅ |
+| `format_check` | refactoring | 1 | 382 | 382 | 101 documents | scan ≤15s | ✅ |
+| `format_range_preview` | refactoring | 1 | 24 | 24 | 1 file, lines 1–400 | read ≤5s | ✅ BUT empty diff hunks (§9.5) |
+| `format_range_apply` | refactoring | 1 | 37 | 37 | 1 file | writer ≤30s | ✅ |
+| `extract_interface_preview` | refactoring | 2 | 2220 | 4428 | 3 members on 1 type | read ≤5s | Second call 3.7s in auto-reload after sibling apply |
+| `extract_interface_apply` | refactoring | 1 | 467 | 467 | 2 files | writer ≤30s | Applied but RESULT FAILED COMPILE (§9.1) |
+| `symbol_search` | analysis | 1 | 169 | 169 | 1 query | read ≤5s | ✅ |
+| `document_symbols` | analysis | 1 | 7 | 7 | 1 file | read ≤5s | ✅ |
+| `type_hierarchy` | analysis | 1 | 4145 | 4145 | cold after auto-reload | read ≤5s | Within budget (cold) |
+| `compile_check` | analysis | 4 | 3144 | 3644 | solution-wide | scan ≤15s | ✅ when unfiltered; false-clean when filtered (§9.5/§9.6) |
+| `move_type_to_file_preview` | refactoring | 1 | 236 | 236 | 1 type | read ≤5s | ✅ (preview body is semantically wrong — §9.2) |
+| `move_type_to_file_apply` | refactoring | 1 | 504 | 504 | 2 files (claimed) | writer ≤30s | Applied but RESULT FAILED COMPILE (§9.2) |
+| `revert_last_apply` | undo | 2 | 2418 | 2477 | 1 op rollback each | writer ≤30s | Runs, BUT leaves created files on disk (§9.3) |
+| `workspace_list` | scaffolding | 1 | 1 | 1 | 1 workspace | read ≤5s | ✅ |
+| `workspace_status` | scaffolding | 1 | 2 | 2 | 1 workspace | read ≤5s | ✅ (after reload) |
+
+## 4. Schema vs behaviour drift (summary — detail in §9)
+
+| Tool | Mismatch kind | Expected | Actual | Severity | See |
+|------|---------------|----------|--------|----------|-----|
+| `extract_interface_preview` | semantic correctness | Generated interface compiles | Missing `using` directive on generated file → CS0246 on apply | **FAIL** | §9.1 |
+| `move_type_to_file_apply` | apply fidelity | Source type removed, target type added, per preview diff | Source type NOT removed; extra file created at wrong path; preview diff both under-reports deletions AND under-reports creations | **FAIL** | §9.2 |
+| `revert_last_apply` | undo completeness | On-disk state restored to pre-apply | Created files remain on disk; csproj mutations not reverted | **FAIL** | §9.3 |
+| `fix_all_preview` | error-path guidance | Consistent `guidanceMessage` on `fixedCount=0` | IDE0028 and IDE0305 return `guidanceMessage: null`; IDE0060/SYSLIB1045/MA0089/xUnit2024 return actionable strings | FLAG | §9.4 |
+| `format_range_preview` | preview fidelity | Preview `unifiedDiff` contains the hunks that apply will write | Returns a diff with only headers (`--- a/\r\n+++ b/\r\n`) and no `@@ … @@` hunks, yet apply DOES modify the file | FLAG | §9.5 |
+| `compile_check` with `projectName` / `file` filter | scope honoured | Compile the filtered project(s) and report errors | Returns `success: true, totalProjects: 0, completedProjects: 0, totalDiagnostics: 0, elapsedMs: 0` — silently reports "clean" even when the unfiltered call shows 6+ errors on those projects | FLAG | §9.5 |
+| `*_apply` tools executed in same batch as sibling `*_apply` | preview-token lifetime | Tokens remain valid until consumed or until the author explicitly mutates the workspace | Token issued by a preview in turn T is invalidated by an unrelated `*_apply` in turn T before its own `*_apply` runs | FLAG | §9.6 |
+| `workspace_list` after applies | state reporting | `isReady: true` once auto-reload finishes | Reports `isReady: false, workspaceErrorCount: 1` even though subsequent tool calls succeed against that workspaceId | FLAG | §9.7 |
+
+## 5. Error message quality
+
+> Phase 9 was not reached directly, but the following probes ran incidentally:
+
+| Tool | Probe input | Rating | Message | Notes |
+|------|-------------|--------|---------|-------|
+| `fix_all_preview` | `diagnosticId=SYSLIB1045, scope=solution` | **actionable** | `"No code fix provider is loaded for diagnostic 'SYSLIB1045'. Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs."` | Good |
+| `fix_all_preview` | `diagnosticId=IDE0060, scope=solution` | **actionable** | `"No code fix provider is loaded for diagnostic 'IDE0060'. The IDE code fix provider for 'IDE0060' could not be loaded (constructor requirements). Try code_fix_preview on individual instances, or use list_analyzers to check if the diagnostic is present."` | Good |
+| `fix_all_preview` | `diagnosticId=MA0089, scope=solution` | **actionable** | Same template as SYSLIB1045 | Good |
+| `fix_all_preview` | `diagnosticId=xUnit2024, scope=solution` | **actionable** | Same template | Good |
+| `fix_all_preview` | `diagnosticId=IDE0028, scope=project/document` | **unhelpful** | `guidanceMessage: null` | See §9.4 |
+| `fix_all_preview` | `diagnosticId=IDE0305, scope=solution` | **unhelpful** | `guidanceMessage: null` | See §9.4 |
+| `extract_interface_apply` | stale preview token (invalidated by sibling `format_range_apply` in same turn) | **actionable** | `"Not found: Preview token '79ef8f84…' not found or expired."` | Good — but the invalidation cause isn't documented |
+| `project_graph` / `workspace_status` | workspaceId after host-process session loss | **actionable** | `"Not found: Workspace '4b3d5b09…' not found or has been closed. Active workspace IDs are listed by workspace_list."` | Good |
+| `diagnostic_details` | unfixable `IDE0028` at specific site | **actionable** | `supportedFixes: []` | Correct behaviour — but then `fix_all_preview` for the same ID returns null guidance instead of the same "no provider" message |
+
+## 6. Parameter-path coverage
+
+| Family | Non-default path tested | Status | Notes |
+|--------|--------------------------|--------|-------|
+| `fix_all_preview` | scope=project (non-default) | ✅ | Returned empty — same path as solution/document because no provider fired |
+| `fix_all_preview` | scope=document (non-default) | ✅ | Same |
+| `format_check` | projectName filter | ✅ | Correctly scoped to 101 Core docs |
+| `project_diagnostics` | summary=true (non-default) | ✅ | Returned 44 distinct IDs with counts |
+| `project_diagnostics` | diagnosticId + limit (non-default) | ✅ | 73 ms |
+| `compile_check` | severity=Error + limit | ✅ | Pagination works |
+| `compile_check` | projectName filter | ❌ FAIL | See §9.5 — returns zero-projects without error |
+| `compile_check` | file filter | ❌ FAIL | Same as projectName — returns zero-projects silently |
+| `extract_interface_preview` | default member set | ⚠️ | Exercised but semantically broken — see §9.1 |
+| `move_type_to_file_preview` | default targetFilePath | ⚠️ | Exercised but preview body diverges from apply — see §9.2 |
+| `scaffold_type_preview` | kind=record / kind=interface | not-tested | Phase 4 not reached |
+| `get_msbuild_properties` | propertyNameFilter | not-tested | Phase 3 not reached |
+| File operations | move with namespace update | not-tested | Phase 2 not reached |
+| Project mutation | conditional property, CPM | not-tested / `skipped-repo-shape` | |
+
+## 7. Prompt verification (Phase 8)
+
+> Phase 8 not reached in this run. All 20 experimental prompts remain `needs-more-evidence`.
+
+## 8. Experimental promotion scorecard
+
+Rubric from the prompt:
+- **promote** — all of: exercised end-to-end with ≥1 non-default path, schema matched behaviour, no FAIL, p50 within budget, preview/apply round-trip clean (if applicable), actionable error on ≥1 negative probe, catalog description matched actual behaviour.
+- **keep-experimental** — exercised with pass signal but missing ≥1 promote criterion.
+- **needs-more-evidence** — not exercised or too shallow to judge.
+- **deprecate** — exercised with FAIL findings that warrant removal or fix-before-promote.
+
+| Kind | Name | Category | Status | p50_ms | schema_ok | error_ok | round_trip_ok | Failures | Recommendation | Evidence |
+|------|------|----------|--------|--------|-----------|----------|----------------|----------|----------------|----------|
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 286 | partial | partial | n/a | 0 | **keep-experimental** | Inconsistent guidance emission (§9.4). |
+| tool | `fix_all_apply` | refactoring | blocked | — | n/a | n/a | n/a | 0 | **needs-more-evidence** | No token available. |
+| tool | `format_range_apply` | refactoring | exercised-apply | 37 | n/a | n/a | yes (partial) | 0 | **keep-experimental** | Apply works, but sibling preview emits empty diff (§9.5). |
+| tool | `extract_interface_preview` | refactoring | exercised | 2220 | FAIL | n/a | no | 1 | **deprecate** (or block promote pending §9.1 fix) | **FAIL §9.1** — generates broken code. |
+| tool | `extract_interface_apply` | refactoring | exercised-apply | 467 | inherits | actionable (stale token) | no | 1 (inherited) | **keep-experimental** conditional on 1c fix | Apply surface fine; payload fidelity is the problem. |
+| tool | `extract_type_apply` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | Not exercised. |
+| tool | `move_type_to_file_apply` | refactoring | exercised-apply | 504 | FAIL | n/a | no | 1 | **deprecate** (or block promote pending §9.2 fix) | **FAIL §9.2** — preview ≠ apply. |
+| tool | `bulk_replace_type_apply` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `extract_method_apply` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `format_check` | refactoring | exercised | 382 | ok | n/a | n/a | 0 | **promote-candidate** | Correctly found 1 violation across 101 docs; projectName filter honoured. Caveat: limited probe (single project). |
+| tool | `restructure_preview` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `replace_string_literals_preview` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `change_signature_preview` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `symbol_refactor_preview` | refactoring | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `create_file_apply` | file-operations | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `move_file_apply` | file-operations | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `delete_file_apply` | file-operations | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `add_central_package_version_preview` | project-mutation | skipped-repo-shape | — | | | | | **needs-more-evidence** | Repo has no CPM. |
+| tool | `apply_project_mutation` | project-mutation | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `scaffold_type_preview` | scaffolding | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `scaffold_type_apply` | scaffolding | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `scaffold_test_apply` | scaffolding | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `scaffold_test_batch_preview` | scaffolding | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `remove_dead_code_apply` | dead-code | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `remove_interface_member_preview` | dead-code | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `apply_multi_file_edit` | editing | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `preview_multi_file_edit` | editing | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `preview_multi_file_edit_apply` | editing | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `apply_with_verify` | undo | needs-more-evidence | — | | | | | **needs-more-evidence** | Would have auto-reverted §9.1/§9.2 — high priority on resume. |
+| tool | `move_type_to_project_preview` | cross-project | needs-more-evidence | — | | | | | **needs-more-evidence** | Likely affected by §9.1 using-directive bug. |
+| tool | `extract_interface_cross_project_preview` | cross-project | needs-more-evidence | — | | | | | **needs-more-evidence** | Same path as §9.1 — likely worse cross-project. |
+| tool | `dependency_inversion_preview` | cross-project | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `migrate_package_preview` | orchestration | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `split_class_preview` | orchestration | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `extract_and_wire_interface_preview` | orchestration | needs-more-evidence | — | | | | | **needs-more-evidence** | Composite wrapping `extract_interface_preview` — blocked pending §9.1 fix. |
+| tool | `apply_composite_preview` | orchestration | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `symbol_impact_sweep` | analysis | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `test_reference_map` | validation | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `validate_workspace` | validation | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| tool | `get_prompt_text` | prompts | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| resource | `source_file_lines` | resources | needs-more-evidence | — | | | | | **needs-more-evidence** | |
+| prompt × 20 | (all Phase 8 prompts) | prompts | needs-more-evidence | — | | n/a | n/a | 0 | **needs-more-evidence** | Phase 8 not reached. |
+
+## 9. MCP server issues (bugs)
+
+### 9.1 `extract_interface_preview` emits interface file without required `using` directive — result fails to compile
+
+| Field | Detail |
+|--------|--------|
+| Tool | `extract_interface_preview` → `extract_interface_apply` |
+| Severity | **High (FAIL)** — produces code that does not compile; silently shipped to disk on apply |
+| Reproducibility | 1/1 on this repo |
+
+**Input:**
+```json
+{
+  "workspaceId": "a041e542b664491e970376f2fbe02c91",
+  "filePath": "C:\\Code-Repo\\DotNet-Network-Documentation\\.worktrees\\exp-promotion\\src\\NetworkDocumentation.Diagrams\\NetworkDocumentation.Diagrams\\DiagramService.cs",
+  "typeName": "DiagramService",
+  "interfaceName": "IDiagramService"
+}
+```
+
+**Source file context (`DiagramService.cs` has `using NetworkDocumentation.Core.Models;` among its top-of-file usings; the 3 public methods use `NetworkInventory` which lives in that namespace).**
+
+**Preview diff for the generated `IDiagramService.cs` (verbatim from the response):**
+```
+--- a/…\IDiagramService.cs
++++ b/…\IDiagramService.cs
+@@ -1,0 +1,7 @@
++namespace NetworkDocumentation.Diagrams;
++public interface IDiagramService
++{
++    void GenerateAll(NetworkInventory inventory, string outputDir);
++    void GenerateAreaScopedDiagrams(NetworkInventory inventory, string mapsDirectory, string diagramSet = "all", bool exportPng = false, string pngLayout = "neato", int pngDpi = 150);
++    void GenerateRegionScopedDiagrams(NetworkInventory inventory, string mapsDirectory);
++}
+```
+No `using NetworkDocumentation.Core.Models;` directive is present, and the types are not fully-qualified.
+
+**Expected:** Either (a) add `using NetworkDocumentation.Core.Models;` to the generated interface file, or (b) fully-qualify `NetworkInventory` as `global::NetworkDocumentation.Core.Models.NetworkInventory`.
+
+**Actual after `extract_interface_apply`:**
+```
+CS0246  The type or namespace name 'NetworkInventory' could not be found …    IDiagramService.cs line 4 col 22
+CS0246  …    IDiagramService.cs line 5 col 37
+CS0246  …    IDiagramService.cs line 6 col 39
+CS0535  'DiagramService' does not implement interface member 'IDiagramService.GenerateAll(NetworkInventory, string)'    DiagramService.cs line 15 col 4
+CS0535  …GenerateAreaScopedDiagrams…    DiagramService.cs line 15 col 4
+CS0535  …GenerateRegionScopedDiagrams…    DiagramService.cs line 15 col 4
+```
+
+**Fix-the-fix hint for the server owner:** The refactoring should copy the relevant namespace imports from the source file (transitively, based on symbol references inside the extracted members). `SyntaxGenerator.AddImports` or `Simplifier.ReduceAsync` with an annotated node set should handle this. Same bug is likely present in `extract_interface_cross_project_preview` (cross-project target has even less chance of inheriting the right usings).
+
+---
+
+### 9.2 `move_type_to_file_apply` leaves duplicate type in source file AND creates a rogue copy at project root — 90 compile errors
+
+| Field | Detail |
+|--------|--------|
+| Tool | `move_type_to_file_preview` → `move_type_to_file_apply` |
+| Severity | **Critical (FAIL)** — preview diff does not match the bytes the apply actually writes; "trust the preview" agent contract is broken both on deletions (under-reported) and on creations (under-reported) |
+| Reproducibility | 1/1 on this repo |
+
+**Input:**
+```json
+{
+  "workspaceId": "a041e542b664491e970376f2fbe02c91",
+  "sourceFilePath": "C:\\Code-Repo\\DotNet-Network-Documentation\\.worktrees\\exp-promotion\\src\\NetworkDocumentation.Core\\NetworkDocumentation.Core\\Diff\\DiffModels.cs",
+  "typeName": "DiffSummary"
+}
+```
+(`targetFilePath` omitted — defaults to `DiffSummary.cs` in the same directory per the tool schema.)
+
+**Preview response (two file changes, verbatim):**
+```
+changes[0].filePath:   …\Diff\DiffModels.cs
+changes[0].unifiedDiff:
+  @@ -54,21 +54,6 @@
+   // ---- Aggregate summary ----
+
+   /// <summary>Aggregate counts for a ChangeSet.</summary>
+  -public class DiffSummary
+  -{
+  -    public int DevicesAdded { get; set; }
+  -    public int DevicesRemoved { get; set; }
+  -    public int DevicesDecommissioned { get; set; }
+  -    public int DevicesChanged { get; set; }
+  -    public int LinksAdded { get; set; }
+  -    public int LinksRemoved { get; set; }
+  -    public int LinksDecommissioned { get; set; }
+  -    public int LinksChanged { get; set; }
+  -
+  -    public int TotalChanges =>
+  -        DevicesAdded + DevicesRemoved + DevicesDecommissioned + DevicesChanged
+  -        + LinksAdded + LinksRemoved + LinksDecommissioned + LinksChanged;
+  -}
+
+   // ---- Full diff result ----
+
+changes[1].filePath:   …\Diff\DiffSummary.cs   (new file)
+changes[1].unifiedDiff:
+  @@ -1,0 +1,15 @@
+  +namespace NetworkDocumentation.Core.Diff;
+  +// ---- Aggregate summary ----
+  +/// <summary>Aggregate counts for a ChangeSet.</summary>
+  +public class DiffSummary
+  +{
+  +    public int DevicesAdded { get; set; }
+  +    … (same body) …
+  +    public int TotalChanges => DevicesAdded + … + LinksChanged;
+  +}
+```
+
+**Apply response:**
+```json
+{
+  "success": true,
+  "appliedFiles": [
+    "…\\Diff\\DiffSummary.cs",
+    "…\\Diff\\DiffModels.cs"
+  ]
+}
+```
+
+**Actual state on disk (post-apply, before revert):**
+1. `Diff/DiffSummary.cs` — CREATED, contains the type. ✅ matches preview[1].
+2. `Diff/DiffModels.cs` — **still contains `public class DiffSummary` at line 57.** The `-` hunks from preview[0] were NOT applied. ❌ contradicts preview[0].
+3. **NEW: project-root-level `src/NetworkDocumentation.Core/NetworkDocumentation.Core/DiffSummary.cs`** — created by the apply, a second copy of the type. **Not mentioned in the preview at all.** ❌ creates a phantom file outside the preview contract.
+
+Verified by `ls src/NetworkDocumentation.Core/NetworkDocumentation.Core/Diff/` showing `DiffSummary.cs` AND `ls src/NetworkDocumentation.Core/NetworkDocumentation.Core/` showing a second `DiffSummary.cs` at project root. Verified by `git status --short` after revert:
+```
+?? src/.../Diff/DiffSummary.cs
+?? src/.../DiffSummary.cs         ← ROGUE (never in preview)
+```
+
+**Compile result after apply:**
+```
+compile_check (no filter) →
+  success: false
+  errorCount: 90
+  first 5 diagnostics:
+    CS0101  The namespace 'NetworkDocumentation.Core.Diff' already contains a definition for 'DiffSummary'    Diff/DiffSummary.cs line 4 col 14
+    CS0229  Ambiguity between 'DiffSummary.DevicesAdded' and 'DiffSummary.DevicesAdded'    DiffEngine.cs line 71 col 13
+    CS0229  … DiffSummary.DevicesRemoved …    DiffEngine.cs line 72 col 13
+    CS0229  … DiffSummary.DevicesDecommissioned …    DiffEngine.cs line 73 col 13
+    CS0229  … DiffSummary.DevicesChanged …    DiffEngine.cs line 74 col 13
+  hasMore: true (90 total; cascade through DiffEngine, DiffRecordMapper, ChangesSheetBuilder, ChangeReportGenerator, InventorySummaryBuilder)
+```
+
+**Expected:** source file's `DiffSummary` class removed per preview[0]; single copy in `Diff/DiffSummary.cs` per preview[1]; no project-root file; `appliedFiles` must enumerate every file the apply actually touched (including csproj mutations if any).
+
+**Fix-the-fix hint for the server owner:**
+- Preview generation and apply execution appear to use **different code paths**. The preview computes hunks via text diff; the apply uses a Roslyn `DocumentAction` that inserts the new file but doesn't carry the source-file delete through. Unify both paths (ideally generate the preview from the same `CodeAction`'s `GetOperationsAsync` output the apply uses).
+- The phantom root-level file suggests the apply resolves `targetFilePath` twice (once correctly to `Diff/DiffSummary.cs`, once incorrectly to project-root `DiffSummary.cs`). Audit the path-resolution logic; check if there's a default-target fallback that fires even when a resolved target already exists.
+- `appliedFiles` should list every file written (including the rogue one, if the fix keeps that logic at all).
+
+---
+
+### 9.3 `revert_last_apply` leaves files created by the apply on disk
+
+| Field | Detail |
+|--------|--------|
+| Tool | `revert_last_apply` |
+| Severity | **High (FAIL)** — documented semantic is "restore previous solution state"; callers that rely on revert to recover from a bad apply will still have broken disk state |
+| Reproducibility | 2/2 (observed after `extract_interface_apply` revert AND after `move_type_to_file_apply` revert) |
+
+**Input (first revert):**
+```json
+{"workspaceId": "a041e542b664491e970376f2fbe02c91"}
+```
+
+**Response:**
+```json
+{
+  "reverted": true,
+  "revertedOperation": "Extract interface 'IDiagramService' from 'DiagramService' with 3 member(s)",
+  "appliedAtUtc": "2026-04-15T14:26:28.8334213Z"
+}
+```
+
+**Actual on-disk state after revert (verified by `git status --short` after cleanup):**
+```
+M  src/NetworkDocumentation.Core/NetworkDocumentation.Core/NetworkDocumentation.Core.csproj
+M  src/NetworkDocumentation.Core/NetworkDocumentation.Core/Utils/InventorySummaryBuilder.cs   ← from format_range, intentionally retained
+M  src/NetworkDocumentation.Diagrams/NetworkDocumentation.Diagrams/NetworkDocumentation.Diagrams.csproj
+?? src/NetworkDocumentation.Core/NetworkDocumentation.Core/Diff/DiffSummary.cs
+?? src/NetworkDocumentation.Core/NetworkDocumentation.Core/DiffSummary.cs
+?? src/NetworkDocumentation.Diagrams/NetworkDocumentation.Diagrams/IDiagramService.cs
+```
+
+**Expected:** `revert_last_apply` should either:
+- (a) delete files that the reverted apply created (`IDiagramService.cs`, `Diff/DiffSummary.cs`, project-root `DiffSummary.cs`) and undo csproj changes; or
+- (b) at minimum return a `warnings: [...]` array naming the files that are NOT automatically removed so callers can clean up (`{"warnings": ["File 'X.cs' was created by apply and left in place; remove manually."]}`).
+
+**Actual:** `reverted: true` with no warnings. Files and csproj edits persist. Required `git reset --hard HEAD && git clean -fd` to recover a clean tree (which is not available to most Roslyn MCP callers).
+
+**Fix-the-fix hint for the server owner:** the revert is snapshot-based (workspace Solution object) but filesystem-side the `Solution.WithDocumentText` / document-add operations already wrote bytes. Either the snapshot restore must re-traverse the filesystem diff vs. `appliedFiles` and remove additions, or the tool must return `warnings` listing the un-reverted artifacts.
+
+---
+
+### 9.4 `fix_all_preview` returns `guidanceMessage: null` for some IDE-series diagnostic IDs
+
+| Field | Detail |
+|--------|--------|
+| Tool | `fix_all_preview` |
+| Severity | FLAG — observable tool behaviour is inconsistent; caller cannot distinguish "no diagnostic occurrences" from "no provider loaded" |
+| Reproducibility | deterministic per ID across scope values |
+
+**Inputs & Responses (abridged):**
+
+| diagnosticId | scope | fixedCount | guidanceMessage | Verdict |
+|---|---|---|---|---|
+| `IDE0028` | project | 0 | **null** | unhelpful |
+| `IDE0028` | document | 0 | **null** | unhelpful |
+| `IDE0090` | solution | 0 | **null** | unhelpful |
+| `IDE0305` | solution | 0 | **null** | unhelpful |
+| `IDE0060` | solution | 0 | `"No code fix provider is loaded for diagnostic 'IDE0060'. The IDE code fix provider for 'IDE0060' could not be loaded (constructor requirements). Try code_fix_preview on individual instances, or use list_analyzers to check if the diagnostic is present."` | actionable |
+| `SYSLIB1045` | solution | 0 | `"No code fix provider is loaded for diagnostic 'SYSLIB1045'. Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs."` | actionable |
+| `MA0089` | solution | 0 | (same template as SYSLIB1045) | actionable |
+| `xUnit2024` | solution | 0 | (same template) | actionable |
+
+**Expected:** whenever `fixedCount === 0`, emit one of the actionable templates above. Never `null`.
+
+**Fix-the-fix hint:** the provider-detection short-circuit for `IDE0028`, `IDE0090`, `IDE0305` (and likely others) returns early without populating `guidanceMessage`. Add a default-fill at the end of `fix_all_preview` when the result is empty: `guidanceMessage ??= $"No code fix provider is loaded for diagnostic '{id}'. …"`.
+
+---
+
+### 9.5 `format_range_preview` returns preview token with empty unified diff; `compile_check` with `projectName`/`file` filter silently reports zero diagnostics after an auto-reload
+
+Two related scope-filter / preview-fidelity defects; grouped because they both produce misleading "clean" signals to the caller.
+
+| Defect | Input | Expected | Actual |
+|---|---|---|---|
+| A. `format_range_preview` empty diff | file with 1 format violation confirmed by `format_check`; range `lines 1–400` | `unifiedDiff` contains the hunks that will change | `unifiedDiff` is just `--- a/…\r\n+++ b/…\r\n` — no `@@` hunks — yet `format_range_apply` with the returned token actually modifies the file |
+| B. `compile_check` filtered false-clean | post-`extract_interface_apply`; `projectName="NetworkDocumentation.Diagrams"` or `file=".../IDiagramService.cs"` | Compile the filtered project/file and report its diagnostics | `{success: true, totalProjects: 0, completedProjects: 0, totalDiagnostics: 0, elapsedMs: 0, staleAction: "auto-reloaded"}` — the same workspace with no filter shows **6 errors** on those exact files |
+
+**Response (A) verbatim:**
+```json
+{
+  "previewToken": "93bab7b9ed9d41e1af8ddeabdd2a6bd6",
+  "description": "Format range in 'InventorySummaryBuilder.cs' (lines 1-400)",
+  "changes": [{
+    "filePath": "…\\InventorySummaryBuilder.cs",
+    "unifiedDiff": "--- a/…\\InventorySummaryBuilder.cs\r\n+++ b/…\\InventorySummaryBuilder.cs\r\n"
+  }]
+}
+```
+
+**Response (B) verbatim:**
+```json
+{
+  "success": true,
+  "errorCount": 0, "warningCount": 0,
+  "totalDiagnostics": 0, "returnedDiagnostics": 0,
+  "completedProjects": 0, "totalProjects": 0,
+  "elapsedMs": 0,
+  "_meta": {"staleAction": "auto-reloaded", "staleReloadMs": 2639}
+}
+```
+
+**Severity:** both FLAG — consequential because they **look** like passing results. An agent running a verify-after-apply loop will conclude "clean" when the workspace is broken.
+
+**Fix-the-fix hints:**
+- (A) Either populate `unifiedDiff` from the same whitespace-delta source the apply uses, OR document in the tool description that the preview is opaque and the caller must apply to see the change.
+- (B) When `projectName` or `file` filter resolves to zero projects in the current `Solution`, return `success: false` plus a message (`"No project matched name 'X' in the current workspace. Did the workspace auto-reload? Re-issue the call."`). Do not silently return `success: true / totalProjects: 0`.
+
+---
+
+### 9.6 Preview-token issued in turn T invalidated by a sibling `*_apply` in the same turn
+
+| Field | Detail |
+|--------|--------|
+| Tool | `extract_interface_apply` (consumer) ; `format_range_apply` (invalidator) |
+| Severity | FLAG — unexpected coupling of preview tokens across unrelated files; not documented in the tool schemas |
+| Reproducibility | 1/1 (observed in the initial 1b+1c parallel batch) |
+
+**Repro:** In a single assistant message, issue `format_range_preview` (file A) AND `extract_interface_preview` (file B) in parallel. Then, in the NEXT assistant message, issue `format_range_apply(tokenA)` AND `extract_interface_apply(tokenB)` in parallel.
+
+**Observed:**
+- `format_range_apply` succeeds, bumps workspace version.
+- `extract_interface_apply` returns `{"error": true, "category": "NotFound", "message": "Preview token '79ef…' not found or expired."}` even though the token was issued seconds earlier and neither the caller nor the filesystem mutated file B.
+
+**Expected:** preview tokens should remain valid across unrelated mutations, OR the tool schema should explicitly document that any `*_apply` call bumps the workspace version and invalidates all live tokens.
+
+**Fix-the-fix hint:** two options — (a) bind preview tokens to the specific file set they target, so unrelated applies don't invalidate them; (b) document the coupling clearly in `format_range_apply` (and every other `*_apply`) description and have agents explicitly sequence applies.
+
+---
+
+### 9.7 `workspace_list` reports `isReady: false, workspaceErrorCount: 1` during refactoring transitions, but the workspace is still usable
+
+| Field | Detail |
+|--------|--------|
+| Tool | `workspace_list` |
+| Severity | FLAG — soft inconsistency; does not block work, but contradicts the contract implied by `isReady` |
+| Reproducibility | 1/1 (observed after two applies + one revert) |
+
+**Input:**
+```json
+{}
+```
+at session state: workspace had just completed `format_range_apply` + reverted `extract_interface_apply`.
+
+**Response:**
+```json
+{
+  "count": 1,
+  "workspaces": [{
+    "workspaceId": "a041e542b664491e970376f2fbe02c91",
+    "workspaceVersion": 7,
+    "workspaceDiagnosticCount": 1,
+    "workspaceErrorCount": 1,
+    "workspaceWarningCount": 0,
+    "isReady": false,
+    "isStale": false,
+    …
+  }]
+}
+```
+
+**Contradiction:** `isReady: false` — but immediately afterwards `compile_check` against this same workspaceId returned 90 real errors from a valid compile (i.e. the workspace was demonstrably ready enough to compile).
+
+**Expected:** either `isReady: true` once the reload settles, or a machine-readable `notReadyReason` field explaining which step the server is still working on.
+
+**Fix-the-fix hint:** the `isReady` flag seems to track `workspaceErrorCount === 0`, but that conflates "workspace infrastructure is usable" with "workspace has zero errors." Separate those signals: `isReady` should remain true once MSBuild graph + Roslyn solution resolve, regardless of diagnostics count.
+
+---
+
+### 9.8 (context / environmental, not a bug) — MCP host may drop workspace sessions between user turns
+
+**Not a server bug** — per the `workspace_load` tool description ("A workspace can become unreachable if (a) the host process restarts …"). Recording for completeness because it surfaced real tool-error output in this run:
+
+- First `workspace_load` created session `4b3d5b097aef4a96b6cb2f51272efafc`.
+- The user turn was interrupted and a new turn started.
+- Next tool call `project_graph` → `"Workspace '4b3d5b09…' not found or has been closed."` — actionable error pointing at `workspace_list`.
+- Re-issuing `workspace_load` created session `a041e542b664491e970376f2fbe02c91` (used for the rest of the run).
+
+Recommendation for the prompt: add a "pre-phase heartbeat" line in Phase 0 reminding agents to `workspace_list` at each phase boundary (the prompt already says this in "Execution strategy and context conservation" §4). No server change needed.
+
+## 10. Improvement suggestions
+
+- **§9.1 fix priority:** `extract_interface_preview` should inject the required `using` directives or emit fully-qualified type names. Same logic likely needed in `extract_interface_cross_project_preview`, `dependency_inversion_preview`, `extract_and_wire_interface_preview`, and the `guided_extract_interface` prompt.
+- **§9.2 fix priority:** unify preview-generation and apply-execution paths for `move_type_to_file_*` so the `unifiedDiff` returned in preview is byte-identical to what the apply writes. Fix the phantom project-root file creation. Ensure `appliedFiles` enumerates every file touched.
+- **§9.3 fix priority:** `revert_last_apply` must either physically remove files created by the forward apply OR return a `warnings: [...]` array naming residual files. Document whichever choice you make in the tool schema.
+- **§9.4 fix:** `fix_all_preview` should always populate `guidanceMessage` when `fixedCount === 0`. Add default-fill `guidanceMessage ??= "No code fix provider is loaded for diagnostic '{id}'. …"`.
+- **§9.5 fix:** (A) populate `format_range_preview.unifiedDiff` with actual hunks or document opacity. (B) `compile_check` with zero-match filter should return `success: false` with an actionable message.
+- **§9.6 fix:** scope preview-token validity to the token's own file set, OR clearly document that any `*_apply` invalidates all live tokens.
+- **§9.7 fix:** split `isReady` into "infrastructure ready" vs "diagnostics clean" — or rename `isReady` to clarify which it means.
+- **Prompt improvement:** add a note to `ai_docs/prompts/experimental-promotion-exercise.md` under "Execution strategy" that **parallel `*_apply` calls in a single turn can invalidate sibling preview tokens**, and recommend sequencing applies one-per-turn during full-surface runs.
+- **Performance:** `project_diagnostics` unfiltered full-solution scan took 20.5s (>15s budget). Recommend (a) a warning in the tool description pointing to `summary=true` or `diagnosticId` filtering for sub-second probes, and/or (b) server-side caching so repeated full scans within a session don't re-analyze.
+- **`apply_with_verify` should be promoted to stable** once §9.1/§9.2 are fixed, because it is exactly the tool that would have caught these failures automatically (preview → apply → compile_check → auto-revert on new errors). Post-fix, a validation run with `rollbackOnError: true` on every Phase 1 preview would have reported §9.1 and §9.2 without manual intervention.
+
+## 11. Known issue regression check
+
+| Source id | Summary | Status |
+|-----------|---------|--------|
+| `ai_docs/backlog.md` (2026-04-15T13:40:00Z) | No open rows reference experimental Roslyn MCP tools | **N/A — no prior MCP experimental-tool rows on record** |
+| `ai_docs/audit-reports/20260413T180408Z_networkdocumentation_experimental-promotion.md` | Prior audit 2 days earlier. §9.1/9.2/9.3/9.4/9.5/9.6/9.7 are new evidence for the next diff; this run did not cross-reference the prior audit in detail. | **deferred to follow-up** |
+| Prompt appendix note `change-signature-preview-callsite-summary` | Documented in prompt as a `keep-experimental` P3 limitation (preview diff omits callsite files). **Not reproduced here — `change_signature_preview` was not exercised.** | **not reproduced (not exercised)** |
+
+---
+
+## Working log (phase-by-phase persistence)
+
+### Phase 0: ✅ complete (14:03–14:04Z)
+- `server_info` → 1.18.0 / catalog 2026.04 / 40 exp tools / 20 exp prompts / 1 exp resource
+- `workspace_load` (2 attempts; first session lost between turns — §9.8)
+- `project_graph` — 9 projects, multi-project, DI-capable
+- `dotnet restore` — clean across all 9 projects
+- Coverage ledger seeded (61 rows)
+
+### Phase 1: ⚠️ partial (14:05–14:35Z)
+- **1a `fix_all_preview`** — exercised-preview-only across 8 IDs. No CodeFix provider loaded. FLAG §9.4 on inconsistent `guidanceMessage` (IDE0028/IDE0090/IDE0305 null vs IDE0060/SYSLIB1045/MA0089/xUnit2024 actionable).
+- **1b `format_range_preview` → `format_range_apply`** — clean round-trip on `InventorySummaryBuilder.cs`. FLAG §9.5-A on empty preview diff.
+- **1c `extract_interface_preview` → `extract_interface_apply`** — **FAIL §9.1** (missing using → 6 compile errors). Reverted. §9.3 discovered (files remained on disk).
+- **1e `move_type_to_file_preview` → `move_type_to_file_apply`** — **FAIL §9.2** (duplicate type + phantom file → 90 compile errors). Reverted. §9.3 confirmed (files remained on disk).
+- Additional incidental findings: §9.5-B (`compile_check` filtered false-clean), §9.6 (sibling-token invalidation), §9.7 (`workspace_list.isReady` contradiction).
+- Post-FAIL cleanup: `git reset --hard HEAD && git clean -fd` → removed 3 leftover files + 2 csproj mutations.
+- Audit terminated after 1e to avoid masking further defects on a destabilized workspace.
+
+### Phases 2–11: ⏸ not exercised
+Explicit resume list = the `needs-more-evidence` rows in §2. Prioritize `apply_with_verify` (Phase 5e) because it would have caught §9.1 and §9.2 automatically.
+
+---
+
+## Completion gate / cleanup
+
+- **Canonical file:** this file — `ai_docs/audit-reports/20260415T140302Z_networkdocumentation_experimental-promotion.md` in the **main repo working tree** (NOT the worktree). ✅
+- **Draft file:** removed from disk after canonical was published.
+- **Worktree:** `.worktrees/exp-promotion` on throwaway branch `exp-promotion-2026-04-15` — removed as part of this audit's cleanup (see §Cleanup executed below). To re-create for a resume run, `git worktree add -b exp-promotion-resume .worktrees/exp-promotion origin/main` and reload the solution.
+
+### Cleanup executed
+
+```powershell
+# worktree was hard-reset at end of Phase 1 (recovered from 3 leftover files + 2 csproj mutations)
+git -C C:\Code-Repo\DotNet-Network-Documentation\.worktrees\exp-promotion reset --hard HEAD
+git -C C:\Code-Repo\DotNet-Network-Documentation\.worktrees\exp-promotion clean -fd
+
+# audit-report draft removed
+rm C:\Code-Repo\DotNet-Network-Documentation\ai_docs\audit-reports\20260415T140302Z_networkdocumentation_experimental-promotion.md.draft.md
+
+# worktree and throwaway branch removed
+git -C C:\Code-Repo\DotNet-Network-Documentation worktree remove .worktrees/exp-promotion
+git -C C:\Code-Repo\DotNet-Network-Documentation branch -D exp-promotion-2026-04-15
+```

--- a/ai_docs/audit-reports/20260415T140403Z_itchatbot_experimental-promotion.md
+++ b/ai_docs/audit-reports/20260415T140403Z_itchatbot_experimental-promotion.md
@@ -1,0 +1,285 @@
+# Experimental Promotion Exercise Report (PARTIAL)
+
+> **Run status:** Phase 1 partially executed; Phases 2–11 not exercised. Exercise was stopped intentionally after Phase 1 surfaced three high-severity regressions. This report is the canonical hand-off for the next agent — all findings below are supported by reproduction steps, file paths, and expected/actual contrasts so the next agent can re-run each probe deterministically without re-reading this session.
+
+## 1. Header
+- **Date:** 2026-04-15T14:04:03Z
+- **Audited solution:** ITChatBot.sln
+- **Audited revision:** worktree branch `worktree-experimental-promotion-2026-04-15` from `main` (commit `ee167149723cc2392c43715312f93371a631e063`)
+- **Entrypoint loaded:** `C:\Code-Repo\IT-Chat-Bot\.claude\worktrees\experimental-promotion-2026-04-15\ITChatBot.sln`
+- **Audit mode:** `full-surface` — disposable worktree used for preview/apply round-trips
+- **Isolation:** Worktree at `.claude/worktrees/experimental-promotion-2026-04-15` (branch `worktree-experimental-promotion-2026-04-15`) — cleanup performed at end of session.
+- **Client:** Claude Code with native Roslyn MCP binding (`mcp__roslyn__*` tools)
+- **Workspace id:** `3c757fc4ef5e49edbbce374bdf665a88`
+- **Server:** `roslyn-mcp 1.18.0+172d3c5118178eae2664768ced630b38d9418309`
+- **Catalog version:** 2026.04
+- **Experimental surface (from `server_info`):** 40 experimental tools, 20 experimental prompts, 1 experimental resource
+- **Scale:** 35 projects, 801 documents (post-restore reload)
+- **Repo shape:** Multi-project .NET 10 solution (`net10.0`). `.editorconfig` at repo root + `tests/`. `Directory.Build.props` present. **No Central Package Management** (`Directory.Packages.props` absent). 17 test projects (xUnit). Analyzers enabled via `Directory.Build.props`. No source generators detected. No multi-targeting.
+- **Prior issue source:** `ai_docs/backlog.md` + prior audit at `ai_docs/audit-reports/20260413T180545Z_itchatbot_experimental-promotion.md` (v1.12.0)
+
+> **Phase 0 drift check:** `server_info` (40 exp tools / 20 exp prompts / 1 exp resource) agreed exactly with `roslyn://server/catalog` and with the prompt appendix for v1.18.0. No surface drift.
+
+### Partial-run caveats
+
+- Phases 2–11 were not executed. Scorecard in §8 only contains entries for the tools actually exercised in Phase 1.
+- Workspace cleanup: all Phase-1 mutations were reverted via `git checkout` + `rm` of the new `IDatabaseOptions.cs` (see Bug 9.1 — `revert_last_apply` does not undo project-file mutations or file creation).
+- Phase 1 encountered repeated validation friction that made continued exercise unwise before the core `extract_*_apply` bugs are addressed (see §9).
+
+## 2. Coverage ledger (experimental surface)
+
+| Kind | Name | Category | Status | Phase | lastElapsedMs | Notes |
+|------|------|----------|--------|-------|---------------|-------|
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 1a | 1099 / 8 / 82 / 1099 | Tried `scope=solution`/`project`/`document`, diagnostic IDs `IDE0130`, `IDE0290`, `IDE0008`, `xUnit1051`, `CA1826`. Info-level IDs silently returned `fixedCount:0` with `guidanceMessage:null`; Warning-level IDs produced actionable guidance (`"No code fix provider is loaded for diagnostic 'CA1826'..."`). No code-fix-provider assembly present in this repo → apply path not reachable. See §5 & §9.5 for the silent-empty-guidance finding. |
+| tool | `fix_all_apply` | refactoring | blocked | 1a | – | Blocked by `fix_all_preview` (no code fix provider loaded). |
+| tool | `format_check` | refactoring | exercised | 1b | 775 (all docs) / 109 (one project) | Clean workspace → 0 violations across 642 docs in 775 ms. Within budget. |
+| tool | `format_range_apply` | refactoring | exercised-apply | 1b | 7 | Round-trip clean. Introduced 9-space indent on DatabaseOptions.cs line 14 via `apply_text_edit`, `format_range_preview` returned token `b95d56c217a0420eadb711fc092ea6d9`, `format_range_apply` restored the canonical 4-space indent. |
+| tool | `extract_interface_preview` | refactoring | exercised | 1c | 912 | Extracted `IDatabaseOptions` from `DatabaseOptions` with 2 members — preview diff was correct and reported both files. |
+| tool | `extract_interface_apply` | refactoring | exercised-apply-FAIL | 1c | 456 | **BUG 9.1** — silently mutated `ITChatBot.Configuration.csproj` by adding `<ItemGroup><Compile Include="IDatabaseOptions.cs" /></ItemGroup>`, which then caused MSBuild `Duplicate 'Compile' items` failure on `workspace_reload`. |
+| tool | `extract_type_preview` | refactoring | exercised | 1d | 2 (refused) / 8 (success) | Refused `AddEvidenceLinksAsync` extraction from `InMemoryConversationRepository` with good actionable message (§9.4). Successfully previewed `Down` extraction from `RemoveConversationExpiresAtUtc`. |
+| tool | `extract_type_apply` | refactoring | exercised-apply-FAIL | 1d | 474 | **BUGS 9.1 + 9.2 + 9.3** — same csproj mutation bug as `extract_interface_apply`, plus duplicate file write to wrong directory, plus preserved `override` modifier on new type without base. |
+| tool | `move_type_to_file_preview` | refactoring | exercised-preview-only | 1e | 3 | Correctly refused with actionable error: "Source file only contains one top-level type. Nested types cannot be extracted with this tool — only top-level type declarations are considered." (This is a repo-shape limit, not a defect.) |
+| tool | `move_type_to_file_apply` | refactoring | needs-more-evidence | 1e | – | Blocked; no multi-type file located in time to retry. |
+| tool | `bulk_replace_type_preview` | refactoring | exercised | 1f | 1108 | Exercised `scope=parameters` (non-default). Correctly rewrote parameter type in `DatabaseOptionsValidator.Validate` but preserved class-level `IValidateOptions<DatabaseOptions>` — which *would* cause the compile to fail under the exact-match interface rule. See §9.6 for the actual compile result. |
+| tool | `bulk_replace_type_apply` | refactoring | exercised-apply-FAIL | 1f | 4 | Applied preview; the resulting file no longer satisfies `IValidateOptions<DatabaseOptions>` because only the method parameter was swapped to `IDatabaseOptions`, not the interface generic. Workspace was reverted via `git checkout`. |
+| tool | `extract_method_preview` | refactoring | exercised | 1g | 2 (refused twice) / 16 (success) | Refused two selections in `SynthesisPromptAssembler.TrimMessagesToContentBudget` with "All selected statements must be in the same block scope" (good actionable error). Succeeded on lines 42-46 of `AmbiguityDetector.Detect`. |
+| tool | `extract_method_apply` | refactoring | exercised-apply | 1g | 6 | Round-trip clean — `compile_check` = 0 errors, `find_references` found the new callsite. **But** preview diff contained formatting defects: missing spaces around `=` at the new callsite, new method declared at column 1 (no class-scope indent), and the multi-line LINQ chain was collapsed to a single long line. See §9.7. |
+| tool | `restructure_preview` (v1.17) | refactoring | needs-more-evidence | 1h | – | Not exercised. |
+| tool | `replace_string_literals_preview` (v1.17) | refactoring | needs-more-evidence | 1i | – | Not exercised. |
+| tool | `change_signature_preview` (v1.18) | refactoring | needs-more-evidence | 1j | – | Not exercised. |
+| tool | `symbol_refactor_preview` (v1.18) | refactoring | needs-more-evidence | 1k | – | Not exercised. |
+| tool | `create_file_apply` | file-operations | needs-more-evidence | 2a | – | Not exercised. |
+| tool | `move_file_apply` | file-operations | needs-more-evidence | 2b | – | Not exercised. |
+| tool | `delete_file_apply` | file-operations | needs-more-evidence | 2c | – | Not exercised. |
+| tool | `add_central_package_version_preview` | project-mutation | needs-more-evidence | 3e | – | Would have been `skipped-repo-shape` (no `Directory.Packages.props`). |
+| tool | `apply_project_mutation` | project-mutation | needs-more-evidence | 3a | – | Not exercised. |
+| tool | `scaffold_type_preview` | scaffolding | needs-more-evidence | 4a | – | Not exercised. |
+| tool | `scaffold_type_apply` | scaffolding | needs-more-evidence | 4a | – | Not exercised. |
+| tool | `scaffold_test_apply` | scaffolding | needs-more-evidence | 4b | – | Not exercised. |
+| tool | `scaffold_test_batch_preview` (v1.17) | scaffolding | needs-more-evidence | 4c | – | Not exercised. |
+| tool | `remove_dead_code_apply` | dead-code | needs-more-evidence | 5a | – | Not exercised. |
+| tool | `remove_interface_member_preview` (v1.15) | dead-code | needs-more-evidence | 5a | – | Not exercised. |
+| tool | `apply_multi_file_edit` | editing | needs-more-evidence | 5b | – | Not exercised. |
+| tool | `preview_multi_file_edit` (v1.17) | editing | needs-more-evidence | 5b-i | – | Not exercised. |
+| tool | `preview_multi_file_edit_apply` (v1.17) | editing | needs-more-evidence | 5b-i | – | Not exercised. |
+| tool | `apply_with_verify` (v1.15) | undo | needs-more-evidence | 5e | – | Not exercised. |
+| tool | `move_type_to_project_preview` | cross-project-refactoring | needs-more-evidence | 6 | – | Not exercised. |
+| tool | `extract_interface_cross_project_preview` | cross-project-refactoring | needs-more-evidence | 6 | – | Not exercised. |
+| tool | `dependency_inversion_preview` | cross-project-refactoring | needs-more-evidence | 6 | – | Not exercised. |
+| tool | `migrate_package_preview` | orchestration | needs-more-evidence | 7 | – | Not exercised. |
+| tool | `split_class_preview` | orchestration | needs-more-evidence | 7 | – | Not exercised. |
+| tool | `extract_and_wire_interface_preview` | orchestration | needs-more-evidence | 7 | – | Not exercised. |
+| tool | `apply_composite_preview` | orchestration | needs-more-evidence | 7 | – | Not exercised. |
+| tool | `symbol_impact_sweep` (v1.17) | analysis | needs-more-evidence | 7c.1 | – | Not exercised. |
+| tool | `test_reference_map` (v1.17) | validation | needs-more-evidence | 7c.2 | – | Not exercised. |
+| tool | `validate_workspace` (v1.18) | validation | needs-more-evidence | 7c.3 | – | Not exercised. |
+| tool | `get_prompt_text` (v1.18) | prompts | needs-more-evidence | 7c.4 | – | Not exercised. |
+| resource | `roslyn://workspace/{id}/file/{path}/lines/{start}-{end}` | resource | needs-more-evidence | 7b | – | Not exercised. |
+| prompt | (all 20 experimental prompts) | prompts | needs-more-evidence | 8 | – | Not exercised. |
+
+**Coverage summary:** exercised/exercised-apply 7 tools; exercised-preview-only 2 tools; exercised-apply-FAIL 3 tools; blocked 1 tool; needs-more-evidence 27 tools + 1 resource + 20 prompts.
+
+## 3. Performance baseline (`_meta.elapsedMs`)
+
+| Tool | Category | Calls | p50_ms | max_ms | Input scale | Budget | Notes |
+|------|----------|-------|--------|--------|-------------|--------|-------|
+| `fix_all_preview` | refactoring | 5 | 8 | 1099 | 1 document / 1 project / 1 solution | ≤15s | Well within budget. |
+| `format_check` | refactoring | 2 | 442 | 775 | 8 docs / 642 docs | ≤15s | Well within budget. |
+| `format_range_preview` | refactoring | 1 | 6381 | 6381 | single line | ≤5s | **FLAG** — included ~6345 ms of `staleAction: "auto-reloaded"` overhead after `apply_text_edit`. Actual in-service time was ~35 ms. |
+| `format_range_apply` | refactoring | 1 | 7 | 7 | 1 file | ≤30s | Fast. |
+| `extract_interface_preview` | refactoring | 1 | 912 | 912 | 2 members | ≤5s | Within budget. |
+| `extract_interface_apply` | refactoring | 1 | 456 | 456 | 2 files | ≤30s | Within budget — but produces invalid csproj (Bug 9.1). |
+| `extract_type_preview` | refactoring | 3 | 2 | 8 | 1–2 members | ≤5s | Fast. |
+| `extract_type_apply` | refactoring | 1 | 474 | 474 | 2 files | ≤30s | Within budget — but three defects (Bugs 9.1, 9.2, 9.3). |
+| `bulk_replace_type_preview` | refactoring | 1 | 1108 | 1108 | 1 file touched | ≤15s | Within budget. |
+| `bulk_replace_type_apply` | refactoring | 1 | 4 | 4 | 1 file | ≤30s | Fast — but produces code that fails `IValidateOptions<T>` exact-match (Bug 9.6). |
+| `extract_method_preview` | refactoring | 3 | 2 | 16 | 13–93 LoC | ≤5s | Fast. |
+| `extract_method_apply` | refactoring | 1 | 6 | 6 | 1 file | ≤30s | Fast; correct semantically, but cosmetic defects in output (Bug 9.7). |
+| `move_type_to_file_preview` | refactoring | 1 | 3 | 3 | 1 file | ≤5s | Fast (refused). |
+| `revert_last_apply` | undo (stable) | 1 | 6709 | 6709 | 1 applied op | ≤30s | Stable tool; included here because the Phase 1 cleanup required it. |
+
+## 4. Schema vs behaviour drift
+
+| Tool | Mismatch kind | Expected | Actual | Severity | Notes |
+|------|---------------|----------|--------|----------|-------|
+| `extract_interface_apply` | Side-effect not documented | Per tool description "Apply a previously previewed interface extraction". Nothing says the tool also mutates `.csproj`. | Writes `<ItemGroup><Compile Include="…" /></ItemGroup>` to the project file. | **High** | The preview diff does not show the csproj change either (see §9.1). |
+| `extract_type_apply` | Side-effect not documented | Per description "Apply a previously previewed type extraction". | Same csproj mutation as above, and writes the extracted-type file to two locations (see §9.1, §9.2). | **High** | |
+| `extract_interface_apply` / `extract_type_apply` | Preview diff incomplete | `changes[].unifiedDiff` should enumerate every file that will change | csproj mutation missing from the preview diff; file-duplication target folder missing from preview diff | **High** | An agent cannot verify the full effect from the preview alone. |
+| `extract_type_apply` response | `appliedFiles` incomplete | `appliedFiles` should list every touched file | Reported 2 `appliedFiles` (the two `.cs` files) but not the csproj, and pointed at the in-subfolder path even though the tool also wrote a second copy at the parent-folder path | **High** | Side-effects invisible to caller. |
+| `extract_method_preview` | Preview produces non-idiomatic code | Output should respect project `.editorconfig` formatting | Call site `var words=NormalizeQuestionWords(questionText);` (missing whitespace around `=`), new method at column 1 (no class-scope indent), multi-line LINQ collapsed to one line | **Medium** | Output compiles but fails style checks (see §9.7). |
+| `fix_all_preview` | Inconsistent guidance | On Info-severity diagnostics with no code fix provider | Returns empty `{ previewToken:"", fixedCount:0, changes:[], guidanceMessage:null }` — silent | **Medium** | On Warning-severity IDs like `CA1826` / `xUnit1051`, it returns a helpful guidanceMessage pointing at `list_analyzers`. The silent path is confusing; agents will assume "0 occurrences" rather than "no fix provider loaded". See §9.5. |
+
+## 5. Error message quality
+
+> Phase 9 negative-probe battery not run. The table below contains the negative paths actually observed during Phase 1.
+
+| Tool | Probe input | Rating | Suggested fix | Notes |
+|------|-------------|--------|---------------|-------|
+| `fix_all_preview` | `diagnosticId="xUnit1051"` (no fix provider loaded) | **actionable** | — | `"No code fix provider is loaded for diagnostic 'xUnit1051'. Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs."` |
+| `fix_all_preview` | `diagnosticId="CA1826"` (no fix provider loaded) | **actionable** | — | Same message template with `CA1826`. |
+| `fix_all_preview` | `diagnosticId="IDE0130"` / `IDE0290` / `IDE0008` (Info-severity) | **unhelpful** | Emit the same `"No code fix provider is loaded…"` guidance when the diagnostic has occurrences but no provider, regardless of severity — or distinguish "no matches" from "no fix provider" in the response | Empty token, `fixedCount:0`, `guidanceMessage:null` — the caller cannot tell whether the diagnostic has no occurrences or whether the fix provider is missing. See §9.5. |
+| `extract_type_preview` | `memberNames=["AddEvidenceLinksAsync"]` references a field that would stay on the source | **actionable** | — | Explicit list of referenced members and a remediation hint. Great error. |
+| `extract_type_preview` | Same input but with `memberNames=["AddEvidenceLinksAsync", "_evidenceLinks"]` — i.e. including the field | **vague** | Accept fields in `memberNames`, or error with "fields are not a supported member kind; refactor the field into a property before retrying" | Tool appears to ignore the field in `memberNames` and emits the same referenced-member error. The error message does not say fields are unsupported, and the schema for `memberNames` is just `string[]`. |
+| `extract_method_preview` | Selection spans two block scopes | **actionable** | — | `"Invalid operation: All selected statements must be in the same block scope.."` — correct. (Stylistic: trailing double dot.) |
+| `move_type_to_file_preview` | Source file has only one top-level type | **actionable** | — | Clear refusal with explanation. |
+
+## 6. Parameter-path coverage
+
+| Family | Non-default path tested | Status | Notes |
+|--------|--------------------------|--------|-------|
+| `fix_all_preview` | `scope=solution` / `scope=project` / `scope=document` | **done** | All three paths exercised. |
+| `format_check` | `projectName=ITChatBot.Configuration` (project scope vs. default solution scope) | **done** | Both paths exercised. |
+| `bulk_replace_type_preview` | `scope=parameters` (non-default vs. `scope=all`) | **done** | Non-default exercised; apply path surfaced the interface-exact-match gap (§9.6). |
+| `extract_type_preview` | `memberNames` containing a field name rather than only methods/properties | **done** (tested but behavior is vague — §5 row 5) | |
+| `scaffold_type_preview` | `kind=record` / `kind=interface` + `implementInterface=false` | **not exercised** | |
+| `get_msbuild_properties` | `propertyNameFilter` | **not exercised** | |
+| File operations | move with `updateNamespace=true` | **not exercised** | |
+| Project mutation | `set_conditional_property_preview`, CPM | **not exercised** | |
+
+## 7. Prompt verification (Phase 8)
+
+Not exercised. All 20 experimental prompts remain `needs-more-evidence`.
+
+## 8. Experimental promotion scorecard
+
+> Partial scorecard — only entries actually exercised in Phase 1. All other experimental entries default to **needs-more-evidence**.
+
+| Kind | Name | Category | Status | p50_ms | schema_ok | error_ok | round_trip_ok | Failures | Recommendation | Evidence |
+|------|------|----------|--------|--------|-----------|----------|----------------|----------|----------------|----------|
+| tool | `fix_all_preview` | refactoring | exercised-preview-only | 8 | partial | partial | n/a | §9.5 silent-guidance on Info-severity | **keep-experimental** | Good guidance on Warning-severity IDs; silent on Info. |
+| tool | `fix_all_apply` | refactoring | blocked | – | unknown | unknown | – | blocked | **needs-more-evidence** | No code-fix provider reachable in this repo. |
+| tool | `format_check` | refactoring | exercised | 442 | yes | n/a | n/a | none | **promote** | Clean run across 642 docs, no schema drift, p50 within budget. |
+| tool | `format_range_apply` | refactoring | exercised-apply | 7 | yes | n/a | yes | none | **keep-experimental** | Round-trip clean; but `format_range_preview` (stable) emits large `staleReloadMs` overhead after `apply_text_edit` (§3 note). Round-trip limited to one small range probe. |
+| tool | `extract_interface_preview` | refactoring | exercised | 912 | yes | n/a | n/a | none | **keep-experimental** | Preview diff is correct but *incomplete* — does not surface the csproj change that `*_apply` later produces (§9.1). |
+| tool | `extract_interface_apply` | refactoring | exercised-apply-FAIL | 456 | **no** | n/a | **no** | §9.1 | **deprecate-or-fix** | Breaks SDK-style projects. Must not promote while the csproj mutation exists. |
+| tool | `extract_type_preview` | refactoring | exercised | 5 | yes | yes | n/a | §9.4 UX follow-up on field-name input | **keep-experimental** | Refusal UX is excellent; minor schema/ux gap on field-name support. |
+| tool | `extract_type_apply` | refactoring | exercised-apply-FAIL | 474 | **no** | n/a | **no** | §9.1 + §9.2 + §9.3 | **deprecate-or-fix** | Three distinct defects, all reproducible. |
+| tool | `move_type_to_file_preview` | refactoring | exercised-preview-only | 3 | yes | yes | n/a | none | **keep-experimental** | Only observed via the refusal path. Needs a multi-type-file probe to meet promotion bar. |
+| tool | `bulk_replace_type_preview` | refactoring | exercised | 1108 | yes | n/a | n/a | §9.6 (scope-semantics) | **keep-experimental** | Non-default path exercised; but the `scope=parameters` semantics needs clarification (does not rewrite generic args even when those are the interface contract). |
+| tool | `bulk_replace_type_apply` | refactoring | exercised-apply-FAIL | 4 | partial | n/a | **no** | §9.6 | **keep-experimental** | Applied the preview faithfully; but the preview semantics left the workspace in a broken state (IValidateOptions<T> parameter-type mismatch). Not the apply tool's fault, but users need a warning. |
+| tool | `extract_method_preview` | refactoring | exercised | 9 | partial | yes | n/a | §9.7 (formatting defects in output) | **keep-experimental** | Semantically correct; cosmetically wrong. |
+| tool | `extract_method_apply` | refactoring | exercised-apply | 6 | partial | n/a | yes | §9.7 | **keep-experimental** | Round-trip compiles; output requires a follow-up `format_document_apply`. |
+
+## 9. MCP server issues (bugs)
+
+### 9.1 `extract_interface_apply` / `extract_type_apply` add `<Compile Include="…">` items that break SDK-style projects
+| Field | Detail |
+|-------|--------|
+| Tool | `extract_interface_apply`, `extract_type_apply` |
+| Reproduction A (extract_interface_apply) | 1. `workspace_load` any SDK-style `.csproj`. 2. `extract_interface_preview(typeName="DatabaseOptions", interfaceName="IDatabaseOptions", filePath=…\DatabaseOptions.cs)`. 3. Apply the token. 4. `workspace_reload`. |
+| Reproduction B (extract_type_apply) | 1. Same workspace. 2. `extract_type_preview(typeName="RemoveConversationExpiresAtUtc", memberNames=["Down"], newTypeName="RemoveConversationExpiresAtUtcRollback", filePath=…\Migrations\20260413203000_RemoveConversationExpiresAtUtc.cs)`. 3. Apply the token. 4. `workspace_reload`. |
+| Expected | Only the new `.cs` file and any modified source files are changed. Project file (`.csproj`) is untouched because the SDK's `EnableDefaultCompileItems=true` default globs `*.cs` automatically. |
+| Actual | `.csproj` gets an appended `<ItemGroup><Compile Include="NewType.cs" /></ItemGroup>`. `workspace_reload` then reports `WORKSPACE_FAILURE` / MSBuild error: `"Duplicate 'Compile' items were included. The .NET SDK includes 'Compile' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultCompileItems' property to 'false' if you want to explicitly include them in your project file. For more information, see https://aka.ms/sdkimplicititems. The duplicate items were: 'IDatabaseOptions.cs'"` |
+| Observed from this run (verbatim) | See `workspace_reload` response, `workspaceDiagnostics[0]`, captured during the extract_interface_apply reproduction — duplicate-Compile diagnostic with `filePath: null`, `severity: "Error"`, category `"Workspace"`. |
+| Side-effect: csproj also reformatted | Tool adds a leading UTF-8 BOM, strips blank lines between `<PropertyGroup>` / `<ItemGroup>` / `</Project>`, and drops the trailing newline. Captured via `git diff src/config/ITChatBot.Configuration.csproj` and `git diff src/data/ITChatBot.Data.csproj`. |
+| Files reproduced against | `src/config/ITChatBot.Configuration.csproj`, `src/data/ITChatBot.Data.csproj` |
+| Severity | **High** — makes apply unusable on the default SDK template shape for .NET 6+. |
+| Reproducibility | 100% on this repo; 2 separate tools on 2 separate projects. |
+| Suggested fix for next agent | (1) Detect SDK-style projects via `EnableDefaultCompileItems` property lookup (already accessible via `evaluate_msbuild_property`). When true, skip the `<Compile Include>` injection. (2) Also preserve csproj whitespace/BOM state — round-trip the file without cosmetic rewrites. (3) Surface the csproj change in the preview's `changes[].unifiedDiff`. (4) Add a post-apply `workspace_reload` smoke test for both tools in the MCP server's integration suite. |
+| Related code locations to inspect | `src/tools/Refactoring/ExtractInterfaceTools.cs`, `src/tools/Refactoring/ExtractTypeTools.cs`, project-mutation helpers under `src/services/ProjectMutation/`. (Paths are educated guesses; the Roslyn-MCP server repo is not checked out here.) |
+
+### 9.2 `extract_type_apply` writes the new type file to two locations
+| Field | Detail |
+|-------|--------|
+| Tool | `extract_type_apply` |
+| Reproduction | Same as 9.1 reproduction B. |
+| Expected | One new file at the path declared by the preview diff: `src\data\Migrations\RemoveConversationExpiresAtUtcRollback.cs`. |
+| Actual | **Two** files with identical contents: (a) `src\data\Migrations\RemoveConversationExpiresAtUtcRollback.cs` and (b) `src\data\RemoveConversationExpiresAtUtcRollback.cs` (parent folder). The csproj injection from 9.1 resolves against the csproj directory (`src\data\`) and therefore references the parent-folder copy. |
+| Observed | `git status --short` after apply showed both `??` paths; `Glob "**/RemoveConversationExpiresAtUtcRollback.cs"` returned both. Contents read via `Read` were byte-identical. |
+| Severity | **High** — silent duplication; later edits to only one copy desync the sources. |
+| Reproducibility | 100% when the extracted type lives in a subfolder of the project. |
+| Suggested fix for next agent | (1) Write the new file exactly at the preview's declared path and nowhere else. (2) If the csproj `<Compile Include>` injection survives (see 9.1), make the include path relative to the declared new-file path. (3) Add a regression test that extracts into a subfolder and asserts `Directory.EnumerateFiles(projectRoot, newTypeName + ".cs", SearchOption.AllDirectories).Count() == 1`. |
+
+### 9.3 `extract_type_apply` preserves `override` when new type does not inherit the base
+| Field | Detail |
+|-------|--------|
+| Tool | `extract_type_apply` |
+| Reproduction | Same as 9.1 reproduction B (source type inherits `Migration` and member `Down` is declared `protected override`). |
+| Expected | Either strip the `override` modifier (method is now a fresh top-level member of a non-inheriting class) or refuse with an actionable error (mirroring the `_evidenceLinks` refusal in §9.4). |
+| Actual | New class emitted as `public sealed class RemoveConversationExpiresAtUtcRollback { public override void Down(MigrationBuilder migrationBuilder) { … } }`. Compile fails with `CS0115: 'RemoveConversationExpiresAtUtcRollback.Down(MigrationBuilder)': no suitable method found to override`. |
+| Observed (verbatim from `compile_check`) | ``{ "id":"CS0115","message":"'RemoveConversationExpiresAtUtcRollback.Down(MigrationBuilder)': no suitable method found to override","severity":"Error","filePath":"…\\src\\data\\Migrations\\RemoveConversationExpiresAtUtcRollback.cs","startLine":6,"startColumn":26 }`` and a mirrored diagnostic for the parent-folder copy. |
+| Severity | **Medium** — detectable at first `compile_check`, but the tool should either rewrite the modifier or refuse. |
+| Suggested fix for next agent | When moving a member into a new top-level type with no base type, rewrite the member's modifier list: drop `override`/`virtual`/`abstract`, and keep `sealed` at class scope only. |
+
+### 9.4 `extract_type_preview` correctly refuses when captured state would stay on the source (PASS)
+| Field | Detail |
+|-------|--------|
+| Tool | `extract_type_preview` |
+| Reproduction | 1. `workspace_load`. 2. `extract_type_preview(typeName="InMemoryConversationRepository", memberNames=["AddEvidenceLinksAsync"], newTypeName="InMemoryEvidenceLinkStore", filePath=…\InMemoryConversationRepository.cs)`. |
+| Expected | Actionable refusal naming the referenced state. |
+| Actual (verbatim) | `"Invalid operation: Refusing to extract type 'InMemoryEvidenceLinkStore' from 'InMemoryConversationRepository': the selected members reference state that would remain on the source type, so the generated code would not compile. Either include the referenced members in the extraction or perform a manual redesign first. Details: Extracted member may reference 'ConcurrentDictionary<Guid, List<MessageEvidenceLink>> InMemoryConversationRepository._evidenceLinks' which remains on the original type 'InMemoryConversationRepository' and is not available in the new type.; Extracted member may reference 'lambda expression' which remains on the original type 'InMemoryConversationRepository' and is not available in the new type.."` |
+| Severity | **Not a bug** — PASS evidence for the refusal UX. Recorded so the next agent does not re-raise it. |
+| UX follow-up (low priority) | `memberNames=["AddEvidenceLinksAsync", "_evidenceLinks"]` still produced the same refusal — the tool did not acknowledge the field in the input. Either accept field names in `memberNames`, or error with "fields are not a supported member kind; refactor the field into a property before retrying". |
+
+### 9.5 `fix_all_preview` returns silent empty result for Info-severity diagnostics without a fix provider
+| Field | Detail |
+|-------|--------|
+| Tool | `fix_all_preview` |
+| Reproduction | `fix_all_preview(diagnosticId="IDE0130" | "IDE0290" | "IDE0008", scope="solution" | "project" | "document", …)` on a workspace where the relevant IDE/CA fix-provider assembly is not loaded. |
+| Expected | Either (a) a non-null `guidanceMessage` telling the caller "no code fix provider is loaded" (as happens on Warning-severity IDs), or (b) explicit `matchedCount` + `fixableCount` fields so the caller can distinguish "no matches" from "matches exist but no provider loaded". |
+| Actual | `{ previewToken:"", diagnosticId:"IDE0130", scope:"solution", fixedCount:0, changes:[], guidanceMessage:null }`. When the same tool is called with `CA1826` / `xUnit1051` instead, a helpful `guidanceMessage` IS produced. |
+| Observed (verbatim, Info vs Warning side-by-side) | `IDE0130 → "guidanceMessage":null`; `CA1826 → "guidanceMessage":"No code fix provider is loaded for diagnostic 'CA1826'. Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs."` |
+| Severity | **Medium** — confusing for agents: the silent path looks identical to "0 occurrences". |
+| Suggested fix for next agent | Emit the same `guidanceMessage` template on all severities when the diagnostic has occurrences but no registered fix provider. Additionally, consider surfacing `occurrenceCount` in the preview response regardless of fixability. |
+
+### 9.6 `bulk_replace_type` `scope=parameters` ignores generic arguments in implemented interfaces
+| Field | Detail |
+|-------|--------|
+| Tool | `bulk_replace_type_preview` / `bulk_replace_type_apply` |
+| Reproduction | 1. Extract `IDatabaseOptions` from `DatabaseOptions` (Phase 1c). 2. `bulk_replace_type_preview(oldTypeName="DatabaseOptions", newTypeName="IDatabaseOptions", scope="parameters")`. 3. Apply. 4. `compile_check`. |
+| Expected | Either (a) rewrite both the method parameter *and* the `IValidateOptions<DatabaseOptions>` generic argument so the class still correctly implements the interface contract, or (b) surface a warning in the preview (`warnings[]` is currently `null`) that the method signature will diverge from the interface. |
+| Actual | Only the parameter type is rewritten. The class still declares `IValidateOptions<DatabaseOptions>` but the `Validate` method now takes `IDatabaseOptions options`, which breaks the interface's exact-match method signature requirement. Workspace needed `git checkout` to recover. |
+| Severity | **Medium** — the tool faithfully did what `scope=parameters` suggests, but the result is almost always wrong in practice when the parameter type appears in the type's implemented-interface generic signature. |
+| Suggested fix for next agent | At minimum emit a `warnings[]` entry when `scope=parameters` touches a parameter whose declaring method overrides/implements a member whose base/interface signature uses the old type. Ideal fix: default scope for this case to `all` or refuse. |
+
+### 9.7 `extract_method_preview` produces output that violates project formatting
+| Field | Detail |
+|-------|--------|
+| Tool | `extract_method_preview` (and therefore `extract_method_apply` when the preview is applied) |
+| Reproduction | `extract_method_preview(filePath=…\AmbiguityDetector.cs, startLine=42, startColumn=9, endLine=46, endColumn=23, methodName="NormalizeQuestionWords")`. |
+| Expected | Output respects project `.editorconfig`: 4-space indent on the new method declaration, spaces around `=` at call site, preserved multi-line LINQ chain. |
+| Actual | Preview diff shows: `var words=NormalizeQuestionWords(questionText);` (no spaces around `=`); `private List<string>? NormalizeQuestionWords(string? questionText)` declared at column 1 with no class-scope indent; multi-line chain `.Split(...).Select(...).Where(...).ToList()` collapsed into a single long physical line. |
+| Observed (verbatim diff extract) | ``-        string normalized = questionText.Trim().ToLowerInvariant();`` → ``+        var words=NormalizeQuestionWords(questionText);``; and ``+private List<string>? NormalizeQuestionWords(string? questionText)`` with body on one line. |
+| Severity | **Medium** — compiles, but requires a follow-up `format_document_apply` to become clean. The preview diff is also misleading because the insertion indent is wrong, which makes reviews harder. |
+| Suggested fix for next agent | Run the generated method through the Roslyn `Formatter.Format` pass (same mechanism `format_document_preview` uses) before emitting the preview, and apply EndOfLine/indent rules from the nearest `.editorconfig`. Preserve original trivia for the extracted block (don't flatten multi-line method chains). |
+| Bonus finding | The nullable return type `List<string>?` is pessimistic — at the extracted call site `questionText` is non-null (checked by the method's own early return at line 35), yet the extracted method accepts `string? questionText`. Not a defect on its own, but it shows the extractor does not consider the caller's null-state narrowing. |
+
+### 9.8 `revert_last_apply` documented limitation interacts poorly with `extract_*_apply` (side-effect cleanup)
+| Field | Detail |
+|-------|--------|
+| Tool | `revert_last_apply` (stable, Phase 5e) |
+| Behaviour (per docs) | "Roslyn preview/apply operations … AND apply_text_edit / apply_multi_file_edit register for undo. File create/delete/move and project file mutations are not revertible." |
+| Observed | After `extract_type_apply`, `revert_last_apply` correctly restored the edited source file but left: (1) the two new `RemoveConversationExpiresAtUtcRollback.cs` files, and (2) the `<Compile Include>` mutation in the csproj. The session had to fall back to `git checkout` + `rm` to recover. |
+| Severity | **Documentation-vs-behaviour alignment** — the doc is accurate, but the practical effect is that `extract_type_apply` is effectively a non-revertible tool. |
+| Suggested fix for next agent | Either (a) make `extract_*_apply` stop mutating the project file and writing duplicate files (Bugs 9.1 & 9.2), at which point `revert_last_apply` would be sufficient, or (b) expand `revert_last_apply`'s slot to include a file-manifest + csproj-snapshot for any tool that touches those axes. |
+
+## 10. Improvement suggestions
+
+- `workspace_load` — when `workspaceWarningCount` / `workspaceErrorCount` are >0 on the initial load and `restoreHint` is non-null, consider an optional `autoRestore=true` parameter that runs `dotnet restore` and reloads automatically. Current session pattern is: load → see CS0246 avalanche → realise restore wasn't run → manually restore → reload.
+- `fix_all_preview` — return `occurrenceCount` alongside `fixedCount` so the caller can tell "0 occurrences" from "occurrences but no fix provider" (see §9.5).
+- `extract_*_apply` — include the pre-change csproj snapshot in the preview token so `revert_last_apply` can unwind project-file edits. Related: §9.8.
+- `extract_type_preview` — document whether `memberNames` accepts fields; either support or refuse with a clear message (§9.4 follow-up).
+- `bulk_replace_type_preview` — when `scope=parameters` touches a parameter whose declaring method is an interface/base-class implementation, emit a `warnings[]` entry (see §9.6).
+- All `*_preview` tools — ensure `changes[].unifiedDiff` enumerates every file that `*_apply` will modify (currently csproj changes are hidden; see §9.1, §4).
+- `extract_method_preview` — run generated code through `Formatter.Format` + `.editorconfig` before returning (see §9.7).
+- Cosmetic: on refusal messages, strip the trailing double-dot (`block scope..` should be `block scope.`). Seen on `extract_method_preview` error text.
+
+## 11. Known issue regression check
+
+> Phase 11 not executed. The prior audit file `20260413T180545Z_itchatbot_experimental-promotion.md` (against `1.12.0`) lists candidates but this run did not reproduce them systematically. Below are the items surfaced incidentally and the agent's best-effort status; treat as **unverified** until Phase 11 is re-run.
+
+| Source id / area | Summary | Status (this run) |
+|------------------|---------|--------------------|
+| prior-audit `extract_type_apply` row | Prior run marked `extract_type_apply` as `exercised-apply` with 5677 ms. This run shows **new** defects: csproj mutation + duplicate-file write + preserved-override. | **regression (new findings)** — see §9.1, §9.2, §9.3 |
+| prior-audit `extract_interface_apply` row | Prior run marked `extract_interface_apply` as `exercised-apply` with 5623 ms. This run shows **new** csproj-mutation defect. | **regression (new findings)** — see §9.1 |
+| prior-audit `revert_last_apply` row | Prior run marked it as `exercised` with positive and negative probes. This run shows it does not cover `extract_type_apply` side-effects (documented behaviour, but a practical gap). | **no change** — see §9.8 |
+| prior-audit `bulk_replace_type` row | Prior run used an "identity-replacement probe"; no issue reported. This run exposed the `scope=parameters` vs. implemented-interface gap. | **new finding** — see §9.6 |
+
+---
+
+## Hand-off notes for the next agent
+
+- The worktree `worktree-experimental-promotion-2026-04-15` was cleaned via `git checkout` + manual removal of `src/config/IDatabaseOptions.cs` and exited via `ExitWorktree(action="remove")` at the end of this session. The branch no longer exists.
+- To re-run Phase 1 reproductions: create a fresh disposable worktree, `workspace_load ITChatBot.sln`, `dotnet restore`, `workspace_reload`, then follow each §9 entry's "Reproduction" step.
+- The highest-leverage next step is fixing §9.1 (csproj mutation) — it unlocks `extract_interface_apply` and `extract_type_apply` for real use and for the remainder of this exercise. §9.2 and §9.3 also live in `extract_type_apply` and are likely the same code path.
+- The next run should execute Phases 2–11 in order. Phase 2 (file operations) should be straightforward; Phase 3 is partially `skipped-repo-shape` (no CPM); Phase 4 should exercise v1.17's `scaffold_test_batch_preview` token path; Phase 7c has four un-exercised v1.17/v1.18 additions that are the highest-value un-audited surface.

--- a/ai_docs/reports/20260422T143323Z_deep-review-rollup.md
+++ b/ai_docs/reports/20260422T143323Z_deep-review-rollup.md
@@ -1,0 +1,47 @@
+# Deep-review rollup
+
+## Scope
+- **Generated:** 20260422T143323Z
+- **Purpose:** Deep-review rollup
+- **Input audit count:** 5
+- **Output path:** ai_docs/reports/20260422T143323Z_deep-review-rollup.md
+
+## Input audits
+| Repo | Date | Client | Revision | Server | File |
+|------|------|--------|----------|--------|------|
+| firewallanalyzer | 2026-04-15 | Claude Code (Opus 4.6 / 1M context) with strict `PreToolUse` hook on `*_apply` | `9123671` on branch `audit/experimental-promotion-20260415` (disposable worktree of `main`) | `roslyn-mcp v1.18.0+172d3c5118178eae2664768ced630b38d9418309` (.NET 10.0.6, Roslyn 5.3.0.0) | ai_docs/audit-reports/20260415T140000Z_firewallanalyzer_experimental-promotion.md |
+| firewallanalyzer |  |  |  |  | ai_docs/audit-reports/20260413T154959Z_firewallanalyzer_mcp-server-audit.md |
+| itchatbot | 2026-04-15T14:04:03Z | Claude Code with native Roslyn MCP binding (`mcp__roslyn__*` tools) | worktree branch `worktree-experimental-promotion-2026-04-15` from `main` (commit `ee167149723cc2392c43715312f93371a631e063`) | `roslyn-mcp 1.18.0+172d3c5118178eae2664768ced630b38d9418309` | ai_docs/audit-reports/20260415T140403Z_itchatbot_experimental-promotion.md |
+| itchatbot |  |  |  |  | ai_docs/audit-reports/20260413T160052Z_itchatbot_mcp-server-audit.md |
+| networkdocumentation | 2026-04-15 (UTC 14:03:02Z start — 15:25:00Z finish) | Claude (Anthropic) via Roslyn MCP stdio | commit `8395fd8` on throwaway branch `exp-promotion-2026-04-15` | roslyn-mcp 1.18.0 (runtime .NET 10.0.6, Roslyn 5.3.0.0, Windows 10.0.26200) | ai_docs/audit-reports/20260415T140302Z_networkdocumentation_experimental-promotion.md |
+
+## Repo matrix coverage
+| Bucket | Covered | Evidence | Notes |
+|--------|---------|----------|-------|
+| Small or single-project repo | | | |
+| Multi-project repo with tests | | | |
+| DI-heavy repo | | | |
+| Source-generator repo | | | |
+| Central Package Management or multi-targeting repo | | | |
+| Large solution representative repo | | | |
+
+## Client coverage
+| Client | Full-surface | Notes |
+|--------|--------------|-------|
+| | | |
+
+## Deduped issues
+| Key | Severity | Evidence | Backlog action |
+|-----|----------|----------|----------------|
+| | | | |
+
+## Blocked-by-client summary
+- 
+
+## Candidate closures
+| Source id | Evidence | Notes |
+|-----------|----------|-------|
+| | | |
+
+## Backlog actions
+- 


### PR DESCRIPTION
Adds the remaining untracked \i_docs/audit-reports/*\ MCP audit + experimental promotion files and the \i_docs/reports/20260422T143323Z_deep-review-rollup.md\ rollup. \ng/verify-ai-docs.ps1\ clean.

Made with [Cursor](https://cursor.com)