### PR TITLE
fix(diagnostic_details): accept startLine/startColumn aliases

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -135,7 +135,10 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "diagnostic_details", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get detailed information and curated fix options for a specific diagnostic occurrence")]
+    [McpServerTool(Name = "diagnostic_details", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
+        "Get detailed information and curated fix options for a specific diagnostic occurrence. " +
+        "Position parameters accept either `line`/`column` or the `startLine`/`startColumn` naming used by other positional tools " +
+        "(find_references, goto_definition, get_code_actions, …); supply exactly one pair.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Inspect one diagnostic occurrence in detail.")]
     public static Task<string> GetDiagnosticDetails(
@@ -145,14 +148,22 @@ public static class AnalysisTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Diagnostic identifier, e.g. CS8019")] string diagnosticId,
         [Description("Absolute path to the source file")] string filePath,
-        [Description("1-based line number")] int line,
-        [Description("1-based column number")] int column,
+        [Description("1-based line number (alias: startLine). Supply exactly one of line/startLine.")] int? line = null,
+        [Description("1-based column number (alias: startColumn). Supply exactly one of column/startColumn.")] int? column = null,
+        [Description("Alias for line, matching the positional-tool convention used by find_references, goto_definition, etc.")] int? startLine = null,
+        [Description("Alias for column, matching the positional-tool convention used by find_references, goto_definition, etc.")] int? startColumn = null,
         CancellationToken ct = default)
     {
+        // Normalize line/column vs startLine/startColumn aliases. Reject ambiguous
+        // (both supplied with different values) and missing-both cases so callers see
+        // a clear parameter error instead of a confusing "diagnostic not found" envelope.
+        var resolvedLine = ResolvePositionAlias(line, startLine, "line", "startLine");
+        var resolvedColumn = ResolvePositionAlias(column, startColumn, "column", "startColumn");
+
         return gate.RunReadAsync(workspaceId, async c =>
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
-            var result = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, line, column, c);
+            var result = await diagnosticService.GetDiagnosticDetailsAsync(workspaceId, diagnosticId, filePath, resolvedLine, resolvedColumn, c);
             if (result is null)
             {
                 // FLAG-1C: surface a structured "not found" envelope instead of raw JSON null,
@@ -162,9 +173,9 @@ public static class AnalysisTools
                     found = false,
                     diagnosticId,
                     filePath,
-                    line,
-                    column,
-                    message = $"No diagnostic with id '{diagnosticId}' was found at {filePath}:{line}:{column}. " +
+                    line = resolvedLine,
+                    column = resolvedColumn,
+                    message = $"No diagnostic with id '{diagnosticId}' was found at {filePath}:{resolvedLine}:{resolvedColumn}. " +
                               "Run project_diagnostics first and copy an exact (id, line, column) tuple from a real entry; " +
                               "diagnostic positions must match the analyzer-reported location, not just the surrounding line.",
                 };
@@ -172,6 +183,30 @@ public static class AnalysisTools
             }
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
+    }
+
+    /// <summary>
+    /// Resolves a positional parameter that accepts two alias names (e.g. <c>line</c> and <c>startLine</c>).
+    /// Exactly one of the two must be supplied; supplying both with conflicting values or supplying
+    /// neither is a parameter error.
+    /// </summary>
+    private static int ResolvePositionAlias(int? primary, int? alias, string primaryName, string aliasName)
+    {
+        if (primary.HasValue && alias.HasValue)
+        {
+            if (primary.Value != alias.Value)
+            {
+                throw new ArgumentException(
+                    $"Conflicting values for '{primaryName}' ({primary.Value}) and its alias '{aliasName}' ({alias.Value}). Supply only one.",
+                    primaryName);
+            }
+            return primary.Value;
+        }
+        if (primary.HasValue) return primary.Value;
+        if (alias.HasValue) return alias.Value;
+        throw new ArgumentException(
+            $"Missing required parameter '{primaryName}' (or its alias '{aliasName}').",
+            primaryName);
     }
 
     [McpServerTool(Name = "type_hierarchy", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get the type hierarchy (base types, derived types, implemented interfaces) for a type at the given position")]

--- a/tests/RoslynMcp.Tests/AnalysisToolsTests.cs
+++ b/tests/RoslynMcp.Tests/AnalysisToolsTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the <c>AnalysisTools</c> MCP tool surface. Focus is tool-wrapper behavior
+/// (parameter shape, aliasing, error envelopes) — service-level semantics are
+/// exercised by <see cref="DiagnosticFixIntegrationTests"/>.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class AnalysisToolsTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    private static string FindDocumentPath(string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        return solution.Projects
+            .SelectMany(project => project.Documents)
+            .First(document => document.Name == name).FilePath!;
+    }
+
+    [TestMethod]
+    public async Task DiagnosticDetails_Accepts_LineColumn_And_StartLineStartColumn_Identically()
+    {
+        // diagnostic-details-param-naming-drift: `diagnostic_details` historically required
+        // `line`/`column` while every other positional tool uses `startLine`/`startColumn`.
+        // The tool should now accept either naming convention with identical results.
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        var legacyJson = await AnalysisTools.GetDiagnosticDetails(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            diagnosticService: DiagnosticService,
+            workspaceId: WorkspaceId,
+            diagnosticId: "CS8019",
+            filePath: animalServicePath,
+            line: 1,
+            column: 1,
+            startLine: null,
+            startColumn: null,
+            ct: CancellationToken.None);
+
+        var aliasJson = await AnalysisTools.GetDiagnosticDetails(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            diagnosticService: DiagnosticService,
+            workspaceId: WorkspaceId,
+            diagnosticId: "CS8019",
+            filePath: animalServicePath,
+            line: null,
+            column: null,
+            startLine: 1,
+            startColumn: 1,
+            ct: CancellationToken.None);
+
+        Assert.AreEqual(legacyJson, aliasJson,
+            "diagnostic_details must produce identical output for line/column vs startLine/startColumn.");
+
+        using var doc = JsonDocument.Parse(legacyJson);
+        // Confirms the call actually resolved a diagnostic (not a not-found envelope).
+        Assert.IsTrue(doc.RootElement.TryGetProperty("diagnostic", out _),
+            $"Expected a resolved diagnostic, got: {legacyJson}");
+    }
+
+    [TestMethod]
+    public async Task DiagnosticDetails_Accepts_Matching_Values_From_Both_Alias_Names()
+    {
+        // When both alias forms are supplied with matching values, treat as a single position
+        // rather than a conflict — callers that are unsure which name the tool accepts may
+        // redundantly send both.
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        var bothJson = await AnalysisTools.GetDiagnosticDetails(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            diagnosticService: DiagnosticService,
+            workspaceId: WorkspaceId,
+            diagnosticId: "CS8019",
+            filePath: animalServicePath,
+            line: 1,
+            column: 1,
+            startLine: 1,
+            startColumn: 1,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(bothJson);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("diagnostic", out _),
+            $"Expected a resolved diagnostic, got: {bothJson}");
+    }
+
+    [TestMethod]
+    public async Task DiagnosticDetails_Rejects_Missing_Position()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        {
+            await AnalysisTools.GetDiagnosticDetails(
+                server: null!,
+                gate: WorkspaceExecutionGate,
+                diagnosticService: DiagnosticService,
+                workspaceId: WorkspaceId,
+                diagnosticId: "CS8019",
+                filePath: animalServicePath,
+                line: null,
+                column: null,
+                startLine: null,
+                startColumn: null,
+                ct: CancellationToken.None);
+        });
+    }
+
+    [TestMethod]
+    public async Task DiagnosticDetails_Rejects_Conflicting_Alias_Values()
+    {
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        {
+            await AnalysisTools.GetDiagnosticDetails(
+                server: null!,
+                gate: WorkspaceExecutionGate,
+                diagnosticService: DiagnosticService,
+                workspaceId: WorkspaceId,
+                diagnosticId: "CS8019",
+                filePath: animalServicePath,
+                line: 1,
+                column: 1,
+                startLine: 5,
+                startColumn: 1,
+                ct: CancellationToken.None);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- `diagnostic_details` previously required `line`/`column` while every other positional tool (`find_references`, `goto_definition`, `get_code_actions`, …) uses `startLine`/`startColumn`, forcing multi-step flows to branch on per-tool schema differences.
- Accept either naming convention on input: `line`/`column` is now optional, `startLine`/`startColumn` are optional aliases, and the handler normalizes them via `ResolvePositionAlias`. Conflicting values or both-missing cases raise a clear `ArgumentException` rather than returning a "diagnostic not found" envelope.
- Tool description updated to document both aliases.

Closes: diagnostic-details-param-naming-drift

## Test plan

- [x] `dotnet build src/RoslynMcp.Host.Stdio` — 0 warnings, 0 errors
- [x] New `AnalysisToolsTests` class: 4 tests cover identical output for both shapes, redundant match, missing-position rejection, conflict rejection — all pass
- [x] Full test suite: `dotnet test` — 850/850 passing
- [x] `eng/verify-release.ps1 -Configuration Release` — passes after flake retry (two unrelated ordering-dependent tests flaked on first full run, passed standalone and on suite rerun)
- [x] `eng/verify-ai-docs.ps1` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)