### PR TITLE
fix(reference-service): align metadata-boundary base-member resolution with member_hierarchy

### DIFF
--- a/samples/SampleSolution/SampleLib/Hierarchy/EquatablePoint.cs
+++ b/samples/SampleSolution/SampleLib/Hierarchy/EquatablePoint.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace SampleLib.Hierarchy;
+
+/// <summary>
+/// Fixture for <c>find-base-members-vs-member-hierarchy-metadata-drift</c>. Implementing
+/// <see cref="IEquatable{T}"/> creates a metadata-boundary base member (the interface sits
+/// in corlib). Before the fix, <c>find_base_members</c>/<c>find_overrides</c> returned 0
+/// while <c>member_hierarchy</c> resolved the base — all three now agree.
+/// </summary>
+public readonly struct EquatablePoint : IEquatable<EquatablePoint>
+{
+    public EquatablePoint(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public int X { get; }
+
+    public int Y { get; }
+
+    public bool Equals(EquatablePoint other) => X == other.X && Y == other.Y;
+
+    public override bool Equals(object? obj) => obj is EquatablePoint other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(X, Y);
+}

--- a/src/RoslynMcp.Core/Models/SymbolRelationshipsDto.cs
+++ b/src/RoslynMcp.Core/Models/SymbolRelationshipsDto.cs
@@ -8,5 +8,5 @@ public sealed record SymbolRelationshipsDto(
     IReadOnlyList<LocationDto> Definitions,
     IReadOnlyList<LocationDto> References,
     IReadOnlyList<LocationDto> Implementations,
-    IReadOnlyList<LocationDto> BaseMembers,
-    IReadOnlyList<LocationDto> Overrides);
+    IReadOnlyList<SymbolDto> BaseMembers,
+    IReadOnlyList<SymbolDto> Overrides);

--- a/src/RoslynMcp.Core/Services/IReferenceService.cs
+++ b/src/RoslynMcp.Core/Services/IReferenceService.cs
@@ -36,8 +36,23 @@ public interface IReferenceService
         SymbolLocator locator,
         CancellationToken ct,
         bool includeGeneratedPartials = false);
-    Task<IReadOnlyList<LocationDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
-    Task<IReadOnlyList<LocationDto>> FindBaseMembersAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+    /// <summary>
+    /// Finds overriding/implementing members for a virtual, abstract, or interface member resolved at
+    /// <paramref name="locator"/>. Returns <see cref="SymbolDto"/> rather than <see cref="LocationDto"/> so
+    /// that members whose definition lives in metadata (e.g. <c>IEquatable&lt;T&gt;.Equals</c>) are not
+    /// silently dropped — a metadata-only result still carries <see cref="SymbolDto.FullyQualifiedName"/>
+    /// with <see cref="SymbolDto.FilePath"/>=<c>null</c>. Aligns with <c>member_hierarchy</c>.
+    /// </summary>
+    Task<IReadOnlyList<SymbolDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    /// <summary>
+    /// Finds base or implemented members for an override or implementation resolved at
+    /// <paramref name="locator"/>. Returns <see cref="SymbolDto"/> rather than <see cref="LocationDto"/> so
+    /// that members whose definition lives in metadata (e.g. <c>IEquatable&lt;T&gt;.Equals</c>) are not
+    /// silently dropped — a metadata-only result still carries <see cref="SymbolDto.FullyQualifiedName"/>
+    /// with <see cref="SymbolDto.FilePath"/>=<c>null</c>. Aligns with <c>member_hierarchy</c>.
+    /// </summary>
+    Task<IReadOnlyList<SymbolDto>> FindBaseMembersAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
     Task<IReadOnlyList<BulkReferenceResultDto>> FindReferencesBulkAsync(
         string workspaceId, IReadOnlyList<BulkSymbolLocator> symbols, bool includeDefinition, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -171,7 +171,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find overriding members for a virtual, abstract, or interface member. Response shape: { count, items }. Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set.")]
+    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find overriding members for a virtual, abstract, or interface member. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) now surface with FilePath=null so count matches member_hierarchy.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find overrides of a virtual or abstract member.")]
     public static Task<string> FindOverrides(
@@ -193,7 +193,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_base_members", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find base or implemented members for an override or implementation")]
+    [McpServerTool(Name = "find_base_members", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find base or implemented members for an override or implementation. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Metadata-boundary bases (e.g. IEquatable<T>.Equals from corlib) surface with FilePath=null so count matches member_hierarchy.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find base or implemented members.")]
     public static Task<string> FindBaseMembers(

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -124,7 +124,7 @@ public sealed class ReferenceService : IReferenceService
             || path.EndsWith(".generated.cs", StringComparison.OrdinalIgnoreCase);
     }
 
-    public async Task<IReadOnlyList<LocationDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    public async Task<IReadOnlyList<SymbolDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
@@ -140,8 +140,19 @@ public sealed class ReferenceService : IReferenceService
         var promoted = PromoteToVirtualRoot(symbol);
 
         var overrides = await SymbolFinder.FindOverridesAsync(promoted, solution, cancellationToken: ct).ConfigureAwait(false);
-        var locations = await SymbolServiceHelpers.SymbolsToLocationsAsync(overrides, solution, ct).ConfigureAwait(false);
-        return OrderLocations(locations);
+
+        // find-base-members-vs-member-hierarchy-metadata-drift: return SymbolDto instead of
+        // LocationDto so metadata-boundary members (e.g. IEquatable<T>.Equals implementations
+        // whose base sits in corlib) are not silently dropped by an IsInSource filter. Aligns
+        // with member_hierarchy, which already maps base members/overrides through SymbolMapper.ToDto.
+        return overrides
+            .Distinct(SymbolEqualityComparer.Default)
+            .Select(overrideSymbol => SymbolMapper.ToDto(overrideSymbol, solution))
+            .OrderBy(d => d.FilePath ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(d => d.StartLine ?? int.MaxValue)
+            .ThenBy(d => d.StartColumn ?? int.MaxValue)
+            .ThenBy(d => d.FullyQualifiedName, StringComparer.Ordinal)
+            .ToList();
     }
 
     private static IReadOnlyList<LocationDto> OrderLocations(IReadOnlyList<LocationDto> dtos) =>
@@ -270,12 +281,28 @@ public sealed class ReferenceService : IReferenceService
         return null;
     }
 
-    public async Task<IReadOnlyList<LocationDto>> FindBaseMembersAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    public Task<IReadOnlyList<SymbolDto>> FindBaseMembersAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
+        return ResolveBaseMembersAsync(solution, locator, ct);
+    }
+
+    private static async Task<IReadOnlyList<SymbolDto>> ResolveBaseMembersAsync(Solution solution, SymbolLocator locator, CancellationToken ct)
+    {
         var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
 
-        return await SymbolServiceHelpers.SymbolsToLocationsAsync(SymbolServiceHelpers.GetBaseMembers(symbol), solution, ct).ConfigureAwait(false);
+        // find-base-members-vs-member-hierarchy-metadata-drift: return SymbolDto instead of
+        // LocationDto so metadata-boundary base members (e.g. IEquatable<T>.Equals from corlib)
+        // are not silently dropped by an IsInSource filter. Aligns with member_hierarchy, which
+        // already maps base members through SymbolMapper.ToDto.
+        return SymbolServiceHelpers.GetBaseMembers(symbol)
+            .Distinct(SymbolEqualityComparer.Default)
+            .Select(baseMember => SymbolMapper.ToDto(baseMember, solution))
+            .OrderBy(d => d.FilePath ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(d => d.StartLine ?? int.MaxValue)
+            .ThenBy(d => d.StartColumn ?? int.MaxValue)
+            .ThenBy(d => d.FullyQualifiedName, StringComparer.Ordinal)
+            .ToList();
     }
 
     public async Task<IReadOnlyList<BulkReferenceResultDto>> FindReferencesBulkAsync(

--- a/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
+++ b/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
@@ -73,7 +73,7 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
             CancellationToken.None);
 
         Assert.IsTrue(
-            fromOverrideSite.Any(l => l.FilePath.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase)),
+            fromOverrideSite.Any(symbol => symbol.FilePath?.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase) == true),
             "Promoted FindOverrides should include Rectangle.Describe in the override set.");
     }
 
@@ -98,8 +98,8 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
         Assert.AreEqual(fromVirtual.Count, fromOverride.Count,
             "Virtual-site and override-site FindOverrides must return the same number of locations.");
         CollectionAssert.AreEquivalent(
-            fromVirtual.Select(l => l.FilePath).ToList(),
-            fromOverride.Select(l => l.FilePath).ToList(),
+            fromVirtual.Select(s => s.FilePath).ToList(),
+            fromOverride.Select(s => s.FilePath).ToList(),
             "The override set must be identical regardless of caret position.");
     }
 
@@ -123,8 +123,8 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
         Assert.AreEqual(fromIface.Count, fromImpl.Count,
             "Implicit interface implementation site should promote to the interface member and match the interface declaration query.");
         CollectionAssert.AreEquivalent(
-            fromIface.Select(l => (l.FilePath, l.StartLine, l.StartColumn)).OrderBy(t => t.FilePath).ToList(),
-            fromImpl.Select(l => (l.FilePath, l.StartLine, l.StartColumn)).OrderBy(t => t.FilePath).ToList(),
+            fromIface.Select(s => (s.FilePath, s.StartLine, s.StartColumn)).OrderBy(t => t.FilePath).ToList(),
+            fromImpl.Select(s => (s.FilePath, s.StartLine, s.StartColumn)).OrderBy(t => t.FilePath).ToList(),
             "Override/implementation locations should match after promotion.");
     }
 

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -184,7 +184,7 @@ public sealed class NamespaceRelocationServiceFixture
                 "Describe",
                 ReferenceTestFile: string.Empty),
             CancellationToken.None);
-        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "scaffold_test_apply", CancellationToken.None);
 
         var contents = await File.ReadAllTextAsync(
             workspace.GetPath("SampleLib.Tests", "NamespaceRelocationServiceFixtureGeneratedTests.cs"),

--- a/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
@@ -32,7 +32,61 @@ public class SemanticExpansionTests : SharedWorkspaceTestBase
             SymbolLocator.BySource(shapeFile.FilePath!, 7, 27),
             CancellationToken.None);
 
-        Assert.IsTrue(overrides.Any(location => location.FilePath.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsTrue(overrides.Any(overrideSymbol => overrideSymbol.FilePath?.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase) == true));
+    }
+
+    // find-base-members-vs-member-hierarchy-metadata-drift: regression — metadata-boundary
+    // bases (IEquatable<T>.Equals from corlib) must surface across all three tools with the
+    // same count. Pre-fix: find_base_members/find_overrides returned count=0 because the
+    // LocationDto materializer filtered out symbols with no IsInSource location.
+    [TestMethod]
+    public async Task Metadata_Boundary_Base_Surfaces_Across_Find_Base_Members_And_Member_Hierarchy()
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var pointFile = solution.Projects
+            .SelectMany(project => project.Documents)
+            .First(document => document.Name == "EquatablePoint.cs");
+
+        // EquatablePoint.Equals(EquatablePoint) — line 23, col 17 (the `Equals` token).
+        var locator = SymbolLocator.BySource(pointFile.FilePath!, 23, 17);
+
+        var baseMembers = await ReferenceService.FindBaseMembersAsync(WorkspaceId, locator, CancellationToken.None);
+        var hierarchy = await SymbolRelationshipService.GetMemberHierarchyAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(hierarchy);
+        Assert.IsTrue(hierarchy.BaseMembers.Count > 0,
+            "member_hierarchy should resolve IEquatable<T>.Equals as a base member.");
+        Assert.AreEqual(
+            hierarchy.BaseMembers.Count,
+            baseMembers.Count,
+            "find_base_members must match member_hierarchy.BaseMembers count — metadata-boundary alignment.");
+        Assert.IsTrue(baseMembers.Any(symbol => symbol.FullyQualifiedName.Contains("IEquatable", StringComparison.Ordinal)),
+            "find_base_members should surface the metadata-only IEquatable<T>.Equals symbol.");
+        Assert.IsTrue(baseMembers.Any(symbol => symbol.FilePath is null),
+            "At least one returned base member should carry FilePath=null (metadata-only).");
+    }
+
+    // find-base-members-vs-member-hierarchy-metadata-drift: regression — find_overrides and
+    // member_hierarchy.Overrides must agree for a metadata-boundary symbol. SymbolFinder
+    // cannot walk into corlib to find IEquatable<T> implementations, so both return 0 — the
+    // important invariant is that they AGREE (no silent drift between the two surfaces).
+    [TestMethod]
+    public async Task Metadata_Boundary_Find_Overrides_Matches_Member_Hierarchy_Overrides()
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var pointFile = solution.Projects
+            .SelectMany(project => project.Documents)
+            .First(document => document.Name == "EquatablePoint.cs");
+
+        var locator = SymbolLocator.BySource(pointFile.FilePath!, 23, 17);
+
+        var overrides = await ReferenceService.FindOverridesAsync(WorkspaceId, locator, CancellationToken.None);
+        var hierarchy = await SymbolRelationshipService.GetMemberHierarchyAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNotNull(hierarchy);
+        Assert.AreEqual(
+            hierarchy.Overrides.Count,
+            overrides.Count,
+            "find_overrides must match member_hierarchy.Overrides count for metadata-boundary symbols.");
     }
 
     [TestMethod]
@@ -46,7 +100,7 @@ public class SemanticExpansionTests : SharedWorkspaceTestBase
             SymbolLocator.BySource(rectangleFile.FilePath!, 16, 28),
             CancellationToken.None);
 
-        Assert.IsTrue(baseMembers.Any(location => location.FilePath.EndsWith("Shape.cs", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsTrue(baseMembers.Any(baseMember => baseMember.FilePath?.EndsWith("Shape.cs", StringComparison.OrdinalIgnoreCase) == true));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- `find_base_members` and `find_overrides` previously returned `LocationDto[]` which filters to source-only locations, silently dropping metadata-boundary symbols (e.g. `IEquatable<T>.Equals` from corlib). `member_hierarchy` mapped the same base-member set through `SymbolMapper.ToDto` and surfaced the metadata symbol with `FilePath=null` — so the three tools disagreed on count for the same anchor.
- `IReferenceService.FindBaseMembersAsync` / `FindOverridesAsync` now return `IReadOnlyList<SymbolDto>`. `SymbolRelationshipsDto.BaseMembers` / `Overrides` follow suit. Metadata-only members surface with `FilePath=null` and a populated `FullyQualifiedName`. Tool descriptions for `find_base_members` / `find_overrides` updated.
- Adds `EquatablePoint` fixture (`samples/SampleSolution/SampleLib/Hierarchy/EquatablePoint.cs`) and two regression tests in `SemanticExpansionTests` covering metadata-boundary alignment across all three tools.

This is an internal-service breaking change (no external API consumers); no shims added.

## Test plan
- [x] `dotnet build RoslynMcp.slnx -c Release` clean
- [x] `dotnet test --filter "SemanticExpansionTests|P4BehavioralBundleTests"` — 18/18 pass (includes 2 new regressions + adapted existing tests for SymbolDto shape)
- [x] `eng/verify-ai-docs.ps1` passes
- [x] Failing tests in full `eng/verify-release.ps1` run are unrelated (parallel-worktree contention on `%TEMP%/RoslynMcpTests` shared with 3 sibling worktrees — `IsolatedWorkspaceTestBase`-derived tests; spot-check passes in isolation)

Closes: find-base-members-vs-member-hierarchy-metadata-drift