### PR TITLE
refactor(roslyn): trim residual complexity (cc-18-19-s6-collapse-nuget)

### DIFF
--- a/src/RoslynMcp.Roslyn/Helpers/NuGetVulnerabilityJsonParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/NuGetVulnerabilityJsonParser.cs
@@ -68,51 +68,92 @@ public static class NuGetVulnerabilityJsonParser
         HashSet<string> seen,
         List<NuGetVulnerablePackageDto> results)
     {
-        if (!framework.TryGetProperty(arrayName, out var pkgs) || pkgs.ValueKind != JsonValueKind.Array)
+        if (!framework.TryGetProperty(arrayName, out var packages) || packages.ValueKind != JsonValueKind.Array)
+        {
+            return;
+}
+        foreach (var package in packages.EnumerateArray())
+        {
+            AddPackageVulnerabilities(package, isTransitive, projectPath, projectName, seen, results);
+        }
+    }
+
+    private static void AddPackageVulnerabilities(
+        JsonElement package,
+        bool isTransitive,
+        string projectPath,
+        string projectName,
+        HashSet<string> seen,
+        List<NuGetVulnerablePackageDto> results)
+    {
+        if (!package.TryGetProperty("vulnerabilities", out var vulnerabilities) || vulnerabilities.ValueKind != JsonValueKind.Array)
         {
             return;
         }
 
-        foreach (var pkg in pkgs.EnumerateArray())
+        var packageId = package.TryGetProperty("id", out var idElement) ? idElement.GetString() ?? "" : "";
+        var resolvedVersion = GetResolvedVersion(package);
+
+        foreach (var vulnerability in vulnerabilities.EnumerateArray())
         {
-            var id = pkg.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
-            var resolved = pkg.TryGetProperty("resolvedVersion", out var rv)
-                ? rv.GetString() ?? ""
-                : pkg.TryGetProperty("requestedVersion", out var rq)
-                    ? rq.GetString() ?? ""
-                    : "";
-
-            if (!pkg.TryGetProperty("vulnerabilities", out var vulns) || vulns.ValueKind != JsonValueKind.Array)
-            {
-                continue;
-            }
-
-            foreach (var vuln in vulns.EnumerateArray())
-            {
-                var severity = vuln.TryGetProperty("severity", out var sev)
-                    ? sev.GetString() ?? "Unknown"
-                    : "Unknown";
-                var advisoryUrl = vuln.TryGetProperty("advisoryurl", out var adv)
-                    ? adv.GetString()
-                    : vuln.TryGetProperty("advisoryUrl", out var adv2)
-                        ? adv2.GetString()
-                        : null;
-
-                var dedupeKey = $"{projectPath}|{id}|{resolved}|{advisoryUrl}|{severity}|{isTransitive}";
-                if (!seen.Add(dedupeKey))
-                {
-                    continue;
-                }
-
-                results.Add(new NuGetVulnerablePackageDto(
-                    id,
-                    resolved,
-                    severity,
-                    advisoryUrl,
-                    projectName,
-                    isTransitive,
-                    PatchedVersion: null));
-            }
+            TryAddVulnerability(
+                vulnerability,
+                packageId,
+                resolvedVersion,
+                isTransitive,
+                projectPath,
+                projectName,
+                seen,
+                results);
         }
     }
+
+    private static string GetResolvedVersion(JsonElement package)
+    {
+        return package.TryGetProperty("resolvedVersion", out var resolvedVersion)
+            ? resolvedVersion.GetString() ?? ""
+            : package.TryGetProperty("requestedVersion", out var requestedVersion)
+                ? requestedVersion.GetString() ?? ""
+                : "";
+    }
+
+    private static void TryAddVulnerability(
+        JsonElement vulnerability,
+        string packageId,
+        string resolvedVersion,
+        bool isTransitive,
+        string projectPath,
+        string projectName,
+        HashSet<string> seen,
+        List<NuGetVulnerablePackageDto> results)
+    {
+        var severity = vulnerability.TryGetProperty("severity", out var severityElement)
+            ? severityElement.GetString() ?? "Unknown"
+            : "Unknown";
+        var advisoryUrl = GetAdvisoryUrl(vulnerability);
+        var dedupeKey = $"{projectPath}|{packageId}|{resolvedVersion}|{advisoryUrl}|{severity}|{isTransitive}";
+        if (!seen.Add(dedupeKey))
+        {
+            return;
+        }
+
+        results.Add(new NuGetVulnerablePackageDto(
+            packageId,
+            resolvedVersion,
+            severity,
+            advisoryUrl,
+            projectName,
+            isTransitive,
+            PatchedVersion: null));
+    }
+
+    private static string? GetAdvisoryUrl(JsonElement vulnerability)
+    {
+        return vulnerability.TryGetProperty("advisoryurl", out var advisoryUrl)
+            ? advisoryUrl.GetString()
+            : vulnerability.TryGetProperty("advisoryUrl", out var camelCaseAdvisoryUrl)
+                ? camelCaseAdvisoryUrl.GetString()
+                : null;
+    }
+
 }

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -1374,62 +1374,112 @@ public sealed class RefactoringService : IRefactoringService
         int startLine,
         int endLine)
     {
-        var startIdx = startLine - 1;
-        var endIdx = endLine - 1;
-        if (startIdx < 0) startIdx = 0;
-        if (endIdx >= text.Lines.Count) endIdx = text.Lines.Count - 1;
-        if (endIdx < startIdx) return text;
-
-        // Identify maximal blank-line runs (length >= 2) whose every line is in [startIdx, endIdx].
-        // Build a set of line indices to drop: keep the first blank in each qualifying run, drop the rest.
-        var dropIndices = new System.Collections.Generic.HashSet<int>();
-        int i = 0;
-        while (i < text.Lines.Count)
+        var (startIdx, endIdx) = NormalizeCollapsedBlankLineRange(text, startLine, endLine);
+        if (endIdx < startIdx)
         {
-            if (!IsBlankLine(text.Lines[i])) { i++; continue; }
-            int runStart = i;
-            int runEnd = i;
+            return text;
+}
+        var dropIndices = CollectBlankLineIndicesToDrop(text, startIdx, endIdx);
+        if (dropIndices.Count == 0)
+        {
+            return text;
+        }
+
+        return BuildCollapsedSourceText(text, dropIndices);
+    }
+
+    private static (int StartIdx, int EndIdx) NormalizeCollapsedBlankLineRange(
+        Microsoft.CodeAnalysis.Text.SourceText text,
+        int startLine,
+        int endLine)
+    {
+        var startIdx = System.Math.Max(0, startLine - 1);
+        var endIdx = System.Math.Min(text.Lines.Count - 1, endLine - 1);
+        return (startIdx, endIdx);
+    }
+
+    private static System.Collections.Generic.HashSet<int> CollectBlankLineIndicesToDrop(
+        Microsoft.CodeAnalysis.Text.SourceText text,
+        int startIdx,
+        int endIdx)
+    {
+        var dropIndices = new System.Collections.Generic.HashSet<int>();
+        var lineIndex = 0;
+        while (lineIndex < text.Lines.Count)
+        {
+            if (!IsBlankLine(text.Lines[lineIndex]))
+            {
+                lineIndex++;
+                continue;
+            }
+
+            var runEnd = lineIndex;
             while (runEnd + 1 < text.Lines.Count && IsBlankLine(text.Lines[runEnd + 1]))
             {
                 runEnd++;
             }
-            // Qualify: run length >= 2 AND entire run inside the requested range.
-            if (runEnd - runStart >= 1 && runStart >= startIdx && runEnd <= endIdx)
+
+            if (lineIndex >= startIdx && runEnd <= endIdx)
             {
-                for (int k = runStart + 1; k <= runEnd; k++)
+                for (var dropIndex = lineIndex + 1; dropIndex <= runEnd; dropIndex++)
                 {
-                    dropIndices.Add(k);
+                    dropIndices.Add(dropIndex);
                 }
             }
-            i = runEnd + 1;
+
+            lineIndex = runEnd + 1;
         }
 
-        if (dropIndices.Count == 0) return text;
-
-        var sb = new System.Text.StringBuilder(text.Length);
-        for (int j = 0; j < text.Lines.Count; j++)
-        {
-            if (dropIndices.Contains(j)) continue;
-            var line = text.Lines[j];
-            sb.Append(line.ToString());
-            var lineBreakStart = line.End;
-            var lineBreakEnd = line.EndIncludingLineBreak;
-            if (lineBreakEnd > lineBreakStart)
-            {
-                var breakSpan = Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(lineBreakStart, lineBreakEnd);
-                sb.Append(text.GetSubText(breakSpan).ToString());
-            }
-        }
-        return Microsoft.CodeAnalysis.Text.SourceText.From(sb.ToString(), text.Encoding, text.ChecksumAlgorithm);
-
-        static bool IsBlankLine(Microsoft.CodeAnalysis.Text.TextLine line)
-        {
-            var s = line.ToString();
-            for (int n = 0; n < s.Length; n++)
-            {
-                if (s[n] != ' ' && s[n] != '\t') return false;
-            }
-            return true;
-        }
+        return dropIndices;
     }
+
+    private static Microsoft.CodeAnalysis.Text.SourceText BuildCollapsedSourceText(
+        Microsoft.CodeAnalysis.Text.SourceText text,
+        System.Collections.Generic.HashSet<int> dropIndices)
+    {
+        var sb = new System.Text.StringBuilder(text.Length);
+        for (var lineIndex = 0; lineIndex < text.Lines.Count; lineIndex++)
+        {
+            if (dropIndices.Contains(lineIndex))
+            {
+                continue;
+            }
+
+            AppendLineAndBreak(sb, text, text.Lines[lineIndex]);
+        }
+
+        return Microsoft.CodeAnalysis.Text.SourceText.From(sb.ToString(), text.Encoding, text.ChecksumAlgorithm);
+    }
+
+    private static void AppendLineAndBreak(
+        System.Text.StringBuilder sb,
+        Microsoft.CodeAnalysis.Text.SourceText text,
+        Microsoft.CodeAnalysis.Text.TextLine line)
+    {
+        sb.Append(line.ToString());
+        var lineBreakStart = line.End;
+        var lineBreakEnd = line.EndIncludingLineBreak;
+        if (lineBreakEnd <= lineBreakStart)
+        {
+            return;
+        }
+
+        var breakSpan = Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(lineBreakStart, lineBreakEnd);
+        sb.Append(text.GetSubText(breakSpan).ToString());
+    }
+
+    private static bool IsBlankLine(Microsoft.CodeAnalysis.Text.TextLine line)
+    {
+        var s = line.ToString();
+        for (var n = 0; n < s.Length; n++)
+        {
+            if (s[n] != ' ' && s[n] != '\t')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 }

--- a/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
@@ -352,4 +352,52 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
             WorkspaceManager.Close(workspaceId);
         }
     }
+
+    [TestMethod]
+    public async Task FormatRangePreview_PreservesBlankLineRunsThatCrossRangeBoundary()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "FormatRangeBoundaryFixture.cs");
+        var content =
+            "namespace SampleLib;\r\n" +
+            "\r\n" +
+            "public class FormatRangeBoundaryFixture\r\n" +
+            "{\r\n" +
+            "    public int Compute(int input)\r\n" +
+            "    {\r\n" +
+            "\r\n" +
+            "\r\n" +
+            "        return input + 1;\r\n" +
+            "    }\r\n" +
+            "}\r\n";
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var preview = await RefactoringService.PreviewFormatRangeAsync(
+                workspaceId, fixturePath,
+                startLine: 8, startColumn: 1,
+                endLine: 9, endColumn: 25,
+                CancellationToken.None);
+
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, "apply must succeed");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+            Assert.AreEqual(content, postApplyText,
+                "blank-line runs that cross the requested range boundary must be preserved verbatim.");
+            Assert.IsTrue(postApplyText.Contains("\r\n\r\n\r\n", StringComparison.Ordinal),
+                $"the boundary-crossing blank-line run should remain intact. Got:\n{postApplyText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
 }

--- a/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
@@ -16,8 +16,7 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : SharedWorkspaceTest
     {
         InitializeServices();
         WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
-    }
-
+}
     [ClassCleanup]
     public static void ClassCleanup() => DisposeServices();
 
@@ -100,6 +99,81 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : SharedWorkspaceTest
         Assert.AreEqual(0, result.LowCount);
         Assert.IsTrue(result.Vulnerabilities.All(v => !v.IsTransitive),
             "topLevelPackages entries should map to IsTransitive=false.");
+    }
+
+    [TestMethod]
+    public async Task ScanNuGetVulnerabilities_WithStubbedExecutor_DeduplicatesAcrossFrameworks()
+    {
+        const string cannedJson = """
+{
+  "version": 1,
+  "parameters": "--vulnerable --include-transitive --format json",
+  "projects": [
+    {
+      "path": "/repo/SampleApp/SampleApp.csproj",
+      "frameworks": [
+        {
+          "framework": "net10.0",
+          "topLevelPackages": [
+            {
+              "id": "Repeated.Package",
+              "resolvedVersion": "3.0.0",
+              "vulnerabilities": [
+                { "severity": "High", "advisoryurl": "https://example/repeated" }
+              ]
+            }
+          ],
+          "transitivePackages": [
+            {
+              "id": "Transitive.Package",
+              "requestedVersion": "5.1.0",
+              "vulnerabilities": [
+                { "severity": "Low", "advisoryUrl": "https://example/transitive" }
+              ]
+            }
+          ]
+        },
+        {
+          "framework": "net9.0",
+          "topLevelPackages": [
+            {
+              "id": "Repeated.Package",
+              "resolvedVersion": "3.0.0",
+              "vulnerabilities": [
+                { "severity": "High", "advisoryurl": "https://example/repeated" }
+              ]
+            }
+          ],
+          "transitivePackages": []
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        var stubExecutor = new StubGatedCommandExecutor(cannedJson);
+        var service = new NuGetDependencyService(
+            WorkspaceManager,
+            stubExecutor,
+            new MsBuildEvaluationService(WorkspaceManager),
+            NullLogger<NuGetDependencyService>.Instance);
+
+        var result = await service.ScanNuGetVulnerabilitiesAsync(
+            WorkspaceId, projectFilter: null, includeTransitive: true, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.ScannedProjects);
+        Assert.AreEqual(2, result.TotalVulnerabilities, "The repeated package should be deduplicated across frameworks.");
+        Assert.IsTrue(result.IncludesTransitive);
+
+        var repeatedPackage = result.Vulnerabilities.Single(v => v.PackageId == "Repeated.Package");
+        Assert.AreEqual("https://example/repeated", repeatedPackage.AdvisoryUrl);
+        Assert.IsFalse(repeatedPackage.IsTransitive);
+
+        var transitivePackage = result.Vulnerabilities.Single(v => v.PackageId == "Transitive.Package");
+        Assert.AreEqual("https://example/transitive", transitivePackage.AdvisoryUrl);
+        Assert.IsTrue(transitivePackage.IsTransitive);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- reduce complexity in `RefactoringService.CollapseBlankLineRunsInRange` by splitting range normalization, drop-index collection, and source-text rebuilding into focused helpers
- reduce complexity in `NuGetVulnerabilityJsonParser.AddPackagesFromFramework` by separating package traversal, resolved-version lookup, advisory-url normalization, and vulnerability dedupe/appending
- add regressions for range-boundary blank-line preservation and NuGet framework dedupe/camel-case advisory parsing

Closes: cc-18-to-19-residuals-post-top10-extraction (tranche `cc-18-19-s6-collapse-nuget`; backlog sync remains orchestrator-owned until the final tranche closes the row)

## Validation
- `mcp__roslyn__.compile_check` on the 4 touched files
- `mcp__roslyn__.test_run` with `TestCategory!=Network&(FullyQualifiedName~RoslynMcp.Tests.NuGetVulnerabilityScanIntegrationTests|FullyQualifiedName~RoslynMcp.Tests.FormatRangeServiceTests)`
- `./eng/verify-ai-docs.ps1`
- `./eng/verify-release.ps1 -Configuration Release`