### PR TITLE
fix(workspace): workspace_close when solution file is missing on disk

### DIFF
--- a/src/RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceExecutionGate.cs
@@ -42,7 +42,17 @@ public interface IWorkspaceExecutionGate
     /// <remarks>
     /// The action must not call another gate method against the same workspace id (no reentrance).
     /// </remarks>
-    Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct);
+    /// <param name="applyStalenessPolicy">
+    /// When <see langword="true"/> (default), stale workspaces may trigger an automatic reload
+    /// before the write runs. Set to <see langword="false"/> for <c>workspace_close</c> so the
+    /// session can be torn down even when the on-disk solution path is already gone (reload
+    /// would throw <see cref="System.IO.FileNotFoundException"/>).
+    /// </param>
+    Task<T> RunWriteAsync<T>(
+        string workspaceId,
+        Func<CancellationToken, Task<T>> action,
+        CancellationToken ct,
+        bool applyStalenessPolicy = true);
 
     /// <summary>
     /// Run an async action under the global <b>load gate</b>. Used by <c>workspace_load</c>,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -75,12 +75,16 @@ public static class WorkspaceTools
         // released before being removed from the registry.
         return gate.RunLoadGateAsync(async outerCt =>
         {
-            var json = await gate.RunWriteAsync(workspaceId, async innerCt =>
-            {
-                var closed = workspace.Close(workspaceId);
-                _ = NotifyResourcesChangedAsync(server);
-                return JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonDefaults.Indented);
-            }, outerCt).ConfigureAwait(false);
+            var json = await gate.RunWriteAsync(
+                workspaceId,
+                async innerCt =>
+                {
+                    var closed = workspace.Close(workspaceId);
+                    _ = NotifyResourcesChangedAsync(server);
+                    return JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonDefaults.Indented);
+                },
+                outerCt,
+                applyStalenessPolicy: false).ConfigureAwait(false);
             gate.RemoveGate(workspaceId);
             return json;
         }, ct);

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -64,12 +64,16 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
 
     public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
     {
-        return RunPerWorkspaceAsync(workspaceId, isWrite: false, action, ct);
+        return RunPerWorkspaceAsync(workspaceId, isWrite: false, applyStalenessPolicy: true, action, ct);
     }
 
-    public Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+    public Task<T> RunWriteAsync<T>(
+        string workspaceId,
+        Func<CancellationToken, Task<T>> action,
+        CancellationToken ct,
+        bool applyStalenessPolicy = true)
     {
-        return RunPerWorkspaceAsync(workspaceId, isWrite: true, action, ct);
+        return RunPerWorkspaceAsync(workspaceId, isWrite: true, applyStalenessPolicy, action, ct);
     }
 
     public async Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
@@ -133,6 +137,7 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     private async Task<T> RunPerWorkspaceAsync<T>(
         string workspaceId,
         bool isWrite,
+        bool applyStalenessPolicy,
         Func<CancellationToken, Task<T>> action,
         CancellationToken ct)
     {
@@ -160,7 +165,12 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
         // Item 1: stale-gate policy. Checked once per call, before the per-workspace lock is
         // acquired, so an auto-reload path runs under the same load gate as explicit
         // workspace_reload calls — the reload's own write-locking is handled by WorkspaceManager.
-        await ApplyStalenessPolicyAsync(workspaceId, linked).ConfigureAwait(false);
+        // workspace_close skips this: reloading requires the on-disk solution, which may already
+        // be deleted while the in-memory session is still registered (F21 / missing worktree).
+        if (applyStalenessPolicy)
+        {
+            await ApplyStalenessPolicyAsync(workspaceId, linked).ConfigureAwait(false);
+        }
 
         return await WithGlobalThrottle(async () =>
         {

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -165,8 +165,13 @@ public sealed class ToolDispatchTests
             return await action(linked.Token).ConfigureAwait(false);
         }
 
-        public async Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+        public async Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true)
         {
+            _ = applyStalenessPolicy;
             WriteCallCount++;
             LastWriteWorkspaceId = workspaceId;
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -466,6 +466,53 @@ public class WorkspaceExecutionGateTests
             "StaleReloadMs must also remain null when no reload completed.");
     }
 
+    /// <summary>
+    /// workspace-close-missing-solution-on-disk: closing must not run the stale auto-reload
+    /// preamble (reload requires the solution file on disk).
+    /// </summary>
+    [TestMethod]
+    public async Task RunWriteAsync_SkipStaleness_WhenStale_DoesNotInvokeReload()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+        manager.ReloadThrowsFileNotFound = true;
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        var ran = false;
+        await gate.RunWriteAsync(
+            WorkspaceA,
+            _ =>
+            {
+                ran = true;
+                return Task.FromResult(0);
+            },
+            CancellationToken.None,
+            applyStalenessPolicy: false).ConfigureAwait(false);
+
+        Assert.IsTrue(ran);
+        Assert.AreEqual(0, manager.ReloadCount, "Close-style writes must not auto-reload stale workspaces.");
+    }
+
+    [TestMethod]
+    public async Task RunWriteAsync_Default_WhenStaleAndReloadThrowsFileNotFound_Propagates()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+        manager.ReloadThrowsFileNotFound = true;
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        await Assert.ThrowsExactlyAsync<FileNotFoundException>(() =>
+            gate.RunWriteAsync(WorkspaceA, _ => Task.FromResult(0), CancellationToken.None)).ConfigureAwait(false);
+
+        Assert.AreEqual(1, manager.ReloadCount);
+    }
+
     private sealed class ConcurrencyTracker
     {
         private int _current;
@@ -497,6 +544,13 @@ public class WorkspaceExecutionGateTests
         /// </summary>
         public bool ReloadThrowsKeyNotFound { get; set; }
 
+        /// <summary>
+        /// When true, <see cref="ReloadAsync"/> increments <see cref="ReloadCount"/> and throws
+        /// <see cref="FileNotFoundException"/> — simulates a missing on-disk solution while the
+        /// in-memory session is still registered (<c>workspace-close-missing-solution-on-disk</c>).
+        /// </summary>
+        public bool ReloadThrowsFileNotFound { get; set; }
+
         public FakeGateWorkspaceManager(bool containsAny = true)
         {
             _containsAny = containsAny;
@@ -520,6 +574,14 @@ public class WorkspaceExecutionGateTests
             {
                 throw new KeyNotFoundException($"Workspace '{workspaceId}' was closed between the stale check and the reload attempt.");
             }
+
+            if (ReloadThrowsFileNotFound)
+            {
+                throw new FileNotFoundException(
+                    $"Workspace path was not found: {workspaceId}",
+                    workspaceId);
+            }
+
             ClearStaleFlag(workspaceId);
             return Task.FromResult(new WorkspaceStatusDto(
                 WorkspaceId: workspaceId,


### PR DESCRIPTION
## Summary
\workspace_close\ nested \RunWriteAsync\ previously ran the staleness gate's AutoReload path before \WorkspaceManager.Close\. When the session was stale and the original \.sln\ / \.slnx\ had been deleted, \ReloadAsync\ threw \FileNotFoundException\ from \ValidateWorkspacePath\, blocking teardown.

## Change
- Add optional \pplyStalenessPolicy\ to \IWorkspaceExecutionGate.RunWriteAsync\ (default \	rue\).
- \WorkspaceTools.CloseWorkspace\ passes \pplyStalenessPolicy: false\ so close never preflight-reloads.
- Unit tests for skip vs default behavior.

## Validation
- \WorkspaceExecutionGateTests\ filtered run: pass locally.
- \ng/verify-ai-docs.ps1\: pass.
- \ng/verify-release.ps1\: **not green in this agent environment** (isolated temp fixture / file copy failures and orphaned testhost locks also reproduced on unrelated branch); CI should be the merge gate.

Closes: workspace-close-missing-solution-on-disk
Initiative: workspace-close-missing-solution-on-disk