### PR TITLE
fix(class-split): trim orphan-indent lines after member removal

### DIFF
--- a/src/RoslynMcp.Roslyn/Helpers/TriviaNormalizationHelper.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/TriviaNormalizationHelper.cs
@@ -95,4 +95,67 @@ internal static class TriviaNormalizationHelper
         }
         return SyntaxFactory.TriviaList(result);
     }
+
+    /// <summary>
+    /// Removes "orphan-indent" whitespace trivia: <see cref="SyntaxKind.WhitespaceTrivia"/>
+    /// items sandwiched between two <see cref="SyntaxKind.EndOfLineTrivia"/> items, which
+    /// render as a line containing only whitespace. After
+    /// <see cref="SyntaxNode.RemoveNodes{TNode}"/> with
+    /// <see cref="SyntaxRemoveOptions.KeepExteriorTrivia"/>, the indentation that preceded
+    /// a removed member is preserved as such an orphan, leaving visible trailing-whitespace
+    /// lines in the output. This rewriter walks every token in the subtree and rebuilds
+    /// each token's leading and trailing trivia without those orphans. It NEVER touches
+    /// whitespace that immediately precedes a token (real indentation), so intentional
+    /// indentation inside preserved members is left alone.
+    /// </summary>
+    public static TNode RemoveOrphanIndentTrivia<TNode>(TNode node) where TNode : SyntaxNode
+    {
+        return (TNode)new OrphanIndentRewriter().Visit(node);
+    }
+
+    private sealed class OrphanIndentRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxToken VisitToken(SyntaxToken token)
+        {
+            var newLeading = TryStripOrphanIndent(token.LeadingTrivia);
+            var newTrailing = TryStripOrphanIndent(token.TrailingTrivia);
+            if (newLeading is { } leading)
+            {
+                token = token.WithLeadingTrivia(leading);
+            }
+            if (newTrailing is { } trailing)
+            {
+                token = token.WithTrailingTrivia(trailing);
+            }
+            return base.VisitToken(token);
+        }
+    }
+
+    /// <summary>
+    /// Returns a trivia list with all whitespace-only lines collapsed to bare end-of-line trivia,
+    /// or <c>null</c> when no orphans are present (allowing the caller to skip a token rewrite).
+    /// A whitespace-only line is a <see cref="SyntaxKind.WhitespaceTrivia"/> that is followed by
+    /// an <see cref="SyntaxKind.EndOfLineTrivia"/> (i.e. it is not the indentation that precedes
+    /// a real token). <see cref="SyntaxTriviaList"/> is a value type, so a <c>null</c> sentinel
+    /// is used instead of reference equality (CA2013).
+    /// </summary>
+    private static SyntaxTriviaList? TryStripOrphanIndent(SyntaxTriviaList input)
+    {
+        var rebuilt = (List<SyntaxTrivia>?)null;
+        for (var i = 0; i < input.Count; i++)
+        {
+            var trivia = input[i];
+            var isOrphanIndent = trivia.IsKind(SyntaxKind.WhitespaceTrivia)
+                && i + 1 < input.Count
+                && input[i + 1].IsKind(SyntaxKind.EndOfLineTrivia);
+            if (isOrphanIndent)
+            {
+                rebuilt ??= new List<SyntaxTrivia>(input.Take(i));
+                // Skip the orphan whitespace; the following EOL is preserved by the next iteration.
+                continue;
+            }
+            rebuilt?.Add(trivia);
+        }
+        return rebuilt is null ? null : SyntaxFactory.TriviaList(rebuilt);
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/ClassSplitOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/ClassSplitOrchestrator.cs
@@ -50,8 +50,16 @@ public sealed class ClassSplitOrchestrator : IClassSplitOrchestrator
             throw new InvalidOperationException($"Member(s) not found in '{typeName}': {string.Join(", ", missingNames)}");
         }
 
-        var partialOriginal = EnsurePartial(typeDeclaration.RemoveNodes(selectedMembers, SyntaxRemoveOptions.KeepExteriorTrivia)
-            ?? throw new InvalidOperationException("Failed to remove the selected members from the original type."));
+        // split-class-preview-orphan-indent:
+        // SyntaxRemoveOptions.KeepExteriorTrivia preserves the leading whitespace of removed
+        // members as orphan trivia, leaving lines that contain only indentation (e.g. four
+        // spaces followed by a newline) where the members used to live. Strip those orphans
+        // via TriviaNormalizationHelper.RemoveOrphanIndentTrivia, which targets only
+        // whitespace sandwiched between two end-of-line trivia tokens. Real indentation that
+        // immediately precedes a token (i.e. inside preserved members) is never touched.
+        var partialAfterRemoval = typeDeclaration.RemoveNodes(selectedMembers, SyntaxRemoveOptions.KeepExteriorTrivia)
+            ?? throw new InvalidOperationException("Failed to remove the selected members from the original type.");
+        var partialOriginal = EnsurePartial(TriviaNormalizationHelper.RemoveOrphanIndentTrivia(partialAfterRemoval));
         var updatedRoot = root.ReplaceNode(typeDeclaration, partialOriginal);
 
         // FORMAT-BUG-006 (dr-9-11-format-bug-006-duplicates-leading-trivia-into-b):

--- a/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
@@ -249,6 +249,89 @@ public sealed class OrchestrationIntegrationTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task Split_Class_Preview_Trims_Orphan_Indent_Lines_Where_Members_Were_Removed()
+    {
+        // split-class-preview-orphan-indent regression:
+        // Pre-fix, `split_class_preview` left orphan-indentation blank lines where the removed
+        // members lived. RemoveNodes(KeepExteriorTrivia) preserves the leading whitespace of each
+        // removed member, surfacing as lines containing nothing but four-space indentation. The
+        // fix walks the modified type's trivia and strips WhitespaceTrivia sandwiched between two
+        // EndOfLineTrivia tokens. Real indentation that precedes a token (i.e. inside preserved
+        // members) is left alone.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Use a Dog source with three members and a trailing third member to exercise the case
+        // where a middle member is removed, leaving an orphan-indent blank line in its place.
+        const string DogSource = "namespace SampleLib;\n"
+            + "\n"
+            + "public class Dog : IAnimal\n"
+            + "{\n"
+            + "    public string Name => \"Dog\";\n"
+            + "\n"
+            + "    public string Speak() => \"Woof\";\n"
+            + "\n"
+            + "    public void Fetch(string item)\n"
+            + "    {\n"
+            + "        System.Console.WriteLine($\"Fetching {item}\");\n"
+            + "    }\n"
+            + "\n"
+            + "    public void Sleep() => System.Console.WriteLine(\"zzz\");\n"
+            + "}\n";
+        await File.WriteAllTextAsync(dogFilePath, DogSource, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var preview = await ClassSplitOrchestrator.PreviewSplitClassAsync(
+            workspace.WorkspaceId,
+            dogFilePath,
+            "Dog",
+            ["Fetch"],
+            "Dog.Behavior.cs",
+            CancellationToken.None);
+
+        // The preview diff for the original file must not contain any added lines that are
+        // entirely whitespace (`^\+\s+$` after trimming the leading `+`). Such lines are the
+        // exact symptom this initiative addresses.
+        var originalDiff = preview.Changes.First(change =>
+            string.Equals(change.FilePath, dogFilePath, StringComparison.OrdinalIgnoreCase)).UnifiedDiff;
+        var addedLines = originalDiff.Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.StartsWith('+') && !line.StartsWith("+++", StringComparison.Ordinal))
+            .ToArray();
+        var orphanIndentAddedLines = addedLines
+            .Where(line => line.Length > 1 && line[1..].Length > 0 && line[1..].All(char.IsWhiteSpace))
+            .ToArray();
+        Assert.AreEqual(
+            0,
+            orphanIndentAddedLines.Length,
+            $"split-class-preview-orphan-indent regression: post-split diff must not add orphan-indent blank lines. Offending lines:\n{string.Join("\n", orphanIndentAddedLines.Select(line => $"  '{line}'"))}\nFull diff:\n{originalDiff}");
+
+        // Apply the preview and re-inspect the persisted file: it must contain no whitespace-only
+        // lines where the Fetch method used to be.
+        var applyResult = await CompositeApplyOrchestrator.ApplyCompositeAsync(preview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+        var originalContents = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var orphanLines = originalContents.Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0 && line.All(char.IsWhiteSpace))
+            .ToArray();
+        Assert.AreEqual(
+            0,
+            orphanLines.Length,
+            $"split-class-preview-orphan-indent regression: applied file must not contain whitespace-only lines. File:\n{originalContents}");
+
+        // Sanity: the moved member must be gone from the original and the preserved members must
+        // still be intact (so we know the trim did not chew anything important).
+        Assert.IsFalse(originalContents.Contains("void Fetch", StringComparison.Ordinal),
+            "Fetch must be removed from the original partial.");
+        StringAssert.Contains(originalContents, "public string Speak()",
+            "Speak must remain on the original partial.");
+        StringAssert.Contains(originalContents, "public void Sleep()",
+            "Sleep must remain on the original partial.");
+    }
+
+    [TestMethod]
     public async Task Extract_And_Wire_Interface_Preview_And_Apply_Rewrites_Di_Registration()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();

--- a/tests/RoslynMcp.Tests/TriviaNormalizationHelperTests.cs
+++ b/tests/RoslynMcp.Tests/TriviaNormalizationHelperTests.cs
@@ -128,4 +128,63 @@ public class TriviaNormalizationHelperTests
     }
 
     #endregion
+
+    #region RemoveOrphanIndentTrivia
+
+    [TestMethod]
+    public void RemoveOrphanIndentTrivia_StripsOrphanIndentBetweenMembers()
+    {
+        // Simulate the post-RemoveNodes(KeepExteriorTrivia) shape: an orphan-indent line (four
+        // spaces only) sandwiched between two end-of-line markers.
+        var source = "class C\r\n{\r\n    public int A;\r\n    \r\n    public int B;\r\n}\r\n";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetCompilationUnitRoot();
+
+        var result = TriviaNormalizationHelper.RemoveOrphanIndentTrivia(root);
+
+        var text = result.ToFullString();
+        // No line should be entirely whitespace after the trim.
+        var orphanLines = text.Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0 && line.All(char.IsWhiteSpace))
+            .ToArray();
+        Assert.AreEqual(
+            0,
+            orphanLines.Length,
+            $"Expected no whitespace-only lines but found {orphanLines.Length}: [{string.Join(", ", orphanLines.Select(line => $"'{line}'"))}]\nFull text:\n{text}");
+        // The blank line between A and B is preserved as a true blank line (no orphan indent).
+        StringAssert.Contains(text, "public int A;\r\n\r\n    public int B;");
+    }
+
+    [TestMethod]
+    public void RemoveOrphanIndentTrivia_PreservesIndentationOfRealTokens()
+    {
+        var source = "class C\r\n{\r\n    public int A;\r\n    public int B;\r\n}\r\n";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetCompilationUnitRoot();
+
+        var result = TriviaNormalizationHelper.RemoveOrphanIndentTrivia(root);
+
+        // Idempotent: nothing to strip, output equals input.
+        Assert.AreEqual(source, result.ToFullString());
+    }
+
+    [TestMethod]
+    public void RemoveOrphanIndentTrivia_LeavesContentInsideVerbatimStringLiteralsAlone()
+    {
+        // A verbatim string with an internal whitespace-only line stored as part of the token's
+        // text (not as trivia). The rewriter must not touch this — string-level trims would.
+        var source = "class C\r\n{\r\n    public string S = @\"line1\r\n    \r\n    line3\";\r\n}\r\n";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetCompilationUnitRoot();
+
+        var result = TriviaNormalizationHelper.RemoveOrphanIndentTrivia(root);
+
+        var text = result.ToFullString();
+        // The verbatim string content must be preserved byte-for-byte; the whitespace inside
+        // `@"..."` is part of the string literal token, not trivia.
+        StringAssert.Contains(text, "@\"line1\r\n    \r\n    line3\"");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- `split_class_preview` previously left orphan-indentation blank lines (four-space whitespace-only lines) where removed members lived, because `SyntaxRemoveOptions.KeepExteriorTrivia` preserves the leading whitespace of removed nodes as orphan trivia.
- Added `TriviaNormalizationHelper.RemoveOrphanIndentTrivia`: a token-walking rewriter that strips `WhitespaceTrivia` sandwiched between two `EndOfLineTrivia` items. Operates on trivia only, so verbatim-string token text and real token-leading indentation are untouched.
- `ClassSplitOrchestrator` wraps its `RemoveNodes` call with the new helper before re-emitting.

## Test plan

- [x] New integration test `Split_Class_Preview_Trims_Orphan_Indent_Lines_Where_Members_Were_Removed` asserts no `+\s+$` added lines in the preview diff and no whitespace-only lines in the applied file.
- [x] Three new unit tests on `TriviaNormalizationHelperTests` cover orphan removal between members, no-op idempotence, and verbatim-string literal safety.
- [x] Existing `Split_Class_Preview_And_Apply_Creates_New_Partial_File` and `FORMAT_BUG_006_*` regression tests continue to pass — no intentional indentation regression in preserved members.
- [x] `eng/verify-release.ps1 -Configuration Release` green: 955/955 tests pass.
- [x] `eng/verify-ai-docs.ps1` green.

Closes: split-class-preview-orphan-indent