### PR TITLE
refactor: split scripting and apply orchestration helpers

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -921,137 +921,220 @@ public sealed class RefactoringService : IRefactoringService
         {
             foreach (var projectChange in solutionChanges.GetProjectChanges())
             {
-                await PersistProjectReferenceChangesAsync(currentSolution, modifiedSolution, projectChange, appliedFiles, ct).ConfigureAwait(false);
-
-                // Snapshot csproj BEFORE we write any new files (the csproj itself is
-                // untouched on disk at this point; capture its canonical bytes).
-                var addedDocuments = projectChange.GetAddedDocuments().ToList();
-                if (addedDocuments.Count > 0)
-                {
-                    var project = modifiedSolution.GetProject(projectChange.ProjectId);
-                    if (project?.FilePath is not null
-                        && ProjectMetadataParser.IsSdkStyleWithDefaultCompileItems(project.FilePath, _logger)
-                        && !sdkProjectCsprojSnapshots.ContainsKey(project.FilePath))
-                    {
-                        var csprojBytes = await File.ReadAllTextAsync(project.FilePath, ct).ConfigureAwait(false);
-                        sdkProjectCsprojSnapshots[project.FilePath] = csprojBytes;
-                    }
-                }
-
-                foreach (var documentId in addedDocuments)
-                {
-                    var document = modifiedSolution.GetDocument(documentId);
-                    if (document?.FilePath is null)
-                    {
-                        continue;
-                    }
-
-                    var directory = Path.GetDirectoryName(document.FilePath);
-                    if (!string.IsNullOrWhiteSpace(directory))
-                    {
-                        Directory.CreateDirectory(directory);
-                    }
-
-                    var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
-                    await File.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
-                    appliedFiles.Add(document.FilePath);
-                }
-
-                foreach (var documentId in projectChange.GetChangedDocuments())
-                {
-                    var document = modifiedSolution.GetDocument(documentId);
-                    if (document?.FilePath is null)
-                    {
-                        continue;
-                    }
-
-                    var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
-                    await File.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
-                    appliedFiles.Add(document.FilePath);
-                }
-
-                foreach (var documentId in projectChange.GetRemovedDocuments())
-                {
-                    var document = currentSolution.GetDocument(documentId);
-                    if (document?.FilePath is null)
-                    {
-                        continue;
-                    }
-
-                    if (File.Exists(document.FilePath))
-                    {
-                        File.Delete(document.FilePath);
-                    }
-
-                    appliedFiles.Add(document.FilePath);
-                }
+                await PersistProjectDocumentChangesAsync(
+                    currentSolution,
+                    modifiedSolution,
+                    projectChange,
+                    sdkProjectCsprojSnapshots,
+                    appliedFiles,
+                    ct).ConfigureAwait(false);
             }
 
-            // scaffold-type-apply-perf: previously every document add/remove triggered a full
-            // workspace reload (~10 s on Jellyfin). Try the in-memory TryApplyChanges path
-            // first — MSBuildWorkspace supports added/removed/changed documents — and only
-            // fall back to ReloadAsync if the workspace rejects the change. TryApplyChanges
-            // bumps WorkspaceSession.Version so per-version caches invalidate correctly.
-            var applied = _workspace.TryApplyChanges(workspaceId, modifiedSolution);
-
-            // Item #5 — re-apply csproj snapshots for SDK-style projects, undoing
-            // any <Compile Include=…/> injection TryApplyChanges wrote to disk. This
-            // runs whether TryApplyChanges succeeded or failed: on failure we'll
-            // ReloadAsync immediately after, and having the csproj back to its
-            // original bytes ensures the reloaded in-memory workspace matches the
-            // pre-apply csproj (the new file is discovered via the SDK glob).
-            foreach (var (csprojPath, originalContent) in sdkProjectCsprojSnapshots)
-            {
-                try
-                {
-                    var currentContent = await File.ReadAllTextAsync(csprojPath, ct).ConfigureAwait(false);
-                    if (!string.Equals(currentContent, originalContent, StringComparison.Ordinal))
-                    {
-                        await File.WriteAllTextAsync(csprojPath, originalContent, ct).ConfigureAwait(false);
-                        _logger.LogDebug(
-                            "Item #5: restored SDK-style csproj {Path} after TryApplyChanges injected an explicit <Compile> item (default glob will pick up the new file on next reload).",
-                            csprojPath);
-                    }
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    // Rare on the apply path since we just wrote sibling files in the same
-                    // directory, but a restore failure here does not invalidate the apply
-                    // itself — the duplicate-Compile error surfaces only on the NEXT reload,
-                    // which the caller will see clearly. Log and continue.
-                    _logger.LogWarning(ex,
-                        "Item #5: failed to restore SDK-style csproj snapshot for {Path}; the project may show a duplicate-<Compile> build error until manually edited.",
-                        csprojPath);
-                }
-            }
-
-            // csproj-reserialization-msbuildworkspace (P2) — second pass, whole-workspace scope.
-            // For every csproj we snapshotted before TryApplyChanges, compare current on-disk bytes
-            // against the snapshot; if the XML is semantically identical (only trivia differs),
-            // restore the snapshot bytes. If semantically different (MSBuild wrote a legitimate
-            // change — new PackageReference, property edit, etc.), keep the new bytes.
-            //
-            // Skip csprojs Item #5 already restored: they're byte-identical by definition.
-            await CsprojSemanticEquality.RestoreTriviaOnlyDriftAsync(
+            await ApplyDocumentSetChangesAsync(
+                workspaceId,
+                modifiedSolution,
+                sdkProjectCsprojSnapshots,
                 allCsprojSnapshots,
-                sdkProjectCsprojSnapshots.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase),
-                _logger,
-                operationTag: "csproj-reserialization-msbuildworkspace",
                 ct).ConfigureAwait(false);
 
-            if (!applied)
-            {
-                _logger.LogInformation(
-                    "TryApplyChanges rejected document-set changes for {WorkspaceId}; falling back to full ReloadAsync.",
-                    workspaceId);
-                await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
-            }
             return (true, appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList());
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
             _logger.LogWarning(ex, "Failed to persist document set changes for workspace {WorkspaceId}", workspaceId);
             return (false, []);
+        }
+    }
+
+    private async Task PersistProjectDocumentChangesAsync(
+        Solution currentSolution,
+        Solution modifiedSolution,
+        ProjectChanges projectChange,
+        Dictionary<string, string> sdkProjectCsprojSnapshots,
+        List<string> appliedFiles,
+        CancellationToken ct)
+    {
+        await PersistProjectReferenceChangesAsync(currentSolution, modifiedSolution, projectChange, appliedFiles, ct).ConfigureAwait(false);
+
+        var addedDocuments = projectChange.GetAddedDocuments().ToList();
+        await SnapshotSdkProjectCsprojAsync(
+            modifiedSolution,
+            projectChange.ProjectId,
+            addedDocuments.Count > 0,
+            sdkProjectCsprojSnapshots,
+            ct).ConfigureAwait(false);
+
+        await PersistAddedDocumentsAsync(modifiedSolution, addedDocuments, appliedFiles, ct).ConfigureAwait(false);
+        await PersistChangedDocumentsAsync(modifiedSolution, projectChange.GetChangedDocuments(), appliedFiles, ct).ConfigureAwait(false);
+        PersistRemovedDocuments(currentSolution, projectChange.GetRemovedDocuments(), appliedFiles);
+    }
+
+    private async Task SnapshotSdkProjectCsprojAsync(
+        Solution modifiedSolution,
+        ProjectId projectId,
+        bool hasAddedDocuments,
+        Dictionary<string, string> sdkProjectCsprojSnapshots,
+        CancellationToken ct)
+    {
+        if (!hasAddedDocuments)
+        {
+            return;
+        }
+
+        var project = modifiedSolution.GetProject(projectId);
+        if (project?.FilePath is null
+            || sdkProjectCsprojSnapshots.ContainsKey(project.FilePath)
+            || !ProjectMetadataParser.IsSdkStyleWithDefaultCompileItems(project.FilePath, _logger))
+        {
+            return;
+        }
+
+        var csprojBytes = await File.ReadAllTextAsync(project.FilePath, ct).ConfigureAwait(false);
+        sdkProjectCsprojSnapshots[project.FilePath] = csprojBytes;
+    }
+
+    private static async Task PersistAddedDocumentsAsync(
+        Solution modifiedSolution,
+        IReadOnlyCollection<DocumentId> addedDocuments,
+        List<string> appliedFiles,
+        CancellationToken ct)
+    {
+        foreach (var documentId in addedDocuments)
+        {
+            var document = modifiedSolution.GetDocument(documentId);
+            if (document?.FilePath is null)
+            {
+                continue;
+            }
+
+            var directory = Path.GetDirectoryName(document.FilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+            await File.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
+            appliedFiles.Add(document.FilePath);
+        }
+    }
+
+    private static async Task PersistChangedDocumentsAsync(
+        Solution modifiedSolution,
+        IEnumerable<DocumentId> changedDocuments,
+        List<string> appliedFiles,
+        CancellationToken ct)
+    {
+        foreach (var documentId in changedDocuments)
+        {
+            var document = modifiedSolution.GetDocument(documentId);
+            if (document?.FilePath is null)
+            {
+                continue;
+            }
+
+            var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+            await File.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
+            appliedFiles.Add(document.FilePath);
+        }
+    }
+
+    private static void PersistRemovedDocuments(
+        Solution currentSolution,
+        IEnumerable<DocumentId> removedDocuments,
+        List<string> appliedFiles)
+    {
+        foreach (var documentId in removedDocuments)
+        {
+            var document = currentSolution.GetDocument(documentId);
+            if (document?.FilePath is null)
+            {
+                continue;
+            }
+
+            if (File.Exists(document.FilePath))
+            {
+                File.Delete(document.FilePath);
+            }
+
+            appliedFiles.Add(document.FilePath);
+        }
+    }
+
+    private async Task ApplyDocumentSetChangesAsync(
+        string workspaceId,
+        Solution modifiedSolution,
+        Dictionary<string, string> sdkProjectCsprojSnapshots,
+        IReadOnlyDictionary<string, string> allCsprojSnapshots,
+        CancellationToken ct)
+    {
+        // scaffold-type-apply-perf: previously every document add/remove triggered a full
+        // workspace reload (~10 s on Jellyfin). Try the in-memory TryApplyChanges path
+        // first — MSBuildWorkspace supports added/removed/changed documents — and only
+        // fall back to ReloadAsync if the workspace rejects the change. TryApplyChanges
+        // bumps WorkspaceSession.Version so per-version caches invalidate correctly.
+        var applied = _workspace.TryApplyChanges(workspaceId, modifiedSolution);
+
+        await RestoreSdkProjectSnapshotsAsync(sdkProjectCsprojSnapshots, ct).ConfigureAwait(false);
+
+        // csproj-reserialization-msbuildworkspace (P2) — second pass, whole-workspace scope.
+        // For every csproj we snapshotted before TryApplyChanges, compare current on-disk bytes
+        // against the snapshot; if the XML is semantically identical (only trivia differs),
+        // restore the snapshot bytes. If semantically different (MSBuild wrote a legitimate
+        // change — new PackageReference, property edit, etc.), keep the new bytes.
+        //
+        // Skip csprojs Item #5 already restored: they're byte-identical by definition.
+        await CsprojSemanticEquality.RestoreTriviaOnlyDriftAsync(
+            allCsprojSnapshots,
+            sdkProjectCsprojSnapshots.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase),
+            _logger,
+            operationTag: "csproj-reserialization-msbuildworkspace",
+            ct).ConfigureAwait(false);
+
+        if (applied)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "TryApplyChanges rejected document-set changes for {WorkspaceId}; falling back to full ReloadAsync.",
+            workspaceId);
+        await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
+    }
+
+    private async Task RestoreSdkProjectSnapshotsAsync(
+        Dictionary<string, string> sdkProjectCsprojSnapshots,
+        CancellationToken ct)
+    {
+        // Item #5 — re-apply csproj snapshots for SDK-style projects, undoing
+        // any <Compile Include=…/> injection TryApplyChanges wrote to disk. This
+        // runs whether TryApplyChanges succeeded or failed: on failure we'll
+        // ReloadAsync immediately after, and having the csproj back to its
+        // original bytes ensures the reloaded in-memory workspace matches the
+        // pre-apply csproj (the new file is discovered via the SDK glob).
+        foreach (var (csprojPath, originalContent) in sdkProjectCsprojSnapshots)
+        {
+            try
+            {
+                var currentContent = await File.ReadAllTextAsync(csprojPath, ct).ConfigureAwait(false);
+                if (!string.Equals(currentContent, originalContent, StringComparison.Ordinal))
+                {
+                    await File.WriteAllTextAsync(csprojPath, originalContent, ct).ConfigureAwait(false);
+                    _logger.LogDebug(
+                        "Item #5: restored SDK-style csproj {Path} after TryApplyChanges injected an explicit <Compile> item (default glob will pick up the new file on next reload).",
+                        csprojPath);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Rare on the apply path since we just wrote sibling files in the same
+                // directory, but a restore failure here does not invalidate the apply
+                // itself — the duplicate-Compile error surfaces only on the NEXT reload,
+                // which the caller will see clearly. Log and continue.
+                _logger.LogWarning(ex,
+                    "Item #5: failed to restore SDK-style csproj snapshot for {Path}; the project may show a duplicate-<Compile> build error until manually edited.",
+                    csprojPath);
+            }
         }
     }
 

--- a/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
@@ -93,7 +93,10 @@ public sealed class ScriptingService : IScriptingService
         var heartbeatInterval = TimeSpan.FromMilliseconds(Math.Max(100, _options.HeartbeatIntervalMs));
 
         var capacityError = await TryAcquireCapacityAsync(effectiveTimeoutSeconds, ct).ConfigureAwait(false);
-        if (capacityError is not null) return capacityError;
+        if (capacityError is not null)
+        {
+            return capacityError;
+        }
 
         Interlocked.Increment(ref _activeEvaluations);
 
@@ -107,22 +110,18 @@ public sealed class ScriptingService : IScriptingService
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(budget);
 
-        var heartbeatCount = 0;
-        var slowWarningEmitted = false;
         Timer? heartbeatTimer = null;
         Timer? deadlineTimer = null;
+        var runState = new ScriptRunState();
 
         // Signaled by EXACTLY ONE of: the worker thread (success/error/cancel) or the deadline timer.
         // RunContinuationsAsynchronously ensures the awaiting frame is not invoked inline on the
         // worker thread or the timer thread.
-        var completion = new TaskCompletionSource<ScriptOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
-        long workerFinished = 0;
-        long slotReleased = 0;
-        long abandonedFlag = 0;
+        var completion = CreateCompletionSource();
 
         void ReleaseSlotOnce()
         {
-            if (Interlocked.Exchange(ref slotReleased, 1) == 0)
+            if (Interlocked.Exchange(ref runState.SlotReleased, 1) == 0)
             {
                 Interlocked.Decrement(ref _activeEvaluations);
                 try { _concurrencyGate.Release(); }
@@ -133,119 +132,32 @@ public sealed class ScriptingService : IScriptingService
 
         try
         {
-            // FLAG-5C: dedicated background thread, NOT a thread-pool thread.
-            var workerThreadName = $"roslyn-mcp.script.{Guid.NewGuid():N}";
-            if (workerThreadName.Length > 32) workerThreadName = workerThreadName[..32];
-            var workerThread = new Thread(() =>
-            {
-                ScriptOutcome outcome;
-                try
-                {
-                    var result = CSharpScript
-                        .EvaluateAsync<object?>(code, scriptOptions, cancellationToken: timeoutCts.Token)
-                        .GetAwaiter().GetResult();
-                    outcome = ScriptOutcome.Success(result);
-                }
-                catch (CompilationErrorException cex)
-                {
-                    outcome = ScriptOutcome.CompilationFailure(cex);
-                }
-                catch (OperationCanceledException)
-                {
-                    outcome = ScriptOutcome.TimedOut();
-                }
-                catch (Exception ex)
-                {
-                    outcome = ScriptOutcome.Runtime(ex);
-                }
-
-                Interlocked.Exchange(ref workerFinished, 1);
-
-                // If the worker was already declared abandoned by the deadline path, recover the
-                // abandoned counter. Otherwise signal completion normally.
-                if (Interlocked.Read(ref abandonedFlag) == 1)
-                {
-                    Interlocked.Decrement(ref _abandonedEvaluations);
-                }
-                else
-                {
-                    completion.TrySetResult(outcome);
-                }
-            })
-            {
-                IsBackground = true,
-                Name = workerThreadName,
-            };
-            workerThread.Start();
-
-            // Wall-clock hard deadline. Timer fires on a thread-pool thread, but TrySetResult
-            // is non-blocking and the awaiting frame uses RunContinuationsAsynchronously so the
-            // continuation runs on a fresh thread-pool thread, never inline on the timer thread.
-            deadlineTimer = new Timer(
-                _ => completion.TrySetResult(ScriptOutcome.HardDeadline()),
-                state: null,
-                dueTime: TimeSpan.FromSeconds(hardDeadlineSeconds),
-                period: Timeout.InfiniteTimeSpan);
-
-            // Heartbeat is also Timer-based so its tear-down is sync (timer.Dispose).
-            heartbeatTimer = new Timer(
-                _ =>
-                {
-                    var index = Interlocked.Increment(ref heartbeatCount);
-                    var elapsed = sw.Elapsed;
-                    onProgress?.Invoke(new ScriptEvaluationProgress(elapsed, budget, index));
-                    if (index == 1)
-                    {
-                        _logger.LogInformation(
-                            "evaluate_csharp: Roslyn script evaluation in progress (budget {BudgetSeconds}s, heartbeat every {HeartbeatMs}ms)",
-                            effectiveTimeoutSeconds,
-                            _options.HeartbeatIntervalMs);
-                    }
-                    if (!slowWarningEmitted && elapsed.TotalSeconds >= _options.StuckWarningSeconds)
-                    {
-                        slowWarningEmitted = true;
-                        _logger.LogWarning(
-                            "evaluate_csharp: still running after {ElapsedSeconds:F1}s — clients often show a static \"Evaluating C#\" step here; " +
-                            "large compile or synchronous script work may continue until timeout ({BudgetSeconds}s).",
-                            elapsed.TotalSeconds,
-                            effectiveTimeoutSeconds);
-                    }
-                },
-                state: null,
-                dueTime: heartbeatInterval,
-                period: heartbeatInterval);
+            var workerThread = StartWorkerThread(code, scriptOptions, timeoutCts.Token, completion, runState);
+            deadlineTimer = CreateDeadlineTimer(completion, hardDeadlineSeconds);
+            heartbeatTimer = CreateHeartbeatTimer(
+                onProgress,
+                sw,
+                budget,
+                effectiveTimeoutSeconds,
+                heartbeatInterval,
+                runState);
 
             // Outer cancellation propagation: if the caller cancels (e.g. MCP request budget),
             // surface OperationCanceledException promptly. Worker thread is then abandoned.
-            using var ctRegistration = ct.Register(static state =>
-            {
-                var tcs = (TaskCompletionSource<ScriptOutcome>)state!;
-                tcs.TrySetResult(ScriptOutcome.OuterCancelled());
-            }, completion);
+            using var ctRegistration = RegisterOuterCancellation(ct, completion);
 
             var raceOutcome = await completion.Task.ConfigureAwait(false);
             sw.Stop();
-
-            // Outer cancellation: surface as OperationCanceledException; mark worker abandoned.
-            if (raceOutcome.Kind == ScriptOutcomeKind.OuterCancelled)
-            {
-                MarkAbandonedIfWorkerStillRunning(timeoutCts, ref workerFinished, ref abandonedFlag);
-                ct.ThrowIfCancellationRequested();
-            }
-
-            // Hard deadline path — Roslyn never finished. Mark thread abandoned and return.
-            if (raceOutcome.Kind == ScriptOutcomeKind.HardDeadline)
-            {
-                if (MarkAbandonedIfWorkerStillRunning(timeoutCts, ref workerFinished, ref abandonedFlag))
-                {
-                    LogHardDeadlineCritical(workerThread.Name, hardDeadlineSeconds, effectiveTimeoutSeconds, graceSeconds);
-                }
-
-                return BuildHardDeadlineDto(sw, heartbeatCount, hardDeadlineSeconds, effectiveTimeoutSeconds, graceSeconds);
-            }
-
-            // Worker finished first — translate the outcome.
-            return BuildOutcomeDto(raceOutcome, sw, heartbeatCount, effectiveTimeoutSeconds);
+            return FinalizeEvaluation(
+                raceOutcome,
+                sw,
+                workerThread.Name,
+                runState,
+                hardDeadlineSeconds,
+                effectiveTimeoutSeconds,
+                graceSeconds,
+                ct,
+                timeoutCts);
         }
         finally
         {
@@ -258,6 +170,190 @@ public sealed class ScriptingService : IScriptingService
             // will not consume a slot.
             ReleaseSlotOnce();
         }
+    }
+
+    private static TaskCompletionSource<ScriptOutcome> CreateCompletionSource() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static CancellationTokenRegistration RegisterOuterCancellation(
+        CancellationToken ct,
+        TaskCompletionSource<ScriptOutcome> completion)
+    {
+        return ct.Register(static state =>
+        {
+            var tcs = (TaskCompletionSource<ScriptOutcome>)state!;
+            tcs.TrySetResult(ScriptOutcome.OuterCancelled());
+        }, completion);
+    }
+
+    private Thread StartWorkerThread(
+        string code,
+        ScriptOptions scriptOptions,
+        CancellationToken timeoutToken,
+        TaskCompletionSource<ScriptOutcome> completion,
+        ScriptRunState runState)
+    {
+        // FLAG-5C: dedicated background thread, NOT a thread-pool thread.
+        var workerThreadName = $"roslyn-mcp.script.{Guid.NewGuid():N}";
+        if (workerThreadName.Length > 32)
+        {
+            workerThreadName = workerThreadName[..32];
+        }
+
+        var workerThread = new Thread(() =>
+        {
+            var outcome = ExecuteScript(code, scriptOptions, timeoutToken);
+            CompleteWorkerThread(completion, outcome, runState);
+        })
+        {
+            IsBackground = true,
+            Name = workerThreadName,
+        };
+        workerThread.Start();
+        return workerThread;
+    }
+
+    private static ScriptOutcome ExecuteScript(
+        string code,
+        ScriptOptions scriptOptions,
+        CancellationToken timeoutToken)
+    {
+        try
+        {
+            var result = CSharpScript
+                .EvaluateAsync<object?>(code, scriptOptions, cancellationToken: timeoutToken)
+                .GetAwaiter().GetResult();
+            return ScriptOutcome.Success(result);
+        }
+        catch (CompilationErrorException cex)
+        {
+            return ScriptOutcome.CompilationFailure(cex);
+        }
+        catch (OperationCanceledException)
+        {
+            return ScriptOutcome.TimedOut();
+        }
+        catch (Exception ex)
+        {
+            return ScriptOutcome.Runtime(ex);
+        }
+    }
+
+    private void CompleteWorkerThread(
+        TaskCompletionSource<ScriptOutcome> completion,
+        ScriptOutcome outcome,
+        ScriptRunState runState)
+    {
+        Interlocked.Exchange(ref runState.WorkerFinished, 1);
+
+        // If the worker was already declared abandoned by the deadline path, recover the
+        // abandoned counter. Otherwise signal completion normally.
+        if (Interlocked.Read(ref runState.AbandonedFlag) == 1)
+        {
+            Interlocked.Decrement(ref _abandonedEvaluations);
+            return;
+        }
+
+        completion.TrySetResult(outcome);
+    }
+
+    private static Timer CreateDeadlineTimer(
+        TaskCompletionSource<ScriptOutcome> completion,
+        int hardDeadlineSeconds)
+    {
+        // Wall-clock hard deadline. Timer fires on a thread-pool thread, but TrySetResult
+        // is non-blocking and the awaiting frame uses RunContinuationsAsynchronously so the
+        // continuation runs on a fresh thread-pool thread, never inline on the timer thread.
+        return new Timer(
+            _ => completion.TrySetResult(ScriptOutcome.HardDeadline()),
+            state: null,
+            dueTime: TimeSpan.FromSeconds(hardDeadlineSeconds),
+            period: Timeout.InfiniteTimeSpan);
+    }
+
+    private Timer CreateHeartbeatTimer(
+        Action<ScriptEvaluationProgress>? onProgress,
+        Stopwatch sw,
+        TimeSpan budget,
+        int effectiveTimeoutSeconds,
+        TimeSpan heartbeatInterval,
+        ScriptRunState runState)
+    {
+        // Heartbeat is also Timer-based so its tear-down is sync (timer.Dispose).
+        return new Timer(
+            _ => EmitHeartbeat(onProgress, sw, budget, effectiveTimeoutSeconds, runState),
+            state: null,
+            dueTime: heartbeatInterval,
+            period: heartbeatInterval);
+    }
+
+    private void EmitHeartbeat(
+        Action<ScriptEvaluationProgress>? onProgress,
+        Stopwatch sw,
+        TimeSpan budget,
+        int effectiveTimeoutSeconds,
+        ScriptRunState runState)
+    {
+        var index = Interlocked.Increment(ref runState.HeartbeatCount);
+        var elapsed = sw.Elapsed;
+        onProgress?.Invoke(new ScriptEvaluationProgress(elapsed, budget, index));
+        if (index == 1)
+        {
+            _logger.LogInformation(
+                "evaluate_csharp: Roslyn script evaluation in progress (budget {BudgetSeconds}s, heartbeat every {HeartbeatMs}ms)",
+                effectiveTimeoutSeconds,
+                _options.HeartbeatIntervalMs);
+        }
+
+        if (runState.SlowWarningEmitted || elapsed.TotalSeconds < _options.StuckWarningSeconds)
+        {
+            return;
+        }
+
+        runState.SlowWarningEmitted = true;
+        _logger.LogWarning(
+            "evaluate_csharp: still running after {ElapsedSeconds:F1}s — clients often show a static \"Evaluating C#\" step here; " +
+            "large compile or synchronous script work may continue until timeout ({BudgetSeconds}s).",
+            elapsed.TotalSeconds,
+            effectiveTimeoutSeconds);
+    }
+
+    private ScriptEvaluationDto FinalizeEvaluation(
+        ScriptOutcome raceOutcome,
+        Stopwatch sw,
+        string? workerThreadName,
+        ScriptRunState runState,
+        int hardDeadlineSeconds,
+        int effectiveTimeoutSeconds,
+        int graceSeconds,
+        CancellationToken ct,
+        CancellationTokenSource timeoutCts)
+    {
+        // Outer cancellation: surface as OperationCanceledException; mark worker abandoned.
+        if (raceOutcome.Kind == ScriptOutcomeKind.OuterCancelled)
+        {
+            MarkAbandonedIfWorkerStillRunning(timeoutCts, runState);
+            ct.ThrowIfCancellationRequested();
+        }
+
+        // Hard deadline path — Roslyn never finished. Mark thread abandoned and return.
+        if (raceOutcome.Kind == ScriptOutcomeKind.HardDeadline)
+        {
+            if (MarkAbandonedIfWorkerStillRunning(timeoutCts, runState))
+            {
+                LogHardDeadlineCritical(workerThreadName, hardDeadlineSeconds, effectiveTimeoutSeconds, graceSeconds);
+            }
+
+            return BuildHardDeadlineDto(
+                sw,
+                runState.HeartbeatCount,
+                hardDeadlineSeconds,
+                effectiveTimeoutSeconds,
+                graceSeconds);
+        }
+
+        // Worker finished first — translate the outcome.
+        return BuildOutcomeDto(raceOutcome, sw, runState.HeartbeatCount, effectiveTimeoutSeconds);
     }
 
     private async Task<ScriptEvaluationDto?> TryAcquireCapacityAsync(int effectiveTimeoutSeconds, CancellationToken ct)
@@ -305,11 +401,10 @@ public sealed class ScriptingService : IScriptingService
     /// </summary>
     private bool MarkAbandonedIfWorkerStillRunning(
         CancellationTokenSource timeoutCts,
-        ref long workerFinished,
-        ref long abandonedFlag)
+        ScriptRunState runState)
     {
-        if (Interlocked.Read(ref workerFinished) != 0) return false;
-        if (Interlocked.Exchange(ref abandonedFlag, 1) != 0) return false;
+        if (Interlocked.Read(ref runState.WorkerFinished) != 0) return false;
+        if (Interlocked.Exchange(ref runState.AbandonedFlag, 1) != 0) return false;
 
         Interlocked.Increment(ref _abandonedEvaluations);
         try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
@@ -456,6 +551,15 @@ public sealed class ScriptingService : IScriptingService
             str = str[..4093] + "...";
 
         return str;
+    }
+
+    private sealed class ScriptRunState
+    {
+        public int HeartbeatCount;
+        public bool SlowWarningEmitted;
+        public long WorkerFinished;
+        public long SlotReleased;
+        public long AbandonedFlag;
     }
 
     private enum ScriptOutcomeKind


### PR DESCRIPTION
## Summary
- split `ScriptingService.EvaluateAsync` into smaller worker, timer, heartbeat, and finalization helpers
- split `RefactoringService.PersistDocumentSetChangesAsync` into per-project persistence and apply-flow helpers without changing the apply path
- keep the current scripting timeout/abandonment behavior and the current csproj snapshot/restore behavior intact while reducing method complexity

## Test plan
- [x] `./eng/verify-release.ps1 -Configuration Release -NoCoverage`
- [x] `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --filter "FullyQualifiedName~RoslynMcp.Tests.ScriptingServiceTests|FullyQualifiedName~RoslynMcp.Tests.CsprojReserializationTests|FullyQualifiedName~RoslynMcp.Tests.SdkStyleCsprojInjectionTests|FullyQualifiedName~RoslynMcp.Tests.FileOperationIntegrationTests|FullyQualifiedName~RoslynMcp.Tests.UndoFileOperationsTests|FullyQualifiedName~RoslynMcp.Tests.ChangeTrackerTests|FullyQualifiedName~RoslynMcp.Tests.CrossProjectRefactoringIntegrationTests|FullyQualifiedName~RoslynMcp.Tests.ScaffoldingIntegrationTests" --nologo`

Generated with [Codex](https://openai.com/codex)