### PR TITLE
refactor(roslyn): split scripting/document persistence helpers (cc-18-19-s1-scripting-persist)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -870,8 +870,6 @@ public sealed class RefactoringService : IRefactoringService
         SolutionChanges solutionChanges,
         CancellationToken ct)
     {
-        var appliedFiles = new List<string>();
-
         // Item #5 — severity-medium-breaks-msbuild-until-csproj-is-hand.
         //
         // MSBuildWorkspace.TryApplyChanges, when it sees an added document in an
@@ -888,8 +886,6 @@ public sealed class RefactoringService : IRefactoringService
         // workspace's view of the added document (TryApplyChanges has already added
         // the document to the in-memory Solution). The next reload picks up the new
         // file through the SDK's default glob, so the on-disk csproj stays clean.
-        var sdkProjectCsprojSnapshots = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
         // csproj-reserialization-msbuildworkspace (P2) — create-file-apply-csproj-side-effect-all-projects.
         //
         // Extends Item #5's snapshot pattern to EVERY csproj in the workspace. MSBuildWorkspace's
@@ -910,6 +906,31 @@ public sealed class RefactoringService : IRefactoringService
         // them. This whole-workspace snapshot is a SECOND pass that handles the other shapes of
         // MSBuild-driven reserialization drift (e.g., csprojs with analyzer references that trigger
         // TryApplyChanges via StripUnresolvedAnalyzerReferences on subsequent reloads).
+        var persistenceState = await CreateDocumentSetPersistenceStateAsync(currentSolution, ct).ConfigureAwait(false);
+
+        try
+        {
+            await PersistDocumentSetChangesCoreAsync(
+                workspaceId,
+                currentSolution,
+                modifiedSolution,
+                solutionChanges,
+                persistenceState,
+                ct).ConfigureAwait(false);
+
+            return (true, persistenceState.GetDistinctAppliedFiles());
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            _logger.LogWarning(ex, "Failed to persist document set changes for workspace {WorkspaceId}", workspaceId);
+            return (false, []);
+        }
+    }
+
+    private async Task<DocumentSetPersistenceState> CreateDocumentSetPersistenceStateAsync(
+        Solution currentSolution,
+        CancellationToken ct)
+    {
         var allCsprojSnapshots = await CsprojSemanticEquality.SnapshotProjectsAsync(
             currentSolution.Projects
                 .Select(project => project.FilePath)
@@ -917,33 +938,37 @@ public sealed class RefactoringService : IRefactoringService
             _logger,
             ct).ConfigureAwait(false);
 
-        try
-        {
-            foreach (var projectChange in solutionChanges.GetProjectChanges())
-            {
-                await PersistProjectDocumentChangesAsync(
-                    currentSolution,
-                    modifiedSolution,
-                    projectChange,
-                    sdkProjectCsprojSnapshots,
-                    appliedFiles,
-                    ct).ConfigureAwait(false);
-            }
+        return new DocumentSetPersistenceState(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            new List<string>(),
+            allCsprojSnapshots);
+    }
 
-            await ApplyDocumentSetChangesAsync(
-                workspaceId,
+    private async Task PersistDocumentSetChangesCoreAsync(
+        string workspaceId,
+        Solution currentSolution,
+        Solution modifiedSolution,
+        SolutionChanges solutionChanges,
+        DocumentSetPersistenceState persistenceState,
+        CancellationToken ct)
+    {
+        foreach (var projectChange in solutionChanges.GetProjectChanges())
+        {
+            await PersistProjectDocumentChangesAsync(
+                currentSolution,
                 modifiedSolution,
-                sdkProjectCsprojSnapshots,
-                allCsprojSnapshots,
+                projectChange,
+                persistenceState.SdkProjectCsprojSnapshots,
+                persistenceState.AppliedFiles,
                 ct).ConfigureAwait(false);
+        }
 
-            return (true, appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList());
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
-        {
-            _logger.LogWarning(ex, "Failed to persist document set changes for workspace {WorkspaceId}", workspaceId);
-            return (false, []);
-        }
+        await ApplyDocumentSetChangesAsync(
+            workspaceId,
+            modifiedSolution,
+            persistenceState.SdkProjectCsprojSnapshots,
+            persistenceState.AllCsprojSnapshots,
+            ct).ConfigureAwait(false);
     }
 
     private async Task PersistProjectDocumentChangesAsync(
@@ -1059,6 +1084,19 @@ public sealed class RefactoringService : IRefactoringService
 
             appliedFiles.Add(document.FilePath);
         }
+    }
+
+    private sealed class DocumentSetPersistenceState(
+        Dictionary<string, string> sdkProjectCsprojSnapshots,
+        List<string> appliedFiles,
+        IReadOnlyDictionary<string, string> allCsprojSnapshots)
+    {
+        public Dictionary<string, string> SdkProjectCsprojSnapshots { get; } = sdkProjectCsprojSnapshots;
+        public List<string> AppliedFiles { get; } = appliedFiles;
+        public IReadOnlyDictionary<string, string> AllCsprojSnapshots { get; } = allCsprojSnapshots;
+
+        public IReadOnlyList<string> GetDistinctAppliedFiles() =>
+            AppliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private async Task ApplyDocumentSetChangesAsync(

--- a/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScriptingService.cs
@@ -84,15 +84,9 @@ public sealed class ScriptingService : IScriptingService
         Action<ScriptEvaluationProgress>? onProgress = null,
         int? timeoutSecondsOverride = null)
     {
-        // UX-002: per-call timeout override; null/<=0 falls back to env-configured default.
-        var effectiveTimeoutSeconds = timeoutSecondsOverride is > 0
-            ? timeoutSecondsOverride.Value
-            : _options.TimeoutSeconds;
-        var graceSeconds = Math.Max(0, _options.WatchdogGraceSeconds);
-        var hardDeadlineSeconds = effectiveTimeoutSeconds + graceSeconds;
-        var heartbeatInterval = TimeSpan.FromMilliseconds(Math.Max(100, _options.HeartbeatIntervalMs));
+        var settings = CreateExecutionSettings(imports, timeoutSecondsOverride);
 
-        var capacityError = await TryAcquireCapacityAsync(effectiveTimeoutSeconds, ct).ConfigureAwait(false);
+        var capacityError = await TryAcquireCapacityAsync(settings.EffectiveTimeoutSeconds, ct).ConfigureAwait(false);
         if (capacityError is not null)
         {
             return capacityError;
@@ -100,76 +94,109 @@ public sealed class ScriptingService : IScriptingService
 
         Interlocked.Increment(ref _activeEvaluations);
 
-        var sw = Stopwatch.StartNew();
-        var budget = TimeSpan.FromSeconds(effectiveTimeoutSeconds);
-        var scriptOptions = BuildScriptOptions(imports);
-
         // The script execution token is the inner token Roslyn sees. We cancel it when the
         // budget elapses, but Roslyn may not honor it for tight loops — that is what the
         // hard deadline below is for.
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(budget);
-
-        Timer? heartbeatTimer = null;
-        Timer? deadlineTimer = null;
-        var runState = new ScriptRunState();
-
-        // Signaled by EXACTLY ONE of: the worker thread (success/error/cancel) or the deadline timer.
-        // RunContinuationsAsynchronously ensures the awaiting frame is not invoked inline on the
-        // worker thread or the timer thread.
-        var completion = CreateCompletionSource();
-
-        void ReleaseSlotOnce()
-        {
-            if (Interlocked.Exchange(ref runState.SlotReleased, 1) == 0)
-            {
-                Interlocked.Decrement(ref _activeEvaluations);
-                try { _concurrencyGate.Release(); }
-                catch (ObjectDisposedException) { /* host shutting down */ }
-                catch (SemaphoreFullException) { /* defensive */ }
-            }
-        }
+        using var timeoutCts = CreateTimeoutTokenSource(ct, settings.Budget);
+        var execution = CreateExecutionContext();
 
         try
         {
-            var workerThread = StartWorkerThread(code, scriptOptions, timeoutCts.Token, completion, runState);
-            deadlineTimer = CreateDeadlineTimer(completion, hardDeadlineSeconds);
-            heartbeatTimer = CreateHeartbeatTimer(
-                onProgress,
-                sw,
-                budget,
-                effectiveTimeoutSeconds,
-                heartbeatInterval,
-                runState);
-
-            // Outer cancellation propagation: if the caller cancels (e.g. MCP request budget),
-            // surface OperationCanceledException promptly. Worker thread is then abandoned.
-            using var ctRegistration = RegisterOuterCancellation(ct, completion);
-
-            var raceOutcome = await completion.Task.ConfigureAwait(false);
-            sw.Stop();
-            return FinalizeEvaluation(
-                raceOutcome,
-                sw,
-                workerThread.Name,
-                runState,
-                hardDeadlineSeconds,
-                effectiveTimeoutSeconds,
-                graceSeconds,
-                ct,
-                timeoutCts);
+            return await RunEvaluationAsync(code, onProgress, ct, timeoutCts, settings, execution).ConfigureAwait(false);
         }
         finally
         {
-            // Tear down timers (synchronous; never blocks).
-            try { heartbeatTimer?.Dispose(); } catch { /* best-effort */ }
-            try { deadlineTimer?.Dispose(); } catch { /* best-effort */ }
-
-            // Always release the slot. The request is done from the caller's perspective. If
-            // the worker thread is still running it has been moved to the abandoned counter and
-            // will not consume a slot.
-            ReleaseSlotOnce();
+            DisposeTimers(execution);
+            ReleaseConcurrencySlot(execution.RunState);
         }
+    }
+
+    private ScriptExecutionSettings CreateExecutionSettings(string[]? imports, int? timeoutSecondsOverride)
+    {
+        // UX-002: per-call timeout override; null/<=0 falls back to env-configured default.
+        var effectiveTimeoutSeconds = timeoutSecondsOverride is > 0
+            ? timeoutSecondsOverride.Value
+            : _options.TimeoutSeconds;
+        var graceSeconds = Math.Max(0, _options.WatchdogGraceSeconds);
+
+        return new ScriptExecutionSettings(
+            EffectiveTimeoutSeconds: effectiveTimeoutSeconds,
+            GraceSeconds: graceSeconds,
+            HardDeadlineSeconds: effectiveTimeoutSeconds + graceSeconds,
+            HeartbeatInterval: TimeSpan.FromMilliseconds(Math.Max(100, _options.HeartbeatIntervalMs)),
+            Budget: TimeSpan.FromSeconds(effectiveTimeoutSeconds),
+            ScriptOptions: BuildScriptOptions(imports));
+    }
+
+    private static CancellationTokenSource CreateTimeoutTokenSource(CancellationToken ct, TimeSpan budget)
+    {
+        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(budget);
+        return timeoutCts;
+    }
+
+    private static ScriptExecutionContext CreateExecutionContext() =>
+        new(Stopwatch.StartNew(), new ScriptRunState(), CreateCompletionSource());
+
+    private async Task<ScriptEvaluationDto> RunEvaluationAsync(
+        string code,
+        Action<ScriptEvaluationProgress>? onProgress,
+        CancellationToken ct,
+        CancellationTokenSource timeoutCts,
+        ScriptExecutionSettings settings,
+        ScriptExecutionContext execution)
+    {
+        var workerThread = StartWorkerThread(
+            code,
+            settings.ScriptOptions,
+            timeoutCts.Token,
+            execution.Completion,
+            execution.RunState);
+        execution.DeadlineTimer = CreateDeadlineTimer(execution.Completion, settings.HardDeadlineSeconds);
+        execution.HeartbeatTimer = CreateHeartbeatTimer(
+            onProgress,
+            execution.Stopwatch,
+            settings.Budget,
+            settings.EffectiveTimeoutSeconds,
+            settings.HeartbeatInterval,
+            execution.RunState);
+
+        // Outer cancellation propagation: if the caller cancels (e.g. MCP request budget),
+        // surface OperationCanceledException promptly. Worker thread is then abandoned.
+        using var ctRegistration = RegisterOuterCancellation(ct, execution.Completion);
+
+        var raceOutcome = await execution.Completion.Task.ConfigureAwait(false);
+        execution.Stopwatch.Stop();
+        return FinalizeEvaluation(
+            raceOutcome,
+            execution.Stopwatch,
+            workerThread.Name,
+            execution.RunState,
+            settings.HardDeadlineSeconds,
+            settings.EffectiveTimeoutSeconds,
+            settings.GraceSeconds,
+            ct,
+            timeoutCts);
+    }
+
+    private void ReleaseConcurrencySlot(ScriptRunState runState)
+    {
+        if (Interlocked.Exchange(ref runState.SlotReleased, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Decrement(ref _activeEvaluations);
+        try { _concurrencyGate.Release(); }
+        catch (ObjectDisposedException) { /* host shutting down */ }
+        catch (SemaphoreFullException) { /* defensive */ }
+    }
+
+    private static void DisposeTimers(ScriptExecutionContext execution)
+    {
+        // Tear down timers (synchronous; never blocks).
+        try { execution.HeartbeatTimer?.Dispose(); } catch { /* best-effort */ }
+        try { execution.DeadlineTimer?.Dispose(); } catch { /* best-effort */ }
     }
 
     private static TaskCompletionSource<ScriptOutcome> CreateCompletionSource() =>
@@ -561,6 +588,26 @@ public sealed class ScriptingService : IScriptingService
         public long SlotReleased;
         public long AbandonedFlag;
     }
+
+    private sealed class ScriptExecutionContext(
+        Stopwatch stopwatch,
+        ScriptRunState runState,
+        TaskCompletionSource<ScriptOutcome> completion)
+    {
+        public Stopwatch Stopwatch { get; } = stopwatch;
+        public ScriptRunState RunState { get; } = runState;
+        public TaskCompletionSource<ScriptOutcome> Completion { get; } = completion;
+        public Timer? HeartbeatTimer { get; set; }
+        public Timer? DeadlineTimer { get; set; }
+    }
+
+    private readonly record struct ScriptExecutionSettings(
+        int EffectiveTimeoutSeconds,
+        int GraceSeconds,
+        int HardDeadlineSeconds,
+        TimeSpan HeartbeatInterval,
+        TimeSpan Budget,
+        ScriptOptions ScriptOptions);
 
     private enum ScriptOutcomeKind
     {

--- a/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
+++ b/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
@@ -121,6 +121,31 @@ public sealed class ScriptingServiceTests
     }
 
     [TestMethod]
+    [Timeout(10_000)]
+    public async Task EvaluateAsync_LongRunningAsyncScript_ReportsHeartbeatProgress()
+    {
+        var options = new ScriptingServiceOptions
+        {
+            HeartbeatIntervalMs = 100,
+            WatchdogGraceSeconds = 1,
+        };
+        var service = new ScriptingService(NullLogger<ScriptingService>.Instance, options);
+        var observedHeartbeats = 0;
+
+        var result = await service.EvaluateAsync(
+            "await Task.Delay(500); 123",
+            imports: null,
+            CancellationToken.None,
+            _ => Interlocked.Increment(ref observedHeartbeats),
+            timeoutSecondsOverride: 5).ConfigureAwait(false);
+
+        Assert.IsTrue(result.Success, result.Error);
+        Assert.AreEqual("123", result.ResultValue);
+        Assert.IsTrue(result.ProgressHeartbeatCount is >= 1, "Expected the DTO to report at least one heartbeat.");
+        Assert.IsTrue(observedHeartbeats >= result.ProgressHeartbeatCount, "Heartbeat callback count should match or exceed the reported timer count.");
+    }
+
+    [TestMethod]
     public async Task EvaluateAsync_SimpleExpression_ReturnsResult()
     {
         var service = new ScriptingService(NullLogger<ScriptingService>.Instance, new ScriptingServiceOptions());


### PR DESCRIPTION
Closes: none (contributes to cc-18-to-19-residuals-post-top10-extraction; row stays open)

## Summary
- split `ScriptingService.EvaluateAsync` into execution-settings, execution-context, and orchestration helpers without changing watchdog/cancellation behavior
- split `RefactoringService.PersistDocumentSetChangesAsync` into persistence-state setup plus a focused core apply helper
- add a regression test that exercises heartbeat progress for a long-running async script

## Validation
- `mcp__roslyn__compile_check` on `RoslynMcp.Roslyn`
- `mcp__roslyn__compile_check` on `RoslynMcp.Tests`
- `mcp__roslyn__test_run --filter "FullyQualifiedName~RoslynMcp.Tests.ScriptingServiceTests|FullyQualifiedName~RoslynMcp.Tests.CsprojReserializationTests|FullyQualifiedName~RoslynMcp.Tests.SdkStyleCsprojInjectionTests"` (27 passed)
- `./eng/verify-ai-docs.ps1`
- `./eng/verify-release.ps1 -Configuration Release`