### PR TITLE
refactor(cohesion): split member access classification (cc-18-19-s7-cohesion-solo)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
@@ -405,44 +405,78 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
     {
         var fields = new HashSet<string>(StringComparer.Ordinal);
         var calls = new HashSet<string>(StringComparer.Ordinal);
-        var methodLocation = method.Locations.FirstOrDefault(l => l.IsInSource);
-        if (methodLocation?.SourceTree is null) return (fields, calls);
-
-        var root = methodLocation.SourceTree.GetRoot(ct);
-        var methodNode = root.FindNode(methodLocation.SourceSpan);
+        var methodNode = FindSourceMethodNode(method, ct);
+        if (methodNode is null) return (fields, calls);
 
         foreach (var identifier in methodNode.DescendantNodes().OfType<IdentifierNameSyntax>())
         {
-            var symbolInfo = semanticModel.GetSymbolInfo(identifier, ct);
-            var referencedSymbol = symbolInfo.Symbol;
+            var referencedSymbol = semanticModel.GetSymbolInfo(identifier, ct).Symbol;
             if (referencedSymbol is null) continue;
 
-            if (referencedSymbol is IFieldSymbol field &&
-                SymbolEqualityComparer.Default.Equals(field.ContainingType, containingType) &&
-                (containingType.IsStatic || !field.IsStatic))
-            {
-                fields.Add(field.Name);
-            }
-            else if (referencedSymbol is IPropertySymbol prop &&
-                     SymbolEqualityComparer.Default.Equals(prop.ContainingType, containingType) &&
-                     (containingType.IsStatic || !prop.IsStatic))
-            {
-                fields.Add(prop.Name);
-            }
-            else if (referencedSymbol is IMethodSymbol calledMethod &&
-                     SymbolEqualityComparer.Default.Equals(calledMethod.ContainingType, containingType) &&
-                     (containingType.IsStatic || !calledMethod.IsStatic) &&
-                     calledMethod.DeclaredAccessibility == Accessibility.Private &&
-                     calledMethod.MethodKind == MethodKind.Ordinary)
-            {
-                // Private method calls create transitive coupling but should NOT appear as
-                // SharedFields. They live in the call map, used only for cluster connectivity.
-                calls.Add(calledMethod.Name);
-            }
+            AddAccessedMember(referencedSymbol, containingType, fields, calls);
         }
 
         return (fields, calls);
     }
+
+    private static SyntaxNode? FindSourceMethodNode(IMethodSymbol method, CancellationToken ct)
+    {
+        var methodLocation = method.Locations.FirstOrDefault(l => l.IsInSource);
+        if (methodLocation?.SourceTree is null) return null;
+
+        var root = methodLocation.SourceTree.GetRoot(ct);
+        return root.FindNode(methodLocation.SourceSpan);
+    }
+
+    private static void AddAccessedMember(
+        ISymbol referencedSymbol, INamedTypeSymbol containingType,
+        HashSet<string> fields, HashSet<string> calls)
+    {
+        var sharedMemberName = GetSharedMemberName(referencedSymbol, containingType);
+        if (sharedMemberName is not null)
+        {
+            fields.Add(sharedMemberName);
+            return;
+        }
+
+        var helperCallName = GetPrivateHelperCallName(referencedSymbol, containingType);
+        if (helperCallName is not null)
+        {
+            // Private method calls create transitive coupling but should NOT appear as
+            // SharedFields. They live in the call map, used only for cluster connectivity.
+            calls.Add(helperCallName);
+        }
+    }
+
+    private static string? GetSharedMemberName(ISymbol referencedSymbol, INamedTypeSymbol containingType) =>
+        referencedSymbol switch
+        {
+            IFieldSymbol field when IsOwnedMember(field, containingType) => field.Name,
+            IPropertySymbol property when IsOwnedMember(property, containingType) => property.Name,
+            _ => null,
+        };
+
+    private static string? GetPrivateHelperCallName(ISymbol referencedSymbol, INamedTypeSymbol containingType) =>
+        referencedSymbol is IMethodSymbol calledMethod
+        && IsOwnedMember(calledMethod, containingType)
+        && calledMethod.DeclaredAccessibility == Accessibility.Private
+        && calledMethod.MethodKind == MethodKind.Ordinary
+            ? calledMethod.Name
+            : null;
+
+    private static bool IsOwnedMember(ISymbol member, INamedTypeSymbol containingType) =>
+        member.ContainingType is not null
+        && SymbolEqualityComparer.Default.Equals(member.ContainingType, containingType)
+        && (containingType.IsStatic || !IsStaticMember(member));
+
+    private static bool IsStaticMember(ISymbol member) =>
+        member switch
+        {
+            IFieldSymbol field => field.IsStatic,
+            IPropertySymbol property => property.IsStatic,
+            IMethodSymbol method => method.IsStatic,
+            _ => false,
+        };
 
     private static bool MethodAccessesMember(
         IMethodSymbol method, ISymbol member,

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -244,6 +244,68 @@ public class AdapterUnderTest
     }
 
     [TestMethod]
+    public async Task GetCohesionMetrics_SharedFields_IncludePrivateProperties_ButNotHelperNames()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        string? workspaceId = null;
+
+        try
+        {
+            var filePath = Path.Combine(copiedRoot, "SampleLib", "PropertyBackedAdapter.cs");
+            await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public class PropertyBackedAdapter
+{
+    private string ConnectionString { get; } = "server";
+
+    public string ReadOne()
+    {
+        return Format(ConnectionString);
+    }
+
+    public string ReadTwo()
+    {
+        return Format(ConnectionString);
+    }
+
+    private static string Format(string connection)
+    {
+        return connection.ToUpperInvariant();
+    }
+}
+""", CancellationToken.None);
+
+            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+            workspaceId = status.WorkspaceId;
+
+            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+            var adapter = metrics.FirstOrDefault(m => m.TypeName == "PropertyBackedAdapter");
+            Assert.IsNotNull(adapter, "PropertyBackedAdapter should appear in cohesion metrics.");
+            Assert.IsTrue(adapter.Clusters.Count >= 1, "PropertyBackedAdapter should have at least one cluster.");
+
+            var sharedFields = adapter.Clusters.SelectMany(cluster => cluster.SharedFields).ToList();
+            CollectionAssert.Contains(sharedFields, "ConnectionString",
+                "Private properties accessed by multiple public methods should still appear in SharedFields.");
+            CollectionAssert.DoesNotContain(sharedFields, "Format",
+                "Private helper method names must stay out of SharedFields.");
+        }
+        finally
+        {
+            if (workspaceId is not null)
+            {
+                WorkspaceManager.Close(workspaceId);
+            }
+
+            DeleteDirectoryIfExists(copiedRoot);
+        }
+    }
+
+    [TestMethod]
     public async Task GetCohesionMetrics_ActionTriadPattern_ClassifiesAsActionTriad_AndDowngradesRecommendation()
     {
         // lcom4-lifecycle-pattern-false-positive: A type ending in `Action`/`Handler`/`Command`/`Stage`


### PR DESCRIPTION
## Summary
- Split `CohesionAnalysisService.FindAccessedMembers` into smaller helpers to reduce cyclomatic complexity while preserving cohesion/member-access semantics.
- Added targeted cohesion regression coverage for the extracted helper paths.
- Final backlog-row closure for `cc-18-to-19-residuals-post-top10-extraction` is orchestrator-owned in the reconcile PR once sibling tranches 4d-4f are merged.

## Closes
- cc-18-to-19-residuals-post-top10-extraction

## Validation
- [x] ./eng/verify-release.ps1 -Configuration Release
- [x] ./eng/verify-ai-docs.ps1