### PR TITLE
fix(type-move): emit structured type-kind error for unsupported kinds (move-type-to-file-preview-enum-support)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
@@ -34,8 +34,44 @@ public sealed class TypeMoveService : ITypeMoveService
             ?? throw new InvalidOperationException("Source document must be a C# compilation unit.");
 
         var typeDecl = sourceRoot.DescendantNodes().OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => string.Equals(t.Identifier.Text, typeName, StringComparison.Ordinal))
-            ?? throw new InvalidOperationException($"Type '{typeName}' not found in {sourceFilePath}.");
+            .FirstOrDefault(t => string.Equals(t.Identifier.Text, typeName, StringComparison.Ordinal));
+
+        if (typeDecl is null)
+        {
+            // Distinguish "symbol found but unsupported kind" from "symbol not found".
+            // EnumDeclarationSyntax derives from BaseTypeDeclarationSyntax (not TypeDeclarationSyntax);
+            // DelegateDeclarationSyntax is a MemberDeclarationSyntax. Both are addressable by name from
+            // symbol_search, so callers reasonably expect the move tool to handle them — surface a
+            // structured error that names the resolved kind instead of the misleading "not found" text.
+            var unsupportedKind = sourceRoot.DescendantNodes()
+                .OfType<BaseTypeDeclarationSyntax>()
+                .FirstOrDefault(t => string.Equals(t.Identifier.Text, typeName, StringComparison.Ordinal))
+                ?.Kind();
+
+            if (unsupportedKind is null)
+            {
+                var unsupportedDelegate = sourceRoot.DescendantNodes()
+                    .OfType<DelegateDeclarationSyntax>()
+                    .FirstOrDefault(d => string.Equals(d.Identifier.Text, typeName, StringComparison.Ordinal));
+                if (unsupportedDelegate is not null)
+                    unsupportedKind = SyntaxKind.DelegateDeclaration;
+            }
+
+            if (unsupportedKind is not null)
+            {
+                var typeKindName = unsupportedKind switch
+                {
+                    SyntaxKind.EnumDeclaration => "Enum",
+                    SyntaxKind.DelegateDeclaration => "Delegate",
+                    _ => unsupportedKind.ToString()!,
+                };
+                throw new InvalidOperationException(
+                    $"type-kind {typeKindName} not supported for this refactor. " +
+                    $"move_type_to_file_preview currently supports class, struct, record, and interface declarations only.");
+            }
+
+            throw new InvalidOperationException($"Type '{typeName}' not found in {sourceFilePath}.");
+        }
 
         // Validate source file has more than one type (otherwise move is pointless)
         var typeCount = sourceRoot.DescendantNodes().OfType<TypeDeclarationSyntax>()

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -62,6 +62,57 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task MoveType_EnumDeclaration_ThrowsStructuredTypeKindError()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        // Append an enum so Cat.cs becomes a multi-type file (a sibling class is required by
+        // the single-type guard) but the *target* of the move is the enum.
+        var catFile = workspace.GetPath("SampleLib", "Cat.cs");
+        File.AppendAllText(catFile, "\npublic enum IngestionTerminalStatus\n{\n    Pending,\n    Completed,\n    Failed,\n}\n");
+
+        var wsId = await workspace.LoadAsync(CancellationToken.None);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            TypeMoveService.PreviewMoveTypeToFileAsync(
+                wsId, doc.FilePath!, "IngestionTerminalStatus", null, CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "type-kind Enum not supported",
+            $"Expected structured type-kind error citing Enum; got: {ex.Message}");
+        // Must NOT degrade into the misleading "not found" wording.
+        Assert.IsFalse(ex.Message.Contains("not found", StringComparison.Ordinal),
+            $"Enum should be reported as unsupported kind, not 'not found': {ex.Message}");
+    }
+
+    [TestMethod]
+    public async Task MoveType_DelegateDeclaration_ThrowsStructuredTypeKindError()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var catFile = workspace.GetPath("SampleLib", "Cat.cs");
+        File.AppendAllText(catFile, "\npublic delegate void NotificationHandler(string message);\n");
+
+        var wsId = await workspace.LoadAsync(CancellationToken.None);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            TypeMoveService.PreviewMoveTypeToFileAsync(
+                wsId, doc.FilePath!, "NotificationHandler", null, CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "type-kind Delegate not supported",
+            $"Expected structured type-kind error citing Delegate; got: {ex.Message}");
+        Assert.IsFalse(ex.Message.Contains("not found", StringComparison.Ordinal),
+            $"Delegate should be reported as unsupported kind, not 'not found': {ex.Message}");
+    }
+
+    [TestMethod]
     public async Task MoveType_NewFile_HasNoLeadingBlankLine()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();


### PR DESCRIPTION
## Summary

- `move_type_to_file_preview` previously returned a misleading `Type 'X' not found` error for enums and delegates, because the resolver only iterated `TypeDeclarationSyntax` (which excludes `EnumDeclarationSyntax` and `DelegateDeclarationSyntax`). Callers who had just resolved the symbol via `symbol_search` reasonably expected the move tool to either move it or reject it with a kind-specific error.
- The resolver now distinguishes "symbol not found" from "symbol found but unsupported kind". When the type-declaration lookup misses, it falls back to `BaseTypeDeclarationSyntax` (catches enums) and `DelegateDeclarationSyntax`. On a hit, it throws `type-kind <Kind> not supported for this refactor` naming the resolved kind (`Enum` / `Delegate`) and the supported kinds (class, struct, record, interface). The "not found" message is only returned when nothing of any kind matches.
- Implementing actual enum / delegate support is deferred to a separate initiative (scope kept tight to the error-shape fix).

## Scope

- `src/RoslynMcp.Roslyn/Services/TypeMoveService.cs` — resolver fallback + structured error
- `tests/RoslynMcp.Tests/TypeMoveTests.cs` — new enum + delegate regression tests

`TypeMoveTools.cs` (the Host.Stdio tool wrapper) is a pure delegating shim; exceptions propagate untouched, so no change was needed there. The error message reaches MCP clients verbatim via `ToolDispatch.ReadByWorkspaceIdAsync`.

## Test plan

- [x] New `MoveType_EnumDeclaration_ThrowsStructuredTypeKindError` — appends `public enum IngestionTerminalStatus { ... }` to `Cat.cs` and asserts the error contains `type-kind Enum not supported` and does NOT contain `not found`.
- [x] New `MoveType_DelegateDeclaration_ThrowsStructuredTypeKindError` — appends a `public delegate void NotificationHandler(string)` and asserts `type-kind Delegate not supported`.
- [x] Existing `MoveType_NonExistentType_ThrowsInvalidOperation` continues to validate the "not found" path for truly-missing identifiers.
- [x] Existing `MoveType_FromMultiTypeFile_CreatesPreview` continues to validate the class success path.
- [x] Targeted test run (Debug + Release): all 7 TypeMoveTests pass.

Closes: move-type-to-file-preview-enum-support

## Validation caveats

The full-suite `./eng/verify-release.ps1` shows 44 pre-existing failures in unrelated subsystems (`CouplingAnalysisTests`, `ExpandedSurfaceIntegrationTests`, `PreviewMultiFileEditSyntaxRegressionTests`) with errors like "Document not found: Dog.cs" and "line 2 but the file only has 1 line". These reproduce against a stashed working tree (clean origin/main) when run in parallel, but the same tests pass individually — classic test-isolation flakiness in temp-dir management. Our targeted Release-mode run of `TypeMoveTests` + `MoveTypeDiskStateTests` passes all 8 tests. `verify-ai-docs.ps1` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)