### PR TITLE
fix(editorconfig): match brace-expansion sections in on-disk key union (set-editorconfig-option-round-trip-asymmetry)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -91,7 +91,7 @@ public sealed class EditorConfigService : IEditorConfigService
     /// Parses the .editorconfig file on disk and yields key-value pairs from
     /// sections that apply to C# files (e.g., [*.cs], [*.{cs,csx,cake}], [*]).
     /// </summary>
-    private static IEnumerable<(string Key, string Value)> ParseEditorconfigCsKeys(string editorconfigPath)
+    internal static IEnumerable<(string Key, string Value)> ParseEditorconfigCsKeys(string editorconfigPath)
     {
         var inApplicableSection = false;
         foreach (var rawLine in File.ReadLines(editorconfigPath))
@@ -102,10 +102,7 @@ public sealed class EditorConfigService : IEditorConfigService
 
             if (line[0] == '[')
             {
-                // Check if the section header matches C# files
-                inApplicableSection = line.Contains("*", StringComparison.Ordinal) &&
-                    (line.Contains(".cs", StringComparison.OrdinalIgnoreCase) ||
-                     !line.Contains('.'));  // [*] applies to all files
+                inApplicableSection = SectionMatchesCSharp(line);
                 continue;
             }
 
@@ -119,6 +116,56 @@ public sealed class EditorConfigService : IEditorConfigService
             if (key.Length > 0 && value.Length > 0)
                 yield return (key, value);
         }
+    }
+
+    /// <summary>
+    /// Returns true if an .editorconfig section header applies to C# source files.
+    /// Recognizes common glob shapes: <c>[*]</c>, <c>[*.cs]</c>, <c>[*.{cs,csx,cake}]</c>,
+    /// <c>[**.cs]</c>, and brace-expansion lists that include <c>cs</c>.
+    /// </summary>
+    internal static bool SectionMatchesCSharp(string sectionHeader)
+    {
+        if (sectionHeader.Length < 2 || sectionHeader[0] != '[' || sectionHeader[^1] != ']')
+            return false;
+
+        var inner = sectionHeader[1..^1].Trim();
+        if (inner.Length == 0) return false;
+
+        // [*] applies to all files.
+        if (inner == "*" || inner == "**") return true;
+
+        // Extract extension portion after the last '.' that isn't inside braces.
+        // Handle brace expansion {cs,csx,cake} by checking each alternative.
+        if (inner.Contains('{', StringComparison.Ordinal) && inner.Contains('}', StringComparison.Ordinal))
+        {
+            var openBrace = inner.IndexOf('{', StringComparison.Ordinal);
+            var closeBrace = inner.IndexOf('}', openBrace);
+            if (closeBrace > openBrace)
+            {
+                var alternatives = inner[(openBrace + 1)..closeBrace]
+                    .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                foreach (var alt in alternatives)
+                {
+                    if (alt.Equals("cs", StringComparison.OrdinalIgnoreCase) ||
+                        alt.Equals("csx", StringComparison.OrdinalIgnoreCase) ||
+                        alt.Equals("cake", StringComparison.OrdinalIgnoreCase) ||
+                        alt.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Simple extension match: [*.cs], [**.cs], [**/*.cs].
+        if (inner.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ||
+            inner.EndsWith(".csx", StringComparison.OrdinalIgnoreCase) ||
+            inner.EndsWith(".cake", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> GetKnownOptionKeys()

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -1,0 +1,66 @@
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for <c>set-editorconfig-option-round-trip-asymmetry</c>:
+/// <see cref="IEditorConfigService.SetOptionAsync"/> writes to
+/// <c>[*.{cs,csx,cake}]</c> but the pre-fix section matcher in
+/// <see cref="IEditorConfigService.GetOptionsAsync"/>'s on-disk supplement
+/// did not recognize brace-expansion glob sections, so keys for unloaded
+/// analyzer ids (e.g. <c>CA9999</c>) were silently dropped on the following read.
+/// </summary>
+[TestClass]
+public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task SetThenGet_UnloadedAnalyzerId_IsReturned()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // CA9999 is not a real analyzer id; no loaded analyzer will report it via
+        // Roslyn's AnalyzerConfigOptionsProvider. The key must still come back from
+        // the on-disk union supplement.
+        const string unloadedKey = "dotnet_diagnostic.CA9999.severity";
+        const string value = "none";
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, unloadedKey, value, CancellationToken.None);
+        Assert.IsTrue(File.Exists(setResult.EditorConfigPath));
+
+        var options = await EditorConfigService.GetOptionsAsync(
+            workspaceId, dogFilePath, CancellationToken.None);
+
+        var entry = options.Options.FirstOrDefault(o =>
+            string.Equals(o.Key, unloadedKey, StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(entry,
+            $"Get must surface '{unloadedKey}' after Set writes it, even when no loaded analyzer reports the id. " +
+            $"Returned keys: {string.Join(", ", options.Options.Select(o => o.Key))}");
+        Assert.AreEqual(value, entry!.Value);
+    }
+
+    [TestMethod]
+    public void SectionMatchesCSharp_RecognizesCommonGlobs()
+    {
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[*]"));
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[*.cs]"));
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[*.{cs,csx,cake}]"));
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[*.{vb,cs}]"));
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[**.cs]"));
+        Assert.IsTrue(EditorConfigService.SectionMatchesCSharp("[*.csx]"));
+
+        Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("[*.vb]"));
+        Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("[*.{vb,fs}]"));
+        Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("[*.json]"));
+        Assert.IsFalse(EditorConfigService.SectionMatchesCSharp(""));
+        Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("not-a-section"));
+    }
+}


### PR DESCRIPTION
## Summary

- `set_editorconfig_option(CA9999.severity=none)` writes to the `[*.{cs,csx,cake}]` section, but the on-disk supplement in `GetOptionsAsync` used a substring heuristic (`line.Contains(".cs")`) that did not match that header — the chars after `*` are `.{cs`, which does not contain `.cs`. The new key was silently dropped on the immediately-following `get_editorconfig_options` call because no loaded analyzer reports unknown ids like `CA9999`.
- Replaced the substring heuristic with `SectionMatchesCSharp`, a proper section-header matcher that recognizes `[*]`, `[*.cs]`, `[*.csx]`, `[*.cake]`, `[**.cs]`, and brace-expansion lists whose alternatives include `cs`/`csx`/`cake` (or any alternative ending in `.cs`).
- Added `EditorConfigServiceTests` covering (1) set-then-get round-trip for an unloaded analyzer id and (2) unit coverage of the section-matcher against common and non-C# glob shapes.

Only consumer of `GetOptionsAsync` in the production tree is `EditorConfigTools` which passes the DTO through unfiltered, so widening the on-disk union has no downstream filtering concern.

## Test plan

- [x] `dotnet build src/RoslynMcp.Roslyn` — clean
- [x] `dotnet build tests/RoslynMcp.Tests` — clean
- [x] `dotnet test --filter FullyQualifiedName~EditorConfigServiceTests` — 2/2 pass (new)
- [x] `dotnet test --filter "FullyQualifiedName~EditorConfig|FullyQualifiedName~SetEditorConfigOption"` — 5/5 pass (new + existing EditUndoCohesion editorconfig tests)

Closes: set-editorconfig-option-round-trip-asymmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)