### PR TITLE
chore: add CHANGELOG.d fragments for sweep #349, #345, #350

### DIFF
--- a/changelog.d/find-duplicate-helpers-framework-wrapper-false-positive.md
+++ b/changelog.d/find-duplicate-helpers-framework-wrapper-false-positive.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_duplicate_helpers` false positives for thin `System.*` / `Microsoft.*` single-forwarder helpers (minimal API, `HttpClient` helpers, etc.): new `DuplicateHelperAnalysisOptions.ExcludeFrameworkWrappers` (default `true`), optional `excludeFrameworkWrappers` on the tool, and matching logic in `UnusedCodeAnalyzer`. Closes `find-duplicate-helpers-framework-wrapper-false-positive` (PR #350).

--- a/changelog.d/preview-multi-file-edit-silent-syntax-acceptance.md
+++ b/changelog.d/preview-multi-file-edit-silent-syntax-acceptance.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `preview_multi_file_edit` now rejects edits that leave invalid C# when `skipSyntaxCheck=false` (F17-style namespace / trivia cases where the parser previously recovered without surfacing errors). Tightens `EditService` syntax validation; adds `PreviewMultiFileEditSyntaxRegressionTests`; tool description aligned in `MultiFileEditTools`. Closes `preview-multi-file-edit-silent-syntax-acceptance` (PR #349).

--- a/changelog.d/workspace-close-missing-solution-on-disk.md
+++ b/changelog.d/workspace-close-missing-solution-on-disk.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_close` no longer fails with `FileNotFoundException` when the on-disk solution file was deleted but the session is still registered — `RunWriteAsync` can skip the staleness auto-reload preflight on close via `applyStalenessPolicy` on `IWorkspaceExecutionGate`, and `CloseWorkspace` passes that so teardown does not re-open a missing path. Closes `workspace-close-missing-solution-on-disk` (PR #345).


### PR DESCRIPTION
Adds the three per-row changelog.d files that were missing for already-shipped backlog initiatives so /bump can consume them at the next release cut.

- preview-multi-file-edit-silent-syntax-acceptance (PR #349)
- workspace-close-missing-solution-on-disk (PR #345)
- ind-duplicate-helpers-framework-wrapper-false-positive (PR #350)


Made with [Cursor](https://cursor.com)