### PR TITLE
fix(replace-string-literals-preview): empty preview on zero matches

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/StringLiteralReplaceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/StringLiteralReplaceService.cs
@@ -93,8 +93,17 @@ public sealed class StringLiteralReplaceService : IStringLiteralReplaceService
 
         if (changes.Count == 0)
         {
-            throw new InvalidOperationException(
-                "replace_string_literals_preview: no matching literals found in scope.");
+            // Structured empty-preview response rather than an exception. Zero matches is a
+            // valid outcome for a find-style preview (e.g. the caller is probing whether a
+            // literal exists in scope); throwing forced callers to `try/catch` on a
+            // semantically benign case. Mirrors the `FixAllService` empty-preview shape —
+            // empty token + empty changes + descriptive `Description`.
+            var emptyDescription = "No matching string literals found in scope.";
+            return new RefactoringPreviewDto(
+                PreviewToken: string.Empty,
+                Description: emptyDescription,
+                Changes: Array.Empty<FileChangeDto>(),
+                Warnings: null);
         }
 
         var description = $"Replace {totalHits} string literal(s) across {changes.Count} file(s)";

--- a/tests/RoslynMcp.Tests/StringLiteralReplaceServiceTests.cs
+++ b/tests/RoslynMcp.Tests/StringLiteralReplaceServiceTests.cs
@@ -1,0 +1,71 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <see cref="StringLiteralReplaceService.PreviewReplaceAsync"/>.
+/// Backlog row replace-string-literals-preview-throws-on-zero-match: the zero-match path
+/// previously threw <see cref="InvalidOperationException"/>; now it must return a
+/// structured empty preview (empty token, empty changes list, descriptive Description)
+/// matching the shape used by FixAllService.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class StringLiteralReplaceServiceTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+    private static StringLiteralReplaceService Service { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
+        Service = new StringLiteralReplaceService(WorkspaceManager, PreviewStore);
+    }
+
+    [TestMethod]
+    public async Task PreviewReplace_ZeroMatches_ReturnsEmptyPreviewInsteadOfThrowing()
+    {
+        // A literal that cannot appear anywhere in the sample workspace. Pre-fix this threw
+        // `InvalidOperationException("... no matching literals found in scope.")`; now the
+        // service must return a structured empty response so callers can treat "no matches"
+        // as a benign outcome rather than an error.
+        var replacements = new[]
+        {
+            new StringLiteralReplacementDto(
+                LiteralValue: "UNLIKELY_LITERAL_THAT_DOES_NOT_EXIST_XYZ_8f2a1c",
+                ReplacementExpression: "Constants.Unused",
+                UsingNamespace: null),
+        };
+
+        var preview = await Service.PreviewReplaceAsync(
+            WorkspaceId,
+            replacements,
+            new RestructureScope(FilePath: null, ProjectName: null),
+            CancellationToken.None);
+
+        Assert.AreEqual(0, preview.Changes.Count, "Empty preview must report zero changes.");
+        Assert.AreEqual(string.Empty, preview.PreviewToken,
+            "Empty preview must use an empty token — there is nothing to redeem.");
+        StringAssert.Contains(preview.Description, "No matching string literals",
+            "Description must explain why the preview is empty.");
+        Assert.IsNull(preview.Warnings);
+    }
+
+    [TestMethod]
+    public async Task PreviewReplace_EmptyReplacementList_StillThrowsArgumentException()
+    {
+        // Guard that the zero-match relaxation didn't weaken input validation. A caller
+        // passing an empty replacements array is a programming error, distinct from a
+        // well-formed replacement that simply doesn't match anything in scope.
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            Service.PreviewReplaceAsync(
+                WorkspaceId,
+                replacements: Array.Empty<StringLiteralReplacementDto>(),
+                new RestructureScope(FilePath: null, ProjectName: null),
+                CancellationToken.None));
+    }
+}


### PR DESCRIPTION
## Summary

- `StringLiteralReplaceService.PreviewReplaceAsync` now returns a structured empty `RefactoringPreviewDto` (empty `PreviewToken`, empty `Changes`, descriptive `Description`) when no literals match in scope — previously it threw `InvalidOperationException`.
- Zero matches on a find-style preview is a benign outcome; callers can probe for literal presence without wrapping in `try/catch`. Shape matches `FixAllService`'s empty-preview convention.
- Input-validation errors (empty replacements array, empty `LiteralValue`, empty `ReplacementExpression`) still throw `ArgumentException`. Only the zero-match outcome path was softened.

## Test plan

- [x] New `StringLiteralReplaceServiceTests.PreviewReplace_ZeroMatches_ReturnsEmptyPreviewInsteadOfThrowing` asserts empty-token + empty-changes + descriptive `Description`.
- [x] New `StringLiteralReplaceServiceTests.PreviewReplace_EmptyReplacementList_StillThrowsArgumentException` guards that input-validation was not weakened.
- [x] `dotnet test --filter "FullyQualifiedName~StringLiteral|FullyQualifiedName~Restructure"` in Release — 7/7 passed.
- [x] `eng/verify-ai-docs.ps1` passed.
- [x] Full `eng/verify-release.ps1` shows only two pre-existing failures unrelated to this change: `NuGetVulnerabilityScanIntegrationTests` (dotnet list timeout, environmental) and `RecordFieldAdditionImpactTests.PreviewAddition_ForNonPositionalRecord_ReportsOnlyWithExpressionSites` (missing `SampleLib/Records/NonPositionalRecord` sample — directory does not exist on main).

Closes: `replace-string-literals-preview-throws-on-zero-match`

Initiative 7 of `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md`.