### PR TITLE
fix(workspace-manager): atomic swap + StaleWorkspaceTransition envelope (autoreload-cascade-stdio-host-crash)

### DIFF
--- a/src/RoslynMcp.Core/Services/StaleWorkspaceTransitionException.cs
+++ b/src/RoslynMcp.Core/Services/StaleWorkspaceTransitionException.cs
@@ -1,0 +1,48 @@
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Signals that a state-read operation on <c>WorkspaceManager</c> raced with (or followed)
+/// an auto-reload transition and could not be served from a coherent snapshot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> the <c>autoreload-cascade-stdio-host-crash</c> regression
+/// (Phase 6k batch on 2026-04-24) showed that two in-turn writers
+/// (<c>preview_record_field_addition</c> + <c>extract_and_wire_interface_preview</c>) each
+/// triggered <c>staleAction=auto-reloaded</c>, and the follow-up <c>workspace_changes</c>
+/// reader raised an unhandled exception on the post-auto-reload state-read path that
+/// terminated the stdio host (new <c>stdioPid</c>, every in-flight preview token lost).
+/// </para>
+///
+/// <para>
+/// The remediation: every <c>WorkspaceManager</c> state-read method that observes the
+/// session in a transition window (<see cref="WorkspaceManager.LoadIntoSessionAsync"/>
+/// actively running, or just-failed with <c>Workspace == null</c>) must throw this
+/// exception instead of propagating a generic <see cref="System.InvalidOperationException"/>
+/// or raw Roslyn/MSBuild exception. The host's <c>ToolErrorHandler</c> recognizes this
+/// type by name and surfaces it as <c>category="StaleWorkspaceTransition"</c> with a
+/// retry hint — callers can re-issue the read after calling <c>workspace_reload</c>
+/// (or on the next turn when the reload has settled).
+/// </para>
+///
+/// <para>
+/// This is a <b>retry-able</b> error, distinct from <c>InvalidOperation</c> (which in
+/// the stale-workspace path would previously have suggested <c>workspace_reload</c> but
+/// did not differentiate a permanent invalid state from a transient transition).
+/// </para>
+/// </remarks>
+public sealed class StaleWorkspaceTransitionException : Exception
+{
+    /// <summary>
+    /// Identifier of the workspace that was in transition when the read failed.
+    /// Carried separately from <see cref="Exception.Message"/> so the error envelope
+    /// can surface it in <c>_meta</c> without re-parsing the message string.
+    /// </summary>
+    public string WorkspaceId { get; }
+
+    public StaleWorkspaceTransitionException(string workspaceId, string message, Exception? inner = null)
+        : base(message, inner)
+    {
+        WorkspaceId = workspaceId;
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -18,6 +18,11 @@ internal static class ToolErrorHandler
 {
     private static readonly Dictionary<Type, Func<Exception, string, ErrorInfo>> ErrorHandlers = new()
     {
+        // autoreload-cascade-stdio-host-crash: wraps a state-read that raced with (or followed)
+        // an auto-reload transition. Registered BEFORE the generic Exception handlers so the
+        // structured category wins over the dictionary walk's InvalidOperation fallback.
+        [typeof(StaleWorkspaceTransitionException)] = (ex, _) => new("StaleWorkspaceTransition",
+            $"Workspace is transitioning between snapshots: {ex.Message}"),
         [typeof(FileNotFoundException)] = (ex, _) => new("FileNotFound",
             $"File not found: {ex.Message}. Verify the file path is absolute and the file exists on disk. " +
             "If the workspace was recently reloaded, the file may have been removed."),

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -482,8 +482,38 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     public Solution GetCurrentSolution(string workspaceId)
     {
         var session = GetRequiredSession(workspaceId);
-        return session.Workspace?.CurrentSolution
-            ?? throw new InvalidOperationException($"Workspace '{workspaceId}' is not loaded.");
+        var workspace = session.Workspace;
+        if (workspace is null)
+        {
+            // autoreload-cascade-stdio-host-crash: a null workspace observed after the session
+            // was registered means a reload failed mid-flight (or is executing on another turn
+            // and has not yet completed the atomic swap). Surface as StaleWorkspaceTransition
+            // so the caller sees a retry-able envelope rather than a generic invalid-operation
+            // that historically let the raw exception terminate the stdio host.
+            throw new StaleWorkspaceTransitionException(
+                workspaceId,
+                $"Workspace '{workspaceId}' is in the middle of a reload transition or its last " +
+                "reload failed. Retry the read after workspace_reload settles, or call " +
+                "workspace_reload explicitly to re-establish a valid snapshot.");
+        }
+
+        try
+        {
+            return workspace.CurrentSolution;
+        }
+        catch (ObjectDisposedException ex)
+        {
+            // Defensive: even with the atomic swap in LoadIntoSessionAsync, if a caller held a
+            // captured reference to the previous workspace across a reload, reading its solution
+            // can observe the disposed instance. Translate that to a structured transition error
+            // (retry-able) rather than letting it bubble as a generic InternalError that killed
+            // the stdio host in the 2026-04-24 cascade.
+            throw new StaleWorkspaceTransitionException(
+                workspaceId,
+                $"Workspace '{workspaceId}' snapshot reference was disposed during a concurrent " +
+                "reload. Retry the read to observe the fresh snapshot.",
+                ex);
+        }
     }
 
     /// <summary>
@@ -605,16 +635,27 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     private async Task LoadIntoSessionAsync(WorkspaceSession session, string path, CancellationToken ct)
     {
         await session.LoadLock.WaitAsync(ct).ConfigureAwait(false);
+        // autoreload-cascade-stdio-host-crash: build the new workspace + diagnostics queue into
+        // locals, then swap them onto the session atomically on success. Previously we disposed
+        // the old `session.Workspace` before creating the new one (and also overwrote
+        // `session.WorkspaceDiagnostics` mid-flight). That left readers with a window where
+        // `session.Workspace` pointed at a disposed MSBuildWorkspace — `.CurrentSolution` on a
+        // disposed workspace throws `ObjectDisposedException`, and the 2026-04-24 two-writer +
+        // reader cascade showed this path could terminate the stdio host. With the swap-on-
+        // success pattern, readers always see EITHER the prior loaded workspace OR the fully
+        // initialized new workspace; the disposed object is never observable.
+        MSBuildWorkspace? newWorkspace = null;
+        ConcurrentQueue<DiagnosticDto>? newDiagnostics = null;
+        MSBuildWorkspace? oldWorkspace = session.Workspace;
         try
         {
-            session.Workspace?.Dispose();
             MsBuildInitializer.EnsureInitialized();
-            session.Workspace = MSBuildWorkspace.Create();
-            session.WorkspaceDiagnostics = new ConcurrentQueue<DiagnosticDto>();
-            session.ProjectStatuses = ImmutableArray<ProjectStatusDto>.Empty;
+            newWorkspace = MSBuildWorkspace.Create();
+            newDiagnostics = new ConcurrentQueue<DiagnosticDto>();
             var fullPath = path;
+            var diagnosticsRef = newDiagnostics; // capture for the handler closure below
 
-            session.Workspace.RegisterWorkspaceFailedHandler(args =>
+            newWorkspace.RegisterWorkspaceFailedHandler(args =>
             {
                 // Normalize at ingress so workspace_load, workspace_status, project_diagnostics,
                 // and the roslyn://workspaces resource all see the same severity. Previously
@@ -632,10 +673,10 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                     StartColumn: null,
                     EndLine: null,
                     EndColumn: null);
-                session.WorkspaceDiagnostics.Enqueue(dto);
-                while (session.WorkspaceDiagnostics.Count > MaxDiagnosticsPerWorkspace)
+                diagnosticsRef.Enqueue(dto);
+                while (diagnosticsRef.Count > MaxDiagnosticsPerWorkspace)
                 {
-                    session.WorkspaceDiagnostics.TryDequeue(out _);
+                    diagnosticsRef.TryDequeue(out _);
                 }
 
                 _logger.LogWarning(
@@ -657,11 +698,11 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             if (fullPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
                 fullPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
             {
-                await session.Workspace.OpenSolutionAsync(fullPath, cancellationToken: ct).ConfigureAwait(false);
+                await newWorkspace.OpenSolutionAsync(fullPath, cancellationToken: ct).ConfigureAwait(false);
             }
             else if (fullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
             {
-                await session.Workspace.OpenProjectAsync(fullPath, cancellationToken: ct).ConfigureAwait(false);
+                await newWorkspace.OpenProjectAsync(fullPath, cancellationToken: ct).ConfigureAwait(false);
             }
             else
             {
@@ -673,20 +714,45 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // Compilation.GetDiagnostics, and Roslyn-internal switches over AnalyzerReference
             // subtypes throw "Unexpected value 'UnresolvedAnalyzerReference'" otherwise. The
             // earlier per-service guards in CompilationCache/FixAllService are now unnecessary.
-            await StripUnresolvedAnalyzerReferencesAsync(session, ct).ConfigureAwait(false);
+            await StripUnresolvedAnalyzerReferencesAsync(session.WorkspaceId, newWorkspace, newDiagnostics, ct).ConfigureAwait(false);
 
-            session.ProjectStatuses = BuildProjectStatuses(session.Workspace.CurrentSolution);
+            var projectStatuses = BuildProjectStatuses(newWorkspace.CurrentSolution);
+            var restoreRequired = DetectRestoreRequired(projectStatuses) ||
+                                  HasRestoreRequiredWorkspaceDiagnostics(newDiagnostics);
+
+            // autoreload-cascade-stdio-host-crash: atomic swap. Assign all session state AFTER
+            // the new workspace is fully loaded so concurrent readers never observe a mid-reload
+            // session (disposed workspace, empty project list, or mismatched LoadedPath).
+            session.Workspace = newWorkspace;
+            session.WorkspaceDiagnostics = newDiagnostics;
+            session.ProjectStatuses = projectStatuses;
             session.LoadedPath = fullPath;
-            session.RestoreRequired = DetectRestoreRequired(session.ProjectStatuses) ||
-                                      HasRestoreRequiredWorkspaceDiagnostics(session.WorkspaceDiagnostics);
+            session.RestoreRequired = restoreRequired;
             session.LoadedAtUtc = DateTimeOffset.UtcNow;
             session.IncrementVersion();
             _previewStore.InvalidateAll(session.WorkspaceId);
 
+            // Transfer succeeded — dispose the prior workspace AFTER readers can no longer
+            // latch onto it through `session.Workspace`. Null out our local so the finally
+            // block doesn't re-dispose or dispose the now-live new workspace.
+            newWorkspace = null;
             LogWorkspaceLoaded(_logger, session.WorkspaceId, fullPath, session.Version, null);
         }
         finally
         {
+            // If the load failed mid-way, dispose the half-initialized new workspace and leave
+            // the session's prior state untouched. Readers continue to see the previous valid
+            // workspace rather than a broken one (or null).
+            newWorkspace?.Dispose();
+            // Dispose the previous workspace now that the swap is visible (or keep it if we
+            // failed and never swapped — the finally's newWorkspace dispose above handles the
+            // failure case; oldWorkspace remains attached to the session).
+            if (newWorkspace is null)
+            {
+                // Successful swap: oldWorkspace was captured before the swap and is no longer
+                // referenced by the session. Safe to dispose.
+                oldWorkspace?.Dispose();
+            }
             session.LoadLock.Release();
         }
     }
@@ -1200,11 +1266,13 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     /// <c>WORKSPACE_UNRESOLVED_ANALYZER</c> warning (severity Warning, not Error) so callers
     /// can still discover that something was filtered.
     /// </summary>
-    private async Task StripUnresolvedAnalyzerReferencesAsync(WorkspaceSession session, CancellationToken ct)
+    private async Task StripUnresolvedAnalyzerReferencesAsync(
+        string workspaceId,
+        MSBuildWorkspace workspace,
+        ConcurrentQueue<DiagnosticDto> diagnosticsQueue,
+        CancellationToken ct)
     {
-        if (session.Workspace is null) return;
-
-        var originalSolution = session.Workspace.CurrentSolution;
+        var originalSolution = workspace.CurrentSolution;
         var solution = originalSolution;
         var strippedCount = 0;
         var newDiagnostics = new List<DiagnosticDto>();
@@ -1263,7 +1331,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             _logger,
             ct).ConfigureAwait(false);
 
-        if (!session.Workspace.TryApplyChanges(solution))
+        if (!workspace.TryApplyChanges(solution))
         {
             // Should be impossible — analyzer reference removal is supported by every workspace
             // implementation. Log and leave the unresolved entries in place; the per-service
@@ -1271,7 +1339,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // surface the failure loudly.
             _logger.LogWarning(
                 "Workspace {WorkspaceId}: TryApplyChanges failed when stripping {Count} UnresolvedAnalyzerReference entries; downstream tools may still crash on them.",
-                session.WorkspaceId, strippedCount);
+                workspaceId, strippedCount);
             return;
         }
 
@@ -1285,16 +1353,16 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 
         foreach (var dto in newDiagnostics)
         {
-            session.WorkspaceDiagnostics.Enqueue(dto);
-            while (session.WorkspaceDiagnostics.Count > MaxDiagnosticsPerWorkspace)
+            diagnosticsQueue.Enqueue(dto);
+            while (diagnosticsQueue.Count > MaxDiagnosticsPerWorkspace)
             {
-                session.WorkspaceDiagnostics.TryDequeue(out _);
+                diagnosticsQueue.TryDequeue(out _);
             }
         }
 
         _logger.LogInformation(
             "Workspace {WorkspaceId}: stripped {Count} UnresolvedAnalyzerReference entries to prevent downstream crashes.",
-            session.WorkspaceId, strippedCount);
+            workspaceId, strippedCount);
     }
 
     private WorkspaceStatusDto BuildStatus(WorkspaceSession session)

--- a/tests/RoslynMcp.Tests/AutoReloadCascadeHostCrashTests.cs
+++ b/tests/RoslynMcp.Tests/AutoReloadCascadeHostCrashTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for <c>autoreload-cascade-stdio-host-crash</c> (P2, 2026-04-24).
+///
+/// <para>
+/// Observed failure: two in-turn writers (<c>preview_record_field_addition</c> +
+/// <c>extract_and_wire_interface_preview</c>) each stamped <c>staleAction=auto-reloaded</c>
+/// in the response envelope. The follow-up reader (<c>workspace_changes</c>) then
+/// terminated the stdio host with <c>MCP error -32000: Connection closed</c>; the server's
+/// <c>stdioPid</c> changed, indicating the .NET process itself died rather than surfacing
+/// a structured tool error.
+/// </para>
+///
+/// <para>
+/// Root cause: <c>WorkspaceManager.LoadIntoSessionAsync</c> disposed the prior
+/// MSBuildWorkspace BEFORE assigning the replacement, leaving a window where
+/// concurrent readers observed <c>session.Workspace</c> pointing at a disposed object.
+/// <c>.CurrentSolution</c> on a disposed workspace throws <see cref="ObjectDisposedException"/>,
+/// which — because the outer tool filter only classifies it as a generic
+/// <c>InternalError</c> — doesn't carry enough structural signal for the caller to know
+/// the condition is retry-able.
+/// </para>
+///
+/// <para>
+/// Remediation: <c>LoadIntoSessionAsync</c> now builds the new workspace into a local,
+/// performs an atomic swap, and disposes the prior workspace only after readers can no
+/// longer reach it through the session. Additionally, <c>GetCurrentSolution</c> wraps
+/// both the "null workspace" case and any residual <see cref="ObjectDisposedException"/>
+/// into a <see cref="StaleWorkspaceTransitionException"/> so callers see a structured
+/// <c>category="StaleWorkspaceTransition"</c> envelope with an explicit retry hint.
+/// </para>
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class AutoReloadCascadeHostCrashTests : SharedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Core classifier contract: a <see cref="StaleWorkspaceTransitionException"/> thrown
+    /// from a tool handler must surface as <c>category="StaleWorkspaceTransition"</c>
+    /// (NOT "InvalidOperation" or "InternalError"). This is the structural signal the
+    /// audit report specifically requested so callers can retry on the next turn.
+    /// </summary>
+    [TestMethod]
+    public async Task StaleWorkspaceTransitionException_Classifies_As_StructuredCategory()
+    {
+        var workspaceId = "ws-transition-under-test";
+        var result = await ToolExecutionTestHarness.RunAsync(
+            "workspace_changes",
+            () => throw new StaleWorkspaceTransitionException(
+                workspaceId,
+                "Workspace is mid-reload; retry after settle."));
+
+        using var json = JsonDocument.Parse(result);
+        Assert.IsTrue(json.RootElement.GetProperty("error").GetBoolean(),
+            "Transition errors must carry error=true in the envelope.");
+        Assert.AreEqual("StaleWorkspaceTransition",
+            json.RootElement.GetProperty("category").GetString(),
+            "Category must be the structured retry-able marker, not a generic InternalError.");
+        Assert.AreEqual("workspace_changes",
+            json.RootElement.GetProperty("tool").GetString(),
+            "The tool name must be preserved in the envelope.");
+        Assert.AreEqual(nameof(StaleWorkspaceTransitionException),
+            json.RootElement.GetProperty("exceptionType").GetString());
+
+        var message = json.RootElement.GetProperty("message").GetString()!;
+        StringAssert.Contains(message, "Workspace is transitioning between snapshots",
+            "Envelope message must contain the structured retry-hint prefix.");
+        StringAssert.Contains(message, "retry after settle",
+            "The originating exception message must be preserved end-to-end.");
+
+        // Internal-error envelopes carry a stack trace; structured known-category envelopes
+        // deliberately omit it to keep the payload small. Verify StaleWorkspaceTransition
+        // lands in the known-category branch, not the InternalError branch.
+        Assert.IsFalse(json.RootElement.TryGetProperty("stackTrace", out _),
+            "StaleWorkspaceTransition is a known category and must not emit a stack trace.");
+    }
+
+    /// <summary>
+    /// Regression: two in-turn writers mark the workspace stale twice, and a follow-up
+    /// reader (<c>workspace_changes</c>) arrives mid-transition. With the atomic-swap fix,
+    /// the reader either sees the prior workspace or the fully loaded new workspace — it
+    /// never observes a disposed / null / half-loaded snapshot. Before the fix, a reader
+    /// that interleaved between <c>session.Workspace?.Dispose()</c> and the reassignment
+    /// threw <see cref="ObjectDisposedException"/>, which escaped as an <c>InternalError</c>
+    /// on the structured envelope; in production this cascade terminated the stdio host.
+    /// </summary>
+    [TestMethod]
+    public async Task TwoWriters_Plus_Reader_InSameTurn_DoesNotCrashHost()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync();
+
+        // Simulate two writer mutations: each marks the workspace stale. In production the
+        // `apply` path enqueues the stale signal; here we invoke it directly so the test is
+        // deterministic (the real MSBuild reload is exercised via ReloadAsync below).
+        FileWatcher.MarkStale(workspaceId, StaleReasons.Apply);
+        FileWatcher.MarkStale(workspaceId, StaleReasons.Apply);
+        Assert.IsTrue(WorkspaceManager.IsStale(workspaceId),
+            "Two writer stale-marks must leave the workspace in the stale state.");
+
+        // Reload once (first writer's auto-reload) — this is the path that previously left a
+        // disposed-workspace window open to concurrent readers.
+        await WorkspaceManager.ReloadAsync(workspaceId, CancellationToken.None);
+
+        // After the atomic-swap fix, GetCurrentSolution must yield a valid, non-disposed
+        // Solution. Before the fix, a rare interleaving surfaced ObjectDisposedException;
+        // after the fix, readers ALWAYS observe either the prior or the new workspace.
+        var solution = WorkspaceManager.GetCurrentSolution(workspaceId);
+        Assert.IsNotNull(solution, "Reader must observe a valid Solution after a reload.");
+        Assert.IsTrue(solution.Projects.Any(),
+            "Post-reload Solution must carry the reloaded projects — no half-initialized snapshot.");
+
+        // Second writer's auto-reload: mark stale again and reload. Reader's subsequent
+        // read must still succeed and must NOT throw.
+        FileWatcher.MarkStale(workspaceId, StaleReasons.Apply);
+        await WorkspaceManager.ReloadAsync(workspaceId, CancellationToken.None);
+
+        // Third consecutive read — the "workspace_changes" reader in the original cascade.
+        // Prior bug: this path could throw ObjectDisposedException that escaped as a host
+        // crash. Post-fix: returns a valid Solution synchronously, no exception.
+        var solutionAfter = WorkspaceManager.GetCurrentSolution(workspaceId);
+        Assert.IsNotNull(solutionAfter, "Reader must observe a valid Solution after a second reload.");
+        Assert.IsTrue(solutionAfter.Projects.Any(),
+            "Double-reload must leave a coherent Solution for the follow-up reader.");
+    }
+
+    /// <summary>
+    /// Exhaustive retry-resilience: across many reload cycles, concurrent reads never
+    /// observe a disposed workspace (they either see the prior or the fresh snapshot).
+    /// This models the long-session shape where dozens of writer+reader turns interleave.
+    /// </summary>
+    [TestMethod]
+    public async Task ConcurrentReload_And_Reads_Never_Throw_DisposedException()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync();
+
+        const int iterations = 5;
+        for (var i = 0; i < iterations; i++)
+        {
+            FileWatcher.MarkStale(workspaceId, StaleReasons.Apply);
+            var reloadTask = WorkspaceManager.ReloadAsync(workspaceId, CancellationToken.None);
+
+            // Race a concurrent reader against the in-flight reload. With the pre-fix
+            // dispose-before-swap pattern this often threw ObjectDisposedException; with
+            // the fix the reader reliably observes either the old or new Solution.
+            var readerTask = Task.Run(() =>
+            {
+                // Spin up a few reads that would have raced the reload's dispose window.
+                for (var j = 0; j < 10; j++)
+                {
+                    var solution = WorkspaceManager.GetCurrentSolution(workspaceId);
+                    Assert.IsNotNull(solution, $"Iter {i} reader {j}: Solution must be non-null.");
+                }
+            });
+
+            await Task.WhenAll(reloadTask, readerTask);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two in-turn writers (`preview_record_field_addition` + `extract_and_wire_interface_preview`) each stamped `staleAction=auto-reloaded`; the follow-up `workspace_changes` reader terminated the stdio host with `MCP error -32000: Connection closed` (new `stdioPid`). Root cause: `WorkspaceManager.LoadIntoSessionAsync` disposed the prior MSBuildWorkspace BEFORE assigning the replacement, so concurrent readers could hit a disposed workspace whose `ObjectDisposedException` escaped as a generic `InternalError` that killed the process.

## Fix

- **Atomic swap** in `LoadIntoSessionAsync`: build the new workspace + diagnostics queue into locals, swap them onto the session after the load succeeds, then dispose the prior workspace. Mid-reload failure leaves the session on the prior valid workspace (old behavior wiped it).
- **Structured envelope** via a new `StaleWorkspaceTransitionException` (in `RoslynMcp.Core`): `GetCurrentSolution` wraps both the "null workspace" case and any residual `ObjectDisposedException` into this type so callers see `category="StaleWorkspaceTransition"` with an explicit retry hint instead of a generic `InvalidOperation` or `InternalError`.
- `ToolErrorHandler.ClassifyError` registers the new exception → structured category mapping.

## Validation

- `./eng/verify-release.ps1 -Configuration Release` — **passed** (834 tests, 0 failures).
- `./eng/verify-ai-docs.ps1` — **passed**.
- New regression suite `AutoReloadCascadeHostCrashTests` (3 tests, all pass):
  - classifier maps `StaleWorkspaceTransitionException` to `category=StaleWorkspaceTransition` with no stack trace (known-category branch)
  - two-writer + reader in the same turn survives the host across back-to-back reloads
  - concurrent reload + reads never observe a disposed workspace

## Test plan

- [x] Unit test for classifier mapping
- [x] End-to-end test for the two-writer + reader cascade
- [x] Race test for concurrent reload vs read
- [x] verify-release (834/834 pass)
- [x] verify-ai-docs

Closes: autoreload-cascade-stdio-host-crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)