### PR TITLE
fix(fix-all-service): emit uniform no-provider guidance across severities

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -77,18 +77,13 @@ public sealed class FixAllService : IFixAllService
             ?? FindCodeFixProvider(analyzerAssemblyProviders, diagnosticId);
         if (provider is null)
         {
-            var alternativeHint = GetAlternativeToolHint(diagnosticId);
             return new FixAllPreviewDto(
                 PreviewToken: "",
                 DiagnosticId: diagnosticId,
                 Scope: scope,
                 FixedCount: 0,
                 Changes: [],
-                GuidanceMessage:
-                    $"No code fix provider is loaded for diagnostic '{diagnosticId}'. " +
-                    (alternativeHint ?? "Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs. " +
-                        "If this is an Info/IDE-series diagnostic without a built-in fix, consider add_pragma_suppression " +
-                        "or an editorconfig severity bump via set_diagnostic_severity."));
+                GuidanceMessage: BuildNoProviderGuidance(diagnosticId));
         }
 
         var fixAllProvider = provider.GetFixAllProvider();
@@ -606,11 +601,48 @@ public sealed class FixAllService : IFixAllService
     }
 
     /// <summary>
+    /// Builds the uniform "no fix provider loaded" guidance returned when neither the
+    /// reflection-loaded CSharp.Features fix providers nor the project's analyzer-reference
+    /// fix providers cover <paramref name="diagnosticId"/>. The message has the same structural
+    /// shape regardless of the diagnostic's severity or whether the id is IDE-prefixed: it
+    /// always names the diagnostic, calls out <c>list_analyzers</c> as the discovery tool, and
+    /// suggests <c>add_pragma_suppression</c> / <c>set_diagnostic_severity</c> as fallbacks.
+    /// When a known id has a more specific alternative tool (e.g. <c>organize_usings_preview</c>
+    /// for <c>IDE0005</c>), that hint is appended.
+    /// </summary>
+    /// <remarks>
+    /// fix-all-preview-silent-on-missing-provider-info-severity: previously the IDE-prefixed
+    /// switch arm in <see cref="GetAlternativeToolHint"/> displaced the <c>list_analyzers</c>
+    /// fallback, so Info-severity ids like <c>IDE0130</c>/<c>IDE0290</c>/<c>IDE0008</c>
+    /// returned a guidance shape that omitted the <c>list_analyzers</c> pointer that
+    /// non-IDE Warning ids (<c>CA1826</c>/<c>xUnit1051</c>) carried. Severity and id-prefix
+    /// must not gate the <c>list_analyzers</c> reference — the baseline guidance is uniform,
+    /// and id-specific tool hints are additive.
+    /// </remarks>
+    internal static string BuildNoProviderGuidance(string diagnosticId)
+    {
+        var baseline =
+            $"No code fix provider is loaded for diagnostic '{diagnosticId}'. " +
+            "Restore analyzer packages (IDE/CA rules). Use list_analyzers to see loaded diagnostic IDs. " +
+            "If this diagnostic has no built-in fix, consider add_pragma_suppression " +
+            "or an editorconfig severity bump via set_diagnostic_severity.";
+
+        var hint = GetAlternativeToolHint(diagnosticId);
+        return hint is null ? baseline : baseline + " " + hint;
+    }
+
+    /// <summary>
     /// Returns an alternative tool suggestion for known IDE diagnostics that lack FixAll providers.
     /// Many IDE code fix providers require constructor parameters that cannot be satisfied via
     /// reflection instantiation, so they are silently skipped. This mapping directs agents to
     /// the correct alternative tool or manual workaround.
     /// </summary>
+    /// <remarks>
+    /// This helper returns ONLY id-specific tool hints — the generic "no provider loaded /
+    /// use list_analyzers" baseline lives in <see cref="BuildNoProviderGuidance"/> and is
+    /// emitted unconditionally. Adding a new id-specific hint here will append it to the
+    /// uniform baseline; do NOT re-state the baseline pointers in the per-id strings.
+    /// </remarks>
     private static string? GetAlternativeToolHint(string diagnosticId) =>
         diagnosticId.ToUpperInvariant() switch
         {
@@ -619,9 +651,6 @@ public sealed class FixAllService : IFixAllService
             "IDE0055" => "Use format_document_preview / format_document_apply for formatting fixes.",
             "IDE0160" or "IDE0161" => "Block-scoped vs file-scoped namespace preferences must be applied manually or with code_fix_preview on individual instances.",
             "IDE0290" => "Primary constructor conversion must be applied manually or with code_fix_preview on individual instances.",
-            _ when diagnosticId.StartsWith("IDE", StringComparison.OrdinalIgnoreCase) =>
-                $"The IDE code fix provider for '{diagnosticId}' could not be loaded (constructor requirements). " +
-                "Try code_fix_preview on individual instances, or use list_analyzers to check if the diagnostic is present.",
             _ => null
         };
 

--- a/tests/RoslynMcp.Tests/FixAllServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FixAllServiceTests.cs
@@ -175,6 +175,83 @@ public sealed class FixAllServiceTests
 
         StringAssert.Contains(thrown.Message, "Sequence contains no elements");
     }
+
+    // ----------------------------------------------------------------------
+    // fix-all-preview-silent-on-missing-provider-info-severity regression coverage.
+    //
+    // Backlog observation: when the registered provider lookup misses (no static
+    // nor analyzer-reference provider covers the id), Info-severity IDE ids
+    // (IDE0130 / IDE0290 / IDE0008) used to return guidance that omitted the
+    // list_analyzers pointer, while Warning-severity non-IDE ids (CA1826 /
+    // xUnit1051) returned a helpful list_analyzers-bearing message. The fix
+    // routes both severities through BuildNoProviderGuidance, which always emits
+    // the same baseline (id name + list_analyzers + add_pragma_suppression /
+    // set_diagnostic_severity fallback) and APPENDS any id-specific tool hint.
+    // Severity and id-prefix must not gate the baseline pointers.
+    // ----------------------------------------------------------------------
+
+    [TestMethod]
+    public void BuildNoProviderGuidance_Info_IDE0130_Includes_List_Analyzers_Pointer()
+    {
+        // IDE0130 (using-directive placement) is Info severity in default editorconfig
+        // and previously fell into the IDE-prefixed switch arm that displaced the
+        // list_analyzers reference. Guarantee the baseline pointer survives.
+        var guidance = FixAllService.BuildNoProviderGuidance("IDE0130");
+
+        StringAssert.Contains(guidance, "IDE0130");
+        StringAssert.Contains(guidance, "No code fix provider is loaded");
+        StringAssert.Contains(guidance, "list_analyzers");
+        StringAssert.Contains(guidance, "add_pragma_suppression");
+        StringAssert.Contains(guidance, "set_diagnostic_severity");
+    }
+
+    [TestMethod]
+    public void BuildNoProviderGuidance_Warning_CA1826_Includes_List_Analyzers_Pointer()
+    {
+        // CA1826 (use-method-instead-of-linq) is Warning severity and non-IDE.
+        // It must produce the SAME baseline as the Info IDE0130 case — the only
+        // legitimate difference is whether GetAlternativeToolHint adds an id-specific
+        // appendage. Severity and id-prefix do not gate the baseline.
+        var guidance = FixAllService.BuildNoProviderGuidance("CA1826");
+
+        StringAssert.Contains(guidance, "CA1826");
+        StringAssert.Contains(guidance, "No code fix provider is loaded");
+        StringAssert.Contains(guidance, "list_analyzers");
+        StringAssert.Contains(guidance, "add_pragma_suppression");
+        StringAssert.Contains(guidance, "set_diagnostic_severity");
+    }
+
+    [TestMethod]
+    public void BuildNoProviderGuidance_Info_And_Warning_Share_Baseline_Shape()
+    {
+        // Direct cross-severity invariant: when neither id has an id-specific hint
+        // appended, the two strings must be byte-identical except for the diagnostic
+        // id substitution. Precludes a future refactor from re-introducing a
+        // severity-keyed branch silently.
+        var info = FixAllService.BuildNoProviderGuidance("IDE0130");
+        var warn = FixAllService.BuildNoProviderGuidance("CA1826");
+
+        // Strip the id from each so the rest of the message can be compared.
+        var infoCanonical = info.Replace("IDE0130", "<ID>", StringComparison.Ordinal);
+        var warnCanonical = warn.Replace("CA1826", "<ID>", StringComparison.Ordinal);
+
+        Assert.AreEqual(warnCanonical, infoCanonical,
+            "Severity and id-prefix must not affect the baseline guidance shape.");
+    }
+
+    [TestMethod]
+    public void BuildNoProviderGuidance_Appends_IdSpecific_Hint_When_Available()
+    {
+        // IDE0005 has a documented organize_usings_preview alternative; the hint
+        // should be appended to (not replace) the uniform baseline. This is the
+        // one place severity-of-id-shape DOES legitimately differ — but only
+        // additively.
+        var guidance = FixAllService.BuildNoProviderGuidance("IDE0005");
+
+        StringAssert.Contains(guidance, "IDE0005");
+        StringAssert.Contains(guidance, "list_analyzers");                      // baseline survives
+        StringAssert.Contains(guidance, "organize_usings_preview");             // id-specific append
+    }
 }
 
 #pragma warning restore RS2008


### PR DESCRIPTION
## Summary

- Route `FixAllService.PreviewFixAllAsync`'s no-provider-loaded branch through a new `BuildNoProviderGuidance` helper so Info-severity IDE ids and Warning-severity non-IDE ids both receive the same baseline message (id named, `list_analyzers` pointer, `add_pragma_suppression` / `set_diagnostic_severity` fallbacks).
- Refactor `GetAlternativeToolHint` to return ONLY id-specific tool hints; the previous IDE-prefixed catch-all arm displaced the `list_analyzers` baseline instead of appending to it. Id-specific hints now append to the uniform baseline.
- Add 4 unit tests pinning the cross-severity invariant: IDE0130 (Info) and CA1826 (Warning) produce byte-identical guidance shapes (excepting the id substitution), id-specific hints append additively, and the `list_analyzers` pointer survives in both severity bands.

## Why

Per the backlog row, agents calling `fix_all_preview` on Info-severity ids (`IDE0130` / `IDE0290` / `IDE0008`) saw guidance shapes that omitted the `list_analyzers` discovery pointer that Warning-severity ids (`CA1826` / `xUnit1051`) carried. Severity and id-prefix should never gate the baseline triage signal — agents need to distinguish "no provider" from "no occurrences" / "no actions" regardless of which diagnostic id they're asking about.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~FixAllServiceTests` — 11 pass (7 existing + 4 new)
- [x] `dotnet test --filter FullyQualifiedName~FixAll` — all 21 FixAll-* tests pass (Debug + Release configs)
- [x] `pwsh ./eng/verify-ai-docs.ps1` — passes (31 SKILL.md generic-check)
- [x] Existing `FixAllServiceGuidanceTests` and `FixAllServiceIntegrationTests` still pass — both anchor on the "No code fix provider" substring which remains in the new baseline.

Closes: fix-all-preview-silent-on-missing-provider-info-severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)