### PR TITLE
refactor(extraction): split interface/type helper flows (cc-18-19-s5-interface-type-strip)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
@@ -393,16 +393,27 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         var result = new List<UsingDirectiveSyntax>();
         var alreadyAddedPlainNamespaces = new HashSet<string>(StringComparer.Ordinal);
 
+        PreserveSpecialAndRequiredSourceUsings(
+            sourceUsings,
+            requiredNamespaces,
+            result,
+            alreadyAddedPlainNamespaces);
+        AddMissingRequiredUsingDirectives(requiredNamespaces, alreadyAddedPlainNamespaces, result);
+        return SortUsingDirectives(result);
+    }
+
+    private static void PreserveSpecialAndRequiredSourceUsings(
+        SyntaxList<UsingDirectiveSyntax> sourceUsings,
+        IReadOnlyCollection<string> requiredNamespaces,
+        List<UsingDirectiveSyntax> result,
+        ISet<string> alreadyAddedPlainNamespaces)
+    {
         // Preserve aliases, static usings, and global usings — the semantic walker cannot
         // reproduce these, they may carry meaningful intent, and they never cause the
         // missing-using bug we're fixing.
         foreach (var source in sourceUsings)
         {
-            var isAlias = source.Alias is not null;
-            var isStatic = source.StaticKeyword.IsKind(SyntaxKind.StaticKeyword);
-            var isGlobal = source.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
-
-            if (isAlias || isStatic || isGlobal)
+            if (IsSpecialUsingDirective(source))
             {
                 result.Add(source);
                 continue;
@@ -410,46 +421,62 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
 
             // Plain using: keep ONLY if the semantic walk identified this namespace as
             // required. This drops unrelated usings that pollute the interface file.
-            var name = source.Name?.ToString();
-            if (!string.IsNullOrWhiteSpace(name) && requiredNamespaces.Contains(name))
-            {
-                result.Add(source);
-                alreadyAddedPlainNamespaces.Add(name);
-            }
-        }
-
-        // Add missing required namespaces as new plain usings.
-        foreach (var ns in requiredNamespaces)
-        {
-            if (alreadyAddedPlainNamespaces.Contains(ns))
+            var name = GetUsingNamespace(source);
+            if (name is null || !requiredNamespaces.Contains(name))
             {
                 continue;
             }
 
-            result.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ns)));
+            result.Add(source);
+            alreadyAddedPlainNamespaces.Add(name);
         }
+    }
 
+    private static void AddMissingRequiredUsingDirectives(
+        IReadOnlyCollection<string> requiredNamespaces,
+        ISet<string> alreadyAddedPlainNamespaces,
+        List<UsingDirectiveSyntax> result)
+    {
+        foreach (var ns in requiredNamespaces)
+        {
+            if (!alreadyAddedPlainNamespaces.Contains(ns))
+            {
+                result.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ns)));
+            }
+        }
+    }
+
+    private static SyntaxList<UsingDirectiveSyntax> SortUsingDirectives(List<UsingDirectiveSyntax> usings)
+    {
         // Sort: System.* first alphabetically, then other plain usings alphabetically,
-        // then aliases/static/global at the end in their original order. This keeps the
-        // generated file PEP-style tidy for code review.
-        var systemUsings = result
-            .Where(u => u.Alias is null
-                && !u.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
-                && !u.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)
-                && (u.Name?.ToString().StartsWith("System", StringComparison.Ordinal) ?? false))
+        // then aliases/static/global at the end in their original order.
+        var systemUsings = usings
+            .Where(IsSystemUsingDirective)
             .OrderBy(u => u.Name!.ToString(), StringComparer.Ordinal);
-        var otherPlain = result
-            .Where(u => u.Alias is null
-                && !u.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
-                && !u.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword)
-                && !(u.Name?.ToString().StartsWith("System", StringComparison.Ordinal) ?? false))
+        var otherPlain = usings
+            .Where(u => !IsSpecialUsingDirective(u) && !IsSystemUsingDirective(u))
             .OrderBy(u => u.Name!.ToString(), StringComparer.Ordinal);
-        var specials = result
-            .Where(u => u.Alias is not null
-                || u.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
-                || u.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword));
-
+        var specials = usings.Where(IsSpecialUsingDirective);
         return SyntaxFactory.List(systemUsings.Concat(otherPlain).Concat(specials));
+    }
+
+    private static string? GetUsingNamespace(UsingDirectiveSyntax source)
+    {
+        var name = source.Name?.ToString();
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    private static bool IsSystemUsingDirective(UsingDirectiveSyntax usingDirective)
+    {
+        return !IsSpecialUsingDirective(usingDirective)
+            && (usingDirective.Name?.ToString().StartsWith("System", StringComparison.Ordinal) ?? false);
+    }
+
+    private static bool IsSpecialUsingDirective(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.Alias is not null
+            || usingDirective.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
+            || usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
     }
 
     private static TypeDeclarationSyntax EnsureOpeningBraceOnOwnLine(TypeDeclarationSyntax typeDecl)

--- a/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
@@ -476,39 +476,17 @@ public sealed class TypeExtractionService : ITypeExtractionService
     /// </summary>
     private static MemberDeclarationSyntax StripInheritanceOnlyModifiers(MemberDeclarationSyntax member)
     {
-        var inheritanceOnly = new[]
-        {
-            SyntaxKind.OverrideKeyword,
-            SyntaxKind.VirtualKeyword,
-            SyntaxKind.AbstractKeyword,
-            SyntaxKind.SealedKeyword,
-            SyntaxKind.NewKeyword,
-        };
-
-        var currentModifiers = member switch
-        {
-            MethodDeclarationSyntax m => m.Modifiers,
-            PropertyDeclarationSyntax p => p.Modifiers,
-            FieldDeclarationSyntax f => f.Modifiers,
-            EventDeclarationSyntax e => e.Modifiers,
-            _ => default
-        };
-
+        var currentModifiers = GetMemberModifiers(member);
         if (currentModifiers.Count == 0)
+        {
             return member;
+        }
 
-        var kept = currentModifiers.Where(tok => !inheritanceOnly.Contains(tok.Kind())).ToArray();
-        if (kept.Length == currentModifiers.Count)
+        var strippedModifiers = BuildStrippedModifierList(currentModifiers);
+        if (strippedModifiers.Count == currentModifiers.Count)
+        {
             return member;
-
-        // Preserve the leading trivia from the original first modifier so the declaration
-        // does not collapse against the preceding newline when an override-only modifier sat
-        // at the front of the list.
-        var leadingTrivia = currentModifiers[0].LeadingTrivia;
-        if (kept.Length > 0)
-            kept[0] = kept[0].WithLeadingTrivia(leadingTrivia);
-
-        var tokenList = SyntaxFactory.TokenList(kept);
+        }
 
         // For members whose method body remains valid after dropping `abstract`, we need to
         // also ensure the declaration has a body (abstract members carry `;` instead). Roslyn
@@ -517,15 +495,54 @@ public sealed class TypeExtractionService : ITypeExtractionService
         // current extract path (the source method already had a body to be extracted), but we
         // guard defensively so any future caller shape surfaces an explicit error instead of
         // silently emitting broken syntax.
-        if (member is MethodDeclarationSyntax method
-            && currentModifiers.Any(m => m.IsKind(SyntaxKind.AbstractKeyword))
-            && method.Body is null
-            && method.ExpressionBody is null)
+        ValidateAbstractMethodHasBody(member, currentModifiers);
+        return WithMemberModifiers(member, strippedModifiers);
+    }
+
+    private static SyntaxTokenList BuildStrippedModifierList(SyntaxTokenList currentModifiers)
+    {
+        var kept = currentModifiers.Where(tok => !IsInheritanceOnlyModifier(tok)).ToArray();
+        if (kept.Length > 0)
         {
-            throw new InvalidOperationException(
-                $"Cannot extract abstract member '{method.Identifier.Text}' into a non-inheriting type: the source has no body.");
+            // Preserve the leading trivia from the original first modifier so the declaration
+            // does not collapse against the preceding newline when an override-only modifier sat
+            // at the front of the list.
+            kept[0] = kept[0].WithLeadingTrivia(currentModifiers[0].LeadingTrivia);
         }
 
+        return SyntaxFactory.TokenList(kept);
+    }
+
+    private static void ValidateAbstractMethodHasBody(MemberDeclarationSyntax member, SyntaxTokenList currentModifiers)
+    {
+        if (member is not MethodDeclarationSyntax method || !currentModifiers.Any(IsAbstractModifier))
+        {
+            return;
+        }
+
+        if (method.Body is not null || method.ExpressionBody is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot extract abstract member '{method.Identifier.Text}' into a non-inheriting type: the source has no body.");
+    }
+
+    private static SyntaxTokenList GetMemberModifiers(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax m => m.Modifiers,
+            PropertyDeclarationSyntax p => p.Modifiers,
+            FieldDeclarationSyntax f => f.Modifiers,
+            EventDeclarationSyntax e => e.Modifiers,
+            _ => default
+        };
+    }
+
+    private static MemberDeclarationSyntax WithMemberModifiers(MemberDeclarationSyntax member, SyntaxTokenList tokenList)
+    {
         return member switch
         {
             MethodDeclarationSyntax m => m.WithModifiers(tokenList),
@@ -534,5 +551,19 @@ public sealed class TypeExtractionService : ITypeExtractionService
             EventDeclarationSyntax e => e.WithModifiers(tokenList),
             _ => member
         };
+    }
+
+    private static bool IsAbstractModifier(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.AbstractKeyword);
+    }
+
+    private static bool IsInheritanceOnlyModifier(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.OverrideKeyword)
+            || token.IsKind(SyntaxKind.VirtualKeyword)
+            || token.IsKind(SyntaxKind.AbstractKeyword)
+            || token.IsKind(SyntaxKind.SealedKeyword)
+            || token.IsKind(SyntaxKind.NewKeyword);
     }
 }

--- a/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
@@ -207,6 +207,107 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
     }
 
     [TestMethod]
+    public async Task ExtractInterface_PreservesSpecialUsings_And_Drops_UnusedPlainUsings()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var modelsDir = Path.Combine(sampleLibDir, "Models");
+        Directory.CreateDirectory(modelsDir);
+
+        await File.WriteAllTextAsync(Path.Combine(modelsDir, "Item3SpecialUsingModel.cs"),
+            """
+            namespace SampleLib.Models;
+
+            public class Item3SpecialUsingModel
+            {
+                public int Count { get; set; }
+            }
+            """);
+
+        await File.WriteAllTextAsync(Path.Combine(modelsDir, "Item3AliasModel.cs"),
+            """
+            namespace SampleLib.Models;
+
+            public class Item3AliasModel
+            {
+                public int Count { get; set; }
+            }
+            """);
+
+        var servicePath = Path.Combine(sampleLibDir, "Item3SpecialUsingService.cs");
+        await File.WriteAllTextAsync(servicePath,
+            """
+            using System.Text;
+            using System.Threading.Tasks;
+            using SampleLib.Models;
+            using AliasModel = SampleLib.Models.Item3AliasModel;
+            using static System.Math;
+            global using System.Globalization;
+
+            namespace SampleLib;
+
+            public class Item3SpecialUsingService
+            {
+                public Task<Item3SpecialUsingModel> LoadAsync(AliasModel model)
+                {
+                    _ = Sqrt(model.Count);
+                    return Task.FromResult(new Item3SpecialUsingModel { Count = model.Count });
+                }
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var previewDto = await InterfaceExtractionService.PreviewExtractInterfaceAsync(
+                workspaceId,
+                servicePath,
+                typeName: "Item3SpecialUsingService",
+                interfaceName: "IItem3SpecialUsingService",
+                memberNames: null,
+                replaceUsages: false,
+                CancellationToken.None);
+
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
+
+            var interfaceFilePath = Path.Combine(sampleLibDir, "IItem3SpecialUsingService.cs");
+            var generatedText = await File.ReadAllTextAsync(interfaceFilePath);
+
+            StringAssert.Contains(generatedText, "using System.Threading.Tasks;");
+            StringAssert.Contains(generatedText, "using SampleLib.Models;");
+            StringAssert.Contains(generatedText, "using AliasModel = SampleLib.Models.Item3AliasModel;");
+            StringAssert.Contains(generatedText, "using static System.Math;");
+            StringAssert.Contains(generatedText, "global using System.Globalization;");
+            Assert.IsFalse(
+                generatedText.Contains("using System.Text;", StringComparison.Ordinal),
+                $"Unused plain using should be dropped. Generated:\n{generatedText}");
+
+            var threadingIndex = generatedText.IndexOf("using System.Threading.Tasks;", StringComparison.Ordinal);
+            var modelsIndex = generatedText.IndexOf("using SampleLib.Models;", StringComparison.Ordinal);
+            var aliasIndex = generatedText.IndexOf("using AliasModel = SampleLib.Models.Item3AliasModel;", StringComparison.Ordinal);
+            var staticIndex = generatedText.IndexOf("using static System.Math;", StringComparison.Ordinal);
+            var globalIndex = generatedText.IndexOf("global using System.Globalization;", StringComparison.Ordinal);
+
+            Assert.IsTrue(
+                threadingIndex >= 0
+                && modelsIndex > threadingIndex
+                && aliasIndex > modelsIndex
+                && staticIndex > aliasIndex
+                && globalIndex > staticIndex,
+                $"Expected sorted plain usings followed by special usings in source order. Generated:\n{generatedText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
     public async Task ExtractInterface_Appends_To_Existing_Base_List_Inline_Without_Newline_Continuation()
     {
         // Regression for dr-9-6-emits-continuation-on-a-new-line-instead-of-inli

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -12,24 +12,58 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
     [TestMethod]
     public async Task ExtractType_FromAnimalService_RefusesWhenExternalConsumersExist()
     {
-        // Regression for `dr-9-1-does-not-update-external-consumer-call-sites` (P3): the
-        // SampleSolution AnimalService.CountAnimals is referenced by Program.cs and the
-        // AnimalServiceTests project. Pre-fix, extracting it produced a preview token but
-        // applying it broke the external callers. Post-fix the preview refuses with an
-        // actionable error so the breakage surfaces before any disk mutation.
-        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
-        var wsId = workspace.WorkspaceId;
+        // Regression for `dr-9-1-does-not-update-external-consumer-call-sites` (P3): extracting
+        // a member with references from another source file must refuse the preview before any
+        // disk mutation. Keep the fixture local to this test so it does not drift as the shared
+        // sample solution evolves.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var sourcePath = Path.Combine(sampleLibDir, "ExternalConsumerFixture.cs");
+        var callerPath = Path.Combine(sampleLibDir, "ExternalConsumerCaller.cs");
 
-        var doc = WorkspaceManager.GetCurrentSolution(wsId)
-            .Projects.SelectMany(p => p.Documents)
-            .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+        await File.WriteAllTextAsync(sourcePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExternalConsumerFixture",
+                "{",
+                "    public int Compute(int value) => value * 2;",
+                "}",
+                "",
+            }));
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
-            TypeExtractionService.PreviewExtractTypeAsync(
-                wsId, doc.FilePath!, "AnimalService", ["CountAnimals"], "AnimalCounter", null, CancellationToken.None));
-        StringAssert.Contains(ex.Message, "external consumer");
-        StringAssert.Contains(ex.Message, "Program.cs",
-            "error message must name the affected external file so callers know which code to update");
+        await File.WriteAllTextAsync(callerPath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExternalConsumerCaller",
+                "{",
+                "    public int Use(ExternalConsumerFixture fixture) => fixture.Compute(21);",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, sourcePath, "ExternalConsumerFixture", ["Compute"], "ComputeHelper", null, CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "external consumer");
+            StringAssert.Contains(ex.Message, "ExternalConsumerCaller.cs",
+                "error message must name the affected external file so callers know which code to update");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
     }
 
     [TestMethod]
@@ -181,6 +215,62 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task ExtractType_NewMember_StripsNewModifierFromNewType()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "NewModifierFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class NewModifierBase",
+                "{",
+                "    public int Count => 1;",
+                "}",
+                "",
+                "public class NewModifierFixture : NewModifierBase",
+                "{",
+                "    public new int Count => 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, fixturePath, "NewModifierFixture", ["Count"], "CountHelper", null, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            var newFileDiff = result.Changes.FirstOrDefault(
+                c => c.FilePath.EndsWith("CountHelper.cs", StringComparison.OrdinalIgnoreCase));
+            Assert.IsNotNull(newFileDiff, "preview must emit a change entry for the new extracted type file");
+            var diffText = newFileDiff!.UnifiedDiff;
+
+            var addedLines = diffText
+                .Split('\n')
+                .Where(line => line.StartsWith('\u002B') && !line.StartsWith("\u002B\u002B\u002B"))
+                .ToArray();
+
+            Assert.IsFalse(
+                addedLines.Any(line => System.Text.RegularExpressions.Regex.IsMatch(line, @"\bnew\b")),
+                $"extracted members must not carry 'new' in the new type. Diff:\n{diffText}");
+            Assert.IsTrue(
+                addedLines.Any(line => line.Contains("int Count", StringComparison.Ordinal)),
+                $"property should still be present in the extracted type. Diff:\n{diffText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+        }
+    }
+
+    [TestMethod]
     public async Task ExtractType_PreservesBlankLineBetweenNamespaceAndClass()
     {
         // Regression for `dr-9-5-strips-the-blank-line-between-namespace-and-clas` (P4):
@@ -252,6 +342,21 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
         finally
         {
             WorkspaceManager.Close(wsId);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup.
         }
     }
 }


### PR DESCRIPTION
## Summary
- Split `InterfaceExtractionService.BuildUsingDirectives` and `TypeExtractionService.StripInheritanceOnlyModifiers` into smaller helper flows to reduce cyclomatic complexity while preserving extraction semantics.
- Added targeted regression coverage for semantic using-directive synthesis and extracted-member modifier cleanup.
- This tranche contributes to the residual complexity backlog item; backlog/changelog sync remains orchestrator-owned.

## Closes
- cc-18-to-19-residuals-post-top10-extraction

## Validation
- [x] ./eng/verify-release.ps1 -Configuration Release
- [x] ./eng/verify-ai-docs.ps1