### PR TITLE
docs(changelog): add missing residual complexity fragment

### DIFF
--- a/changelog.d/cc-18-to-19-residuals-post-top10-extraction.md
+++ b/changelog.d/cc-18-to-19-residuals-post-top10-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Reduced cyclomatic complexity in `ScriptingService`, `RefactoringService`, `MutationAnalysisService`, `ScaffoldingService`, `CodePatternAnalyzer`, and `TestDiscoveryService` across the first three residual-complexity tranches (PRs #357, #358, #359). Follow-up to `cc-18-to-19-residuals-post-top10-extraction`.


### PR DESCRIPTION
## Summary
- add the missing changelog fragment for the first three `cc-18-to-19-residuals-post-top10-extraction` tranches
- record the already-merged maintenance work from PRs #357, #358, and #359 in the fragment-based changelog flow

## Test plan
- [x] content-only changelog fragment review

Generated with [Codex](https://Codex.com/Codex)