### PR TITLE
feat(workspace): auto-restore stale package inputs (workspace-reload-auto-restore)

### DIFF
--- a/src/RoslynMcp.Core/Models/WorkspaceStatusDto.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceStatusDto.cs
@@ -38,7 +38,8 @@ public sealed record WorkspaceStatusDto(
     IReadOnlyList<DiagnosticDto> WorkspaceDiagnostics,
     [property: JsonPropertyName("staleReason")]
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? StaleReason = null);
+    string? StaleReason = null,
+    bool RestoreRequired = false);
 
 /// <summary>
 /// Represents the status of a project within a loaded workspace.

--- a/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
@@ -17,6 +17,7 @@ namespace RoslynMcp.Core.Models;
 ///   <item><description><see cref="IsStale"/> is false — no pending external changes.</description></item>
 ///   <item><description><see cref="AnalyzersReady"/> — every required analyzer reference resolved.</description></item>
 ///   <item><description><see cref="WorkspaceErrorCount"/> is zero.</description></item>
+///   <item><description><see cref="RestoreRequired"/> is false — package-restore inputs still match the loaded assets snapshot.</description></item>
 /// </list>
 /// <para>
 /// Pre-bundle the formula was just <c>IsLoaded &amp;&amp; !IsStale &amp;&amp; errors == 0</c>; analyzer-resolution
@@ -41,6 +42,7 @@ public sealed record WorkspaceStatusSummaryDto(
     int WorkspaceWarningCount,
     bool IsReady,
     bool AnalyzersReady,
+    bool RestoreRequired,
     string? RestoreHint,
     string? SolutionFileName)
 {
@@ -74,12 +76,14 @@ public sealed record WorkspaceStatusSummaryDto(
 
         var analyzersReady = unresolvedAnalyzerWarnings == 0;
         var solutionFileName = GetSolutionOrProjectFileName(status.LoadedPath);
-        var isReady = status.IsLoaded && !status.IsStale && analyzersReady && errors == 0;
+        var restoreRequired = status.RestoreRequired;
+        var isReady = status.IsLoaded && !status.IsStale && analyzersReady && errors == 0 && !restoreRequired;
         var restoreHint = BuildRestoreHint(
             status.WorkspaceDiagnostics,
             isStale: status.IsStale,
             errors: errors,
-            unresolvedAnalyzerWarnings: unresolvedAnalyzerWarnings);
+            unresolvedAnalyzerWarnings: unresolvedAnalyzerWarnings,
+            restoreRequired: restoreRequired);
 
         return new WorkspaceStatusSummaryDto(
             WorkspaceId: status.WorkspaceId,
@@ -96,6 +100,7 @@ public sealed record WorkspaceStatusSummaryDto(
             WorkspaceWarningCount: warnings,
             IsReady: isReady,
             AnalyzersReady: analyzersReady,
+            RestoreRequired: restoreRequired,
             RestoreHint: restoreHint,
             SolutionFileName: solutionFileName);
     }
@@ -114,8 +119,14 @@ public sealed record WorkspaceStatusSummaryDto(
         IReadOnlyList<DiagnosticDto> workspaceDiagnostics,
         bool isStale,
         int errors,
-        int unresolvedAnalyzerWarnings)
+        int unresolvedAnalyzerWarnings,
+        bool restoreRequired)
     {
+        if (restoreRequired)
+        {
+            return "Package-restore inputs changed since the last restore. Run `dotnet restore` on the solution or project, then `workspace_reload`.";
+        }
+
         if (unresolvedAnalyzerWarnings > 0)
         {
             return $"{unresolvedAnalyzerWarnings} analyzer reference(s) failed to load — analyzer-driven tools (e.g. find_unused_symbols, project_diagnostics) will under-report. Run `dotnet restore` on the solution and reload the workspace.";

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -13,15 +13,17 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class WorkspaceTools
 {
 
-    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj file into the workspace for semantic analysis. Returns a lean summary by default — pass verbose=true for the full per-project tree (large solutions can produce ~30 KB or more). Idempotent by path: if the same solution/project file is already loaded in this host process, workspace_load returns the EXISTING WorkspaceId instead of creating a new one — no extra workspace slot is consumed. DocumentCount note: the per-project DocumentCount often exceeds the <Compile> item count (from evaluate_msbuild_items) by about 3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit <Compile> items. Sessions persist for the lifetime of the stdio host process — there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 8) forced an eviction. When a previously valid workspaceId returns 'Workspace was not found', call workspace_load again rather than treating it as an error.")]
+    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj file into the workspace for semantic analysis. Returns a lean summary by default — pass verbose=true for the full per-project tree (large solutions can produce ~30 KB or more). Idempotent by path: if the same solution/project file is already loaded in this host process, workspace_load returns the EXISTING WorkspaceId instead of creating a new one — no extra workspace slot is consumed. Set autoRestore=true to run dotnet restore and one follow-up reload when the loaded status reports restoreRequired=true. DocumentCount note: the per-project DocumentCount often exceeds the <Compile> item count (from evaluate_msbuild_items) by about 3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit <Compile> items. Sessions persist for the lifetime of the stdio host process — there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 8) forced an eviction. When a previously valid workspaceId returns 'Workspace was not found', call workspace_load again rather than treating it as an error.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Load a .sln, .slnx, or .csproj into a named Roslyn workspace session.")]
     public static Task<string> LoadWorkspace(
         McpServer server,
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
+        IDotnetCommandRunner commandRunner,
         [Description("Absolute path to a .sln, .slnx, or .csproj file")] string path,
         [Description("When true, return the full per-project tree and workspace diagnostics. Default false returns only counts and load state.")] bool verbose = false,
+        [Description("When true and the loaded status reports restoreRequired=true, run `dotnet restore` on the target and reload once before returning.")] bool autoRestore = false,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
@@ -29,7 +31,8 @@ public static class WorkspaceTools
         {
             ProgressHelper.Report(progress, 0, 1);
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, path, c).ConfigureAwait(false);
-            var status = await workspace.LoadAsync(path, c);
+            var status = await workspace.LoadAsync(path, c).ConfigureAwait(false);
+            status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, c).ConfigureAwait(false);
             ProgressHelper.Report(progress, 1, 1);
             _ = NotifyResourcesChangedAsync(server);
             return verbose
@@ -38,22 +41,25 @@ public static class WorkspaceTools
         }, ct);
     }
 
-    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes")]
+    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes. Set autoRestore=true to run dotnet restore and one follow-up reload when the reloaded status reports restoreRequired=true.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Reload an existing workspace session from disk.")]
     public static Task<string> ReloadWorkspace(
         McpServer server,
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
+        IDotnetCommandRunner commandRunner,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        CancellationToken ct)
+        [Description("When true and the reloaded status reports restoreRequired=true, run `dotnet restore` on the loaded target and reload once before returning.")] bool autoRestore = false,
+        CancellationToken ct = default)
     {
         // Reload acquires both the global load gate AND the per-workspace write lock so that
         // any in-flight readers on this workspace complete before the solution is replaced.
         return gate.RunLoadGateAsync(outerCt =>
             gate.RunWriteAsync(workspaceId, async innerCt =>
             {
-                var status = await workspace.ReloadAsync(workspaceId, innerCt);
+                var status = await workspace.ReloadAsync(workspaceId, innerCt).ConfigureAwait(false);
+                status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, innerCt).ConfigureAwait(false);
                 _ = NotifyResourcesChangedAsync(server);
                 return JsonSerializer.Serialize(status, JsonDefaults.Indented);
             }, outerCt), ct);
@@ -235,6 +241,57 @@ public static class WorkspaceTools
                 text = slice
             }, JsonDefaults.Indented);
         }, ct);
+    }
+
+    internal static async Task<WorkspaceStatusDto> RestoreAndReloadIfRequiredAsync(
+        IDotnetCommandRunner commandRunner,
+        IWorkspaceManager workspace,
+        WorkspaceStatusDto status,
+        bool autoRestore,
+        CancellationToken ct)
+    {
+        if (!autoRestore || !status.RestoreRequired || string.IsNullOrWhiteSpace(status.LoadedPath))
+        {
+            return status;
+        }
+
+        var workingDirectory = Path.GetDirectoryName(status.LoadedPath);
+        if (string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            throw new InvalidOperationException(
+                $"workspace auto-restore could not determine a working directory for '{status.LoadedPath}'.");
+        }
+
+        var execution = await commandRunner.RunAsync(
+            workingDirectory,
+            status.LoadedPath,
+            ["restore", status.LoadedPath, "--nologo"],
+            ct).ConfigureAwait(false);
+
+        if (!execution.Succeeded)
+        {
+            throw new InvalidOperationException(BuildRestoreFailureMessage(status.LoadedPath, execution));
+        }
+
+        return await workspace.ReloadAsync(status.WorkspaceId, ct).ConfigureAwait(false);
+    }
+
+    private static string BuildRestoreFailureMessage(string targetPath, CommandExecutionDto execution)
+    {
+        static string TrimOutput(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return "(empty)";
+            }
+
+            var trimmed = text.Trim();
+            return trimmed.Length <= 500 ? trimmed : trimmed[^500..];
+        }
+
+        return
+            $"workspace auto-restore failed for '{targetPath}' (exit code {execution.ExitCode}). " +
+            $"stdout tail: {TrimOutput(execution.StdOut)} stderr tail: {TrimOutput(execution.StdErr)}";
     }
 
     /// <summary>

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Text.Json;
 using System.Threading;
 using System.Xml.Linq;
 
@@ -676,6 +677,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 
             session.ProjectStatuses = BuildProjectStatuses(session.Workspace.CurrentSolution);
             session.LoadedPath = fullPath;
+            session.RestoreRequired = DetectRestoreRequired(session.ProjectStatuses) ||
+                                      HasRestoreRequiredWorkspaceDiagnostics(session.WorkspaceDiagnostics);
             session.LoadedAtUtc = DateTimeOffset.UtcNow;
             session.IncrementVersion();
             _previewStore.InvalidateAll(session.WorkspaceId);
@@ -866,6 +869,326 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         }
     }
 
+    private bool DetectRestoreRequired(ImmutableArray<ProjectStatusDto> projects)
+    {
+        foreach (var project in projects)
+        {
+            if (IsRestoreRequired(project.FilePath))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool IsRestoreRequired(string projectFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilePath) || !File.Exists(projectFilePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var expectedPackages = CollectExpectedPackages(projectFilePath);
+            if (expectedPackages.Count == 0)
+            {
+                return false;
+            }
+
+            var assets = LoadAssetsPackageVersions(projectFilePath);
+            if (assets is null)
+            {
+                return true;
+            }
+
+            foreach (var (packageId, expectation) in expectedPackages)
+            {
+                if (!assets.Value.PackageVersions.TryGetValue(packageId, out var assetVersions))
+                {
+                    return true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(expectation.RequestedVersion) &&
+                    !PackageVersionMatches(expectation.RequestedVersion!, assetVersions))
+                {
+                    return true;
+                }
+
+                if (expectation.UsesCentralVersion)
+                {
+                    if (string.IsNullOrWhiteSpace(expectation.RequestedVersion) ||
+                        !assets.Value.CentralPackageVersions.TryGetValue(packageId, out var centralVersions) ||
+                        !PackageVersionMatches(expectation.RequestedVersion!, centralVersions))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
+        {
+            _logger.LogDebug(ex, "restore-drift detection skipped for '{ProjectFilePath}'", projectFilePath);
+        }
+
+        return false;
+    }
+
+    private static Dictionary<string, PackageExpectation> CollectExpectedPackages(string projectFilePath)
+    {
+        var expected = new Dictionary<string, PackageExpectation>(StringComparer.OrdinalIgnoreCase);
+        var centralPackages = LoadCentralPackageVersions(MsBuildMetadataHelper.FindDirectoryPackagesProps(projectFilePath));
+
+        foreach (var documentPath in EnumeratePackageReferenceDocuments(projectFilePath))
+        {
+            XDocument document;
+            try
+            {
+                document = XDocument.Load(documentPath, LoadOptions.PreserveWhitespace);
+            }
+            catch (System.Xml.XmlException)
+            {
+                continue;
+            }
+
+            foreach (var element in document
+                         .Descendants()
+                         .Where(candidate => string.Equals(candidate.Name.LocalName, "PackageReference", StringComparison.OrdinalIgnoreCase)))
+            {
+                var packageId = GetXmlValue(element, "Include") ?? GetXmlValue(element, "Update");
+                if (string.IsNullOrWhiteSpace(packageId))
+                {
+                    continue;
+                }
+
+                var explicitVersion =
+                    GetXmlValue(element, "VersionOverride") ??
+                    GetChildValue(element, "VersionOverride") ??
+                    GetXmlValue(element, "Version") ??
+                    GetChildValue(element, "Version");
+
+                centralPackages.TryGetValue(packageId, out var centralVersion);
+                var usesCentralVersion = string.IsNullOrWhiteSpace(explicitVersion) &&
+                                         !string.IsNullOrWhiteSpace(centralVersion);
+                expected[packageId] = new PackageExpectation(
+                    usesCentralVersion ? centralVersion : explicitVersion,
+                    usesCentralVersion);
+            }
+        }
+
+        return expected;
+    }
+
+    private static IEnumerable<string> EnumeratePackageReferenceDocuments(string projectFilePath)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var buildPropsPath = FindNearestFile(projectFilePath, "Directory.Build.props");
+        if (!string.IsNullOrWhiteSpace(buildPropsPath) && seen.Add(buildPropsPath))
+        {
+            yield return buildPropsPath;
+        }
+
+        if (seen.Add(projectFilePath))
+        {
+            yield return projectFilePath;
+        }
+
+        var buildTargetsPath = FindNearestFile(projectFilePath, "Directory.Build.targets");
+        if (!string.IsNullOrWhiteSpace(buildTargetsPath) && seen.Add(buildTargetsPath))
+        {
+            yield return buildTargetsPath;
+        }
+    }
+
+    private static string? FindNearestFile(string path, string fileName)
+    {
+        var directory = Path.GetDirectoryName(path);
+        while (!string.IsNullOrWhiteSpace(directory))
+        {
+            var candidate = Path.Combine(directory, fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, string> LoadCentralPackageVersions(string? packagesPropsPath)
+    {
+        var centralPackages = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(packagesPropsPath) || !File.Exists(packagesPropsPath))
+        {
+            return centralPackages;
+        }
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Load(packagesPropsPath, LoadOptions.PreserveWhitespace);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return centralPackages;
+        }
+
+        foreach (var element in document
+                     .Descendants()
+                     .Where(candidate => string.Equals(candidate.Name.LocalName, "PackageVersion", StringComparison.OrdinalIgnoreCase)))
+        {
+            var packageId = GetXmlValue(element, "Include");
+            var version = GetXmlValue(element, "Version") ?? GetChildValue(element, "Version");
+            if (!string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(version))
+            {
+                centralPackages[packageId] = version;
+            }
+        }
+
+        return centralPackages;
+    }
+
+    private static (Dictionary<string, HashSet<string>> PackageVersions, Dictionary<string, HashSet<string>> CentralPackageVersions)? LoadAssetsPackageVersions(string projectFilePath)
+    {
+        var projectDirectory = Path.GetDirectoryName(projectFilePath);
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+        {
+            return null;
+        }
+
+        var assetsPath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+        if (!File.Exists(assetsPath))
+        {
+            return null;
+        }
+
+        using var stream = File.OpenRead(assetsPath);
+        using var document = JsonDocument.Parse(stream);
+        if (!document.RootElement.TryGetProperty("project", out var project) ||
+            !project.TryGetProperty("frameworks", out var frameworks) ||
+            frameworks.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var packageVersions = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var centralPackageVersions = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var framework in frameworks.EnumerateObject())
+        {
+            if (framework.Value.TryGetProperty("dependencies", out var dependencies) &&
+                dependencies.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dependency in dependencies.EnumerateObject())
+                {
+                    if (!dependency.Value.TryGetProperty("version", out var versionElement) ||
+                        versionElement.ValueKind != JsonValueKind.String)
+                    {
+                        continue;
+                    }
+
+                    AddVersion(packageVersions, dependency.Name, versionElement.GetString());
+                }
+            }
+
+            if (framework.Value.TryGetProperty("centralPackageVersions", out var centralVersions) &&
+                centralVersions.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var centralVersion in centralVersions.EnumerateObject())
+                {
+                    AddVersion(centralPackageVersions, centralVersion.Name, centralVersion.Value.GetString());
+                }
+            }
+        }
+
+        return (packageVersions, centralPackageVersions);
+    }
+
+    private static void AddVersion(Dictionary<string, HashSet<string>> versions, string packageId, string? version)
+    {
+        if (string.IsNullOrWhiteSpace(packageId) || string.IsNullOrWhiteSpace(version))
+        {
+            return;
+        }
+
+        if (!versions.TryGetValue(packageId, out var values))
+        {
+            values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            versions[packageId] = values;
+        }
+
+        values.Add(version.Trim());
+    }
+
+    private static bool PackageVersionMatches(string expectedVersion, IReadOnlySet<string> actualVersions)
+    {
+        var expected = expectedVersion.Trim();
+        if (string.IsNullOrWhiteSpace(expected))
+        {
+            return false;
+        }
+
+        if (actualVersions.Contains(expected))
+        {
+            return true;
+        }
+
+        if (expected.StartsWith("[", StringComparison.Ordinal) || expected.StartsWith("(", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return actualVersions.Contains($"[{expected}, )");
+    }
+
+    private static string? GetXmlValue(XElement element, string localName)
+    {
+        return element.Attributes().FirstOrDefault(attribute =>
+            string.Equals(attribute.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase))?.Value?.Trim();
+    }
+
+    private static string? GetChildValue(XElement element, string localName)
+    {
+        return element.Elements().FirstOrDefault(child =>
+            string.Equals(child.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase))?.Value?.Trim();
+    }
+
+    private static bool HasRestoreRequiredWorkspaceDiagnostics(IEnumerable<DiagnosticDto> diagnostics)
+    {
+        var suspiciousDiagnostics = 0;
+        foreach (var diagnostic in diagnostics)
+        {
+            if (string.Equals(diagnostic.Id, "WORKSPACE_UNRESOLVED_ANALYZER", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(diagnostic.Id, "CS0234", StringComparison.OrdinalIgnoreCase))
+            {
+                suspiciousDiagnostics++;
+                continue;
+            }
+
+            var message = diagnostic.Message;
+            if (message is null)
+            {
+                continue;
+            }
+
+            if (message.Contains("could not be found", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("does not exist in the namespace", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("could not load file or assembly", StringComparison.OrdinalIgnoreCase))
+            {
+                suspiciousDiagnostics++;
+            }
+        }
+
+        return suspiciousDiagnostics >= 3;
+    }
+
     /// <summary>
     /// Removes <see cref="UnresolvedAnalyzerReference"/> entries from every project in the
     /// loaded workspace. These entries are produced when an analyzer file referenced by the
@@ -996,7 +1319,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 IsLoaded: false,
                 IsStale: isStale,
                 WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray(),
-                StaleReason: staleReason);
+                StaleReason: staleReason,
+                RestoreRequired: session.RestoreRequired);
         }
 
         var projects = session.ProjectStatuses;
@@ -1013,7 +1337,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             IsLoaded: true,
             IsStale: isStale,
             WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray(),
-            StaleReason: staleReason);
+            StaleReason: staleReason,
+            RestoreRequired: session.RestoreRequired);
     }
 
     private WorkspaceSession GetRequiredSession(string workspaceId)
@@ -1101,6 +1426,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         }).ToImmutableArray();
     }
 
+    private readonly record struct PackageExpectation(string? RequestedVersion, bool UsesCentralVersion);
+
     private sealed class WorkspaceSession(string workspaceId) : IDisposable
     {
         private int _version;
@@ -1111,6 +1438,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         public ImmutableArray<ProjectStatusDto> ProjectStatuses { get; set; } = ImmutableArray<ProjectStatusDto>.Empty;
         public MSBuildWorkspace? Workspace { get; set; }
         public string? LoadedPath { get; set; }
+        public bool RestoreRequired { get; set; }
         public DateTimeOffset LoadedAtUtc { get; set; } = DateTimeOffset.UtcNow;
         public DateTimeOffset LastAccessedUtc { get; set; } = DateTimeOffset.UtcNow;
         public int Version => Volatile.Read(ref _version);

--- a/tests/RoslynMcp.Tests/WorkspaceLoadRestoreRaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceLoadRestoreRaceTests.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -234,6 +237,60 @@ public sealed class WorkspaceLoadRestoreRaceTests : SharedWorkspaceTestBase
         }
     }
 
+    [TestMethod]
+    public async Task ReloadAsync_WithAutoRestore_ClearsRestoreRequiredAfterPackageVersionEdit()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        using var manager = CreateIsolatedManager(restoreRaceWaitMs: 0);
+        var commandRunner = new DotnetCommandRunner();
+
+        try
+        {
+            await RunRestoreAsync(commandRunner, copiedSolutionPath, CancellationToken.None);
+
+            var status = await manager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            Assert.IsFalse(status.RestoreRequired, "Freshly restored workspace should not report restore drift.");
+
+            var packagesPropsPath = Path.Combine(copiedRoot, "Directory.Packages.props");
+            var originalProps = await File.ReadAllTextAsync(packagesPropsPath, CancellationToken.None);
+            const string originalVersion = "<PackageVersion Include=\"Microsoft.NET.Test.Sdk\" Version=\"17.14.0\" />";
+            const string updatedVersion = "<PackageVersion Include=\"Microsoft.NET.Test.Sdk\" Version=\"17.14.1\" />";
+            StringAssert.Contains(originalProps, originalVersion, "Test fixture drifted; update the expected central package version.");
+            await File.WriteAllTextAsync(
+                packagesPropsPath,
+                originalProps.Replace(originalVersion, updatedVersion, StringComparison.Ordinal),
+                CancellationToken.None);
+
+            status = await manager.ReloadAsync(status.WorkspaceId, CancellationToken.None);
+            Assert.IsTrue(status.RestoreRequired, "Reload must signal restoreRequired after a package-version edit without restore.");
+
+            var summary = WorkspaceStatusSummaryDto.From(status);
+            Assert.IsTrue(summary.RestoreRequired, "Summary projection must preserve restoreRequired.");
+            StringAssert.Contains(summary.RestoreHint ?? string.Empty, "dotnet restore",
+                "Summary hint should point callers at restore when package inputs drift.");
+
+            status = await WorkspaceTools.RestoreAndReloadIfRequiredAsync(
+                commandRunner,
+                manager,
+                status,
+                autoRestore: true,
+                CancellationToken.None);
+
+            Assert.IsFalse(status.RestoreRequired, "Auto-restore should clear restoreRequired after rerunning restore and reload.");
+            Assert.AreEqual(
+                "17.14.1",
+                ReadCentralPackageVersion(
+                    Path.Combine(copiedRoot, "SampleLib.Tests", "obj", "project.assets.json"),
+                    "Microsoft.NET.Test.Sdk"),
+                "dotnet restore should refresh project.assets.json to the edited central package version.");
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
     /// <summary>
     /// Removes every <c>obj/</c> subtree in the copied sample solution so the probe sees
     /// a clean tree before each test seeds its own artefacts. Guards against cross-test
@@ -271,5 +328,47 @@ public sealed class WorkspaceLoadRestoreRaceTests : SharedWorkspaceTestBase
                 MaxConcurrentWorkspaces = 4,
                 RestoreRaceWaitMs = restoreRaceWaitMs,
             });
+    }
+
+    private static async Task RunRestoreAsync(DotnetCommandRunner commandRunner, string solutionPath, CancellationToken ct)
+    {
+        var workingDirectory = Path.GetDirectoryName(solutionPath)!;
+        var execution = await commandRunner.RunAsync(
+            workingDirectory,
+            solutionPath,
+            ["restore", solutionPath, "--nologo"],
+            ct);
+
+        Assert.IsTrue(
+            execution.Succeeded,
+            $"dotnet restore failed for test fixture. ExitCode={execution.ExitCode} StdOut={execution.StdOut} StdErr={execution.StdErr}");
+    }
+
+    private static string? ReadCentralPackageVersion(string assetsPath, string packageId)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        if (!document.RootElement.TryGetProperty("project", out var project) ||
+            !project.TryGetProperty("frameworks", out var frameworks))
+        {
+            return null;
+        }
+
+        foreach (var framework in frameworks.EnumerateObject())
+        {
+            if (!framework.Value.TryGetProperty("centralPackageVersions", out var centralVersions))
+            {
+                continue;
+            }
+
+            foreach (var package in centralVersions.EnumerateObject())
+            {
+                if (string.Equals(package.Name, packageId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return package.Value.GetString();
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- detect package-restore drift in workspace status and summaries via a new `restoreRequired` signal
- add `autoRestore` to `workspace_load` and `workspace_reload` so callers can opt into `dotnet restore` plus one follow-up reload
- cover the central-package-version drift path with a restore-race regression test

## Closes
- `workspace-reload-auto-restore`

## Validation
- [x] `dotnet test RoslynMcp.slnx --nologo --filter "FullyQualifiedName~WorkspaceLoadRestoreRaceTests|FullyQualifiedName~WorkspaceStatusSummaryDtoTests"`
- [x] `./eng/verify-ai-docs.ps1`
- [x] `./eng/verify-release.ps1 -Configuration Release`