### PR TITLE
fix(scaffold-test-preview): emit per-arg placeholders for target ctors (scaffold-test-preview-ctor-arg-stubs)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -131,7 +131,8 @@ public sealed class ScaffoldingService : IScaffoldingService
             Solution: solution,
             ProjectDirectory: projectDirectory,
             TestNamespace: project.Name,
-            Framework: ResolveTestFramework(request.TestFramework, project.FilePath));
+            Framework: ResolveTestFramework(request.TestFramework, project.FilePath),
+            NSubstituteAvailable: IsNSubstituteAvailable(testProject));
     }
 
     private static async Task<List<Compilation>> LoadBatchCompilationsAsync(
@@ -185,7 +186,8 @@ public sealed class ScaffoldingService : IScaffoldingService
         var typeInfo = ResolveTargetTypeAndMethodFromCache(
             cachedCompilations,
             lookupName,
-            target.TargetMethodName);
+            target.TargetMethodName,
+            context.NSubstituteAvailable);
         if (typeInfo.MatchedType is null)
         {
             state.Warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
@@ -268,7 +270,8 @@ public sealed class ScaffoldingService : IScaffoldingService
         Solution Solution,
         string ProjectDirectory,
         string TestNamespace,
-        string Framework);
+        string Framework,
+        bool NSubstituteAvailable);
 
     private sealed class BatchScaffoldState
     {
@@ -304,7 +307,10 @@ public sealed class ScaffoldingService : IScaffoldingService
     /// </summary>
     private static ResolvedTargetTypeInfo
         ResolveTargetTypeAndMethodFromCache(
-            IReadOnlyList<Compilation> compilations, string targetTypeName, string? targetMethodName)
+            IReadOnlyList<Compilation> compilations,
+            string targetTypeName,
+            string? targetMethodName,
+            bool nsubstituteAvailable = false)
     {
         INamedTypeSymbol? matchedType = null;
         foreach (var compilation in compilations)
@@ -317,7 +323,7 @@ public sealed class ScaffoldingService : IScaffoldingService
             }
         }
 
-        return CreateResolvedTargetTypeInfo(matchedType, targetMethodName, warnOnPrivateMethod: false);
+        return CreateResolvedTargetTypeInfo(matchedType, targetMethodName, warnOnPrivateMethod: false, nsubstituteAvailable);
     }
 
     public async Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(string workspaceId, ScaffoldTestDto request, CancellationToken ct)
@@ -404,7 +410,11 @@ public sealed class ScaffoldingService : IScaffoldingService
         var serviceNamespace = serviceSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : serviceSymbol.ContainingNamespace.ToDisplayString();
-        var constructorArgs = BuildConstructorArgs(serviceSymbol);
+        var testRoslynProject = solution.Projects.FirstOrDefault(p =>
+            string.Equals(p.Name, testProject.Name, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(p.FilePath, testProject.FilePath, StringComparison.OrdinalIgnoreCase));
+        var nsubstituteAvailable = IsNSubstituteAvailable(testRoslynProject);
+        var constructorArgs = BuildConstructorArgs(serviceSymbol, nsubstituteAvailable);
         var publicMethods = CollectPublicTestableMethods(serviceSymbol);
 
         var content = BuildFirstTestFileContent(
@@ -895,7 +905,8 @@ public sealed class ScaffoldingService : IScaffoldingService
 
         var projectsToSearch = GetProjectsToSearch(solution, testProject);
         var matchedType = await FindTargetTypeAsync(projectsToSearch, targetTypeName, ct).ConfigureAwait(false);
-        return CreateResolvedTargetTypeInfo(matchedType, targetMethodName, warnOnPrivateMethod: true);
+        var nsubstituteAvailable = IsNSubstituteAvailable(testProject);
+        return CreateResolvedTargetTypeInfo(matchedType, targetMethodName, warnOnPrivateMethod: true, nsubstituteAvailable);
     }
 
     private static List<Project> GetProjectsToSearch(Solution solution, Project testProject)
@@ -958,7 +969,8 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static ResolvedTargetTypeInfo CreateResolvedTargetTypeInfo(
         INamedTypeSymbol? matchedType,
         string? targetMethodName,
-        bool warnOnPrivateMethod)
+        bool warnOnPrivateMethod,
+        bool nsubstituteAvailable = false)
     {
         if (matchedType is null)
         {
@@ -968,7 +980,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var targetNamespace = matchedType.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : matchedType.ContainingNamespace.ToDisplayString();
-        var constructorArgs = BuildConstructorArgs(matchedType);
+        var constructorArgs = BuildConstructorArgs(matchedType, nsubstituteAvailable);
         var warnings = new List<string>();
         var targetMethod = ResolveTargetMethod(matchedType, targetMethodName, warnOnPrivateMethod, warnings);
 
@@ -1021,22 +1033,29 @@ public sealed class ScaffoldingService : IScaffoldingService
         return targetMethod;
     }
 
-    private static string BuildConstructorArgs(INamedTypeSymbol type)
+    private static string BuildConstructorArgs(INamedTypeSymbol type, bool nsubstituteAvailable = false)
     {
         var constructors = type.Constructors
             .Where(c => !c.IsImplicitlyDeclared || c.Parameters.Length == 0)
             .Where(c => c.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal)
-            .OrderBy(c => c.Parameters.Length)
             .ToList();
 
         if (constructors.Count == 0)
             return string.Empty;
 
-        var bestCtor = constructors[0];
+        // Prefer a parameterless ctor when one exists — `new T()` always compiles and is the
+        // shape callers expect for POCOs. When no parameterless ctor is accessible (the
+        // DI-registered-service case this fix targets — `NamespaceRelocationService` and
+        // similar expose a single ctor(IFoo, IBar, …)), fall through to the widest accessible
+        // ctor and synthesize per-param placeholders below
+        // (scaffold-test-preview-ctor-arg-stubs).
+        var bestCtor = constructors.FirstOrDefault(c => c.Parameters.Length == 0)
+            ?? constructors.OrderByDescending(c => c.Parameters.Length).First();
         if (bestCtor.Parameters.Length == 0)
             return string.Empty;
 
-        var args = bestCtor.Parameters.Select(p => $"{BuildArgExpression(p.Type)} /* {p.Name} */");
+        var args = bestCtor.Parameters.Select(p =>
+            $"{BuildArgExpression(p.Type, nsubstituteAvailable)} /* {p.Name} */");
         return string.Join(", ", args);
     }
 
@@ -1049,7 +1068,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     /// throws <c>NullReferenceException</c> on the first call when the parameter is a non-null
     /// collection interface — observed in the 2026-04-07 ITChatBot legacy-mutex audit.
     /// </summary>
-    private static string BuildArgExpression(ITypeSymbol parameterType)
+    internal static string BuildArgExpression(ITypeSymbol parameterType, bool nsubstituteAvailable = false)
     {
         var displayName = parameterType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
@@ -1081,7 +1100,72 @@ public sealed class ScaffoldingService : IScaffoldingService
             }
         }
 
+        // Interfaces and abstract classes cannot be instantiated via `default(T)` in a way that
+        // produces a usable collaborator — `default` gives null and the first call throws NRE.
+        // When the test project references NSubstitute we emit `Substitute.For<T>()`; otherwise
+        // we emit a TODO placeholder so the caller notices and supplies a real/faked instance.
+        if (parameterType.TypeKind == TypeKind.Interface ||
+            (parameterType.TypeKind == TypeKind.Class && parameterType.IsAbstract))
+        {
+            return nsubstituteAvailable
+                ? $"NSubstitute.Substitute.For<{displayName}>()"
+                : $"default({displayName})! /* TODO: provide a test double for {displayName} */";
+        }
+
+        // Concrete class with an accessible parameterless ctor → safe to `new T()`. Structs go
+        // through `default(T)` (the existing fallback).
+        if (parameterType is INamedTypeSymbol concrete &&
+            concrete.TypeKind == TypeKind.Class &&
+            !concrete.IsAbstract &&
+            HasAccessibleParameterlessCtor(concrete))
+        {
+            return $"new {displayName}()";
+        }
+
+        // Concrete class without a parameterless ctor: can't safely construct. Emit a TODO so
+        // the caller swaps in the right factory. Previously emitted `default(T)` silently.
+        if (parameterType is INamedTypeSymbol concreteNoCtor &&
+            concreteNoCtor.TypeKind == TypeKind.Class &&
+            !concreteNoCtor.IsAbstract)
+        {
+            return nsubstituteAvailable
+                ? $"NSubstitute.Substitute.For<{displayName}>()"
+                : $"default({displayName})! /* TODO: provide a test double for {displayName} */";
+        }
+
         return $"default({displayName})";
+    }
+
+    private static bool HasAccessibleParameterlessCtor(INamedTypeSymbol type)
+    {
+        // A class with NO declared instance ctors has an implicit parameterless ctor.
+        var instanceCtors = type.InstanceConstructors
+            .Where(c => c.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal)
+            .ToList();
+        if (instanceCtors.Count == 0) return false;
+        return instanceCtors.Any(c => c.Parameters.Length == 0);
+    }
+
+    /// <summary>
+    /// Detects whether the given Roslyn project has NSubstitute on its reference graph, either
+    /// as a direct <c>PackageReference</c> or brought in transitively via a project reference
+    /// (e.g. a shared test-infra project). Uses MetadataReferences so transitive closure is
+    /// handled by MSBuild's existing resolution — covers both cases the plan calls out
+    /// (test project references AND the target test project's NuGet graph).
+    /// </summary>
+    internal static bool IsNSubstituteAvailable(Project? testProject)
+    {
+        if (testProject is null) return false;
+        foreach (var reference in testProject.MetadataReferences)
+        {
+            if (reference.Display is null) continue;
+            var fileName = Path.GetFileNameWithoutExtension(reference.Display);
+            if (string.Equals(fileName, "NSubstitute", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ProjectStatusDto ResolveProject(string workspaceId, string projectName)

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -130,6 +130,127 @@ public class BulkProcessor
     }
 
     [TestMethod]
+    public async Task Scaffold_Test_DIService_WithInterfaceAndConcreteCtorArgs_EmitsPerArgPlaceholders()
+    {
+        // BUG fix (scaffold-test-preview-ctor-arg-stubs): when the target's primary ctor
+        // requires arguments (the canonical DI-registered-service shape), scaffold_test_preview
+        // previously picked the wrong ctor or emitted `new T()`, producing a non-compiling
+        // scaffold. The fix probes the widest accessible ctor when no parameterless ctor
+        // exists and synthesizes per-param placeholders:
+        //   - interface / abstract class → `default(T)!` with a TODO when NSubstitute is not
+        //     referenced by the test project; `NSubstitute.Substitute.For<T>()` when it is.
+        //   - concrete class with parameterless ctor → `new T()`.
+        //   - concrete class without parameterless ctor → TODO placeholder.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var fixturePath = workspace.GetPath("SampleLib", "NamespaceRelocationServiceFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, """
+namespace SampleLib;
+
+public interface ILogger
+{
+    void Log(string message);
+}
+
+public sealed class Clock
+{
+    public System.DateTime Now => System.DateTime.UtcNow;
+}
+
+public sealed class NamespaceRelocationServiceFixture
+{
+    private readonly ILogger _logger;
+    private readonly Clock _clock;
+    private readonly string _name;
+
+    public NamespaceRelocationServiceFixture(ILogger logger, Clock clock, string name)
+    {
+        _logger = logger;
+        _clock = clock;
+        _name = name;
+    }
+
+    public string Describe() => _name;
+}
+""", CancellationToken.None);
+
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "NamespaceRelocationServiceFixture",
+                "Describe",
+                ReferenceTestFile: string.Empty),
+            CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+
+        var contents = await File.ReadAllTextAsync(
+            workspace.GetPath("SampleLib.Tests", "NamespaceRelocationServiceFixtureGeneratedTests.cs"),
+            CancellationToken.None);
+
+        // Should NOT emit the bare `new NamespaceRelocationServiceFixture()` — that was the
+        // pre-fix output and does not compile.
+        Assert.IsFalse(
+            contents.Contains("new NamespaceRelocationServiceFixture()"),
+            "Scaffold must not emit a parameterless `new T()` when the target ctor requires args — got:\n" + contents);
+
+        // Interface arg: SampleLib.Tests does NOT reference NSubstitute in this test harness,
+        // so the TODO placeholder branch applies.
+        StringAssert.Contains(contents, "default(ILogger)!",
+            "Interface ctor arg should be emitted as `default(T)!` with a TODO when NSubstitute is not referenced.");
+        StringAssert.Contains(contents, "TODO",
+            "Interface ctor arg placeholder should carry a TODO comment so callers notice.");
+        StringAssert.Contains(contents, "/* logger */",
+            "Ctor arg should retain the parameter-name breadcrumb.");
+
+        // Concrete class with parameterless ctor: scaffolded as `new Clock()`.
+        StringAssert.Contains(contents, "new Clock()",
+            "Concrete ctor arg with an accessible parameterless ctor should be emitted as `new T()`.");
+        StringAssert.Contains(contents, "/* clock */",
+            "Concrete ctor arg should retain the parameter-name breadcrumb.");
+
+        // String arg: existing behaviour — `string.Empty`.
+        StringAssert.Contains(contents, "string.Empty",
+            "String ctor arg should be emitted as `string.Empty`.");
+    }
+
+    [TestMethod]
+    public void BuildArgExpression_InterfaceArg_WithNSubstitute_EmitsSubstituteFor()
+    {
+        // Covers the NSubstitute-available branch of BuildArgExpression — the SampleLib.Tests
+        // integration fixture does NOT reference NSubstitute, so this unit-level assertion is
+        // what pins the `NSubstitute.Substitute.For<T>()` emission.
+        var source = """
+namespace Acme;
+
+public interface IFoo { }
+public sealed class Bar { }
+""";
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
+        var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+            "Test",
+            [tree],
+            [Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var foo = compilation.GetTypeByMetadataName("Acme.IFoo")!;
+        var bar = compilation.GetTypeByMetadataName("Acme.Bar")!;
+
+        var withSub = RoslynMcp.Roslyn.Services.ScaffoldingService.BuildArgExpression(foo, nsubstituteAvailable: true);
+        var withoutSub = RoslynMcp.Roslyn.Services.ScaffoldingService.BuildArgExpression(foo, nsubstituteAvailable: false);
+        var concrete = RoslynMcp.Roslyn.Services.ScaffoldingService.BuildArgExpression(bar, nsubstituteAvailable: false);
+
+        StringAssert.Contains(withSub, "NSubstitute.Substitute.For<IFoo>()",
+            "Interface arg with NSubstitute available should emit Substitute.For<T>().");
+        StringAssert.Contains(withoutSub, "default(IFoo)!",
+            "Interface arg without NSubstitute should emit default(T)! with TODO.");
+        StringAssert.Contains(withoutSub, "TODO",
+            "Interface arg placeholder should include TODO.");
+        StringAssert.Contains(concrete, "new Bar()",
+            "Concrete class with parameterless ctor should emit new T().");
+    }
+
+    [TestMethod]
     public async Task Scaffold_Type_NamespaceNotMatchingProject_GetsFolderStructure()
     {
         // BUG fix (scaffold-defaults-improvements / b): when the namespace does not start


### PR DESCRIPTION
## Summary

- `scaffold_test_preview` previously picked the smallest accessible ctor and emitted `new T()` for DI-registered services (e.g. a `ctor(ILogger, IClock, string)` shape), producing a non-compiling scaffold.
- `BuildConstructorArgs` now prefers a parameterless ctor when one exists and falls through to the widest accessible ctor otherwise, synthesizing per-parameter placeholders:
  - interface / abstract class → `NSubstitute.Substitute.For<T>()` when the test project references NSubstitute (direct or transitive via `Project.MetadataReferences`); otherwise `default(T)!` with a TODO breadcrumb.
  - concrete class with an accessible parameterless ctor → `new T()`.
  - concrete class without a parameterless ctor → TODO placeholder (or `Substitute.For<T>()` when NSubstitute is available).
- NSubstitute detection covers both paths the plan calls out (test-project references AND the target test project's NuGet graph) by probing `Project.MetadataReferences` — MSBuild's existing reference resolution handles transitive closure.
- Threaded through all three entry points: `PreviewScaffoldTestAsync`, batch (`ProcessBatchScaffoldTarget` via `BatchScaffoldContext`), and `PreviewScaffoldFirstTestFileAsync`.

Closes: scaffold-test-preview-ctor-arg-stubs

## Test plan

- [x] New integration test `Scaffold_Test_DIService_WithInterfaceAndConcreteCtorArgs_EmitsPerArgPlaceholders` — asserts interface arg becomes `default(T)!` + TODO when NSubstitute not referenced, concrete arg with parameterless ctor becomes `new T()`, string arg stays `string.Empty`, and `new T()` is NOT emitted for the parent DI service.
- [x] New unit test `BuildArgExpression_InterfaceArg_WithNSubstitute_EmitsSubstituteFor` — covers the NSubstitute-available branch via `InternalsVisibleTo`.
- [x] All 20 Scaffolding tests pass (targeted run, Debug + Release).
- [x] `verify-ai-docs.ps1` passes.
- [ ] `verify-release.ps1` — full suite shows pre-existing parallel-workspace-fixture flakiness (`DirectoryNotFoundException` on copied `SampleLib/*.cs` paths) affecting ~20 tests including many unrelated to this change (`ApplyTextEdit_*`, `ExtractMethod_*`, `Migrate_Package_*`). Every failing scaffold-specific test passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)