### PR TITLE
fix(validation): validate_workspace overallStatus without false compile-error (validate-workspace-overallstatus-false-positive)

### DIFF
--- a/src/RoslynMcp.Core/Models/CompileCheckDto.cs
+++ b/src/RoslynMcp.Core/Models/CompileCheckDto.cs
@@ -3,7 +3,9 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents the result of an in-memory compilation check without invoking dotnet build.
 /// </summary>
-/// <param name="Success">True when there are zero errors across the unfiltered total.</param>
+/// <param name="Success">True when there are zero errors, the run was not cancelled, and at least
+/// one project was evaluated (<c>CompletedProjects &gt; 0</c>). A vacuous result (e.g. zero
+/// projects after filtering) is <see langword="false"/> even when <see cref="ErrorCount"/> is 0.</param>
 /// <param name="ErrorCount">Total error count across the unfiltered solution (or filtered scope).</param>
 /// <param name="WarningCount">Total warning count across the unfiltered solution (or filtered scope).</param>
 /// <param name="TotalDiagnostics">Total diagnostics matching the filters before pagination is applied.</param>

--- a/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
@@ -65,4 +65,92 @@ public sealed class WorkspaceValidationOverallStatusTests
 
         Assert.AreEqual("compile-error", status);
     }
+
+    [TestMethod]
+    public void ComputeOverallStatus_TotalProjectsNonZero_ButNoProjectsCompleted_ZeroErrorCount_YieldsClean()
+    {
+        var compile = new CompileCheckDto(
+            Success: false,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            RestoreHint: null,
+            Cancelled: false,
+            CompletedProjects: 0,
+            TotalProjects: 3);
+
+        var status = WorkspaceValidationService.ComputeOverallStatus(
+            compile,
+            Array.Empty<DiagnosticDto>(),
+            null,
+            runTests: false);
+
+        Assert.AreEqual("clean", status, "incomplete / vacuous compile_check must not be compile-error with zero errors");
+    }
+
+    [TestMethod]
+    public void ComputeOverallStatus_CompilerErrorOnlyInMergedErrors_YieldsCompileError()
+    {
+        var compileClean = new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            Cancelled: false,
+            CompletedProjects: 1,
+            TotalProjects: 1);
+
+        var merged = new DiagnosticDto(
+            "CS0103", "x", "Error", "Compiler", "Y.cs", 2, 1, 2, 5);
+
+        var status = WorkspaceValidationService.ComputeOverallStatus(
+            compileClean,
+            [merged],
+            null,
+            runTests: false);
+
+        Assert.AreEqual("compile-error", status);
+    }
+
+    [TestMethod]
+    public void ComputeOverallStatus_NonCompilerErrorInMerge_YieldsAnalyzerError()
+    {
+        var compileClean = new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            Cancelled: false,
+            CompletedProjects: 1,
+            TotalProjects: 1);
+
+        var merged = new DiagnosticDto(
+            "CA1000", "x", "Error", "Design", "Z.cs", 1, 1, 1, 10);
+
+        var status = WorkspaceValidationService.ComputeOverallStatus(
+            compileClean,
+            [merged],
+            null,
+            runTests: false);
+
+        Assert.AreEqual("analyzer-error", status);
+    }
 }


### PR DESCRIPTION
## Summary
**Product fix** for \alidate_workspace\ false \compile-error\ is already on \main\ (PR #343). This PR completes the initiative by:
- Documenting accurate \CompileCheckDto.Success\ semantics (vacuous / no-project-completed vs real errors).
- Extending \WorkspaceValidationOverallStatusTests\ with merge-union cases: \TotalProjects>0\ with \CompletedProjects==0\, compiler errors only in the merged diagnostic list, and analyzer-only errors.

## Initiative
- **id:** \alidate-workspace-overallstatus-false-positive\
- Closes: \alidate-workspace-overallstatus-false-positive\ (orchestrator backlog row; row removal in reconcile PR)

## Verify
- \ng/verify-ai-docs.ps1\: **passed** (local)
- \WorkspaceValidationOverallStatusTests\: **5 passed** (local)
- Full \erify-release.ps1\ suite: local host shows many unrelated temp/fixture failures (also on unmodified \main\); CI is source of truth.

## shims
None.