### PR TITLE
fix(workspace-execution-gate): retry once on stale-snapshot error after auto-reload (auto-reload-retry-inside-call)

### DIFF
--- a/src/RoslynMcp.Core/Models/GateMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/GateMetricsDto.cs
@@ -24,6 +24,16 @@ namespace RoslynMcp.Core.Models;
 /// not stale or the policy was set to <c>off</c>.
 /// </param>
 /// <param name="StaleReloadMs">Milliseconds spent inside <c>workspace_reload</c> when <paramref name="StaleAction"/> is <c>auto-reloaded</c>. <see langword="null"/> otherwise.</param>
+/// <param name="RetriedAfterReload">
+/// auto-reload-retry-inside-call: <see langword="true"/> when the workspace execution gate
+/// retried the action once after an auto-reload because the first attempt failed with a
+/// transient stale-snapshot error (e.g., <c>"Document not found"</c>). Surfaces in the
+/// response envelope so callers can correlate "auto-reloaded" calls that needed an
+/// internal second pass to succeed; <see langword="null"/> when no retry occurred (the
+/// common case). When the retry itself fails, the original exception is propagated and
+/// this flag remains <see langword="null"/> — callers see the structured error without a
+/// false success signal.
+/// </param>
 public sealed record GateMetricsDto(
     string? GateMode,
     long QueuedMs,
@@ -31,4 +41,5 @@ public sealed record GateMetricsDto(
     int? HeartbeatCount,
     long ElapsedMs = 0,
     string? StaleAction = null,
-    long? StaleReloadMs = null);
+    long? StaleReloadMs = null,
+    bool? RetriedAfterReload = null);

--- a/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
+++ b/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
@@ -74,5 +74,13 @@ public sealed class GateMetricsBuilder
     /// <summary>Milliseconds spent reloading when <see cref="StaleAction"/> is <c>auto-reloaded</c>.</summary>
     public long? StaleReloadMs { get; set; }
 
-    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs);
+    /// <summary>
+    /// auto-reload-retry-inside-call: <see langword="true"/> when the workspace execution gate
+    /// retried the action once after an auto-reload (because the first attempt failed with a
+    /// transient stale-snapshot error such as <c>"Document not found"</c>). Stays <see langword="null"/>
+    /// when no retry occurred or when the retry itself failed.
+    /// </summary>
+    public bool? RetriedAfterReload { get; set; }
+
+    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload);
 }

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -180,16 +180,110 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 using (await rwLock.WriterLockAsync(linked).ConfigureAwait(false))
                 {
                     EnsureWorkspaceStillExists(workspaceId);
-                    return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => action(linked)).ConfigureAwait(false);
+                    return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked)).ConfigureAwait(false);
                 }
             }
 
             using (await rwLock.ReaderLockAsync(linked).ConfigureAwait(false))
             {
                 EnsureWorkspaceStillExists(workspaceId);
-                return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => action(linked)).ConfigureAwait(false);
+                return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked)).ConfigureAwait(false);
             }
         }, linked).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: when <see cref="ApplyStalenessPolicyAsync"/> just
+    /// auto-reloaded the workspace for this call (<see cref="AmbientGateMetrics.StaleAction"/>
+    /// stamped <c>"auto-reloaded"</c>) and the action immediately fails with a transient
+    /// stale-snapshot error (<c>"Document not found"</c> / <c>"not found in workspace"</c>),
+    /// retry the action exactly once. The action's closure re-resolves through
+    /// <see cref="IWorkspaceManager.GetCurrentSolution"/> on each invocation, so the second
+    /// attempt sees the post-reload snapshot.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why this exists:</b> the audit-driven workflow showed <c>format_document_preview</c>,
+    /// <c>get_completions</c>, and <c>find_references_bulk</c> returning <c>"Document not found"</c>
+    /// with <c>staleAction="auto-reloaded"</c> stamped — the reload had succeeded but the
+    /// action's first snapshot read still observed the pre-reload solution (file watcher /
+    /// MSBuildWorkspace settling window). The next-turn retry from the caller always succeeded.
+    /// </para>
+    /// <para>
+    /// <b>Cap and scope:</b> the retry is hard-capped at 1 (no cascade — see plan Risks). It
+    /// fires <i>only</i> when <c>StaleAction == "auto-reloaded"</c>, so error paths outside an
+    /// auto-reload window propagate unchanged. Total time is bounded by the request timeout's
+    /// linked cancellation token (<paramref name="ct"/>); a second attempt that runs out of
+    /// budget surfaces the original exception via the standard catch-and-rethrow at the end.
+    /// </para>
+    /// <para>
+    /// <b>Telemetry:</b> on retry, <see cref="AmbientGateMetrics.RetriedAfterReload"/> is set
+    /// to <see langword="true"/> regardless of whether the retry succeeds. Callers see the
+    /// flag in <c>_meta.retriedAfterReload</c> on both success envelopes (the read finally
+    /// landed) and error envelopes (the workspace really did lose the document).
+    /// </para>
+    /// </remarks>
+    private static async Task<T> RunActionWithPostReloadRetryAsync<T>(
+        Func<CancellationToken, Task<T>> action,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await action(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ShouldRetryAfterAutoReload(ex))
+        {
+            // Stamp the retry flag BEFORE the second attempt so the response envelope shows
+            // retriedAfterReload=true on both the success path AND the eventual-failure path.
+            // The eventual-failure path is informative for telemetry — it confirms the retry
+            // ran but the workspace genuinely lost the document.
+            if (AmbientGateMetrics.Current is { } metrics)
+            {
+                metrics.RetriedAfterReload = true;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            return await action(ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="ex"/> is a transient stale-snapshot
+    /// error <i>and</i> the current request just auto-reloaded the workspace. The intersection
+    /// is deliberately narrow: any one condition alone is not enough to justify a retry.
+    /// </summary>
+    private static bool ShouldRetryAfterAutoReload(Exception ex)
+    {
+        if (AmbientGateMetrics.Current?.StaleAction != "auto-reloaded")
+        {
+            return false;
+        }
+
+        // Cancellation must always propagate immediately; a retry would just hit the same
+        // cancelled token. OperationCanceledException covers TaskCanceledException too.
+        if (ex is OperationCanceledException)
+        {
+            return false;
+        }
+
+        // Already retried once on this call — never cascade. Retry is hard-capped at 1.
+        if (AmbientGateMetrics.Current?.RetriedAfterReload == true)
+        {
+            return false;
+        }
+
+        // Stale-snapshot errors surface in three exception shapes across the service layer:
+        //   - InvalidOperationException("Document not found: ...") — DocumentResolution helper
+        //   - FileNotFoundException("Document not found in workspace: ...") — EditorConfigService,
+        //     FixAllService, FlowAnalysisService, OperationService
+        //   - KeyNotFoundException("Document not found: ...") / similar — SyntaxTools,
+        //     WorkspaceResources
+        // Match by message substring so any service that follows the same naming convention
+        // is covered without a hard-coded type list.
+        var message = ex.Message ?? string.Empty;
+        return ex is (InvalidOperationException or FileNotFoundException or KeyNotFoundException) &&
+               (message.Contains("Document not found", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("not found in workspace", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -513,6 +513,179 @@ public class WorkspaceExecutionGateTests
         Assert.AreEqual(1, manager.ReloadCount);
     }
 
+    // ---------- auto-reload-retry-inside-call: post-reload retry ----------
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: after the gate auto-reloads a stale workspace, if the
+    /// action's first attempt fails with a transient stale-snapshot error
+    /// (<c>"Document not found"</c>), the gate retries exactly once. The closure re-resolves
+    /// against the post-reload snapshot, so the second attempt sees the fresh state and
+    /// succeeds. The response envelope carries <c>retriedAfterReload=true</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task StalenessPolicy_AutoReload_ActionFailsWithDocumentNotFound_RetriesOnceAndSucceeds()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+
+        var attempts = 0;
+        var result = await gate.RunReadAsync(WorkspaceA, _ =>
+        {
+            var n = Interlocked.Increment(ref attempts);
+            if (n == 1)
+            {
+                // Simulate the post-reload "Document not found" race the audit observed.
+                throw new InvalidOperationException("Document not found: C:/path/to/File.cs");
+            }
+            return Task.FromResult(42);
+        }, CancellationToken.None);
+
+        Assert.AreEqual(2, attempts, "Action must run twice — once for the failing attempt, once for the post-reload retry.");
+        Assert.AreEqual(42, result, "The retry's return value must propagate to the caller.");
+        Assert.AreEqual(1, manager.ReloadCount, "Auto-reload should fire exactly once for the stale workspace; the retry must not trigger a second reload.");
+        var metrics = AmbientGateMetrics.Current;
+        Assert.IsNotNull(metrics);
+        Assert.AreEqual("auto-reloaded", metrics!.StaleAction);
+        Assert.AreEqual(true, metrics.RetriedAfterReload,
+            "Successful retry after auto-reload must stamp retriedAfterReload=true so callers can correlate the recovered call.");
+    }
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: cap the retry at 1. If the second attempt also fails
+    /// with the same transient error, the original exception propagates. The retry flag stays
+    /// <c>true</c> so the error envelope still records that a recovery attempt was made.
+    /// </summary>
+    [TestMethod]
+    public async Task StalenessPolicy_AutoReload_ActionAlwaysFails_RetriesOnceThenPropagates()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+
+        var attempts = 0;
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            gate.RunReadAsync<int>(WorkspaceA, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("Document not found: C:/path/to/Missing.cs");
+            }, CancellationToken.None)).ConfigureAwait(false);
+
+        Assert.AreEqual(2, attempts, "Action must run twice (cap at 1 retry); a third attempt would indicate the cap was breached.");
+        Assert.AreEqual(1, manager.ReloadCount, "Reload count must remain 1 even when the retry also fails.");
+        var metrics = AmbientGateMetrics.Current;
+        Assert.IsNotNull(metrics);
+        Assert.AreEqual(true, metrics!.RetriedAfterReload,
+            "Even when the retry surfaces the original exception, the flag stamps so telemetry can attribute the failure.");
+    }
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: only retry when the workspace was just auto-reloaded.
+    /// A "Document not found" without an auto-reload window is a permanent error (the file
+    /// genuinely is not in the solution), so retrying would just burn a round-trip.
+    /// </summary>
+    [TestMethod]
+    public async Task FreshWorkspace_ActionFailsWithDocumentNotFound_DoesNotRetry()
+    {
+        var manager = new FakeGateWorkspaceManager(); // not stale
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+
+        var attempts = 0;
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            gate.RunReadAsync<int>(WorkspaceA, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("Document not found: C:/path/to/Missing.cs");
+            }, CancellationToken.None)).ConfigureAwait(false);
+
+        Assert.AreEqual(1, attempts, "Action must run exactly once when no auto-reload happened — Document-not-found is a permanent error here.");
+        var metrics = AmbientGateMetrics.Current;
+        Assert.IsNotNull(metrics);
+        Assert.IsNull(metrics!.StaleAction, "No stale workspace, no auto-reload, no stamped action.");
+        Assert.IsNull(metrics.RetriedAfterReload, "Retry flag must remain null outside the auto-reload window.");
+    }
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: only retry on stale-snapshot exception shapes. An
+    /// unrelated <see cref="InvalidOperationException"/> (e.g. an analyzer crash) must
+    /// propagate immediately even after an auto-reload — silently retrying would mask
+    /// genuine bugs and burn user time.
+    /// </summary>
+    [TestMethod]
+    public async Task StalenessPolicy_AutoReload_ActionFailsWithUnrelatedError_DoesNotRetry()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+
+        var attempts = 0;
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            gate.RunReadAsync<int>(WorkspaceA, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                // Not a stale-snapshot shape — analyzer-style failure.
+                throw new InvalidOperationException("Analyzer 'FooAnalyzer' crashed during compilation.");
+            }, CancellationToken.None)).ConfigureAwait(false);
+
+        Assert.AreEqual(1, attempts, "Unrelated exceptions must not trigger the retry path.");
+        var metrics = AmbientGateMetrics.Current;
+        Assert.IsNotNull(metrics);
+        Assert.AreEqual("auto-reloaded", metrics!.StaleAction);
+        Assert.IsNull(metrics.RetriedAfterReload, "Retry flag must remain null when the failure is outside the stale-snapshot shape.");
+    }
+
+    /// <summary>
+    /// auto-reload-retry-inside-call: cancellation must short-circuit the retry. If the
+    /// caller's request timeout fires (or they cancel), the second attempt must not run —
+    /// it would just hit the same cancelled token. The original exception propagates.
+    /// </summary>
+    [TestMethod]
+    public async Task StalenessPolicy_AutoReload_CancellationDuringFailureSkipsRetry()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+
+        using var cts = new CancellationTokenSource();
+        var attempts = 0;
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            gate.RunReadAsync<int>(WorkspaceA, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                // Cancel before throwing the would-be-retryable exception. The retry path
+                // honors the linked token so the second attempt must NOT run.
+                cts.Cancel();
+                throw new InvalidOperationException("Document not found: C:/path/to/File.cs");
+            }, cts.Token)).ConfigureAwait(false);
+
+        Assert.AreEqual(1, attempts, "Cancellation between attempts must skip the retry — the second attempt would just hit the same cancelled token.");
+    }
+
     private sealed class ConcurrencyTracker
     {
         private int _current;


### PR DESCRIPTION
## Summary

After `ApplyStalenessPolicyAsync` auto-reloads a stale workspace, the action's first attempt occasionally still observed the pre-reload snapshot and surfaced `"Document not found"` with `staleAction="auto-reloaded"` — the server self-healed but the caller saw an error (`format_document_preview` / `get_completions` / `find_references_bulk` in the audit retros). The next-turn retry from the caller always succeeded.

`WorkspaceExecutionGate.RunPerWorkspaceAsync` now retries the action exactly once when the current request just stamped `staleAction="auto-reloaded"` AND the first attempt threw a transient stale-snapshot exception (`InvalidOperationException` / `FileNotFoundException` / `KeyNotFoundException` with `"Document not found"` or `"not found in workspace"` in the message). The retry's closure re-resolves through `IWorkspaceManager.GetCurrentSolution`, so the second attempt sees the post-reload snapshot.

- **Hard cap at 1** (no cascade — see plan Risks).
- **Cancellation short-circuits** the retry; the second attempt never runs after `OperationCanceledException` (or once the linked request-timeout token fires).
- **Unrelated failures propagate immediately** — only stale-snapshot exception shapes trigger retry.
- **Telemetry:** `RetriedAfterReload=true` is stamped on `AmbientGateMetrics` whenever a retry runs, so `_meta.retriedAfterReload` appears in both the recovered-success envelope and the eventual-failure envelope.

## Files changed

- `src/RoslynMcp.Core/Models/GateMetricsDto.cs` — add `RetriedAfterReload` to the response-envelope DTO.
- `src/RoslynMcp.Core/Services/AmbientGateMetrics.cs` — add the matching builder field and thread it through `ToDto()`.
- `src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs` — wrap `action(linked)` with `RunActionWithPostReloadRetryAsync`; the retry condition is centralized in the static `ShouldRetryAfterAutoReload` helper.
- `tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs` — five new tests covering: success-on-retry, fail-twice-propagate, fresh-workspace-no-retry, unrelated-error-no-retry, cancellation-skips-retry.

## Test plan

- [x] Build succeeds in Debug (`dotnet build`).
- [x] All 24 `WorkspaceExecutionGateTests` pass (5 new + 19 existing) — verified 3× for stability.
- [x] All 49 workspace-related tests pass (gate + manager + auto-reload-cascade + tool-error-handler).
- [x] `verify-ai-docs.ps1` passes.

`verify-release.ps1` was attempted but exhibits known pre-existing test-parallelism flakiness (tracked as initiative #34 `ci-test-parallelization-audit`); the same flakes appear on baseline before this change. The workspace-related test groups (49 tests) pass cleanly.

Closes: `auto-reload-retry-inside-call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)