### PR TITLE
release: v1.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.29.1] - 2026-04-24
+
+### Fixed
+
+- **Fixed:** `find_dead_fields(usageKind=never-read)` no longer flags DI-captured fields (e.g. `_options`, `_factory`) as removable when a chained `remove_dead_code_preview` will refuse with `"still has references"`. Every `DeadFieldDto` hit gains `removalBlockedBy` (nullable list of `Kind@Path:Line:Col` markers — ctor-enclosed writes tagged `ConstructorWrite@...`) and `safelyRemovable` (`false` when any source reference survives). Prefers metadata-surface over cascading remove, keeping `UnusedCodeAnalyzer` focused on classification (`find-dead-fields-remove-dead-code-contract-break`).
+- **Fixed:** `fix_all_preview` now returns a structured `FixAllProviderCrash` envelope instead of surfacing a raw `InvalidOperationException` (notably the IDE0300 `"Sequence contains no elements"` crash) or an indistinguishable empty `FixAllPreviewDto`. `FixAllService.PreviewFixAllAsync` narrows the two provider call-site catches (`GetFixAsync` + `GetOperationsAsync`) from broad `Exception` to `InvalidOperationException` only; `FixAllPreviewDto` gains optional `Error` / `Category` / `PerOccurrenceFallbackAvailable` fields; tool description documents the envelope (`fix-all-preview-sequence-contains-no-elements`).
+- **Fixed:** `organize_usings_preview` returning `"Invalid operation: Document not found"` after an auto-reload cascade (e.g. `remove_dead_code_apply` earlier in the turn) while `format_document_preview` succeeded on the same file. Extracts `RoslynMcp.Roslyn.Helpers.DocumentResolution` — `GetDocumentFromFreshSolutionOrThrow` re-acquires the current `Solution` from `IWorkspaceManager` at call time so the post-auto-reload snapshot is honored, and `GetDocumentInSolutionOrThrow` handles accumulator paths. `RefactoringService` (organize-usings / format-document / format-range / code-fix previews) and `EditService.ResolveDocumentAndTextAsync` route through the shared helper with a unified `InvalidOperationException("Document not found: ...")` (`organize-usings-preview-document-not-found-after-apply`).
+- **Fixed:** `scaffold_test_preview` no longer emits a dotted class identifier when callers pass a fully-qualified type name after an ambiguity-resolution hint. `ScaffoldingService.PreviewScaffoldTestAsync` + `ProcessBatchScaffoldTarget` now strip input to the last identifier segment for resolver lookup, then thread the matched `INamedTypeSymbol.Name` through `BuildTestContent` to every downstream template site (filename, class-name, ctor call, static invocation, `typeof(T)`) so dotted input produces compiling single-identifier output (`scaffold-test-preview-dotted-identifier`).
+
+### Changed
+
+- **Changed:** `/roslyn-mcp:update` skill gains a repo-local maintainer override at `.claude/skills/update/SKILL.md` that leads Layer 2 with the agent-executable `pwsh eng/update-claude-plugin.ps1` updater and keeps `/plugin marketplace update` + `/plugin install` as a fallback. Surfaced during the v1.29.0 release-cut (PR #377) where the Claude Code client responded with `/plugin isn't available in this environment`, leaving Layer 1 updated but Layer 2 stuck at 1.28.1 in the plugin cache — the bundled PowerShell script already replicated the slash-command flow (pull marketplace clone, re-sync cache from git-tracked files, prune stale versions, update `installed_plugins.json` + `known_marketplaces.json`), but the shipped skill couldn't reference repo-specific `eng/` paths under `verify-skills-are-generic.ps1`. The shipped generic skill keeps its `/plugin`-only guidance plus a pointer to the `.claude/skills/` override for maintainers in-repo.
+
 ## [1.29.0] - 2026-04-23
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.29.0</Version>
+    <Version>1.29.1</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/find-dead-fields-remove-dead-code-contract-break.md
+++ b/changelog.d/find-dead-fields-remove-dead-code-contract-break.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_dead_fields(usageKind=never-read)` no longer flags DI-captured fields (e.g. `_options`, `_factory`) as removable when a chained `remove_dead_code_preview` will refuse with `"still has references"`. Every `DeadFieldDto` hit gains `removalBlockedBy` (nullable list of `Kind@Path:Line:Col` markers — ctor-enclosed writes tagged `ConstructorWrite@...`) and `safelyRemovable` (`false` when any source reference survives). Prefers metadata-surface over cascading remove, keeping `UnusedCodeAnalyzer` focused on classification (`find-dead-fields-remove-dead-code-contract-break`).

--- a/changelog.d/fix-all-preview-sequence-contains-no-elements.md
+++ b/changelog.d/fix-all-preview-sequence-contains-no-elements.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `fix_all_preview` now returns a structured `FixAllProviderCrash` envelope instead of surfacing a raw `InvalidOperationException` (notably the IDE0300 `"Sequence contains no elements"` crash) or an indistinguishable empty `FixAllPreviewDto`. `FixAllService.PreviewFixAllAsync` narrows the two provider call-site catches (`GetFixAsync` + `GetOperationsAsync`) from broad `Exception` to `InvalidOperationException` only; `FixAllPreviewDto` gains optional `Error` / `Category` / `PerOccurrenceFallbackAvailable` fields; tool description documents the envelope (`fix-all-preview-sequence-contains-no-elements`).

--- a/changelog.d/organize-usings-preview-document-not-found-after-apply.md
+++ b/changelog.d/organize-usings-preview-document-not-found-after-apply.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `organize_usings_preview` returning `"Invalid operation: Document not found"` after an auto-reload cascade (e.g. `remove_dead_code_apply` earlier in the turn) while `format_document_preview` succeeded on the same file. Extracts `RoslynMcp.Roslyn.Helpers.DocumentResolution` — `GetDocumentFromFreshSolutionOrThrow` re-acquires the current `Solution` from `IWorkspaceManager` at call time so the post-auto-reload snapshot is honored, and `GetDocumentInSolutionOrThrow` handles accumulator paths. `RefactoringService` (organize-usings / format-document / format-range / code-fix previews) and `EditService.ResolveDocumentAndTextAsync` route through the shared helper with a unified `InvalidOperationException("Document not found: ...")` (`organize-usings-preview-document-not-found-after-apply`).

--- a/changelog.d/scaffold-test-preview-dotted-identifier.md
+++ b/changelog.d/scaffold-test-preview-dotted-identifier.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `scaffold_test_preview` no longer emits a dotted class identifier when callers pass a fully-qualified type name after an ambiguity-resolution hint. `ScaffoldingService.PreviewScaffoldTestAsync` + `ProcessBatchScaffoldTarget` now strip input to the last identifier segment for resolver lookup, then thread the matched `INamedTypeSymbol.Name` through `BuildTestContent` to every downstream template site (filename, class-name, ctor call, static invocation, `typeof(T)`) so dotted input produces compiling single-identifier output (`scaffold-test-preview-dotted-identifier`).

--- a/changelog.d/update-skill-layer2-script.md
+++ b/changelog.d/update-skill-layer2-script.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** `/roslyn-mcp:update` skill gains a repo-local maintainer override at `.claude/skills/update/SKILL.md` that leads Layer 2 with the agent-executable `pwsh eng/update-claude-plugin.ps1` updater and keeps `/plugin marketplace update` + `/plugin install` as a fallback. Surfaced during the v1.29.0 release-cut (PR #377) where the Claude Code client responded with `/plugin isn't available in this environment`, leaving Layer 1 updated but Layer 2 stuck at 1.28.1 in the plugin cache — the bundled PowerShell script already replicated the slash-command flow (pull marketplace clone, re-sync cache from git-tracked files, prune stale versions, update `installed_plugins.json` + `known_marketplaces.json`), but the shipped skill couldn't reference repo-specific `eng/` paths under `verify-skills-are-generic.ps1`. The shipped generic skill keeps its `/plugin`-only guidance plus a pointer to the `.claude/skills/` override for maintainers in-repo.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary
- Version bump to v1.29.1 (patch) — 4 Fixed + 1 Changed entries consumed from `changelog.d/`.
- Ships four P2 bug fixes merged in batch-1 of `ai_docs/plans/20260424T041204Z_backlog-sweep/`: scaffold-test dotted-identifier, fix-all-preview crash envelope, organize-usings post-reload resolver, find-dead-fields removalBlockedBy metadata.
- Plus the v1.29.0 post-release learning: `/roslyn-mcp:update` skill gains a repo-local maintainer override that leads Layer 2 with `pwsh eng/update-claude-plugin.ps1`.

## Test plan
- [x] `eng/verify-version-drift.ps1`: all 5 files agree on 1.29.1
- [x] `eng/verify-release.ps1 -Configuration Release`: 831/831 tests pass
- [x] `eng/verify-ai-docs.ps1`: shipped skills generic (31 SKILL.md checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)