### PR TITLE
refactor(roslyn): simplify security and restructure matching

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/RestructureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RestructureService.cs
@@ -142,13 +142,25 @@ public sealed class RestructureService : IRestructureService
         var names = new HashSet<string>(StringComparer.Ordinal);
         foreach (var identifier in pattern.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
         {
-            var match = PlaceholderPattern.Match(identifier.Identifier.ValueText);
-            if (match.Success && match.Length == identifier.Identifier.ValueText.Length)
+            if (TryGetPlaceholderName(identifier.Identifier.ValueText, out var name))
             {
-                names.Add(match.Groups["name"].Value);
+                names.Add(name);
             }
         }
         return names;
+    }
+
+    private static bool TryGetPlaceholderName(string text, out string name)
+    {
+        var match = PlaceholderPattern.Match(text);
+        if (match.Success && match.Length == text.Length)
+        {
+            name = match.Groups["name"].Value;
+            return true;
+        }
+
+        name = string.Empty;
+        return false;
     }
 
     private static IEnumerable<Project> EnumerateProjects(Solution solution, RestructureScope scope)
@@ -225,69 +237,101 @@ public sealed class RestructureService : IRestructureService
         private bool TryMatch(SyntaxNode patternNode, SyntaxNode candidate, Dictionary<string, SyntaxNode> captures)
         {
             // Placeholder: any leaf identifier __name__ captures whatever candidate is.
-            if (patternNode is IdentifierNameSyntax id)
+            if (TryCaptureIdentifierPlaceholder(patternNode, candidate, captures, out var placeholderMatched))
             {
-                var text = id.Identifier.ValueText;
-                var match = PlaceholderPattern.Match(text);
-                if (match.Success && match.Length == text.Length)
-                {
-                    var name = match.Groups["name"].Value;
-                    if (captures.TryGetValue(name, out var existing))
-                    {
-                        return SyntaxFactory.AreEquivalent(existing, candidate, topLevel: false);
-                    }
-                    captures[name] = candidate;
-                    return true;
-                }
+                return placeholderMatched;
             }
 
             if (patternNode.RawKind != candidate.RawKind) return false;
 
+            return TryMatchChildren(patternNode, candidate, captures);
+        }
+
+        private bool TryMatchChildren(SyntaxNode patternNode, SyntaxNode candidate, Dictionary<string, SyntaxNode> captures)
+        {
             var patternChildren = patternNode.ChildNodesAndTokens().ToArray();
             var candidateChildren = candidate.ChildNodesAndTokens().ToArray();
             if (patternChildren.Length != candidateChildren.Length) return false;
 
             for (var i = 0; i < patternChildren.Length; i++)
             {
-                var pc = patternChildren[i];
-                var cc = candidateChildren[i];
-                if (pc.IsNode && cc.IsNode)
-                {
-                    if (!TryMatch(pc.AsNode()!, cc.AsNode()!, captures)) return false;
-                }
-                else if (pc.IsToken && cc.IsToken)
-                {
-                    if (pc.RawKind != cc.RawKind) return false;
-                    var pt = pc.AsToken();
-                    var ct2 = cc.AsToken();
-                    // Token-level placeholders: an identifier token whose text matches
-                    // __foo__ acts like a placeholder too (covers identifier-shape patterns
-                    // like __name__.Method()).
-                    var tokenText = pt.ValueText;
-                    var placeholderMatch = PlaceholderPattern.Match(tokenText);
-                    if (placeholderMatch.Success && placeholderMatch.Length == tokenText.Length)
-                    {
-                        // Represent a captured token as an identifier-name syntax so substitution
-                        // can splice it back in uniformly.
-                        var name = placeholderMatch.Groups["name"].Value;
-                        var newIdent = SyntaxFactory.IdentifierName(ct2.ValueText);
-                        if (captures.TryGetValue(name, out var existing))
-                        {
-                            if (!SyntaxFactory.AreEquivalent(existing, newIdent, topLevel: false)) return false;
-                        }
-                        else
-                        {
-                            captures[name] = newIdent;
-                        }
-                        continue;
-                    }
-                    if (!string.Equals(pt.ValueText, ct2.ValueText, StringComparison.Ordinal)) return false;
-                }
-                else
+                if (!TryMatchChild(patternChildren[i], candidateChildren[i], captures))
                 {
                     return false;
                 }
             }
+
+            return true;
+        }
+
+        private bool TryMatchChild(
+            SyntaxNodeOrToken patternChild,
+            SyntaxNodeOrToken candidateChild,
+            Dictionary<string, SyntaxNode> captures)
+        {
+            if (patternChild.IsNode && candidateChild.IsNode)
+            {
+                return TryMatch(patternChild.AsNode()!, candidateChild.AsNode()!, captures);
+            }
+
+            if (patternChild.IsToken && candidateChild.IsToken)
+            {
+                return TryMatchToken(patternChild.AsToken(), candidateChild.AsToken(), captures);
+            }
+
+            return false;
+        }
+
+        private static bool TryCaptureIdentifierPlaceholder(
+            SyntaxNode patternNode,
+            SyntaxNode candidate,
+            Dictionary<string, SyntaxNode> captures,
+            out bool placeholderMatched)
+        {
+            placeholderMatched = false;
+            if (patternNode is not IdentifierNameSyntax identifier ||
+                !TryGetPlaceholderName(identifier.Identifier.ValueText, out var name))
+            {
+                return false;
+            }
+
+            placeholderMatched = TryCapturePlaceholder(name, candidate, captures);
+            return true;
+        }
+
+        private static bool TryMatchToken(
+            SyntaxToken patternToken,
+            SyntaxToken candidateToken,
+            Dictionary<string, SyntaxNode> captures)
+        {
+            if (patternToken.RawKind != candidateToken.RawKind)
+            {
+                return false;
+            }
+
+            // Token-level placeholders: an identifier token whose text matches __foo__
+            // acts like a placeholder too (covers identifier-shape patterns like
+            // __name__.Method()).
+            if (TryGetPlaceholderName(patternToken.ValueText, out var name))
+            {
+                var capturedToken = SyntaxFactory.IdentifierName(candidateToken.ValueText);
+                return TryCapturePlaceholder(name, capturedToken, captures);
+            }
+
+            return string.Equals(patternToken.ValueText, candidateToken.ValueText, StringComparison.Ordinal);
+        }
+
+        private static bool TryCapturePlaceholder(
+            string name,
+            SyntaxNode candidate,
+            Dictionary<string, SyntaxNode> captures)
+        {
+            if (captures.TryGetValue(name, out var existing))
+            {
+                return SyntaxFactory.AreEquivalent(existing, candidate, topLevel: false);
+            }
+
+            captures[name] = candidate;
             return true;
         }
 

--- a/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SecurityDiagnosticService.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using Microsoft.Extensions.Logging;
@@ -116,73 +117,10 @@ public sealed class SecurityDiagnosticService : ISecurityDiagnosticService
         ct.ThrowIfCancellationRequested();
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
-        var netAnalyzersPresent = false;
-        var securityCodeScanFromAssembly = false;
-        var pumaFromAssembly = false;
+        var analyzerPresence = DetectAnalyzerAssemblies(solution, ct);
+        var nugetPackages = await CollectNuGetPackagesAsync(solution, workspaceId, ct).ConfigureAwait(false);
 
-        foreach (var project in solution.Projects)
-        {
-            ct.ThrowIfCancellationRequested();
-            foreach (var analyzerRef in project.AnalyzerReferences)
-            {
-                var displayName = analyzerRef.Display ?? string.Empty;
-
-                if (!netAnalyzersPresent && MatchesAnyPrefix(displayName, NetAnalyzerAssemblyPrefixes))
-                    netAnalyzersPresent = true;
-
-                if (!securityCodeScanFromAssembly && MatchesAnyPrefix(displayName, SecurityCodeScanAssemblyPrefixes))
-                    securityCodeScanFromAssembly = true;
-
-                if (!pumaFromAssembly && MatchesAnyPrefix(displayName, PumaSecurityAssemblyPrefixes))
-                    pumaFromAssembly = true;
-            }
-        }
-
-        var nugetPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var project in solution.Projects)
-        {
-            ct.ThrowIfCancellationRequested();
-            if (string.IsNullOrWhiteSpace(project.FilePath))
-                continue;
-
-            try
-            {
-                var evaluated = await _msBuildEvaluation.EvaluateItemsAsync(
-                    workspaceId, project.Name, "PackageReference", ct).ConfigureAwait(false);
-
-                foreach (var item in evaluated.Items)
-                {
-                    if (!string.IsNullOrWhiteSpace(item.Include))
-                        nugetPackages.Add(item.Include);
-                }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogDebug(ex, "Could not evaluate PackageReference items for project '{ProjectName}'", project.Name);
-            }
-        }
-
-        var securityRelatedNuget = nugetPackages
-            .Where(IsSecurityRelatedNuGetPackage)
-            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var securityCodeScanPresent = securityCodeScanFromAssembly ||
-            nugetPackages.Any(p => p.Contains("SecurityCodeScan", StringComparison.OrdinalIgnoreCase));
-
-        var pumaPresent = pumaFromAssembly ||
-            nugetPackages.Any(p => p.Contains("Puma.Security", StringComparison.OrdinalIgnoreCase));
-
-        var missingPackages = new List<string>();
-        if (!securityCodeScanPresent)
-            missingPackages.AddRange(RecommendedPackages);
-
-        return new SecurityAnalyzerStatusDto(
-            NetAnalyzersPresent: netAnalyzersPresent,
-            SecurityCodeScanPresent: securityCodeScanPresent,
-            MissingRecommendedPackages: missingPackages,
-            PumaSecurityRulesPresent: pumaPresent,
-            SecurityRelatedNuGetPackages: securityRelatedNuget);
+        return CreateAnalyzerStatus(analyzerPresence, nugetPackages);
     }
 
     private static bool IsSecurityRelatedNuGetPackage(string packageId) =>
@@ -201,6 +139,106 @@ public sealed class SecurityDiagnosticService : ISecurityDiagnosticService
         }
         return false;
     }
+
+    private async Task<HashSet<string>> CollectNuGetPackagesAsync(Solution solution, string workspaceId, CancellationToken ct)
+    {
+        var nugetPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in solution.Projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(project.FilePath))
+            {
+                continue;
+            }
+
+            try
+            {
+                var evaluated = await _msBuildEvaluation.EvaluateItemsAsync(
+                    workspaceId, project.Name, "PackageReference", ct).ConfigureAwait(false);
+
+                foreach (var item in evaluated.Items)
+                {
+                    if (!string.IsNullOrWhiteSpace(item.Include))
+                    {
+                        nugetPackages.Add(item.Include);
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(ex, "Could not evaluate PackageReference items for project '{ProjectName}'", project.Name);
+            }
+        }
+
+        return nugetPackages;
+    }
+
+    private static AnalyzerPresence DetectAnalyzerAssemblies(Solution solution, CancellationToken ct)
+    {
+        var netAnalyzersPresent = false;
+        var securityCodeScanPresent = false;
+        var pumaPresent = false;
+
+        foreach (var project in solution.Projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            foreach (var analyzerRef in project.AnalyzerReferences)
+            {
+                var displayName = analyzerRef.Display ?? string.Empty;
+
+                if (!netAnalyzersPresent && MatchesAnyPrefix(displayName, NetAnalyzerAssemblyPrefixes))
+                {
+                    netAnalyzersPresent = true;
+                }
+
+                if (!securityCodeScanPresent && MatchesAnyPrefix(displayName, SecurityCodeScanAssemblyPrefixes))
+                {
+                    securityCodeScanPresent = true;
+                }
+
+                if (!pumaPresent && MatchesAnyPrefix(displayName, PumaSecurityAssemblyPrefixes))
+                {
+                    pumaPresent = true;
+                }
+            }
+        }
+
+        return new AnalyzerPresence(netAnalyzersPresent, securityCodeScanPresent, pumaPresent);
+    }
+
+    private static SecurityAnalyzerStatusDto CreateAnalyzerStatus(
+        AnalyzerPresence analyzerPresence,
+        IReadOnlyCollection<string> nugetPackages)
+    {
+        var securityRelatedNuget = nugetPackages
+            .Where(IsSecurityRelatedNuGetPackage)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var securityCodeScanPresent = analyzerPresence.SecurityCodeScanPresent ||
+            nugetPackages.Any(p => p.Contains("SecurityCodeScan", StringComparison.OrdinalIgnoreCase));
+
+        var pumaPresent = analyzerPresence.PumaPresent ||
+            nugetPackages.Any(p => p.Contains("Puma.Security", StringComparison.OrdinalIgnoreCase));
+
+        var missingPackages = new List<string>();
+        if (!securityCodeScanPresent)
+        {
+            missingPackages.AddRange(RecommendedPackages);
+        }
+
+        return new SecurityAnalyzerStatusDto(
+            NetAnalyzersPresent: analyzerPresence.NetAnalyzersPresent,
+            SecurityCodeScanPresent: securityCodeScanPresent,
+            MissingRecommendedPackages: missingPackages,
+            PumaSecurityRulesPresent: pumaPresent,
+            SecurityRelatedNuGetPackages: securityRelatedNuget);
+    }
+
+    private readonly record struct AnalyzerPresence(
+        bool NetAnalyzersPresent,
+        bool SecurityCodeScanPresent,
+        bool PumaPresent);
 
     private static int GetSeverityOrder(string severity) =>
         severity switch

--- a/tests/RoslynMcp.Tests/RestructureServiceTests.cs
+++ b/tests/RoslynMcp.Tests/RestructureServiceTests.cs
@@ -82,4 +82,26 @@ public sealed class RestructureServiceTests : SharedWorkspaceTestBase
         StringAssert.Contains(ex.Message, "no matches found",
             "Orphaned-placeholder validation must not fire for a literal-only pattern/goal pair.");
     }
+
+    [TestMethod]
+    public async Task PreviewRestructure_RepeatedPlaceholder_RequiresConsistentTokenCapture()
+    {
+        var refactoringProbePath = Path.Combine(
+            Path.GetDirectoryName(SampleSolutionPath)!,
+            "SampleLib",
+            "RefactoringProbe.cs");
+
+        var preview = await Service.PreviewRestructureAsync(
+            WorkspaceId,
+            pattern: "__name__ = __name__ * 2;",
+            goal: "__name__ *= 2;",
+            scope: new RestructureScope(refactoringProbePath, null),
+            ct: CancellationToken.None);
+
+        Assert.AreEqual(1, preview.Changes.Count,
+            "The repeated-placeholder pattern should match exactly the `result = result * 2;` statement.");
+        StringAssert.Contains(preview.Description, "1 match(es)");
+        StringAssert.Contains(preview.Changes[0].UnifiedDiff, "result *= 2;");
+        StringAssert.Contains(preview.Changes[0].UnifiedDiff, "-        result = result * 2;");
+    }
 }

--- a/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
@@ -163,8 +163,47 @@ public class SecurityDiagnosticIntegrationTests : SharedWorkspaceTestBase
         CollectionAssert.DoesNotContain(
             status.MissingRecommendedPackages.ToList(),
             "SecurityCodeScan.VS2019",
-            "The archived SecurityCodeScan.VS2019 package must not appear in MissingRecommendedPackages " +
-            "— recommending an archived package gives consumers bad advice.");
+             "The archived SecurityCodeScan.VS2019 package must not appear in MissingRecommendedPackages " +
+             "— recommending an archived package gives consumers bad advice.");
+    }
+
+    [TestMethod]
+    public async Task AnalyzerStatus_PackageReferencesDriveSecurityPackageFlags_AndSorting()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        var copiedWorkspaceId = string.Empty;
+
+        try
+        {
+            InjectSecurityPackageReferences(Path.Combine(copiedRoot, "SampleLib", "SampleLib.csproj"));
+            copiedWorkspaceId = (await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None)).WorkspaceId;
+
+            var status = await SecurityService.GetAnalyzerStatusAsync(copiedWorkspaceId, CancellationToken.None);
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Puma.Security.Rules",
+                    "SecurityCodeScan.VS2019",
+                    "SonarAnalyzer.CSharp",
+                },
+                status.SecurityRelatedNuGetPackages?.ToArray() ?? [],
+                "Security-related PackageReference items should be deduced from MSBuild evaluation and sorted.");
+            Assert.IsTrue(status.SecurityCodeScanPresent,
+                "SecurityCodeScanPresent should flip on when the package exists even without an analyzer assembly.");
+            Assert.IsTrue(status.PumaSecurityRulesPresent,
+                "PumaSecurityRulesPresent should flip on when the package exists even without an analyzer assembly.");
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(copiedWorkspaceId))
+            {
+                WorkspaceManager.Close(copiedWorkspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
     }
 
     // ── Catalog Tests ──
@@ -328,5 +367,20 @@ public class SecurityDiagnosticIntegrationTests : SharedWorkspaceTestBase
                 finding.FilePath?.Contains("InsecureLib", StringComparison.OrdinalIgnoreCase) == true,
                 $"Finding in unexpected path: {finding.FilePath}");
         }
+    }
+
+    private static void InjectSecurityPackageReferences(string csprojPath)
+    {
+        var content = File.ReadAllText(csprojPath);
+        var packageReferenceSnippet = """
+              <ItemGroup>
+                <PackageReference Include="SonarAnalyzer.CSharp" Version="9.26.0.0" />
+                <PackageReference Include="Puma.Security.Rules" Version="1.0.0" />
+                <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        File.WriteAllText(csprojPath, content.Replace("</Project>", packageReferenceSnippet, StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary
- reduce branching in `SecurityDiagnosticService.GetAnalyzerStatusAsync` by separating analyzer detection, package collection, and DTO assembly
- simplify `RestructureService.StructuralRewriter.TryMatch` by isolating placeholder, token, and child matching helpers
- add direct regression coverage for package-derived analyzer status and repeated-placeholder restructure previews

Backlog correlation: cc-18-to-19-residuals-post-top10-extraction / tranche cc-18-19-s4-security-restructure
Closes: none (maintenance tranche; backlog row remains open until tranche 4g)

## Validation
- `dotnet restore RoslynMcp.slnx --nologo`
- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj --filter "FullyQualifiedName~SecurityDiagnosticIntegrationTests|FullyQualifiedName~RestructureServiceTests" --nologo`
- `./eng/verify-ai-docs.ps1`
- `dotnet build-server shutdown`
- `./eng/verify-release.ps1 -Configuration Release`
