### PR TITLE
fix(analysis): reduce find_duplicate_helpers framework glue false positives

### DIFF
--- a/src/RoslynMcp.Core/Services/DuplicateHelperAnalysisOptions.cs
+++ b/src/RoslynMcp.Core/Services/DuplicateHelperAnalysisOptions.cs
@@ -13,4 +13,14 @@ public sealed record DuplicateHelperAnalysisOptions
 
     /// <summary>Maximum number of hits to return. Defaults to 50.</summary>
     public int Limit { get; init; } = 50;
+
+    /// <summary>
+    /// When <see langword="true"/> (default), omit hits whose sole delegation target is declared
+    /// in a framework-glue namespace — thin forwarders to ASP.NET Core HTTP primitives
+    /// (<c>Microsoft.AspNetCore.Http.Results</c>, minimal-API shapes) or <c>System.Net.Http</c>
+    /// (<c>HttpClient</c> helpers). Those wrappers are often load-bearing (endpoint binding,
+    /// test harnesses) rather than redundant reinventions of BCL primitives. Set to
+    /// <see langword="false"/> to restore the pre-filter behavior.
+    /// </summary>
+    public bool ExcludeFrameworkWrappers { get; init; } = true;
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -205,13 +205,14 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicate_helpers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),
-     Description("Find private/internal static helpers (on `static class` hosts) whose body is a single ≤ 2-statement delegation to a method declared in a non-source assembly (BCL or referenced NuGet) — the \"reinvented `string.IsNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull`\" pattern that `find_unused_symbols` misses because the helper IS used locally. Conservative: expression-bodied forwarders and `{ return Target(...); }` bodies return Confidence=high; a single null-guard followed by the delegation returns Confidence=medium. Any body that calls the solution's own code (same-solution assembly), or does more than a pure re-wrap, is not flagged. Intentionally distinct from `find_duplicated_methods` (which buckets internal-to-internal structural duplicates); this tool targets internal-vs-referenced-library duplicates.")]
+     Description("Find private/internal static helpers (on `static class` hosts) whose body is a single ≤ 2-statement delegation to a method declared in a non-source assembly (BCL or referenced NuGet) — the \"reinvented `string.IsNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull`\" pattern that `find_unused_symbols` misses because the helper IS used locally. Conservative: expression-bodied forwarders and `{ return Target(...); }` bodies return Confidence=high; a single null-guard followed by the delegation returns Confidence=medium. By default, thin forwarders into ASP.NET Core HTTP (`Microsoft.AspNetCore.*`, e.g. `Results.Ok`) and `System.Net.Http` (`HttpClient` helpers) are omitted as framework glue rather than redundant primitives. Set `excludeFrameworkWrappers=false` to include those. Any body that calls the solution's own code (same-solution assembly), or does more than a pure re-wrap, is not flagged. Intentionally distinct from `find_duplicated_methods` (which buckets internal-to-internal structural duplicates); this tool targets internal-vs-referenced-library duplicates.")]
     public static Task<string> FindDuplicateHelpers(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
         [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
+        [Description("When true (default), omit delegations into Microsoft.AspNetCore.* and System.Net.Http* as framework glue (minimal APIs, HTTP client helpers).")] bool excludeFrameworkWrappers = true,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
@@ -221,7 +222,8 @@ public static class AdvancedAnalysisTools
                 new DuplicateHelperAnalysisOptions
                 {
                     ProjectFilter = projectFilter,
-                    Limit = limit
+                    Limit = limit,
+                    ExcludeFrameworkWrappers = excludeFrameworkWrappers
                 },
                 c);
             return JsonSerializer.Serialize(new { count = results.Count, helpers = results }, JsonDefaults.Indented);

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -569,7 +569,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                 {
                     if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
 
-                    var hit = TryClassifyHelperAsDuplicate(methodDecl, semanticModel, project, ct);
+                    var hit = TryClassifyHelperAsDuplicate(methodDecl, semanticModel, project, options, ct);
                     if (hit is not null) results.Add(hit);
                 }
             }
@@ -588,6 +588,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         MethodDeclarationSyntax methodDecl,
         SemanticModel semanticModel,
         Project project,
+        DuplicateHelperAnalysisOptions analysisOptions,
         CancellationToken ct)
     {
         if (semanticModel.GetDeclaredSymbol(methodDecl, ct) is not IMethodSymbol methodSymbol)
@@ -641,6 +642,9 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         if (SymbolEqualityComparer.Default.Equals(targetSymbol.ContainingType, hostType))
             return null;
 
+        if (IsFrameworkGlueWrapperTarget(targetSymbol, analysisOptions.ExcludeFrameworkWrappers))
+            return null;
+
         var lineSpan = methodDecl.Identifier.GetLocation().GetLineSpan();
         var confidence = statementCount <= 1 ? "high" : "medium";
 
@@ -654,6 +658,34 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             CanonicalTarget: targetSymbol.ToDisplayString(),
             CanonicalTargetAssembly: targetAssembly.Name,
             Confidence: confidence);
+    }
+
+    /// <summary>
+    /// Thin forwarders to ASP.NET Core HTTP and System.Net.Http API entry points are
+    /// usually intentional (minimal APIs, test extensions), not reinvented primitive helpers.
+    /// </summary>
+    private static bool IsFrameworkGlueWrapperTarget(IMethodSymbol targetSymbol, bool excludeFrameworkWrappers)
+    {
+        if (!excludeFrameworkWrappers) return false;
+
+        for (var ns = targetSymbol.ContainingNamespace;
+             ns is { IsGlobalNamespace: false };
+             ns = ns.ContainingNamespace)
+        {
+            var display = ns.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            if (display.StartsWith("global::", StringComparison.Ordinal))
+                display = display["global::".Length..];
+
+            if (display.StartsWith("Microsoft.AspNetCore.", StringComparison.Ordinal)
+                || string.Equals(display, "Microsoft.AspNetCore", StringComparison.Ordinal))
+                return true;
+
+            // System.Net.Http, System.Net.Http.Headers, System.Net.Http.Json, etc.
+            if (display.StartsWith("System.Net.Http", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -222,6 +223,68 @@ public sealed class DuplicateHelperDetectionTests
     }
 
     [TestMethod]
+    public async Task FindDuplicateHelpers_HttpClientForwarder_IsNotDetected_ByDefault()
+    {
+        const string source = """
+            using System.Net.Http;
+            using System.Threading.Tasks;
+            namespace Sample;
+            internal static class IntegrationTestHttpExtensions
+            {
+                public static Task<HttpResponseMessage> GetRelativeAsync(HttpClient client, string uri) => client.GetAsync(uri);
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(
+            source,
+            MetadataReference.CreateFromFile(typeof(HttpClient).Assembly.Location));
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "HttpClient delegation helpers should be filtered as framework glue by default.");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicateHelpers_HttpClientForwarder_IsDetected_WhenExclusionOff()
+    {
+        const string source = """
+            using System.Net.Http;
+            using System.Threading.Tasks;
+            namespace Sample;
+            internal static class IntegrationTestHttpExtensions
+            {
+                public static Task<HttpResponseMessage> GetRelativeAsync(HttpClient client, string uri) => client.GetAsync(uri);
+            }
+            """;
+
+        var compileErrors = await GetCompilationErrorsAsync(
+            source,
+            MetadataReference.CreateFromFile(typeof(HttpClient).Assembly.Location));
+        Assert.AreEqual(
+            string.Empty,
+            compileErrors,
+            "In-memory fixture must compile so GetSymbolInfo binds HttpClient.GetAsync.");
+
+        var analyzer = BuildAnalyzerWithSource(
+            source,
+            MetadataReference.CreateFromFile(typeof(HttpClient).Assembly.Location));
+
+        var hits = await analyzer.FindDuplicateHelpersAsync(
+            WorkspaceId,
+            new DuplicateHelperAnalysisOptions { ExcludeFrameworkWrappers = false },
+            default);
+
+        Assert.AreEqual(1, hits.Count, "Opt-out should surface System.Net.Http glue forwarders again.");
+        Assert.IsTrue(
+            hits[0].CanonicalTarget.Contains("GetAsync", StringComparison.Ordinal),
+            $"Expected HttpClient.GetAsync; got '{hits[0].CanonicalTarget}'.");
+    }
+
+    [TestMethod]
     public async Task FindDuplicateHelpers_LimitCapsResults()
     {
         // Confirm the `Limit` option clamps the result count even when more hits exist.
@@ -251,8 +314,44 @@ public sealed class DuplicateHelperDetectionTests
     /// calls to <see cref="System.String"/> in <c>System.Private.CoreLib</c> for the
     /// detector's non-source-assembly check to fire.
     /// </summary>
-    private static UnusedCodeAnalyzer BuildAnalyzerWithSource(string source)
+    private static UnusedCodeAnalyzer BuildAnalyzerWithSource(string source, params MetadataReference[] additionalMetadataReferences)
     {
+        var workspace = CreateAdhocWorkspace(source, additionalMetadataReferences);
+        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
+        var cache = new CompilationCache(wsManager);
+        return new UnusedCodeAnalyzer(
+            wsManager,
+            cache,
+            NullLogger<UnusedCodeAnalyzer>.Instance);
+    }
+
+    private static AdhocWorkspace CreateAdhocWorkspace(string source, params MetadataReference[] additionalMetadataReferences)
+    {
+        var metadataRefs = new List<MetadataReference>(1 + additionalMetadataReferences.Length)
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+        };
+
+        if (additionalMetadataReferences.Length > 0)
+        {
+            var coreDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            // System.Net.Http (and other satellite facades) need facades next to System.Private.CoreLib
+            // in lightweight AdhocWorkspace fixtures (matches CS0012 chains in real solutions).
+            foreach (var facade in new[]
+                     {
+                         "System.Runtime.dll",
+                         "System.Private.Uri.dll",
+                         "System.Net.Primitives.dll",
+                     })
+            {
+                var path = Path.Combine(coreDir, facade);
+                if (File.Exists(path))
+                    metadataRefs.Add(MetadataReference.CreateFromFile(path));
+            }
+        }
+
+        metadataRefs.AddRange(additionalMetadataReferences);
+
         var workspace = new AdhocWorkspace();
         var projectId = ProjectId.CreateNewId();
         var projectInfo = ProjectInfo.Create(
@@ -263,10 +362,7 @@ public sealed class DuplicateHelperDetectionTests
             language: LanguageNames.CSharp,
             filePath: Path.Combine(Path.GetTempPath(), "TestAsm.csproj"),
             compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-            metadataReferences:
-            [
-                MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
-            ]);
+            metadataReferences: metadataRefs.ToArray());
         workspace.AddProject(projectInfo);
 
         var docId = DocumentId.CreateNewId(projectId);
@@ -282,12 +378,16 @@ public sealed class DuplicateHelperDetectionTests
                     VersionStamp.Create(),
                     fullPath))));
 
-        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
-        var cache = new CompilationCache(wsManager);
-        return new UnusedCodeAnalyzer(
-            wsManager,
-            cache,
-            NullLogger<UnusedCodeAnalyzer>.Instance);
+        return workspace;
+    }
+
+    private static async Task<string> GetCompilationErrorsAsync(string source, params MetadataReference[] additionalMetadataReferences)
+    {
+        var workspace = CreateAdhocWorkspace(source, additionalMetadataReferences);
+        var project = workspace.CurrentSolution.Projects.First();
+        var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
+        var errors = compilation!.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        return errors.Length == 0 ? string.Empty : string.Join(Environment.NewLine, errors.Select(d => d.ToString()));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Thin static forwarders into \Microsoft.AspNetCore.*\ (minimal API / \Results.*\ shapes) and \System.Net.Http*\ (\HttpClient\ helpers) are usually load-bearing, not redundant BCL reinventions. This change skips them by default and adds MCP opt-out.

## Changes
- \DuplicateHelperAnalysisOptions.ExcludeFrameworkWrappers\ (default \	rue\)
- \UnusedCodeAnalyzer\: namespace walk for delegation targets
- \ind_duplicate_helpers\: \xcludeFrameworkWrappers\ parameter + tool description
- Tests: HttpClient forwarder excluded by default; \ExcludeFrameworkWrappers=false\ restores hit; AdhocWorkspace fixture adds facade refs when binding \System.Net.Http\

## Validation
- \./eng/verify-release.ps1 -Configuration Release\
- \./eng/verify-ai-docs.ps1\

Closes: find-duplicate-helpers-framework-wrapper-false-positive

Made with [Cursor](https://cursor.com)