### PR TITLE
feat(analysis): add find_dead_fields tool (find-dead-fields-across-classes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **160 tools** (107 stable / 53 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **161 tools** (107 stable / 54 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/src/RoslynMcp.Core/Models/DeadFieldDto.cs
+++ b/src/RoslynMcp.Core/Models/DeadFieldDto.cs
@@ -1,0 +1,31 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Represents a source-declared field whose observed source usage is incomplete:
+/// never read, never written, or never either.
+/// See <see cref="IUnusedCodeAnalyzer.FindDeadFieldsAsync"/> for the heuristic that
+/// produces these hits.
+/// </summary>
+/// <param name="SymbolName">The field name (e.g. <c>_count</c>).</param>
+/// <param name="ContainingType">The declaring type that owns the field.</param>
+/// <param name="FilePath">Absolute path to the source file declaring the field.</param>
+/// <param name="Line">1-based declaration line.</param>
+/// <param name="Column">1-based declaration column.</param>
+/// <param name="ProjectName">Roslyn project containing the field.</param>
+/// <param name="UsageKind">One of <c>never-read</c>, <c>never-written</c>, or <c>never-either</c>.</param>
+/// <param name="ReadReferenceCount">Number of source references classified as reads.</param>
+/// <param name="WriteReferenceCount">Number of source references classified as writes, plus a declaration initializer when present.</param>
+/// <param name="SymbolHandle">Stable symbol handle for follow-up tools.</param>
+/// <param name="Confidence">Heuristic confidence: high (non-public), medium (public/protected surface).</param>
+public sealed record DeadFieldDto(
+    string SymbolName,
+    string? ContainingType,
+    string FilePath,
+    int Line,
+    int Column,
+    string ProjectName,
+    string UsageKind,
+    int ReadReferenceCount,
+    int WriteReferenceCount,
+    string? SymbolHandle,
+    string Confidence);

--- a/src/RoslynMcp.Core/Services/DeadFieldsAnalysisOptions.cs
+++ b/src/RoslynMcp.Core/Services/DeadFieldsAnalysisOptions.cs
@@ -1,0 +1,29 @@
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Controls which projects and field-usage categories are scanned when finding
+/// source-declared fields that are never read, never written, or never either.
+/// </summary>
+public sealed record DeadFieldsAnalysisOptions
+{
+    /// <summary>
+    /// Optional project name filter. When non-null, only that project is scanned.
+    /// </summary>
+    public string? ProjectFilter { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, include public/protected fields whose deadness may be
+    /// masked by external consumers. Default <see langword="false"/> keeps the results
+    /// conservative for in-repo cleanup.
+    /// </summary>
+    public bool IncludePublic { get; init; }
+
+    /// <summary>
+    /// Optional usage-kind filter. Accepted values: <c>never-read</c>,
+    /// <c>never-written</c>, <c>never-either</c>. When null, all three are returned.
+    /// </summary>
+    public string? UsageKindFilter { get; init; }
+
+    /// <summary>Maximum number of hits to return. Defaults to 50.</summary>
+    public int Limit { get; init; } = 50;
+}

--- a/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Core/Services/IUnusedCodeAnalyzer.cs
@@ -30,6 +30,19 @@ public interface IUnusedCodeAnalyzer
         CancellationToken ct);
 
     /// <summary>
+    /// Finds source-declared fields whose observed in-solution usage is incomplete:
+    /// never read, never written, or never either. Classification is based on Roslyn
+    /// reference finding plus declaration initializers (which count as writes). Enum
+    /// members, constants, compiler-generated backing fields, and generated files are
+    /// skipped. Public/protected fields are excluded by default because external callers
+    /// may legitimately read or write them.
+    /// </summary>
+    Task<IReadOnlyList<DeadFieldDto>> FindDeadFieldsAsync(
+        string workspaceId,
+        DeadFieldsAnalysisOptions options,
+        CancellationToken ct);
+
+    /// <summary>
     /// Finds method-local variables whose only write is not followed by any read —
     /// the class of waste IDE0059 ("Unnecessary assignment of a value") covers when the
     /// diagnostic is at its default severity. Walks every method-like body (methods,

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
@@ -28,6 +28,7 @@ public static partial class ServerSurfaceCatalog
         Tool("find_duplicated_methods", "advanced-analysis", "stable", true, false, "Find clusters of near-duplicate method bodies by AST-normalized hash."),
         Tool("find_duplicate_helpers", "advanced-analysis", "experimental", true, false, "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),
         Tool("find_dead_locals", "advanced-analysis", "experimental", true, false, "Find method-local variables whose only write is not followed by any read."),
+        Tool("find_dead_fields", "advanced-analysis", "experimental", true, false, "Find source-declared fields that are never read, never written, or never either."),
         Tool("symbol_impact_sweep", "analysis", "experimental", true, false, "Sweep downstream impact of a symbol change: references + switch-exhaustiveness diagnostics + mapper-suffix callsites."),
         Tool("test_reference_map", "validation", "experimental", true, false, "Statically map source symbols to test references; returns covered/uncovered symbol lists and a coverage percentage. Supports offset/limit pagination and projectName scoping."),
         Tool("validate_workspace", "validation", "experimental", true, false, "Composite post-edit validation: compile_check + project_diagnostics (errors) + test_related_files (+ optional test_run)."),

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -83,7 +83,7 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **159 tools** (107 stable / 52 experimental), **9 resources**, and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **161 tools** (107 stable / 54 experimental), **9 resources**, and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -202,6 +202,36 @@ public static class AdvancedAnalysisTools
         }, ct);
     }
 
+    [McpServerTool(Name = "find_dead_fields", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("advanced-analysis", "experimental", true, false,
+        "Find source-declared fields that are never read, never written, or never either."),
+     Description("Find source-declared fields whose in-solution usage is incomplete: `never-read`, `never-written`, or `never-either`. Classification uses Roslyn reference finding plus declaration initializers (which count as writes). Skips enum members, constants, compiler-generated backing fields, field-like event storage, and generated files. By default excludes public/protected fields because external consumers may legitimately read or write them; set `includePublic=true` to include that surface. Optional `usageKind` filter accepts `never-read`, `never-written`, or `never-either`.")]
+    public static Task<string> FindDeadFields(
+        IWorkspaceExecutionGate gate,
+        IUnusedCodeAnalyzer unusedCodeAnalyzer,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Include public/protected fields in the scan (default: false).")] bool includePublic = false,
+        [Description("Optional: restrict results to one usage kind: `never-read`, `never-written`, or `never-either`. Default: all kinds.")] string? usageKind = null,
+        [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var results = await unusedCodeAnalyzer.FindDeadFieldsAsync(
+                workspaceId,
+                new DeadFieldsAnalysisOptions
+                {
+                    ProjectFilter = projectFilter,
+                    IncludePublic = includePublic,
+                    UsageKindFilter = usageKind,
+                    Limit = limit
+                },
+                c);
+            return JsonSerializer.Serialize(new { count = results.Count, deadFields = results }, JsonDefaults.Indented);
+        }, ct);
+    }
+
     [McpServerTool(Name = "find_duplicate_helpers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -579,6 +579,66 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     }
 
     /// <summary>
+    /// Finds source-declared fields whose observed source usage is incomplete:
+    /// never read, never written, or never either. See
+    /// <see cref="IUnusedCodeAnalyzer.FindDeadFieldsAsync"/> for the contract.
+    /// </summary>
+    public async Task<IReadOnlyList<DeadFieldDto>> FindDeadFieldsAsync(
+        string workspaceId,
+        DeadFieldsAnalysisOptions options,
+        CancellationToken ct)
+    {
+        ValidateDeadFieldUsageKindFilter(options.UsageKindFilter);
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var results = new List<DeadFieldDto>();
+        var processedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+        var projects = ProjectFilterHelper.FilterProjects(solution, options.ProjectFilter);
+        foreach (var project in projects)
+        {
+            if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+                if (PathFilter.IsGeneratedOrContentFile(tree.FilePath)) continue;
+
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct).ConfigureAwait(false);
+
+                foreach (var declarator in root.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+                {
+                    if (ct.IsCancellationRequested || results.Count >= options.Limit) break;
+
+                    if (semanticModel.GetDeclaredSymbol(declarator, ct) is not IFieldSymbol field)
+                        continue;
+                    if (!IsCandidateSymbol(field, processedSymbols))
+                        continue;
+                    if (ShouldSkipFieldForDeadFieldAnalysis(field, options.IncludePublic))
+                        continue;
+
+                    var dto = await TryBuildDeadFieldDtoAsync(
+                        field,
+                        declarator,
+                        solution,
+                        project.Name,
+                        options.UsageKindFilter,
+                        ct).ConfigureAwait(false);
+                    if (dto is null) continue;
+
+                    results.Add(dto);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Inspects a method declaration and, when its host is a static helper class,
     /// its effective accessibility is non-public, and its body is a single
     /// ≤ 2-statement delegation to a non-source-declared method, returns a
@@ -741,6 +801,173 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     {
         // Higher enum value = more visible (Public=6, Internal=4, Private=1).
         return ((int)a < (int)b) ? a : b;
+    }
+
+    private static void ValidateDeadFieldUsageKindFilter(string? usageKindFilter)
+    {
+        if (usageKindFilter is null) return;
+
+        if (!IsAcceptedDeadFieldUsageKind(usageKindFilter))
+        {
+            throw new ArgumentException(
+                $"Unsupported usageKind '{usageKindFilter}'. Expected never-read, never-written, or never-either.",
+                nameof(usageKindFilter));
+        }
+    }
+
+    private static bool IsAcceptedDeadFieldUsageKind(string usageKind) =>
+        usageKind is "never-read" or "never-written" or "never-either";
+
+    private static bool ShouldSkipFieldForDeadFieldAnalysis(IFieldSymbol field, bool includePublic)
+    {
+        if (field.IsImplicitlyDeclared) return true;
+        if (field.AssociatedSymbol is not null) return true;
+        if (field.ContainingType?.TypeKind == TypeKind.Enum) return true;
+        if (field.IsConst) return true;
+        if (field.Name.Length == 0) return true;
+
+        var effectiveAccessibility = field.ContainingType is null
+            ? field.DeclaredAccessibility
+            : MinAccessibility(field.DeclaredAccessibility, field.ContainingType.DeclaredAccessibility);
+
+        if (!includePublic && effectiveAccessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal)
+            return true;
+
+        return false;
+    }
+
+    private async Task<DeadFieldDto?> TryBuildDeadFieldDtoAsync(
+        IFieldSymbol field,
+        VariableDeclaratorSyntax declarator,
+        Solution solution,
+        string projectName,
+        string? usageKindFilter,
+        CancellationToken ct)
+    {
+        var locations = await SymbolFinder.FindReferencesAsync(field, solution, ct).ConfigureAwait(false);
+        var (readCount, writeCount) = ClassifyDeadFieldReferenceCounts(locations);
+
+        if (declarator.Initializer is not null)
+        {
+            writeCount++;
+        }
+
+        var usageKind = DetermineDeadFieldUsageKind(readCount, writeCount);
+        if (usageKind is null) return null;
+        if (usageKindFilter is not null && !string.Equals(usageKind, usageKindFilter, StringComparison.Ordinal))
+            return null;
+
+        return BuildDeadFieldDto(field, projectName, usageKind, readCount, writeCount);
+    }
+
+    private static (int ReadCount, int WriteCount) ClassifyDeadFieldReferenceCounts(IEnumerable<ReferencedSymbol> referencedSymbols)
+    {
+        var readCount = 0;
+        var writeCount = 0;
+
+        foreach (var location in referencedSymbols.SelectMany(symbol => symbol.Locations))
+        {
+            if (location.IsImplicit) continue;
+            if (!location.Location.IsInSource) continue;
+
+            switch (ClassifyDeadFieldReferenceLocation(location))
+            {
+                case "Write":
+                    writeCount++;
+                    break;
+                case "ReadWrite":
+                    readCount++;
+                    writeCount++;
+                    break;
+                default:
+                    readCount++;
+                    break;
+            }
+        }
+
+        return (readCount, writeCount);
+    }
+
+    private static string ClassifyDeadFieldReferenceLocation(ReferenceLocation refLocation)
+    {
+        var syntaxNode = refLocation.Location.SourceTree?
+            .GetRoot()
+            .FindNode(refLocation.Location.SourceSpan);
+
+        if (syntaxNode is null)
+        {
+            return "Read";
+        }
+
+        return syntaxNode.Parent switch
+        {
+            AssignmentExpressionSyntax assignment when assignment.Left == syntaxNode
+                => assignment.Kind() is SyntaxKind.AddAssignmentExpression
+                    or SyntaxKind.SubtractAssignmentExpression
+                    or SyntaxKind.MultiplyAssignmentExpression
+                    or SyntaxKind.DivideAssignmentExpression
+                    ? "ReadWrite"
+                    : "Write",
+            MemberAccessExpressionSyntax memberAccess
+                when memberAccess.Parent is AssignmentExpressionSyntax memberAssignment
+                     && memberAssignment.Left == memberAccess
+                => "Write",
+            PrefixUnaryExpressionSyntax prefix
+                when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression)
+                => "ReadWrite",
+            PostfixUnaryExpressionSyntax postfix
+                when postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression)
+                => "ReadWrite",
+            ArgumentSyntax arg when arg.RefKindKeyword.IsKind(SyntaxKind.RefKeyword)
+                => "ReadWrite",
+            ArgumentSyntax arg when arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)
+                => "Write",
+            _ => "Read"
+        };
+    }
+
+    private static string? DetermineDeadFieldUsageKind(int readCount, int writeCount)
+    {
+        if (readCount == 0 && writeCount == 0) return "never-either";
+        if (readCount == 0) return "never-read";
+        if (writeCount == 0) return "never-written";
+        return null;
+    }
+
+    private static DeadFieldDto? BuildDeadFieldDto(
+        IFieldSymbol field,
+        string projectName,
+        string usageKind,
+        int readCount,
+        int writeCount)
+    {
+        var location = field.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location is null) return null;
+
+        var lineSpan = location.GetLineSpan();
+        return new DeadFieldDto(
+            SymbolName: field.Name,
+            ContainingType: field.ContainingType?.Name,
+            FilePath: lineSpan.Path,
+            Line: lineSpan.StartLinePosition.Line + 1,
+            Column: lineSpan.StartLinePosition.Character + 1,
+            ProjectName: projectName,
+            UsageKind: usageKind,
+            ReadReferenceCount: readCount,
+            WriteReferenceCount: writeCount,
+            SymbolHandle: SymbolHandleSerializer.CreateHandle(field),
+            Confidence: ComputeDeadFieldConfidence(field));
+    }
+
+    private static string ComputeDeadFieldConfidence(IFieldSymbol field)
+    {
+        var effectiveAccessibility = field.ContainingType is null
+            ? field.DeclaredAccessibility
+            : MinAccessibility(field.DeclaredAccessibility, field.ContainingType.DeclaredAccessibility);
+
+        return effectiveAccessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal
+            ? "medium"
+            : "high";
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
@@ -1,0 +1,302 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UnusedCodeAnalyzer.FindDeadFieldsAsync"/>. Uses an
+/// in-memory <see cref="AdhocWorkspace"/> so the detector can classify source-declared
+/// fields as never-read, never-written, or never-either without relying on the sample
+/// solution's incidental shapes.
+/// </summary>
+[TestClass]
+public sealed class DeadFieldDetectorTests
+{
+    private const string WorkspaceId = "dead-field-test-ws";
+
+    [TestMethod]
+    public async Task FindDeadFields_FieldWithInitializerAndNoReads_IsNeverRead()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count = 5;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count);
+        Assert.AreEqual("_count", hits[0].SymbolName);
+        Assert.AreEqual("never-read", hits[0].UsageKind);
+        Assert.AreEqual(0, hits[0].ReadReferenceCount);
+        Assert.AreEqual(1, hits[0].WriteReferenceCount);
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_FieldReadButNeverWritten_IsNeverWritten()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count;
+                public int Read() => _count;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count);
+        Assert.AreEqual("_count", hits[0].SymbolName);
+        Assert.AreEqual("never-written", hits[0].UsageKind);
+        Assert.AreEqual(1, hits[0].ReadReferenceCount);
+        Assert.AreEqual(0, hits[0].WriteReferenceCount);
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_FieldWithoutReferencesOrInitializer_IsNeverEither()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(1, hits.Count);
+        Assert.AreEqual("_count", hits[0].SymbolName);
+        Assert.AreEqual("never-either", hits[0].UsageKind);
+        Assert.AreEqual(0, hits[0].ReadReferenceCount);
+        Assert.AreEqual(0, hits[0].WriteReferenceCount);
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_FieldWrittenAndRead_IsNotFlagged()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count;
+
+                public void Set(int value)
+                {
+                    _count = value;
+                }
+
+                public int Read() => _count;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count);
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_RefArgumentCountsAsReadWrite()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count;
+
+                public void Touch()
+                {
+                    Bump(ref _count);
+                }
+
+                private static void Bump(ref int value)
+                {
+                    value++;
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            "Passing a field by ref must count as both a read and a write.");
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_DefaultExcludesPublicFields_AndUsageKindFilterWorks()
+    {
+        const string source = """
+            namespace Sample;
+            public sealed class Counter
+            {
+                public int PublicField = 1;
+                private int _neverRead = 1;
+                private int _neverWritten;
+
+                public int Read() => _neverWritten;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var defaultHits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        CollectionAssert.AreEquivalent(
+            new[] { "_neverRead", "_neverWritten" },
+            defaultHits.Select(hit => hit.SymbolName).OrderBy(name => name).ToArray());
+
+        var filteredHits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions
+            {
+                IncludePublic = true,
+                UsageKindFilter = "never-read"
+            },
+            default);
+
+        CollectionAssert.AreEquivalent(
+            new[] { "PublicField", "_neverRead" },
+            filteredHits.Select(hit => hit.SymbolName).OrderBy(name => name).ToArray());
+        Assert.IsTrue(filteredHits.All(hit => hit.UsageKind == "never-read"));
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_LimitCapsResults()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _a;
+                private int _b;
+                private int _c;
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions { Limit = 2 },
+            default);
+
+        Assert.AreEqual(2, hits.Count);
+    }
+
+    private static UnusedCodeAnalyzer BuildAnalyzerWithSource(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "TestAsm",
+            assemblyName: "TestAsm",
+            language: LanguageNames.CSharp,
+            filePath: Path.Combine(Path.GetTempPath(), "TestAsm.csproj"),
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        workspace.AddProject(projectInfo);
+
+        var docId = DocumentId.CreateNewId(projectId);
+        var fileName = "Sample.cs";
+        var fullPath = Path.Combine(Path.GetTempPath(), fileName);
+        workspace.AddDocument(DocumentInfo.Create(
+            docId,
+            fileName,
+            filePath: fullPath,
+            loader: TextLoader.From(
+                TextAndVersion.Create(
+                    SourceText.From(source),
+                    VersionStamp.Create(),
+                    fullPath))));
+
+        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
+        var cache = new CompilationCache(wsManager);
+        return new UnusedCodeAnalyzer(
+            wsManager,
+            cache,
+            NullLogger<UnusedCodeAnalyzer>.Instance);
+    }
+
+    private sealed class TestWorkspaceManager : IWorkspaceManager
+    {
+        private readonly string _workspaceId;
+        private readonly AdhocWorkspace _workspace;
+
+        public event Action<string>? WorkspaceClosed;
+        public event Action<string>? WorkspaceReloaded;
+
+        public TestWorkspaceManager(string workspaceId, AdhocWorkspace workspace)
+        {
+            _workspaceId = workspaceId;
+            _workspace = workspace;
+        }
+
+        public void RaiseWorkspaceClosed(string workspaceId) => WorkspaceClosed?.Invoke(workspaceId);
+        public void RaiseWorkspaceReloaded(string workspaceId) => WorkspaceReloaded?.Invoke(workspaceId);
+
+        public Solution GetCurrentSolution(string workspaceId)
+        {
+            return workspaceId == _workspaceId
+                ? _workspace.CurrentSolution
+                : throw new InvalidOperationException($"Unknown workspace {workspaceId}");
+        }
+
+        public int GetCurrentVersion(string workspaceId) => 1;
+        public void RestoreVersion(string workspaceId, int version) { }
+        public bool ContainsWorkspace(string workspaceId) => workspaceId == _workspaceId;
+        public bool IsStale(string workspaceId) => false;
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -96,6 +96,21 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
             ct: CancellationToken.None);
         using var complexityDoc = JsonDocument.Parse(complexityJson);
         Assert.IsTrue(complexityDoc.RootElement.GetProperty("metrics").GetArrayLength() > 0);
+
+        var deadFieldsJson = await AdvancedAnalysisTools.FindDeadFields(
+            WorkspaceExecutionGate,
+            UnusedCodeAnalyzer,
+            WorkspaceId,
+            projectFilter: "SampleLib",
+            includePublic: false,
+            usageKind: "never-read",
+            limit: 20,
+            ct: CancellationToken.None);
+        using var deadFieldsDoc = JsonDocument.Parse(deadFieldsJson);
+        var deadFields = deadFieldsDoc.RootElement.GetProperty("deadFields").EnumerateArray().ToList();
+        Assert.IsTrue(deadFields.Any(field =>
+            field.GetProperty("symbolName").GetString() == "_unusedForDiagnostics"
+            && field.GetProperty("usageKind").GetString() == "never-read"));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- add experimental `find_dead_fields` for never-read / never-written / never-either source fields
- wire the new analysis through `AdvancedAnalysisTools`, the server surface catalog, and docs/tool counts
- add focused detector coverage plus an integration assertion on the expanded surface

## Closes
- Closes: `find-dead-fields-across-classes`

## Validation
- [x] `./eng/verify-ai-docs.ps1`
- [x] `./eng/verify-release.ps1 -Configuration Release`

## Notes
- `find_dead_fields` defaults to non-public fields; `includePublic=true` opts into public/protected surface.
