### PR TITLE
feat(catalog): publish prompt parameters[] schema on catalog resource

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Catalog/PromptParameterIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/PromptParameterIndex.cs
@@ -1,0 +1,133 @@
+using System.ComponentModel;
+using System.Reflection;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Catalog;
+
+/// <summary>
+/// get-prompt-text-publish-parameter-schema: cached reflection over every
+/// <see cref="McpServerPromptAttribute"/>-attributed method in the Host.Stdio assembly,
+/// projecting each prompt's user-facing parameters (i.e. excluding DI services and
+/// <see cref="CancellationToken"/>) into a JSON-friendly schema list.
+/// <para>
+/// The catalog publishes this list per prompt via
+/// <c>roslyn://server/catalog/prompts/{offset}/{limit}</c> so callers can build
+/// <c>parametersJson</c> for <c>get_prompt_text</c> without a 2-roundtrip learn-then-invoke
+/// loop. Reflection runs once at first access; the dictionary is immutable thereafter.
+/// </para>
+/// </summary>
+internal static class PromptParameterIndex
+{
+    private static readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<PromptParameterEntry>>> s_index =
+        new(BuildIndex, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Returns the cached parameter schema for <paramref name="promptName"/>, or an empty list
+    /// when the prompt has no user-facing parameters or is not registered. Never returns
+    /// <see langword="null"/> so callers can iterate without a null check.
+    /// </summary>
+    public static IReadOnlyList<PromptParameterEntry> GetParameters(string promptName)
+    {
+        if (string.IsNullOrEmpty(promptName)) return Array.Empty<PromptParameterEntry>();
+        return s_index.Value.TryGetValue(promptName, out var parameters)
+            ? parameters
+            : Array.Empty<PromptParameterEntry>();
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<PromptParameterEntry>> BuildIndex()
+    {
+        // Anchor on a known prompt-host type so we walk the same assembly that MCP discovery uses.
+        var assembly = typeof(Prompts.RoslynPrompts).Assembly;
+        var dict = new Dictionary<string, IReadOnlyList<PromptParameterEntry>>(StringComparer.Ordinal);
+
+        foreach (var type in assembly.GetTypes())
+        {
+            // Prompt methods are public static (per [McpServerPromptType] convention) but include
+            // NonPublic for forward-compatibility with internal-test prompts.
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                var attr = method.GetCustomAttribute<McpServerPromptAttribute>();
+                if (attr?.Name is null) continue;
+
+                var parameters = method.GetParameters()
+                    .Where(p => !IsServiceType(p.ParameterType) && p.ParameterType != typeof(CancellationToken))
+                    .Select(BuildEntry)
+                    .ToArray();
+                dict[attr.Name] = parameters;
+            }
+        }
+
+        return dict;
+    }
+
+    private static PromptParameterEntry BuildEntry(ParameterInfo parameter)
+    {
+        var description = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description;
+        var typeName = FormatTypeName(parameter.ParameterType);
+        var required = !parameter.HasDefaultValue;
+        var defaultValue = parameter.HasDefaultValue ? FormatDefaultValue(parameter.DefaultValue) : null;
+
+        return new PromptParameterEntry(
+            Name: parameter.Name ?? string.Empty,
+            Type: typeName,
+            Required: required,
+            DefaultValue: defaultValue,
+            Description: description);
+    }
+
+    /// <summary>
+    /// Returns a stable, JSON-friendly type label. Nullable value types collapse to
+    /// <c>{type}?</c>; reference types (which are nullable in the C# 8+ annotation model but
+    /// which reflection cannot fully introspect for nullable-annotation context) keep the bare
+    /// name. Generic types format as <c>List&lt;string&gt;</c> rather than CLR backtick-arity.
+    /// </summary>
+    private static string FormatTypeName(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying is not null) return FormatTypeName(underlying) + "?";
+
+        if (type.IsGenericType)
+        {
+            var name = type.Name;
+            var tickIdx = name.IndexOf('`', StringComparison.Ordinal);
+            if (tickIdx >= 0) name = name[..tickIdx];
+            var args = type.GetGenericArguments().Select(FormatTypeName);
+            return $"{name}<{string.Join(", ", args)}>";
+        }
+
+        // Map common primitives to their C# keyword form for readability.
+        return type.FullName switch
+        {
+            "System.String" => "string",
+            "System.Int32" => "int",
+            "System.Int64" => "long",
+            "System.Boolean" => "bool",
+            "System.Double" => "double",
+            "System.Single" => "float",
+            "System.Decimal" => "decimal",
+            "System.Byte" => "byte",
+            "System.Object" => "object",
+            _ => type.Name,
+        };
+    }
+
+    /// <summary>
+    /// Project the <see cref="ParameterInfo.DefaultValue"/> sentinel onto a JSON-stable form.
+    /// Strings stay as strings; numbers and booleans stay as their unboxed value;
+    /// <see cref="DBNull"/> (the BCL sentinel for "no default supplied") and <see langword="null"/>
+    /// both collapse to JSON <c>null</c>.
+    /// </summary>
+    private static object? FormatDefaultValue(object? defaultValue)
+    {
+        if (defaultValue is null || defaultValue is DBNull) return null;
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Mirrors <c>PromptShimTools.IsServiceType</c>: prompts receive DI services either via
+    /// interface-typed parameters or via the <c>Microsoft.Extensions</c> namespace family. Both
+    /// are resolved by the host at invoke time and must NOT appear in the published schema.
+    /// </summary>
+    private static bool IsServiceType(Type t) =>
+        t.IsInterface || t.Namespace?.StartsWith("Microsoft.Extensions", StringComparison.Ordinal) == true;
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -134,13 +134,18 @@ public static partial class ServerSurfaceCatalog
         entries.Count(entry => string.Equals(entry.SupportTier, tier, StringComparison.Ordinal));
 
     private static SurfaceEntry Tool(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
-        new("tool", name, category, supportTier, readOnly, destructive, summary, null);
+        new("tool", name, category, supportTier, readOnly, destructive, summary, UriTemplate: null, Parameters: null);
 
     private static SurfaceEntry Resource(string name, string category, string supportTier, bool readOnly, bool destructive, string summary, string uriTemplate) =>
-        new("resource", name, category, supportTier, readOnly, destructive, summary, uriTemplate);
+        new("resource", name, category, supportTier, readOnly, destructive, summary, uriTemplate, Parameters: null);
 
+    // get-prompt-text-publish-parameter-schema: the prompt factory always splices the
+    // PromptParameterIndex's reflected parameter list onto the entry. Reflection runs once at
+    // type init (Lazy<>), so populating per-row here is O(1) lookup after the first hit.
     private static SurfaceEntry Prompt(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
-        new("prompt", name, category, supportTier, readOnly, destructive, summary, null);
+        new("prompt", name, category, supportTier, readOnly, destructive, summary,
+            UriTemplate: null,
+            Parameters: PromptParameterIndex.GetParameters(name));
 }
 
 /// <summary>
@@ -154,6 +159,12 @@ public static partial class ServerSurfaceCatalog
 /// <param name="Destructive">When <see langword="true"/>, the entry performs an irreversible or high-impact change.</param>
 /// <param name="Summary">A short human-readable description of what the entry does.</param>
 /// <param name="UriTemplate">The URI template for resource entries, or <see langword="null"/> for tools and prompts.</param>
+/// <param name="Parameters">
+/// get-prompt-text-publish-parameter-schema: the user-facing parameter schema for prompt entries
+/// (<see cref="ServerSurfaceCatalog.Prompts"/>); <see langword="null"/> for tools and resources.
+/// Excludes DI-resolved services and <see cref="CancellationToken"/> — only the values an agent
+/// must supply via <c>parametersJson</c> on <c>get_prompt_text</c>.
+/// </param>
 public sealed record SurfaceEntry(
     string Kind,
     string Name,
@@ -162,7 +173,26 @@ public sealed record SurfaceEntry(
     bool ReadOnly,
     bool Destructive,
     string Summary,
-    string? UriTemplate);
+    string? UriTemplate,
+    IReadOnlyList<PromptParameterEntry>? Parameters);
+
+/// <summary>
+/// get-prompt-text-publish-parameter-schema: per-parameter schema row published on each
+/// prompt entry in <c>roslyn://server/catalog/prompts/{offset}/{limit}</c>. Lets callers
+/// build the <c>parametersJson</c> argument for <c>get_prompt_text</c> without a failing
+/// invocation to discover the signature.
+/// </summary>
+/// <param name="Name">The parameter name, matching the prompt method's parameter symbol.</param>
+/// <param name="Type">A C#-style type label (e.g. <c>string</c>, <c>int?</c>, <c>List&lt;string&gt;</c>).</param>
+/// <param name="Required">When <see langword="true"/>, the parameter has no default and MUST be supplied.</param>
+/// <param name="DefaultValue">The default value for optional parameters, or <see langword="null"/> when required (or when the default is itself <see langword="null"/>).</param>
+/// <param name="Description">The <see cref="System.ComponentModel.DescriptionAttribute"/> text on the parameter, when present.</param>
+public sealed record PromptParameterEntry(
+    string Name,
+    string Type,
+    bool Required,
+    object? DefaultValue,
+    string? Description);
 
 /// <summary>
 /// Provides a count summary of stable and experimental entries for each surface kind.

--- a/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
@@ -56,10 +56,16 @@ public static class PromptShimTools
         // Prompt methods return Task<IEnumerable<PromptMessage>> (or sometimes the
         // synchronous variant). Await the task and project messages into a JSON-friendly shape.
         var messages = await UnwrapPromptResultAsync(result).ConfigureAwait(false);
+
+        // get-prompt-text-publish-parameter-schema: surface the same parameter schema the
+        // catalog publishes so a caller introspecting via the tool channel (no resource/list
+        // round-trip) gets the names/types/required flags in one hop.
+        var parameterSchema = PromptParameterIndex.GetParameters(promptName);
         var dto = new
         {
             promptName,
-            parameterCount = method.GetParameters().Count(p => !IsServiceType(p.ParameterType) && p.ParameterType != typeof(CancellationToken)),
+            parameterCount = parameterSchema.Count,
+            parameters = parameterSchema,
             messages = messages.Select(m => new
             {
                 role = m.Role.ToString().ToLowerInvariant(),

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -144,6 +144,122 @@ public sealed class SurfaceCatalogTests
         Assert.IsTrue(tools.TryGetProperty("experimental", out _));
     }
 
+    // get-prompt-text-publish-parameter-schema: catalog prompt entries must publish a
+    // parameters[] array per prompt so callers can build parametersJson for get_prompt_text
+    // without a 2-roundtrip learn-then-invoke loop. The 3-param `debug_test_failure` (1 required
+    // + 2 optional) is the representative shape from the plan: it covers required-parameter
+    // serialization, optional-parameter default-value serialization (string? defaulting to null),
+    // and the DI-service / CancellationToken exclusion (ITestRunnerService and `ct` must NOT
+    // appear).
+    [TestMethod]
+    public void Prompts_PublishParameterSchema_OnCatalogEntry()
+    {
+        var promptEntries = ServerSurfaceCatalog.Prompts;
+        // Every prompt must carry a non-null Parameters list — the empty-prompt case is allowed
+        // (some prompts take no user-facing args) but null is reserved for tools / resources.
+        foreach (var prompt in promptEntries)
+        {
+            Assert.IsNotNull(prompt.Parameters,
+                $"Prompt '{prompt.Name}' must publish a parameters[] array (got null).");
+        }
+
+        var debug = promptEntries.Single(p => p.Name == "debug_test_failure");
+        Assert.IsNotNull(debug.Parameters);
+        Assert.AreEqual(3, debug.Parameters!.Count,
+            "debug_test_failure exposes 3 user-facing params: workspaceId, projectName, filter "
+            + "(ITestRunnerService and CancellationToken are DI-resolved and must be excluded).");
+
+        var workspaceId = debug.Parameters.Single(p => p.Name == "workspaceId");
+        Assert.AreEqual("string", workspaceId.Type);
+        Assert.IsTrue(workspaceId.Required, "workspaceId has no default and must be Required=true.");
+        Assert.IsNull(workspaceId.DefaultValue);
+        Assert.AreEqual("The workspace session identifier", workspaceId.Description);
+
+        var projectName = debug.Parameters.Single(p => p.Name == "projectName");
+        Assert.AreEqual("string", projectName.Type, "Nullable reference type collapses to bare 'string' in the schema.");
+        Assert.IsFalse(projectName.Required, "projectName has a `= null` default and must be Required=false.");
+        Assert.IsNull(projectName.DefaultValue, "DefaultValue=null mirrors the C# `= null` default.");
+        Assert.AreEqual("Optional: specific test project name", projectName.Description);
+
+        var filter = debug.Parameters.Single(p => p.Name == "filter");
+        Assert.IsFalse(filter.Required);
+        Assert.IsNull(filter.DefaultValue);
+    }
+
+    [TestMethod]
+    public void Prompts_ExcludeServicesAndCancellationToken_FromParameterSchema()
+    {
+        // Guard against schema regression: every prompt parameter list must be free of
+        // CancellationToken and Microsoft.Extensions.* / interface-typed DI services. The
+        // catalog publishes only the values an agent must supply via parametersJson.
+        foreach (var prompt in ServerSurfaceCatalog.Prompts)
+        {
+            Assert.IsNotNull(prompt.Parameters);
+            foreach (var p in prompt.Parameters!)
+            {
+                Assert.AreNotEqual("CancellationToken", p.Type,
+                    $"Prompt '{prompt.Name}' parameter '{p.Name}' must not surface CancellationToken.");
+
+                // Heuristic: a leading 'I' followed by an uppercase letter strongly suggests an
+                // interface-typed DI service slipped through (e.g. 'IDiagnosticService'). The
+                // PromptParameterIndex.IsServiceType filter must drop those before publish.
+                var looksLikeInterface = p.Type.Length > 1
+                    && p.Type[0] == 'I'
+                    && char.IsUpper(p.Type[1]);
+                Assert.IsFalse(looksLikeInterface,
+                    $"Prompt '{prompt.Name}' parameter '{p.Name}' looks like an interface type ('{p.Type}') — DI services must be filtered out before publishing.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Prompts_PublishedAsJson_UsesCamelCaseSchemaFields()
+    {
+        // End-to-end: the camelCase serializer config that ServerResources uses must produce
+        // exactly the field names callers will read — `parameters` (not `Parameters`),
+        // `defaultValue` (not `DefaultValue`), etc. A regression to PascalCase would silently
+        // break consumers parsing by JSON-key.
+        var page = ServerSurfaceCatalog.PageEntries(
+            ServerSurfaceCatalog.Prompts, offset: 0, limit: 200, resourceName: "test");
+        var json = JsonSerializer.Serialize(page, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+        using var doc = JsonDocument.Parse(json);
+        var entries = doc.RootElement.GetProperty("entries");
+        var debug = entries.EnumerateArray().Single(e => e.GetProperty("name").GetString() == "debug_test_failure");
+
+        Assert.IsTrue(debug.TryGetProperty("parameters", out var parameters),
+            "Catalog prompt entry must publish 'parameters' (camelCase) field.");
+        Assert.AreEqual(JsonValueKind.Array, parameters.ValueKind);
+        Assert.AreEqual(3, parameters.GetArrayLength());
+
+        var workspaceIdParam = parameters.EnumerateArray().Single(p => p.GetProperty("name").GetString() == "workspaceId");
+        Assert.AreEqual("string", workspaceIdParam.GetProperty("type").GetString());
+        Assert.IsTrue(workspaceIdParam.GetProperty("required").GetBoolean());
+        Assert.IsTrue(workspaceIdParam.TryGetProperty("defaultValue", out var dv) && dv.ValueKind == JsonValueKind.Null,
+            "Required parameter must serialize defaultValue as JSON null.");
+        Assert.AreEqual("The workspace session identifier",
+            workspaceIdParam.GetProperty("description").GetString());
+    }
+
+    [TestMethod]
+    public void Prompts_OptionalNullableValueType_FormatsAsCSharpKeywordWithQuestionMark()
+    {
+        // refactor_and_validate has `int? endLine = null` and `int? endColumn = null` —
+        // the schema must report Required=false and DefaultValue=null with type label "int?".
+        // Picking this prompt (alongside debug_test_failure) gives coverage of nullable
+        // value-type parameters distinct from nullable reference-type parameters.
+        var refactor = ServerSurfaceCatalog.Prompts.SingleOrDefault(p => p.Name == "refactor_and_validate");
+        Assert.IsNotNull(refactor);
+        Assert.IsNotNull(refactor!.Parameters);
+
+        var endLine = refactor.Parameters!.Single(p => p.Name == "endLine");
+        Assert.AreEqual("int?", endLine.Type, "Nullable<int> formats as 'int?' for readability.");
+        Assert.IsFalse(endLine.Required);
+        Assert.IsNull(endLine.DefaultValue);
+    }
+
     private static string[] GetRegisteredNames<TAttribute>(Assembly assembly)
         where TAttribute : Attribute
     {


### PR DESCRIPTION
## Summary

Catalog prompt entries (`roslyn://server/catalog/prompts/{offset}/{limit}`) now include `parameters: [{name, type, required, defaultValue, description}]` per prompt. Callers can build `parametersJson` for `get_prompt_text` in one hop instead of the prior 2-roundtrip learn-then-invoke loop (call `get_prompt_text` with empty `parametersJson`, parse the error, retry with the right shape).

- New `PromptParameterIndex` (cached `Lazy<>` reflection at first access) projects every `[McpServerPrompt]` method's user-facing parameters into a JSON-friendly schema list, filtering DI-resolved services and `CancellationToken`.
- `SurfaceEntry` record extended with `Parameters: IReadOnlyList<PromptParameterEntry>?` (non-optional — null for tools/resources, populated for prompts). Breaking change to the catalog DTO shape, allowed per session policy.
- `PromptShimTools.GetPromptText` returns the same schema in its `parameters` field so tool-channel introspection matches the resource-channel data.

Reflection runs once at type init; per-row catalog construction is an O(1) dictionary lookup. No per-request reflection cost.

Closes: `get-prompt-text-publish-parameter-schema`

## Test plan

- [x] `dotnet build RoslynMcp.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test --filter "FullyQualifiedName~SurfaceCatalogTests"` — 11 passed (3 new tests for the schema)
- [x] `dotnet test --filter "FullyQualifiedName~ServerSurfaceCatalogAnalyzerTests|FullyQualifiedName~StartupDiagnostics|FullyQualifiedName~ReadmeSurfaceCount|FullyQualifiedName~Prompt"` — 34 passed (Release config)
- [x] `dotnet test --filter "FullyQualifiedName~Catalog|...|FullyQualifiedName~Surface"` — 67 passed (broader catalog/resource sweep, Release config)
- [x] `eng/verify-ai-docs.ps1` — passed
- [x] `eng/verify-release.ps1` — change-related tests green; the 22 unrelated failures are the pre-existing cleanup-race flakes localized in initiative #34 of the same plan (`ci-test-parallelization-audit`); confirmed they pass in isolation