### PR TITLE
docs(update-skill): prefer eng/update-claude-plugin.ps1 for Layer 2

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: update
+description: "Maintainer-local override of the shipped /roslyn-mcp:update skill. Use when: updating Layer 2 (Claude Code plugin cache) from this repo checkout and the user's client does not support /plugin slash-commands. Adds an agent-executable PowerShell fallback that the shipped generic skill cannot mention."
+user-invocable: true
+argument-hint: ""
+---
+
+# Update Roslyn MCP Plugin (maintainer override)
+
+This `.claude/skills/update/` override is auto-discovered **only inside the Roslyn-Backed-MCP repo checkout** and takes precedence over the shipped `skills/update/SKILL.md` when present. It exists because shipped skills are scanned for repo-specific paths (`eng/...`) by `eng/verify-skills-are-generic.ps1` — so the shipped skill has to stay on the `/plugin` slash-command path, but maintainers in-repo have a PowerShell updater that works when the client refuses `/plugin`.
+
+## Workflow (Layer 1 unchanged, Layer 2 replaced)
+
+### Step 1: Check Current Version
+
+Call `server_info`. Report current version, latest NuGet version, `updateAvailable`.
+
+### Step 2: Update Layer 1 — Global Tool
+
+```bash
+dotnet tool update -g Darylmcd.RoslynMcp || dotnet tool install -g Darylmcd.RoslynMcp
+```
+
+In-repo alternatives: `just tool-update` (NuGet.org) or `just tool-install-local` after `just pack`.
+
+### Step 3: Update Layer 2 — Claude Code Plugin
+
+**Preferred (agent-executable, works even when `/plugin` slash-commands are unavailable):**
+
+```bash
+pwsh -NoProfile -File eng/update-claude-plugin.ps1
+```
+
+The script replicates `/plugin marketplace update` + `/plugin install` without going through the client:
+
+- `git pull`s the marketplace clone at `~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/`
+- Re-syncs the plugin cache at `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<new-version>/` from git-tracked files only (710+ files at 1.29.0)
+- Prunes stale `<old-version>/` cache directories
+- Updates `installed_plugins.json` + `known_marketplaces.json` with the new version, commit SHA, and UTC timestamp
+
+Requires the plugin to have been installed through Claude Code at least once (so the marketplace clone exists). Reports resolved version, target cache dir, copied-file count, and pruned stale dirs.
+
+**Fallback (chat-side, if you prefer to go through the client):**
+
+```
+/plugin marketplace update roslyn-mcp-marketplace
+/plugin install roslyn-mcp@roslyn-mcp-marketplace
+```
+
+If the client responds with `/plugin isn't available in this environment`, use the PowerShell path above.
+
+### Step 4: Report
+
+Same as the shipped skill — previous version, new version, layers updated, **reminder to restart Claude Code**.
+
+## Why this override exists
+
+During the v1.29.0 release-cut (PR #377), the Claude Code client refused `/plugin` slash-commands with `/plugin isn't available in this environment`. Layer 1 was updated via `just tool-install-local` but Layer 2 sat at 1.28.1 in the plugin cache. The repo already shipped `eng/update-claude-plugin.ps1` (a maintainer-only script, agent-executable, idempotent) that does exactly what the two slash-commands do — it just wasn't the documented primary path because the shipped skill isn't allowed to reference repo-specific `eng/` paths under `verify-skills-are-generic.ps1`. This override closes that gap for anyone running `/roslyn-mcp:update` from inside the Roslyn-Backed-MCP repo.

--- a/changelog.d/update-skill-layer2-script.md
+++ b/changelog.d/update-skill-layer2-script.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** `/roslyn-mcp:update` skill gains a repo-local maintainer override at `.claude/skills/update/SKILL.md` that leads Layer 2 with the agent-executable `pwsh eng/update-claude-plugin.ps1` updater and keeps `/plugin marketplace update` + `/plugin install` as a fallback. Surfaced during the v1.29.0 release-cut (PR #377) where the Claude Code client responded with `/plugin isn't available in this environment`, leaving Layer 1 updated but Layer 2 stuck at 1.28.1 in the plugin cache — the bundled PowerShell script already replicated the slash-command flow (pull marketplace clone, re-sync cache from git-tracked files, prune stale versions, update `installed_plugins.json` + `known_marketplaces.json`), but the shipped skill couldn't reference repo-specific `eng/` paths under `verify-skills-are-generic.ps1`. The shipped generic skill keeps its `/plugin`-only guidance plus a pointer to the `.claude/skills/` override for maintainers in-repo.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -57,7 +57,7 @@ Tell the user to run these two commands in the Claude Code chat input (they are 
 /plugin install roslyn-mcp@roslyn-mcp-marketplace
 ```
 
-**Note:** If the user's Claude Code client does not support `/plugin` slash commands (i.e., they get a normal chat response instead of the client executing the command), tell them to update via their client's plugin/marketplace UI, or to uninstall and reinstall the plugin from the marketplace.
+**Note:** If the user's Claude Code client does not support `/plugin` slash commands (i.e., they get `/plugin isn't available in this environment`), tell them to update via their client's plugin/marketplace UI, or to uninstall and reinstall the plugin from the marketplace. Maintainers with the Roslyn-Backed-MCP source tree checked out have an agent-executable PowerShell fallback — see the repo-local override in `.claude/skills/update/` if present.
 
 ### Step 4: Report
 


### PR DESCRIPTION
## Summary

- Rewrites the `/roslyn-mcp:update` skill Step 3 to lead with the agent-executable `pwsh eng/update-claude-plugin.ps1` and treat `/plugin marketplace update` + `/plugin install` as a chat-side fallback.
- Surfaced during the v1.29.0 release-cut (#377) where the Claude Code client responded with `/plugin isn't available in this environment` — the PowerShell updater already replicated the slash-command flow, it just wasn't documented as the primary path.

## Test plan

- [x] `changelog.d/update-skill-layer2-script.md` fragment added (category: Changed)
- [ ] Next release-cut consumes the fragment into `## [X.Y.Z]` Changed section

🤖 Generated with [Claude Code](https://claude.com/claude-code)