### PR TITLE
fix(scaffold-test-preview): strip dotted FQN before emitting class identifier

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -179,20 +179,24 @@ public sealed class ScaffoldingService : IScaffoldingService
             return;
         }
 
-        var testFilePath = Path.Combine(context.ProjectDirectory, $"{target.TargetTypeName}GeneratedTests.cs");
-        if (SymbolResolver.FindDocument(state.Accumulator, testFilePath) is not null || File.Exists(testFilePath))
-        {
-            state.Warnings.Add($"Skipped '{target.TargetTypeName}': target file already exists at '{testFilePath}'.");
-            return;
-        }
-
+        // See PreviewScaffoldTestAsync — accept dotted FQN input, resolve via simple name,
+        // and let the matched symbol supply the authoritative class identifier.
+        var lookupName = StripToSimpleTypeName(target.TargetTypeName);
         var typeInfo = ResolveTargetTypeAndMethodFromCache(
             cachedCompilations,
-            target.TargetTypeName,
+            lookupName,
             target.TargetMethodName);
         if (typeInfo.MatchedType is null)
         {
             state.Warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
+            return;
+        }
+
+        var simpleTypeName = typeInfo.MatchedType.Name;
+        var testFilePath = Path.Combine(context.ProjectDirectory, $"{simpleTypeName}GeneratedTests.cs");
+        if (SymbolResolver.FindDocument(state.Accumulator, testFilePath) is not null || File.Exists(testFilePath))
+        {
+            state.Warnings.Add($"Skipped '{target.TargetTypeName}': target file already exists at '{testFilePath}'.");
             return;
         }
 
@@ -213,6 +217,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var content = BuildTestContent(
             context.TestNamespace,
             dto,
+            simpleTypeName,
             typeInfo.TargetNamespace,
             typeInfo.ConstructorArgs,
             context.Framework,
@@ -321,13 +326,21 @@ public sealed class ScaffoldingService : IScaffoldingService
         ValidateIsTestProject(project);
         var projectDirectory = Path.GetDirectoryName(project.FilePath)
             ?? throw new InvalidOperationException($"Project directory could not be resolved for '{project.FilePath}'.");
-        var testFilePath = Path.Combine(projectDirectory, $"{request.TargetTypeName}GeneratedTests.cs");
         var testNamespace = project.Name;
 
         var framework = ResolveTestFramework(request.TestFramework, project.FilePath);
 
+        // Accept a dotted FQN as input (callers who hit the ambiguity error get pointed at
+        // "the fully qualified type name", then re-invoke with `Namespace.Type`). The resolver
+        // only ever looks up the simple name, so strip to that for lookup — and treat the
+        // matched symbol's Name as authoritative once we have it, so the downstream class
+        // identifier is always a single identifier (dotted identifiers are a CS syntax error).
+        var lookupName = StripToSimpleTypeName(request.TargetTypeName);
         var typeInfo = await ResolveTargetTypeAndMethodAsync(
-            workspaceId, request.TestProjectName, request.TargetTypeName, request.TargetMethodName, ct).ConfigureAwait(false);
+            workspaceId, request.TestProjectName, lookupName, request.TargetMethodName, ct).ConfigureAwait(false);
+
+        var simpleTypeName = typeInfo.MatchedType?.Name ?? lookupName;
+        var testFilePath = Path.Combine(projectDirectory, $"{simpleTypeName}GeneratedTests.cs");
 
         // Sibling-pattern inference (scaffold-test-sibling-pattern-inference). When an explicit
         // referenceTestFile is supplied we use that as the pattern source; otherwise we
@@ -337,7 +350,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var siblingWarnings = siblingInference.Warnings;
 
         var content = BuildTestContent(
-            testNamespace, request, typeInfo.TargetNamespace, typeInfo.ConstructorArgs, framework,
+            testNamespace, request, simpleTypeName, typeInfo.TargetNamespace, typeInfo.ConstructorArgs, framework,
             typeInfo.TargetMethod, typeInfo.MatchedType, siblingInference.Pattern);
         var preview = await _fileOperationService.PreviewCreateFileAsync(workspaceId, new CreateFileDto(project.Name, testFilePath, content), ct).ConfigureAwait(false);
 
@@ -1634,6 +1647,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildTestContent(
         string testNamespace,
         ScaffoldTestDto request,
+        string simpleTypeName,
         string targetNamespace,
         string constructorArgs,
         string framework,
@@ -1653,18 +1667,34 @@ public sealed class ScaffoldingService : IScaffoldingService
         var ctorCall = useStaticScaffold
             ? string.Empty
             : string.IsNullOrWhiteSpace(constructorArgs)
-                ? $"new {request.TargetTypeName}()"
-                : $"new {request.TargetTypeName}({constructorArgs})";
+                ? $"new {simpleTypeName}()"
+                : $"new {simpleTypeName}({constructorArgs})";
 
         var methodTargetBlock = BuildMethodTargetInvocationBlock(
-            framework, request.TargetTypeName, request.TargetMethodName, targetMethod, useStaticScaffold);
+            framework, simpleTypeName, request.TargetMethodName, targetMethod, useStaticScaffold);
 
         return framework switch
         {
-            "xunit" => BuildXUnitTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
-            "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
-            _ => BuildMSTestTestContent(testNamespace, usingDirective, request.TargetTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
+            "xunit" => BuildXUnitTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
+            "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
+            _ => BuildMSTestTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
         };
+    }
+
+    /// <summary>
+    /// Strip a dotted input (e.g. <c>"SampleLib.Hierarchy.Circle"</c>) to its last identifier
+    /// segment so it can be used both as a lookup key against <see cref="Compilation.GetSymbolsWithName"/>
+    /// (which indexes on the simple name) and as a C# identifier in scaffolded output. Callers
+    /// sometimes arrive here with a fully-qualified name because the ambiguity-resolution
+    /// error message suggests "use the fully qualified type name" — without this strip, the
+    /// dotted input would flow into the class-name template and produce a CS syntax error.
+    /// </summary>
+    private static string StripToSimpleTypeName(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return input;
+        var lastDot = input.LastIndexOf('.');
+        return lastDot < 0 ? input : input[(lastDot + 1)..];
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -329,4 +329,92 @@ public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
         StringAssert.Contains(dogContents, "Speak_Needs_Test");
         StringAssert.Contains(animalServiceContents, "GetAllAnimals_Needs_Test");
     }
+
+    [TestMethod]
+    public async Task Scaffold_Test_DottedTargetTypeName_TopLevel_Yields_SingleIdentifier_ClassName()
+    {
+        // Regression for scaffold-test-preview-dotted-identifier: callers who hit the
+        // ambiguity-resolution error are told to "use the fully qualified type name" and
+        // then re-invoke with `Namespace.Type`. Previously that dotted input was stamped
+        // verbatim into the class-name template, emitting
+        // `public class SampleLib.Hierarchy.CircleGeneratedTests` — a CS syntax error. The
+        // fix uses `TypeSymbol.Name` (unqualified) so only the simple identifier lands in
+        // the class and file names, while the `using SampleLib.Hierarchy;` brings the type
+        // into scope for the constructor call.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var expectedFilePath = workspace.GetPath("SampleLib.Tests", "CircleGeneratedTests.cs");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "SampleLib.Hierarchy.Circle",
+                ReferenceTestFile: string.Empty),
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.IsTrue(File.Exists(expectedFilePath),
+            $"Expected scaffolded file at '{expectedFilePath}' — dotted FQN input must be stripped to the simple name for the filename.");
+
+        var contents = await File.ReadAllTextAsync(expectedFilePath, CancellationToken.None);
+
+        // Class identifier must be a single identifier — a dotted identifier is a CS syntax error.
+        StringAssert.Contains(contents, "public class CircleGeneratedTests");
+        Assert.IsFalse(contents.Contains("SampleLib.Hierarchy.CircleGeneratedTests"),
+            "Scaffold must NOT emit a dotted class identifier — this is a CS syntax error.");
+
+        // The `using` for the target namespace brings Circle into scope for `new Circle(...)`.
+        StringAssert.Contains(contents, "using SampleLib.Hierarchy;");
+        StringAssert.Contains(contents, "new Circle(");
+    }
+
+    [TestMethod]
+    public async Task Scaffold_Test_DottedTargetTypeName_NestedType_Yields_SingleIdentifier_ClassName()
+    {
+        // Companion to the top-level regression above: a nested type's "FQN" looks like
+        // `Namespace.Outer.Inner`, and the scaffold must still emit a single-identifier
+        // class name. We inject a fixture with a nested type so the test is self-contained
+        // and does not depend on sample-solution evolution.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var fixturePath = workspace.GetPath("SampleLib", "NestedFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, """
+namespace SampleLib;
+
+public class NestedHost
+{
+    public class NestedInner
+    {
+        public string Speak() => "inner";
+    }
+}
+""", CancellationToken.None);
+
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var expectedFilePath = workspace.GetPath("SampleLib.Tests", "NestedInnerGeneratedTests.cs");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "SampleLib.NestedHost.NestedInner",
+                "Speak",
+                ReferenceTestFile: string.Empty),
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.IsTrue(File.Exists(expectedFilePath),
+            $"Expected scaffolded file at '{expectedFilePath}' — nested-type FQN must be stripped to the simple name.");
+
+        var contents = await File.ReadAllTextAsync(expectedFilePath, CancellationToken.None);
+
+        StringAssert.Contains(contents, "public class NestedInnerGeneratedTests");
+        Assert.IsFalse(contents.Contains("NestedHost.NestedInnerGeneratedTests"),
+            "Scaffold must NOT emit a dotted class identifier for nested types either.");
+        StringAssert.Contains(contents, "Speak_Needs_Test");
+    }
 }


### PR DESCRIPTION
## Summary

- `ScaffoldingService.PreviewScaffoldTestAsync` and `ProcessBatchScaffoldTarget` now strip the caller-supplied `TargetTypeName` to its last identifier segment for resolver lookup, then use the matched `INamedTypeSymbol.Name` as the authoritative class identifier threaded through `BuildTestContent`.
- Previously, callers who re-invoked with a fully-qualified name (because the ambiguity-resolution error suggests "use the fully qualified type name") got `public class Ns.Type.FooGeneratedTests` — a CS syntax error.
- Two regression tests cover top-level (`SampleLib.Hierarchy.Circle`) and nested-type (`SampleLib.NestedHost.NestedInner`) inputs, asserting single-identifier class names and correct filenames.

## Test plan

- [x] `dotnet build src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj` — 0 warnings, 0 errors
- [x] `dotnet test --filter FullyQualifiedName~Scaffolding` (Debug): 11/11 passed
- [x] `dotnet test --filter FullyQualifiedName~Scaffolding` (Release): 15/15 passed (includes neighboring scaffolding suites)
- [x] `./eng/verify-ai-docs.ps1` — passed
- [x] `./eng/verify-release.ps1 -Configuration Release` — 4 unrelated flakes (coupling-metrics, record-field-addition-impact, validation integration, workspace-load-restore-race) pass when re-run in isolation and are unrelated to the changed files
- [x] `shims-added: 0` — no backwards-compat constructors, overloads, or null-gated degraded paths

Closes: `scaffold-test-preview-dotted-identifier`