### PR TITLE
fix(dead-fields): count compound-assignment + member-access writes (find-dead-fields-compound-assignment-writes)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -955,19 +955,23 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             return "Read";
         }
 
-        return syntaxNode.Parent switch
+        // Walk up through any `MemberAccessExpressionSyntax` wrapper so `obj.field`
+        // and bare `field` references classify the same way. Without this step a
+        // field accessed through a qualifier (e.g. `acc.ErrorCount++` or
+        // `Interlocked.Increment(ref acc.ErrorCount)`) would be pinned to the
+        // MemberAccess node whose parent is the postfix / argument — but the
+        // existing arms only match when the reference is the MemberAccess's own
+        // operand, so those write-sites silently classified as `Read`.
+        var effectiveNode = syntaxNode;
+        if (syntaxNode.Parent is MemberAccessExpressionSyntax ma && ma.Name == syntaxNode)
         {
-            AssignmentExpressionSyntax assignment when assignment.Left == syntaxNode
-                => assignment.Kind() is SyntaxKind.AddAssignmentExpression
-                    or SyntaxKind.SubtractAssignmentExpression
-                    or SyntaxKind.MultiplyAssignmentExpression
-                    or SyntaxKind.DivideAssignmentExpression
-                    ? "ReadWrite"
-                    : "Write",
-            MemberAccessExpressionSyntax memberAccess
-                when memberAccess.Parent is AssignmentExpressionSyntax memberAssignment
-                     && memberAssignment.Left == memberAccess
-                => "Write",
+            effectiveNode = ma;
+        }
+
+        return effectiveNode.Parent switch
+        {
+            AssignmentExpressionSyntax assignment when assignment.Left == effectiveNode
+                => ClassifyAssignment(assignment),
             PrefixUnaryExpressionSyntax prefix
                 when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression)
                 => "ReadWrite",
@@ -981,6 +985,17 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             _ => "Read"
         };
     }
+
+    /// <summary>
+    /// Classifies an assignment-expression LHS reference. A simple `=` is a pure
+    /// write; every compound form (`+=`, `-=`, `*=`, `/=`, `%=`, `|=`, `&amp;=`,
+    /// `^=`, `&lt;&lt;=`, `&gt;&gt;=`, `&gt;&gt;&gt;=`, `??=`) reads the current
+    /// value before writing it back, so they all classify as ReadWrite.
+    /// </summary>
+    private static string ClassifyAssignment(AssignmentExpressionSyntax assignment)
+        => assignment.Kind() == SyntaxKind.SimpleAssignmentExpression
+            ? "Write"
+            : "ReadWrite";
 
     private static string? DetermineDeadFieldUsageKind(int readCount, int writeCount)
     {

--- a/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
@@ -270,6 +270,128 @@ public sealed class DeadFieldDetectorTests
         Assert.IsNull(hit.RemovalBlockedBy);
     }
 
+    // Regression coverage for `find-dead-fields-compound-assignment-writes`:
+    // every compound-assignment operator + `++`/`--` on both bare and member-access
+    // field references must count as a write so the field is never classified as
+    // `never-written`. `Interlocked.*` callsites that take the field by `ref` are
+    // covered by the existing `RefKeyword` arm; adding the member-access case
+    // here ensures `Interlocked.Increment(ref acc.field)` works for qualified refs.
+    [DataTestMethod]
+    [DataRow("_count++;", DisplayName = "PostfixIncrement")]
+    [DataRow("_count--;", DisplayName = "PostfixDecrement")]
+    [DataRow("++_count;", DisplayName = "PrefixIncrement")]
+    [DataRow("--_count;", DisplayName = "PrefixDecrement")]
+    [DataRow("_count += 1;", DisplayName = "AddAssign")]
+    [DataRow("_count -= 1;", DisplayName = "SubtractAssign")]
+    [DataRow("_count *= 2;", DisplayName = "MultiplyAssign")]
+    [DataRow("_count /= 2;", DisplayName = "DivideAssign")]
+    [DataRow("_count %= 2;", DisplayName = "ModuloAssign")]
+    [DataRow("_count <<= 1;", DisplayName = "LeftShiftAssign")]
+    [DataRow("_count >>= 1;", DisplayName = "RightShiftAssign")]
+    [DataRow("_count |= 1;", DisplayName = "OrAssign")]
+    [DataRow("_count &= 1;", DisplayName = "AndAssign")]
+    [DataRow("_count ^= 1;", DisplayName = "XorAssign")]
+    public async Task FindDeadFields_CompoundAssignmentCountsAsWrite(string statement)
+    {
+        var source = $$"""
+            namespace Sample;
+            internal sealed class Counter
+            {
+                private int _count;
+
+                public int Touch()
+                {
+                    {{statement}}
+                    return _count;
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.AreEqual(0, hits.Count,
+            $"Compound statement `{statement}` must register a write reference — otherwise the field is falsely classified as never-written.");
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_MemberAccessCompoundAssignmentCountsAsWrite()
+    {
+        // `acc.ErrorCount++` from the diagnosis: the reference is the Name node of a
+        // MemberAccessExpression. Prior to the fix, the classifier returned "Read"
+        // because only the MemberAccess→Assignment arm matched, not the Postfix
+        // case. This test locks in the unwrap that promotes MemberAccess to the
+        // effective reference node before matching operator arms.
+        const string source = """
+            namespace Sample;
+            internal sealed class Accumulator
+            {
+                public int ErrorCount;
+            }
+            internal sealed class Consumer
+            {
+                public int Touch(Accumulator acc)
+                {
+                    acc.ErrorCount++;
+                    acc.ErrorCount += 2;
+                    return acc.ErrorCount;
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions { IncludePublic = true },
+            default);
+
+        var errorCount = hits.FirstOrDefault(hit => hit.SymbolName == "ErrorCount");
+        Assert.IsNull(errorCount,
+            "`acc.ErrorCount++` and `acc.ErrorCount += 2` must both count as writes on the field reference.");
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_InterlockedIncrementCountsAsReadWrite()
+    {
+        // `Interlocked.Increment(ref acc.ErrorCount)` — the `ref` arg carries a
+        // MemberAccess to the field. The existing `RefKeyword` arm only matched
+        // bare field references; the MemberAccess unwrap extends it to qualified
+        // field references, so the canonical `Interlocked.*` pattern no longer
+        // silently drops as `Read`.
+        const string source = """
+            using System.Threading;
+            namespace Sample;
+            internal sealed class Accumulator
+            {
+                public int ErrorCount;
+            }
+            internal sealed class Consumer
+            {
+                public int Touch(Accumulator acc)
+                {
+                    Interlocked.Increment(ref acc.ErrorCount);
+                    return acc.ErrorCount;
+                }
+            }
+            """;
+
+        var analyzer = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions { IncludePublic = true },
+            default);
+
+        var errorCount = hits.FirstOrDefault(hit => hit.SymbolName == "ErrorCount");
+        Assert.IsNull(errorCount,
+            "`Interlocked.Increment(ref acc.ErrorCount)` must count as a write on the qualified field reference.");
+    }
+
     [TestMethod]
     public async Task FindDeadFields_LimitCapsResults()
     {


### PR DESCRIPTION
## Summary
- `find_dead_fields` was classifying `acc.ErrorCount++`, `acc.ErrorCount += 2`, and `Interlocked.Increment(ref acc.ErrorCount)` as `Read` — the reference node resolved to the `Name` of a `MemberAccessExpression`, and the existing switch only matched MemberAccess when it was the LHS of a simple assignment. Every compound / unary / ref-arg form on a qualified field reference silently dropped through to the `Read` default.
- Unwrap `MemberAccessExpression.Name` to the MemberAccess itself before matching operator arms, so bare-field and qualified-field references classify identically.
- Collapse the compound-assignment arm to a single predicate so every non-`=` operator (`+=`, `-=`, `*=`, `/=`, `%=`, `|=`, `&=`, `^=`, `<<=`, `>>=`, `>>>=`, `??=`) counts as ReadWrite (previously only `+=`/`-=`/`*=`/`/=` were ReadWrite; the bitwise/shift forms silently classified as `Write`-only).

## Test plan
- [x] `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --filter "FullyQualifiedName~DeadFieldDetectorTests"` — 25 passed
- [x] Full `./eng/verify-release.ps1 -Configuration Release` — 886/886 passed in isolated run
- [x] `./eng/verify-ai-docs.ps1` — passed
- [x] New coverage: 14-row `DataTestMethod` per compound operator on a bare field + dedicated MemberAccess-compound-assignment test + `Interlocked.Increment(ref acc.ErrorCount)` qualified-ref test

Closes: find-dead-fields-compound-assignment-writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)