### PR TITLE
feat(symbol-tools): add summary + maxItemsPerSymbol to find_references_bulk (find-references-bulk-summary-mode)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -312,9 +312,10 @@ public static class SymbolTools
     }
 
     [McpServerTool(Name = "find_references_bulk", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
-        "Find references for multiple symbols in one call (max 50). Returns { count, results } where each result has key, referenceCount, references, and optional error. " +
+        "Find references for multiple symbols in one call (max 50). Returns { count, results } where each result has key, referenceCount, references, truncated, and optional error. " +
         "Parameter name must be `symbols` (array of objects). Do NOT pass symbolHandles or a JSON string array. " +
-        "Each element must set exactly one of: symbolHandle, metadataName, or filePath+line+column.")]
+        "Each element must set exactly one of: symbolHandle, metadataName, or filePath+line+column. " +
+        "Pass `summary=true` to drop per-ref preview text and `maxItemsPerSymbol=N` to cap each symbol's reference list so the aggregate envelope stays under the MCP payload cap (overflowed at 120 KB without bounds).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Resolve references for multiple symbols in one request.")]
     public static Task<string> FindReferencesBulk(
@@ -323,12 +324,64 @@ public static class SymbolTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Array of locator objects (max 50). Example shape: symbols: [ { metadataName: \"SampleLib.IAnimal\" }, { filePath: \"C:/src/x.cs\", line: 10, column: 5 } ]")] BulkSymbolLocator[] symbols,
         [Description("Include the definition location in each result (default: false)")] bool includeDefinition = false,
+        [Description("When true, drops per-ref preview text to keep each symbol's references small for high-fan-out batches. File path + line + column + classification still populated. Default false preserves the v1.18.2 shape.")] bool summary = false,
+        [Description("Maximum number of reference locations to keep per symbol (default: 100). Applied BEFORE the outer envelope is assembled so the cap actually bounds aggregate output. Each result's `truncated` flag indicates whether its list was trimmed; `referenceCount` still reflects the full pre-cap total so callers can page follow-up queries via find_references.")] int maxItemsPerSymbol = 100,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            if (maxItemsPerSymbol < 1)
+                throw new ArgumentException("maxItemsPerSymbol must be >= 1.", nameof(maxItemsPerSymbol));
+
             var results = await referenceService.FindReferencesBulkAsync(workspaceId, symbols, includeDefinition, c);
-            return JsonSerializer.Serialize(new { count = results.Count, results }, JsonDefaults.Indented);
+
+            // Apply the per-symbol cap + summary stripping BEFORE assembling the outer envelope.
+            // Serializing the raw service result and then paging post-hoc would still materialize
+            // the full preview payload in memory and in the JSON output — the whole point of
+            // summary/maxItemsPerSymbol is to bound the aggregate size, so the bound has to
+            // happen upstream of JsonSerializer.Serialize.
+            var shaped = new List<object>(results.Count);
+            foreach (var r in results)
+            {
+                var fullCount = r.References.Count;
+                var cappedCount = Math.Min(fullCount, maxItemsPerSymbol);
+                var truncated = fullCount > cappedCount;
+
+                IReadOnlyList<LocationDto> shapedRefs;
+                if (summary || truncated)
+                {
+                    var buffer = new List<LocationDto>(cappedCount);
+                    for (var i = 0; i < cappedCount; i++)
+                    {
+                        var loc = r.References[i];
+                        buffer.Add(summary ? loc with { PreviewText = null } : loc);
+                    }
+                    shapedRefs = buffer;
+                }
+                else
+                {
+                    shapedRefs = r.References;
+                }
+
+                shaped.Add(new
+                {
+                    key = r.Key,
+                    resolvedSymbol = r.ResolvedSymbol,
+                    referenceCount = r.ReferenceCount,
+                    returnedCount = shapedRefs.Count,
+                    truncated,
+                    references = shapedRefs,
+                    error = r.Error,
+                });
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                count = shaped.Count,
+                summary,
+                maxItemsPerSymbol,
+                results = shaped,
+            }, JsonDefaults.Indented);
         }, ct);
     }
 

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -223,6 +223,129 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task FindReferencesBulk_Applies_Summary_And_PerSymbolLimit_Before_Envelope()
+    {
+        // find-references-bulk-summary-mode: before this change, find_references_bulk applied no
+        // per-symbol cap and always serialized preview text for every hit. Across a 2-symbol batch
+        // against high-fan-out targets, the aggregate envelope overflowed the MCP payload cap
+        // (observed 120 KB). Two expectations:
+        //   1) summary=true drops PreviewText from every returned reference.
+        //   2) maxItemsPerSymbol=N caps each symbol's reference list to N items BEFORE the outer
+        //      envelope is assembled. `truncated=true` + `referenceCount > returnedCount` signal
+        //      that the caller should follow up with find_references (paged) for full coverage.
+
+        var symbols = new[]
+        {
+            new BulkSymbolLocator(SymbolHandle: null, MetadataName: "SampleLib.IAnimal",
+                FilePath: null, Line: null, Column: null),
+            new BulkSymbolLocator(SymbolHandle: null, MetadataName: "SampleLib.Dog",
+                FilePath: null, Line: null, Column: null),
+        };
+
+        // Baseline: no summary, no cap — capture sizes so we can assert the bounded shape is
+        // strictly smaller AND the per-symbol cap actually trimmed at least one symbol.
+        var fullJson = await SymbolTools.FindReferencesBulk(
+            WorkspaceExecutionGate,
+            ReferenceService,
+            WorkspaceId,
+            symbols,
+            includeDefinition: false,
+            summary: false,
+            maxItemsPerSymbol: 100,
+            ct: CancellationToken.None);
+
+        using var fullDoc = JsonDocument.Parse(fullJson);
+        var fullResults = fullDoc.RootElement.GetProperty("results").EnumerateArray().ToList();
+        Assert.AreEqual(2, fullResults.Count);
+        foreach (var r in fullResults)
+        {
+            Assert.IsFalse(r.GetProperty("truncated").GetBoolean(),
+                "Baseline run with maxItemsPerSymbol=100 should not truncate SampleLib targets.");
+        }
+
+        // Bounded: summary=true strips preview text, maxItemsPerSymbol=1 trims each symbol to
+        // one reference. That floor (1 ref × 2 symbols) guarantees the envelope is smaller than
+        // the baseline for this sample workspace, which has multiple refs per symbol.
+        var boundedJson = await SymbolTools.FindReferencesBulk(
+            WorkspaceExecutionGate,
+            ReferenceService,
+            WorkspaceId,
+            symbols,
+            includeDefinition: false,
+            summary: true,
+            maxItemsPerSymbol: 1,
+            ct: CancellationToken.None);
+
+        using var boundedDoc = JsonDocument.Parse(boundedJson);
+        Assert.AreEqual(2, boundedDoc.RootElement.GetProperty("count").GetInt32());
+        Assert.IsTrue(boundedDoc.RootElement.GetProperty("summary").GetBoolean());
+        Assert.AreEqual(1, boundedDoc.RootElement.GetProperty("maxItemsPerSymbol").GetInt32());
+
+        var boundedResults = boundedDoc.RootElement.GetProperty("results").EnumerateArray().ToList();
+        Assert.AreEqual(2, boundedResults.Count);
+
+        var anyTruncated = false;
+        foreach (var r in boundedResults)
+        {
+            // referenceCount is the pre-cap total; returnedCount is what we actually included.
+            var totalRefs = r.GetProperty("referenceCount").GetInt32();
+            var returned = r.GetProperty("returnedCount").GetInt32();
+            Assert.IsTrue(returned <= 1,
+                $"maxItemsPerSymbol=1 must cap returned list (saw {returned}).");
+
+            var refs = r.GetProperty("references").EnumerateArray().ToList();
+            Assert.AreEqual(returned, refs.Count,
+                "references array length must match returnedCount.");
+
+            // Every included ref must have PreviewText omitted under summary=true. JSON serializer
+            // emits null fields explicitly — either the property is absent or its value is null.
+            foreach (var refEl in refs)
+            {
+                if (refEl.TryGetProperty("previewText", out var previewEl))
+                {
+                    Assert.AreEqual(JsonValueKind.Null, previewEl.ValueKind,
+                        "summary=true must null out previewText on every returned reference.");
+                }
+            }
+
+            var truncated = r.GetProperty("truncated").GetBoolean();
+            if (truncated)
+            {
+                anyTruncated = true;
+                Assert.IsTrue(totalRefs > returned,
+                    "truncated=true must imply referenceCount > returnedCount.");
+            }
+        }
+
+        Assert.IsTrue(anyTruncated,
+            "With maxItemsPerSymbol=1 against 2 high-fan-out SampleLib targets, at least one result must report truncated=true.");
+
+        // Aggregate payload size must strictly shrink — this is the whole point of the knob.
+        Assert.IsTrue(boundedJson.Length < fullJson.Length,
+            $"Bounded envelope ({boundedJson.Length} bytes) must be smaller than baseline ({fullJson.Length} bytes) when summary+cap are applied.");
+    }
+
+    [TestMethod]
+    public async Task FindReferencesBulk_InvalidMaxItemsPerSymbol_Throws()
+    {
+        var symbols = new[]
+        {
+            new BulkSymbolLocator(SymbolHandle: null, MetadataName: "SampleLib.IAnimal",
+                FilePath: null, Line: null, Column: null),
+        };
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() => SymbolTools.FindReferencesBulk(
+            WorkspaceExecutionGate,
+            ReferenceService,
+            WorkspaceId,
+            symbols,
+            includeDefinition: false,
+            summary: false,
+            maxItemsPerSymbol: 0,
+            ct: CancellationToken.None));
+    }
+
+    [TestMethod]
     public async Task Relationship_And_Cohesion_Tools_Expose_New_Limit_And_Interface_Flags()
     {
         var iAnimalPath = FindDocumentPath("IAnimal.cs");


### PR DESCRIPTION
## Summary

- Adds `summary` (drop per-ref preview text) and `maxItemsPerSymbol` (per-symbol reference cap) to the `find_references_bulk` MCP tool wrapper, mirroring the existing `find_references(summary=true)` contract.
- Per-symbol shaping runs BEFORE the outer envelope is assembled so the cap actually bounds aggregate output — a post-hoc trim of an already-serialized envelope would defeat the purpose.
- Each result now surfaces `referenceCount` (full pre-cap total), `returnedCount` (kept after cap), and `truncated` (bool) so callers can follow up with paginated `find_references` for the tail.
- Tool-surface-only — `IReferenceService.FindReferencesBulkAsync` is unchanged, so no downstream consumer updates are required.

## Background

Before this change, `find_references_bulk` applied no per-symbol cap and always serialized preview text for every hit. The inner `limit` concept on `find_references` did not exist on the bulk path, so a 2-symbol batch against high-fan-out targets overflowed the MCP 120 KB payload cap. Backlog row: `find-references-bulk-summary-mode` (P3-UX).

## Test plan

- [x] `dotnet build` — Host.Stdio + Tests (0 warnings, 0 errors)
- [x] New test `FindReferencesBulk_Applies_Summary_And_PerSymbolLimit_Before_Envelope` — asserts (a) `summary=true` nulls previewText on every returned ref, (b) `maxItemsPerSymbol=1` caps each symbol's reference list, (c) `truncated=true` implies `referenceCount > returnedCount`, (d) bounded envelope byte-size strictly smaller than baseline.
- [x] New test `FindReferencesBulk_InvalidMaxItemsPerSymbol_Throws` — argument validation on `maxItemsPerSymbol < 1`.
- [x] `verify-ai-docs.ps1` — passed.
- [x] 49 SymbolTools-surface tests pass (`ExpandedSurfaceIntegrationTests`, `P4BehavioralBundleTests`, `SymbolMapperTests`, `MetadataNameLocatorTests`, `ErrorResponseObservabilityTests`, `Top10V3RegressionTests`).
- [x] Note: the full `RoslynMcp.Tests` suite has 23 pre-existing baseline failures on `main` (extract-method selection-span, extract-interface fixture paths, DI lifetime overrides, change-signature preview, namespace-relocation). Confirmed by reproducing `DiLifetimeOverrideTests.ShowLifetimeOverrides_Off_Default_Result_Matches_Legacy_Shape` on clean `main` without my changes. None of these touch `SymbolTools`.

Closes: find-references-bulk-summary-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)