### PR TITLE
fix(add-package-reference): detect CPM/imported-present packages before diff

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -43,14 +43,31 @@ public sealed class ProjectMutationService : IProjectMutationService
         _changeTracker = changeTracker;
     }
 
-    public Task<RefactoringPreviewDto> PreviewAddPackageReferenceAsync(string workspaceId, AddPackageReferenceDto request, CancellationToken ct)
+    public async Task<RefactoringPreviewDto> PreviewAddPackageReferenceAsync(string workspaceId, AddPackageReferenceDto request, CancellationToken ct)
     {
         var project = ResolveProject(workspaceId, request.ProjectName);
         var warnings = new List<string>();
         var packagesPropsPath = ResolveDirectoryPackagesPropsPath(workspaceId);
         var usesCentralPackageManagement = packagesPropsPath is not null && MsBuildMetadataHelper.IsCentralPackageManagementEnabled(packagesPropsPath);
 
-        return PreviewProjectMutationAsync(workspaceId, project, document =>
+        // add-package-reference-preview-cpm-duplicate-detection: Probe the evaluated
+        // PackageReference item graph so we catch packages injected via
+        // Directory.Build.props / Directory.Packages.props / SDK imports. The XDocument
+        // check below only sees references declared in the .csproj itself, so an
+        // implicit/transitive-via-imports reference would silently duplicate.
+        var evaluatedPackages = await _msbuildEvaluation
+            .EvaluateItemsAsync(workspaceId, request.ProjectName, "PackageReference", ct)
+            .ConfigureAwait(false);
+        if (evaluatedPackages.Items.Any(item =>
+                string.Equals(item.Include, request.PackageId, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Package reference '{request.PackageId}' is already present in the evaluated project graph " +
+                "(declared in the .csproj or imported via Directory.Build.props / Directory.Packages.props / SDK imports). " +
+                "No changes needed.");
+        }
+
+        return await PreviewProjectMutationAsync(workspaceId, project, document =>
         {
             if (document.Descendants("PackageReference").Any(element =>
                     string.Equals((string?)element.Attribute("Include"), request.PackageId, StringComparison.OrdinalIgnoreCase)))
@@ -76,7 +93,7 @@ public sealed class ProjectMutationService : IProjectMutationService
 
             var itemGroup = GetOrCreateItemGroup(document, "PackageReference");
             AddChildElementPreservingIndentation(itemGroup, packageReference);
-        }, $"Add package reference '{request.PackageId}'", ct, warnings);
+        }, $"Add package reference '{request.PackageId}'", ct, warnings).ConfigureAwait(false);
     }
 
     public Task<RefactoringPreviewDto> PreviewRemovePackageReferenceAsync(string workspaceId, RemovePackageReferenceDto request, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -337,4 +337,28 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
             string.Equals((string?)r.Attribute("Include"), "Humanizer.Core", StringComparison.OrdinalIgnoreCase)),
             "PackageReference must be absent after remove.");
     }
+
+    [TestMethod]
+    public async Task Add_Package_Reference_Preview_Rejects_Package_Already_Imported_From_Directory_Build_Props()
+    {
+        // add-package-reference-preview-cpm-duplicate-detection: when a package is already
+        // present in the evaluated project graph because Directory.Build.props contributes a
+        // `<PackageReference Include="..." />` for every project, trying to add the same
+        // package via the tool must not silently emit a duplicate. The pre-fix behavior only
+        // scanned the csproj XML, missed the imported reference, and happily added a second
+        // `<PackageReference>` that NuGet later refuses.
+        //
+        // The sample fixture's Directory.Build.props already declares Microsoft.CodeAnalysis.NetAnalyzers
+        // as a PackageReference for every project, so it acts as the "transitive-present" repro.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            ProjectMutationService.PreviewAddPackageReferenceAsync(
+                workspace.WorkspaceId,
+                new AddPackageReferenceDto("SampleLib", "Microsoft.CodeAnalysis.NetAnalyzers", "10.0.100"),
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "already present");
+        StringAssert.Contains(ex.Message, "Microsoft.CodeAnalysis.NetAnalyzers");
+    }
 }


### PR DESCRIPTION
## Summary

- `add_package_reference_preview` now probes the evaluated `PackageReference` item graph via `IMsBuildEvaluationService` before building the diff. If the target package is already contributed to the project (declared in the .csproj, imported via `Directory.Build.props`, listed in `Directory.Packages.props`, or dragged in by SDK imports), the tool raises "already present in the evaluated project graph" instead of emitting a duplicate `<PackageReference>`.
- Pre-fix, the check only scanned the .csproj XML, so a package imported from `Directory.Build.props` was invisible and the tool happily duplicated it — NuGet later rejected the build.
- Probe is scoped to the target project (one MSBuild `LoadProject`), matching the pattern already used by `PreviewAddTargetFrameworkAsync`.
- Regression test uses the sample fixture's `Directory.Build.props` (which injects `Microsoft.CodeAnalysis.NetAnalyzers` etc. for every project) as the transitive-present repro.

Closes: `add-package-reference-preview-cpm-duplicate-detection`

## Test plan

- [x] `dotnet build RoslynMcp.slnx` clean
- [x] `dotnet test --filter "FullyQualifiedName~Add_Package_Reference"` (Release) passes 5/5 — includes new regression test and existing CPM-active-omit-version / non-transitive-add cases
- [x] `./eng/verify-ai-docs.ps1` passes
- [ ] Full `verify-release` shows some parallel-test flakiness (DirectoryNotFoundException on fixture copy) reproducible without this change — unrelated