### PR TITLE
fix(unused-code): extend convention filter for MCP attrs, xUnit CollectionDefinition, HealthResponseWriter

### DIFF
--- a/samples/SampleSolution/SampleLib/ConventionFixtures.cs
+++ b/samples/SampleSolution/SampleLib/ConventionFixtures.cs
@@ -1,6 +1,7 @@
 // Test fixture for find_unused_symbols convention-awareness. Defines stub base types
 // inline so the sample project does not need NuGet dependencies on Microsoft.AspNetCore,
-// Microsoft.EntityFrameworkCore, FluentValidation, Microsoft.AspNetCore.SignalR.
+// Microsoft.EntityFrameworkCore, FluentValidation, Microsoft.AspNetCore.SignalR,
+// Microsoft.Extensions.Diagnostics.HealthChecks, ModelContextProtocol.Server, xunit.
 // Detection in UnusedCodeAnalyzer is name-shape based.
 namespace SampleLib.ConventionFixtures;
 
@@ -11,6 +12,29 @@ public abstract class PageModel { }
 public abstract class Migration { }
 public abstract class ModelSnapshot { }
 public sealed class HttpContext { }
+public sealed class HealthReport { }
+
+// Stub attributes — simple-name match is enough for detection.
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class McpServerToolTypeAttribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class McpServerPromptTypeAttribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class McpServerResourceTypeAttribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class CollectionDefinitionAttribute : Attribute
+{
+    public CollectionDefinitionAttribute(string name) { Name = name; }
+    public string Name { get; }
+}
+
+// Intentionally-similar attribute used to assert that name-shape matching does NOT
+// accidentally swallow unrelated attributes whose names merely contain the substrings.
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class NotMcpServerToolTypeAttribute : Attribute { }
 
 // Convention-shaped samples — these MUST NOT be reported as unused when
 // excludeConventionInvoked is true (the default).
@@ -38,9 +62,50 @@ public sealed class LoggingMiddleware
     public Task InvokeAsync(HttpContext context) => Task.CompletedTask;
 }
 
+// ASP.NET HealthCheck response-writer shape: bound to
+// HealthCheckOptions.ResponseWriter via delegate reference, so the declaring type
+// has no direct C# call site.
+public sealed class HealthResponseWriter
+{
+    public Task WriteAsync(HttpContext context, HealthReport report) => Task.CompletedTask;
+}
+
+// MCP server catalog types — discovered by reflection via the
+// ModelContextProtocol.Server host.
+[McpServerToolType]
+public sealed class SampleMcpToolCatalog
+{
+    public void Register() { }
+}
+
+[McpServerPromptType]
+public sealed class SampleMcpPromptCatalog
+{
+    public void Register() { }
+}
+
+[McpServerResourceType]
+public sealed class SampleMcpResourceCatalog
+{
+    public void Register() { }
+}
+
+// xUnit collection-definition holder — xUnit resolves this via attribute reflection.
+[CollectionDefinition("WebHost serial collection")]
+public sealed class WebHostSerialCollection
+{
+}
+
 // Control: this IS truly unused and SHOULD still be reported even with the convention
 // filter on. It does not match any convention shape.
 internal sealed class TrulyUnusedConcreteType
 {
     public void Unused() { }
+}
+
+// Negative control: the attribute is named similarly to the MCP family but is NOT
+// on the whitelist. The holder must surface as unused when convention filter is on.
+[NotMcpServerToolType]
+internal sealed class NotConventionInvokedHolder
+{
 }

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -287,15 +287,49 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
 
         // 3. ASP.NET middleware shape: public InvokeAsync(HttpContext) or Invoke(HttpContext).
         //    Match the parameter type by simple name only so we don't pull Microsoft.AspNetCore.Http.
+        //    ASP.NET HealthCheck response-writer shape: method taking (HttpContext, HealthReport).
+        //    HealthCheck writers are registered via Action<HttpContext, HealthReport> delegates
+        //    (`ResponseWriter = MyType.WriteAsync`), so direct C# call sites don't exist even
+        //    though the method is live.
         foreach (var member in type.GetMembers().OfType<IMethodSymbol>())
         {
             if (member.DeclaredAccessibility != Accessibility.Public) continue;
-            if (member.Name is not ("InvokeAsync" or "Invoke")) continue;
-            if (member.Parameters.Length < 1) continue;
-            if (member.Parameters[0].Type.Name == "HttpContext") return true;
+
+            if (member.Name is "InvokeAsync" or "Invoke"
+                && member.Parameters.Length >= 1
+                && member.Parameters[0].Type.Name == "HttpContext")
+                return true;
+
+            if (member.Parameters.Length == 2
+                && member.Parameters[0].Type.Name == "HttpContext"
+                && member.Parameters[1].Type.Name == "HealthReport")
+                return true;
         }
 
-        // 4. Reuse the existing test-fixture detection so xUnit/MSTest/NUnit fixture types are
+        // 4. Attribute-based convention markers applied to the type declaration itself.
+        //    Covered families:
+        //      - MCP server catalogs: [McpServerToolType] / [McpServerPromptType] / [McpServerResourceType].
+        //        The ModelContextProtocol host discovers these types via reflection; no C# call
+        //        site exists for the class declaration.
+        //      - xUnit [CollectionDefinition("name")] holder types. xUnit looks them up by attribute;
+        //        the class itself is never constructed by user code.
+        foreach (var attribute in type.GetAttributes())
+        {
+            var name = attribute.AttributeClass?.Name;
+            if (name is null) continue;
+
+            var normalized = name.EndsWith("Attribute", StringComparison.Ordinal)
+                ? name[..^"Attribute".Length]
+                : name;
+
+            if (normalized is "McpServerToolType"
+                or "McpServerPromptType"
+                or "McpServerResourceType"
+                or "CollectionDefinition")
+                return true;
+        }
+
+        // 5. Reuse the existing test-fixture detection so xUnit/MSTest/NUnit fixture types are
         //    uniformly excluded under the convention-invoked umbrella.
         return IsLikelyTestFixtureType(type);
     }

--- a/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
@@ -139,6 +139,21 @@ public sealed class DeadCodeIntegrationTests : SharedWorkspaceTestBase
             "EF *ModelSnapshot must be excluded under default excludeConventionInvoked.");
         Assert.IsFalse(unusedNames.Contains("LoggingMiddleware"),
             "ASP.NET middleware (Invoke/InvokeAsync(HttpContext) shape) must be excluded under default excludeConventionInvoked.");
+        Assert.IsFalse(unusedNames.Contains("HealthResponseWriter"),
+            "ASP.NET HealthCheck response-writer shape (HttpContext, HealthReport) must be excluded under default excludeConventionInvoked.");
+        Assert.IsFalse(unusedNames.Contains("SampleMcpToolCatalog"),
+            "[McpServerToolType] holder must be excluded under default excludeConventionInvoked.");
+        Assert.IsFalse(unusedNames.Contains("SampleMcpPromptCatalog"),
+            "[McpServerPromptType] holder must be excluded under default excludeConventionInvoked.");
+        Assert.IsFalse(unusedNames.Contains("SampleMcpResourceCatalog"),
+            "[McpServerResourceType] holder must be excluded under default excludeConventionInvoked.");
+        Assert.IsFalse(unusedNames.Contains("WebHostSerialCollection"),
+            "xUnit [CollectionDefinition] holder must be excluded under default excludeConventionInvoked.");
+
+        // Negative control: the attribute simply contains 'McpServerToolType' as a substring
+        // but is not on the whitelist. It must NOT be excluded.
+        Assert.IsTrue(unusedNames.Contains("NotConventionInvokedHolder"),
+            "Attributes that are not on the whitelist must not accidentally trigger the convention filter.");
     }
 
     [TestMethod]
@@ -171,6 +186,12 @@ public sealed class DeadCodeIntegrationTests : SharedWorkspaceTestBase
             "Convention exclusion off — MyDbContextModelSnapshot should be reported as unused.");
         Assert.IsTrue(unusedNames.Contains("LoggingMiddleware"),
             "Convention exclusion off — LoggingMiddleware should be reported as unused.");
+        Assert.IsTrue(unusedNames.Contains("HealthResponseWriter"),
+            "Convention exclusion off — HealthResponseWriter should be reported as unused.");
+        Assert.IsTrue(unusedNames.Contains("SampleMcpToolCatalog"),
+            "Convention exclusion off — SampleMcpToolCatalog should be reported as unused.");
+        Assert.IsTrue(unusedNames.Contains("WebHostSerialCollection"),
+            "Convention exclusion off — WebHostSerialCollection should be reported as unused.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Extends `UnusedCodeAnalyzer.IsConventionInvokedType` so `find_unused_symbols(excludeConventionInvoked=true)` no longer false-positives three previously-missing convention-invoked shapes:

- `[McpServerToolType]` / `[McpServerPromptType]` / `[McpServerResourceType]` holders (discovered by reflection via the ModelContextProtocol.Server host).
- xUnit `[CollectionDefinition("name")]` holder classes.
- ASP.NET HealthCheck response-writer shape: public method taking `(HttpContext, HealthReport)` — bound to `HealthCheckOptions.ResponseWriter` via delegate reference, so no direct C# call site exists.

Detection remains name-shape based (no NuGet dependencies introduced).

## Test plan

- [x] New fixtures in `samples/SampleSolution/SampleLib/ConventionFixtures.cs` cover every new pattern, plus a negative-control attribute (`[NotMcpServerToolType]`) to assert the whitelist is not substring-matched.
- [x] `DeadCodeIntegrationTests.FindUnusedSymbols_Default_ExcludesConventionInvokedTypes` extended with positive assertions for each new shape and a negative-control assertion.
- [x] `DeadCodeIntegrationTests.FindUnusedSymbols_ExcludeConventionInvokedFalse_IncludesConventionTypes` extended to confirm the new shapes DO surface when the filter is off.
- [x] `dotnet test --filter FullyQualifiedName~DeadCodeIntegrationTests` → 7/7 pass.
- [x] `dotnet test --filter "FullyQualifiedName~UnusedCode|DeadCode|DeadField|DeadLocal|DuplicateHelper"` → 42/42 pass.
- [x] `dotnet build RoslynMcp.slnx -c Release` clean.

Closes: find-unused-symbols-convention-filter-gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)