### PR TITLE
fix(preview-store): pin tokens to workspace-version range (format-range-apply-preview-token-lifetime)

### DIFF
--- a/src/RoslynMcp.Core/Services/BoundedStore.cs
+++ b/src/RoslynMcp.Core/Services/BoundedStore.cs
@@ -66,6 +66,22 @@ public abstract class BoundedStore<TEntry> where TEntry : IBoundedStoreEntry
         }
     }
 
+    /// <summary>
+    /// Drops every entry for which <paramref name="shouldDrop"/> returns <see langword="true"/>.
+    /// Hook for derived stores that need a richer eviction policy than workspace-id matching
+    /// (e.g. <c>PreviewStore.InvalidateOnVersionBump</c>, which compares the post-bump
+    /// workspace version against a per-entry pinned-range ceiling).
+    /// </summary>
+    protected void InvalidateWhere(Func<TEntry, bool> shouldDrop)
+    {
+        ArgumentNullException.ThrowIfNull(shouldDrop);
+        foreach (var kvp in _entries)
+        {
+            if (shouldDrop(kvp.Value))
+                _entries.TryRemove(kvp.Key, out _);
+        }
+    }
+
     public string? PeekWorkspaceId(string token)
     {
         if (!_entries.TryGetValue(token, out var entry))

--- a/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
@@ -71,6 +71,33 @@ public interface IPreviewStore
     void InvalidateAll(string? workspaceId = null);
 
     /// <summary>
+    /// <b>format-range-apply-preview-token-lifetime:</b> drops only the entries belonging to
+    /// <paramref name="workspaceId"/> whose pinned workspace-version range no longer covers
+    /// <paramref name="newWorkspaceVersion"/>. Each entry is pinned at Store time to a range
+    /// <c>[StoreVersion, StoreVersion + MaxVersionSpan]</c>; an auto-reload that nudges the
+    /// workspace version by one bump leaves tokens in the range valid (so a preview → reload
+    /// → apply sequence that fits inside a single version bump still redeems), while a second
+    /// reload pushes the version past the pinned ceiling and the token is dropped.
+    /// </summary>
+    /// <remarks>
+    /// Replaces the prior "wipe-on-reload" behavior at
+    /// <c>WorkspaceManager.LoadIntoSessionAsync</c>, which called
+    /// <see cref="InvalidateAll(string)"/> indiscriminately and surfaced as
+    /// <c>"Preview token not found or expired"</c> on every <c>format_range_apply</c>
+    /// (and other <c>*_apply</c>) call that raced against a file-watcher auto-reload within
+    /// the preview's TTL window. The captured <c>OriginalSolution</c>/<c>ModifiedSolution</c>
+    /// snapshots are immutable Roslyn graphs and remain readable after the underlying
+    /// <c>MSBuildWorkspace</c> is disposed by reload, so the apply path's existing
+    /// cross-lineage rebase (<c>RebaseModifiedSolutionOntoCurrentAsync</c> in
+    /// <c>RefactoringService</c>) safely replays the preview's diff onto the post-reload
+    /// solution. <see cref="InvalidateAll(string)"/> remains the right call for the
+    /// workspace-close path, where the workspace is going away entirely.
+    /// </remarks>
+    /// <param name="workspaceId">The workspace whose entries are version-checked.</param>
+    /// <param name="newWorkspaceVersion">The post-bump workspace version.</param>
+    void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion);
+
+    /// <summary>
     /// Returns the workspace identifier associated with a preview token without consuming the entry,
     /// or <see langword="null"/> if the token is expired or not found.
     /// </summary>

--- a/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
@@ -18,16 +18,47 @@ namespace RoslynMcp.Roslyn.Services;
 /// AND the <c>ModifiedSolution</c> (with the preview's edits applied). The apply path computes
 /// the preview's intended diff as <c>ModifiedSolution.GetChanges(OriginalSolution)</c> and
 /// replays only THAT diff onto the current workspace solution. Sibling <c>*_apply</c> calls
-/// against unrelated files no longer invalidate this entry: the workspace lifecycle (Close,
-/// Reload) is the only event that drops tokens via <see cref="InvalidateAll"/>. The workspace
-/// version tracked on the entry is retained for telemetry and diagnostics only — it is no
-/// longer used to reject an apply.
+/// against unrelated files no longer invalidate this entry: token pruning is driven by
+/// workspace lifecycle alone — close uses <see cref="InvalidateAll"/>, reload uses the
+/// pinned-range <see cref="InvalidateOnVersionBump"/> (see paragraph below).
+/// </para>
+/// <para>
+/// <b>format-range-apply-preview-token-lifetime:</b> reload-driven invalidation now follows a
+/// pinned workspace-version range instead of nuking every token on every reload. Each entry
+/// records a <see cref="PreviewEntry.MaxRedeemableVersion"/> ceiling at Store time, computed
+/// as <c>WorkspaceVersion + <see cref="DefaultMaxVersionSpan"/></c>. The
+/// <see cref="InvalidateOnVersionBump"/> hook (called from
+/// <c>WorkspaceManager.LoadIntoSessionAsync</c> after the post-reload version bump) drops only
+/// the entries whose ceiling has been crossed, so a preview &#x2192; one auto-reload &#x2192;
+/// apply sequence inside the TTL window still redeems. The captured Solution snapshots are
+/// immutable Roslyn graphs and remain readable after the workspace's <c>MSBuildWorkspace</c>
+/// is disposed by reload — the apply path's existing
+/// <c>RebaseModifiedSolutionOntoCurrentAsync</c> in <c>RefactoringService</c> replays the
+/// preview's diff onto the post-reload solution by file path, not by lineage. Workspace close
+/// still wipes every token via <see cref="InvalidateAll"/>; that path remains correct because
+/// the workspace itself is going away.
 /// </para>
 /// </remarks>
 public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPreviewStore
 {
-    public PreviewStore(int maxEntries = 20, TimeSpan? ttl = null)
-        : base(maxEntries, ttl ?? TimeSpan.FromMinutes(5)) { }
+    /// <summary>
+    /// format-range-apply-preview-token-lifetime: ceiling on how many workspace-version bumps
+    /// a preview token may survive past its store-time version before
+    /// <see cref="InvalidateOnVersionBump"/> drops it. <c>1</c> means a token stored at version
+    /// <c>V</c> is still redeemable at <c>V+1</c> (one intervening auto-reload OR one sibling
+    /// apply) but not at <c>V+2</c>. Selected to bound stale-preview risk while covering the
+    /// observed preview &#x2192; auto-reload &#x2192; apply window (typically &lt;5 s in
+    /// practice). The TTL bound on the store still applies independently.
+    /// </summary>
+    public const int DefaultMaxVersionSpan = 1;
+
+    private readonly int _maxVersionSpan;
+
+    public PreviewStore(int maxEntries = 20, TimeSpan? ttl = null, int maxVersionSpan = DefaultMaxVersionSpan)
+        : base(maxEntries, ttl ?? TimeSpan.FromMinutes(5))
+    {
+        _maxVersionSpan = maxVersionSpan >= 0 ? maxVersionSpan : DefaultMaxVersionSpan;
+    }
 
     /// <summary>
     /// Legacy overload — assumes the preview's diff was not truncated. Kept so unrelated
@@ -68,7 +99,18 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         int workspaceVersion,
         string description,
         bool diffTruncated)
-        => StoreEntry(new PreviewEntry(workspaceId, originalSolution, modifiedSolution, workspaceVersion, description, diffTruncated, DateTime.UtcNow));
+        => StoreEntry(new PreviewEntry(
+            workspaceId,
+            originalSolution,
+            modifiedSolution,
+            workspaceVersion,
+            // format-range-apply-preview-token-lifetime: pin the redeemable version range at
+            // Store time so InvalidateOnVersionBump can drop only entries whose range has been
+            // exceeded, rather than wiping every token on every reload.
+            MaxRedeemableVersion: workspaceVersion + _maxVersionSpan,
+            description,
+            diffTruncated,
+            DateTime.UtcNow));
 
     /// <summary>
     /// Convenience: when the caller has a freshly-computed <see cref="FileChangeDto"/> list
@@ -117,11 +159,24 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         return (entry.WorkspaceId, entry.OriginalSolution, entry.ModifiedSolution, entry.WorkspaceVersion, entry.Description, entry.DiffTruncated);
     }
 
+    /// <inheritdoc />
+    public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(workspaceId);
+        InvalidateWhere(entry =>
+            string.Equals(entry.WorkspaceId, workspaceId, StringComparison.Ordinal)
+            && newWorkspaceVersion > entry.MaxRedeemableVersion);
+    }
+
     public sealed record PreviewEntry(
         string WorkspaceId,
         Solution OriginalSolution,
         Solution ModifiedSolution,
         int WorkspaceVersion,
+        // format-range-apply-preview-token-lifetime: ceiling for InvalidateOnVersionBump.
+        // Computed at Store time as `WorkspaceVersion + DefaultMaxVersionSpan`. An entry is
+        // dropped on reload only when the post-bump workspace version exceeds this ceiling.
+        int MaxRedeemableVersion,
         string Description,
         bool DiffTruncated,
         DateTime CreatedAt) : IBoundedStoreEntry;

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -591,10 +591,14 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // not destroy those references. The apply path rebases each token's snapshot
             // against the CURRENT solution via `modifiedSolution.GetChanges(currentSolution)`
             // at redemption time (RefactoringService.ApplyRefactoringAsync), so unrelated
-            // workspace moves don't need to invalidate tokens. InvalidateAll remains wired
-            // to workspace-lifecycle events (Close, LoadIntoSessionAsync) where the underlying
-            // MSBuildWorkspace is disposed and the captured Solution references become
-            // orphaned.
+            // workspace moves don't need to invalidate tokens.
+            //
+            // format-range-apply-preview-token-lifetime: sibling-apply bumps the session
+            // version (above) but does NOT call any preview-store invalidation here — pruning
+            // is reload- and close-driven only. The pinned-range eviction triggered by the
+            // next reload uses the live `session.Version` so any version bumps that have
+            // happened in the meantime (sibling apply, prior reload) count against each
+            // token's pinned ceiling at that point.
             LogChangesApplied(_logger, workspaceId, session.Version, null);
         }
         else
@@ -730,7 +734,16 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             session.RestoreRequired = restoreRequired;
             session.LoadedAtUtc = DateTimeOffset.UtcNow;
             session.IncrementVersion();
-            _previewStore.InvalidateAll(session.WorkspaceId);
+            // format-range-apply-preview-token-lifetime: drop only the tokens whose pinned
+            // workspace-version range has been exceeded by this reload bump (default span = 1,
+            // so a preview → single-reload → apply sequence inside the TTL window still
+            // redeems). Replaces the prior unconditional `InvalidateAll` that surfaced as
+            // "Preview token not found or expired" on every `*_apply` racing a watcher-driven
+            // auto-reload. The captured Roslyn `Solution` snapshots are immutable graphs and
+            // remain readable after the prior `MSBuildWorkspace` is disposed below — the apply
+            // path's `RebaseModifiedSolutionOntoCurrentAsync` matches documents by file path,
+            // so the post-reload `ProjectId`/`DocumentId` lineage divergence is handled.
+            _previewStore.InvalidateOnVersionBump(session.WorkspaceId, session.Version);
 
             // Transfer succeeded — dispose the prior workspace AFTER readers can no longer
             // latch onto it through `session.Workspace`. Null out our local so the finally

--- a/tests/RoslynMcp.Tests/FileOperationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/FileOperationIntegrationTests.cs
@@ -66,8 +66,15 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
         Assert.IsNull(SymbolResolver.FindDocument(WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId), targetFilePath));
     }
 
+    /// <summary>
+    /// format-range-apply-preview-token-lifetime: previews survive a single auto-reload
+    /// (one workspace-version bump) inside the pinned range, but two reloads push past
+    /// <see cref="PreviewStore.DefaultMaxVersionSpan"/> = 1 and the token drops with the
+    /// "stale" error. Mirrors the create-file integration shape that this test originally
+    /// covered, updated to the post-bundle pinned-range contract.
+    /// </summary>
     [TestMethod]
-    public async Task File_Operation_Preview_Token_Is_Rejected_When_Workspace_Becomes_Stale()
+    public async Task File_Operation_Preview_Token_Is_Rejected_After_Two_Reloads()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
         var newFilePath = workspace.GetPath("SampleLib", "Generated", "StaleBird.cs");
@@ -77,11 +84,14 @@ public sealed class FileOperationIntegrationTests : IsolatedWorkspaceTestBase
             new CreateFileDto("SampleLib", newFilePath, "namespace SampleLib.Generated;\n\npublic sealed class StaleBird { }\n"),
             CancellationToken.None);
 
+        // Two reload bumps push past the pinned ceiling (V + 1) — token gets dropped on
+        // the second reload's InvalidateOnVersionBump.
+        await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
         await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
-        Assert.IsFalse(applyResult.Success, "Stale previews should be rejected.");
+        Assert.IsFalse(applyResult.Success, "Stale previews (two reloads past pinned range) should be rejected.");
         StringAssert.Contains(applyResult.Error ?? string.Empty, "stale");
         Assert.IsFalse(File.Exists(newFilePath));
     }

--- a/tests/RoslynMcp.Tests/IntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/IntegrationTests.cs
@@ -356,8 +356,15 @@ public class IntegrationTests : SharedWorkspaceTestBase
         }
     }
 
+    /// <summary>
+    /// format-range-apply-preview-token-lifetime: tokens survive a single auto-reload
+    /// (one version bump within DefaultMaxVersionSpan = 1) but a second reload pushes past
+    /// the pinned ceiling and drops the token, surfacing the "stale" rejection. End-to-end
+    /// integration variant — mirrors PreviewStoreTests' unit-level coverage and ensures the
+    /// rejection still flows up through <c>RefactoringService.ApplyRefactoringAsync</c>.
+    /// </summary>
     [TestMethod]
-    public async Task Preview_Token_Is_Rejected_When_Workspace_Becomes_Stale()
+    public async Task Preview_Token_Is_Rejected_After_Two_Reloads()
     {
         var isolatedSolutionPath = CreateSampleSolutionCopy();
         var isolatedRoot = Path.GetDirectoryName(isolatedSolutionPath)!;
@@ -372,10 +379,12 @@ public class IntegrationTests : SharedWorkspaceTestBase
                 isolatedWorkspaceId,
                 serviceFilePath,
                 CancellationToken.None);
+            // Two reloads push the version past the pinned ceiling (V + 1) — token dropped.
+            await WorkspaceManager.ReloadAsync(isolatedWorkspaceId, CancellationToken.None);
             await WorkspaceManager.ReloadAsync(isolatedWorkspaceId, CancellationToken.None);
 
             var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
-            Assert.IsFalse(applyResult.Success, "Stale previews should be rejected.");
+            Assert.IsFalse(applyResult.Success, "Two reloads must push past the pinned ceiling and reject the apply.");
             StringAssert.Contains(applyResult.Error ?? string.Empty, "stale");
         }
         finally

--- a/tests/RoslynMcp.Tests/PreviewStoreTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewStoreTests.cs
@@ -95,4 +95,122 @@ public class PreviewStoreTests
         Assert.IsNotNull(_store.Retrieve(token2));
         workspace.Dispose();
     }
+
+    // ---------------------------------------------------------------
+    // format-range-apply-preview-token-lifetime: pinned-version-range
+    // tests covering the auto-reload-vs-apply lifetime contract.
+    // ---------------------------------------------------------------
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Single_Bump_Within_Default_Span_Keeps_Token_Redeemable()
+    {
+        // Mirrors the real-world failure documented in the diagnosis:
+        //   format_range_preview at workspace version V → file watcher fires within 5 s
+        //   → WorkspaceManager.LoadIntoSessionAsync bumps version to V+1 → apply must
+        //   still redeem the token. Default DefaultMaxVersionSpan = 1 covers this case.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var token = _store.Store("workspace-1", solution, workspaceVersion: 1, "format range");
+
+        _store.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 2);
+
+        var entry = _store.Retrieve(token);
+        Assert.IsNotNull(entry, "token stored at V=1 should survive a single reload bump to V=2 with DefaultMaxVersionSpan=1");
+        Assert.AreEqual(1, entry.Value.WorkspaceVersion);
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Two_Bumps_Past_Default_Span_Drops_Token()
+    {
+        // Bounded-span test: a second auto-reload pushes the workspace version past the
+        // pinned ceiling (V + 1 with DefaultMaxVersionSpan = 1), so the token MUST drop.
+        // Guards against the range-policy regressing into "tokens never expire on reload."
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var token = _store.Store("workspace-1", solution, workspaceVersion: 1, "format range");
+
+        _store.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 3);
+
+        Assert.IsNull(_store.Retrieve(token), "token at V=1 with span=1 has ceiling V=2, so V=3 must drop it");
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Same_Version_Is_Noop()
+    {
+        // Defensive: if a future caller hands the post-bump version 1 (matching the
+        // store-time version), the token must NOT be dropped. This guards against an
+        // off-by-one where `newVersion >= ceiling` accidentally replaces `>` and starts
+        // dropping tokens at the same version they were stored.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var token = _store.Store("workspace-1", solution, workspaceVersion: 1, "format range");
+
+        _store.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 1);
+
+        Assert.IsNotNull(_store.Retrieve(token));
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Other_Workspace_Tokens_Unaffected()
+    {
+        // Cross-workspace isolation: a reload of workspace A must not touch tokens
+        // belonging to workspace B regardless of version, since the per-workspace version
+        // counters are independent.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var tokenA = _store.Store("workspace-A", solution, workspaceVersion: 1, "preview-A");
+        var tokenB = _store.Store("workspace-B", solution, workspaceVersion: 1, "preview-B");
+
+        _store.InvalidateOnVersionBump("workspace-A", newWorkspaceVersion: 99);
+
+        Assert.IsNull(_store.Retrieve(tokenA));
+        Assert.IsNotNull(_store.Retrieve(tokenB), "InvalidateOnVersionBump must scope to the target workspaceId");
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Custom_MaxVersionSpan_Of_Zero_Drops_On_Any_Bump()
+    {
+        // Custom span = 0 means tokens cannot survive any reload bump at all (test sentinel
+        // — production callers always go through the default-span ctor, but the knob exists
+        // so tests and future tuning can dial up/down without source edits).
+        var strict = new PreviewStore(maxEntries: 20, ttl: null, maxVersionSpan: 0);
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var token = strict.Store("workspace-1", solution, workspaceVersion: 1, "preview");
+
+        strict.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 2);
+
+        Assert.IsNull(strict.Retrieve(token), "with span=0, the pinned ceiling equals store-time version, so any later bump drops the token");
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Custom_MaxVersionSpan_Of_Two_Survives_Two_Bumps()
+    {
+        // Sanity check that the span knob lets a deployment widen the window if the default
+        // turns out too tight. The asymmetric expectation (span=2 → V=3 redeems, V=4 drops)
+        // also pins the off-by-one boundary.
+        var lenient = new PreviewStore(maxEntries: 20, ttl: null, maxVersionSpan: 2);
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        var token = lenient.Store("workspace-1", solution, workspaceVersion: 1, "preview");
+
+        lenient.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 3);
+        Assert.IsNotNull(lenient.Retrieve(token), "span=2 ceiling is V=3, must survive V=3");
+
+        lenient.InvalidateOnVersionBump("workspace-1", newWorkspaceVersion: 4);
+        Assert.IsNull(lenient.Retrieve(token), "span=2 ceiling is V=3, V=4 must drop");
+    }
+
+    [TestMethod]
+    public void InvalidateOnVersionBump_Throws_On_Null_Or_Empty_WorkspaceId()
+    {
+        // Defensive: `null`/empty workspaceId would otherwise drop nothing (entries always
+        // have a non-null WorkspaceId), masking a programming error at the call site.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        _store.Store("workspace-1", solution, 1, "test");
+
+        Assert.ThrowsException<ArgumentNullException>(() => _store.InvalidateOnVersionBump(null!, 1));
+        Assert.ThrowsException<ArgumentException>(() => _store.InvalidateOnVersionBump(string.Empty, 1));
+    }
 }

--- a/tests/RoslynMcp.Tests/PreviewTokenCrossCouplingTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewTokenCrossCouplingTests.cs
@@ -136,14 +136,15 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
     }
 
     /// <summary>
-    /// Workspace lifecycle still invalidates tokens: a <see cref="WorkspaceManager.ReloadAsync"/>
-    /// disposes the underlying MSBuildWorkspace and the Solution references captured by
-    /// every live preview become orphans, so the preview store's lifecycle hook must drop
-    /// them. This is the ONE code path that should still invalidate siblings, and the
-    /// "stale" error message must still surface to callers.
+    /// format-range-apply-preview-token-lifetime: a SINGLE reload no longer wipes live
+    /// tokens. <see cref="PreviewStore.DefaultMaxVersionSpan"/> = 1 means a token stored at
+    /// version V survives one auto-reload bump to V+1. The apply path's
+    /// <c>RebaseModifiedSolutionOntoCurrentAsync</c> replays the captured diff onto the
+    /// post-reload solution, so the file-creation produced by the preview lands on disk
+    /// even though the underlying <c>MSBuildWorkspace</c> was disposed during reload.
     /// </summary>
     [TestMethod]
-    public async Task Workspace_Reload_Still_Invalidates_All_Live_Tokens()
+    public async Task Workspace_Reload_Within_Pinned_Range_Keeps_Token_Redeemable()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
         var targetFilePath = workspace.GetPath("SampleLib", "Generated", "ReloadInvalidates.cs");
@@ -157,14 +158,47 @@ public sealed class PreviewTokenCrossCouplingTests : IsolatedWorkspaceTestBase
             CancellationToken.None);
         Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
 
-        // Lifecycle event — drops all tokens (captured Solution refs now orphaned).
+        // Single reload bumps the workspace version once — within DefaultMaxVersionSpan=1,
+        // so InvalidateOnVersionBump leaves this token alone.
         await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
 
         var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
 
-        Assert.IsFalse(applyResult.Success,
-            "Reload must still invalidate live preview tokens.");
+        Assert.IsTrue(applyResult.Success,
+            $"Token stored at V should survive a single reload to V+1 with DefaultMaxVersionSpan=1. Error: {applyResult.Error}");
+        Assert.IsTrue(File.Exists(targetFilePath), "Apply must persist the file even after one intervening reload.");
+    }
+
+    /// <summary>
+    /// format-range-apply-preview-token-lifetime: bounded-range guarantee — a SECOND reload
+    /// pushes the workspace version past the pinned ceiling
+    /// (V + <see cref="PreviewStore.DefaultMaxVersionSpan"/> = V + 1), so the token MUST
+    /// drop and the apply path must surface the "stale" rejection. Guards against the range
+    /// policy regressing into "tokens never expire on reload."
+    /// </summary>
+    [TestMethod]
+    public async Task Workspace_Reload_Twice_Drops_Token_And_Surfaces_Stale_Error()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var targetFilePath = workspace.GetPath("SampleLib", "Generated", "TwoReloadsDrop.cs");
+
+        var preview = await FileOperationService.PreviewCreateFileAsync(
+            workspace.WorkspaceId,
+            new CreateFileDto(
+                "SampleLib",
+                targetFilePath,
+                "namespace SampleLib.Generated;\n\npublic sealed class TwoReloadsDrop { }\n"),
+            CancellationToken.None);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
+
+        // Two reload bumps push version past the pinned ceiling — token gets dropped.
+        await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
+        await WorkspaceManager.ReloadAsync(workspace.WorkspaceId, CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsFalse(applyResult.Success, "Two reloads must push past the pinned ceiling and drop the token.");
         StringAssert.Contains(applyResult.Error ?? string.Empty, "stale");
-        Assert.IsFalse(File.Exists(targetFilePath), "Invalidated token must not mutate disk.");
+        Assert.IsFalse(File.Exists(targetFilePath), "Dropped token must not mutate disk.");
     }
 }

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -218,5 +218,7 @@ public sealed class ToolDispatchTests
         public void Invalidate(string token) => throw new NotSupportedException();
 
         public void InvalidateAll(string? workspaceId = null) => throw new NotSupportedException();
+
+        public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- Replace the unconditional `_previewStore.InvalidateAll(workspaceId)` call on workspace reload with a new pinned-range eviction hook (`IPreviewStore.InvalidateOnVersionBump`). Each `PreviewEntry` now carries a `MaxRedeemableVersion` ceiling computed at Store time as `WorkspaceVersion + DefaultMaxVersionSpan` (default span = 1).
- Fixes the `format_range_apply(previewToken)` failure documented in the backlog row: "Preview token '<id>' not found or expired" surfacing within ~5s of preview when a file-watcher-driven auto-reload intervened. The same fix covers every other `*_apply` tool sharing the preview store.
- The captured Roslyn `Solution` snapshots are immutable graphs and remain readable after the prior `MSBuildWorkspace` is disposed by reload, so the apply path's existing `RefactoringService.RebaseModifiedSolutionOntoCurrentAsync` replays the captured diff onto the post-reload solution cleanly. `InvalidateAll(workspaceId)` remains wired to workspace close.

## Behavior

| Sequence | Old | New |
|----------|-----|-----|
| preview at V -> apply | redeems | redeems |
| preview at V -> 1 reload (V+1) -> apply | rejected ("not found") | **redeems** |
| preview at V -> 2 reloads (V+2) -> apply | rejected | rejected ("stale") |
| preview at V -> sibling apply (V+1) -> apply | redeems | redeems |
| workspace close | drops all tokens | drops all tokens (unchanged) |

## Files

| Production | Tests |
|-----------|-------|
| `src/RoslynMcp.Roslyn/Services/PreviewStore.cs` | `tests/RoslynMcp.Tests/PreviewStoreTests.cs` |
| `src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs` | `tests/RoslynMcp.Tests/PreviewTokenCrossCouplingTests.cs` |
| `src/RoslynMcp.Core/Services/BoundedStore.cs` | `tests/RoslynMcp.Tests/IntegrationTests.cs` |
| `src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs` | `tests/RoslynMcp.Tests/FileOperationIntegrationTests.cs` |
|  | `tests/RoslynMcp.Tests/ToolDispatchTests.cs` (FakePreviewStore stub) |

Production scope grew beyond the plan's "1 file" estimate because the contract change required touching the interface (`IPreviewStore`), a new sweep helper on the base class (`BoundedStore.InvalidateWhere`), and the call site (`WorkspaceManager.LoadIntoSessionAsync`). No back-compat shims, no new optional parameters with null fallbacks — every call site was updated.

## Test plan
- [x] 6 new `PreviewStoreTests` cover the pinned-range contract (single-bump survives, two-bumps drops, same-version no-op, cross-workspace isolation, custom span = 0/2 knob, null/empty workspaceId guard).
- [x] Integration tests added: `Workspace_Reload_Within_Pinned_Range_Keeps_Token_Redeemable` (positive case), `Workspace_Reload_Twice_Drops_Token_And_Surfaces_Stale_Error` (rejection case).
- [x] 3 pre-existing integration tests that locked in the old wipe-on-reload semantics were updated to do 2 reloads (keeps the rejection-path coverage under the new contract).
- [x] `eng/verify-release.ps1 -Configuration Release` passes (935/935 tests, ExitCode 0).
- [x] `eng/verify-ai-docs.ps1` passes.

Closes: format-range-apply-preview-token-lifetime

Generated with Claude Code.