### PR TITLE
fix(workspace-changes): wire editorconfig writers + discriminate apply tool names

### DIFF
--- a/src/RoslynMcp.Core/Services/IEditService.cs
+++ b/src/RoslynMcp.Core/Services/IEditService.cs
@@ -32,10 +32,19 @@ public interface IEditService
     /// snapshot this call captured can be reverted — prior-turn edits are never
     /// touched. Ignored when <paramref name="verify"/> is <c>false</c>.
     /// </param>
+    /// <remarks>
+    /// <paramref name="toolName"/> carries the originating MCP tool name to
+    /// <see cref="IChangeTracker.RecordChange"/> so <c>workspace_changes</c> reports the writer
+    /// that actually ran (e.g. <c>add_pragma_suppression</c>, <c>pragma_scope_widen</c>,
+    /// <c>apply_text_edit</c>) instead of collapsing every <see cref="IEditService"/> caller
+    /// into a generic <c>apply_text_edit</c> bucket
+    /// (<c>workspace-changes-log-missing-editorconfig-writers</c>).
+    /// </remarks>
     Task<TextEditResultDto> ApplyTextEditsAsync(
         string workspaceId,
         string filePath,
         IReadOnlyList<TextEditDto> edits,
+        string toolName,
         CancellationToken ct,
         bool skipSyntaxCheck = false,
         bool verify = false,
@@ -63,6 +72,7 @@ public interface IEditService
     Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
         string workspaceId,
         IReadOnlyList<FileEditsDto> fileEdits,
+        string toolName,
         CancellationToken ct,
         bool skipSyntaxCheck = false,
         bool verify = false,

--- a/src/RoslynMcp.Core/Services/IEditorConfigService.cs
+++ b/src/RoslynMcp.Core/Services/IEditorConfigService.cs
@@ -15,6 +15,12 @@ public interface IEditorConfigService
     /// <summary>
     /// Sets or updates an .editorconfig key for files matching C# sources, creating a file next to the source tree if needed.
     /// </summary>
+    /// <param name="toolName">
+    /// The originating MCP tool name (e.g. <c>set_editorconfig_option</c> or
+    /// <c>set_diagnostic_severity</c>). Threaded through to
+    /// <see cref="IChangeTracker.RecordChange"/> so <c>workspace_changes</c> reports the writer
+    /// that actually ran (<c>workspace-changes-log-missing-editorconfig-writers</c>).
+    /// </param>
     Task<EditorConfigWriteResultDto> SetOptionAsync(
-        string workspaceId, string sourceFilePath, string key, string value, CancellationToken ct);
+        string workspaceId, string sourceFilePath, string key, string value, string toolName, CancellationToken ct);
 }

--- a/src/RoslynMcp.Core/Services/IRefactoringService.cs
+++ b/src/RoslynMcp.Core/Services/IRefactoringService.cs
@@ -32,8 +32,15 @@ public interface IRefactoringService
     /// Applies a previously previewed refactoring to the workspace.
     /// </summary>
     /// <param name="previewToken">The token returned by a prior preview call.</param>
+    /// <param name="toolName">
+    /// The originating MCP tool name (e.g. <c>rename_apply</c>, <c>code_fix_apply</c>,
+    /// <c>format_document_apply</c>). Threaded through to <see cref="IChangeTracker.RecordChange"/>
+    /// so <c>workspace_changes</c> can discriminate writers rather than collapsing every
+    /// preview-based apply into a generic <c>refactoring_apply</c> bucket
+    /// (<c>workspace-changes-log-missing-editorconfig-writers</c>).
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
-    Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, CancellationToken ct);
+    Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct);
 
     /// <summary>
     /// Item #4 — apply a preview with an explicit <paramref name="force"/> override.
@@ -43,7 +50,7 @@ public interface IRefactoringService
     /// apply without full visibility — the agent accepts responsibility for the
     /// unreviewed changes.
     /// </summary>
-    Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, bool force, CancellationToken ct);
+    Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, bool force, CancellationToken ct);
 
     /// <summary>
     /// Previews removing unused <c>using</c> directives and sorting the remaining ones for the given file.

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -41,7 +41,7 @@ public static class ApplyWithVerifyTool
                 var preErrors = ExtractErrorFingerprints(preBaseline);
 
                 // Apply
-                var applyResult = await refactoringService.ApplyRefactoringAsync(previewToken, c).ConfigureAwait(false);
+                var applyResult = await refactoringService.ApplyRefactoringAsync(previewToken, "apply_with_verify", c).ConfigureAwait(false);
                 if (!applyResult.Success)
                 {
                     return JsonSerializer.Serialize(new

--- a/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
@@ -50,7 +50,7 @@ public static class BulkRefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "bulk_replace_type_apply", c),
             ct);
 
     // replace-invocation-pattern-refactor: method-level ergonomic pair to bulk_replace_type_preview.

--- a/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
@@ -75,6 +75,6 @@ public static class CodeActionTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "apply_code_action", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/DeadCodeTools.cs
@@ -51,6 +51,6 @@ public static class DeadCodeTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "remove_dead_code_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -30,7 +30,7 @@ public static class EditTools
         return gate.RunWriteAsync(workspaceId, async c =>
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
-            var result = await editService.ApplyTextEditsAsync(workspaceId, filePath, edits, c, skipSyntaxCheck, verify, autoRevertOnError);
+            var result = await editService.ApplyTextEditsAsync(workspaceId, filePath, edits, "apply_text_edit", c, skipSyntaxCheck, verify, autoRevertOnError);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
@@ -47,6 +47,6 @@ public static class EditorConfigTools
         => ToolDispatch.PreviewWithWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => editorConfigService.SetOptionAsync(workspaceId, filePath, key, value, c),
+            c => editorConfigService.SetOptionAsync(workspaceId, filePath, key, value, "set_editorconfig_option", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -52,7 +52,7 @@ public static class ExtractMethodTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_method_apply", c),
             ct);
 
     [McpServerTool(Name = "extract_shared_expression_to_helper_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]

--- a/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
@@ -59,7 +59,7 @@ public static class FileOperationTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "create_file_apply", c),
             ct);
 
     [McpServerTool(Name = "delete_file_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
@@ -96,7 +96,7 @@ public static class FileOperationTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "delete_file_apply", c),
             ct);
 
     [McpServerTool(Name = "move_file_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
@@ -140,6 +140,6 @@ public static class FileOperationTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "move_file_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
@@ -48,6 +48,6 @@ public static class FixAllTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "fix_all_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -51,6 +51,6 @@ public static class InterfaceExtractionTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_interface_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -46,7 +46,7 @@ public static class MultiFileEditTools
                 await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, fileEdit.FilePath, c).ConfigureAwait(false);
             }
 
-            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, c, skipSyntaxCheck, verify, autoRevertOnError).ConfigureAwait(false);
+            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, "apply_multi_file_edit", c, skipSyntaxCheck, verify, autoRevertOnError).ConfigureAwait(false);
             return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
         }, ct);
     }
@@ -89,6 +89,6 @@ public static class MultiFileEditTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "preview_multi_file_edit_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -51,7 +51,7 @@ public static class RefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "rename_apply", c),
             ct);
 
     [McpServerTool(Name = "organize_usings_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview organizing using directives in a file: removes unused usings and sorts them")]
@@ -82,7 +82,7 @@ public static class RefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "organize_usings_apply", c),
             ct);
 
     [McpServerTool(Name = "format_document_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview formatting a document: applies standard C# formatting rules")]
@@ -113,7 +113,7 @@ public static class RefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "format_document_apply", c),
             ct);
 
     [McpServerTool(Name = "code_fix_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview a curated code fix for a specific diagnostic occurrence")]
@@ -148,7 +148,7 @@ public static class RefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "code_fix_apply", c),
             ct);
 
     [McpServerTool(Name = "format_range_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
@@ -185,7 +185,7 @@ public static class RefactoringTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "format_range_apply", c),
             ct);
 
     [McpServerTool(Name = "format_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -81,7 +81,7 @@ public static class ScaffoldingTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "scaffold_type_apply", c),
             ct);
 
     [McpServerTool(Name = "scaffold_test_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
@@ -121,7 +121,7 @@ public static class ScaffoldingTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "scaffold_test_apply", c),
             ct);
 
     [McpServerTool(Name = "scaffold_first_test_file_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -51,6 +51,6 @@ public static class TypeExtractionTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_type_apply", c),
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -50,7 +50,7 @@ public static class TypeMoveTools
             gate,
             previewStore,
             previewToken,
-            c => refactoringService.ApplyRefactoringAsync(previewToken, c),
+            c => refactoringService.ApplyRefactoringAsync(previewToken, "move_type_to_file_apply", c),
             ct);
 
     [McpServerTool(Name = "change_type_namespace_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -37,6 +37,7 @@ public sealed class EditService : IEditService
         string workspaceId,
         string filePath,
         IReadOnlyList<TextEditDto> edits,
+        string toolName,
         CancellationToken ct,
         bool skipSyntaxCheck = false,
         bool verify = false,
@@ -85,7 +86,7 @@ public sealed class EditService : IEditService
             solution,
             fileSnapshots);
 
-        var coreResult = await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, document, sourceText, newSourceText, ct).ConfigureAwait(false);
+        var coreResult = await ApplyTextEditsCoreAsync(workspaceId, filePath, edits, solution, document, sourceText, newSourceText, toolName, ct).ConfigureAwait(false);
 
         // Only wire up verify when the core apply actually wrote the edit. When the
         // core path returns Success=false (e.g. MSBuildWorkspace.TryApplyChanges
@@ -109,6 +110,7 @@ public sealed class EditService : IEditService
     public async Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
         string workspaceId,
         IReadOnlyList<FileEditsDto> fileEdits,
+        string toolName,
         CancellationToken ct,
         bool skipSyntaxCheck = false,
         bool verify = false,
@@ -173,7 +175,7 @@ public sealed class EditService : IEditService
             }
 
             var result = await ApplyTextEditsCoreAsync(
-                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, document, sourceText, merged, ct).ConfigureAwait(false);
+                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, document, sourceText, merged, toolName, ct).ConfigureAwait(false);
             var diff = result.Changes.Count > 0
                 ? string.Join("\n", result.Changes.Select(ch => ch.UnifiedDiff))
                 : null;
@@ -471,6 +473,7 @@ public sealed class EditService : IEditService
         Document document,
         SourceText sourceText,
         SourceText newSourceText,
+        string toolName,
         CancellationToken ct)
     {
         var normalizedPath = Path.GetFullPath(filePath);
@@ -501,7 +504,7 @@ public sealed class EditService : IEditService
 
         _changeTracker?.RecordChange(workspaceId,
             $"Apply text edit to {Path.GetFileName(filePath)}",
-            [filePath], "apply_text_edit");
+            [filePath], toolName);
 
         return new TextEditResultDto(true, filePath, edits.Count, [fileChange], null);
     }

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -12,12 +12,18 @@ public sealed class EditorConfigService : IEditorConfigService
     private readonly IWorkspaceManager _workspace;
     private readonly ILogger<EditorConfigService> _logger;
     private readonly IUndoService? _undoService;
+    private readonly IChangeTracker? _changeTracker;
 
-    public EditorConfigService(IWorkspaceManager workspace, ILogger<EditorConfigService> logger, IUndoService? undoService = null)
+    public EditorConfigService(
+        IWorkspaceManager workspace,
+        ILogger<EditorConfigService> logger,
+        IUndoService? undoService = null,
+        IChangeTracker? changeTracker = null)
     {
         _workspace = workspace;
         _logger = logger;
         _undoService = undoService;
+        _changeTracker = changeTracker;
     }
 
     public async Task<EditorConfigOptionsDto> GetOptionsAsync(
@@ -295,7 +301,7 @@ public sealed class EditorConfigService : IEditorConfigService
     }
 
     public Task<EditorConfigWriteResultDto> SetOptionAsync(
-        string workspaceId, string sourceFilePath, string key, string value, CancellationToken ct)
+        string workspaceId, string sourceFilePath, string key, string value, string toolName, CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
         _ = _workspace.GetCurrentSolution(workspaceId);
@@ -338,6 +344,16 @@ public sealed class EditorConfigService : IEditorConfigService
         }
 
         File.WriteAllLines(editorconfigPath, lines);
+
+        // workspace-changes-log-missing-editorconfig-writers: route the editorconfig write
+        // through ChangeTracker so `workspace_changes` surfaces the originating tool name
+        // (`set_editorconfig_option` or `set_diagnostic_severity`) instead of omitting
+        // editorconfig applies entirely.
+        _changeTracker?.RecordChange(
+            workspaceId,
+            $"Set .editorconfig option '{key.Trim()}' in {Path.GetFileName(editorconfigPath)}",
+            [editorconfigPath],
+            toolName);
 
         return Task.FromResult(new EditorConfigWriteResultDto(editorconfigPath, key, value, created));
     }

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -205,10 +205,10 @@ public sealed class RefactoringService : IRefactoringService
     /// Applies a previously previewed refactoring. Validates the preview token against the current
     /// workspace version to reject stale changes.
     /// </summary>
-    public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, CancellationToken ct)
-        => ApplyRefactoringAsync(previewToken, force: false, ct);
+    public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct)
+        => ApplyRefactoringAsync(previewToken, toolName, force: false, ct);
 
-    public async Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, bool force, CancellationToken ct)
+    public async Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, bool force, CancellationToken ct)
     {
         var entry = _previewStore.Retrieve(previewToken);
         if (entry is null)
@@ -320,7 +320,7 @@ public sealed class RefactoringService : IRefactoringService
             return new ApplyResultDto(false, [], "Failed to apply changes to the workspace.");
         }
 
-        _changeTracker?.RecordChange(workspaceId, description, appliedFiles, "refactoring_apply");
+        _changeTracker?.RecordChange(workspaceId, description, appliedFiles, toolName);
         _logger.LogInformation("Applied refactoring '{Description}' to {Count} file(s)", description, appliedFiles.Count);
 
         // Rotate the symbol handle for refactors that change symbol identity (rename).

--- a/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
@@ -47,7 +47,7 @@ public sealed class SuppressionService : ISuppressionService
         }
 
         var key = $"dotnet_diagnostic.{diagnosticId.Trim()}.severity";
-        return _editorConfig.SetOptionAsync(workspaceId, sourceFilePath, key, severity.Trim(), ct);
+        return _editorConfig.SetOptionAsync(workspaceId, sourceFilePath, key, severity.Trim(), "set_diagnostic_severity", ct);
     }
 
     public Task<TextEditResultDto> AddPragmaWarningDisableAsync(
@@ -65,7 +65,7 @@ public sealed class SuppressionService : ISuppressionService
 
         var pragma = $"#pragma warning disable {diagnosticId.Trim()}{Environment.NewLine}";
         var edit = new TextEditDto(line, 1, line, 1, pragma);
-        return _editService.ApplyTextEditsAsync(workspaceId, filePath, [edit], ct);
+        return _editService.ApplyTextEditsAsync(workspaceId, filePath, [edit], "add_pragma_suppression", ct);
     }
 
     public async Task<PragmaVerifyResultDto> VerifyPragmaSuppressesAsync(
@@ -218,6 +218,7 @@ public sealed class SuppressionService : ISuppressionService
             workspaceId,
             filePath,
             edits,
+            "pragma_scope_widen",
             ct,
             skipSyntaxCheck: false,
             verify: false,

--- a/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
@@ -83,7 +83,7 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
                 // The previous step persisted its own preview token; we don't need it after the
                 // text changes have flowed into the workspace. Apply the step so the next op
                 // sees the rewritten state.
-                await _refactoringService.ApplyRefactoringAsync(stepPreview.PreviewToken, ct).ConfigureAwait(false);
+                await _refactoringService.ApplyRefactoringAsync(stepPreview.PreviewToken, "symbol_refactor_preview", ct).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
@@ -37,8 +37,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var result = await EditService.ApplyTextEditsAsync(
             workspaceId,
             dogFilePath,
-            new[] { edit },
-            CancellationToken.None,
+            new[] { edit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: false,
             autoRevertOnError: false);
@@ -67,8 +66,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var result = await EditService.ApplyTextEditsAsync(
             workspaceId,
             dogFilePath,
-            new[] { edit },
-            CancellationToken.None,
+            new[] { edit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: true,
             autoRevertOnError: false);
@@ -103,8 +101,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var result = await EditService.ApplyTextEditsAsync(
             workspaceId,
             dogFilePath,
-            new[] { edit },
-            CancellationToken.None,
+            new[] { edit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: true,
             autoRevertOnError: false);
@@ -143,8 +140,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var result = await EditService.ApplyTextEditsAsync(
             workspaceId,
             dogFilePath,
-            new[] { edit },
-            CancellationToken.None,
+            new[] { edit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: true,
             autoRevertOnError: true);
@@ -182,7 +178,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var originalCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
         var catEdit = ReplaceSpeakReturnEdit(originalCat, "PreExistingErrorMarker");
         var call1 = await EditService.ApplyTextEditsAsync(
-            workspaceId, catFilePath, new[] { catEdit }, CancellationToken.None,
+            workspaceId, catFilePath, new[] { catEdit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false, verify: false, autoRevertOnError: false);
         Assert.IsTrue(call1.Success);
         Assert.IsNull(call1.Verification, "Sanity: call 1 should not have a Verification field.");
@@ -201,7 +197,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
         var originalDog = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
         var dogEdit = AppendCommentEdit(originalDog, "// benign-in-broken-workspace");
         var call2 = await EditService.ApplyTextEditsAsync(
-            workspaceId, dogFilePath, new[] { dogEdit }, CancellationToken.None,
+            workspaceId, dogFilePath, new[] { dogEdit }, "apply_text_edit", CancellationToken.None,
             skipSyntaxCheck: false, verify: true, autoRevertOnError: true);
 
         Assert.IsTrue(call2.Success);
@@ -240,8 +236,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
 
         var result = await EditService.ApplyMultiFileTextEditsAsync(
             workspaceId,
-            fileEdits,
-            CancellationToken.None,
+            fileEdits, "apply_multi_file_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: true,
             autoRevertOnError: false);
@@ -279,8 +274,7 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
 
         var result = await EditService.ApplyMultiFileTextEditsAsync(
             workspaceId,
-            fileEdits,
-            CancellationToken.None,
+            fileEdits, "apply_multi_file_edit", CancellationToken.None,
             skipSyntaxCheck: false,
             verify: true,
             autoRevertOnError: true);

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
@@ -95,7 +95,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
             // Apply and inspect the resulting file. The previous bug rendered as
             // `public int Compute(int a, int b, int c = 0) {` (one line) — body brace
             // concatenated. Post-fix the body brace stays on its own line.
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -161,7 +161,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
 
             var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspaceId, locator, request, CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -348,7 +348,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
 
             var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspaceId, locator, request, CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success);
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -411,7 +411,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
 
             var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspaceId, locator, request, CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -494,7 +494,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
             Assert.IsNotNull(preview.PreviewToken);
             Assert.IsTrue(preview.Changes.Count >= 1, "preview must report at least the declaration file");
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -567,7 +567,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
                 workspaceId, locator, request, CancellationToken.None);
             Assert.IsNotNull(preview.PreviewToken);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -631,7 +631,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
 
             var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspaceId, locator, request, CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -752,7 +752,7 @@ public sealed class ChangeSignaturePreviewTests : TestBase
 
             var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspaceId, locator, request, CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success);
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);

--- a/tests/RoslynMcp.Tests/ChangeTrackerTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeTrackerTests.cs
@@ -1,10 +1,14 @@
 using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
 /// <summary>
 /// Verifies that the ChangeTracker records mutations applied through
-/// RefactoringService and EditService apply paths.
+/// RefactoringService, EditService, and EditorConfigService apply paths —
+/// and that each writer surfaces with its originating MCP tool name rather
+/// than collapsing into a generic bucket
+/// (<c>workspace-changes-log-missing-editorconfig-writers</c>).
 /// </summary>
 [TestClass]
 public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
@@ -15,8 +19,11 @@ public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
     [ClassCleanup]
     public static void ClassCleanup() => DisposeServices();
 
+    private static SuppressionService CreateSuppressionService() =>
+        new SuppressionService(EditorConfigService, EditService, WorkspaceManager, CompileCheckService);
+
     [TestMethod]
-    public async Task RenameApply_RecordsChange()
+    public async Task RenameApply_RecordsRenameToolName()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var wsId = workspace.WorkspaceId;
@@ -30,12 +37,158 @@ public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
         var locator = SymbolLocator.BySource(doc.FilePath!, 5, 6);
         var preview = await RefactoringService.PreviewRenameAsync(
             wsId, locator, "Doggo", CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "rename_apply", CancellationToken.None);
 
         var changes = ChangeTracker.GetChanges(wsId);
         Assert.AreEqual(1, changes.Count, "Expected exactly 1 change after rename apply.");
-        Assert.AreEqual("refactoring_apply", changes[0].ToolName);
+        Assert.AreEqual("rename_apply", changes[0].ToolName,
+            "Rename apply must surface as 'rename_apply' rather than the legacy 'refactoring_apply' bucket.");
         Assert.IsTrue(changes[0].AffectedFiles.Count > 0, "Rename should affect at least one file.");
+    }
+
+    [TestMethod]
+    public async Task FormatDocumentApply_RecordsFormatToolName()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+
+        var preview = await RefactoringService.PreviewFormatDocumentAsync(
+            wsId, doc.FilePath!, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "format_document_apply", CancellationToken.None);
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count);
+        Assert.AreEqual("format_document_apply", changes[0].ToolName,
+            "format_document_apply must not collapse into 'refactoring_apply'.");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_RecordsApplyTextEditToolName()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+
+        var edit = new TextEditDto(1, 1, 1, 1, "// leading comment\n");
+        var result = await EditService.ApplyTextEditsAsync(
+            wsId, doc.FilePath!, [edit], "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(result.Success, "Text edit should apply.");
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count);
+        Assert.AreEqual("apply_text_edit", changes[0].ToolName);
+    }
+
+    [TestMethod]
+    public async Task SetEditorConfigOption_RecordsEditorConfigToolName()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var setResult = await EditorConfigService.SetOptionAsync(
+            wsId, dogFilePath, "dotnet_diagnostic.CA1702.severity", "warning",
+            "set_editorconfig_option", CancellationToken.None);
+        Assert.IsTrue(File.Exists(setResult.EditorConfigPath));
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count,
+            "set_editorconfig_option must produce a workspace_changes entry — " +
+            "previously the editorconfig writer silently bypassed ChangeTracker.");
+        Assert.AreEqual("set_editorconfig_option", changes[0].ToolName);
+        CollectionAssert.Contains(
+            changes[0].AffectedFiles.ToList(),
+            setResult.EditorConfigPath,
+            "The recorded affected-file set must include the written .editorconfig path.");
+    }
+
+    [TestMethod]
+    public async Task SetDiagnosticSeverity_RecordsSeverityToolName()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var result = await CreateSuppressionService().SetDiagnosticSeverityAsync(
+            wsId, "CA1703", "warning", dogFilePath, CancellationToken.None);
+        Assert.IsTrue(File.Exists(result.EditorConfigPath));
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count,
+            "set_diagnostic_severity must produce a workspace_changes entry; " +
+            "it previously shared the editorconfig-silent-writer bug.");
+        Assert.AreEqual("set_diagnostic_severity", changes[0].ToolName,
+            "The originating tool name must be 'set_diagnostic_severity' rather than " +
+            "the underlying 'set_editorconfig_option' helper it delegates to.");
+    }
+
+    [TestMethod]
+    public async Task DistinctWriters_ProduceDistinctToolNames()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+        var dogPath = doc.FilePath!;
+
+        // Writer 1: rename_apply (RefactoringService)
+        var locator = SymbolLocator.BySource(dogPath, 5, 6);
+        var renamePreview = await RefactoringService.PreviewRenameAsync(
+            wsId, locator, "Doggo", CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(
+            renamePreview.PreviewToken, "rename_apply", CancellationToken.None);
+
+        // After the rename the file lives at Doggo.cs on disk, so fetch the current
+        // path for the next apply from the workspace.
+        var currentDogPath = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Dog.cs") == true || d.FilePath?.EndsWith("Doggo.cs") == true)
+            .FilePath!;
+
+        // Writer 2: apply_text_edit (EditService)
+        var edit = new TextEditDto(1, 1, 1, 1, "// comment\n");
+        await EditService.ApplyTextEditsAsync(
+            wsId, currentDogPath, [edit], "apply_text_edit", CancellationToken.None);
+
+        // Writer 3: set_editorconfig_option (EditorConfigService)
+        await EditorConfigService.SetOptionAsync(
+            wsId, currentDogPath, "dotnet_diagnostic.CA1704.severity", "warning",
+            "set_editorconfig_option", CancellationToken.None);
+
+        // Writer 4: set_diagnostic_severity (SuppressionService → EditorConfigService)
+        await CreateSuppressionService().SetDiagnosticSeverityAsync(
+            wsId, "CA1705", "suggestion", currentDogPath, CancellationToken.None);
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        var toolNames = changes.Select(c => c.ToolName).ToList();
+
+        CollectionAssert.Contains(toolNames, "rename_apply");
+        CollectionAssert.Contains(toolNames, "apply_text_edit");
+        CollectionAssert.Contains(toolNames, "set_editorconfig_option");
+        CollectionAssert.Contains(toolNames, "set_diagnostic_severity");
+
+        // No writer may collapse into the legacy generic buckets.
+        CollectionAssert.DoesNotContain(toolNames, "refactoring_apply",
+            "rename_apply must not degrade to the generic 'refactoring_apply' label.");
     }
 
     [TestMethod]
@@ -54,7 +207,7 @@ public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
         var locator = SymbolLocator.BySource(doc.FilePath!, 5, 6);
         var preview1 = await RefactoringService.PreviewRenameAsync(
             wsId, locator, "Doggo", CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview1.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview1.PreviewToken, "rename_apply", CancellationToken.None);
 
         // Second apply: format
         var doc2 = WorkspaceManager.GetCurrentSolution(wsId)
@@ -63,7 +216,7 @@ public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
 
         var preview2 = await RefactoringService.PreviewFormatDocumentAsync(
             wsId, doc2.FilePath!, CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview2.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview2.PreviewToken, "format_document_apply", CancellationToken.None);
 
         var changes = ChangeTracker.GetChanges(wsId);
         Assert.AreEqual(2, changes.Count, "Expected 2 changes.");

--- a/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
@@ -35,7 +35,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             "Contracts",
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(interfaceFilePath));
 
@@ -66,7 +66,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             CancellationToken.None,
             preserveNamespace: false);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsFalse(File.Exists(sourceFilePath));
         Assert.IsTrue(File.Exists(targetFilePath));
@@ -97,7 +97,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             CancellationToken.None,
             preserveNamespace: true);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         var movedText = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(movedText, "namespace SampleLib");
@@ -125,7 +125,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             "Contracts",
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(interfaceFilePath));
 
@@ -163,7 +163,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             "Contracts",
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
         var interfaceText = await File.ReadAllTextAsync(interfaceFilePath, CancellationToken.None);
@@ -264,7 +264,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             "Contracts",
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
         var sourceContents = await File.ReadAllTextAsync(sourceFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/CsprojReserializationTests.cs
+++ b/tests/RoslynMcp.Tests/CsprojReserializationTests.cs
@@ -249,7 +249,7 @@ public sealed class CsprojReserializationTests : TestBase
                     Content: "namespace SampleLib;\n\npublic static class CsprojDriftGuard\n{\n    public const string Marker = \"csproj-reserialization\";\n}\n"),
                 CancellationToken.None);
 
-            await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(File.Exists(newFilePath), "The generated file must be on disk after apply.");
 

--- a/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DeadCodeIntegrationTests.cs
@@ -50,7 +50,7 @@ public sealed class DeadCodeIntegrationTests : SharedWorkspaceTestBase
                 new RoslynMcp.Core.Models.DeadCodeRemovalDto([unusedField.SymbolHandle!]),
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(applyResult.Success, applyResult.Error);
             var contents = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
@@ -84,7 +84,7 @@ public class DiagnosticFixIntegrationTests : SharedWorkspaceTestBase
 
             Assert.IsTrue(preview.Changes.Count > 0, "Code fix preview should produce changes.");
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(applyResult.Success, applyResult.Error);
             var contents = await File.ReadAllTextAsync(serviceFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
@@ -39,7 +39,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(1, 1, 1, 1, null!);
 
         var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "null NewText");
     }
 
@@ -53,7 +53,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(5, 10, 5, 5, "x");
 
         var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "reversed range");
     }
 
@@ -67,7 +67,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(9999, 1, 9999, 1, "oops");
 
         var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "9999");
     }
 
@@ -81,7 +81,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(1, 0, 1, 1, "oops");
 
         var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None));
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "1-based");
     }
 
@@ -95,7 +95,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(5, 10, 5, 5, "x"); // reversed
         try
         {
-            await EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+            await EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
             Assert.Fail("Expected ArgumentException.");
         }
         catch (ArgumentException)
@@ -119,7 +119,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var e2 = new TextEditDto(5, 6, 5, 20, "y");
 
         var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { e1, e2 }, CancellationToken.None));
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { e1, e2 }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "overlapping");
     }
 
@@ -132,7 +132,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
 
         // Remove the closing brace of the class (line 13: `}`).
         var edit = new TextEditDto(13, 1, 13, 2, "");
-        var result = await EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+        var result = await EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
 
         Assert.IsFalse(result.Success);
         Assert.IsNotNull(result.SyntaxErrors);
@@ -150,7 +150,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
 
         var edit = new TextEditDto(13, 1, 13, 2, "");
         var result = await EditService.ApplyTextEditsAsync(
-            workspace.WorkspaceId, dogFilePath, new[] { edit }, CancellationToken.None, skipSyntaxCheck: true);
+            workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None, skipSyntaxCheck: true);
 
         Assert.IsTrue(result.Success);
         Assert.IsNull(result.SyntaxErrors);
@@ -175,7 +175,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         // Normal apply: capture the file snapshot on the undo stack.
         var lines = originalText.Split('\n');
         var appendEdit = new TextEditDto(lines.Length, lines[^1].Length + 1, lines.Length, lines[^1].Length + 1, "\n// apply marker");
-        var applyResult = await EditService.ApplyTextEditsAsync(workspaceId, dogFilePath, new[] { appendEdit }, CancellationToken.None);
+        var applyResult = await EditService.ApplyTextEditsAsync(workspaceId, dogFilePath, new[] { appendEdit }, "apply_text_edit", CancellationToken.None);
         Assert.IsTrue(applyResult.Success);
 
         // Simulate post-apply disk drift: a second out-of-band write that the workspace
@@ -209,7 +209,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         await File.WriteAllTextAsync(editorconfigPath, originalContent, CancellationToken.None);
 
         var setResult = await EditorConfigService.SetOptionAsync(
-            workspaceId, dogFilePath, "dotnet_diagnostic.CA1000.severity", "warning", CancellationToken.None);
+            workspaceId, dogFilePath, "dotnet_diagnostic.CA1000.severity", "warning", "set_editorconfig_option", CancellationToken.None);
         Assert.AreEqual(editorconfigPath, setResult.EditorConfigPath);
         Assert.IsFalse(setResult.CreatedNewFile);
 
@@ -240,7 +240,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         if (File.Exists(candidatePath)) File.Delete(candidatePath);
 
         var setResult = await EditorConfigService.SetOptionAsync(
-            workspaceId, dogFilePath, "dotnet_diagnostic.CA1001.severity", "warning", CancellationToken.None);
+            workspaceId, dogFilePath, "dotnet_diagnostic.CA1001.severity", "warning", "set_editorconfig_option", CancellationToken.None);
         // The implementation may locate an existing .editorconfig higher in the tree; only assert
         // the created-on-this-call case, which is what the "revert deletes it" contract covers.
         if (!setResult.CreatedNewFile)

--- a/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
@@ -32,7 +32,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         var edit = new TextEditDto(lastLine, lastColumn, lastLine, lastColumn, "\n// inserted by test");
 
         var result = await EditService.ApplyTextEditsAsync(
-            workspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
         Assert.IsTrue(result.Success, "ApplyTextEditsAsync should report success.");
 
         var afterEdit = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
@@ -73,7 +73,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
             new FileEditsDto(catFilePath, new[] { catEdit }),
         };
 
-        var dto = await EditService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, CancellationToken.None);
+        var dto = await EditService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, "apply_multi_file_edit", CancellationToken.None);
         Assert.IsTrue(dto.Success);
         Assert.AreEqual(2, dto.FilesModified);
 
@@ -110,7 +110,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         var preview = await RefactoringService.PreviewRenameAsync(
             workspaceId, locator, "ICreature", CancellationToken.None);
         var renameApply = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(renameApply.Success, renameApply.Error);
 
         // Capture the post-rename file state — the text edit's snapshot should restore THIS,
@@ -124,7 +124,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         // POST-RENAME state.
         var edit = AppendCommentEdit(postRenameDog, "// after rename");
         var editResult = await EditService.ApplyTextEditsAsync(
-            workspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
         Assert.IsTrue(editResult.Success);
 
         // Revert: should restore the post-rename state (rename is preserved).
@@ -153,7 +153,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         var dogText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
         var edit = AppendCommentEdit(dogText, "// snapshot probe");
 
-        await EditService.ApplyTextEditsAsync(workspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+        await EditService.ApplyTextEditsAsync(workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
 
         var entry = UndoService.GetLastOperation(workspaceId);
         Assert.IsNotNull(entry, "apply_text_edit must register an undo entry.");
@@ -198,7 +198,7 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
             "    public string Speak() => \"Bark\";");
 
         var result = await EditService.ApplyTextEditsAsync(
-            workspaceId, dogFilePath, new[] { edit }, CancellationToken.None);
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
         Assert.IsTrue(result.Success);
 
         var afterEdit = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
         const string value = "none";
 
         var setResult = await EditorConfigService.SetOptionAsync(
-            workspaceId, dogFilePath, unloadedKey, value, CancellationToken.None);
+            workspaceId, dogFilePath, unloadedKey, value, "set_editorconfig_option", CancellationToken.None);
         Assert.IsTrue(File.Exists(setResult.EditorConfigPath));
 
         var options = await EditorConfigService.GetOptionsAsync(

--- a/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
@@ -91,7 +91,7 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
                 replaceUsages: false,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             var interfaceFilePath = Path.Combine(sampleLibDir, "IItem3InventoryService.cs");
@@ -186,7 +186,7 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
                 replaceUsages: false,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             var interfaceFilePath = Path.Combine(sampleLibDir, "IItem3GenericService.cs");
@@ -271,7 +271,7 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
                 replaceUsages: false,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             var interfaceFilePath = Path.Combine(sampleLibDir, "IItem3SpecialUsingService.cs");
@@ -359,7 +359,7 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
                 replaceUsages: false,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             var updatedSourceText = await File.ReadAllTextAsync(servicePath);

--- a/tests/RoslynMcp.Tests/ExtractMethodFormatRegressionTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodFormatRegressionTests.cs
@@ -63,7 +63,7 @@ public sealed class ExtractMethodFormatRegressionTests : TestBase
                 methodName: "ComputeIntermediate",
                 ct: CancellationToken.None);
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(apply.Success, $"Apply must succeed. Error: {apply.Error}");
 
             var updated = await File.ReadAllTextAsync(fixturePath);
@@ -136,7 +136,7 @@ public sealed class ExtractMethodFormatRegressionTests : TestBase
                 methodName: "ComputeCombined",
                 ct: CancellationToken.None);
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(apply.Success, $"Apply must succeed. Error: {apply.Error}");
 
             var updated = await File.ReadAllTextAsync(fixturePath);
@@ -210,7 +210,7 @@ public sealed class ExtractMethodFormatRegressionTests : TestBase
                 methodName: "BuildDoubled",
                 ct: CancellationToken.None);
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(apply.Success, $"Apply must succeed. Error: {apply.Error}");
 
             var post = await File.ReadAllTextAsync(fixturePath);

--- a/tests/RoslynMcp.Tests/ExtractMethodTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodTests.cs
@@ -62,7 +62,7 @@ public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
             CancellationToken.None);
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, "Apply should succeed.");
 
@@ -172,7 +172,7 @@ public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
             $"Must NOT emit `var result = TransformResult(...)` — that re-declares the existing local. Diff:\n{diff}");
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, "Apply must succeed.");
 
         var compileResult = await CompileCheckService.CheckAsync(

--- a/tests/RoslynMcp.Tests/ExtractMethodThisExclusionTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodThisExclusionTests.cs
@@ -70,7 +70,7 @@ public sealed class ExtractMethodThisExclusionTests : TestBase
                 methodName: "CalculateResult",
                 ct: CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             var updated = await File.ReadAllTextAsync(fixturePath);
@@ -132,7 +132,7 @@ public sealed class ExtractMethodThisExclusionTests : TestBase
                 methodName: "ComputeTripledFromDoubled",
                 ct: CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Static extraction must still work. Got error: {applyResult.Error}");
 
             var updated = await File.ReadAllTextAsync(fixturePath);

--- a/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
@@ -153,7 +153,7 @@ public sealed class ExtractSharedExpressionTests : IsolatedWorkspaceTestBase
             CancellationToken.None);
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, "Apply should succeed.");
 
         var compileResult = await CompileCheckService.CheckAsync(

--- a/tests/RoslynMcp.Tests/FileOperationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/FileOperationIntegrationTests.cs
@@ -35,7 +35,7 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
         Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
         Assert.IsTrue(preview.Changes.Any(change => string.Equals(change.FilePath, newFilePath, StringComparison.OrdinalIgnoreCase)));
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(newFilePath));
@@ -59,7 +59,7 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
         Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
         Assert.IsTrue(preview.Changes.Any(change => string.Equals(change.FilePath, targetFilePath, StringComparison.OrdinalIgnoreCase)));
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsFalse(File.Exists(targetFilePath));
@@ -79,7 +79,7 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
 
         await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsFalse(applyResult.Success, "Stale previews should be rejected.");
         StringAssert.Contains(applyResult.Error ?? string.Empty, "stale");
@@ -101,7 +101,7 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(preview.Changes.Any(change => string.Equals(change.FilePath, sourceFilePath, StringComparison.OrdinalIgnoreCase)));
         Assert.IsTrue(preview.Changes.Any(change => string.Equals(change.FilePath, destinationFilePath, StringComparison.OrdinalIgnoreCase)));
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsFalse(File.Exists(sourceFilePath));

--- a/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
@@ -171,7 +171,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
 
             // Apply the preview and compare on-disk text to the preview's expected text.
             var preApplyText = await File.ReadAllTextAsync(fixturePath);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, "apply must succeed");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -248,7 +248,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
                 "no changes expected when the requested range is already clean");
 
             var preApplyText = await File.ReadAllTextAsync(fixturePath);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success);
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -324,7 +324,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
                 endLine: 14, endColumn: 6,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, "apply must succeed");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);
@@ -386,7 +386,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
                 endLine: 9, endColumn: 25,
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, "apply must succeed");
 
             var postApplyText = await File.ReadAllTextAsync(fixturePath);

--- a/tests/RoslynMcp.Tests/IntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/IntegrationTests.cs
@@ -342,7 +342,7 @@ public class IntegrationTests : SharedWorkspaceTestBase
                 CancellationToken.None);
             Assert.IsTrue(preview.Changes.Count > 0, "Rename preview should produce file changes.");
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, applyResult.Error);
 
             var dogContents = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
@@ -374,7 +374,7 @@ public class IntegrationTests : SharedWorkspaceTestBase
                 CancellationToken.None);
             await WorkspaceManager.ReloadAsync(isolatedWorkspaceId, CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsFalse(applyResult.Success, "Stale previews should be rejected.");
             StringAssert.Contains(applyResult.Error ?? string.Empty, "stale");
         }
@@ -400,7 +400,7 @@ public class IntegrationTests : SharedWorkspaceTestBase
                 isolatedWorkspaceId,
                 serviceFilePath,
                 CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(applyResult.Success, applyResult.Error);
             var serviceContents = await File.ReadAllTextAsync(serviceFilePath, CancellationToken.None);
@@ -428,7 +428,7 @@ public class IntegrationTests : SharedWorkspaceTestBase
                 isolatedWorkspaceId,
                 serviceFilePath,
                 CancellationToken.None);
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(applyResult.Success, applyResult.Error);
             var serviceContents = await File.ReadAllTextAsync(serviceFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/MoveTypeDiskStateTests.cs
+++ b/tests/RoslynMcp.Tests/MoveTypeDiskStateTests.cs
@@ -71,7 +71,7 @@ public sealed class MoveTypeDiskStateTests : TestBase
             Assert.IsTrue(previewDto.Changes.Count >= 2,
                 $"Expected at least source-modification + target-creation in preview. Got {previewDto.Changes.Count}.");
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Apply failed: {applyResult.Error}");
 
             // Expected post-apply shape.

--- a/tests/RoslynMcp.Tests/PostApplySymbolRotationTests.cs
+++ b/tests/RoslynMcp.Tests/PostApplySymbolRotationTests.cs
@@ -35,7 +35,7 @@ public sealed class PostApplySymbolRotationTests : SharedWorkspaceTestBase
                 workspaceId, locator, "GetAllAnimalsRotated", CancellationToken.None);
             Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(apply.Success, apply.Error);
             Assert.IsNotNull(apply.MutatedSymbol, "Rename apply must return a rotated handle in MutatedSymbol.");
@@ -72,7 +72,7 @@ public sealed class PostApplySymbolRotationTests : SharedWorkspaceTestBase
                 workspaceId, targetFile, CancellationToken.None);
             Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(apply.Success, apply.Error);
             Assert.IsNull(

--- a/tests/RoslynMcp.Tests/PreviewTokenCrossCouplingTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewTokenCrossCouplingTests.cs
@@ -66,7 +66,7 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
         // Apply A first — this bumps the workspace version. Pre-fix, the `TryApplyChanges`
         // path called `_previewStore.InvalidateAll(workspaceId)`, so token B would be
         // dropped here even though nothing about file B changed.
-        var applyA = await RefactoringService.ApplyRefactoringAsync(previewA.PreviewToken, CancellationToken.None);
+        var applyA = await RefactoringService.ApplyRefactoringAsync(previewA.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyA.Success, applyA.Error);
         Assert.IsTrue(File.Exists(firstFilePath));
 
@@ -74,7 +74,7 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
         // "Preview token is invalid, expired, or stale because the workspace changed
         // since the preview was generated." (audit §9.6, §5 "extract_interface_apply
         // stale preview token (invalidated by sibling format_range_apply in same turn)").
-        var applyB = await RefactoringService.ApplyRefactoringAsync(previewB.PreviewToken, CancellationToken.None);
+        var applyB = await RefactoringService.ApplyRefactoringAsync(previewB.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyB.Success,
             $"Sibling apply must not invalidate unrelated preview tokens. Got: {applyB.Error}");
         Assert.IsTrue(File.Exists(secondFilePath));
@@ -123,10 +123,10 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
         Assert.IsFalse(string.IsNullOrWhiteSpace(previewA.PreviewToken));
         Assert.IsFalse(string.IsNullOrWhiteSpace(previewB.PreviewToken));
 
-        var applyA = await RefactoringService.ApplyRefactoringAsync(previewA.PreviewToken, CancellationToken.None);
+        var applyA = await RefactoringService.ApplyRefactoringAsync(previewA.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyA.Success, applyA.Error);
 
-        var applyB = await RefactoringService.ApplyRefactoringAsync(previewB.PreviewToken, CancellationToken.None);
+        var applyB = await RefactoringService.ApplyRefactoringAsync(previewB.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyB.Success,
             $"Sibling text-edit apply must not invalidate unrelated preview tokens. Got: {applyB.Error}");
 
@@ -160,7 +160,7 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
         // Lifecycle event — drops all tokens (captured Solution refs now orphaned).
         await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsFalse(applyResult.Success,
             "Reload must still invalidate live preview tokens.");

--- a/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
@@ -163,7 +163,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
                 wsId, probeFilePath, CancellationToken.None);
             Assert.IsNotNull(preview.PreviewToken);
 
-            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(apply.Success, apply.Error);
 
             var resultText = await File.ReadAllTextAsync(probeFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/RenameSummaryModeTests.cs
+++ b/tests/RoslynMcp.Tests/RenameSummaryModeTests.cs
@@ -98,7 +98,7 @@ public sealed class RenameSummaryModeTests : SharedWorkspaceTestBase
             var token = doc.RootElement.GetProperty("previewToken").GetString();
             Assert.IsFalse(string.IsNullOrWhiteSpace(token));
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(token!, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(token!, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, $"Summary-mode apply must succeed. Error: {applyResult.Error}");
 
             var postRename = await File.ReadAllTextAsync(animalServicePath);

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -48,7 +48,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
             new ScaffoldFirstTestFileDto("SampleLib.Dog", "SampleLib.Tests"),
             CancellationToken.None);
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(destinationPath),
@@ -119,7 +119,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
                 TestProjectName: null),
             CancellationToken.None);
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(destinationPath),

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -28,7 +28,7 @@ public sealed class ScaffoldingIntegrationTests : IsolatedWorkspaceTestBase
             new ScaffoldTypeDto("SampleLib", "Bird", "class", "SampleLib.Generated"),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(targetFilePath));
@@ -49,7 +49,7 @@ public sealed class ScaffoldingIntegrationTests : IsolatedWorkspaceTestBase
             workspace.WorkspaceId,
             new ScaffoldTypeDto("SampleLib", "Bird", "class", "SampleLib.Generated"),
             CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "internal sealed class Bird");
@@ -68,7 +68,7 @@ public sealed class ScaffoldingIntegrationTests : IsolatedWorkspaceTestBase
             workspace.WorkspaceId,
             new ScaffoldTypeDto("SampleLib", "IThing", "interface", "SampleLib.Contracts"),
             CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "public interface IThing");
@@ -117,7 +117,7 @@ public class BulkProcessor
             workspace.WorkspaceId,
             new ScaffoldTestDto("SampleLib.Tests", "BulkProcessor", "Sum"),
             CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         var contents = await File.ReadAllTextAsync(
             workspace.GetPath("SampleLib.Tests", "BulkProcessorGeneratedTests.cs"),
@@ -142,7 +142,7 @@ public class BulkProcessor
             workspace.WorkspaceId,
             new ScaffoldTypeDto("SampleLib", "Widget", "class", "Acme.Domain"),
             CancellationToken.None);
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(expectedPath),
@@ -163,7 +163,7 @@ public class BulkProcessor
             new ScaffoldTestDto("SampleLib.Tests", "Dog", "Speak", ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(targetFilePath));
@@ -202,7 +202,7 @@ public class HiddenBehavior
             preview.Warnings[0],
             "Target method 'BuildSecret' is private — the scaffold uses reflection to invoke it;");
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
         var contents = await File.ReadAllTextAsync(
@@ -257,7 +257,7 @@ public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
                 ReferenceTestFile: siblingPath),
             CancellationToken.None);
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         var scaffoldPath = workspace.GetPath("SampleLib.Tests", "AnimalServiceGeneratedTests.cs");
@@ -316,8 +316,7 @@ public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
             "Batch scaffold preview should aggregate one file-creation diff per target.");
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken,
-            CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(dogPath), $"Expected scaffolded file at {dogPath}.");
@@ -352,7 +351,7 @@ public class HealthEndpointTests : IClassFixture<CustomWebApplicationFactory>
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(expectedFilePath),
@@ -404,7 +403,7 @@ public class NestedHost
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         Assert.IsTrue(File.Exists(expectedFilePath),
@@ -447,7 +446,7 @@ public static class StaticUtil
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         var contents = await File.ReadAllTextAsync(expectedFilePath, CancellationToken.None);
@@ -490,7 +489,7 @@ public class TenantConstants
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         var contents = await File.ReadAllTextAsync(expectedFilePath, CancellationToken.None);
@@ -533,7 +532,7 @@ public class SnapshotContentHasher
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
 
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
         Assert.IsTrue(applyResult.Success, applyResult.Error);
         var contents = await File.ReadAllTextAsync(expectedFilePath, CancellationToken.None);

--- a/tests/RoslynMcp.Tests/SdkStyleCsprojInjectionTests.cs
+++ b/tests/RoslynMcp.Tests/SdkStyleCsprojInjectionTests.cs
@@ -134,7 +134,7 @@ public sealed class SdkStyleCsprojInjectionTests : TestBase
                     Content: "namespace SampleLib;\n\npublic static class Item5Guard\n{\n    public const string Marker = \"item-5\";\n}\n"),
                 CancellationToken.None);
 
-            await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
 
             Assert.IsTrue(File.Exists(newFilePath), "The generated file must be on disk after apply.");
 

--- a/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class SuppressionServiceTests
         string? capturedKey = null;
         var editor = new StubEditorConfig
         {
-            OnSetOption = (_, _, key, _, _) =>
+            OnSetOption = (_, _, key, _, _, _) =>
             {
                 capturedKey = key;
                 return Task.FromResult(new EditorConfigWriteResultDto("/x/.editorconfig", key, "warning", false));
@@ -54,7 +54,7 @@ public sealed class SuppressionServiceTests
         TextEditDto? captured = null;
         var edits = new StubEditService
         {
-            OnApply = (_, _, editsToApply, _, _) =>
+            OnApply = (_, _, editsToApply, _, _, _) =>
             {
                 captured = editsToApply.Single();
                 return Task.FromResult(new TextEditResultDto(true, "/src/Program.cs", 1, []));
@@ -69,20 +69,20 @@ public sealed class SuppressionServiceTests
 
     private sealed class StubEditorConfig : IEditorConfigService
     {
-        public Func<string, string, string, string, CancellationToken, Task<EditorConfigWriteResultDto>>? OnSetOption { get; init; }
+        public Func<string, string, string, string, string, CancellationToken, Task<EditorConfigWriteResultDto>>? OnSetOption { get; init; }
 
         public Task<EditorConfigOptionsDto> GetOptionsAsync(string workspaceId, string filePath, CancellationToken ct) =>
             throw new NotSupportedException();
 
         public Task<EditorConfigWriteResultDto> SetOptionAsync(
-            string workspaceId, string sourceFilePath, string key, string value, CancellationToken ct) =>
-            OnSetOption?.Invoke(workspaceId, sourceFilePath, key, value, ct)
+            string workspaceId, string sourceFilePath, string key, string value, string toolName, CancellationToken ct) =>
+            OnSetOption?.Invoke(workspaceId, sourceFilePath, key, value, toolName, ct)
             ?? Task.FromResult(new EditorConfigWriteResultDto("", key, value, false));
     }
 
     private sealed class StubEditService : IEditService
     {
-        public Func<string, string, IReadOnlyList<TextEditDto>, CancellationToken, bool, Task<TextEditResultDto>>? OnApply { get; init; }
+        public Func<string, string, IReadOnlyList<TextEditDto>, string, CancellationToken, bool, Task<TextEditResultDto>>? OnApply { get; init; }
 
         // SuppressionService only forwards the default (verify=false, autoRevertOnError=false)
         // parameter values to apply_text_edit. The stub ignores them — it verifies that the
@@ -91,16 +91,18 @@ public sealed class SuppressionServiceTests
             string workspaceId,
             string filePath,
             IReadOnlyList<TextEditDto> edits,
+            string toolName,
             CancellationToken ct,
             bool skipSyntaxCheck = false,
             bool verify = false,
             bool autoRevertOnError = false) =>
-            OnApply?.Invoke(workspaceId, filePath, edits, ct, skipSyntaxCheck)
+            OnApply?.Invoke(workspaceId, filePath, edits, toolName, ct, skipSyntaxCheck)
             ?? Task.FromResult(new TextEditResultDto(false, filePath, 0, []));
 
         public Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
             string workspaceId,
             IReadOnlyList<FileEditsDto> fileEdits,
+            string toolName,
             CancellationToken ct,
             bool skipSyntaxCheck = false,
             bool verify = false,

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -270,7 +270,8 @@ internal sealed class TestServiceContainer
             EditorConfigService = new EditorConfigService(
                 workspaceManager,
                 NullLogger<EditorConfigService>.Instance,
-                undoService),
+                undoService,
+                changeTracker),
             MsBuildEvaluationService = msBuildEvaluationService,
             ExtractMethodService = new ExtractMethodService(
                 workspaceManager,

--- a/tests/RoslynMcp.Tests/TruncatedPreviewApplyGateTests.cs
+++ b/tests/RoslynMcp.Tests/TruncatedPreviewApplyGateTests.cs
@@ -42,7 +42,7 @@ public sealed class TruncatedPreviewApplyGateTests : TestBase
             description: "Item #4 truncation gate probe",
             diffTruncated: true);
 
-        var result = await RefactoringService.ApplyRefactoringAsync(token, force: false, CancellationToken.None);
+        var result = await RefactoringService.ApplyRefactoringAsync(token, "test_apply", force: false, CancellationToken.None);
 
         Assert.IsFalse(result.Success, "Truncated preview must refuse to apply without force.");
         Assert.IsNotNull(result.Error, "Refusal must carry an actionable error message.");
@@ -70,7 +70,7 @@ public sealed class TruncatedPreviewApplyGateTests : TestBase
         // that's already loaded, no real disk mutation occurs, but the apply call must
         // proceed past the truncation gate (Success=true, or if Success=false it's for
         // reasons other than the gate).
-        var result = await RefactoringService.ApplyRefactoringAsync(token, force: true, CancellationToken.None);
+        var result = await RefactoringService.ApplyRefactoringAsync(token, "test_apply", force: true, CancellationToken.None);
 
         // The apply may have nothing to do (identity solution) — both Success paths
         // are acceptable. What MUST be true: the Error does NOT mention truncation.
@@ -96,7 +96,7 @@ public sealed class TruncatedPreviewApplyGateTests : TestBase
             description: "Item #4 non-truncated probe",
             diffTruncated: false);
 
-        var result = await RefactoringService.ApplyRefactoringAsync(token, force: false, CancellationToken.None);
+        var result = await RefactoringService.ApplyRefactoringAsync(token, "test_apply", force: false, CancellationToken.None);
 
         // Identity solution apply; again the gate must not fire. Any failure MUST not
         // reference truncation.

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -130,7 +130,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             wsId, doc.FilePath!, "Kitten", null, CancellationToken.None);
         Assert.IsNotNull(preview.PreviewToken);
 
-        var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(apply.Success, apply.Error);
 
         var newFilePath = workspace.GetPath("SampleLib", "Kitten.cs");
@@ -159,7 +159,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
 
         var preview = await TypeMoveService.PreviewMoveTypeToFileAsync(
             wsId, doc.FilePath!, "Kitten", null, CancellationToken.None);
-        var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(apply.Success, apply.Error);
 
         var content = await File.ReadAllTextAsync(workspace.GetPath("SampleLib", "Kitten.cs"), CancellationToken.None);

--- a/tests/RoslynMcp.Tests/UndoFileOperationsTests.cs
+++ b/tests/RoslynMcp.Tests/UndoFileOperationsTests.cs
@@ -48,7 +48,7 @@ public sealed class UndoFileOperationsTests : TestBase
                     Content: "namespace SampleLib;\npublic static class Item2Guard_CreatedOnly { }\n"),
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, "Apply must succeed as a precondition.");
             Assert.IsTrue(File.Exists(newFilePath), "File must be on disk after apply.");
 
@@ -89,7 +89,7 @@ public sealed class UndoFileOperationsTests : TestBase
                 new DeleteFileDto(targetFilePath),
                 CancellationToken.None);
 
-            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(previewDto.PreviewToken, "test_apply", CancellationToken.None);
             Assert.IsTrue(applyResult.Success, "Delete apply must succeed as a precondition.");
             Assert.IsFalse(File.Exists(targetFilePath), "File must be gone from disk after delete apply.");
 

--- a/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/UndoIntegrationTests.cs
@@ -38,7 +38,7 @@ public sealed class UndoIntegrationTests : IsolatedWorkspaceTestBase
 
         // Apply the rename
         var applyResult = await RefactoringService.ApplyRefactoringAsync(
-            preview.PreviewToken, CancellationToken.None);
+            preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
         // Verify the rename took effect
@@ -93,7 +93,7 @@ public sealed class UndoIntegrationTests : IsolatedWorkspaceTestBase
 
         var preview = await RefactoringService.PreviewRenameAsync(workspaceId, locator, "ICreature", CancellationToken.None);
         Assert.IsNotNull(preview.PreviewToken);
-        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
         // After apply, disk must show the rename.


### PR DESCRIPTION
## Summary

- `workspace_changes` previously omitted `set_editorconfig_option` and `set_diagnostic_severity` applies entirely — their service paths bypassed `ChangeTracker` — and collapsed every preview-redeeming `*_apply` into the generic `refactoring_apply` / `apply_text_edit` buckets.
- Wires both editorconfig writers through `ChangeTracker.Record` with discriminated tool names (`set_editorconfig_option`, `set_diagnostic_severity`).
- Threads the originating MCP tool name through `IRefactoringService.ApplyRefactoringAsync`, `IEditService.ApplyTextEditsAsync`, and `IEditService.ApplyMultiFileTextEditsAsync` so each `*_apply` surfaces with its own identity (`rename_apply`, `code_fix_apply`, `format_document_apply`, `remove_dead_code_apply`, `extract_method_apply`, `extract_interface_apply`, `move_type_to_file_apply`, `bulk_replace_type_apply`, `apply_code_action`, `apply_with_verify`, `apply_text_edit`, `apply_multi_file_edit`, `add_pragma_suppression`, `pragma_scope_widen`, etc.).
- Breaking change in internal services: `IRefactoringService`, `IEditService`, and `IEditorConfigService` gain a required `toolName` parameter. No backward-compat shim — every internal caller is updated.
- Adds `ChangeTrackerTests` regression coverage that asserts each writer surfaces with its own discriminated tool name and that `rename_apply` no longer collapses into the legacy `refactoring_apply` bucket.

## Test plan

- [x] `dotnet build RoslynMcp.slnx -c Release` — clean
- [x] `./eng/verify-ai-docs.ps1` — passes
- [x] `./eng/verify-release.ps1 -Configuration Release` — 901/901 tests pass
- [x] New `ChangeTrackerTests` cover: rename_apply / format_document_apply / apply_text_edit / set_editorconfig_option / set_diagnostic_severity / multi-writer discrimination

Closes: workspace-changes-log-missing-editorconfig-writers

🤖 Generated with [Claude Code](https://claude.com/claude-code)