### PR TITLE
docs(workspace-health): expand description with error-recovery keywords

### DIFF
--- a/skills/workspace-health/SKILL.md
+++ b/skills/workspace-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-health
-description: "One-shot status report on the running Roslyn MCP server and any loaded workspaces. Use when: troubleshooting the server, onboarding a session, confirming readiness before a sensitive operation, listing loaded workspaces, or checking for staleness/degraded state."
+description: "One-shot status report on the running Roslyn MCP server and any loaded workspaces. Use when: troubleshooting the server, onboarding a session, confirming readiness before a sensitive operation, listing loaded workspaces, checking for staleness/degraded state, or recovering from `Server \"roslyn\" is not connected`, `InvalidArgument: Parameter is required`, `NotFound: No symbol found matching`, or any `workspace_load` / `find_references` / `go_to_definition` / `code_fix_preview` / `get_prompt_text` parameter-validation failure — these indicate workspace staleness, server restart, or stale workspace IDs and this skill is the canonical recovery path."
 user-invocable: true
 argument-hint: "(optional) workspace ID to focus on; default: all"
 ---


### PR DESCRIPTION
## Summary

The `workspace-health` skill is the canonical recovery path for stale-workspace and parameter-validation errors, but its description didn't surface those error strings. Agents that encountered them tended to retry blindly rather than invoke the skill — the description wording didn't match the symptom they observed.

## Change

Adds common error patterns to the description so the skill triggers on observation of:

- `Server "roslyn" is not connected`
- `InvalidArgument: Parameter is required`
- `NotFound: No symbol found matching`
- `workspace_load` / `find_references` / `go_to_definition` / `code_fix_preview` / `get_prompt_text` parameter-validation failures

Description-only edit. No behavior change.

## Test plan

- [ ] CI green (markdown-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)