### PR TITLE
fix(validation-bundle): structured error envelope on validate_recent_git_changes

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -38,16 +38,42 @@ public static class ValidationBundleTools
      McpToolMetadata("validation", "experimental", true, false,
         "post-edit-validate-workspace-scoped-to-touched-files: auto-scoped validation companion that derives changedFilePaths from git status --porcelain, falls back to full-workspace scope with a warning when git is unavailable or the solution is outside a git repo."),
      Description("Post-edit validation bundle that auto-derives the changed-file set from `git status --porcelain` in the solution directory, eliminating the manual path-enumeration step. Internally forwards to validate_workspace with the derived list. Falls back to full-workspace scope and surfaces the fallback via the Warnings field when git is unavailable (not on PATH, solution outside a git repo, git exited non-zero). Prefer this over validate_workspace when you have uncommitted edits and want the bundle scoped to the touched-file set.")]
-    public static Task<string> ValidateRecentGitChanges(
+    public static async Task<string> ValidateRecentGitChanges(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("When true, runs the discovered related tests via dotnet test --filter. Default: false (discovery only).")] bool runTests = false,
         [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default false preserves the full response shape.")] bool summary = false,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
-            gate,
-            workspaceId,
-            c => validationService.ValidateRecentGitChangesAsync(workspaceId, runTests, c, summary),
-            ct);
+    {
+        // validate-recent-git-changes-bare-error-envelope: belt-and-suspenders structured-envelope
+        // wrap. The StructuredCallToolFilter already catches handler exceptions and formats them
+        // via ToolErrorHandler.ClassifyAndFormat + InjectMetaIfPossible, but field reports across
+        // 4 audits (self, TradeWise, NetworkDoc, FirewallAnalyzer) observed the bare SDK
+        // "An error occurred invoking 'validate_recent_git_changes'." string instead of the
+        // structured envelope. To guarantee the envelope regardless of filter wiring or SDK
+        // transport quirks, we wrap the dispatch in an in-handler try/catch that classifies the
+        // exception locally and returns the JSON envelope directly from the tool body. When the
+        // filter IS active, this is a no-op pass-through on the success path; on the failure
+        // path, the filter sees a well-formed JSON string (not an exception) and just injects
+        // _meta. OperationCanceledException still propagates (cooperative cancellation is a
+        // protocol signal, not a tool error) — matching the filter's own contract.
+        try
+        {
+            return await ToolDispatch.ReadByWorkspaceIdAsync(
+                gate,
+                workspaceId,
+                c => validationService.ValidateRecentGitChangesAsync(workspaceId, runTests, c, summary),
+                ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var envelope = ToolErrorHandler.ClassifyAndFormat(ex, "validate_recent_git_changes");
+            return ToolErrorHandler.InjectMetaIfPossible(envelope, "validate_recent_git_changes");
+        }
+    }
 }

--- a/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for <c>validate-recent-git-changes-bare-error-envelope</c> (P3-UX): external
+/// audits (self, TradeWise, NetworkDoc, FirewallAnalyzer) observed
+/// <c>validate_recent_git_changes</c> returning the bare SDK string
+/// <c>"An error occurred invoking 'validate_recent_git_changes'."</c> instead of the
+/// <c>{category, tool, message, exceptionType, _meta}</c> structured envelope that
+/// <c>validate_workspace</c> produces. The handler is now wrapped in an in-body
+/// try/catch that routes failures through <see cref="ToolErrorHandler.ClassifyAndFormat"/> +
+/// <see cref="ToolErrorHandler.InjectMetaIfPossible"/>, guaranteeing the structured
+/// envelope regardless of whether the <c>StructuredCallToolFilter</c> catch path fires.
+/// </summary>
+[TestClass]
+public sealed class ValidationBundleToolsTests
+{
+    [TestMethod]
+    public async Task ValidateRecentGitChanges_ServiceThrowsFileNotFound_ReturnsStructuredEnvelope()
+    {
+        // Simulates the "git not on PATH" class of failure: the subprocess launch is expected
+        // to be caught inside the service and surfaced as a Warnings entry — but if for any
+        // reason the exception escapes (e.g. a downstream Path.GetFullPath throw on malformed
+        // output), the handler must still produce the structured envelope.
+        var gate = new PassThroughGate();
+        var service = new ThrowingValidationService(new FileNotFoundException("git: No such file or directory"));
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var result = await ValidationBundleTools.ValidateRecentGitChanges(
+            gate, service, workspaceId: "ws-1", runTests: false, summary: false, ct: default);
+
+        AssertStructuredEnvelope(result, expectedTool: "validate_recent_git_changes");
+        var doc = JsonDocument.Parse(result);
+        Assert.AreEqual("FileNotFound", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("FileNotFoundException", doc.RootElement.GetProperty("exceptionType").GetString());
+        StringAssert.Contains(doc.RootElement.GetProperty("message").GetString(), "git",
+            "Envelope message should carry the inner-exception detail so the caller can correct the problem.");
+    }
+
+    [TestMethod]
+    public async Task ValidateRecentGitChanges_ServiceThrowsInvalidOperation_ReturnsStructuredEnvelope()
+    {
+        // Simulates the "solution outside a git repo" failure mode where the workspace
+        // status has no LoadedPath and ResolveSolutionDirectory throws InvalidOperationException.
+        var gate = new PassThroughGate();
+        var service = new ThrowingValidationService(
+            new InvalidOperationException("Workspace 'ws-1' is not loaded."));
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var result = await ValidationBundleTools.ValidateRecentGitChanges(
+            gate, service, workspaceId: "ws-1", runTests: false, summary: false, ct: default);
+
+        AssertStructuredEnvelope(result, expectedTool: "validate_recent_git_changes");
+        var doc = JsonDocument.Parse(result);
+        Assert.AreEqual("InvalidOperation", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("InvalidOperationException", doc.RootElement.GetProperty("exceptionType").GetString());
+    }
+
+    [TestMethod]
+    public async Task ValidateRecentGitChanges_SuccessPath_ReturnsDtoJson_NotErrorEnvelope()
+    {
+        // The envelope-wrapper must pass through success results byte-for-byte (modulo _meta
+        // injection). This test pins the contract that we didn't accidentally wrap every
+        // response as an error envelope.
+        var gate = new PassThroughGate();
+        var dto = new WorkspaceValidationDto(
+            OverallStatus: "clean",
+            ChangedFilePaths: Array.Empty<string>(),
+            UnknownFilePaths: Array.Empty<string>(),
+            CompileResult: new CompileCheckDto(
+                Success: true,
+                ErrorCount: 0,
+                WarningCount: 0,
+                TotalDiagnostics: 0,
+                ReturnedDiagnostics: 0,
+                Offset: 0,
+                Limit: 200,
+                HasMore: false,
+                Diagnostics: Array.Empty<DiagnosticDto>(),
+                ElapsedMs: 0),
+            ErrorDiagnostics: Array.Empty<DiagnosticDto>(),
+            WarningCount: 0,
+            DiscoveredTests: Array.Empty<RelatedTestCaseDto>(),
+            DotnetTestFilter: null,
+            TestRunResult: null,
+            Warnings: Array.Empty<string>());
+        var service = new SuccessfulValidationService(dto);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var result = await ValidationBundleTools.ValidateRecentGitChanges(
+            gate, service, workspaceId: "ws-1", runTests: false, summary: false, ct: default);
+
+        var doc = JsonDocument.Parse(result);
+        Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+            "Success path must not emit the {error:true,...} envelope.");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("overallStatus", out var status),
+            "Success response should carry the DTO's overallStatus field.");
+        Assert.AreEqual("clean", status.GetString());
+    }
+
+    [TestMethod]
+    public async Task ValidateRecentGitChanges_OperationCanceled_PropagatesWithoutWrapping()
+    {
+        // Cooperative cancellation is a protocol-level signal — it must propagate out of the
+        // tool body unwrapped so the SDK can emit the JSON-RPC cancellation envelope. Wrapping
+        // it into an error envelope would lose that contract and make the client think the
+        // tool itself failed.
+        var gate = new PassThroughGate();
+        var service = new ThrowingValidationService(new OperationCanceledException("caller cancelled"));
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            ValidationBundleTools.ValidateRecentGitChanges(
+                gate, service, workspaceId: "ws-1", runTests: false, summary: false, ct: default));
+    }
+
+    private static void AssertStructuredEnvelope(string result, string expectedTool)
+    {
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result), "Handler must always return a non-empty JSON string.");
+        var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("error", out var errorFlag) && errorFlag.GetBoolean(),
+            "Structured error envelope must carry error:true.");
+        Assert.IsTrue(root.TryGetProperty("category", out _),
+            "Structured error envelope must carry a 'category' field.");
+        Assert.IsTrue(root.TryGetProperty("tool", out var tool),
+            "Structured error envelope must carry a 'tool' field.");
+        Assert.AreEqual(expectedTool, tool.GetString());
+        Assert.IsTrue(root.TryGetProperty("message", out _),
+            "Structured error envelope must carry a 'message' field.");
+        Assert.IsTrue(root.TryGetProperty("exceptionType", out _),
+            "Structured error envelope must carry an 'exceptionType' field.");
+        Assert.IsTrue(root.TryGetProperty("_meta", out _),
+            "Structured error envelope must carry a '_meta' block (gate metrics injected by ToolErrorHandler.InjectMetaIfPossible).");
+    }
+
+    /// <summary>
+    /// Trivial gate stub that runs the action synchronously without contention. Keeps the
+    /// tests focused on the tool-level envelope-wrapping contract, not the gate's own
+    /// serialization behavior (that's covered by <see cref="ToolDispatchTests"/>).
+    /// </summary>
+    private sealed class PassThroughGate : IWorkspaceExecutionGate
+    {
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => action(ct);
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true)
+            => action(ct);
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public void RemoveGate(string workspaceId)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Stand-in for <see cref="IWorkspaceValidationService"/> that throws the supplied
+    /// exception on the <c>ValidateRecentGitChangesAsync</c> entry point. Used to exercise
+    /// the tool's envelope-wrapping path without wiring a real Roslyn workspace / git subprocess.
+    /// </summary>
+    private sealed class ThrowingValidationService : IWorkspaceValidationService
+    {
+        private readonly Exception _toThrow;
+        public ThrowingValidationService(Exception toThrow) => _toThrow = toThrow;
+
+        public Task<WorkspaceValidationDto> ValidateAsync(
+            string workspaceId, IReadOnlyList<string>? changedFilePaths, bool runTests,
+            CancellationToken ct, bool summary = false)
+            => Task.FromException<WorkspaceValidationDto>(_toThrow);
+
+        public Task<WorkspaceValidationDto> ValidateRecentGitChangesAsync(
+            string workspaceId, bool runTests, CancellationToken ct, bool summary = false)
+            => Task.FromException<WorkspaceValidationDto>(_toThrow);
+    }
+
+    /// <summary>
+    /// Stand-in that returns a pre-built DTO on the <c>ValidateRecentGitChangesAsync</c>
+    /// entry point, so the success-path pass-through contract can be asserted.
+    /// </summary>
+    private sealed class SuccessfulValidationService : IWorkspaceValidationService
+    {
+        private readonly WorkspaceValidationDto _dto;
+        public SuccessfulValidationService(WorkspaceValidationDto dto) => _dto = dto;
+
+        public Task<WorkspaceValidationDto> ValidateAsync(
+            string workspaceId, IReadOnlyList<string>? changedFilePaths, bool runTests,
+            CancellationToken ct, bool summary = false)
+            => Task.FromResult(_dto);
+
+        public Task<WorkspaceValidationDto> ValidateRecentGitChangesAsync(
+            string workspaceId, bool runTests, CancellationToken ct, bool summary = false)
+            => Task.FromResult(_dto);
+    }
+}


### PR DESCRIPTION
## Summary

- External audits across 4 sibling repos observed `validate_recent_git_changes` returning the bare SDK string `"An error occurred invoking 'validate_recent_git_changes'."` instead of the structured `{category, tool, message, exceptionType, _meta}` envelope that `validate_workspace` produces.
- `StructuredCallToolFilter` already wraps every `tools/call` dispatch, but the field reports indicate a belt-and-suspenders wrap at the handler level is needed to guarantee the envelope regardless of filter wiring or SDK transport quirks.
- `ValidateRecentGitChanges` now wraps its `ToolDispatch.ReadByWorkspaceIdAsync` call in an in-body try/catch that routes exceptions through `ToolErrorHandler.ClassifyAndFormat` + `InjectMetaIfPossible`, returning a well-formed JSON envelope directly from the tool body. `OperationCanceledException` still propagates unwrapped so cooperative cancellation stays a protocol-level signal.

## Test plan

- [x] `ValidationBundleToolsTests.ValidateRecentGitChanges_ServiceThrowsFileNotFound_ReturnsStructuredEnvelope` — covers the "git not on PATH" class of failure.
- [x] `ValidationBundleToolsTests.ValidateRecentGitChanges_ServiceThrowsInvalidOperation_ReturnsStructuredEnvelope` — covers the "solution outside a git repo" / workspace-not-loaded path.
- [x] `ValidationBundleToolsTests.ValidateRecentGitChanges_SuccessPath_ReturnsDtoJson_NotErrorEnvelope` — pins the success pass-through contract so the wrapper doesn't accidentally reshape successful responses.
- [x] `ValidationBundleToolsTests.ValidateRecentGitChanges_OperationCanceled_PropagatesWithoutWrapping` — pins the cancellation contract.
- [x] `dotnet build src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj -c Release` — clean.
- [x] Related tests (ValidationBundle, StructuredCallToolFilter, ToolDispatch, ToolErrorHandler) — 41/41 pass.
- [x] `./eng/verify-ai-docs.ps1` — clean.

Full `verify-release.ps1` surfaced 4 pre-existing parallel-execution flakes unrelated to this PR (temp-dir races in `ProjectMutationIntegrationTests`, `ScaffoldingIntegrationTests`, `CouplingAnalysisTests`, `ValidationIntegrationTests`); all 4 pass cleanly when run in isolation.

Closes: validate-recent-git-changes-bare-error-envelope