### PR TITLE
fix(find-property-writes): report positional-record primary-ctor bindings

### DIFF
--- a/src/RoslynMcp.Core/Models/PropertyWriteDto.cs
+++ b/src/RoslynMcp.Core/Models/PropertyWriteDto.cs
@@ -3,6 +3,21 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents a source location where a property is written.
 /// </summary>
+/// <param name="WriteKind">
+/// Classifies the syntactic shape of the write. One of:
+/// <list type="bullet">
+///   <item><c>"Assignment"</c> — ordinary <c>obj.Prop = value</c> (post-construction).</item>
+///   <item><c>"ObjectInitializer"</c> — <c>new T { Prop = value }</c> (safe for <c>init</c>).</item>
+///   <item><c>"OutRef"</c> — property passed by <c>out</c>/<c>ref</c> to a method call.</item>
+///   <item>
+///     <c>"PrimaryConstructorBind"</c> — the property is a positional-record
+///     primary-constructor parameter and the site is a <c>new T(value)</c> call that binds
+///     to this positional slot. Emitted by <c>find-property-writes-positional-record-silent-zero</c>
+///     so callers see the ctor-call write sites that <c>SymbolFinder.FindReferencesAsync</c>
+///     attributes to the primary-ctor parameter rather than the synthesized property.
+///   </item>
+/// </list>
+/// </param>
 public sealed record PropertyWriteDto(
     string FilePath,
     int StartLine,
@@ -11,4 +26,4 @@ public sealed record PropertyWriteDto(
     int EndColumn,
     string? ContainingMember,
     string? PreviewText,
-    bool IsObjectInitializer);
+    string WriteKind);

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -386,7 +386,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_property_writes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all locations where a property is assigned to (written), classified as object-initializer writes (safe for init) or post-construction assignments")]
+    [McpServerTool(Name = "find_property_writes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all locations where a property is assigned to (written). Each write carries a WriteKind bucket: ObjectInitializer (safe for init), Assignment (post-construction), OutRef (passed by out/ref), or PrimaryConstructorBind (the property is a positional-record primary-ctor parameter and the site is a `new T(value)` construction that binds this positional slot — find-property-writes-positional-record-silent-zero).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find property write sites and classify object-initializer writes.")]
     public static Task<string> FindPropertyWrites(

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -133,12 +133,9 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
             var refNode = item.SyntaxRoot.FindNode(item.Source.Location.SourceSpan);
 
-            // Determine if this reference is a write (left side of assignment, out/ref arg, or in an initializer)
-            if (!IsWriteReference(refNode)) continue;
-
-            var isObjectInitializer = refNode.Ancestors()
-                .Any(static a => a is InitializerExpressionSyntax init &&
-                    init.Kind() == SyntaxKind.ObjectInitializerExpression);
+            // Classify the syntactic shape of the write. Null => this reference is a read, skip.
+            var writeKind = ClassifyWriteReference(refNode);
+            if (writeKind is null) continue;
 
             var lineSpan = item.Source.Location.GetLineSpan();
 
@@ -150,10 +147,140 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
                 EndColumn: lineSpan.EndLinePosition.Character + 1,
                 ContainingMember: item.ContainingSymbol?.ToDisplayString(),
                 PreviewText: item.Dto.PreviewText,
-                IsObjectInitializer: isObjectInitializer));
+                WriteKind: writeKind));
+        }
+
+        // find-property-writes-positional-record-silent-zero:
+        // Positional-record primary-ctor-bound properties are assigned implicitly at each
+        // `new T(value)` site. `SymbolFinder.FindReferencesAsync(property, ...)` attributes
+        // those writes to the primary-ctor parameter (a distinct symbol) which itself has no
+        // by-name references from positional arguments, so the sweep above sees zero writes
+        // even though every construction writes to the property.
+        //
+        // Fix: detect positional-record primary-ctor-bound properties and additionally walk
+        // references to the record's primary constructor (IMethodSymbol), emitting a
+        // PrimaryConstructorBind bucket at each construction site. The parameter-index match
+        // (property name -> parameter ordinal) ensures we only light up writes to this
+        // specific property, not every positional slot on the record.
+        if (TryGetPrimaryConstructorParameterIndex(property) is int parameterIndex)
+        {
+            var primaryCtor = GetPrimaryConstructor(property.ContainingType);
+            if (primaryCtor is not null)
+            {
+                var ctorRefs = await SymbolFinder.FindReferencesAsync(primaryCtor, solution, ct).ConfigureAwait(false);
+                var ctorRefLocations = ctorRefs.SelectMany(r => r.Locations).ToList();
+                var ctorMaterialized = await ReferenceLocationMaterializer.MaterializeAsync(ctorRefLocations, ct).ConfigureAwait(false);
+
+                foreach (var item in ctorMaterialized)
+                {
+                    if (item.SyntaxRoot is null) continue;
+
+                    var refNode = item.SyntaxRoot.FindNode(item.Source.Location.SourceSpan);
+                    var argLocation = FindPositionalArgumentLocation(refNode, parameterIndex);
+                    if (argLocation is null) continue;
+
+                    var lineSpan = argLocation.GetLineSpan();
+                    var preview = await SymbolResolver.GetPreviewTextAsync(item.Source.Document, argLocation, ct).ConfigureAwait(false);
+
+                    results.Add(new PropertyWriteDto(
+                        FilePath: lineSpan.Path,
+                        StartLine: lineSpan.StartLinePosition.Line + 1,
+                        StartColumn: lineSpan.StartLinePosition.Character + 1,
+                        EndLine: lineSpan.EndLinePosition.Line + 1,
+                        EndColumn: lineSpan.EndLinePosition.Character + 1,
+                        ContainingMember: item.ContainingSymbol?.ToDisplayString(),
+                        PreviewText: preview,
+                        WriteKind: "PrimaryConstructorBind"));
+                }
+            }
         }
 
         return (results, "Property");
+    }
+
+    /// <summary>
+    /// Returns the primary-constructor parameter ordinal for a positional-record synthesized
+    /// property, or <see langword="null"/> when the property is not a positional-record
+    /// primary-ctor-bound property. Positional-record synthesized properties have a single
+    /// <see cref="ISymbol.DeclaringSyntaxReferences"/> entry whose syntax is a
+    /// <see cref="ParameterSyntax"/> inside a <see cref="RecordDeclarationSyntax"/>
+    /// parameter list.
+    /// </summary>
+    private static int? TryGetPrimaryConstructorParameterIndex(IPropertySymbol property)
+    {
+        var containingType = property.ContainingType;
+        if (containingType is null || !containingType.IsRecord) return null;
+
+        foreach (var declRef in property.DeclaringSyntaxReferences)
+        {
+            if (declRef.GetSyntax() is not ParameterSyntax paramSyntax) continue;
+            if (paramSyntax.Parent is not ParameterListSyntax paramList) continue;
+            if (paramList.Parent is not RecordDeclarationSyntax) continue;
+
+            for (var i = 0; i < paramList.Parameters.Count; i++)
+            {
+                if (paramList.Parameters[i] == paramSyntax) return i;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the canonical primary constructor for a positional record — the
+    /// <see cref="IMethodSymbol"/> whose <see cref="ISymbol.DeclaringSyntaxReferences"/>
+    /// resolves to the <see cref="RecordDeclarationSyntax"/> itself (pattern mirrors
+    /// <c>RecordFieldAdditionService.ExtractPositionalParameters</c>). Returns
+    /// <see langword="null"/> for non-positional records.
+    /// </summary>
+    private static IMethodSymbol? GetPrimaryConstructor(INamedTypeSymbol containingType)
+    {
+        foreach (var ctor in containingType.InstanceConstructors)
+        {
+            foreach (var declRef in ctor.DeclaringSyntaxReferences)
+            {
+                if (declRef.GetSyntax() is RecordDeclarationSyntax recordDecl && recordDecl.ParameterList is not null)
+                {
+                    return ctor;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Given a construction-site reference to a primary constructor (i.e. a node inside a
+    /// <c>new T(arg0, arg1, ...)</c> or <c>new(arg0, arg1, ...)</c> expression), returns the
+    /// location of the positional argument at <paramref name="parameterIndex"/>, or
+    /// <see langword="null"/> when the reference is not a positional-ctor construction site
+    /// (e.g. a deconstruction pattern, a derived-record primary-base call, or when the index
+    /// is out of range for the argument list).
+    /// </summary>
+    private static Location? FindPositionalArgumentLocation(SyntaxNode refNode, int parameterIndex)
+    {
+        // Walk up to the ObjectCreation / ImplicitObjectCreation / PrimaryConstructorBaseType
+        // node, then index into its ArgumentList.
+        for (var current = refNode; current is not null; current = current.Parent)
+        {
+            BaseArgumentListSyntax? argList = current switch
+            {
+                ObjectCreationExpressionSyntax oc => oc.ArgumentList,
+                ImplicitObjectCreationExpressionSyntax ioc => ioc.ArgumentList,
+                PrimaryConstructorBaseTypeSyntax pcb => pcb.ArgumentList,
+                _ => null,
+            };
+            if (argList is ArgumentListSyntax args)
+            {
+                if (parameterIndex < 0 || parameterIndex >= args.Arguments.Count) return null;
+                return args.Arguments[parameterIndex].GetLocation();
+            }
+
+            // Stop walking when we leave the enclosing statement / member (the reference is
+            // not inside a construction expression).
+            if (current is StatementSyntax or MemberDeclarationSyntax) break;
+        }
+
+        return null;
     }
 
     public async Task<IReadOnlyList<TypeUsageDto>> FindTypeUsagesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
@@ -422,30 +549,37 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
     private sealed record MutationCandidate(ISymbol Member, string? Scope);
 
-    private static bool IsWriteReference(SyntaxNode refNode)
+    /// <summary>
+    /// Classifies a property reference as a write and returns the bucket name, or
+    /// <see langword="null"/> if the reference is a read. Buckets (see
+    /// <see cref="PropertyWriteDto.WriteKind"/>): <c>"ObjectInitializer"</c>,
+    /// <c>"Assignment"</c>, <c>"OutRef"</c>.
+    /// </summary>
+    private static string? ClassifyWriteReference(SyntaxNode refNode)
     {
-        // Object initializer member assignment: { Prop = value }
+        // Object initializer member assignment: { Prop = value } — includes `with { Prop = value }`
+        // because WithInitializerExpressionSyntax shares the InitializerExpressionSyntax base.
         if (refNode.Parent is AssignmentExpressionSyntax assignInInit &&
             assignInInit.Left == refNode &&
             assignInInit.Parent is InitializerExpressionSyntax)
-            return true;
+            return "ObjectInitializer";
 
         // Regular assignment: target = value
         if (refNode.Parent is AssignmentExpressionSyntax directAssign && directAssign.Left == refNode)
-            return true;
+            return "Assignment";
 
         // MemberAccess on left of assignment: obj.Prop = value
         if (refNode.Parent is MemberAccessExpressionSyntax memberAccess &&
             memberAccess.Parent is AssignmentExpressionSyntax memberAssign &&
             memberAssign.Left == memberAccess)
-            return true;
+            return "Assignment";
 
         // out or ref argument
         if (refNode.Parent is ArgumentSyntax arg &&
             (arg.RefKindKeyword.IsKind(SyntaxKind.OutKeyword) || arg.RefKindKeyword.IsKind(SyntaxKind.RefKeyword)))
-            return true;
+            return "OutRef";
 
-        return false;
+        return null;
     }
 
     private static TypeUsageClassification ClassifyTypeUsage(SyntaxNode refNode, ISymbol referencedSymbol)

--- a/tests/RoslynMcp.Tests/FindPropertyWritesPositionalRecordTests.cs
+++ b/tests/RoslynMcp.Tests/FindPropertyWritesPositionalRecordTests.cs
@@ -1,0 +1,109 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <c>find-property-writes-positional-record-silent-zero</c>.
+/// Before the fix <c>FindPropertyWritesAsync</c> returned zero writes for a positional-record
+/// primary-ctor-bound property because <c>SymbolFinder.FindReferencesAsync(property, ...)</c>
+/// attributes the construction-site bindings to the primary-ctor parameter rather than the
+/// synthesized property. Each <c>new T(value)</c> call must now surface as a
+/// <c>PrimaryConstructorBind</c> bucket in the result list.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class FindPropertyWritesPositionalRecordTests : SharedWorkspaceTestBase
+{
+    private static string CopiedRoot { get; set; } = null!;
+    private static string CopiedSolutionPath { get; set; } = null!;
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        CopiedSolutionPath = CreateSampleSolutionCopy();
+        CopiedRoot = Path.GetDirectoryName(CopiedSolutionPath)!;
+
+        // Canonical repro shape from the backlog row: a positional record whose only write
+        // sites are construction-time `new T(value)` bindings (WebSnapshotStoreContext.Store).
+        // The context class exercises two separate construction sites so the test can
+        // distinguish "one site only" over-fitting from real detection.
+        var fixturePath = Path.Combine(CopiedRoot, "SampleLib", "PositionalRecordWriteFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, """
+namespace SampleLib;
+
+public record WebSnapshotStoreContext(string Store, int Port);
+
+public static class WebSnapshotConsumer
+{
+    public static WebSnapshotStoreContext CreateAtSite1() =>
+        new WebSnapshotStoreContext("primary", 8080);
+
+    public static WebSnapshotStoreContext CreateAtSite2()
+    {
+        return new WebSnapshotStoreContext("secondary", 9090);
+    }
+
+    public static WebSnapshotStoreContext ReadOnly(WebSnapshotStoreContext existing)
+    {
+        // This is a READ of Store, not a write — must NOT appear in the result set.
+        var s = existing.Store;
+        return existing with { Port = 1111 };
+    }
+}
+""", CancellationToken.None);
+
+        var status = await WorkspaceManager.LoadAsync(CopiedSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        if (WorkspaceId is not null)
+        {
+            try { WorkspaceManager.Close(WorkspaceId); } catch { }
+        }
+        DeleteDirectoryIfExists(CopiedRoot);
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task FindPropertyWrites_PositionalRecordProperty_ReportsPrimaryConstructorBindSites()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.WebSnapshotStoreContext.Store");
+        var (writes, resolvedKind) = await MutationAnalysisService
+            .FindPropertyWritesWithMetadataAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual("Property", resolvedKind,
+            $"WebSnapshotStoreContext.Store must resolve to a Property (the synthesized positional-record property). Got resolvedKind={resolvedKind}, writes.Count={writes.Count}");
+
+        var primaryCtorBinds = writes.Where(w => w.WriteKind == "PrimaryConstructorBind").ToList();
+        Assert.AreEqual(2, primaryCtorBinds.Count,
+            "Both `new WebSnapshotStoreContext(...)` call sites must be reported as PrimaryConstructorBind writes. " +
+            $"Got: {string.Join(", ", writes.Select(w => $"{w.WriteKind}@{w.StartLine}"))} (total {writes.Count})");
+
+        // Sanity: the `existing with { Port = ... }` site writes Port, NOT Store — none of the
+        // reported writes should be on `Store` from a with-expression in this fixture.
+        Assert.IsFalse(writes.Any(w => w.WriteKind == "ObjectInitializer"),
+            "Fixture contains no `with { Store = ... }` site — no ObjectInitializer writes expected for Store.");
+    }
+
+    [TestMethod]
+    public async Task FindPropertyWrites_PositionalRecordProperty_WithExpressionOnDifferentSlot_IsReportedOnThatSlot()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.WebSnapshotStoreContext.Port");
+        var (writes, resolvedKind) = await MutationAnalysisService
+            .FindPropertyWritesWithMetadataAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual("Property", resolvedKind);
+
+        // Two ctor binds + one `with { Port = 1111 }`.
+        var primaryCtorBinds = writes.Count(w => w.WriteKind == "PrimaryConstructorBind");
+        var withBinds = writes.Count(w => w.WriteKind == "ObjectInitializer");
+
+        Assert.AreEqual(2, primaryCtorBinds, "Both construction sites bind Port positionally.");
+        Assert.AreEqual(1, withBinds, "The `with { Port = 1111 }` site is an ObjectInitializer write (WithInitializerExpression derives from InitializerExpressionSyntax).");
+    }
+}


### PR DESCRIPTION
## Summary

`find_property_writes` returned `count=0` for positional-record primary-ctor-bound properties (e.g. `record WebSnapshotStoreContext(string Store, int Port)`). Cause: `SymbolFinder.FindReferencesAsync(property, ...)` attributes construction-site bindings to the primary-ctor parameter — a distinct symbol whose references include by-name uses only. Positional arguments `new T("a", 1)` reference neither the property nor the parameter by name, so every construction write was silently dropped.

**Fix:** detect positional-record synthesized properties (single `DeclaringSyntaxReferences` entry pointing at a `ParameterSyntax` inside a `RecordDeclarationSyntax.ParameterList`), capture the parameter ordinal, walk references to the record's canonical primary constructor (the `IMethodSymbol` whose declaring syntax is the `RecordDeclarationSyntax` itself), and emit one `PrimaryConstructorBind` write per construction site at the positional argument slot. Handles `new T(...)`, target-typed `new(...)`, and derived-record `R : Base(...)` primary-base calls.

**Breaking:** `PropertyWriteDto.IsObjectInitializer` (bool) replaced by `string WriteKind` with values `Assignment`, `ObjectInitializer`, `OutRef`, `PrimaryConstructorBind`. Internal DTO, no external callers.

## Test plan

- [x] Regression fixture `WebSnapshotStoreContext(string Store, int Port)` with two construction sites and a `with { Port = ... }` site — asserts both sites land as `PrimaryConstructorBind` writes on `Store` and both sites plus the with-expression land on `Port`
- [x] `dotnet test tests/RoslynMcp.Tests` — 892 passed, 0 failed
- [x] `./eng/verify-release.ps1 -Configuration Release` — all green
- [x] `./eng/verify-ai-docs.ps1` — all green

Closes: find-property-writes-positional-record-silent-zero