### PR TITLE
refactor: split mutation and batch scaffold flows

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -202,135 +202,223 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
         if (symbol is not INamedTypeSymbol namedType) return null;
 
+        var compilation = await ResolveContainingCompilationAsync(solution, namedType, ct).ConfigureAwait(false);
+        var candidates = GetMutationCandidates(namedType, compilation);
+
+        if (candidates.Length == 0)
+        {
+            return CreateTypeMutationDto(namedType, solution, []);
+        }
+
+        var mutatingMembers = await BuildMutatingMembersAsync(solution, namedType, candidates, ct).ConfigureAwait(false);
+        return CreateTypeMutationDto(namedType, solution, mutatingMembers);
+    }
+
+    private async Task<Compilation?> ResolveContainingCompilationAsync(
+        Solution solution,
+        INamedTypeSymbol namedType,
+        CancellationToken ct)
+    {
         // Get the compilation that defines the type so the side-effect classifier can read
         // semantic models against the same compilation as the symbol.
-        Compilation? compilation = null;
         foreach (var project in solution.Projects)
         {
             var projectCompilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
-            if (projectCompilation is null) continue;
+            if (projectCompilation is null)
+            {
+                continue;
+            }
+
             if (SymbolEqualityComparer.Default.Equals(projectCompilation.Assembly, namedType.ContainingAssembly))
             {
-                compilation = projectCompilation;
-                break;
+                return projectCompilation;
             }
         }
 
+        return null;
+    }
+
+    private static MutationCandidate[] GetMutationCandidates(INamedTypeSymbol namedType, Compilation? compilation)
+    {
         // Filter to mutating members up front so we can fan out the expensive
         // SymbolFinder.FindReferencesAsync calls in parallel while preserving declaration order.
         // Each candidate carries its computed scope so we don't recompute it inside the parallel
         // member tasks.
-        var candidates = namedType.GetMembers()
-            .Select(m => (Member: m, Scope: ClassifyMutationScope(m, namedType, compilation)))
-            .Where(t => t.Scope is not null)
+        return namedType.GetMembers()
+            .Select(member => new MutationCandidate(member, ClassifyMutationScope(member, namedType, compilation)))
+            .Where(candidate => candidate.Scope is not null)
+            .Select(candidate => candidate with { Scope = candidate.Scope! })
             .ToArray();
+    }
 
-        if (candidates.Length == 0)
-        {
-            return new TypeMutationDto(
-                Type: SymbolMapper.ToDto(namedType, solution),
-                MutatingMembers: [],
-                Summary: $"Type '{namedType.Name}' has 0 mutating member(s) with 0 external caller(s).");
-        }
-
+    private async Task<MutatingMemberDto[]> BuildMutatingMembersAsync(
+        Solution solution,
+        INamedTypeSymbol namedType,
+        IReadOnlyList<MutationCandidate> candidates,
+        CancellationToken ct)
+    {
         // Concurrent caches shared across the parallel member tasks. Roslyn's per-document
         // caches mean these are mostly redundant after warmup, but the dictionary still saves
         // the async-state-machine cost on hot documents.
         var rootCache = new ConcurrentDictionary<DocumentId, SyntaxNode?>();
         var modelCache = new ConcurrentDictionary<DocumentId, SemanticModel?>();
-
         var parallelism = Math.Clamp(Environment.ProcessorCount, 4, 16);
         using var semaphore = new SemaphoreSlim(parallelism, parallelism);
 
-        async Task<MutatingMemberDto> ProcessMemberAsync(ISymbol member, string mutationScope)
+        var memberTasks = new Task<MutatingMemberDto>[candidates.Count];
+        for (var i = 0; i < candidates.Count; i++)
         {
-            await semaphore.WaitAsync(ct).ConfigureAwait(false);
-            try
+            memberTasks[i] = BuildMutatingMemberAsync(
+                solution,
+                namedType,
+                candidates[i],
+                rootCache,
+                modelCache,
+                semaphore,
+                ct);
+        }
+
+        return await Task.WhenAll(memberTasks).ConfigureAwait(false);
+    }
+
+    private async Task<MutatingMemberDto> BuildMutatingMemberAsync(
+        Solution solution,
+        INamedTypeSymbol namedType,
+        MutationCandidate candidate,
+        ConcurrentDictionary<DocumentId, SyntaxNode?> rootCache,
+        ConcurrentDictionary<DocumentId, SemanticModel?> modelCache,
+        SemaphoreSlim semaphore,
+        CancellationToken ct)
+    {
+        await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var callers = new List<MutationCallerDto>();
+            var references = await SymbolFinder.FindReferencesAsync(candidate.Member, solution, ct).ConfigureAwait(false);
+
+            foreach (var refSymbol in references)
             {
-                var callers = new List<MutationCallerDto>();
-                var references = await SymbolFinder.FindReferencesAsync(member, solution, ct).ConfigureAwait(false);
-
-                foreach (var refSymbol in references)
+                foreach (var refLocation in refSymbol.Locations)
                 {
-                    foreach (var refLocation in refSymbol.Locations)
+                    var caller = await BuildMutationCallerAsync(
+                        refLocation,
+                        namedType,
+                        rootCache,
+                        modelCache,
+                        ct).ConfigureAwait(false);
+                    if (caller is not null)
                     {
-                        var doc = refLocation.Document;
-
-                        // ConcurrentDictionary has no async value factory, so we check-then-add.
-                        // The race is benign: at worst two members fetch the same document's
-                        // root/model concurrently and one TryAdd loses; the result is identical.
-                        if (!rootCache.TryGetValue(doc.Id, out var root))
-                        {
-                            root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-                            rootCache.TryAdd(doc.Id, root);
-                        }
-                        if (!modelCache.TryGetValue(doc.Id, out var model))
-                        {
-                            model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
-                            modelCache.TryAdd(doc.Id, model);
-                        }
-
-                        // For interface-implemented members (e.g. Dispose), filter to only calls
-                        // where the receiver type matches the target type
-                        if (root is not null && model is not null && !IsReceiverOfTargetType(root, model, refLocation.Location, namedType, ct))
-                            continue;
-
-                        var containingSymbol = root is not null && model is not null
-                            ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
-                            : null;
-
-                        // Skip calls from within the type itself (internal mutators calling each other)
-                        if (containingSymbol is not null &&
-                            SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
-                            continue;
-
-                        var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
-                        var phase = ClassifyCallerPhase(root, model, refLocation.Location, namedType);
-                        var lineSpan = refLocation.Location.GetLineSpan();
-
-                        callers.Add(new MutationCallerDto(
-                            FilePath: lineSpan.Path,
-                            StartLine: lineSpan.StartLinePosition.Line + 1,
-                            StartColumn: lineSpan.StartLinePosition.Character + 1,
-                            ContainingMember: containingSymbol?.ToDisplayString(),
-                            PreviewText: preview,
-                            CallerPhase: phase));
+                        callers.Add(caller);
                     }
                 }
+            }
 
-                var memberLoc = member.Locations.FirstOrDefault(l => l.IsInSource);
-                return new MutatingMemberDto(
-                    Name: member.Name,
-                    FullyQualifiedName: member.ToDisplayString(),
-                    Kind: member.Kind.ToString(),
-                    FilePath: memberLoc?.GetLineSpan().Path,
-                    Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
-                    ExternalCallers: callers,
-                    MutationScope: mutationScope);
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            var memberLoc = candidate.Member.Locations.FirstOrDefault(location => location.IsInSource);
+            return new MutatingMemberDto(
+                Name: candidate.Member.Name,
+                FullyQualifiedName: candidate.Member.ToDisplayString(),
+                Kind: candidate.Member.Kind.ToString(),
+                FilePath: memberLoc?.GetLineSpan().Path,
+                Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
+                ExternalCallers: callers,
+                MutationScope: candidate.Scope!);
         }
-
-        var memberTasks = new Task<MutatingMemberDto>[candidates.Length];
-        for (var i = 0; i < candidates.Length; i++)
+        finally
         {
-            // Scope is non-null because the .Where filter above kept only entries with a scope.
-            memberTasks[i] = ProcessMemberAsync(candidates[i].Member, candidates[i].Scope!);
+            semaphore.Release();
+        }
+    }
+
+    private async Task<MutationCallerDto?> BuildMutationCallerAsync(
+        ReferenceLocation refLocation,
+        INamedTypeSymbol namedType,
+        ConcurrentDictionary<DocumentId, SyntaxNode?> rootCache,
+        ConcurrentDictionary<DocumentId, SemanticModel?> modelCache,
+        CancellationToken ct)
+    {
+        var doc = refLocation.Document;
+        var root = await GetCachedSyntaxRootAsync(doc, rootCache, ct).ConfigureAwait(false);
+        var model = await GetCachedSemanticModelAsync(doc, modelCache, ct).ConfigureAwait(false);
+
+        // For interface-implemented members (e.g. Dispose), filter to only calls
+        // where the receiver type matches the target type.
+        if (root is not null && model is not null && !IsReceiverOfTargetType(root, model, refLocation.Location, namedType, ct))
+        {
+            return null;
         }
 
-        var mutatingMembers = await Task.WhenAll(memberTasks).ConfigureAwait(false);
+        var containingSymbol = root is not null && model is not null
+            ? SymbolServiceHelpers.GetContainingSymbolFromRoot(root, model, refLocation.Location, ct)
+            : null;
 
-        var summary = $"Type '{namedType.Name}' has {mutatingMembers.Length} mutating member(s) " +
-                      $"with {mutatingMembers.Sum(m => m.ExternalCallers.Count)} external caller(s).";
+        // Skip calls from within the type itself (internal mutators calling each other).
+        if (containingSymbol is not null &&
+            SymbolEqualityComparer.Default.Equals(containingSymbol.ContainingType, namedType))
+        {
+            return null;
+        }
+
+        var preview = await SymbolResolver.GetPreviewTextAsync(doc, refLocation.Location, ct).ConfigureAwait(false);
+        var phase = ClassifyCallerPhase(root, model, refLocation.Location, namedType);
+        var lineSpan = refLocation.Location.GetLineSpan();
+
+        return new MutationCallerDto(
+            FilePath: lineSpan.Path,
+            StartLine: lineSpan.StartLinePosition.Line + 1,
+            StartColumn: lineSpan.StartLinePosition.Character + 1,
+            ContainingMember: containingSymbol?.ToDisplayString(),
+            PreviewText: preview,
+            CallerPhase: phase);
+    }
+
+    private static async Task<SyntaxNode?> GetCachedSyntaxRootAsync(
+        Document document,
+        ConcurrentDictionary<DocumentId, SyntaxNode?> rootCache,
+        CancellationToken ct)
+    {
+        // ConcurrentDictionary has no async value factory, so we check-then-add.
+        // The race is benign: at worst two members fetch the same document's root concurrently
+        // and one TryAdd loses; the result is identical.
+        if (rootCache.TryGetValue(document.Id, out var root))
+        {
+            return root;
+        }
+
+        root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+        rootCache.TryAdd(document.Id, root);
+        return root;
+    }
+
+    private static async Task<SemanticModel?> GetCachedSemanticModelAsync(
+        Document document,
+        ConcurrentDictionary<DocumentId, SemanticModel?> modelCache,
+        CancellationToken ct)
+    {
+        if (modelCache.TryGetValue(document.Id, out var model))
+        {
+            return model;
+        }
+
+        model = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
+        modelCache.TryAdd(document.Id, model);
+        return model;
+    }
+
+    private static TypeMutationDto CreateTypeMutationDto(
+        INamedTypeSymbol namedType,
+        Solution solution,
+        IReadOnlyList<MutatingMemberDto> mutatingMembers)
+    {
+        var summary = $"Type '{namedType.Name}' has {mutatingMembers.Count} mutating member(s) " +
+                      $"with {mutatingMembers.Sum(member => member.ExternalCallers.Count)} external caller(s).";
 
         return new TypeMutationDto(
             Type: SymbolMapper.ToDto(namedType, solution),
             MutatingMembers: mutatingMembers,
             Summary: summary);
     }
+
+    private sealed record MutationCandidate(ISymbol Member, string? Scope);
 
     private static bool IsWriteReference(SyntaxNode refNode)
     {

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -92,101 +92,194 @@ public sealed class ScaffoldingService : IScaffoldingService
     public async Task<RefactoringPreviewDto> PreviewScaffoldTestBatchAsync(
         string workspaceId, ScaffoldTestBatchDto request, CancellationToken ct)
     {
+        ValidateBatchScaffoldRequest(request);
+        var context = CreateBatchScaffoldContext(workspaceId, request);
+        var cachedCompilations = await LoadBatchCompilationsAsync(context.Solution, context.TestProject, ct).ConfigureAwait(false);
+        var state = new BatchScaffoldState(context.Solution);
+
+        foreach (var target in request.Targets)
+        {
+            ProcessBatchScaffoldTarget(target, request, context, cachedCompilations, state, ct);
+        }
+
+        return await CreateBatchScaffoldPreviewAsync(workspaceId, context.Project, state, ct).ConfigureAwait(false);
+    }
+
+    private static void ValidateBatchScaffoldRequest(ScaffoldTestBatchDto request)
+    {
         if (request.Targets is null || request.Targets.Count == 0)
         {
             throw new InvalidOperationException("scaffold_test_batch_preview requires at least one target.");
         }
+    }
 
+    private BatchScaffoldContext CreateBatchScaffoldContext(string workspaceId, ScaffoldTestBatchDto request)
+    {
         var project = ResolveProject(workspaceId, request.TestProjectName);
         ValidateIsTestProject(project);
         var projectDirectory = Path.GetDirectoryName(project.FilePath)
             ?? throw new InvalidOperationException($"Project directory could not be resolved for '{project.FilePath}'.");
-        var testNamespace = project.Name;
-        var framework = ResolveTestFramework(request.TestFramework, project.FilePath);
-
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var testProject = solution.Projects.FirstOrDefault(p =>
             string.Equals(p.Name, request.TestProjectName, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(p.FilePath, request.TestProjectName, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Test project not loaded: {request.TestProjectName}");
 
+        return new BatchScaffoldContext(
+            Project: project,
+            TestProject: testProject,
+            Solution: solution,
+            ProjectDirectory: projectDirectory,
+            TestNamespace: project.Name,
+            Framework: ResolveTestFramework(request.TestFramework, project.FilePath));
+    }
+
+    private static async Task<List<Compilation>> LoadBatchCompilationsAsync(
+        Solution solution,
+        Project testProject,
+        CancellationToken ct)
+    {
         // Cache source-project compilations once to avoid N× GetCompilationAsync across targets
         // (the primary perf win over iterating PreviewScaffoldTestAsync).
         var projectsToSearch = new List<Project> { testProject };
         foreach (var projectRef in testProject.ProjectReferences)
         {
             var referenced = solution.GetProject(projectRef.ProjectId);
-            if (referenced is not null) projectsToSearch.Add(referenced);
+            if (referenced is not null)
+            {
+                projectsToSearch.Add(referenced);
+            }
         }
+
         var cachedCompilations = new List<Compilation>();
-        foreach (var p in projectsToSearch)
+        foreach (var project in projectsToSearch)
         {
-            var compilation = await p.GetCompilationAsync(ct).ConfigureAwait(false);
-            if (compilation is not null) cachedCompilations.Add(compilation);
+            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (compilation is not null)
+            {
+                cachedCompilations.Add(compilation);
+            }
         }
 
-        var accumulator = solution;
-        var warnings = new List<string>();
-        var createdFiles = new List<string>();
-        var skippedTargets = new List<string>();
+        return cachedCompilations;
+    }
 
-        foreach (var target in request.Targets)
+    private static void ProcessBatchScaffoldTarget(
+        ScaffoldTestBatchTargetDto target,
+        ScaffoldTestBatchDto request,
+        BatchScaffoldContext context,
+        IReadOnlyList<Compilation> cachedCompilations,
+        BatchScaffoldState state,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(target.TargetTypeName))
         {
-            ct.ThrowIfCancellationRequested();
-            if (string.IsNullOrWhiteSpace(target.TargetTypeName))
-            {
-                warnings.Add("Skipped empty target type name.");
-                continue;
-            }
-
-            var testFilePath = Path.Combine(projectDirectory, $"{target.TargetTypeName}GeneratedTests.cs");
-            if (SymbolResolver.FindDocument(accumulator, testFilePath) is not null || File.Exists(testFilePath))
-            {
-                skippedTargets.Add(target.TargetTypeName);
-                warnings.Add($"Skipped '{target.TargetTypeName}': target file already exists at '{testFilePath}'.");
-                continue;
-            }
-
-            var typeInfo = ResolveTargetTypeAndMethodFromCache(
-                cachedCompilations, target.TargetTypeName, target.TargetMethodName);
-            if (typeInfo.matchedType is null)
-            {
-                warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
-                continue;
-            }
-            if (typeInfo.warnings is not null) warnings.AddRange(typeInfo.warnings);
-
-            var dto = new ScaffoldTestDto(request.TestProjectName, target.TargetTypeName, target.TargetMethodName, request.TestFramework);
-            // Batch scaffolding intentionally does NOT apply sibling-pattern inference — a batch
-            // run typically targets a homogenous set of production types and callers want the
-            // generic scaffold. Sibling inference is available via per-target scaffold_test_preview.
-            var content = BuildTestContent(
-                testNamespace, dto, typeInfo.targetNamespace, typeInfo.constructorArgs, framework,
-                typeInfo.targetMethod, typeInfo.matchedType, siblingPattern: null);
-
-            var projInAccumulator = accumulator.GetProject(testProject.Id)
-                ?? throw new InvalidOperationException("Test project disappeared from working solution snapshot.");
-            var folders = Array.Empty<string>();
-            var newDoc = projInAccumulator.AddDocument(
-                Path.GetFileName(testFilePath),
-                Microsoft.CodeAnalysis.Text.SourceText.From(content),
-                folders,
-                testFilePath);
-            accumulator = newDoc.Project.Solution;
-            createdFiles.Add(testFilePath);
+            state.Warnings.Add("Skipped empty target type name.");
+            return;
         }
 
-        if (createdFiles.Count == 0)
+        var testFilePath = Path.Combine(context.ProjectDirectory, $"{target.TargetTypeName}GeneratedTests.cs");
+        if (SymbolResolver.FindDocument(state.Accumulator, testFilePath) is not null || File.Exists(testFilePath))
+        {
+            state.Warnings.Add($"Skipped '{target.TargetTypeName}': target file already exists at '{testFilePath}'.");
+            return;
+        }
+
+        var typeInfo = ResolveTargetTypeAndMethodFromCache(
+            cachedCompilations,
+            target.TargetTypeName,
+            target.TargetMethodName);
+        if (typeInfo.matchedType is null)
+        {
+            state.Warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
+            return;
+        }
+
+        if (typeInfo.warnings is not null)
+        {
+            state.Warnings.AddRange(typeInfo.warnings);
+        }
+
+        var dto = new ScaffoldTestDto(
+            request.TestProjectName,
+            target.TargetTypeName,
+            target.TargetMethodName,
+            request.TestFramework);
+
+        // Batch scaffolding intentionally does NOT apply sibling-pattern inference — a batch
+        // run typically targets a homogenous set of production types and callers want the
+        // generic scaffold. Sibling inference is available via per-target scaffold_test_preview.
+        var content = BuildTestContent(
+            context.TestNamespace,
+            dto,
+            typeInfo.targetNamespace,
+            typeInfo.constructorArgs,
+            context.Framework,
+            typeInfo.targetMethod,
+            typeInfo.matchedType,
+            siblingPattern: null);
+
+        var testProject = state.Accumulator.GetProject(context.TestProject.Id)
+            ?? throw new InvalidOperationException("Test project disappeared from working solution snapshot.");
+        var newDocument = testProject.AddDocument(
+            Path.GetFileName(testFilePath),
+            Microsoft.CodeAnalysis.Text.SourceText.From(content),
+            folders: [],
+            filePath: testFilePath);
+
+        state.Accumulator = newDocument.Project.Solution;
+        state.CreatedFiles.Add(testFilePath);
+    }
+
+    private async Task<RefactoringPreviewDto> CreateBatchScaffoldPreviewAsync(
+        string workspaceId,
+        ProjectStatusDto project,
+        BatchScaffoldState state,
+        CancellationToken ct)
+    {
+        if (state.CreatedFiles.Count == 0)
         {
             throw new InvalidOperationException(
                 "scaffold_test_batch_preview produced no file creations. See Warnings for per-target reasons.");
         }
 
-        var changes = await Helpers.SolutionDiffHelper.ComputeChangesAsync(solution, accumulator, ct).ConfigureAwait(false);
-        var description = $"Scaffold {createdFiles.Count} test file(s) in project '{project.Name}'";
-        var token = _previewStore.Store(workspaceId, accumulator, _workspace.GetCurrentVersion(workspaceId), description);
+        var changes = await Helpers.SolutionDiffHelper
+            .ComputeChangesAsync(state.OriginalSolution, state.Accumulator, ct)
+            .ConfigureAwait(false);
+        var description = $"Scaffold {state.CreatedFiles.Count} test file(s) in project '{project.Name}'";
+        var token = _previewStore.Store(workspaceId, state.Accumulator, _workspace.GetCurrentVersion(workspaceId), description);
 
-        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
+        return new RefactoringPreviewDto(
+            token,
+            description,
+            changes,
+            state.Warnings.Count > 0 ? state.Warnings : null);
+    }
+
+    private sealed record BatchScaffoldContext(
+        ProjectStatusDto Project,
+        Project TestProject,
+        Solution Solution,
+        string ProjectDirectory,
+        string TestNamespace,
+        string Framework);
+
+    private sealed class BatchScaffoldState
+    {
+        public BatchScaffoldState(Solution originalSolution)
+        {
+            OriginalSolution = originalSolution;
+            Accumulator = originalSolution;
+        }
+
+        public Solution OriginalSolution { get; }
+
+        public Solution Accumulator { get; set; }
+
+        public List<string> Warnings { get; } = [];
+
+        public List<string> CreatedFiles { get; } = [];
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -252,4 +252,40 @@ public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
         StringAssert.Contains(contents, "using Acme.Integration.Support;",
             "Sibling-carried using directive should be replicated so the scaffold resolves its types.");
     }
+
+    [TestMethod]
+    public async Task Scaffold_Test_Batch_Preview_And_Apply_Creates_Multiple_Test_Files()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogPath = workspace.GetPath("SampleLib.Tests", "DogGeneratedTests.cs");
+        var animalServicePath = workspace.GetPath("SampleLib.Tests", "AnimalServiceGeneratedTests.cs");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestBatchAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestBatchDto(
+                "SampleLib.Tests",
+                [
+                    new ScaffoldTestBatchTargetDto("Dog", "Speak"),
+                    new ScaffoldTestBatchTargetDto("AnimalService", "GetAllAnimals")
+                ],
+                "auto"),
+            CancellationToken.None);
+
+        Assert.AreEqual(2, preview.Changes.Count,
+            "Batch scaffold preview should aggregate one file-creation diff per target.");
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken,
+            CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.IsTrue(File.Exists(dogPath), $"Expected scaffolded file at {dogPath}.");
+        Assert.IsTrue(File.Exists(animalServicePath), $"Expected scaffolded file at {animalServicePath}.");
+
+        var dogContents = await File.ReadAllTextAsync(dogPath, CancellationToken.None);
+        var animalServiceContents = await File.ReadAllTextAsync(animalServicePath, CancellationToken.None);
+
+        StringAssert.Contains(dogContents, "Speak_Needs_Test");
+        StringAssert.Contains(animalServiceContents, "GetAllAnimals_Needs_Test");
+    }
 }


### PR DESCRIPTION
## Summary
- extract helper paths from `MutationAnalysisService.FindTypeMutationsAsync` so compilation lookup, candidate selection, and per-member caller collection stay isolated from the coordinator
- extract batch scaffold setup, cached-compilation loading, per-target processing, and preview creation from `ScaffoldingService.PreviewScaffoldTestBatchAsync` without changing generated output
- add direct integration coverage for batch scaffold preview/apply across multiple generated test files

## Test plan
- [x] `mcp__roslyn__.compile_check` on `RoslynMcp.Roslyn`
- [x] `mcp__roslyn__.compile_check` on `RoslynMcp.Tests`
- [x] targeted `mcp__roslyn__.test_run` for `ScaffoldingIntegrationTests` and `MutationAnalysisSideEffectsTests`
- [x] `./eng/verify-release.ps1 -Configuration Release -NoCoverage`

Generated with [Codex](https://Codex.com/Codex)