### PR TITLE
fix(change-signature): default op=add to end-append instead of internal-index error (change-signature-preview-add-unhelpful-error)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
@@ -85,10 +85,22 @@ public sealed class ChangeSignatureService : IChangeSignatureService
         if (string.IsNullOrWhiteSpace(request.ParameterType))
             throw new ArgumentException("op='add' requires ParameterType.", nameof(request));
 
+        // change-signature-preview-add-unhelpful-error:
+        // When the caller does not supply Position, default to end-append (the intent is
+        // unambiguous — "add a new parameter named X of type Y" means "append it"). When
+        // the caller supplies a Position that exceeds Parameters.Length, raise an
+        // actionable error citing the user-facing fields (Name + ParameterType + the
+        // valid Position range) instead of bubbling an internal ArgumentOutOfRangeException
+        // with paramName='index'. Pre-fix this surfaced as
+        // "Parameter 'index' has an out-of-range value" and forced agents to guess.
         var insertPosition = request.Position ?? method.Parameters.Length;
         if (insertPosition < 0 || insertPosition > method.Parameters.Length)
             throw new ArgumentException(
-                $"Position {insertPosition} is out of range (0..{method.Parameters.Length}).", nameof(request));
+                $"op='add' Position={insertPosition} is out of range for adding parameter " +
+                $"'{request.Name}: {request.ParameterType}' to {method.ToDisplayString()} " +
+                $"(method has {method.Parameters.Length} existing parameter(s); " +
+                $"valid Position is 0..{method.Parameters.Length}, or omit Position to append at end).",
+                nameof(request));
 
         // change-signature-preview-brace-concat-on-add-op:
         // Build the new parameter via SyntaxFactory.ParseParameter — the parser produces a
@@ -116,8 +128,18 @@ public sealed class ChangeSignatureService : IChangeSignatureService
             {
                 if (isPositional)
                 {
+                    // change-signature-preview-add-unhelpful-error:
+                    // Existing callsites may pass fewer arguments than the method declares
+                    // (default-valued parameters are common, e.g. CancellationToken at the
+                    // end). args.Insert(insertPosition, ...) where insertPosition > args.Count
+                    // throws ArgumentOutOfRangeException with paramName='index' — that's the
+                    // unhelpful internal error the row reports. Clamp to args.Count so the
+                    // splice always lands at a valid index; semantically the new arg still
+                    // appends at the end of THIS callsite, which matches the declaration's
+                    // append-at-end behavior.
+                    var clampedInsert = Math.Min(insertPosition, args.Count);
                     var newArg = SyntaxFactory.Argument(SyntaxFactory.ParseExpression(argText));
-                    return args.Insert(insertPosition, newArg.WithLeadingTrivia(insertPosition == 0 ? default : SyntaxFactory.Space));
+                    return args.Insert(clampedInsert, newArg.WithLeadingTrivia(clampedInsert == 0 ? default : SyntaxFactory.Space));
                 }
                 // Caller uses named args — splice by name so we don't break existing positions.
                 var named = SyntaxFactory.Argument(

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
@@ -424,6 +424,294 @@ public sealed class ChangeSignaturePreviewTests : TestBase
         }
     }
 
+    /// <summary>
+    /// change-signature-preview-add-unhelpful-error: pre-fix
+    /// `change_signature_preview(op=add, name=cancellationToken, parameterType=CancellationToken)`
+    /// against a method whose existing callsites pass fewer args than declared (the typical
+    /// "default-valued trailing param" shape that motivates adding a CancellationToken in
+    /// the first place) failed with `"Parameter 'index' has an out-of-range value"` — an
+    /// internal `ArgumentOutOfRangeException` from
+    /// `SeparatedSyntaxList&lt;ArgumentSyntax&gt;.Insert(insertPosition, ...)` where
+    /// `insertPosition` (= method.Parameters.Length) exceeded `args.Count`. The user reached
+    /// a hard stop and could not see the preview at all. Post-fix the callsite splice
+    /// clamps to `args.Count`, so the preview succeeds and the declaration is rewritten
+    /// with the new parameter appended at the end (end-append default).
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_AddOp_CancellationToken_SucceedsWithEndAppend_WhenCallsiteOmitsDefaultArg()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        // Method already has a default-valued parameter that the caller omits — this is the
+        // shape that previously broke. method has 2 params (the second has a default value);
+        // callsite passes only 1 arg. Adding `CancellationToken ct = default` at end makes
+        // insertPosition=2 but args.Count=1 → pre-fix throws.
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureCtAppendFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "using System.Threading;",
+            "",
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureCtAppendFixture",
+            "{",
+            "    public int Compute(int a, int b = 0)",
+            "    {",
+            "        return a + b;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(1);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            // Caret on `Compute` (line 7, column 16). Add CancellationToken at end (no Position
+            // specified — defaults to method.Parameters.Length=2).
+            var locator = SymbolLocator.BySource(fixturePath, line: 7, column: 16);
+            var request = new ChangeSignatureRequest(
+                Op: "add",
+                Name: "cancellationToken",
+                ParameterType: "System.Threading.CancellationToken",
+                Position: null, // explicit end-append default
+                NewName: null,
+                DefaultValue: "default");
+
+            // Pre-fix this throws ArgumentOutOfRangeException with paramName='index'.
+            // Post-fix the preview succeeds and the declaration is rewritten.
+            var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspaceId, locator, request, CancellationToken.None);
+            Assert.IsNotNull(preview.PreviewToken);
+            Assert.IsTrue(preview.Changes.Count >= 1, "preview must report at least the declaration file");
+
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+            StringAssert.Contains(postApplyText, "int a, int b = 0, System.Threading.CancellationToken cancellationToken = default",
+                $"new parameter must append at end of declaration; got:\n{postApplyText}");
+            // Callsite Compute(1) remains valid post-rewrite because both `b` and the new
+            // CancellationToken parameter have defaults — the file still compiles. The
+            // backlog row's contract is "preview succeeds + declaration shows the change",
+            // not "every callsite is rewritten" (that's a separate concern tracked by
+            // change-signature-preview-callsite-summary).
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-preview-add-unhelpful-error: with an explicit Position equal to
+    /// method.Parameters.Length the behavior must match the omitted-Position default —
+    /// the preview must succeed without bubbling the internal `ArgumentOutOfRangeException`
+    /// from the callsite-arg splice. Guards against a regression where the explicit-position
+    /// branch loses the clamping and reverts to the unhelpful "index out of range" error.
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_AddOp_ExplicitEndPosition_Succeeds_WhenCallsiteOmitsDefaultArg()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureExplicitEndFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "using System.Threading;",
+            "",
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureExplicitEndFixture",
+            "{",
+            "    public int Compute(int a, int b = 0)",
+            "    {",
+            "        return a + b;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(1);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 7, column: 16);
+            var request = new ChangeSignatureRequest(
+                Op: "add",
+                Name: "cancellationToken",
+                ParameterType: "System.Threading.CancellationToken",
+                Position: 2, // explicit end-position
+                NewName: null,
+                DefaultValue: "default");
+
+            var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspaceId, locator, request, CancellationToken.None);
+            Assert.IsNotNull(preview.PreviewToken);
+
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+            StringAssert.Contains(postApplyText, "int a, int b = 0, System.Threading.CancellationToken cancellationToken = default",
+                $"explicit end-position must succeed same as omitted-Position; got:\n{postApplyText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-preview-add-unhelpful-error risk: ensure the end-append clamping
+    /// fix doesn't collide with positional inserts. With Position=0 (head insert) and a
+    /// callsite that already has the right arg count, the new parameter must splice in at
+    /// the front of the declaration. Math.Min(0, args.Count) is still 0, so positional
+    /// behavior is unchanged.
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_AddOp_HeadPosition_StillSplicesAtFrontOfDeclaration()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureHeadPosFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureHeadPosFixture",
+            "{",
+            "    public int Compute(int a)",
+            "    {",
+            "        return a;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(42);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+            var request = new ChangeSignatureRequest(
+                Op: "add",
+                Name: "prefix",
+                ParameterType: "string",
+                Position: 0, // head insert — Math.Min(0, args.Count) must remain 0
+                NewName: null,
+                DefaultValue: "\"\"");
+
+            var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspaceId, locator, request, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+            // Declaration: `string prefix = ""` then `int a`.
+            StringAssert.Contains(postApplyText, "string prefix = \"\", int a",
+                $"head insert must put new parameter first in declaration; got:\n{postApplyText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-preview-add-unhelpful-error: when the caller supplies an explicit
+    /// Position that genuinely exceeds method.Parameters.Length (i.e. user error, not a
+    /// callsite-omits-default case), the error must cite user-facing fields (Name +
+    /// ParameterType + the valid range) instead of bubbling an internal
+    /// ArgumentOutOfRangeException with paramName='index'.
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_AddOp_OutOfRangePosition_EmitsActionableError()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureOutOfRangeFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureOutOfRangeFixture",
+            "{",
+            "    public int Compute(int a, int b)",
+            "    {",
+            "        return a + b;",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+            var request = new ChangeSignatureRequest(
+                Op: "add",
+                Name: "cancellationToken",
+                ParameterType: "System.Threading.CancellationToken",
+                Position: 99, // genuinely out of range — method has 2 params, valid 0..2
+                NewName: null,
+                DefaultValue: "default");
+
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, request, CancellationToken.None));
+
+            // Error must cite Name, ParameterType, valid range, and the "omit Position" hint.
+            // Must NOT mention internal "index" identifier.
+            StringAssert.Contains(ex.Message, "cancellationToken",
+                $"error must cite caller-supplied Name; got: {ex.Message}");
+            StringAssert.Contains(ex.Message, "CancellationToken",
+                $"error must cite caller-supplied ParameterType; got: {ex.Message}");
+            StringAssert.Contains(ex.Message, "0..2",
+                $"error must cite the valid Position range; got: {ex.Message}");
+            StringAssert.Contains(ex.Message, "omit Position",
+                $"error must hint that omitting Position appends at end; got: {ex.Message}");
+            Assert.IsFalse(ex.Message.Contains("Parameter 'index'", StringComparison.Ordinal),
+                $"error must NOT leak the internal 'index' paramName; got: {ex.Message}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
     [TestMethod]
     public async Task ChangeSignaturePreview_RemoveOp_CaretOnParameter_ExplicitPositionOverridesAutoResolve()
     {


### PR DESCRIPTION
## Summary

`change_signature_preview(op=add, name=cancellationToken, parameterType=System.Threading.CancellationToken)` failed with `"Parameter 'index' has an out-of-range value"` whenever the target method had existing callsites that passed fewer args than declared — the typical shape that motivates adding a CancellationToken in the first place. The error referenced an internal `'index'` paramName (from `SeparatedSyntaxList<ArgumentSyntax>.Insert`) and the user reached a hard stop before the preview ever materialized.

- **Clamped callsite splice** in `ChangeSignatureService.PreviewAddParameterAsync`: the positional-callsite lambda now clamps `insertPosition` to `args.Count` so end-append against the declaration cleanly appends at the end of shorter callsites too. Callsites like `Compute(1)` remain valid post-rewrite because the new parameter has a default value (end-append intent is unambiguous).
- **Actionable error shape** for genuinely-out-of-range explicit `Position` values: `ArgumentException` now cites caller-supplied `Name` + `ParameterType` + valid `0..N` range + the "omit Position to append at end" hint, instead of bubbling an internal `ArgumentOutOfRangeException` with `paramName='index'`.

## Files changed

- `src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs` — clamp callsite-arg splice; rewrite out-of-range error message.
- `tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs` — 4 new regression tests.

## Test plan

- [x] `op=add, name=cancellationToken` with callsite-omits-default-arg → preview succeeds + declaration shows end-appended parameter.
- [x] Explicit `Position=method.Parameters.Length` → same end-append behavior as omitted-Position default.
- [x] Head insert (`Position=0`) still splices at front of declaration — `Math.Min(0, args.Count)` is 0, no positional-callsite collision.
- [x] Genuinely out-of-range `Position=99` → actionable error citing Name, ParameterType, valid range; no `'index'` paramName leakage.
- [x] All 10 `ChangeSignaturePreview*` tests pass (6 existing + 4 new).
- [x] Full `./eng/verify-release.ps1 -Configuration Release` passes (861/861).
- [x] `./eng/verify-ai-docs.ps1` passes.

Closes: change-signature-preview-add-unhelpful-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)