### PR TITLE
fix(symbol-search): reject empty queries with structured envelope (symbol-search-empty-query-overflow)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -28,6 +28,18 @@ public static class SymbolTools
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            // Guard: empty/whitespace queries would otherwise dump the full workspace symbol index
+            // (observed 70-80 KB payloads on mid-sized solutions). Return a structured empty-query
+            // envelope so the caller gets an actionable note instead of a giant unfiltered dump.
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    count = 0,
+                    symbols = Array.Empty<object>(),
+                    note = "query must be non-empty — pass a bare substring like 'Animal' to find 'AnimalService', 'IAnimal', etc."
+                }, JsonDefaults.Indented);
+            }
             var results = await symbolSearchService.SearchSymbolsAsync(workspaceId, query, projectName, kind, @namespace, limit, c);
             return JsonSerializer.Serialize(new { count = results.Count, symbols = results }, JsonDefaults.Indented);
         }, ct);

--- a/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
@@ -46,6 +46,58 @@ public sealed class Top10V3RegressionTests : IsolatedWorkspaceTestBase
             "symbol_search response must now carry _meta — the whole point of the shape wrap.");
     }
 
+    // ── symbol-search-empty-query-overflow: guard empty/whitespace queries ──
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("\t")]
+    [DataRow("   \t  \r\n ")]
+    public async Task SymbolSearch_EmptyOrWhitespaceQuery_ReturnsStructuredEmptyEnvelope(string query)
+    {
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                WorkspaceExecutionGate, SymbolSearchService, _workspaceId,
+                query: query,
+                projectName: null, kind: null, @namespace: null, limit: 50,
+                CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("count", out var count),
+            "Empty-query envelope must expose 'count'.");
+        Assert.AreEqual(0, count.GetInt32(),
+            "Empty/whitespace queries must NOT dump the workspace index — count must be 0.");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("symbols", out var symbols),
+            "Empty-query envelope must expose an empty 'symbols' array.");
+        Assert.AreEqual(JsonValueKind.Array, symbols.ValueKind);
+        Assert.AreEqual(0, symbols.GetArrayLength());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("note", out var note),
+            "Empty-query envelope must carry a 'note' explaining why the query was rejected.");
+        Assert.IsTrue(note.GetString()!.Contains("non-empty", StringComparison.OrdinalIgnoreCase),
+            "Note should state the query must be non-empty.");
+    }
+
+    [TestMethod]
+    public async Task SymbolSearch_NonEmptyQuery_DoesNotEmitRejectionNote()
+    {
+        // Control case: a genuine query keeps the normal response shape without the 'note'
+        // field, so clients can disambiguate the empty-query envelope from real results.
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                WorkspaceExecutionGate, SymbolSearchService, _workspaceId,
+                query: "AnimalService",
+                projectName: null, kind: null, @namespace: null, limit: 10,
+                CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(doc.RootElement.TryGetProperty("note", out _),
+            "Valid queries must not emit the empty-query rejection 'note' field.");
+        Assert.IsTrue(doc.RootElement.GetProperty("count").GetInt32() >= 1,
+            "Valid query 'AnimalService' should still return at least one hit.");
+    }
+
     // ── roslyn-mcp-complexity-subset-rerun: filePaths list parameter ──
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Empty / whitespace `query` arguments to `symbol_search` previously dumped the full workspace symbol index (70-80 KB payload observed on mid-sized solutions).
- Guard-clause the tool handler in `SymbolTools.SearchSymbols` to return a structured empty-query envelope (`{count:0, symbols:[], note:"query must be non-empty — ..."}`) before delegating into `ISymbolSearchService`.
- New unit tests cover `""`, `" "`, `"\t"`, and mixed-whitespace inputs; control test confirms a valid query keeps the normal response shape without the `note` field so callers can disambiguate the rejection envelope from real empty-result hits.

## Test plan
- [x] `mcp__roslyn__compile_check` on `SymbolTools.cs` and `Top10V3RegressionTests.cs` — 0 errors / 0 warnings.
- [x] `dotnet test --filter FullyQualifiedName~Top10V3RegressionTests.SymbolSearch` — 6 passed (original regression + 4 DataRow + control).
- [x] `./eng/verify-release.ps1 -Configuration Release` — clean re-run: 836 passed, publish + hash manifest + coverage emitted. (First run had 3 pre-existing test-isolation flakes unrelated to this change — `PostApplySymbolRotationTests.OrganizeUsingsApply_Does_Not_Set_MutatedSymbol`, `CouplingAnalysisTests.GetCouplingMetrics_BaseTypeAndInterface_CountTowardEfferent`, `RefactoringToolsIntegrationTests.OrganizeUsings_RemovesUnusedUsings_DoesNotLeaveBlankLines`; all passed when re-run in isolation and absent from the second full run.)
- [x] `./eng/verify-ai-docs.ps1` — AI docs validation passed.

Closes: `symbol-search-empty-query-overflow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)