### PR TITLE
feat(test-discovery)!: wrap test_related in paged envelope to match test_related_files (test-related-response-envelope-parity)

### DIFF
--- a/src/RoslynMcp.Core/Models/RelatedTestsForFilesDto.cs
+++ b/src/RoslynMcp.Core/Models/RelatedTestsForFilesDto.cs
@@ -12,8 +12,36 @@ public sealed record RelatedTestCaseDto(
     IReadOnlyList<string> TriggeredByFiles);
 
 /// <summary>
-/// Represents the related tests and filter expression for a set of files.
+/// Pagination envelope shared by <see cref="RelatedTestsForFilesDto"/> and
+/// <see cref="RelatedTestsForSymbolDto"/>. <c>Total</c> is the count before <c>maxResults</c>
+/// truncation; <c>Returned</c> is the size of the <c>Tests</c> list; <c>HasMore</c> is
+/// <see langword="true"/> when <c>Total &gt; Returned</c>.
 /// </summary>
+public sealed record PaginationInfo(
+    int Total,
+    int Returned,
+    bool HasMore);
+
+/// <summary>
+/// Represents the related tests and filter expression for a set of changed files.
+/// </summary>
+/// <remarks>
+/// test-related-response-envelope-parity: <c>test_related</c> and <c>test_related_files</c>
+/// share this envelope shape (<c>tests</c>, <c>dotnetTestFilter</c>, <c>pagination</c>) so
+/// callers can route either response through the same downstream filter +
+/// <c>test_run --filter</c> pipeline.
+/// </remarks>
 public sealed record RelatedTestsForFilesDto(
     IReadOnlyList<RelatedTestCaseDto> Tests,
-    string DotnetTestFilter);
+    string DotnetTestFilter,
+    PaginationInfo Pagination);
+
+/// <summary>
+/// Represents the related tests and filter expression for a single symbol. Mirrors
+/// <see cref="RelatedTestsForFilesDto"/> envelope shape — <c>TriggeredByFiles</c> is empty
+/// for symbol-mode results because the trigger is the symbol itself, not a changed file.
+/// </summary>
+public sealed record RelatedTestsForSymbolDto(
+    IReadOnlyList<RelatedTestCaseDto> Tests,
+    string DotnetTestFilter,
+    PaginationInfo Pagination);

--- a/src/RoslynMcp.Core/Services/ITestDiscoveryService.cs
+++ b/src/RoslynMcp.Core/Services/ITestDiscoveryService.cs
@@ -9,6 +9,16 @@ namespace RoslynMcp.Core.Services;
 public interface ITestDiscoveryService
 {
     Task<TestDiscoveryDto> DiscoverTestsAsync(string workspaceId, CancellationToken ct);
-    Task<IReadOnlyList<TestCaseDto>> FindRelatedTestsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
-    Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct);
+
+    /// <summary>
+    /// Find tests related to <paramref name="locator"/>'s symbol. Returns the same envelope
+    /// shape as <see cref="FindRelatedTestsForFilesAsync"/> — <c>tests</c>,
+    /// <c>dotnetTestFilter</c>, <c>pagination</c> — so callers can route either response
+    /// through the same downstream <c>test_run --filter</c> pipeline.
+    /// </summary>
+    Task<RelatedTestsForSymbolDto> FindRelatedTestsAsync(
+        string workspaceId, SymbolLocator locator, int maxResults, CancellationToken ct);
+
+    Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(
+        string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -170,12 +170,13 @@ public static class ValidationTools
         [Description("Optional: 1-based column number")] int? column = null,
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
+        [Description("Maximum number of test cases to return (default: 100)")] int maxResults = 100,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
-            var result = await testDiscoveryService.FindRelatedTestsAsync(workspaceId, locator, c);
+            var result = await testDiscoveryService.FindRelatedTestsAsync(workspaceId, locator, maxResults, c);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -92,14 +92,56 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         return result;
     }
 
-    public async Task<IReadOnlyList<TestCaseDto>> FindRelatedTestsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    public async Task<RelatedTestsForSymbolDto> FindRelatedTestsAsync(
+        string workspaceId, SymbolLocator locator, int maxResults, CancellationToken ct)
     {
         var discovery = await DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
         var solution = _workspaceManager.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        return symbol is null
+
+        IReadOnlyList<TestCaseDto> rawMatches = symbol is null
             ? []
             : await CollectRelatedTestsAsync(discovery, solution, symbol, ct).ConfigureAwait(false);
+
+        // Project lookup so we can populate ProjectName on the envelope element type
+        // (RelatedTestCaseDto), matching test_related_files's shape.
+        var projectLookup = discovery.TestProjects
+            .SelectMany(p => p.Tests.Select(t => (t.FullyQualifiedName, p.ProjectName)))
+            .GroupBy(x => x.FullyQualifiedName, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First().ProjectName, StringComparer.Ordinal);
+
+        var enriched = rawMatches
+            .Select(t => new RelatedTestCaseDto(
+                DisplayName: t.DisplayName,
+                FullyQualifiedName: t.FullyQualifiedName,
+                ProjectName: projectLookup.TryGetValue(t.FullyQualifiedName, out var p) ? p : string.Empty,
+                FilePath: t.FilePath,
+                Line: t.Line,
+                // Symbol-mode has no source file trigger — the trigger is the symbol itself.
+                TriggeredByFiles: []))
+            .ToList();
+
+        var total = enriched.Count;
+        var page = enriched.Take(maxResults).ToList();
+        var dotnetFilter = SynthesizeDotnetTestFilter(page.Select(t => t.FullyQualifiedName));
+        return new RelatedTestsForSymbolDto(
+            page,
+            dotnetFilter,
+            new PaginationInfo(Total: total, Returned: page.Count, HasMore: total > page.Count));
+    }
+
+    /// <summary>
+    /// Build a <c>dotnet test --filter</c> expression from a sequence of fully-qualified test
+    /// names. Shared by <c>test_related</c> and <c>test_related_files</c> so the two tools
+    /// emit identically-shaped filter strings.
+    /// </summary>
+    internal static string SynthesizeDotnetTestFilter(IEnumerable<string> fullyQualifiedNames)
+    {
+        var filterParts = fullyQualifiedNames
+            .Distinct(StringComparer.Ordinal)
+            .Select(fqn => $"FullyQualifiedName~{fqn}")
+            .ToList();
+        return filterParts.Count > 0 ? string.Join("|", filterParts) : string.Empty;
     }
 
     private static HashSet<string> BuildRelatedTestSearchTerms(ISymbol symbol)
@@ -344,6 +386,7 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             .SelectMany(p => p.Tests)
             .ToDictionary(t => t.FullyQualifiedName, StringComparer.Ordinal);
 
+        var total = testToTriggers.Count;
         var results = testToTriggers
             .Take(maxResults)
             .Select(kv =>
@@ -360,14 +403,11 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             })
             .ToList();
 
-        var filterParts = results
-            .Select(t => t.FullyQualifiedName)
-            .Distinct()
-            .Select(fqn => $"FullyQualifiedName~{fqn}")
-            .ToList();
-        var dotnetFilter = filterParts.Count > 0 ? string.Join("|", filterParts) : string.Empty;
-
-        return new RelatedTestsForFilesDto(results, dotnetFilter);
+        var dotnetFilter = SynthesizeDotnetTestFilter(results.Select(t => t.FullyQualifiedName));
+        return new RelatedTestsForFilesDto(
+            results,
+            dotnetFilter,
+            new PaginationInfo(Total: total, Returned: results.Count, HasMore: total > results.Count));
     }
 
     private static readonly HashSet<string> TestAttributeNames = new(StringComparer.Ordinal)

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -114,7 +114,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
 
         // Stage 3: discover related tests for the changed files (no test execution yet).
         var related = changedFiles.Count == 0
-            ? new RelatedTestsForFilesDto([], string.Empty)
+            ? new RelatedTestsForFilesDto([], string.Empty, new PaginationInfo(0, 0, false))
             : await _testDiscovery
                 .FindRelatedTestsForFilesAsync(workspaceId, changedFiles, MaxRelatedTestsCap, ct)
                 .ConfigureAwait(false);

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -125,11 +125,12 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
         var result = await TestDiscoveryService.FindRelatedTestsAsync(
             WorkspaceId,
             RoslynMcp.Core.Models.SymbolLocator.ByMetadataName("SampleLib.IAnimal.Name"),
+            maxResults: 100,
             CancellationToken.None);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.Any(t => t.FilePath?.EndsWith("AnimalServiceTests.cs", StringComparison.OrdinalIgnoreCase) == true),
-            $"Expected AnimalServiceTests.cs to surface via interface-dispatch augmentation; got: {string.Join(", ", result.Select(t => t.FilePath))}");
+        Assert.IsTrue(result.Tests.Any(t => t.FilePath?.EndsWith("AnimalServiceTests.cs", StringComparison.OrdinalIgnoreCase) == true),
+            $"Expected AnimalServiceTests.cs to surface via interface-dispatch augmentation; got: {string.Join(", ", result.Tests.Select(t => t.FilePath))}");
     }
 
     [TestMethod]
@@ -138,9 +139,70 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
         var result = await TestDiscoveryService.FindRelatedTestsAsync(
             WorkspaceId,
             RoslynMcp.Core.Models.SymbolLocator.ByMetadataName("SampleLib.DoesNotExist"),
+            maxResults: 100,
             CancellationToken.None);
 
-        Assert.AreEqual(0, result.Count);
+        Assert.AreEqual(0, result.Tests.Count);
+        Assert.AreEqual(0, result.Pagination.Total);
+        Assert.AreEqual(0, result.Pagination.Returned);
+        Assert.IsFalse(result.Pagination.HasMore);
+        Assert.AreEqual(string.Empty, result.DotnetTestFilter);
+    }
+
+    // test-related-response-envelope-parity: test_related and test_related_files MUST emit
+    // identically-shaped envelopes — Tests / DotnetTestFilter / Pagination — so callers can
+    // route either response through the same downstream test_run --filter pipeline. This
+    // regression test asserts the JSON property surface matches.
+    [TestMethod]
+    public async Task TestRelated_EnvelopeMatchesTestRelatedFiles()
+    {
+        var symbolJson = await ValidationTools.FindRelatedTests(
+            WorkspaceExecutionGate,
+            TestDiscoveryService,
+            WorkspaceId,
+            filePath: null,
+            line: null,
+            column: null,
+            symbolHandle: null,
+            metadataName: "SampleLib.IAnimal.Name",
+            maxResults: 100,
+            ct: CancellationToken.None);
+
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+        var filesJson = await ValidationTools.FindRelatedTestsForFiles(
+            WorkspaceExecutionGate,
+            TestDiscoveryService,
+            WorkspaceId,
+            new[] { animalServicePath },
+            maxResults: 100,
+            CancellationToken.None);
+
+        using var symbolDoc = JsonDocument.Parse(symbolJson);
+        using var filesDoc = JsonDocument.Parse(filesJson);
+
+        var symbolProps = symbolDoc.RootElement.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        var filesProps = filesDoc.RootElement.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        CollectionAssert.AreEqual(symbolProps, filesProps,
+            $"Envelope property surface differs. test_related: [{string.Join(",", symbolProps)}], test_related_files: [{string.Join(",", filesProps)}]");
+
+        // Pagination sub-shape parity.
+        var symbolPagination = symbolDoc.RootElement.GetProperty("pagination");
+        var filesPagination = filesDoc.RootElement.GetProperty("pagination");
+        var symbolPagProps = symbolPagination.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        var filesPagProps = filesPagination.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+        CollectionAssert.AreEqual(symbolPagProps, filesPagProps,
+            $"Pagination property surface differs. test_related: [{string.Join(",", symbolPagProps)}], test_related_files: [{string.Join(",", filesPagProps)}]");
+
+        // First test (if present) should expose the same property surface in both envelopes.
+        var symbolTests = symbolDoc.RootElement.GetProperty("tests");
+        var filesTests = filesDoc.RootElement.GetProperty("tests");
+        if (symbolTests.GetArrayLength() > 0 && filesTests.GetArrayLength() > 0)
+        {
+            var symbolTestProps = symbolTests[0].EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+            var filesTestProps = filesTests[0].EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+            CollectionAssert.AreEqual(symbolTestProps, filesTestProps,
+                $"Test element property surface differs. test_related: [{string.Join(",", symbolTestProps)}], test_related_files: [{string.Join(",", filesTestProps)}]");
+        }
     }
 
     private static string FindDocumentPath(string name)


### PR DESCRIPTION
## Summary

BREAKING: Wraps `test_related` in the same `{tests, dotnetTestFilter, pagination}` envelope shape as `test_related_files` so callers can route either response through the same downstream `test_run --filter` pipeline.

- Introduces `PaginationInfo {total, returned, hasMore}` shared by both DTOs.
- Adds `RelatedTestsForSymbolDto` for the symbol-mode tool; promotes the inner element type to `RelatedTestCaseDto` (populates `ProjectName` from discovery, emits empty `TriggeredByFiles` since the symbol is the trigger).
- Adds `PaginationInfo` to the existing `RelatedTestsForFilesDto`.
- Extracts `SynthesizeDotnetTestFilter` helper shared by both tools (plan's "reuse filter-synthesis helper").
- Adds `maxResults` (default `100`) to the `test_related` tool surface + `FindRelatedTestsAsync` signature, matching `test_related_files`.
- Regression test `TestRelated_EnvelopeMatchesTestRelatedFiles` asserts JSON property-surface parity (top-level envelope, `pagination` sub-shape, and first-test element shape).

No backward-compat shims — per session policy, breaking changes in internal services are acceptable. The `WorkspaceValidationService` empty-path constructor site and three `ValidationToolsIntegrationTests` call-sites were updated to the new shape in the same commit.

## Test plan

- [x] `RoslynMcp.slnx` builds clean (0 warnings / 0 errors).
- [x] `pwsh ./eng/verify-ai-docs.ps1` passes.
- [x] `pwsh ./eng/verify-release.ps1 -Configuration Release` passes end-to-end (858 tests passed, Release config).
- [x] Targeted `dotnet test --filter FullyQualifiedName~TestRelated` passes all 4 tests incl. the new envelope-parity regression.
- [x] `dotnet test RoslynMcp.slnx --no-build` clean run: **859 passed / 0 failed** (Debug).

Closes: test-related-response-envelope-parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)