### PR TITLE
fix(find-type-mutations): cover collection-field writes in async lifecycle methods

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -678,11 +678,37 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
     private static bool HasMutatingCollectionCall(SyntaxNode methodNode)
     {
-        return methodNode.DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .Any(inv => inv.Expression is MemberAccessExpressionSyntax access &&
-                        access.Name.Identifier.Text is "Add" or "Remove" or "Clear" or "Insert"
-                                                            or "RemoveAt" or "AddRange" or "RemoveAll");
+        foreach (var descendant in methodNode.DescendantNodes())
+        {
+            // find-type-mutations-undercounts-lifecycle-writes: recognize the full family of
+            // collection-mutation APIs used by ConcurrentDictionary / ConcurrentBag / ConcurrentQueue /
+            // ConcurrentStack / Channel / HashSet / Stack / Queue, not just the List<T> surface.
+            // WorkspaceManager.LoadAsync / Close mutate `_sessions` via TryAdd / TryRemove — without
+            // these names in the list they were invisible to find_type_mutations even though they
+            // are the canonical lifecycle mutators.
+            if (descendant is InvocationExpressionSyntax inv &&
+                inv.Expression is MemberAccessExpressionSyntax access &&
+                access.Name.Identifier.Text is "Add" or "Remove" or "Clear" or "Insert"
+                    or "RemoveAt" or "AddRange" or "RemoveAll"
+                    or "TryAdd" or "TryRemove" or "TryUpdate" or "AddOrUpdate" or "GetOrAdd"
+                    or "Push" or "Pop" or "TryPop"
+                    or "Enqueue" or "Dequeue" or "TryDequeue"
+                    or "Set" or "SetItem" or "Replace" or "Swap"
+                    or "ExceptWith" or "IntersectWith" or "SymmetricExceptWith" or "UnionWith")
+            {
+                return true;
+            }
+
+            // Indexer-write: `_field[key] = value` or `this[key] = value`. ElementAccessExpression
+            // on the left side of an assignment is a collection write that HasInstanceFieldAssignment
+            // does not cover (it only matches MemberAccess and bare-identifier LHS).
+            if (descendant is AssignmentExpressionSyntax assign &&
+                assign.Left is ElementAccessExpressionSyntax)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/MutationAnalysisSideEffectsTests.cs
+++ b/tests/RoslynMcp.Tests/MutationAnalysisSideEffectsTests.cs
@@ -56,6 +56,49 @@ public class FileSnapshotStoreSample
 }
 """, CancellationToken.None);
 
+        // Fixture #3: a lifecycle-manager class that mutates a ConcurrentDictionary field via
+        // TryAdd / TryRemove / indexer-write / Clear across sync + async methods. Regression
+        // guard for find-type-mutations-undercounts-lifecycle-writes — pre-fix only the Clear()
+        // call in DisposeAll was detected because TryAdd / TryRemove were not in the mutator
+        // name list and indexer-writes were not recognized as collection mutations.
+        var lifecyclePath = Path.Combine(CopiedRoot, "SampleLib", "LifecycleManagerSample.cs");
+        await File.WriteAllTextAsync(lifecyclePath, """
+namespace SampleLib;
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class LifecycleManagerSample
+{
+    private readonly ConcurrentDictionary<string, string> _sessions = new();
+
+    public async Task<string> LoadAsync(string path, CancellationToken ct)
+    {
+        await Task.Yield();
+        var id = System.Guid.NewGuid().ToString();
+        _sessions.TryAdd(id, path);
+        return id;
+    }
+
+    public async Task ReloadAsync(string id, CancellationToken ct)
+    {
+        await Task.Yield();
+        _sessions[id] = "reloaded";
+    }
+
+    public bool Close(string id)
+    {
+        return _sessions.TryRemove(id, out _);
+    }
+
+    public void DisposeAll()
+    {
+        _sessions.Clear();
+    }
+}
+""", CancellationToken.None);
+
         // Fixture #2: a no-side-effect computational class — should report zero mutations.
         var pureClassPath = Path.Combine(CopiedRoot, "SampleLib", "PureComputeSample.cs");
         await File.WriteAllTextAsync(pureClassPath, """
@@ -109,6 +152,31 @@ public class PureComputeSample
         Assert.IsNotNull(deleteManifest);
         Assert.AreEqual(SideEffectClassifier.Scopes.IO, deleteManifest.MutationScope,
             "File.Delete should classify as IO.");
+    }
+
+    [TestMethod]
+    public async Task FindTypeMutations_LifecycleManager_FlagsAsyncCollectionMutators()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.LifecycleManagerSample");
+        var result = await MutationAnalysisService.FindTypeMutationsAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result, "LifecycleManagerSample should resolve to a named type.");
+
+        // Regression: at least LoadAsync (TryAdd), ReloadAsync (indexer-write), Close (TryRemove),
+        // DisposeAll (Clear) — four mutating members. Pre-fix only DisposeAll was detected because
+        // TryAdd/TryRemove were missing from the collection-mutator name list and indexer-writes
+        // were not recognized as collection mutations.
+        var mutatorNames = result.MutatingMembers.Select(m => m.Name).ToHashSet();
+        Assert.IsTrue(mutatorNames.Contains("LoadAsync"),
+            $"LoadAsync (TryAdd in async body) should be flagged. Got: [{string.Join(", ", mutatorNames)}]");
+        Assert.IsTrue(mutatorNames.Contains("ReloadAsync"),
+            $"ReloadAsync (indexer-write in async body) should be flagged. Got: [{string.Join(", ", mutatorNames)}]");
+        Assert.IsTrue(mutatorNames.Contains("Close"),
+            $"Close (TryRemove) should be flagged. Got: [{string.Join(", ", mutatorNames)}]");
+        Assert.IsTrue(mutatorNames.Contains("DisposeAll"),
+            $"DisposeAll (Clear) should be flagged. Got: [{string.Join(", ", mutatorNames)}]");
+        Assert.IsTrue(result.MutatingMembers.Count >= 4,
+            $"Expected at least 4 mutating members on LifecycleManagerSample, got {result.MutatingMembers.Count}.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- Extend `MutationAnalysisService.HasMutatingCollectionCall` to cover `ConcurrentDictionary` / concurrent-collection / set / channel APIs (`TryAdd`, `TryRemove`, `TryUpdate`, `AddOrUpdate`, `GetOrAdd`, `Push`, `Pop`, `TryPop`, `Enqueue`, `Dequeue`, `TryDequeue`, `Set`, `SetItem`, `Replace`, `Swap`, `ExceptWith`, `IntersectWith`, `SymmetricExceptWith`, `UnionWith`).
- Recognize indexer-write assignments (`_field[key] = value`) as collection mutations — `ElementAccessExpressionSyntax` on the left side of an assignment.
- Regression test fixture `LifecycleManagerSample` asserts `LoadAsync` (TryAdd in async body), `ReloadAsync` (indexer-write in async body), `Close` (TryRemove), and `DisposeAll` (Clear) are all flagged. Pre-fix only `DisposeAll` was detected — matching the backlog-row observation that `find_type_mutations(WorkspaceManager)` surfaced only 2 mutators despite async lifecycle methods mutating `_sessions`.

Closes: find-type-mutations-undercounts-lifecycle-writes

## Test plan

- [x] New regression test `FindTypeMutations_LifecycleManager_FlagsAsyncCollectionMutators` passes.
- [x] Existing `MutationAnalysisSideEffectsTests` (IO / pure-compute) still pass.
- [x] `dotnet build src/RoslynMcp.Roslyn` clean.
- [x] `eng/verify-ai-docs.ps1` passes.
- [x] `eng/verify-release.ps1` — 2 unrelated pre-existing failures (confirmed reproducible on main without this PR's changes): `OrganizeUsings_Preview_Succeeds_After_MidSequence_WorkspaceReload`, `Source_Generated_Documents_Are_Listed_For_Project` (dotnet build 5-min timeout).