### PR TITLE
feat(server-info): surface previous-process metadata on post-restart probes (host-recycle-opacity)

### DIFF
--- a/src/RoslynMcp.Core/Models/ConnectionStateDto.cs
+++ b/src/RoslynMcp.Core/Models/ConnectionStateDto.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// <c>mcp-connection-session-resilience</c> + <c>connection-state-ready-unsatisfiable-preload</c>
+/// + <c>host-recycle-opacity</c>: canonical shape for the <c>connection</c> subfield emitted by
+/// <c>server_info</c> and the <c>server_heartbeat</c> tool.
+/// <para>
+/// Consumers use this block to distinguish "transport reachable" from
+/// "workspace-scoped tools will succeed":
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>idle</c> — the stdio transport is up and the server is fully initialized,
+///     but no workspace has been loaded yet. This is a terminal pre-load state (NOT a transient
+///     "initializing" step). Consumers must call <c>workspace_load</c> to advance to <c>ready</c>.</description></item>
+///   <item><description><c>ready</c> — at least one workspace session is loaded; workspace-scoped
+///     tools will resolve.</description></item>
+///   <item><description><c>degraded</c> — reserved for future use when the server hit a startup
+///     error but is still answering the protocol. Not emitted today.</description></item>
+/// </list>
+/// <para>
+/// <strong>Recycle metadata (<c>host-recycle-opacity</c>):</strong> when the host stdio process is
+/// recycled mid-session (idle eviction, watchdog timeout, client disconnect, etc.), the prior
+/// process writes a small disk record on shutdown and the next host instance reads it on startup.
+/// The first <c>server_info</c> / <c>server_heartbeat</c> probe after that restart carries
+/// <see cref="PreviousStdioPid"/>, <see cref="PreviousExitedAtUtc"/>, and
+/// <see cref="PreviousRecycleReason"/>, then the in-memory copy is cleared so subsequent probes
+/// only ever surface those fields once. <c>previousRecycleReason</c> is one of:
+/// <c>idle-eviction</c> / <c>watchdog</c> / <c>client-disconnect</c> / <c>graceful</c> /
+/// <c>unknown</c>. Stale on-disk records (older than the configured TTL) are surfaced with
+/// reason <c>unknown</c> rather than dropped silently — operators always get something actionable.
+/// </para>
+/// </summary>
+public sealed record ConnectionStateDto(
+    [property: JsonPropertyName("state")]
+    string State,
+
+    [property: JsonPropertyName("loadedWorkspaceCount")]
+    int LoadedWorkspaceCount,
+
+    [property: JsonPropertyName("stdioPid")]
+    int StdioPid,
+
+    [property: JsonPropertyName("serverStartedAt")]
+    string ServerStartedAt,
+
+    /// <summary>
+    /// The PID of the previous host stdio process, captured from disk at startup and surfaced on
+    /// the FIRST <c>server_info</c> / <c>server_heartbeat</c> probe of the new process. Null on
+    /// every subsequent probe (consume-once semantics) and on a cold start with no prior record.
+    /// </summary>
+    [property: JsonPropertyName("previousStdioPid")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? PreviousStdioPid = null,
+
+    /// <summary>
+    /// ISO-8601 UTC timestamp when the previous host process recorded its shutdown. Surfaced
+    /// once after a restart, alongside <see cref="PreviousStdioPid"/>. Null on subsequent probes
+    /// and on cold starts with no prior record.
+    /// </summary>
+    [property: JsonPropertyName("previousExitedAt")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? PreviousExitedAtUtc = null,
+
+    /// <summary>
+    /// Why the previous process exited. Values: <c>graceful</c> (clean shutdown via
+    /// <c>ApplicationStopping</c>), <c>idle-eviction</c>, <c>watchdog</c>, <c>client-disconnect</c>,
+    /// <c>unknown</c> (record was stale or the previous process never wrote a reason — most likely
+    /// a crash). Null on subsequent probes after the first one and on cold starts.
+    /// </summary>
+    [property: JsonPropertyName("previousRecycleReason")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? PreviousRecycleReason = null);

--- a/src/RoslynMcp.Host.Stdio/Diagnostics/HostProcessMetadataSnapshotProvider.cs
+++ b/src/RoslynMcp.Host.Stdio/Diagnostics/HostProcessMetadataSnapshotProvider.cs
@@ -1,0 +1,81 @@
+namespace RoslynMcp.Host.Stdio.Diagnostics;
+
+/// <summary>
+/// <c>host-recycle-opacity</c>: process-wide publisher for the previous-host-process snapshot
+/// captured by <see cref="HostProcessMetadataStore.LoadPrevious"/> at startup. Mirrors the
+/// <see cref="SurfaceRegistrationSnapshot"/> pattern so static <c>ServerTools</c> methods can
+/// reach the snapshot without taking a constructor dependency.
+/// <para>
+/// <strong>Consume-once semantics:</strong> <see cref="Consume"/> returns the snapshot on the
+/// first call after <see cref="Publish"/> and <see langword="null"/> on every subsequent call.
+/// This is enforced atomically (volatile + lock) so two concurrent <c>server_info</c> probes
+/// during a startup race don't both see the previous-* fields. The contract from the backlog
+/// row is "first probe after restart carries previous-*; second probe does not" — the
+/// PROVIDER, not the consumer, owns that invariant.
+/// </para>
+/// <para>
+/// Test paths that construct <see cref="Tools.ServerTools"/> without booting the host either
+/// leave the provider unpublished (getting clean cold-start behavior) or stage a snapshot via
+/// <see cref="Publish"/> in a try/finally that calls <see cref="Reset"/> in the finally block.
+/// </para>
+/// </summary>
+public static class HostProcessMetadataSnapshotProvider
+{
+    private static readonly object s_lock = new();
+    private static volatile HostProcessMetadataSnapshot? s_snapshot;
+    private static volatile bool s_consumed;
+
+    /// <summary>
+    /// Publishes a snapshot for consumption by the next <see cref="Consume"/> call. Pass
+    /// <see langword="null"/> to declare "no previous-process record was found" — the provider
+    /// then short-circuits all future <see cref="Consume"/> calls to <see langword="null"/>
+    /// without waiting for the consume-once flag to flip.
+    /// <para>
+    /// Calling <see cref="Publish"/> a second time after <see cref="Consume"/> has already
+    /// drained the first snapshot resets the consume-once latch — useful for tests that
+    /// simulate multiple restart cycles in a single test run. Production code calls
+    /// <see cref="Publish"/> exactly once at host startup.
+    /// </para>
+    /// </summary>
+    public static void Publish(HostProcessMetadataSnapshot? snapshot)
+    {
+        lock (s_lock)
+        {
+            s_snapshot = snapshot;
+            s_consumed = false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the published snapshot exactly once. The first call after <see cref="Publish"/>
+    /// returns the snapshot if one was published; every subsequent call returns
+    /// <see langword="null"/>. Thread-safe — concurrent first-callers race on the lock and
+    /// only one observes the non-null snapshot.
+    /// </summary>
+    public static HostProcessMetadataSnapshot? Consume()
+    {
+        lock (s_lock)
+        {
+            if (s_consumed)
+            {
+                return null;
+            }
+
+            s_consumed = true;
+            return s_snapshot;
+        }
+    }
+
+    /// <summary>
+    /// Test hook — clears the published snapshot and resets the consume-once latch back to
+    /// "ready to consume". Production code should never call this.
+    /// </summary>
+    public static void Reset()
+    {
+        lock (s_lock)
+        {
+            s_snapshot = null;
+            s_consumed = false;
+        }
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Diagnostics/HostProcessMetadataStore.cs
+++ b/src/RoslynMcp.Host.Stdio/Diagnostics/HostProcessMetadataStore.cs
@@ -1,0 +1,307 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace RoslynMcp.Host.Stdio.Diagnostics;
+
+/// <summary>
+/// <c>host-recycle-opacity</c>: lightweight disk-backed lifecycle store that lets a freshly-started
+/// host stdio process surface metadata about the PRIOR process — pid, exit time, recycle reason —
+/// on its first <c>server_info</c> / <c>server_heartbeat</c> probe. Pre-fix, when the host was
+/// recycled mid-session (idle eviction, watchdog kill, client disconnect, crash), every
+/// subsequent workspace-scoped tool call returned <c>NotFound</c> with no recycle reason —
+/// the agent had to guess "did the process die?" by elimination.
+/// <para>
+/// The store has two halves:
+/// </para>
+/// <list type="number">
+///   <item><description><see cref="LoadPrevious"/> — called once at host startup. Reads
+///     the on-disk record (if any), validates it is fresh enough (<see cref="StaleAfter"/>),
+///     and returns a snapshot. Subsequent calls return <see langword="null"/> — the snapshot
+///     is consume-once so a second probe never re-emits previous-* fields.</description></item>
+///   <item><description><see cref="WriteCurrent"/> — called on graceful shutdown via the
+///     <c>ApplicationStopping</c> hook. Persists the current PID, exit timestamp, and recycle
+///     reason so the NEXT process can read them.</description></item>
+/// </list>
+/// <para>
+/// <strong>Persistence path:</strong> Windows uses <c>%LOCALAPPDATA%\roslyn-mcp\host-process.json</c>
+/// (per-user, survives reboot, not synced to OneDrive when LocalAppData is at the default location).
+/// Linux / macOS fall back to <c>$XDG_STATE_HOME/roslyn-mcp/host-process.json</c> with
+/// <c>~/.local/state/roslyn-mcp/host-process.json</c> as the XDG default. Tests can override via
+/// constructor injection.
+/// </para>
+/// <para>
+/// <strong>TTL:</strong> a record older than 24 hours is treated as stale. We still surface
+/// <c>previousStdioPid</c> / <c>previousExitedAt</c> if those parsed cleanly, but the recycle
+/// reason is normalized to <c>unknown</c> and the timestamp is preserved verbatim — operators
+/// always get a signal even if the prior session was paused for a long time. A record that
+/// fails to parse at all is silently discarded; the file is best-effort, not load-bearing.
+/// </para>
+/// <para>
+/// <strong>Crash safety:</strong> the file is written via temp-file + atomic-replace so a crash
+/// during the write produces either the prior content or the new content, never a half-file.
+/// We guard against stale writes (TTL) on read rather than on shutdown — a host that crashed
+/// mid-write and left no file is indistinguishable from a cold start, and that is the
+/// correct behavior: emit nothing.
+/// </para>
+/// </summary>
+public sealed class HostProcessMetadataStore
+{
+    /// <summary>
+    /// Records older than this are surfaced with reason <c>unknown</c> rather than the persisted
+    /// reason. 24 hours is the longest plausible "the user paused work for the night and came
+    /// back" window — anything beyond that is almost certainly a stale record from a long-dead
+    /// process whose recycle context is no longer interesting.
+    /// </summary>
+    public static readonly TimeSpan StaleAfter = TimeSpan.FromHours(24);
+
+    private const string FileName = "host-process.json";
+    private const string DirectoryName = "roslyn-mcp";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly string _filePath;
+    private readonly ILogger? _logger;
+    private readonly TimeSpan _staleAfter;
+    private readonly Func<DateTime> _utcNow;
+    private HostProcessMetadataSnapshot? _previous;
+    private bool _previousLoaded;
+
+    /// <summary>
+    /// Production constructor — uses the default OS-specific path and the system clock.
+    /// </summary>
+    public HostProcessMetadataStore(ILogger? logger = null)
+        : this(ResolveDefaultPath(), StaleAfter, () => DateTime.UtcNow, logger)
+    {
+    }
+
+    /// <summary>
+    /// Test constructor — injects a custom path, stale-after window, and clock.
+    /// </summary>
+    public HostProcessMetadataStore(string filePath, TimeSpan staleAfter, Func<DateTime> utcNow, ILogger? logger = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        _filePath = filePath;
+        _staleAfter = staleAfter;
+        _utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Path to the persisted host-process metadata file. Exposed for diagnostics and tests;
+    /// not part of any tool's wire contract.
+    /// </summary>
+    public string FilePath => _filePath;
+
+    /// <summary>
+    /// Reads and CACHES the previous-process snapshot at first call. Subsequent calls return
+    /// the same cached value. Consume-once semantics live in
+    /// <see cref="HostProcessMetadataSnapshotProvider"/>; this method is idempotent so callers
+    /// can inspect or re-publish without burning the latch.
+    /// <para>
+    /// Side-effect: deletes the on-disk record after a successful read so the same snapshot
+    /// is not surfaced twice across separate process lifetimes (e.g. if the next host crashes
+    /// before it gets a chance to write its own metadata).
+    /// </para>
+    /// </summary>
+    public HostProcessMetadataSnapshot? LoadPrevious()
+    {
+        EnsureLoaded();
+        return _previous;
+    }
+
+    /// <summary>
+    /// Persists the current host-process metadata to disk. Best-effort: any IO failure is
+    /// logged at <see cref="LogLevel.Warning"/> and swallowed — losing the next probe's
+    /// previous-* fields is far less bad than crashing on shutdown because LocalAppData
+    /// is read-only or full.
+    /// </summary>
+    /// <param name="recycleReason">Why the current process is exiting. <c>graceful</c> for
+    /// the <c>ApplicationStopping</c> path; other values reserved for future watchdog /
+    /// idle-eviction code that knows specifically why it terminated.</param>
+    public void WriteCurrent(string recycleReason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(recycleReason);
+
+        try
+        {
+            var record = new HostProcessMetadataRecord(
+                StdioPid: Environment.ProcessId,
+                ExitedAtUtc: _utcNow().ToString("O", CultureInfo.InvariantCulture),
+                RecycleReason: recycleReason);
+
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Temp-file + atomic-replace: a crash mid-write leaves either the old file or the
+            // new one, never a half-written file that fails to parse.
+            var tempPath = _filePath + ".tmp";
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(record, s_jsonOptions));
+            // File.Move with overwrite is atomic on NTFS and ext4. On macOS APFS it is also
+            // atomic per-inode. Best-effort fallback: if Move fails, copy + delete (also OK
+            // here because a partial state simply means the next process sees no record).
+            try
+            {
+                File.Move(tempPath, _filePath, overwrite: true);
+            }
+            catch (IOException)
+            {
+                File.Copy(tempPath, _filePath, overwrite: true);
+                try { File.Delete(tempPath); } catch { /* leave the .tmp; not load-bearing */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Shutdown path — never throw. The next process simply won't surface previous-*
+            // metadata; that is identical to a cold start and is harmless.
+            _logger?.LogWarning(ex,
+                "Failed to write host-process metadata to {FilePath}. " +
+                "The next process will not surface previousStdioPid/previousExitedAt/previousRecycleReason. " +
+                "This is non-fatal — the file is best-effort observability.",
+                _filePath);
+        }
+    }
+
+    private void EnsureLoaded()
+    {
+        // Idempotent: only the first call hits the disk. We don't bother locking the load
+        // path because only a single thread (the host startup path) has any legitimate
+        // reason to call EnsureLoaded before ConsumePrevious is reachable.
+        if (_previousLoaded)
+        {
+            return;
+        }
+
+        _previousLoaded = true;
+
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return;
+            }
+
+            var json = File.ReadAllText(_filePath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return;
+            }
+
+            var record = JsonSerializer.Deserialize<HostProcessMetadataRecord>(json, s_jsonOptions);
+            if (record is null || record.StdioPid <= 0 || string.IsNullOrWhiteSpace(record.ExitedAtUtc))
+            {
+                _logger?.LogDebug(
+                    "host-process metadata at {FilePath} is missing required fields — discarding.",
+                    _filePath);
+                return;
+            }
+
+            // Parse the timestamp once so we can decide TTL vs preserve.
+            DateTime? exitedAt = null;
+            if (DateTime.TryParse(
+                    record.ExitedAtUtc,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var parsed))
+            {
+                exitedAt = parsed;
+            }
+
+            // TTL guard: if the timestamp is older than StaleAfter, we still surface the pid
+            // and timestamp (operators want SOMETHING) but normalize the reason to "unknown" —
+            // a multi-day-old recycle reason is unreliable signal.
+            var reason = record.RecycleReason;
+            if (exitedAt is { } exitedTimestamp && (_utcNow() - exitedTimestamp) > _staleAfter)
+            {
+                reason = "unknown";
+            }
+            else if (string.IsNullOrWhiteSpace(reason))
+            {
+                reason = "unknown";
+            }
+
+            // Best-effort: delete the on-disk record after we've loaded it. This prevents the
+            // SAME record from being re-surfaced if the next host process crashes before it
+            // gets a chance to write its own metadata. If the delete fails, the next read
+            // will just see the same record again — annoying but not broken.
+            try
+            {
+                File.Delete(_filePath);
+            }
+            catch (Exception deleteEx)
+            {
+                _logger?.LogDebug(deleteEx,
+                    "Could not delete host-process metadata at {FilePath} after read — " +
+                    "the record may resurface on the next startup, which is harmless.",
+                    _filePath);
+            }
+
+            _previous = new HostProcessMetadataSnapshot(
+                StdioPid: record.StdioPid,
+                ExitedAtUtc: record.ExitedAtUtc,
+                RecycleReason: reason);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort read — corrupt JSON, IO errors, etc. Log and proceed with no
+            // previous-* fields. This matches cold-start behavior.
+            _logger?.LogDebug(ex,
+                "Could not read host-process metadata at {FilePath}. " +
+                "Treating as a cold start.",
+                _filePath);
+        }
+    }
+
+    /// <summary>
+    /// Default file path: <c>%LOCALAPPDATA%/roslyn-mcp/host-process.json</c> on Windows,
+    /// <c>$XDG_STATE_HOME/roslyn-mcp/host-process.json</c> on Linux/macOS, or the
+    /// platform-equivalent <c>SpecialFolder.LocalApplicationData</c> as a final fallback.
+    /// </summary>
+    public static string ResolveDefaultPath()
+    {
+        // Prefer XDG_STATE_HOME on Linux/macOS so it follows the freedesktop spec. Falls back
+        // to LOCALAPPDATA / SpecialFolder.LocalApplicationData when XDG isn't set.
+        var xdg = Environment.GetEnvironmentVariable("XDG_STATE_HOME");
+        if (!string.IsNullOrWhiteSpace(xdg))
+        {
+            return Path.Combine(xdg, DirectoryName, FileName);
+        }
+
+        var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(local))
+        {
+            return Path.Combine(local, DirectoryName, FileName);
+        }
+
+        // Last-ditch fallback: temp directory. Survives the process but not a reboot — that's
+        // OK because cross-reboot recycle metadata is not interesting (the OS killed everything).
+        return Path.Combine(Path.GetTempPath(), DirectoryName, FileName);
+    }
+}
+
+/// <summary>
+/// On-disk shape of the host-process metadata record. Internal — the public consumer-facing
+/// shape is <see cref="HostProcessMetadataSnapshot"/> after TTL normalization.
+/// </summary>
+internal sealed record HostProcessMetadataRecord(
+    [property: JsonPropertyName("stdioPid")] int StdioPid,
+    [property: JsonPropertyName("exitedAtUtc")] string ExitedAtUtc,
+    [property: JsonPropertyName("recycleReason")] string RecycleReason);
+
+/// <summary>
+/// In-memory snapshot of the previous host-process metadata, normalized for the
+/// <c>connection</c> wire shape. <c>RecycleReason</c> here is post-TTL: a stale record yields
+/// <c>unknown</c> regardless of what was on disk.
+/// </summary>
+public sealed record HostProcessMetadataSnapshot(
+    int StdioPid,
+    string ExitedAtUtc,
+    string RecycleReason);

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -97,6 +97,18 @@ var assemblyVersion = typeof(RoslynMcp.Host.Stdio.McpLoggingProvider).Assembly
 StartupDiagnostics.LogStartup(startupLogger, surfaceReport, assemblyVersion);
 SurfaceRegistrationSnapshot.Value = surfaceReport;
 
+// host-recycle-opacity: read the previous host process's exit metadata (if any) from disk
+// and publish it for the FIRST server_info / server_heartbeat probe to surface. The
+// provider's Consume() drains the snapshot exactly once — subsequent probes see clean state.
+// The on-disk record is deleted by LoadPrevious() so we never replay a stale snapshot across
+// multiple processes. Cold start with no prior record publishes null, which the provider
+// treats as "no previous-* fields ever". The store is also kept around so the
+// ApplicationStopping handler can write the current process's exit metadata on shutdown.
+var hostProcessMetadataLogger = host.Services.GetRequiredService<ILoggerFactory>()
+    .CreateLogger("HostProcessMetadata");
+var hostProcessMetadataStore = new HostProcessMetadataStore(hostProcessMetadataLogger);
+HostProcessMetadataSnapshotProvider.Publish(hostProcessMetadataStore.LoadPrevious());
+
 // FLAG-D: Emit a structured Information event when the host starts with no loaded workspaces.
 // Clients that surface MCP `notifications/message` (via McpLoggingProvider) will see this
 // proactively after a transparent subprocess restart instead of discovering the missing
@@ -120,6 +132,14 @@ lifetime.ApplicationStopping.Register(() =>
     {
         disposable.Dispose();
     }
+
+    // host-recycle-opacity: persist current-process exit metadata so the NEXT host process
+    // can surface previousStdioPid / previousExitedAt / previousRecycleReason on its first
+    // probe. We tag this path "graceful" — the only call site here is the
+    // ApplicationStopping hook, which only fires on a clean shutdown. Future watchdog /
+    // idle-eviction code that knows specifically why it terminated will pass its own reason.
+    hostProcessMetadataStore.WriteCurrent(recycleReason: "graceful");
+
     // Flush stdout so buffered MCP JSON responses are delivered before the process exits.
     // Without this, non-SDK clients using bash pipes may receive 0 bytes on stdout.
     Console.Out.Flush();

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Core.Services;
@@ -14,9 +15,9 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class ServerTools
 {
     /// <summary>
-    /// mcp-connection-session-resilience + connection-state-ready-unsatisfiable-preload:
-    /// canonical shape for the <c>connection</c> subfield emitted by <c>server_info</c>
-    /// and the <c>server_heartbeat</c> tool.
+    /// mcp-connection-session-resilience + connection-state-ready-unsatisfiable-preload
+    /// + host-recycle-opacity: builds the <see cref="ConnectionStateDto"/> emitted by
+    /// <c>server_info</c> and <c>server_heartbeat</c>.
     /// <para>
     /// Consumers use this block to distinguish "transport reachable" from
     /// "workspace-scoped tools will succeed":
@@ -34,21 +35,38 @@ public static class ServerTools
     /// advances off pre-load on its own — a workspace_load call is required — so the
     /// state is now named <c>"idle"</c> to reflect reality.
     /// </para>
+    /// <para>
+    /// <strong>host-recycle-opacity:</strong> the FIRST probe of a freshly-started host
+    /// process surfaces <c>previousStdioPid</c> / <c>previousExitedAt</c> /
+    /// <c>previousRecycleReason</c> drawn from the <see cref="HostProcessMetadataStore"/>
+    /// snapshot published via <see cref="HostProcessMetadataSnapshotProvider"/>. Subsequent
+    /// probes omit those fields (consume-once semantics) so callers always know "this is the
+    /// first probe after the recycle". Unit-test paths that construct ServerTools without
+    /// publishing a snapshot get clean cold-start behavior — the optional fields are absent.
+    /// </para>
     /// </summary>
-    private static object BuildConnection(IWorkspaceManager workspace)
+    internal static ConnectionStateDto BuildConnection(IWorkspaceManager workspace)
     {
         var loadedWorkspaceCount = workspace.ListWorkspaces().Count;
         // connection-state-ready-unsatisfiable-preload: pre-load state is "idle", not
         // "initializing". The server does not auto-advance from pre-load; a workspace_load
         // call is the only transition, so the label must be terminal, not transient.
         var state = loadedWorkspaceCount >= 1 ? "ready" : "idle";
-        return new
-        {
-            state,
-            loadedWorkspaceCount,
-            stdioPid = Environment.ProcessId,
-            serverStartedAt = s_serverStartedAtUtc.ToString("O")
-        };
+
+        // host-recycle-opacity: drain the previous-process snapshot exactly once. The provider
+        // returns null after the first call, so subsequent probes see clean state. Tests that
+        // construct ServerTools without wiring the snapshot (provider unset) get null here
+        // and the optional fields are omitted from the JSON.
+        var previous = HostProcessMetadataSnapshotProvider.Consume();
+
+        return new ConnectionStateDto(
+            State: state,
+            LoadedWorkspaceCount: loadedWorkspaceCount,
+            StdioPid: Environment.ProcessId,
+            ServerStartedAt: s_serverStartedAtUtc.ToString("O"),
+            PreviousStdioPid: previous?.StdioPid,
+            PreviousExitedAtUtc: previous?.ExitedAtUtc,
+            PreviousRecycleReason: previous?.RecycleReason);
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/HostProcessMetadataTests.cs
+++ b/tests/RoslynMcp.Tests/HostProcessMetadataTests.cs
@@ -1,0 +1,416 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Services;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for <c>host-recycle-opacity</c>: when the roslyn-mcp host stdio process is
+/// recycled mid-session (idle eviction, watchdog kill, client disconnect, crash), every
+/// subsequent workspace-scoped tool call returned <c>NotFound</c> with no recycle reason.
+/// Post-fix the previous process writes a small disk record on shutdown, the next host
+/// instance reads it on startup, and the FIRST <c>server_info</c> / <c>server_heartbeat</c>
+/// probe surfaces <c>previousStdioPid</c> / <c>previousExitedAt</c> /
+/// <c>previousRecycleReason</c> exactly once.
+/// <para>
+/// These tests cover three layers:
+/// </para>
+/// <list type="number">
+///   <item><description>Disk store — round-trip, atomic write, TTL guard, missing/corrupt files
+///     all behave correctly.</description></item>
+///   <item><description>Snapshot provider — consume-once semantics under concurrent access.</description></item>
+///   <item><description>End-to-end — restart sequence (process A writes, process B reads + surfaces)
+///     produces the expected wire shape on both <c>server_info</c> and <c>server_heartbeat</c>;
+///     SECOND probe of process B drops the previous-* fields.</description></item>
+/// </list>
+/// </summary>
+[TestClass]
+public sealed class HostProcessMetadataTests
+{
+    private string _tempDir = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Each test gets a clean temp dir so they cannot pollute each other. Persisted
+        // metadata is per-user, so without isolation a parallel test runner would race.
+        _tempDir = Path.Combine(Path.GetTempPath(), "RoslynMcpTests", "host-process-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        // Provider is a process-wide singleton; reset between tests so a leaked snapshot
+        // from a prior test cannot bleed forward.
+        HostProcessMetadataSnapshotProvider.Reset();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort — another test may hold a lock; the assembly cleanup will sweep.
+        }
+
+        HostProcessMetadataSnapshotProvider.Reset();
+    }
+
+    private string PathInTemp() => Path.Combine(_tempDir, "host-process.json");
+
+    [TestMethod]
+    public void WriteCurrent_ThenLoadPrevious_RoundTripsAllFields()
+    {
+        var fixedNow = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        // Process A: writes its exit metadata.
+        var writer = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow);
+        writer.WriteCurrent(recycleReason: "graceful");
+
+        Assert.IsTrue(File.Exists(path), "WriteCurrent must produce the on-disk record.");
+
+        // Process B: reads the record.
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow.AddMinutes(1));
+        var snapshot = reader.LoadPrevious();
+
+        Assert.IsNotNull(snapshot, "LoadPrevious must return a snapshot when the file exists with valid content.");
+        Assert.AreEqual(Environment.ProcessId, snapshot.StdioPid,
+            "Round-tripped pid must match the writer process — the test process is both writer and reader.");
+        Assert.AreEqual("graceful", snapshot.RecycleReason);
+        Assert.IsTrue(DateTime.TryParse(snapshot.ExitedAtUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed),
+            $"ExitedAtUtc must parse as a DateTime (got '{snapshot.ExitedAtUtc}').");
+        Assert.AreEqual(fixedNow, parsed,
+            "Round-tripped exit timestamp must match the writer's UtcNow at write time.");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_DeletesOnDiskRecord_AfterRead()
+    {
+        var fixedNow = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        var writer = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow);
+        writer.WriteCurrent(recycleReason: "graceful");
+        Assert.IsTrue(File.Exists(path), "Pre-read sanity check.");
+
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow);
+        reader.LoadPrevious();
+
+        Assert.IsFalse(File.Exists(path),
+            "LoadPrevious must delete the on-disk record after read so the same snapshot " +
+            "is never replayed across multiple processes (e.g. if the next host crashes " +
+            "before writing its own metadata).");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_OldRecord_PreservesFields_NormalizesReasonToUnknown()
+    {
+        // TTL guard: a record older than StaleAfter (24h) keeps its pid + timestamp but the
+        // reason is normalized to "unknown" — operators get something but don't trust an
+        // ancient recycle reason.
+        var writeTime = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        var writer = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => writeTime);
+        writer.WriteCurrent(recycleReason: "watchdog");
+
+        // Read 25 hours later — beyond the 24h TTL.
+        var staleNow = writeTime.AddHours(25);
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => staleNow);
+        var snapshot = reader.LoadPrevious();
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual(Environment.ProcessId, snapshot.StdioPid,
+            "Stale-record pid must still surface — operators want SOMETHING.");
+        Assert.AreEqual("unknown", snapshot.RecycleReason,
+            "Stale records must report reason=unknown rather than the persisted (untrusted) reason.");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_FreshRecord_PreservesPersistedReason()
+    {
+        // Counterpoint to the TTL test: a record well within the window keeps its persisted
+        // reason — TTL only fires for genuinely-old records.
+        var writeTime = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        var writer = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => writeTime);
+        writer.WriteCurrent(recycleReason: "watchdog");
+
+        // Read 1 hour later — well within TTL.
+        var freshNow = writeTime.AddHours(1);
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => freshNow);
+        var snapshot = reader.LoadPrevious();
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual("watchdog", snapshot.RecycleReason,
+            "Fresh records must surface their persisted recycle reason verbatim.");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_MissingFile_ReturnsNull()
+    {
+        // Cold start: no prior record exists. Must return null cleanly without throwing.
+        var path = PathInTemp();
+        Assert.IsFalse(File.Exists(path));
+
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => DateTime.UtcNow);
+        Assert.IsNull(reader.LoadPrevious());
+    }
+
+    [TestMethod]
+    public void LoadPrevious_CorruptJson_ReturnsNull_WithoutThrowing()
+    {
+        // Best-effort parsing: a corrupt file must not crash startup.
+        var path = PathInTemp();
+        File.WriteAllText(path, "{ this is not valid JSON ::: ");
+
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => DateTime.UtcNow);
+        Assert.IsNull(reader.LoadPrevious(),
+            "Corrupt JSON must be treated as 'no prior record' rather than crashing the host startup path.");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_MissingRequiredFields_ReturnsNull()
+    {
+        // A record with valid JSON but missing pid / timestamp is unsalvageable — discard it.
+        var path = PathInTemp();
+        File.WriteAllText(path, """{"recycleReason":"graceful"}""");
+
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => DateTime.UtcNow);
+        Assert.IsNull(reader.LoadPrevious(),
+            "A record without pid/exitedAt is missing the load-bearing fields — must be discarded.");
+    }
+
+    [TestMethod]
+    public void LoadPrevious_IsCachedAcrossCalls_NoExtraDiskReads()
+    {
+        // LoadPrevious caches its first result. Subsequent calls must return the SAME
+        // snapshot reference without re-reading the file (which would fail since
+        // we delete the file after the first read).
+        var fixedNow = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        var writer = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow);
+        writer.WriteCurrent(recycleReason: "graceful");
+
+        var reader = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => fixedNow);
+        var first = reader.LoadPrevious();
+        var second = reader.LoadPrevious();
+        var third = reader.LoadPrevious();
+
+        Assert.IsNotNull(first);
+        Assert.AreSame(first, second, "LoadPrevious must cache and return the same snapshot reference.");
+        Assert.AreSame(first, third, "Caching must persist across many calls — not just two.");
+    }
+
+    [TestMethod]
+    public void Provider_ConsumeAfterPublish_ReturnsSnapshotOnce_NullThereafter()
+    {
+        // The CONTRACT from the backlog row: first probe after restart carries previous-*;
+        // second probe does not. The provider's Consume() owns that invariant.
+        var snapshot = new HostProcessMetadataSnapshot(
+            StdioPid: 12345,
+            ExitedAtUtc: "2026-04-25T11:59:59.0000000Z",
+            RecycleReason: "graceful");
+
+        HostProcessMetadataSnapshotProvider.Publish(snapshot);
+
+        var first = HostProcessMetadataSnapshotProvider.Consume();
+        var second = HostProcessMetadataSnapshotProvider.Consume();
+        var third = HostProcessMetadataSnapshotProvider.Consume();
+
+        Assert.AreSame(snapshot, first, "First Consume() after Publish() must return the published snapshot.");
+        Assert.IsNull(second, "Second Consume() must return null — consume-once semantics are the wire contract.");
+        Assert.IsNull(third, "All subsequent Consume() calls must return null.");
+    }
+
+    [TestMethod]
+    public void Provider_PublishNull_ConsumeReturnsNull()
+    {
+        // Cold start: no prior record. Publishing null is the canonical "no metadata" signal.
+        HostProcessMetadataSnapshotProvider.Publish(snapshot: null);
+
+        Assert.IsNull(HostProcessMetadataSnapshotProvider.Consume(),
+            "Publishing null must short-circuit Consume() to null — no previous-* fields ever surface.");
+    }
+
+    [TestMethod]
+    public void ServerInfo_FirstProbeAfterRestart_CarriesPreviousMetadata()
+    {
+        // End-to-end: simulate the restart sequence by publishing a snapshot directly to
+        // the provider, then call ServerTools.GetServerInfo and verify the wire shape.
+        var snapshot = new HostProcessMetadataSnapshot(
+            StdioPid: 99999,
+            ExitedAtUtc: "2026-04-25T11:59:59.0000000Z",
+            RecycleReason: "graceful");
+        HostProcessMetadataSnapshotProvider.Publish(snapshot);
+
+        var json = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+
+        using var doc = JsonDocument.Parse(json);
+        var connection = doc.RootElement.GetProperty("connection");
+
+        Assert.AreEqual(99999, connection.GetProperty("previousStdioPid").GetInt32(),
+            "First probe after restart must carry previousStdioPid from the published snapshot.");
+        Assert.AreEqual("2026-04-25T11:59:59.0000000Z", connection.GetProperty("previousExitedAt").GetString(),
+            "First probe after restart must carry previousExitedAt from the published snapshot.");
+        Assert.AreEqual("graceful", connection.GetProperty("previousRecycleReason").GetString(),
+            "First probe after restart must carry previousRecycleReason from the published snapshot.");
+    }
+
+    [TestMethod]
+    public void ServerInfo_SecondProbe_DropsPreviousMetadata()
+    {
+        // The wire contract: previous-* fields appear EXACTLY ONCE per host lifetime.
+        // A polling consumer that calls server_info twice in quick succession must see the
+        // fields on probe #1 only.
+        var snapshot = new HostProcessMetadataSnapshot(
+            StdioPid: 99999,
+            ExitedAtUtc: "2026-04-25T11:59:59.0000000Z",
+            RecycleReason: "graceful");
+        HostProcessMetadataSnapshotProvider.Publish(snapshot);
+
+        // First probe drains the provider.
+        _ = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+
+        // Second probe must NOT carry previous-* fields.
+        var secondJson = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+        using var secondDoc = JsonDocument.Parse(secondJson);
+        var secondConnection = secondDoc.RootElement.GetProperty("connection");
+
+        Assert.IsFalse(secondConnection.TryGetProperty("previousStdioPid", out _),
+            "Second probe MUST NOT carry previousStdioPid — consume-once semantics are the wire contract.");
+        Assert.IsFalse(secondConnection.TryGetProperty("previousExitedAt", out _),
+            "Second probe MUST NOT carry previousExitedAt.");
+        Assert.IsFalse(secondConnection.TryGetProperty("previousRecycleReason", out _),
+            "Second probe MUST NOT carry previousRecycleReason.");
+    }
+
+    [TestMethod]
+    public void ServerHeartbeat_FirstProbeAfterRestart_CarriesPreviousMetadata()
+    {
+        // server_heartbeat shares the connection block with server_info. The previous-*
+        // fields must appear there too — consumers polling via the cheap heartbeat tool
+        // should see the same recycle metadata as full server_info pollers.
+        var snapshot = new HostProcessMetadataSnapshot(
+            StdioPid: 88888,
+            ExitedAtUtc: "2026-04-25T10:30:00.0000000Z",
+            RecycleReason: "watchdog");
+        HostProcessMetadataSnapshotProvider.Publish(snapshot);
+
+        var json = ServerTools.GetServerHeartbeat(new FakeWorkspaceManager()).GetAwaiter().GetResult();
+
+        using var doc = JsonDocument.Parse(json);
+        var connection = doc.RootElement.GetProperty("connection");
+
+        Assert.AreEqual(88888, connection.GetProperty("previousStdioPid").GetInt32());
+        Assert.AreEqual("2026-04-25T10:30:00.0000000Z", connection.GetProperty("previousExitedAt").GetString());
+        Assert.AreEqual("watchdog", connection.GetProperty("previousRecycleReason").GetString());
+    }
+
+    [TestMethod]
+    public void ServerInfo_ColdStart_NoSnapshotPublished_OmitsPreviousMetadata()
+    {
+        // No Publish() call: the provider has nothing to consume. The previous-* fields must
+        // be ABSENT from the wire (not present-with-null) so consumers can use TryGetProperty
+        // as a presence check.
+        // (Cleanup() called Reset() before this test, so the provider is clean.)
+
+        var json = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+        using var doc = JsonDocument.Parse(json);
+        var connection = doc.RootElement.GetProperty("connection");
+
+        Assert.IsFalse(connection.TryGetProperty("previousStdioPid", out _),
+            "Cold start must not emit previousStdioPid.");
+        Assert.IsFalse(connection.TryGetProperty("previousExitedAt", out _),
+            "Cold start must not emit previousExitedAt.");
+        Assert.IsFalse(connection.TryGetProperty("previousRecycleReason", out _),
+            "Cold start must not emit previousRecycleReason.");
+
+        // Sanity: the existing connection fields are still there. We didn't break the shape.
+        Assert.IsTrue(connection.TryGetProperty("state", out _));
+        Assert.IsTrue(connection.TryGetProperty("loadedWorkspaceCount", out _));
+        Assert.IsTrue(connection.TryGetProperty("stdioPid", out _));
+        Assert.IsTrue(connection.TryGetProperty("serverStartedAt", out _));
+    }
+
+    [TestMethod]
+    public void EndToEnd_DiskWriteRead_RestartSequence_FirstProbeOnlyCarriesMetadata()
+    {
+        // Full integration: write metadata to disk (process A), then read + publish + consume
+        // (process B), simulating the actual restart sequence. Verifies the disk store and
+        // the provider compose correctly when wired the way Program.cs wires them.
+        var writeTime = new DateTime(2026, 4, 25, 12, 0, 0, DateTimeKind.Utc);
+        var path = PathInTemp();
+
+        // Process A — graceful shutdown writes its metadata.
+        var processA = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => writeTime);
+        processA.WriteCurrent(recycleReason: "graceful");
+        Assert.IsTrue(File.Exists(path));
+
+        // Process B — startup loads + publishes + first probe consumes.
+        var processB = new HostProcessMetadataStore(path, HostProcessMetadataStore.StaleAfter, () => writeTime.AddSeconds(2));
+        var loaded = processB.LoadPrevious();
+        Assert.IsNotNull(loaded, "LoadPrevious must return a snapshot from the on-disk record.");
+        HostProcessMetadataSnapshotProvider.Publish(loaded);
+
+        // First probe.
+        var firstJson = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+        using var firstDoc = JsonDocument.Parse(firstJson);
+        var firstConn = firstDoc.RootElement.GetProperty("connection");
+        Assert.AreEqual(Environment.ProcessId, firstConn.GetProperty("previousStdioPid").GetInt32(),
+            "First probe after disk-loaded restart must carry the writer's pid.");
+        Assert.AreEqual("graceful", firstConn.GetProperty("previousRecycleReason").GetString());
+
+        // Second probe — fields must drop.
+        var secondJson = ServerTools.GetServerInfo(new FakeWorkspaceManager(), new FakeVersionProvider()).GetAwaiter().GetResult();
+        using var secondDoc = JsonDocument.Parse(secondJson);
+        var secondConn = secondDoc.RootElement.GetProperty("connection");
+        Assert.IsFalse(secondConn.TryGetProperty("previousStdioPid", out _),
+            "Second probe must not re-emit previous-* fields — consume-once is enforced by the provider.");
+    }
+
+    /// <summary>
+    /// Minimal fake — only ListWorkspaces is invoked by ServerTools.BuildConnection. Every
+    /// other member throws to surface mistakes if a future refactor accidentally calls them
+    /// from the connection-building path.
+    /// </summary>
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+        public event Action<string>? WorkspaceReloaded { add { } remove { } }
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => false;
+        public bool IsStale(string workspaceId) => false;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => Array.Empty<WorkspaceStatusDto>();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+    }
+
+    private sealed class FakeVersionProvider : ILatestVersionProvider
+    {
+        public string? GetLatestVersion() => null;
+    }
+}


### PR DESCRIPTION
## Summary

Pre-fix, when the roslyn-mcp host stdio process was recycled mid-session (idle eviction, watchdog kill, client disconnect, crash), every subsequent workspace-scoped tool call returned `NotFound` with no recycle reason. Agents had to guess "did the process die?" by elimination of every other failure mode.

Post-fix, the previous host process writes a small disk record on graceful shutdown, the next host instance reads it on startup, and the FIRST `server_info` / `server_heartbeat` probe surfaces `previousStdioPid` / `previousExitedAt` / `previousRecycleReason` exactly once. Every subsequent probe drops those fields, so the wire signal is unambiguously "this is the first probe after the recycle".

## Components

- **`ConnectionStateDto`** (`src/RoslynMcp.Core/Models/`) — extracted canonical wire shape for the `connection` subfield. Existing fields (`state`, `loadedWorkspaceCount`, `stdioPid`, `serverStartedAt`) keep their JSON property names verbatim. Three new optional fields: `previousStdioPid`, `previousExitedAt`, `previousRecycleReason` (omitted from the wire when null).
- **`HostProcessMetadataStore`** (`src/RoslynMcp.Host.Stdio/Diagnostics/`) — disk persistence module. Temp-file + atomic-replace write at `%LOCALAPPDATA%/roslyn-mcp/host-process.json` (Windows) or `$XDG_STATE_HOME/roslyn-mcp/host-process.json` (POSIX). 24h TTL guard: stale records still surface the pid + timestamp but normalize the reason to `unknown`. Best-effort: corrupt JSON or IO failures fall through to clean cold-start without crashing the host. The on-disk record is deleted after read to prevent replay across multiple processes.
- **`HostProcessMetadataSnapshotProvider`** (same dir) — process-wide consume-once latch (mirrors the existing `SurfaceRegistrationSnapshot` pattern) so static `ServerTools` methods can reach the snapshot without a constructor dependency. `Consume()` returns the snapshot on the first call after `Publish()` and `null` on every subsequent call. Thread-safe.
- **`ServerTools.BuildConnection`** — now returns `ConnectionStateDto` instead of an inline anonymous object, and drains the provider's snapshot. The serialized JSON shape stays identical for cold-start callers; restart callers see the new fields on probe #1 only.
- **`Program.cs`** wires both halves: `LoadPrevious` + `Publish` on startup, `WriteCurrent("graceful")` on `ApplicationStopping`. Future watchdog / idle-eviction code that knows specifically why it terminated will pass its own reason.

Recycle reason values: `graceful` (clean shutdown via `ApplicationStopping`), `idle-eviction`, `watchdog`, `client-disconnect`, `unknown` (stale record or no persisted reason — most likely a crash).

## Test plan

- [x] `HostProcessMetadataTests.cs` (15 tests):
  - Disk store: round-trip all fields; LoadPrevious deletes on-disk record after read; old record (>24h) preserves pid+timestamp but normalizes reason to `unknown`; fresh record preserves persisted reason; missing/corrupt/incomplete files return null without throwing; LoadPrevious is cached across calls.
  - Snapshot provider: consume-once semantics enforced; publishing null short-circuits Consume to null.
  - End-to-end: `server_info` and `server_heartbeat` first-probe carries previous-* fields, second probe drops them; cold start (no Publish) omits previous-* fields entirely; full disk round-trip simulating actual restart sequence.
- [x] All 30 ServerHeartbeatTests + StartupDiagnosticsTests + ServerInfoUpdateLatestTests still pass — wire shape unchanged for cold-start.
- [x] 825 non-flaky tests pass in Release mode (excluded suites: heavy filesystem/NuGet integration tests with known pre-existing flakes — unrelated to this change).
- [x] `verify-ai-docs.ps1` green.

Closes: `host-recycle-opacity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)