### PR TITLE
fix(server-tools): rename pre-load connection.state to "idle" (connection-state-ready-unsatisfiable-preload)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -14,22 +14,34 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class ServerTools
 {
     /// <summary>
-    /// mcp-connection-session-resilience: canonical shape for the <c>connection</c>
-    /// subfield emitted by <c>server_info</c> and the new <c>server_heartbeat</c> tool.
+    /// mcp-connection-session-resilience + connection-state-ready-unsatisfiable-preload:
+    /// canonical shape for the <c>connection</c> subfield emitted by <c>server_info</c>
+    /// and the <c>server_heartbeat</c> tool.
     /// <para>
     /// Consumers use this block to distinguish "transport reachable" from
     /// "workspace-scoped tools will succeed":
     /// </para>
     /// <list type="bullet">
+    ///   <item><description><c>idle</c> — the stdio transport is up and the server is fully initialized, but no workspace has been loaded yet. This is a terminal pre-load state (NOT a transient "initializing" step). Consumers must call <c>workspace_load</c> to advance to <c>ready</c>. Prompts that previously gated on <c>state==ready</c> should now gate on <c>state in {idle, ready}</c> when they mean "server responsive"; prompts that genuinely require a loaded workspace should still gate on <c>state==ready</c>.</description></item>
     ///   <item><description><c>ready</c> — at least one workspace session is loaded; workspace-scoped tools will resolve.</description></item>
-    ///   <item><description><c>initializing</c> — the stdio transport is up but no workspace has been loaded yet. Consumers must call <c>workspace_load</c> first.</description></item>
     ///   <item><description><c>degraded</c> — reserved for future use when the server hit a startup error but is still answering the protocol. Not emitted today.</description></item>
     /// </list>
+    /// <para>
+    /// Prior to the <c>connection-state-ready-unsatisfiable-preload</c> fix the pre-load
+    /// state was reported as <c>"initializing"</c>. That label implied a transient
+    /// intermediate step and broke hard-gate prompts that polled for the transition off
+    /// <c>"initializing"</c> before any workspace had been requested. The server never
+    /// advances off pre-load on its own — a workspace_load call is required — so the
+    /// state is now named <c>"idle"</c> to reflect reality.
+    /// </para>
     /// </summary>
     private static object BuildConnection(IWorkspaceManager workspace)
     {
         var loadedWorkspaceCount = workspace.ListWorkspaces().Count;
-        var state = loadedWorkspaceCount >= 1 ? "ready" : "initializing";
+        // connection-state-ready-unsatisfiable-preload: pre-load state is "idle", not
+        // "initializing". The server does not auto-advance from pre-load; a workspace_load
+        // call is the only transition, so the label must be terminal, not transient.
+        var state = loadedWorkspaceCount >= 1 ? "ready" : "idle";
         return new
         {
             state,
@@ -64,7 +76,7 @@ public static class ServerTools
     [McpServerTool(Name = "server_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("server", "stable", true, false,
         "Inspect server capabilities, versions, and support tiers."),
-     Description("Get server version, capabilities, runtime information, and loaded workspace count. workspaceCount reflects sessions at call time and may briefly lag if invoked in parallel with or immediately after workspace_load; use workspace_list for authoritative session enumeration. Prompts tier note: the response carries prompts.stable and prompts.experimental from the live catalog; all currently-exposed prompts are experimental until promoted, so stable=0 with a nonzero experimental count is expected — it is NOT a missing-surface bug. Connection readiness: the response includes a `connection` subfield with state=ready|initializing|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt — use this (or the lighter `server_heartbeat` tool) to distinguish transport-reachable from workspace-loaded before calling workspace-scoped tools.")]
+     Description("Get server version, capabilities, runtime information, and loaded workspace count. workspaceCount reflects sessions at call time and may briefly lag if invoked in parallel with or immediately after workspace_load; use workspace_list for authoritative session enumeration. Prompts tier note: the response carries prompts.stable and prompts.experimental from the live catalog; all currently-exposed prompts are experimental until promoted, so stable=0 with a nonzero experimental count is expected — it is NOT a missing-surface bug. Connection readiness: the response includes a `connection` subfield with state=idle|ready|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt — use this (or the lighter `server_heartbeat` tool) to distinguish transport-reachable from workspace-loaded before calling workspace-scoped tools. State machine: `idle` = transport up but no workspace loaded (terminal pre-load state; server does NOT auto-advance — call `workspace_load` to transition to `ready`). `ready` = at least one workspace loaded; workspace-scoped tools will resolve. `degraded` = reserved for future use (not emitted today). Prompts that previously gated on `state==ready` to mean 'server responsive' should gate on `state in {idle, ready}`; prompts that genuinely require a loaded workspace should continue to gate on `state==ready`.")]
     public static Task<string> GetServerInfo(
         IWorkspaceManager workspace,
         ILatestVersionProvider versionChecker)
@@ -178,7 +190,7 @@ public static class ServerTools
     [McpServerTool(Name = "server_heartbeat", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("server", "stable", true, false,
         "Lightweight connection readiness probe — returns state/loadedWorkspaceCount/stdioPid/serverStartedAt without the full server_info payload."),
-     Description("Return the connection readiness block only — state=ready|initializing|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt. Cheaper than server_info (no version, catalog, or update metadata). Use this to poll for 'at least one workspace loaded' before calling workspace-scoped tools.")]
+     Description("Return the connection readiness block only — state=idle|ready|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt. Cheaper than server_info (no version, catalog, or update metadata). State machine: `idle` = transport up but no workspace loaded (terminal pre-load state; server does NOT auto-advance — call `workspace_load` to transition to `ready`). `ready` = at least one workspace loaded; workspace-scoped tools will resolve. `degraded` = reserved for future use (not emitted today). Use this to poll for 'at least one workspace loaded' before calling workspace-scoped tools; do NOT poll waiting for `idle` to transition off its own — a `workspace_load` call is required.")]
     public static Task<string> GetServerHeartbeat(IWorkspaceManager workspace)
     {
         var payload = new { connection = BuildConnection(workspace) };

--- a/tests/RoslynMcp.Tests/ServerHeartbeatTests.cs
+++ b/tests/RoslynMcp.Tests/ServerHeartbeatTests.cs
@@ -66,14 +66,18 @@ public sealed class ServerHeartbeatTests
     }
 
     [TestMethod]
-    public async Task Heartbeat_NoWorkspaceLoaded_ReturnsInitializingWithZeroCount()
+    public async Task Heartbeat_NoWorkspaceLoaded_ReturnsIdleWithZeroCount()
     {
+        // connection-state-ready-unsatisfiable-preload: pre-load state is "idle", a
+        // terminal label, not the previous "initializing" which incorrectly implied a
+        // transient step that would auto-advance. The server only transitions via an
+        // explicit workspace_load call.
         var json = await ServerTools.GetServerHeartbeat(new FakeWorkspaceManager(loadedCount: 0));
         using var doc = JsonDocument.Parse(json);
 
         var connection = doc.RootElement.GetProperty("connection");
-        Assert.AreEqual("initializing", connection.GetProperty("state").GetString(),
-            "state must be 'initializing' when no workspace has been loaded yet.");
+        Assert.AreEqual("idle", connection.GetProperty("state").GetString(),
+            "state must be 'idle' when no workspace has been loaded yet (terminal pre-load state, NOT 'initializing').");
         Assert.AreEqual(0, connection.GetProperty("loadedWorkspaceCount").GetInt32());
         AssertIdentityFieldsPresent(connection);
     }
@@ -89,6 +93,48 @@ public sealed class ServerHeartbeatTests
             "state must be 'ready' once at least one workspace is loaded.");
         Assert.AreEqual(1, connection.GetProperty("loadedWorkspaceCount").GetInt32());
         AssertIdentityFieldsPresent(connection);
+    }
+
+    [TestMethod]
+    public async Task Heartbeat_PreLoadToPostLoadTransition_IdleToReady()
+    {
+        // connection-state-ready-unsatisfiable-preload: explicit test of the only
+        // allowed state transition. The server starts at `idle` (pre-load) and flips
+        // to `ready` the moment ListWorkspaces() reports a loaded session. There is
+        // no transient intermediate `initializing` step — the label `idle` is terminal
+        // until workspace_load is called. A hard-gate prompt that polls through this
+        // transition should observe exactly two distinct states in order: idle, ready.
+        var preLoadJson = await ServerTools.GetServerHeartbeat(new FakeWorkspaceManager(loadedCount: 0));
+        using var preLoadDoc = JsonDocument.Parse(preLoadJson);
+        Assert.AreEqual(
+            "idle",
+            preLoadDoc.RootElement.GetProperty("connection").GetProperty("state").GetString(),
+            "pre-load state must be 'idle' — reverts to the broken 'initializing' label if this fails.");
+
+        var postLoadJson = await ServerTools.GetServerHeartbeat(new FakeWorkspaceManager(loadedCount: 1));
+        using var postLoadDoc = JsonDocument.Parse(postLoadJson);
+        Assert.AreEqual(
+            "ready",
+            postLoadDoc.RootElement.GetProperty("connection").GetProperty("state").GetString(),
+            "post-load state must flip to 'ready' once at least one workspace is loaded.");
+    }
+
+    [TestMethod]
+    public async Task ServerInfo_PreLoad_ReportsIdleNotInitializing()
+    {
+        // connection-state-ready-unsatisfiable-preload: matches the heartbeat's shape
+        // but verifies the inline `connection` block on `server_info`. Prompts like
+        // `deep-review-and-refactor.md`'s Phase -1 hard gate previously saw
+        // `state=initializing` here and waited for it to flip without ever calling
+        // workspace_load — that broken polling loop is what this fix closes.
+        var json = await ServerTools.GetServerInfo(new FakeWorkspaceManager(loadedCount: 0), new FakeVersionProvider(null));
+        using var doc = JsonDocument.Parse(json);
+
+        var connection = doc.RootElement.GetProperty("connection");
+        Assert.AreEqual("idle", connection.GetProperty("state").GetString(),
+            "server_info.connection.state must be 'idle' pre-load, not 'initializing'.");
+        Assert.AreNotEqual("initializing", connection.GetProperty("state").GetString(),
+            "server_info.connection.state must NOT revert to the legacy 'initializing' label.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

**BREAKING — `Changed`:** `server_info.connection.state` and `server_heartbeat.connection.state` now report `idle` before any workspace is loaded (previously the unsatisfiable `initializing`).

- Pre-load state `"initializing"` implied a transient step that would auto-advance — it did not. A `workspace_load` call is the only transition off pre-load, so hard-gate prompts that polled for `"initializing"` → `"ready"` without calling `workspace_load` hung indefinitely.
- New label `"idle"` is terminal and accurate: transport up, server fully initialized, no workspace loaded. Prompts meaning "server responsive" should gate on `state in {idle, ready}`; prompts requiring a loaded workspace should continue to gate on `state==ready`.
- Tool descriptions on `server_info` and `server_heartbeat` now document the state machine explicitly (`idle|ready|degraded`) so consumers do not need to guess transitions.

## Scope

- `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs` — single-line state-string change + updated `[Description]` copy on the two affected tools; XML doc rewritten to describe the terminal-not-transient nature of `idle`.
- `tests/RoslynMcp.Tests/ServerHeartbeatTests.cs` — renamed the pre-load test; added two new tests covering the `idle → ready` transition and the `server_info` inline connection block.

`McpToolMetadata` summaries were left unchanged to keep parity with `ServerSurfaceCatalog` (catalog-drift test would fail otherwise; the rich state-machine docs live in the `[Description]` text that actually reaches MCP clients).

## Test plan

- [x] `ServerHeartbeatTests` — all 6 tests pass (4 original + 2 new)
- [x] Release-mode targeted pass: heartbeat + server_info + SurfaceCatalog drift checks (23 tests passed)
- [x] `verify-ai-docs.ps1` passed
- [x] Full `verify-release.ps1` test pass returns the same 33 pre-existing flakes seen on `main` (FormatRange temp-dir race, concurrent-reload timeout, pragma temp-file race) — none touch ServerTools; confirmed by running 3 of the failing tests individually on main, all passed

Closes: connection-state-ready-unsatisfiable-preload

Generated with [Claude Code](https://claude.com/claude-code)