### PR TITLE
fix(editing): preview_multi_file_edit syntax validation (F17 / parser recovery)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -62,7 +62,7 @@ public static class MultiFileEditTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Array of file edits. Each has filePath (string) and edits (array of TextEditDto with startLine, startColumn, endLine, endColumn, newText)")] FileEditsDto[] fileEdits,
         CancellationToken ct = default,
-        [Description("When false (default), each C# file is parsed after edits; syntax errors surface as an error response.")] bool skipSyntaxCheck = false)
+        [Description("When false (default), each C# file is parsed after edits; all non-hidden parse diagnostics and parser-recovered skipped text reject the preview. Set true only for intentional intermediate states.")] bool skipSyntaxCheck = false)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -503,16 +503,38 @@ public sealed class EditService : IEditService
     private static IReadOnlyList<TextEditSyntaxErrorDto> GetCSharpSyntaxErrors(SourceText newSourceText, string filePath)
     {
         var tree = CSharpSyntaxTree.ParseText(newSourceText, path: filePath);
+        var root = tree.GetRoot();
         var list = new List<TextEditSyntaxErrorDto>();
         foreach (var d in tree.GetDiagnostics())
         {
-            if (d.Severity != DiagnosticSeverity.Error)
+            if (d.Severity == DiagnosticSeverity.Hidden)
             {
                 continue;
             }
 
+            // #warning in source (CS1030) is a directive diagnostic, not a malformed-tree
+            // signal; blocking apply on it would false-positive for intentional warnings.
+            if (d is { Severity: DiagnosticSeverity.Warning, Id: "CS1030" })
+            {
+                continue;
+            }
+
+            // A standalone syntax tree's diagnostics are lexer/parser (plus directive)
+            // only. The prior filter (Error only) could accept invalid C# when Roslyn's
+            // recovery path reported only non-Error severities, or when skipped tokens did
+            // not re-surface on the whole tree. Treat other non-Hidden tree diagnostics
+            // and skipped text as a syntax check failure. Callers that need a deliberate
+            // intermediate can pass skipSyntaxCheck=true.
             var lineSpan = d.Location.GetLineSpan().StartLinePosition;
             list.Add(new TextEditSyntaxErrorDto(lineSpan.Line + 1, lineSpan.Character + 1, d.GetMessage()));
+        }
+
+        if (list.Count == 0 && root.ContainsSkippedText)
+        {
+            list.Add(new TextEditSyntaxErrorDto(
+                1,
+                1,
+                "C# source contains parser recovered text (skipped tokens) without a listable top-level tree diagnostic. Pass skipSyntaxCheck=true if the intermediate state is intentional."));
         }
 
         return list;

--- a/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression: <c>preview_multi_file_edit</c> with default <c>skipSyntaxCheck=false</c> must
+/// not emit a clean preview for parser-recovery shapes (Jellyfin F17: file-scoped namespace,
+/// line comment, stray brace) that previously passed <c>GetCSharpSyntaxErrors</c> when the
+/// tree only surfaced non-Error severities or skipped text without a severed Error diagnostic.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class PreviewMultiFileEditSyntaxRegressionTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task PreviewMultiFile_F17NamespaceCommentBrace_ThrowsWhenSyntaxCheckEnabled()
+    {
+        var edit = new EditService(
+            WorkspaceManager,
+            NullLogger<EditService>.Instance,
+            UndoService,
+            ChangeTracker,
+            PreviewStore,
+            CompileCheckService);
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var canonicalDog = Path.Combine(RepositoryRootPath, "samples", "SampleSolution", "SampleLib", "Dog.cs");
+        var firstLine = (await File.ReadAllTextAsync(canonicalDog, CancellationToken.None))
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries)[0];
+        var colAfterLine1 = firstLine.Length + 1;
+        var fileEdits = new[]
+        {
+            new FileEditsDto(
+                dogFilePath,
+                new[] { new TextEditDto(1, colAfterLine1, 1, colAfterLine1, "\n// F17\n{\n") }),
+        };
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        {
+            await edit.PreviewMultiFileTextEditsAsync(
+                workspaceId, fileEdits, CancellationToken.None, skipSyntaxCheck: false);
+        });
+        StringAssert.Contains(ex.Message, "preview_multi_file_edit", StringComparison.Ordinal);
+        StringAssert.Contains(ex.Message, "syntax", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [TestMethod]
+    public async Task PreviewMultiFile_F17Shape_SkipSyntaxCheck_StillProducesPreview()
+    {
+        var edit = new EditService(
+            WorkspaceManager,
+            NullLogger<EditService>.Instance,
+            UndoService,
+            ChangeTracker,
+            PreviewStore,
+            CompileCheckService);
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var canonicalDog = Path.Combine(RepositoryRootPath, "samples", "SampleSolution", "SampleLib", "Dog.cs");
+        var firstLine = (await File.ReadAllTextAsync(canonicalDog, CancellationToken.None))
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries)[0];
+        var colAfterLine1 = firstLine.Length + 1;
+        var fileEdits = new[]
+        {
+            new FileEditsDto(
+                dogFilePath,
+                new[] { new TextEditDto(1, colAfterLine1, 1, colAfterLine1, "\n// F17\n{\n") }),
+        };
+
+        var dto = await edit.PreviewMultiFileTextEditsAsync(
+            workspaceId, fileEdits, CancellationToken.None, skipSyntaxCheck: true);
+
+        Assert.IsFalse(string.IsNullOrEmpty(dto.PreviewToken));
+        Assert.IsTrue(dto.Changes?.Count > 0);
+    }
+}


### PR DESCRIPTION
## Summary
Tightens \GetCSharpSyntaxErrors\ so \preview_multi_file_edit\ with \skipSyntaxCheck=false\ does not silently accept invalid C# when Roslyn reports only non-Error parser diagnostics (e.g. Jellyfin F17-style namespace + comment + stray brace), and when the tree contains parser-recovered skipped text without a listable Error.

- Collect all non-hidden syntax-tree diagnostics; exclude \CS1030\ (\#warning\) so intentional source directives are not false positives.
- Backstop: \SyntaxNode.ContainsSkippedText\ when no listable diagnostics remain.
- Doc string on \preview_multi_file_edit\ \skipSyntaxCheck\ parameter.
- Regression tests (F17 insert on \samples/SampleSolution\ \Dog.cs\) using a test-local \EditService\ wired with \IPreviewStore\.

**Initiative:** \preview-multi-file-edit-silent-syntax-acceptance\ (backlog-sweep 2026-04-22).

**Validation:** \dotnet build\ Release; \PreviewMultiFileEditSyntaxRegressionTests\; \ng/verify-ai-docs.ps1\ passed. Full \ng/verify-release.ps1\ showed intermittent temp-fixture/temp-path failures in this environment (parallel \RoslynMcpTests\ copies under \%TEMP%\); CI should be the merge gate.

Refs: initiative \preview-multi-file-edit-silent-syntax-acceptance\ (row close via orchestrator reconcile).

Made with [Cursor](https://cursor.com)