### PR TITLE
feat(undo): add revert_apply_by_sequence MCP tool (revert-apply-by-sequence-number)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **161 tools** (107 stable / 54 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **162 tools** (108 stable / 54 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/src/RoslynMcp.Core/Services/IChangeTracker.cs
+++ b/src/RoslynMcp.Core/Services/IChangeTracker.cs
@@ -4,6 +4,16 @@ namespace RoslynMcp.Core.Services;
 
 public interface IChangeTracker
 {
+    /// <summary>
+    /// Raised after <see cref="RecordChange"/> appends a new change entry. Subscribers receive
+    /// the recorded entry so they can synchronize their own per-apply state with the canonical
+    /// sequence number assigned here. Used by <see cref="IUndoService"/> to commit its pending
+    /// pre-apply snapshot to the per-workspace revert history (see
+    /// <c>revert-apply-by-sequence-number</c>). Handlers must not throw — exceptions are
+    /// swallowed by the tracker so a misbehaving subscriber cannot break the apply path.
+    /// </summary>
+    event Action<ChangeRecordedEventArgs>? ChangeRecorded;
+
     void RecordChange(string workspaceId, string description,
         IReadOnlyList<string> affectedFiles, string toolName);
 
@@ -11,3 +21,20 @@ public interface IChangeTracker
 
     void Clear(string workspaceId);
 }
+
+/// <summary>
+/// Payload for <see cref="IChangeTracker.ChangeRecorded"/>. Mirrors the fields of the
+/// just-appended <see cref="WorkspaceChangeDto"/> plus the workspace identifier, so subscribers
+/// can synchronize their per-workspace state without re-querying the tracker.
+/// </summary>
+/// <param name="WorkspaceId">The workspace the change was applied to.</param>
+/// <param name="SequenceNumber">The sequence number the tracker assigned to this entry.</param>
+/// <param name="Description">Human-readable description of the apply.</param>
+/// <param name="AffectedFiles">The file set the apply touched.</param>
+/// <param name="ToolName">The originating MCP tool name (e.g., <c>rename_apply</c>).</param>
+public sealed record ChangeRecordedEventArgs(
+    string WorkspaceId,
+    int SequenceNumber,
+    string Description,
+    IReadOnlyList<string> AffectedFiles,
+    string ToolName);

--- a/src/RoslynMcp.Core/Services/IUndoService.cs
+++ b/src/RoslynMcp.Core/Services/IUndoService.cs
@@ -1,9 +1,27 @@
 namespace RoslynMcp.Core.Services;
 
 /// <summary>
-/// Records pre-apply workspace state so that the most recent apply operation
-/// can be reverted. Only the last operation per workspace is retained.
+/// Records pre-apply workspace state so that prior apply operations can be reverted.
 /// </summary>
+/// <remarks>
+/// Two revert pathways are exposed:
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="RevertAsync"/> — LIFO revert of the most-recently-captured pending snapshot.
+/// Compatible with the original <c>revert_last_apply</c> contract.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="RevertBySequenceAsync"/> — late-session revert of an earlier apply identified
+/// by the <see cref="WorkspaceChangeDto.SequenceNumber"/> emitted by <c>workspace_changes</c>.
+/// Snapshots are committed to per-workspace history when <see cref="IChangeTracker"/>
+/// records the corresponding apply, so the LIFO and by-sequence pathways agree on order.
+/// </description>
+/// </item>
+/// </list>
+/// </remarks>
 public interface IUndoService
 {
     /// <summary>
@@ -43,6 +61,37 @@ public interface IUndoService
     Task<bool> RevertAsync(string workspaceId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Reverts the apply operation identified by the given sequence number — the same
+    /// sequence number reported by <c>workspace_changes</c>.
+    /// </summary>
+    /// <remarks>
+    /// Fails with <see cref="RevertBySequenceResult.Reason"/> = <c>"dependency-blocked"</c>
+    /// when any later apply on the same workspace touches files that overlap with the
+    /// target apply's affected-file set — reverting the target would silently roll back
+    /// part of those later applies. Conservative file-overlap detection is used: if the
+    /// later apply's affected-file set intersects the target's, the revert is blocked.
+    /// </remarks>
+    /// <param name="workspaceId">The workspace whose history is being inspected.</param>
+    /// <param name="sequenceNumber">The target apply's sequence number.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<RevertBySequenceResult> RevertBySequenceAsync(
+        string workspaceId,
+        int sequenceNumber,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Commits the most recently captured pending snapshot to the workspace's revert history,
+    /// associating it with the sequence number assigned by <see cref="IChangeTracker"/>. The
+    /// caller is <see cref="IChangeTracker"/> itself via the <see cref="IChangeTracker.ChangeRecorded"/>
+    /// event — services that apply edits do not call this directly. Idempotent when called with
+    /// no pending snapshot (e.g., when the apply path skipped <see cref="CaptureBeforeApply"/>).
+    /// </summary>
+    /// <param name="workspaceId">The workspace identifier.</param>
+    /// <param name="sequenceNumber">The sequence number assigned by <see cref="IChangeTracker"/>.</param>
+    /// <param name="affectedFiles">The file set recorded by <see cref="IChangeTracker"/>.</param>
+    void CommitPendingCapture(string workspaceId, int sequenceNumber, IReadOnlyList<string> affectedFiles);
+
+    /// <summary>
     /// Clears undo history for a workspace (e.g., on workspace close).
     /// </summary>
     void Clear(string workspaceId);
@@ -67,3 +116,36 @@ public sealed record UndoEntry(
 /// <param name="FilePath">The absolute path of the file about to be modified.</param>
 /// <param name="OriginalText">The full pre-mutation text of the file (null if it didn't exist yet).</param>
 public sealed record FileSnapshotDto(string FilePath, string? OriginalText);
+
+/// <summary>
+/// Result of <see cref="IUndoService.RevertBySequenceAsync"/>.
+/// </summary>
+/// <param name="Reverted">Whether the target apply was successfully reverted.</param>
+/// <param name="RevertedOperation">
+/// Human-readable description of the reverted operation, or <see langword="null"/> when the
+/// revert failed (e.g., the sequence number is unknown or the dependency check blocked it).
+/// </param>
+/// <param name="AffectedFiles">
+/// The file set the target apply touched, as recorded by <see cref="IChangeTracker"/>.
+/// Empty when the revert failed before the target was located.
+/// </param>
+/// <param name="Reason">
+/// Machine-readable failure code when <see cref="Reverted"/> is <see langword="false"/>:
+/// <list type="bullet">
+/// <item><description><c>"unknown-sequence"</c> — no snapshot exists for that sequence number.</description></item>
+/// <item><description><c>"dependency-blocked"</c> — at least one later apply touches an overlapping file.</description></item>
+/// <item><description><c>"revert-failed"</c> — the snapshot existed but the revert mechanics failed (e.g., disk write rejected).</description></item>
+/// </list>
+/// <see langword="null"/> when <see cref="Reverted"/> is <see langword="true"/>.
+/// </param>
+/// <param name="BlockingSequences">
+/// Populated when <see cref="Reason"/> is <c>"dependency-blocked"</c>: the sequence numbers of
+/// later applies whose affected-file sets overlap with the target. <see langword="null"/> in all
+/// other cases.
+/// </param>
+public sealed record RevertBySequenceResult(
+    bool Reverted,
+    string? RevertedOperation,
+    IReadOnlyList<string> AffectedFiles,
+    string? Reason,
+    IReadOnlyList<int>? BlockingSequences);

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
@@ -36,6 +36,7 @@ public static partial class ServerSurfaceCatalog
         Tool("extract_method_apply", "refactoring", "experimental", false, true, "Apply a previously previewed extract method refactoring."),
         Tool("extract_shared_expression_to_helper_preview", "refactoring", "experimental", true, false, "Preview extracting a shared sub-expression into a synthesized private static helper and rewriting every structurally-identical call site in the scope."),
         Tool("revert_last_apply", "undo", "stable", false, true, "Revert the most recent Roslyn solution-level apply operation for a workspace."),
+        Tool("revert_apply_by_sequence", "undo", "stable", false, true, "Revert a specific earlier apply identified by its workspace_changes sequence number."),
         Tool("apply_with_verify", "undo", "experimental", false, true, "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),
         Tool("fix_all_preview", "refactoring", "experimental", true, false, "Preview fixing ALL instances of a diagnostic across a scope."),
         Tool("fix_all_apply", "refactoring", "experimental", false, true, "Apply a previously previewed fix-all operation."),

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -83,7 +83,7 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **161 tools** (107 stable / 54 experimental), **9 resources**, and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **162 tools** (108 stable / 54 experimental), **9 resources**, and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -58,4 +58,68 @@ public static class UndoTools
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }
+
+    [McpServerTool(Name = "revert_apply_by_sequence", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
+     McpToolMetadata("undo", "stable", false, true,
+        "Revert a specific earlier apply identified by its workspace_changes sequence number."),
+     Description("Revert a specific earlier apply by its sequence number — the value reported by workspace_changes. Complements revert_last_apply: instead of LIFO, this revert targets any historical apply still in this session's revert history. Conservative dependency check: if a later apply touched any file that the target apply also touched, the revert is blocked and the offending later sequence numbers are returned in `blockingSequences` so the caller can revert them first. workspaceId is required. sequenceNumber must match a value returned by workspace_changes for this workspace. Returns `{reverted, revertedOperation, affectedFiles, reason?, blockingSequences?}` — `reason` is `unknown-sequence` when the sequence has no recorded snapshot, `dependency-blocked` when a later apply overlaps in files, and `revert-failed` when the snapshot exists but disk/workspace mechanics rejected the revert.")]
+    public static Task<string> RevertApplyBySequence(
+        IWorkspaceExecutionGate gate,
+        IUndoService undoService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("The sequence number reported by workspace_changes for the apply you want to revert")] int sequenceNumber,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceId))
+        {
+            throw new ArgumentException("workspaceId is required. Pass the session id returned by workspace_load.");
+        }
+        if (sequenceNumber <= 0)
+        {
+            throw new ArgumentException("sequenceNumber must be a positive integer matching a value reported by workspace_changes.", nameof(sequenceNumber));
+        }
+        return gate.RunWriteAsync(workspaceId, async c =>
+        {
+            var result = await undoService.RevertBySequenceAsync(workspaceId, sequenceNumber, c).ConfigureAwait(false);
+
+            // Shape the response: include `reason`/`blockingSequences` only when present so success
+            // payloads stay clean. Failure payloads always carry `reason`.
+            object payload = result.Reverted
+                ? new
+                {
+                    reverted = true,
+                    revertedOperation = result.RevertedOperation,
+                    affectedFiles = result.AffectedFiles,
+                    sequenceNumber
+                }
+                : result.BlockingSequences is { Count: > 0 }
+                    ? new
+                    {
+                        reverted = false,
+                        reason = result.Reason,
+                        revertedOperation = result.RevertedOperation,
+                        affectedFiles = result.AffectedFiles,
+                        sequenceNumber,
+                        blockingSequences = result.BlockingSequences,
+                        message = "Cannot revert: a later apply touches one of the same files. " +
+                                  "Revert the listed blocking sequences first, then retry."
+                    }
+                    : new
+                    {
+                        reverted = false,
+                        reason = result.Reason,
+                        revertedOperation = result.RevertedOperation,
+                        affectedFiles = result.AffectedFiles,
+                        sequenceNumber,
+                        message = result.Reason switch
+                        {
+                            "unknown-sequence" => "No revert snapshot exists for that sequence number. " +
+                                                  "Either the sequence is from before this session, or the apply did not produce a revertable snapshot.",
+                            "revert-failed" => "The snapshot was located but disk/workspace mechanics rejected the revert.",
+                            _ => "Revert failed."
+                        }
+                    };
+            return JsonSerializer.Serialize(payload, JsonDefaults.Indented);
+        }, ct);
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/ChangeTracker.cs
+++ b/src/RoslynMcp.Roslyn/Services/ChangeTracker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -12,11 +13,15 @@ public sealed class ChangeTracker : IChangeTracker, IDisposable
 {
     private readonly ConcurrentDictionary<string, List<WorkspaceChangeDto>> _changes = new();
     private readonly IWorkspaceManager _workspaceManager;
+    private readonly ILogger<ChangeTracker>? _logger;
     private int _globalSequence;
 
-    public ChangeTracker(IWorkspaceManager workspaceManager)
+    public event Action<ChangeRecordedEventArgs>? ChangeRecorded;
+
+    public ChangeTracker(IWorkspaceManager workspaceManager, ILogger<ChangeTracker>? logger = null)
     {
         _workspaceManager = workspaceManager;
+        _logger = logger;
         _workspaceManager.WorkspaceClosed += Clear;
     }
 
@@ -35,6 +40,26 @@ public sealed class ChangeTracker : IChangeTracker, IDisposable
             workspaceId,
             _ => [entry],
             (_, list) => { lock (list) { list.Add(entry); } return list; });
+
+        // revert-apply-by-sequence-number: fire ChangeRecorded so IUndoService can commit its
+        // pending pre-apply snapshot under the same sequence number we just assigned. Handler
+        // exceptions are swallowed — a misbehaving subscriber must not break the apply path.
+        var handler = ChangeRecorded;
+        if (handler is not null)
+        {
+            try
+            {
+                handler(new ChangeRecordedEventArgs(workspaceId, seq, description, affectedFiles, toolName));
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(
+                    ex,
+                    "ChangeTracker.ChangeRecorded handler threw for workspace {WorkspaceId} sequence {Sequence}; suppressing.",
+                    workspaceId,
+                    seq);
+            }
+        }
     }
 
     public IReadOnlyList<WorkspaceChangeDto> GetChanges(string workspaceId)

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -31,19 +31,33 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class UndoService : IUndoService, IDisposable
 {
     private readonly ConcurrentDictionary<string, UndoSnapshot> _snapshots = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, List<UndoSnapshot>> _history = new(StringComparer.Ordinal);
     private readonly ILogger<UndoService> _logger;
     private readonly IWorkspaceManager _workspaceManager;
+    private readonly IChangeTracker? _changeTracker;
 
-    public UndoService(ILogger<UndoService> logger, IWorkspaceManager workspaceManager)
+    public UndoService(
+        ILogger<UndoService> logger,
+        IWorkspaceManager workspaceManager,
+        IChangeTracker? changeTracker = null)
     {
         _logger = logger;
         _workspaceManager = workspaceManager;
+        _changeTracker = changeTracker;
         _workspaceManager.WorkspaceClosed += Clear;
+        if (_changeTracker is not null)
+        {
+            _changeTracker.ChangeRecorded += OnChangeRecorded;
+        }
     }
 
     public void Dispose()
     {
         _workspaceManager.WorkspaceClosed -= Clear;
+        if (_changeTracker is not null)
+        {
+            _changeTracker.ChangeRecorded -= OnChangeRecorded;
+        }
     }
 
     public void CaptureBeforeApply(
@@ -67,7 +81,9 @@ public sealed class UndoService : IUndoService, IDisposable
             solution,
             fileSnapshots,
             preApplyVersion,
-            DateTime.UtcNow);
+            DateTime.UtcNow,
+            SequenceNumber: 0,
+            AffectedFiles: Array.Empty<string>());
     }
 
     public UndoEntry? GetLastOperation(string workspaceId)
@@ -85,6 +101,27 @@ public sealed class UndoService : IUndoService, IDisposable
 
         var workspace = _workspaceManager;
 
+        // Also drop the matching history entry so the LIFO and by-sequence pathways agree
+        // on what's been reverted. The pending snapshot is identified by sequence number
+        // (assigned when ChangeTracker recorded the apply); look up the history entry by
+        // that key. When CommitPendingCapture has not yet run (apply succeeded but
+        // ChangeRecorded handler has not fired), the history list is empty for this id —
+        // skip silently.
+        if (snapshot.SequenceNumber > 0 && _history.TryGetValue(workspaceId, out var historyList))
+        {
+            lock (historyList)
+            {
+                for (var i = historyList.Count - 1; i >= 0; i--)
+                {
+                    if (historyList[i].SequenceNumber == snapshot.SequenceNumber)
+                    {
+                        historyList.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+        }
+
         // Fast path: the caller provided an explicit file-snapshot list. Restore those
         // files directly — authoritative, independent of the workspace solution state.
         if (snapshot.FileSnapshots is { Count: > 0 })
@@ -95,6 +132,136 @@ public sealed class UndoService : IUndoService, IDisposable
         // Legacy path: solution-based restore with a snapshot-wide walk so empty-GetChanges
         // no longer silently wins.
         return await RevertFromSolutionSnapshotAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RevertBySequenceResult> RevertBySequenceAsync(
+        string workspaceId,
+        int sequenceNumber,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_history.TryGetValue(workspaceId, out var historyList))
+        {
+            return new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: null,
+                AffectedFiles: Array.Empty<string>(),
+                Reason: "unknown-sequence",
+                BlockingSequences: null);
+        }
+
+        UndoSnapshot? target;
+        List<UndoSnapshot> laterApplies;
+        lock (historyList)
+        {
+            target = historyList.FirstOrDefault(s => s.SequenceNumber == sequenceNumber);
+            laterApplies = target is null
+                ? new List<UndoSnapshot>()
+                : historyList
+                    .Where(s => s.SequenceNumber > sequenceNumber)
+                    .ToList();
+        }
+
+        if (target is null)
+        {
+            return new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: null,
+                AffectedFiles: Array.Empty<string>(),
+                Reason: "unknown-sequence",
+                BlockingSequences: null);
+        }
+
+        // Conservative dependency check: if any later apply touches a file that the target
+        // apply also touched, reverting the target would silently roll back part of those
+        // later applies. Block the revert and surface the offending sequence numbers so the
+        // caller can revert them first if desired.
+        var targetFiles = new HashSet<string>(target.AffectedFiles, StringComparer.OrdinalIgnoreCase);
+        var blocking = new List<int>();
+        foreach (var later in laterApplies)
+        {
+            foreach (var file in later.AffectedFiles)
+            {
+                if (targetFiles.Contains(file))
+                {
+                    blocking.Add(later.SequenceNumber);
+                    break;
+                }
+            }
+        }
+
+        if (blocking.Count > 0)
+        {
+            return new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: target.Description,
+                AffectedFiles: target.AffectedFiles,
+                Reason: "dependency-blocked",
+                BlockingSequences: blocking);
+        }
+
+        // Apply the revert. Drop the history entry first so concurrent callers can't double-revert.
+        lock (historyList)
+        {
+            historyList.RemoveAll(s => s.SequenceNumber == sequenceNumber);
+        }
+
+        // If this is also the pending LIFO snapshot, drop it from _snapshots too — keeps
+        // GetLastOperation / RevertAsync consistent.
+        if (_snapshots.TryGetValue(workspaceId, out var pending) && pending.SequenceNumber == sequenceNumber)
+        {
+            _snapshots.TryRemove(workspaceId, out _);
+        }
+
+        bool reverted;
+        if (target.FileSnapshots is { Count: > 0 })
+        {
+            reverted = await RevertFromFileSnapshotsAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            reverted = await RevertFromSolutionSnapshotAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!reverted)
+        {
+            return new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: target.Description,
+                AffectedFiles: target.AffectedFiles,
+                Reason: "revert-failed",
+                BlockingSequences: null);
+        }
+
+        return new RevertBySequenceResult(
+            Reverted: true,
+            RevertedOperation: target.Description,
+            AffectedFiles: target.AffectedFiles,
+            Reason: null,
+            BlockingSequences: null);
+    }
+
+    public void CommitPendingCapture(string workspaceId, int sequenceNumber, IReadOnlyList<string> affectedFiles)
+    {
+        if (!_snapshots.TryGetValue(workspaceId, out var pending))
+        {
+            // No pending snapshot — apply path skipped CaptureBeforeApply (e.g., a no-op tool
+            // that records a change without producing a revertable diff). Nothing to commit.
+            return;
+        }
+
+        var promoted = pending with { SequenceNumber = sequenceNumber, AffectedFiles = affectedFiles };
+        _snapshots[workspaceId] = promoted;
+
+        var historyList = _history.GetOrAdd(workspaceId, _ => new List<UndoSnapshot>());
+        lock (historyList)
+        {
+            historyList.Add(promoted);
+        }
+    }
+
+    private void OnChangeRecorded(ChangeRecordedEventArgs e)
+    {
+        CommitPendingCapture(e.WorkspaceId, e.SequenceNumber, e.AffectedFiles);
     }
 
     private async Task<bool> RevertFromFileSnapshotsAsync(
@@ -354,6 +521,7 @@ public sealed class UndoService : IUndoService, IDisposable
     public void Clear(string workspaceId)
     {
         _snapshots.TryRemove(workspaceId, out _);
+        _history.TryRemove(workspaceId, out _);
     }
 
     private sealed record UndoSnapshot(
@@ -362,5 +530,7 @@ public sealed class UndoService : IUndoService, IDisposable
         Solution? PreApplySolution,
         IReadOnlyList<FileSnapshotDto>? FileSnapshots,
         int PreApplyWorkspaceVersion,
-        DateTime AppliedAtUtc);
+        DateTime AppliedAtUtc,
+        int SequenceNumber,
+        IReadOnlyList<string> AffectedFiles);
 }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -92,8 +92,8 @@ internal sealed class TestServiceContainer
             workspaceManager,
             compilationCache,
             NullLogger<DiagnosticService>.Instance);
-        var undoService = new UndoService(NullLogger<UndoService>.Instance, workspaceManager);
         var changeTracker = new ChangeTracker(workspaceManager);
+        var undoService = new UndoService(NullLogger<UndoService>.Instance, workspaceManager, changeTracker);
         var msBuildEvaluationService = new MsBuildEvaluationService(workspaceManager);
         var namespaceDependencyService = new NamespaceDependencyService(
             workspaceManager,

--- a/tests/RoslynMcp.Tests/UndoServiceTests.cs
+++ b/tests/RoslynMcp.Tests/UndoServiceTests.cs
@@ -1,0 +1,149 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Verifies <see cref="IUndoService.RevertBySequenceAsync"/> — late-session revert of an
+/// earlier apply identified by its <see cref="WorkspaceChangeDto.SequenceNumber"/>. Pairs
+/// with <see cref="EditUndoIntegrationTests"/> (LIFO revert) and <see cref="ChangeTrackerTests"/>
+/// (sequence-number assignment) — this fixture pins the dependency-block contract that is
+/// unique to <c>revert_apply_by_sequence</c>.
+/// </summary>
+[TestClass]
+public sealed class UndoServiceTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task RevertBySequence_NonOverlappingApplies_RestoresEarlierApply()
+    {
+        // Apply A (text edit to Dog.cs) then Apply B (text edit to Cat.cs). Revert A by
+        // sequence number — B does not touch Dog.cs, so the dependency check must NOT
+        // block the revert. Disk content for Dog.cs returns to pre-A state; Cat.cs keeps
+        // its post-B content.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+        var dogOriginal = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var catOriginal = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+
+        // Apply A: insert a comment at the top of Dog.cs.
+        var dogEdit = new TextEditDto(1, 1, 1, 1, "// apply A\n");
+        var resultA = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { dogEdit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultA.Success, "Apply A should succeed.");
+
+        // Apply B: insert a comment at the top of Cat.cs.
+        var catEdit = new TextEditDto(1, 1, 1, 1, "// apply B\n");
+        var resultB = await EditService.ApplyTextEditsAsync(
+            workspaceId, catFilePath, new[] { catEdit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultB.Success, "Apply B should succeed.");
+
+        var changes = ChangeTracker.GetChanges(workspaceId);
+        Assert.AreEqual(2, changes.Count, "Expected 2 recorded changes.");
+        var sequenceA = changes[0].SequenceNumber;
+        var sequenceB = changes[1].SequenceNumber;
+        Assert.IsTrue(sequenceA < sequenceB, "Sequence numbers should increase per apply.");
+
+        // Revert A by sequence — B's affected files do not overlap with A's, so this must succeed.
+        var revertResult = await UndoService.RevertBySequenceAsync(
+            workspaceId, sequenceA, CancellationToken.None);
+
+        Assert.IsTrue(revertResult.Reverted,
+            $"Expected revert of non-overlapping apply A to succeed; got reason={revertResult.Reason}.");
+        Assert.IsNull(revertResult.Reason);
+        Assert.IsNotNull(revertResult.RevertedOperation);
+
+        // Dog.cs (apply A's target) is back to its original content; Cat.cs (apply B's target)
+        // keeps its post-B content because B was NOT reverted.
+        var dogAfterRevert = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(dogOriginal, dogAfterRevert,
+            "Dog.cs should be restored to its pre-apply-A content after revert-by-sequence(A).");
+
+        var catAfterRevert = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+        StringAssert.Contains(catAfterRevert, "// apply B",
+            "Cat.cs should retain apply B's edit — only apply A was reverted.");
+        Assert.AreNotEqual(catOriginal, catAfterRevert,
+            "Cat.cs should still be at its post-apply-B state.");
+    }
+
+    [TestMethod]
+    public async Task RevertBySequence_LaterApplyOverlapsTargetFiles_DependencyBlocked()
+    {
+        // Apply A and Apply B both touch Dog.cs. Revert A by sequence — the conservative
+        // dependency check must block the revert and surface B's sequence number as a
+        // blocker so the caller can revert B first.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Apply A: insert a comment at the top of Dog.cs.
+        var editA = new TextEditDto(1, 1, 1, 1, "// apply A\n");
+        var resultA = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { editA }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultA.Success, "Apply A should succeed.");
+
+        // Apply B: insert another comment at the top of Dog.cs (now line 1 holds the apply-A
+        // comment; insert above that). B touches the SAME file as A, so revert A must be blocked.
+        var editB = new TextEditDto(1, 1, 1, 1, "// apply B\n");
+        var resultB = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { editB }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultB.Success, "Apply B should succeed.");
+
+        var changes = ChangeTracker.GetChanges(workspaceId);
+        Assert.AreEqual(2, changes.Count, "Expected 2 recorded changes.");
+        var sequenceA = changes[0].SequenceNumber;
+        var sequenceB = changes[1].SequenceNumber;
+
+        // Try to revert A — B touches Dog.cs which is also in A's affected set.
+        var revertResult = await UndoService.RevertBySequenceAsync(
+            workspaceId, sequenceA, CancellationToken.None);
+
+        Assert.IsFalse(revertResult.Reverted, "Revert must be blocked when a later apply overlaps.");
+        Assert.AreEqual("dependency-blocked", revertResult.Reason);
+        Assert.IsNotNull(revertResult.BlockingSequences);
+        CollectionAssert.Contains(
+            revertResult.BlockingSequences!.ToList(),
+            sequenceB,
+            "Apply B's sequence number must appear in BlockingSequences because it touches Dog.cs.");
+
+        // Disk for Dog.cs must remain at its post-apply-B state — no partial revert.
+        var dogAfterBlock = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        StringAssert.Contains(dogAfterBlock, "// apply B",
+            "Apply B's edit must remain on disk — dependency-blocked revert must not partially roll back.");
+        StringAssert.Contains(dogAfterBlock, "// apply A",
+            "Apply A's edit must also remain on disk — dependency-blocked revert must not roll it back partially.");
+    }
+
+    [TestMethod]
+    public async Task RevertBySequence_UnknownSequence_ReturnsUnknownSequenceReason()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        // No applies have happened — every sequence number is unknown for this workspace.
+        var revertResult = await UndoService.RevertBySequenceAsync(
+            workspaceId, sequenceNumber: 9999, CancellationToken.None);
+
+        Assert.IsFalse(revertResult.Reverted);
+        Assert.AreEqual("unknown-sequence", revertResult.Reason);
+        Assert.IsNull(revertResult.BlockingSequences);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `revert_apply_by_sequence(workspaceId, sequenceNumber)` MCP tool to revert any earlier apply identified by its `workspace_changes` sequence number — complement to LIFO-only `revert_last_apply`.
- Conservative file-overlap dependency check: blocks revert if any later apply touched overlapping files, surfacing blocking sequences so the caller can revert them first.
- `UndoService` now retains a per-workspace history of committed snapshots keyed by sequence number, synchronized with `ChangeTracker` via a new `ChangeRecorded` event.

## Implementation

- **Core contract** (`IUndoService.cs`, `IChangeTracker.cs`): new `RevertBySequenceAsync` + `CommitPendingCapture` on `IUndoService`; new `ChangeRecorded` event + `ChangeRecordedEventArgs` on `IChangeTracker`; new `RevertBySequenceResult` DTO with `Reason` codes (`unknown-sequence`, `dependency-blocked`, `revert-failed`).
- **Roslyn impl** (`UndoService.cs`, `ChangeTracker.cs`): `UndoService` retains `_history` per-workspace, subscribes to `IChangeTracker.ChangeRecorded` to promote pending captures into history with their assigned sequence number. `ChangeTracker.RecordChange` now fires the event synchronously (handler exceptions swallowed).
- **Host.Stdio surface** (`UndoTools.cs`): new `[McpServerTool] RevertApplyBySequence` returning `{reverted, revertedOperation, affectedFiles, sequenceNumber, reason?, blockingSequences?, message?}`.
- **Catalog** (`ServerSurfaceCatalog.Refactoring.cs`): new entry. Forced by RMCP001/RMCP002 surface-parity analyzer.
- **Addenda**: `TestServiceContainer.cs` reorders `ChangeTracker` before `UndoService` so the new optional `IChangeTracker` parameter is wired in tests; `README.md` + `src/RoslynMcp.Host.Stdio/README.md` bump surface count to 162 (108 stable / 54 experimental).
- **Tests** (`UndoServiceTests.cs`): three tests pinning the contract — non-overlap happy path, overlap dependency-blocked path with `blockingSequences`, unknown-sequence path returning `reason="unknown-sequence"`.

No backwards-compat shims added. The new optional `IChangeTracker` parameter on `UndoService`'s constructor is graceful degradation, not a shim — when null (e.g., in tests that don't need history), revert-by-sequence simply returns `unknown-sequence` because no committed history exists.

## Test plan

- [x] `dotnet build RoslynMcp.slnx` — clean (0 warnings, 0 errors).
- [x] `UndoServiceTests` — all 3 tests pass (non-overlap revert, dependency-blocked, unknown-sequence).
- [x] `UndoIntegrationTests`, `EditUndoIntegrationTests`, `EditUndoCohesionTests`, `UndoFileOperationsTests`, `ChangeTrackerTests` — all 31 tests still pass (LIFO `revert_last_apply` semantics unchanged).
- [x] `SurfaceCatalogTests`, `ReadmeSurfaceCountTests`, `ServerInfoTests` — all 16 pass (surface count + catalog parity for the new tool).
- [x] `eng/verify-release.ps1 -Configuration Release` — full suite passes 942/942 (some runs hit known parallel-test temp-dir contention flakiness; clean on retry, identical to baseline behavior on main).
- [x] `eng/verify-ai-docs.ps1` — passes.

Closes: `revert-apply-by-sequence-number`

🤖 Generated with [Claude Code](https://claude.com/claude-code)