### PR TITLE
refactor: split semantic query and test discovery flows

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -317,24 +317,30 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
     {
         var predicates = new List<Func<ISymbol, bool>>();
         var predicateLabels = new List<string>();
-        var q = query.ToLowerInvariant().Trim();
+        var normalizedQuery = query.ToLowerInvariant().Trim();
 
+        AddKeywordPredicates(predicates, predicateLabels, normalizedQuery);
+        AddStaticPredicate(predicates, predicateLabels, normalizedQuery);
+        AddClassPredicate(predicates, predicateLabels, normalizedQuery);
+        AddAccessibilityPredicate(predicates, predicateLabels, normalizedQuery);
+        AddReturnTypePredicateWithLabel(predicates, predicateLabels, normalizedQuery);
+        AddImplementingPredicateWithLabel(predicates, predicateLabels, normalizedQuery);
+        AddParameterCountPredicate(predicates, predicateLabels, normalizedQuery);
+
+        return CreateSemanticQueryParse(query, predicates, predicateLabels);
+    }
+
+    private static void AddKeywordPredicates(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
         // Simple keyword predicates from the lookup table.
         // Use a word boundary for "interface" so "IDisposable" does not trigger the interface symbol filter.
         // BUG-N8: "asynchronous" must not satisfy the "async" keyword (substring match would).
         foreach (var (keyword, predicate) in KeywordPredicates)
         {
-            if (keyword == "interface")
-            {
-                if (!Regex.IsMatch(q, @"\binterface\b"))
-                    continue;
-            }
-            else if (keyword == "async")
-            {
-                if (!Regex.IsMatch(q, @"\basync\b"))
-                    continue;
-            }
-            else if (!q.Contains(keyword))
+            if (!MatchesKeyword(query, keyword))
             {
                 continue;
             }
@@ -342,63 +348,125 @@ public sealed class CodePatternAnalyzer : ICodePatternAnalyzer
             predicates.Add(predicate);
             predicateLabels.Add($"keyword:{keyword}");
         }
+    }
 
-        // "static" with guard against "non-static"
-        if (q.Contains("static") && !q.Contains("non-static"))
+    private static bool MatchesKeyword(string query, string keyword)
+    {
+        return keyword switch
         {
-            predicates.Add(s => s.IsStatic);
-            predicateLabels.Add("keyword:static");
+            "interface" => Regex.IsMatch(query, @"\binterface\b"),
+            "async" => Regex.IsMatch(query, @"\basync\b"),
+            _ => query.Contains(keyword, StringComparison.Ordinal)
+        };
+    }
+
+    private static void AddStaticPredicate(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        if (!query.Contains("static", StringComparison.Ordinal) || query.Contains("non-static", StringComparison.Ordinal))
+        {
+            return;
         }
 
-        // "classes" with guard against "classes implementing"
-        if (q.Contains("class") && !q.Contains("classes implementing"))
+        predicates.Add(symbol => symbol.IsStatic);
+        predicateLabels.Add("keyword:static");
+    }
+
+    private static void AddClassPredicate(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        if (!query.Contains("class", StringComparison.Ordinal) || query.Contains("classes implementing", StringComparison.Ordinal))
         {
-            predicates.Add(s => s is INamedTypeSymbol { TypeKind: TypeKind.Class });
-            predicateLabels.Add("keyword:class");
+            return;
         }
 
-        // Accessibility keywords (mutually exclusive) — capture to local to avoid closure issue
+        predicates.Add(symbol => symbol is INamedTypeSymbol { TypeKind: TypeKind.Class });
+        predicateLabels.Add("keyword:class");
+    }
+
+    private static void AddAccessibilityPredicate(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        // Accessibility keywords are mutually exclusive. Capture to local to avoid closure issues.
         foreach (var (keyword, accessibility) in AccessibilityKeywords)
         {
-            var capturedAccessibility = accessibility;
-            if (keyword == "public" ? q.Contains("public") && !q.Contains("non-public") : q.Contains(keyword))
+            if (!MatchesAccessibilityKeyword(query, keyword))
             {
-                predicates.Add(s => s.DeclaredAccessibility == capturedAccessibility);
-                predicateLabels.Add($"accessibility:{keyword}");
-                break;
+                continue;
             }
-        }
 
-        // "returning/returns <type>"
-        var beforeReturn = predicates.Count;
-        AddReturnTypePredicate(predicates, q);
-        if (predicates.Count > beforeReturn)
+            var capturedAccessibility = accessibility;
+            predicates.Add(symbol => symbol.DeclaredAccessibility == capturedAccessibility);
+            predicateLabels.Add($"accessibility:{keyword}");
+            return;
+        }
+    }
+
+    private static bool MatchesAccessibilityKeyword(string query, string keyword)
+    {
+        return keyword == "public"
+            ? query.Contains("public", StringComparison.Ordinal) && !query.Contains("non-public", StringComparison.Ordinal)
+            : query.Contains(keyword, StringComparison.Ordinal);
+    }
+
+    private static void AddReturnTypePredicateWithLabel(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        var beforeCount = predicates.Count;
+        AddReturnTypePredicate(predicates, query);
+        if (predicates.Count > beforeCount)
         {
             predicateLabels.Add("returning-type");
         }
+    }
 
-        // "implementing <interface>"
-        var beforeImpl = predicates.Count;
-        AddImplementingPredicate(predicates, q);
-        if (predicates.Count > beforeImpl)
+    private static void AddImplementingPredicateWithLabel(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        var beforeCount = predicates.Count;
+        AddImplementingPredicate(predicates, query);
+        if (predicates.Count > beforeCount)
         {
             predicateLabels.Add("implementing-interface");
         }
+    }
 
-        // "more than N parameters"
-        var paramMatch = System.Text.RegularExpressions.Regex.Match(q, @"(?:more than|>)\s*(\d+)\s*param");
-        if (paramMatch.Success && int.TryParse(paramMatch.Groups[1].Value, out var minParams))
+    private static void AddParameterCountPredicate(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        var paramMatch = System.Text.RegularExpressions.Regex.Match(query, @"(?:more than|>)\s*(\d+)\s*param");
+        if (!paramMatch.Success || !int.TryParse(paramMatch.Groups[1].Value, out var minParams))
         {
-            predicates.Add(s => s is IMethodSymbol m && m.Parameters.Length > minParams);
-            predicateLabels.Add($"min-parameters:{minParams}");
+            return;
         }
 
-        var tokens = ExtractTokens(query);
+        predicates.Add(symbol => symbol is IMethodSymbol method && method.Parameters.Length > minParams);
+        predicateLabels.Add($"min-parameters:{minParams}");
+    }
 
-        // Fallback: name-based search
+    private static SemanticQueryParse CreateSemanticQueryParse(
+        string originalQuery,
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels)
+    {
+        var tokens = ExtractTokens(originalQuery);
+
+        // Fallback: name-based search.
         if (predicates.Count == 0)
         {
-            predicates.Add(s => s.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
+            predicates.Add(symbol => symbol.Name.Contains(originalQuery, StringComparison.OrdinalIgnoreCase));
             predicateLabels.Add("name-contains");
             return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: true);
         }

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -97,83 +97,132 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         var discovery = await DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null)
-        {
-            return [];
-        }
+        if (symbol is null) return [];
 
+        var discoveredTests = discovery.TestProjects.SelectMany(project => project.Tests).ToList();
+        var searchTerms = BuildRelatedTestSearchTerms(symbol);
+        var collected = CollectHeuristicRelatedTests(discoveredTests, searchTerms);
+
+        await TryAugmentRelatedTestsFromReferencesAsync(
+            symbol,
+            solution,
+            discoveredTests,
+            collected,
+            ct).ConfigureAwait(false);
+
+        return collected.Values.ToList();
+    }
+
+    private static HashSet<string> BuildRelatedTestSearchTerms(ISymbol symbol)
+    {
         var searchTerms = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { symbol.Name };
         if (symbol.ContainingType is not null)
         {
             searchTerms.Add(symbol.ContainingType.Name);
         }
 
+        return searchTerms;
+    }
+
+    private static Dictionary<string, TestCaseDto> CollectHeuristicRelatedTests(
+        IReadOnlyList<TestCaseDto> discoveredTests,
+        IReadOnlySet<string> searchTerms)
+    {
         // test-related-empty-for-valid-symbol: name heuristic misses tests that dispatch
         // through an interface (test method references `IService.Method()` but this symbol
-        // is the concrete `MyService.Method`). Walk every derived / implementing symbol + the
-        // symbol itself with SymbolFinder.FindReferencesAsync and collect the test files those
-        // references sit in — then look up any test method whose FilePath matches a reference
-        // file. The heuristic name-match is kept as a fast-path (covers the majority case where
-        // the test method name contains the symbol name) and the reference sweep augments it
-        // for interface-dispatched cases.
+        // is the concrete `MyService.Method`). Keep the heuristic as a fast path, then augment
+        // it with the reference sweep below for interface-dispatched cases.
         var collected = new Dictionary<string, TestCaseDto>(StringComparer.Ordinal);
-
-        foreach (var test in discovery.TestProjects.SelectMany(project => project.Tests))
+        foreach (var test in discoveredTests)
         {
-            if (searchTerms.Any(term =>
-                    test.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
-                    test.FullyQualifiedName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
-                    (test.FilePath?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)))
+            if (searchTerms.Any(term => MatchesRelatedTestTerm(test, term)))
             {
                 collected[test.FullyQualifiedName] = test;
             }
         }
 
+        return collected;
+    }
+
+    private static bool MatchesRelatedTestTerm(TestCaseDto test, string term)
+    {
+        return test.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+               test.FullyQualifiedName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+               (test.FilePath?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private async Task TryAugmentRelatedTestsFromReferencesAsync(
+        ISymbol symbol,
+        Solution solution,
+        IReadOnlyList<TestCaseDto> discoveredTests,
+        Dictionary<string, TestCaseDto> collected,
+        CancellationToken ct)
+    {
         // Reference-based augmentation: collect files that contain a reference to `symbol`
         // (or any override / implementation when the symbol is abstract / interface). Test
         // methods whose file path matches are considered related.
         try
         {
-            var referencedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var symbolsToWalk = await CollectSymbolAndImplementationsAsync(symbol, solution, ct).ConfigureAwait(false);
-
-            foreach (var candidate in symbolsToWalk)
+            var referencedFilePaths = await CollectReferencedFilePathsAsync(symbol, solution, ct).ConfigureAwait(false);
+            if (referencedFilePaths.Count == 0)
             {
-                ct.ThrowIfCancellationRequested();
-                var references = await SymbolFinder.FindReferencesAsync(candidate, solution, ct).ConfigureAwait(false);
-                foreach (var refSet in references)
-                {
-                    foreach (var loc in refSet.Locations)
-                    {
-                        var path = loc.Document.FilePath;
-                        if (!string.IsNullOrWhiteSpace(path))
-                        {
-                            referencedFilePaths.Add(Path.GetFullPath(path));
-                        }
-                    }
-                }
+                return;
             }
 
-            if (referencedFilePaths.Count > 0)
+            foreach (var test in discoveredTests)
             {
-                foreach (var test in discovery.TestProjects.SelectMany(project => project.Tests))
+                if (string.IsNullOrWhiteSpace(test.FilePath))
                 {
-                    if (string.IsNullOrWhiteSpace(test.FilePath)) continue;
-                    if (referencedFilePaths.Contains(Path.GetFullPath(test.FilePath)))
-                    {
-                        collected.TryAdd(test.FullyQualifiedName, test);
-                    }
+                    continue;
+                }
+
+                if (referencedFilePaths.Contains(Path.GetFullPath(test.FilePath)))
+                {
+                    collected.TryAdd(test.FullyQualifiedName, test);
                 }
             }
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             // Reference-sweep is best-effort augmentation — never let it break the heuristic path.
             _logger.LogWarning(ex, "FindRelatedTests reference-sweep augmentation failed; returning heuristic results only.");
         }
+    }
 
-        return collected.Values.ToList();
+    private static async Task<HashSet<string>> CollectReferencedFilePathsAsync(
+        ISymbol symbol,
+        Solution solution,
+        CancellationToken ct)
+    {
+        var referencedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var symbolsToWalk = await CollectSymbolAndImplementationsAsync(symbol, solution, ct).ConfigureAwait(false);
+
+        foreach (var candidate in symbolsToWalk)
+        {
+            ct.ThrowIfCancellationRequested();
+            var references = await SymbolFinder.FindReferencesAsync(candidate, solution, ct).ConfigureAwait(false);
+            foreach (var refSet in references)
+            {
+                foreach (var location in refSet.Locations)
+                {
+                    AddReferencedFilePath(referencedFilePaths, location.Document.FilePath);
+                }
+            }
+        }
+
+        return referencedFilePaths;
+    }
+
+    private static void AddReferencedFilePath(HashSet<string> referencedFilePaths, string? filePath)
+    {
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            referencedFilePaths.Add(Path.GetFullPath(filePath));
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- extract helper branches from `CodePatternAnalyzer.ParseSemanticQuery` so keyword, accessibility, return-type, implementation, and parameter-count parsing stay isolated from the final parse assembly
- extract the heuristic search-term path and reference-augmentation path from `TestDiscoveryService.FindRelatedTestsAsync` while preserving its interface-dispatch behavior
- keep the tranche scoped to the two production methods covered by the current residual-complexity plan

## Test plan
- [x] `mcp__roslyn__.compile_check` on `RoslynMcp.Roslyn`
- [x] targeted `mcp__roslyn__.test_run` for semantic-search regressions and `ValidationToolsIntegrationTests.TestRelated_InterfaceMemberCalledByTestsViaDispatch_SurfacesTheTest`
- [x] `./eng/verify-release.ps1 -Configuration Release -NoCoverage`

Generated with [Codex](https://Codex.com/Codex)