### PR TITLE
fix(impact-sweep): use pre-cap totals in suggestedTasks string

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
@@ -61,6 +61,15 @@ public sealed class ImpactSweepService : IImpactSweepService
         // surface paired-DTO mapper findings (To*/From* asymmetry).
         var persistenceFindings = await CollectPersistenceLayerFindingsAsync(workspaceId, locator, ct).ConfigureAwait(false);
 
+        // symbol-impact-sweep-suggested-tasks-count-drift: capture pre-cap totals BEFORE
+        // truncation so the suggested-tasks string reports the true blast radius (e.g. "Review
+        // 193 reference(s)") rather than the truncated list length ("Review 10 reference(s)").
+        // The capped lists are what we return to the caller, but reviewers need the unbounded
+        // count to size the work.
+        var totalReferenceCount = references.Count;
+        var totalDiagnosticCount = diagnostics.Count;
+        var totalMapperCount = mapperCallsites.Count;
+
         // symbol-impact-sweep-output-size-blowup: maxItemsPerCategory truncates each list
         // INDEPENDENTLY (so a 1500-ref symbol with 0 mapper callsites still returns the
         // mapper-callsite list). Persistence findings are not capped — they are always
@@ -72,7 +81,7 @@ public sealed class ImpactSweepService : IImpactSweepService
             diagnostics = diagnostics.Take(cap).ToList();
         }
 
-        var tasks = BuildSuggestedTasks(references.Count, diagnostics.Count, mapperCallsites.Count, persistenceFindings.Count);
+        var tasks = BuildSuggestedTasks(totalReferenceCount, totalDiagnosticCount, totalMapperCount, persistenceFindings.Count);
 
         return new SymbolImpactSweepDto(
             SymbolDisplay: symbolDisplay,

--- a/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
@@ -94,4 +94,43 @@ public sealed class SymbolImpactSweepBudgetTests : SharedWorkspaceTestBase
         // populate up to their own cap.
         Assert.IsTrue(unboundedResult.References.Count >= cappedResult.References.Count);
     }
+
+    /// <summary>
+    /// Regression for `symbol-impact-sweep-suggested-tasks-count-drift` (P4): the
+    /// suggested-tasks string was previously built from the truncated list length
+    /// (`references.Count` after `Take(cap)`), so a 193-ref symbol capped at 10 reported
+    /// "Review 10 reference(s)" instead of the true blast radius. Reviewers cannot size the
+    /// work from the capped count. The fix captures pre-cap totals before the `Take(cap)`
+    /// pass and feeds those into the task-string builder.
+    /// </summary>
+    [TestMethod]
+    public async Task SweepAsync_SuggestedTasks_ReportsPreCapReferenceTotal()
+    {
+        var animalDoc = WorkspaceManager.GetCurrentSolution(WorkspaceId)
+            .Projects.SelectMany(p => p.Documents)
+            .FirstOrDefault(d => d.Name == "IAnimal.cs");
+        Assert.IsNotNull(animalDoc);
+
+        var locator = SymbolLocator.BySource(animalDoc.FilePath!, line: 5, column: 10);
+
+        // Run unbounded first to capture the true total — the IAnimal sample fixture has
+        // multiple references; we just need >= 2 to make the truncation observable.
+        var unboundedResult = await _impactSweepService.SweepAsync(WorkspaceId, locator, CancellationToken.None);
+        var totalReferenceCount = unboundedResult.References.Count;
+        Assert.IsTrue(totalReferenceCount >= 2,
+            $"sample fixture must have >=2 IAnimal references for this test to be meaningful (got {totalReferenceCount})");
+
+        // Cap to 1 so the truncated list length (1) differs from the pre-cap total (>=2).
+        var cappedResult = await _impactSweepService.SweepAsync(
+            WorkspaceId, locator, CancellationToken.None, summary: false, maxItemsPerCategory: 1);
+
+        Assert.AreEqual(1, cappedResult.References.Count, "guard: cap must have truncated to 1");
+
+        // The suggested-tasks string MUST cite the pre-cap total, not the capped list length.
+        var referenceTask = cappedResult.SuggestedTasks
+            .FirstOrDefault(t => t.StartsWith("Review ", StringComparison.Ordinal));
+        Assert.IsNotNull(referenceTask, "expected a 'Review N reference(s)' task entry");
+        StringAssert.Contains(referenceTask, $"Review {totalReferenceCount} reference(s)",
+            $"task-string must report pre-cap total {totalReferenceCount}, not truncated list length 1 (got: '{referenceTask}')");
+    }
 }


### PR DESCRIPTION
## Summary

- `symbol_impact_sweep` reported `suggestedTasks: ["Review 10 reference(s)..."]` on a 193-ref symbol because `BuildSuggestedTasks` was called AFTER `maxItemsPerCategory` truncated the list. It received the post-cap list length instead of the true blast radius.
- Capture pre-cap counts (`totalReferenceCount`, `totalDiagnosticCount`, `totalMapperCount`) before the `Take(cap)` pass and feed those into `BuildSuggestedTasks`. The capped lists still ship to the caller; only the task-string regains accuracy.
- Adds regression test `SweepAsync_SuggestedTasks_ReportsPreCapReferenceTotal`.

## Files changed

- `src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs` — capture pre-cap counts before truncation.
- `tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs` — add regression test.

## Test plan

- [x] `dotnet build RoslynMcp.slnx` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter "FullyQualifiedName~SymbolImpactSweep"` passes 4/4 in Debug.
- [x] `dotnet test --filter "FullyQualifiedName~SymbolImpactSweep|FullyQualifiedName~ImpactSweep"` passes 4/4 in Release.
- [x] `eng/verify-ai-docs.ps1` passes.
- [ ] CI green.

Closes: symbol-impact-sweep-suggested-tasks-count-drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)