### PR TITLE
refactor(roslyn): reduce parser and test-discovery complexity (cc-18-19-s3-codepattern-testdiscovery)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -321,40 +321,61 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         var predicateLabels = new List<string>();
         var q = query.ToLowerInvariant().Trim();
 
+        AddBaseSemanticPredicates(predicates, predicateLabels, q);
+        AddAccessibilityPredicate(predicates, predicateLabels, q);
+        AddAdvancedSemanticPredicates(predicates, predicateLabels, q);
+        return BuildSemanticQueryParse(query, predicates, predicateLabels);
+    }
+
+    private static void AddBaseSemanticPredicates(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string q)
+    {
         AddKeywordPredicates(predicates, predicateLabels, q);
         AddStaticPredicate(predicates, predicateLabels, q);
         AddClassPredicate(predicates, predicateLabels, q);
-        AddAccessibilityPredicate(predicates, predicateLabels, q);
+    }
 
-        // "returning/returns <type>"
-        var beforeReturn = predicates.Count;
-        AddReturnTypePredicate(predicates, q);
-        if (predicates.Count > beforeReturn)
+    private static void AddAdvancedSemanticPredicates(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string query)
+    {
+        AddPredicateLabelIfAdded(predicates, predicateLabels, "returning-type", () => AddReturnTypePredicate(predicates, query));
+        AddPredicateLabelIfAdded(predicates, predicateLabels, "implementing-interface", () => AddImplementingPredicate(predicates, query));
+        AddParameterCountPredicate(predicates, predicateLabels, query);
+    }
+
+    private static void AddPredicateLabelIfAdded(
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels,
+        string label,
+        Action addPredicate)
+    {
+        var beforeCount = predicates.Count;
+        addPredicate();
+        if (predicates.Count > beforeCount)
         {
-            predicateLabels.Add("returning-type");
+            predicateLabels.Add(label);
         }
+    }
 
-        // "implementing <interface>"
-        var beforeImpl = predicates.Count;
-        AddImplementingPredicate(predicates, q);
-        if (predicates.Count > beforeImpl)
-        {
-            predicateLabels.Add("implementing-interface");
-        }
-
-        AddParameterCountPredicate(predicates, predicateLabels, q);
-
+    private static SemanticQueryParse BuildSemanticQueryParse(
+        string query,
+        List<Func<ISymbol, bool>> predicates,
+        List<string> predicateLabels)
+    {
         var tokens = ExtractTokens(query);
+        if (predicates.Count > 0)
+        {
+            return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: false);
+        }
 
         // Fallback: name-based search
-        if (predicates.Count == 0)
-        {
-            predicates.Add(s => s.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
-            predicateLabels.Add("name-contains");
-            return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: true);
-        }
-
-        return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: false);
+        predicates.Add(s => s.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
+        predicateLabels.Add("name-contains");
+        return new SemanticQueryParse(predicates, predicateLabels, tokens, UsedImplicitNameOnly: true);
     }
 
     private static void AddKeywordPredicates(

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -97,20 +97,9 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         var discovery = await DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        if (symbol is null) return [];
-
-        var discoveredTests = discovery.TestProjects.SelectMany(project => project.Tests).ToList();
-        var searchTerms = BuildRelatedTestSearchTerms(symbol);
-        var collected = CollectHeuristicRelatedTests(discoveredTests, searchTerms);
-
-        await TryAugmentRelatedTestsFromReferencesAsync(
-            symbol,
-            solution,
-            discoveredTests,
-            collected,
-            ct).ConfigureAwait(false);
-
-        return collected.Values.ToList();
+        return symbol is null
+            ? []
+            : await CollectRelatedTestsAsync(discovery, solution, symbol, ct).ConfigureAwait(false);
     }
 
     private static HashSet<string> BuildRelatedTestSearchTerms(ISymbol symbol)
@@ -122,6 +111,30 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         }
 
         return searchTerms;
+    }
+
+    private async Task<IReadOnlyList<TestCaseDto>> CollectRelatedTestsAsync(
+        TestDiscoveryDto discovery,
+        Solution solution,
+        ISymbol symbol,
+        CancellationToken ct)
+    {
+        var discoveredTests = FlattenDiscoveredTests(discovery);
+        var collected = CollectHeuristicRelatedTests(discoveredTests, BuildRelatedTestSearchTerms(symbol));
+
+        await TryAugmentRelatedTestsFromReferencesAsync(
+            symbol,
+            solution,
+            discoveredTests,
+            collected,
+            ct).ConfigureAwait(false);
+
+        return collected.Values.ToList();
+    }
+
+    private static List<TestCaseDto> FlattenDiscoveredTests(TestDiscoveryDto discovery)
+    {
+        return discovery.TestProjects.SelectMany(project => project.Tests).ToList();
     }
 
     private static Dictionary<string, TestCaseDto> CollectHeuristicRelatedTests(

--- a/tests/RoslynMcp.Tests/BacklogFixTests.cs
+++ b/tests/RoslynMcp.Tests/BacklogFixTests.cs
@@ -164,6 +164,8 @@ public sealed class BacklogFixTests : SharedWorkspaceTestBase
         var response = await CodePatternAnalyzer.SemanticSearchAsync(
             workspaceId, "classes implementing IDisposable", "SampleLib", 50, CancellationToken.None);
 
+        Assert.IsNotNull(response.Debug);
+        CollectionAssert.Contains(response.Debug!.AppliedPredicates.ToList(), "implementing-interface");
         Assert.IsTrue(
             response.Results.Any(r => r.SymbolName == "BacklogDisposableSample"),
             "Expected disposable sample class.");
@@ -177,6 +179,8 @@ public sealed class BacklogFixTests : SharedWorkspaceTestBase
         var response = await CodePatternAnalyzer.SemanticSearchAsync(
             workspaceId, "methods returning Task<bool>", "SampleLib", 50, CancellationToken.None);
 
+        Assert.IsNotNull(response.Debug);
+        CollectionAssert.Contains(response.Debug!.AppliedPredicates.ToList(), "returning-type");
         Assert.IsTrue(
             response.Results.Any(r => r.SymbolName == "ReturnsBoolAsync"),
             "Expected method returning Task<bool>.");

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -132,6 +132,17 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
             $"Expected AnimalServiceTests.cs to surface via interface-dispatch augmentation; got: {string.Join(", ", result.Select(t => t.FilePath))}");
     }
 
+    [TestMethod]
+    public async Task TestRelated_UnknownSymbol_ReturnsEmptyList()
+    {
+        var result = await TestDiscoveryService.FindRelatedTestsAsync(
+            WorkspaceId,
+            RoslynMcp.Core.Models.SymbolLocator.ByMetadataName("SampleLib.DoesNotExist"),
+            CancellationToken.None);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
     private static string FindDocumentPath(string name)
     {
         var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);


### PR DESCRIPTION
## Summary
- reduce `CodePatternAnalyzer.ParseSemanticQuery` to helper-driven orchestration for base predicates, labeled advanced predicates, and fallback parse construction
- slim `TestDiscoveryService.FindRelatedTestsAsync` to early-return plus a dedicated collection helper
- strengthen the directly corresponding tests around structured predicate labels and empty-symbol related-test results

## Validation
- `mcp__roslyn__.compile_check` on the four edited files (0 errors after restore/reload)
- `mcp__roslyn__.test_run --filter "FullyQualifiedName~RoslynMcp.Tests.BacklogFixTests.SemanticSearch_ClassesImplementingIDisposable_FindsDisposableClass|FullyQualifiedName~RoslynMcp.Tests.BacklogFixTests.SemanticSearch_MethodsReturningTaskBool_FindsSample|FullyQualifiedName~RoslynMcp.Tests.ValidationToolsIntegrationTests.TestRelated_InterfaceMemberCalledByTestsViaDispatch_SurfacesTheTest|FullyQualifiedName~RoslynMcp.Tests.ValidationToolsIntegrationTests.TestRelated_UnknownSymbol_ReturnsEmptyList"`
- `./eng/verify-ai-docs.ps1`
- `./eng/verify-release.ps1 -Configuration Release`

Closes: none
Contributes-to: cc-18-to-19-residuals-post-top10-extraction