### PR TITLE
fix(diagnostic-details): short-circuit to single-document scan (diagnostic-details-perf-budget-overrun)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -288,11 +288,96 @@ public sealed class DiagnosticService : IDiagnosticService
             }
         }
 
-        // Cold path: cache miss (no prior list call, or workspace was reloaded). Re-run
-        // the search across projects in parallel and warm the cache for next time.
+        // Cold path: cache miss (no prior list call, or workspace was reloaded).
+        // diagnostic-details-perf-budget-overrun: short-circuit to a single-document
+        // diagnostic scan when we can resolve the supplied filePath to specific Document(s)
+        // in the solution. This avoids the solution-wide compile + analyzer pass (previously
+        // ~16s on large solutions) in favor of a per-document syntax+semantic+analyzer scan
+        // that finishes in <2s. The detail tool's contract already requires filePath + line +
+        // column, so this path is always available for the diagnostic_details caller.
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var diagnostic = await FindDiagnosticAsync(workspaceId, solution, version, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
-        return diagnostic is null ? null : BuildDetailsDto(diagnostic);
+        var diagnostic = await FindDiagnosticInDocumentAsync(workspaceId, solution, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
+        if (diagnostic is not null)
+        {
+            return BuildDetailsDto(diagnostic);
+        }
+
+        // If the file did not resolve to any Document (e.g., a generated file path, or a
+        // workspace-level diagnostic with no source location), fall back to the legacy
+        // solution-wide search so we don't regress discoverability.
+        var fallbackDiagnostic = await FindDiagnosticAsync(workspaceId, solution, version, diagnosticId, filePath, line, column, ct).ConfigureAwait(false);
+        return fallbackDiagnostic is null ? null : BuildDetailsDto(fallbackDiagnostic);
+    }
+
+    /// <summary>
+    /// diagnostic-details-perf-budget-overrun: single-document diagnostic scan. Resolves
+    /// <paramref name="filePath"/> to the matching Document(s) via
+    /// <see cref="Solution.GetDocumentIdsWithFilePath"/> and runs only the per-document
+    /// analyzer + compiler passes needed to find the target diagnostic. Returns null when
+    /// the file does not resolve to any Document; caller falls back to the full scan.
+    /// </summary>
+    private async Task<Diagnostic?> FindDiagnosticInDocumentAsync(
+        string workspaceId,
+        Solution solution,
+        string diagnosticId,
+        string filePath,
+        int line,
+        int column,
+        CancellationToken ct)
+    {
+        var documentIds = solution.GetDocumentIdsWithFilePath(filePath);
+        if (documentIds.IsDefaultOrEmpty) return null;
+
+        foreach (var documentId in documentIds)
+        {
+            var document = solution.GetDocument(documentId);
+            if (document is null) continue;
+
+            var tree = await document.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
+            if (tree is null) continue;
+
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, document.Project, ct).ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            // Compiler diagnostics scoped to the single syntax tree — avoids walking every
+            // tree in the compilation.
+            var compilerDiagnostics = compilation.GetDiagnostics(ct).Where(d => d.Location.SourceTree == tree);
+            foreach (var d in compilerDiagnostics)
+            {
+                if (DiagnosticMatchesLocation(d, diagnosticId, filePath, line, column))
+                    return d;
+            }
+
+            // Analyzer diagnostics scoped to the single document. We use the syntax- and
+            // semantic-diagnostic APIs on CompilationWithAnalyzers so analyzers registered
+            // via RegisterSyntaxTreeAction / RegisterSemanticModelAction / RegisterSymbolAction
+            // only run for this document's tree + model.
+            var compilationWithAnalyzers = await _compilationCache
+                .GetCompilationWithAnalyzersAsync(workspaceId, document.Project, ct)
+                .ConfigureAwait(false);
+            if (compilationWithAnalyzers is null) continue;
+
+            var syntaxAnalyzerDiagnostics = await compilationWithAnalyzers
+                .GetAnalyzerSyntaxDiagnosticsAsync(tree, ct).ConfigureAwait(false);
+            foreach (var d in syntaxAnalyzerDiagnostics)
+            {
+                if (DiagnosticMatchesLocation(d, diagnosticId, filePath, line, column))
+                    return d;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
+            if (semanticModel is null) continue;
+
+            var semanticAnalyzerDiagnostics = await compilationWithAnalyzers
+                .GetAnalyzerSemanticDiagnosticsAsync(semanticModel, filterSpan: null, ct).ConfigureAwait(false);
+            foreach (var d in semanticAnalyzerDiagnostics)
+            {
+                if (DiagnosticMatchesLocation(d, diagnosticId, filePath, line, column))
+                    return d;
+            }
+        }
+
+        return null;
     }
 
     private static DiagnosticDetailsDto BuildDetailsDto(Diagnostic diagnostic) => new(

--- a/tests/RoslynMcp.Tests/DiagnosticServicePerfTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticServicePerfTests.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// diagnostic-details-perf-budget-overrun: guards the single-document short-circuit in
+/// <see cref="RoslynMcp.Roslyn.Services.DiagnosticService.GetDiagnosticDetailsAsync"/>
+/// against future regressions. The cold path previously ran a solution-wide compile +
+/// analyzer pass (~16s on large solutions); the fast path scopes to the supplied
+/// document and must stay well under the perf budget.
+/// <para>
+/// Uses an isolated workspace copy (not the shared sample workspace) so the mid-test
+/// <see cref="RoslynMcp.Roslyn.Services.WorkspaceManager.ReloadAsync"/> calls do not
+/// race with other test classes that read from <see cref="SharedWorkspaceTestBase"/>.
+/// </para>
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class DiagnosticServicePerfTests : TestBase
+{
+    // The plan calls for a <2s budget on a representative solution. CI runners (especially
+    // GitHub Actions hosted Windows runners) frequently run ~2x slower than local hardware
+    // for first-cold compilation + analyzer setup, so the guard here is set at 5s to catch
+    // the real regression (the 16s solution-wide scan reported on the row) without flaking
+    // on legitimate runner variance. The measured local latency is logged via TestContext
+    // so the margin between observed and budget stays visible.
+    private const int ColdPathPerfBudgetMs = 5000;
+
+    private static string _workspaceId = null!;
+    private static string _copiedSolutionRoot = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        _copiedSolutionRoot = Path.GetDirectoryName(copiedSolutionPath)!;
+        var copied = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        _workspaceId = copied.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        try { DeleteDirectoryIfExists(_copiedSolutionRoot); }
+        finally { DisposeServices(); }
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticDetailsAsync_ColdPath_StaysUnderPerfBudget()
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(_workspaceId);
+        var animalServiceFile = solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == "AnimalService.cs");
+
+        // Force a cold path (no warm cache) by reloading the workspace. Reload invalidates
+        // both the per-project diagnostic cache and the full-result cache, so the next call
+        // to GetDiagnosticDetailsAsync cannot hit the warm-cache fast path and must exercise
+        // the single-document short-circuit.
+        await WorkspaceManager.ReloadAsync(_workspaceId, CancellationToken.None);
+
+        var stopwatch = Stopwatch.StartNew();
+        var details = await DiagnosticService.GetDiagnosticDetailsAsync(
+            _workspaceId,
+            diagnosticId: "CS8019",
+            filePath: animalServiceFile.FilePath!,
+            line: 1,
+            column: 1,
+            CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.IsNotNull(details, "CS8019 must be found on a cold cache via the single-document path.");
+        Assert.AreEqual("CS8019", details.Diagnostic.Id);
+
+        // Record the measured latency so future regressions show up in the test output.
+        TestContext?.WriteLine($"Cold-path diagnostic_details latency: {stopwatch.ElapsedMilliseconds} ms (budget: {ColdPathPerfBudgetMs} ms)");
+
+        Assert.IsTrue(
+            stopwatch.ElapsedMilliseconds < ColdPathPerfBudgetMs,
+            $"Cold-path GetDiagnosticDetailsAsync took {stopwatch.ElapsedMilliseconds} ms; budget is {ColdPathPerfBudgetMs} ms. " +
+            "The single-document short-circuit in DiagnosticService.FindDiagnosticInDocumentAsync may have regressed back to a solution-wide scan.");
+    }
+
+    [TestMethod]
+    public async Task GetDiagnosticDetailsAsync_FastPath_MatchesFullScanForSemanticDiagnostic()
+    {
+        // Parity test: the single-document short-circuit must find the same diagnostic that
+        // the legacy solution-wide scan (still exercised by the warm cache + the fallback)
+        // reports. CS0414 is a semantic-model diagnostic, not an analyzer one — it exercises
+        // the Compilation.GetDiagnostics path inside FindDiagnosticInDocumentAsync.
+        var solution = WorkspaceManager.GetCurrentSolution(_workspaceId);
+        var probeFile = solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == "DiagnosticsProbe.cs");
+
+        // Warm-cache path (list call populates the per-workspace Diagnostic cache used by
+        // the fast warm path in GetDiagnosticDetailsAsync).
+        _ = await DiagnosticService.GetDiagnosticsAsync(
+            _workspaceId,
+            projectFilter: null,
+            fileFilter: null,
+            severityFilter: null,
+            diagnosticIdFilter: null,
+            CancellationToken.None);
+
+        var warm = await DiagnosticService.GetDiagnosticDetailsAsync(
+            _workspaceId,
+            diagnosticId: "CS0414",
+            filePath: probeFile.FilePath!,
+            line: 9,
+            column: 24,
+            CancellationToken.None);
+
+        // Cold-cache path (exercises FindDiagnosticInDocumentAsync directly).
+        await WorkspaceManager.ReloadAsync(_workspaceId, CancellationToken.None);
+
+        var cold = await DiagnosticService.GetDiagnosticDetailsAsync(
+            _workspaceId,
+            diagnosticId: "CS0414",
+            filePath: probeFile.FilePath!,
+            line: 9,
+            column: 24,
+            CancellationToken.None);
+
+        Assert.IsNotNull(warm, "Warm-path must find CS0414.");
+        Assert.IsNotNull(cold, "Cold-path (single-document short-circuit) must find CS0414.");
+        Assert.AreEqual(warm.Diagnostic.Id, cold.Diagnostic.Id);
+        Assert.AreEqual(warm.Diagnostic.Severity, cold.Diagnostic.Severity);
+        Assert.AreEqual(warm.Diagnostic.FilePath, cold.Diagnostic.FilePath);
+        Assert.AreEqual(warm.Diagnostic.StartLine, cold.Diagnostic.StartLine);
+        Assert.AreEqual(warm.Diagnostic.StartColumn, cold.Diagnostic.StartColumn);
+        Assert.AreEqual(warm.Description, cold.Description);
+        Assert.AreEqual(warm.HelpLinkUri, cold.HelpLinkUri);
+        Assert.AreEqual(warm.GuidanceMessage, cold.GuidanceMessage);
+        Assert.AreEqual(warm.SupportedFixes.Count, cold.SupportedFixes.Count);
+    }
+
+    public TestContext? TestContext { get; set; }
+}


### PR DESCRIPTION
## Summary

- `DiagnosticService.GetDiagnosticDetailsAsync` previously ran a solution-wide compile + analyzer pass on cold-cache lookups, costing ~16s on large solutions even though `filePath` + `line` + `column` are required parameters that pin the lookup to a single document.
- Adds `FindDiagnosticInDocumentAsync`: resolves the supplied path via `Solution.GetDocumentIdsWithFilePath`, then runs only single-document compiler + syntax-analyzer + semantic-analyzer passes (`Compilation.GetDiagnostics` filtered to one `SyntaxTree`, `GetAnalyzerSyntaxDiagnosticsAsync(tree)`, `GetAnalyzerSemanticDiagnosticsAsync(model)`).
- Solution-wide path still runs as a fallback when `filePath` does not resolve to any `Document` (generated paths, in-memory diagnostics) so discoverability is preserved.
- Adds `DiagnosticServicePerfTests` (perf budget + warm/cold parity for CS0414). Tests use an isolated workspace copy to avoid racing with other classes that share `SharedWorkspaceTestBase`.

## Test plan

- [x] `dotnet build RoslynMcp.slnx -c Release` (clean, 0 warnings)
- [x] `dotnet test --filter DiagnosticServicePerfTests` x3 (stable, ~1s each)
- [x] `dotnet test --filter "DiagnosticServicePerfTests|DiagnosticFixIntegrationTests|DiagnosticServiceFilterTotalsTests|AnalysisToolsTests|ProjectDiagnostics"` (20/20 passed)
- [x] `eng/verify-ai-docs.ps1`
- [x] `eng/verify-release.ps1` — pre-existing infra flakes (MSBuild child-node crashes; tracked as initiative `ci-test-parallelization-audit`) reproduce on pristine `origin/main` and are unrelated to this change.

Closes: diagnostic-details-perf-budget-overrun

🤖 Generated with [Claude Code](https://claude.com/claude-code)