### PR TITLE
docs(runtime): document parallel read fan-out (host-parallel-mcp-reads)

### DIFF
--- a/ai_docs/domains/tool-usage-guide.md
+++ b/ai_docs/domains/tool-usage-guide.md
@@ -25,6 +25,20 @@ Call `discover_capabilities` with a category to get contextual guidance, or use 
 
 **"I need to verify after a multi-file edit"** → `validate_recent_git_changes` (auto-scoped to `git status`), or `validate_workspace` with an explicit `changedFilePaths` — see [Verification workflow](#verification-workflow-post-edit-default)
 
+## Parallel read fan-out
+
+If you need several independent answers from the same loaded workspace, issue
+read-only calls in parallel when the client supports concurrent MCP requests.
+Good pairings include multiple `find_references` / `symbol_search` lookups, or
+navigation plus `compile_check`.
+
+- Safe: read-only analysis/navigation/verification on an already-loaded
+  workspace.
+- Unsafe to overlap: `workspace_load`, `workspace_reload`, `workspace_close`,
+  and all `*_apply` / `apply_*` mutation flows.
+- If the host serializes requests, fall back to sequential calls and note that
+  the client blocked parallelism rather than the server.
+
 ## Verification workflow (post-edit default)
 
 After any C# edit — `Edit`, `Write`, or `*_apply` — the canonical verify for

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -113,6 +113,22 @@ Prefer Roslyn MCP read tools over shell/Grep in normal sessions, including boots
 
 Canonical pattern-to-tool mappings live in `bootstrap-read-tool-primer.md`.
 
+### Parallel read-only calls
+
+When the client or host can issue multiple MCP requests concurrently, read-only
+workspace tools may fan out in parallel against the same loaded workspace. The
+server's `WorkspaceExecutionGate` allows overlapping reads on one workspace and
+serializes writers/lifecycle calls around them.
+
+- Safe parallel fan-out candidates: `symbol_search`, `find_references`,
+  `find_consumers`, `document_symbols`, `compile_check`, and other read-only
+  navigation/analysis calls after `workspace_load`.
+- Do not overlap reads with write/lifecycle operations on the same workspace:
+  `*_apply`, `apply_*`, `workspace_load`, `workspace_reload`, and
+  `workspace_close` stay serialized by design.
+- If the host serializes MCP tool calls, expect no speedup. That is a client
+  limitation, not a server-side correctness bug.
+
 ### Write-side by session shape
 
 | Session shape | Preferred write path |


### PR DESCRIPTION
## Summary
- document when parallel read-only MCP calls are safe against a loaded workspace
- cross-link the runtime policy and tool-usage guide on what can and cannot overlap
- clarify that client-side serialization blocks speedup even when the server permits concurrent reads

## Closes
- none (initiative documents current server behavior only; `host-parallel-mcp-reads` stays open)

## Validation
- [x] `./eng/verify-ai-docs.ps1`