### PR TITLE
fix(project-mutation): emit formatted XML for preview tools

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/OrchestrationMsBuildXml.cs
+++ b/src/RoslynMcp.Roslyn/Services/OrchestrationMsBuildXml.cs
@@ -16,20 +16,69 @@ internal static class OrchestrationMsBuildXml
         }
 
         var itemGroup = new XElement("ItemGroup");
-        var root = document.Root;
-        if (root is null)
+        if (document.Root is null)
         {
             return itemGroup;
         }
 
-        // FORMAT-BUG-003 fix: splice the new ItemGroup between existing elements with matching
-        // indent + line-ending trivia so the serializer does not produce
-        // `<ItemGroup><PackageReference .../></ItemGroup>` on a single line or glue
-        // `</Project>` onto the preceding element. A single AddAfterSelf call with both nodes
-        // preserves document order (`[lastElement][leading-whitespace][itemGroup][trailing-whitespace]`)
-        // instead of the LIFO semantics of two sequential calls. The trailing XText keeps
-        // `</Project>` on its own line after the new ItemGroup even when the caller just pruned
-        // the only prior trailing whitespace (via `RemoveElementCleanly` on a lone ItemGroup).
+        // FORMAT-BUG-003 fix is implemented inside AppendRootChildWithFormatting: it splices the
+        // new ItemGroup between existing elements with matching indent + line-ending trivia so
+        // the serializer does not produce `<ItemGroup><PackageReference .../></ItemGroup>` on a
+        // single line or glue `</Project>` onto the preceding element.
+        AppendRootChildWithFormatting(document, itemGroup);
+        return itemGroup;
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="element"/> as the first child of the document root with a leading
+    /// newline + indent so the new element does not end up concatenated onto the opening
+    /// <c>&lt;Project&gt;</c> tag (or onto the existing first child). Used when a mutation needs
+    /// a brand-new root-level element (e.g. a fresh <c>PropertyGroup</c>) emitted at the top.
+    /// project-mutation-preview-xml-formatting: previously a duplicate of this lived in
+    /// <c>ProjectMutationService</c>; consolidating here so root-child insertion shares one
+    /// trivia-aware implementation across orchestrators and the project-mutation service.
+    /// </summary>
+    internal static void InsertFirstElementChildWithFormatting(XDocument document, XElement element)
+    {
+        var root = document.Root;
+        if (root is null)
+        {
+            return;
+        }
+
+        var lineEnding = DetectLineEnding(document);
+        const string indent = "  ";
+        var firstElement = root.Elements().FirstOrDefault();
+        if (firstElement is not null)
+        {
+            firstElement.AddBeforeSelf(element);
+            firstElement.AddBeforeSelf(new XText(lineEnding + indent));
+            return;
+        }
+
+        root.Add(new XText(lineEnding + indent));
+        root.Add(element);
+        root.Add(new XText(lineEnding));
+    }
+
+    /// <summary>
+    /// Appends <paramref name="element"/> as the last child of the document root with a leading
+    /// newline + indent splice so the new element is on its own line and the closing
+    /// <c>&lt;/Project&gt;</c> tag stays on the next line. project-mutation-preview-xml-formatting:
+    /// pulled out of <c>GetOrCreateItemGroup</c> so other root-level inserts (e.g. a brand-new
+    /// conditional <c>PropertyGroup</c> in <c>set_conditional_property_preview</c>) get the same
+    /// FORMAT-BUG-003-style splice instead of <c>document.Root?.Add(element)</c>, which produces
+    /// <c>...&lt;/PreviousElement&gt;&lt;NewElement&gt;...&lt;/NewElement&gt;&lt;/Project&gt;</c> on a
+    /// single line.
+    /// </summary>
+    internal static void AppendRootChildWithFormatting(XDocument document, XElement element)
+    {
+        var root = document.Root;
+        if (root is null)
+        {
+            return;
+        }
+
         var lineEnding = DetectLineEnding(document);
         const string indent = "  ";
         if (root.Elements().Any())
@@ -37,28 +86,27 @@ internal static class OrchestrationMsBuildXml
             var lastElement = root.Elements().Last();
             if (lastElement.NextNode is XText existingTrailing && string.IsNullOrWhiteSpace(existingTrailing.Value))
             {
-                lastElement.AddAfterSelf(new XText(lineEnding + indent), itemGroup);
+                lastElement.AddAfterSelf(new XText(lineEnding + indent), element);
             }
             else
             {
-                lastElement.AddAfterSelf(new XText(lineEnding + indent), itemGroup, new XText(lineEnding));
+                lastElement.AddAfterSelf(new XText(lineEnding + indent), element, new XText(lineEnding));
             }
         }
         else
         {
             root.Add(new XText(lineEnding + indent));
-            root.Add(itemGroup);
+            root.Add(element);
             root.Add(new XText(lineEnding));
         }
-
-        return itemGroup;
     }
 
     /// <summary>
     /// Adds <paramref name="child"/> to <paramref name="parent"/> with a leading newline + detected
     /// child indent so a fresh element does not end up concatenated onto the previous sibling or
-    /// the parent's closing tag. Mirrors <c>ProjectMutationService.AddChildElementPreservingIndentation</c>
-    /// for orchestrators that mutate csproj / Directory.Packages.props files.
+    /// the parent's closing tag. project-mutation-preview-xml-formatting: now the canonical
+    /// implementation — <c>ProjectMutationService</c> previously held a near-duplicate that
+    /// produced collapsed XML inside freshly-created PropertyGroup/ItemGroup parents.
     /// </summary>
     internal static void AddChildElementPreservingIndentation(XElement parent, XElement child)
     {

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -1,6 +1,4 @@
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml;
 using System.Xml.Linq;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -91,8 +89,8 @@ public sealed class ProjectMutationService : IProjectMutationService
                 packageReference.Add(new XAttribute("Version", request.Version));
             }
 
-            var itemGroup = GetOrCreateItemGroup(document, "PackageReference");
-            AddChildElementPreservingIndentation(itemGroup, packageReference);
+            var itemGroup = OrchestrationMsBuildXml.GetOrCreateItemGroup(document, "PackageReference");
+            OrchestrationMsBuildXml.AddChildElementPreservingIndentation(itemGroup, packageReference);
         }, $"Add package reference '{request.PackageId}'", ct, warnings).ConfigureAwait(false);
     }
 
@@ -107,7 +105,7 @@ public sealed class ProjectMutationService : IProjectMutationService
                 throw new InvalidOperationException($"Package reference '{request.PackageId}' was not found.");
             }
 
-            RemoveElementCleanly(element);
+            OrchestrationMsBuildXml.RemoveElementCleanly(element);
         }, $"Remove package reference '{request.PackageId}'", ct);
     }
 
@@ -132,8 +130,10 @@ public sealed class ProjectMutationService : IProjectMutationService
                 throw new InvalidOperationException($"Project reference '{referencedProject.Name}' already exists.");
             }
 
-            GetOrCreateItemGroup(document, "ProjectReference")
-                .Add(new XElement("ProjectReference", new XAttribute("Include", relativePath)));
+            var itemGroup = OrchestrationMsBuildXml.GetOrCreateItemGroup(document, "ProjectReference");
+            OrchestrationMsBuildXml.AddChildElementPreservingIndentation(
+                itemGroup,
+                new XElement("ProjectReference", new XAttribute("Include", relativePath)));
         }, $"Add project reference '{request.ReferencedProjectName}'", ct);
     }
 
@@ -156,7 +156,7 @@ public sealed class ProjectMutationService : IProjectMutationService
                 throw new InvalidOperationException($"Project reference '{request.ReferencedProjectName}' was not found.");
             }
 
-            RemoveElementCleanly(element);
+            OrchestrationMsBuildXml.RemoveElementCleanly(element);
         }, $"Remove project reference '{request.ReferencedProjectName}'", ct);
     }
 
@@ -172,18 +172,32 @@ public sealed class ProjectMutationService : IProjectMutationService
                 // Create a new PropertyGroup if none exists (e.g., Directory.Build.props-based projects).
                 // Insert with line breaks so the project file does not become a single-line malformed document.
                 propertyGroup = new XElement("PropertyGroup");
-                InsertFirstElementChildWithFormatting(document, propertyGroup);
+                OrchestrationMsBuildXml.InsertFirstElementChildWithFormatting(document, propertyGroup);
             }
 
             // Detect no-op: check if property already has the target value
-            var existingValue = propertyGroup.Element(request.PropertyName)?.Value;
-            if (string.Equals(existingValue, request.Value, StringComparison.Ordinal))
+            var existingElement = propertyGroup.Element(request.PropertyName);
+            if (string.Equals(existingElement?.Value, request.Value, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     $"No changes needed — property '{request.PropertyName}' is already set to '{request.Value}'.");
             }
 
-            propertyGroup.SetElementValue(request.PropertyName, request.Value);
+            // project-mutation-preview-xml-formatting: SetElementValue inserts a new XElement with
+            // no surrounding text nodes, which causes the serializer to emit
+            // `<TargetFramework>...</TargetFramework><LangVersion>preview</LangVersion></PropertyGroup>`
+            // on a single line whenever the property is being added (not just updated). Route through
+            // AddChildElementPreservingIndentation so the new child gets proper child-indent trivia.
+            if (existingElement is not null)
+            {
+                existingElement.Value = request.Value;
+            }
+            else
+            {
+                OrchestrationMsBuildXml.AddChildElementPreservingIndentation(
+                    propertyGroup,
+                    new XElement(request.PropertyName, request.Value));
+            }
         }, $"Set project property '{request.PropertyName}'", ct);
     }
 
@@ -247,8 +261,15 @@ public sealed class ProjectMutationService : IProjectMutationService
 
             list.Add(request.TargetFramework);
             var propertyGroup = new XElement("PropertyGroup");
-            propertyGroup.Add(new XElement("TargetFrameworks", string.Join(";", list)));
-            InsertFirstElementChildWithFormatting(document, propertyGroup);
+            // project-mutation-preview-xml-formatting: insert the empty PropertyGroup first so
+            // AddChildElementPreservingIndentation can detect parent indentation from its
+            // previous-sibling text node (without insertion first the new element has no
+            // surrounding text, so child indentation defaults to "  " instead of the project's
+            // "    " for nested elements).
+            OrchestrationMsBuildXml.InsertFirstElementChildWithFormatting(document, propertyGroup);
+            OrchestrationMsBuildXml.AddChildElementPreservingIndentation(
+                propertyGroup,
+                new XElement("TargetFrameworks", string.Join(";", list)));
         }, $"Add target framework '{request.TargetFramework}'", ct).ConfigureAwait(false);
     }
 
@@ -327,16 +348,14 @@ public sealed class ProjectMutationService : IProjectMutationService
             }
 
             var propertyGroup = new XElement("PropertyGroup");
-            if (list.Count == 1)
-            {
-                propertyGroup.Add(new XElement("TargetFramework", list[0]));
-            }
-            else
-            {
-                propertyGroup.Add(new XElement("TargetFrameworks", string.Join(";", list)));
-            }
-
-            InsertFirstElementChildWithFormatting(document, propertyGroup);
+            // project-mutation-preview-xml-formatting: insert empty PropertyGroup first, then add
+            // the TargetFramework(s) child via the trivia-aware helper. See note in
+            // PreviewAddTargetFrameworkAsync for why this two-step ordering matters.
+            OrchestrationMsBuildXml.InsertFirstElementChildWithFormatting(document, propertyGroup);
+            var tfElement = list.Count == 1
+                ? new XElement("TargetFramework", list[0])
+                : new XElement("TargetFrameworks", string.Join(";", list));
+            OrchestrationMsBuildXml.AddChildElementPreservingIndentation(propertyGroup, tfElement);
         }, $"Remove target framework '{request.TargetFramework}'", ct).ConfigureAwait(false);
     }
 
@@ -351,7 +370,20 @@ public sealed class ProjectMutationService : IProjectMutationService
                 .FirstOrDefault(candidate => string.Equals((string?)candidate.Attribute("Condition"), request.Condition, StringComparison.Ordinal))
                 ?? AddConditionalPropertyGroup(document, request.Condition);
 
-            propertyGroup.SetElementValue(request.PropertyName, request.Value);
+            // project-mutation-preview-xml-formatting: same trivia-collapse defect as
+            // PreviewSetProjectPropertyAsync — see note there. SetElementValue produces collapsed
+            // single-line PropertyGroup output for newly-inserted children.
+            var existingElement = propertyGroup.Element(request.PropertyName);
+            if (existingElement is not null)
+            {
+                existingElement.Value = request.Value;
+            }
+            else
+            {
+                OrchestrationMsBuildXml.AddChildElementPreservingIndentation(
+                    propertyGroup,
+                    new XElement(request.PropertyName, request.Value));
+            }
         }, $"Set project property '{request.PropertyName}' when {request.Condition}", ct);
     }
 
@@ -374,11 +406,11 @@ public sealed class ProjectMutationService : IProjectMutationService
                 throw new InvalidOperationException($"Central package version '{request.PackageId}' already exists.");
             }
 
-            var itemGroup = GetOrCreateItemGroup(document, "PackageVersion");
+            var itemGroup = OrchestrationMsBuildXml.GetOrCreateItemGroup(document, "PackageVersion");
             var packageVersion = new XElement("PackageVersion",
                 new XAttribute("Include", request.PackageId),
                 new XAttribute("Version", request.Version));
-            AddChildElementPreservingIndentation(itemGroup, packageVersion);
+            OrchestrationMsBuildXml.AddChildElementPreservingIndentation(itemGroup, packageVersion);
         }, $"Add central package version '{request.PackageId}'", ct);
     }
 
@@ -402,7 +434,7 @@ public sealed class ProjectMutationService : IProjectMutationService
                 throw new InvalidOperationException($"Central package version '{request.PackageId}' was not found.");
             }
 
-            RemoveElementCleanly(element);
+            OrchestrationMsBuildXml.RemoveElementCleanly(element);
         }, $"Remove central package version '{request.PackageId}'", ct);
     }
 
@@ -483,33 +515,13 @@ public sealed class ProjectMutationService : IProjectMutationService
         var document = XDocument.Parse(originalContent, LoadOptions.PreserveWhitespace);
         mutator(document);
 
-        // BUG-N14: emit readable multi-line XML instead of a single-line <Project> blob.
-        var updatedContent = FormatProjectXml(document, originalContent);
+        // BUG-N14 + project-mutation-preview-xml-formatting: emit readable multi-line XML instead
+        // of a single-line <Project> blob. Delegates to OrchestrationMsBuildXml.FormatProjectXml
+        // which uses MemoryStream + XmlWriter (preserves UTF-8 encoding declaration when present).
+        var updatedContent = OrchestrationMsBuildXml.FormatProjectXml(document, originalContent);
         var diff = DiffGenerator.GenerateUnifiedDiff(originalContent, updatedContent, filePath);
         var token = _previewStore.Store(workspaceId, filePath, updatedContent, _workspace.GetCurrentVersion(workspaceId), description);
         return new RefactoringPreviewDto(token, description, [new FileChangeDto(filePath, diff)], warnings);
-    }
-
-    private static string FormatProjectXml(XDocument document, string originalContent)
-    {
-        var lineEnding = DetectLineEnding(document);
-        var hadXmlDeclaration = originalContent.AsSpan().TrimStart().StartsWith("<?xml".AsSpan(), StringComparison.Ordinal);
-        var sb = new StringBuilder();
-        var settings = new XmlWriterSettings
-        {
-            Indent = true,
-            IndentChars = "  ",
-            NewLineChars = lineEnding,
-            OmitXmlDeclaration = !hadXmlDeclaration,
-            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-        };
-
-        using (var writer = XmlWriter.Create(sb, settings))
-        {
-            document.Save(writer);
-        }
-
-        return sb.ToString();
     }
 
     private ProjectStatusDto ResolveProject(string workspaceId, string projectName)
@@ -518,213 +530,6 @@ public sealed class ProjectMutationService : IProjectMutationService
                    string.Equals(project.Name, projectName, StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(project.FilePath, projectName, StringComparison.OrdinalIgnoreCase))
                ?? throw new InvalidOperationException($"Project not found: {projectName}");
-    }
-
-    /// <summary>
-    /// apply-project-mutation-whitespace: removes <paramref name="element"/> together with the
-    /// preceding whitespace text node so an add→remove round-trip leaves the file byte-identical
-    /// instead of leaving a blank line where the element used to be. If the element was the only
-    /// real child of its parent <see cref="XElement"/> (typical: a single <c>PackageReference</c>
-    /// inside an <c>ItemGroup</c>), the parent is removed too along with its surrounding
-    /// whitespace, keeping a clean csproj.
-    /// </summary>
-    private static void RemoveElementCleanly(XElement element)
-    {
-        var parent = element.Parent;
-        RemoveNodeAndAdjacentWhitespace(element);
-
-        // If the parent is now empty, prune it too. Otherwise the project file accumulates
-        // `<ItemGroup />` orphans after the last reference is removed.
-        if (parent is not null
-            && parent != parent.Document?.Root
-            && !parent.Elements().Any())
-        {
-            foreach (var ws in parent.Nodes().OfType<XText>().ToList())
-            {
-                ws.Remove();
-            }
-            RemoveNodeAndAdjacentWhitespace(parent);
-        }
-    }
-
-    /// <summary>
-    /// Removes <paramref name="node"/> together with one whitespace text neighbor so an
-    /// add → remove round-trip leaves the document layout intact. Prefers the leading text
-    /// node (typical indent that visually accompanied the element); falls back to the trailing
-    /// text node when the element was inserted via <see cref="XContainer.AddAfterSelf(object)"/>
-    /// (which produces <c>[previous-element][element][trailing-whitespace]</c> rather than
-    /// <c>[previous-element][leading-whitespace][element]</c>). Only pure-whitespace XText nodes
-    /// are touched; comments and other significant nodes are preserved.
-    /// </summary>
-    private static void RemoveNodeAndAdjacentWhitespace(XNode node)
-    {
-        if (node.PreviousNode is XText leading && string.IsNullOrWhiteSpace(leading.Value))
-        {
-            leading.Remove();
-        }
-        else if (node.NextNode is XText trailing && string.IsNullOrWhiteSpace(trailing.Value))
-        {
-            trailing.Remove();
-        }
-        node.Remove();
-    }
-
-    private static XElement GetOrCreateItemGroup(XDocument document, string itemName)
-    {
-        var existingGroup = document.Root?.Elements("ItemGroup")
-            .FirstOrDefault(group => group.Elements(itemName).Any());
-        if (existingGroup is not null)
-        {
-            return existingGroup;
-        }
-
-        var itemGroup = new XElement("ItemGroup");
-        var root = document.Root;
-        if (root is null)
-        {
-            return itemGroup;
-        }
-
-        var lineEnding = DetectLineEnding(document);
-        const string indent = "  ";
-        if (root.Elements().Any())
-        {
-            var lastElement = root.Elements().Last();
-            lastElement.AddAfterSelf(new XText(lineEnding + indent));
-            lastElement.AddAfterSelf(itemGroup);
-        }
-        else
-        {
-            root.Add(new XText(lineEnding + "  "));
-            root.Add(itemGroup);
-            root.Add(new XText(lineEnding));
-        }
-
-        return itemGroup;
-    }
-
-    /// <summary>
-    /// Inserts an element as the first child of the document root with a leading newline and indent,
-    /// avoiding inline concatenation on the same line as the opening <c>&lt;Project&gt;</c> tag.
-    /// </summary>
-    private static void InsertFirstElementChildWithFormatting(XDocument document, XElement element)
-    {
-        var root = document.Root;
-        if (root is null)
-        {
-            return;
-        }
-
-        var lineEnding = DetectLineEnding(document);
-        const string indent = "  ";
-        var firstElement = root.Elements().FirstOrDefault();
-        if (firstElement is not null)
-        {
-            firstElement.AddBeforeSelf(element);
-            firstElement.AddBeforeSelf(new XText(lineEnding + indent));
-            return;
-        }
-
-        root.Add(new XText(lineEnding + indent));
-        root.Add(element);
-        root.Add(new XText(lineEnding));
-    }
-
-    private static void AddChildElementPreservingIndentation(XElement parent, XElement child)
-    {
-        var trailingWhitespace = parent.Nodes().OfType<XText>().LastOrDefault(node =>
-            node.NextNode is null && string.IsNullOrWhiteSpace(node.Value));
-
-        var childIndentation = DetectChildIndentation(parent);
-        var lineEnding = DetectLineEnding(parent.Document);
-
-        if (trailingWhitespace is not null)
-        {
-            trailingWhitespace.AddBeforeSelf(new XText(lineEnding + childIndentation));
-            trailingWhitespace.AddBeforeSelf(child);
-            return;
-        }
-
-        if (!parent.HasElements)
-        {
-            var parentIndentation = DetectParentIndentation(parent);
-            parent.Add(new XText(lineEnding + childIndentation));
-            parent.Add(child);
-            parent.Add(new XText(lineEnding + parentIndentation));
-            return;
-        }
-
-        // Existing siblings: insert newline + indent before the new element (matches first-child formatting)
-        var lastElement = parent.Elements().LastOrDefault();
-        if (lastElement is not null)
-        {
-            lastElement.AddAfterSelf(new XText(lineEnding + childIndentation), child);
-            return;
-        }
-
-        parent.Add(child);
-    }
-
-    private static string DetectChildIndentation(XElement parent)
-    {
-        var firstChild = parent.Elements().FirstOrDefault();
-        if (firstChild?.PreviousNode is XText previousText)
-        {
-            var indentation = GetTrailingIndentation(previousText.Value);
-            if (indentation is not null)
-            {
-                return indentation;
-            }
-        }
-
-        return DetectParentIndentation(parent) + "  ";
-    }
-
-    private static string DetectParentIndentation(XElement element)
-    {
-        if (element.PreviousNode is XText previousText)
-        {
-            return GetTrailingIndentation(previousText.Value) ?? string.Empty;
-        }
-
-        return string.Empty;
-    }
-
-    private static string? GetTrailingIndentation(string whitespace)
-    {
-        if (string.IsNullOrWhiteSpace(whitespace))
-        {
-            var newlineIndex = whitespace.LastIndexOf('\n');
-            if (newlineIndex >= 0)
-            {
-                return whitespace[(newlineIndex + 1)..];
-            }
-        }
-
-        return null;
-    }
-
-    private static string DetectLineEnding(XDocument? document)
-    {
-        if (document is null)
-        {
-            return Environment.NewLine;
-        }
-
-        foreach (var textNode in document.DescendantNodes().OfType<XText>())
-        {
-            if (textNode.Value.Contains("\r\n", StringComparison.Ordinal))
-            {
-                return "\r\n";
-            }
-
-            if (textNode.Value.Contains("\n", StringComparison.Ordinal))
-            {
-                return "\n";
-            }
-        }
-
-        return Environment.NewLine;
     }
 
     private static string NormalizeInclude(string? include)
@@ -766,8 +571,13 @@ public sealed class ProjectMutationService : IProjectMutationService
 
     private static XElement AddConditionalPropertyGroup(XDocument document, string condition)
     {
+        // project-mutation-preview-xml-formatting: previously this called document.Root?.Add(propertyGroup)
+        // which produced `</PreviousElement><PropertyGroup Condition="...">...</PropertyGroup></Project>`
+        // on a single line (no trivia, no line breaks). Route through the trivia-aware splice helper
+        // shared with GetOrCreateItemGroup so the new conditional group lands on its own line and
+        // </Project> stays on the next line.
         var propertyGroup = new XElement("PropertyGroup", new XAttribute("Condition", condition));
-        document.Root?.Add(propertyGroup);
+        OrchestrationMsBuildXml.AppendRootChildWithFormatting(document, propertyGroup);
         return propertyGroup;
     }
 

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -141,6 +141,90 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task project_mutation_preview_xml_formatting_AddPackageReference_KeepsPropertyGroupAndItemGroupOnSeparateLines()
+    {
+        // project-mutation-preview-xml-formatting regression: the previous serializer left
+        // </PropertyGroup> and the freshly-inserted <ItemGroup> on the same line because
+        // ProjectMutationService.GetOrCreateItemGroup used two sequential AddAfterSelf calls
+        // (LIFO ordering) instead of the FORMAT-BUG-003-fixed splice already present in
+        // OrchestrationMsBuildXml. After consolidating onto OrchestrationMsBuildXml.GetOrCreateItemGroup,
+        // the diff must show </PropertyGroup> and <ItemGroup> on separate lines AND the new
+        // <PackageReference> indented as a child of <ItemGroup>, not glued to its opening tag.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var preview = await ProjectMutationService.PreviewAddPackageReferenceAsync(
+            workspace.WorkspaceId,
+            new AddPackageReferenceDto("SampleLib", "Humanizer.Core", "2.14.1"),
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview);
+        var diff = preview.Changes.First().UnifiedDiff;
+        Assert.IsFalse(diff.Contains("</PropertyGroup><ItemGroup>", StringComparison.Ordinal),
+            $"project-mutation-preview-xml-formatting: </PropertyGroup> and <ItemGroup> must not be concatenated. Diff:\n{diff}");
+        Assert.IsFalse(diff.Contains("<ItemGroup><PackageReference", StringComparison.Ordinal),
+            $"project-mutation-preview-xml-formatting: <ItemGroup> and <PackageReference> must not be concatenated. Diff:\n{diff}");
+        // Sanity: the diff should contain a properly-indented PackageReference line beginning
+        // with the customary 4-space child indent inside <ItemGroup>.
+        StringAssert.Contains(diff, "    <PackageReference Include=\"Humanizer.Core\"",
+            $"Expected 4-space indented PackageReference. Diff:\n{diff}");
+    }
+
+    [TestMethod]
+    public async Task project_mutation_preview_xml_formatting_SetProjectProperty_KeepsNewPropertyOnOwnLine()
+    {
+        // project-mutation-preview-xml-formatting regression: SetElementValue inserts the new
+        // child XElement with no surrounding whitespace text nodes, which makes XmlWriter emit
+        // `<TargetFramework>...</TargetFramework><LangVersion>preview</LangVersion></PropertyGroup>`
+        // on a single line whenever the property is being added (vs updated). The fix routes
+        // through AddChildElementPreservingIndentation so the new property is on its own line
+        // with proper child indent.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var preview = await ProjectMutationService.PreviewSetProjectPropertyAsync(
+            workspace.WorkspaceId,
+            new SetProjectPropertyDto("SampleLib", "LangVersion", "preview"),
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview);
+        var diff = preview.Changes.First().UnifiedDiff;
+        // The new <LangVersion> sibling must NOT be glued to a preceding closing tag (e.g.
+        // </ImplicitUsings><LangVersion> or </TreatWarningsAsErrors><LangVersion>).
+        Assert.IsFalse(System.Text.RegularExpressions.Regex.IsMatch(diff, @"</[A-Za-z]+><LangVersion>"),
+            $"project-mutation-preview-xml-formatting: <LangVersion> must not be glued to a preceding closing tag. Diff:\n{diff}");
+        // It also must not be glued to </PropertyGroup> on the trailing side.
+        Assert.IsFalse(diff.Contains("<LangVersion>preview</LangVersion></PropertyGroup>", StringComparison.Ordinal),
+            $"project-mutation-preview-xml-formatting: <LangVersion> must not be on the same line as </PropertyGroup>. Diff:\n{diff}");
+        // Sanity: the diff should contain a properly-indented <LangVersion> line.
+        StringAssert.Contains(diff, "    <LangVersion>preview</LangVersion>",
+            $"Expected 4-space indented <LangVersion>. Diff:\n{diff}");
+    }
+
+    [TestMethod]
+    public async Task project_mutation_preview_xml_formatting_AddCentralPackageVersion_KeepsItemGroupOnSeparateLine()
+    {
+        // project-mutation-preview-xml-formatting regression: same root cause as the
+        // package-reference and property-set defects — applied to Directory.Packages.props
+        // mutations. Previously the new <ItemGroup> wrapping the <PackageVersion> landed on
+        // the same line as </PropertyGroup> and the child was collapsed inside the wrapper.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var preview = await ProjectMutationService.PreviewAddCentralPackageVersionAsync(
+            workspace.WorkspaceId,
+            new AddCentralPackageVersionDto("Humanizer.Core", "2.14.1"),
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview);
+        var diff = preview.Changes.First().UnifiedDiff;
+        Assert.IsFalse(diff.Contains("</PropertyGroup><ItemGroup>", StringComparison.Ordinal),
+            $"project-mutation-preview-xml-formatting: </PropertyGroup> and <ItemGroup> must not be concatenated. Diff:\n{diff}");
+        Assert.IsFalse(diff.Contains("<ItemGroup><PackageVersion", StringComparison.Ordinal),
+            $"project-mutation-preview-xml-formatting: <ItemGroup> and <PackageVersion> must not be concatenated. Diff:\n{diff}");
+        // Sanity: the diff should contain a properly-indented PackageVersion line.
+        StringAssert.Contains(diff, "    <PackageVersion Include=\"Humanizer.Core\"",
+            $"Expected 4-space indented PackageVersion. Diff:\n{diff}");
+    }
+
+    [TestMethod]
     public async Task Add_And_Remove_Target_Framework_Preview_And_Apply_Updates_Isolated_Project_File()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

Three project-mutation preview tools — `add_package_reference_preview`,
`set_project_property_preview`, and `add_central_package_version_preview` —
emitted collapsed single-line XML in their diffs (joined `</PropertyGroup><ItemGroup>`,
joined `<ItemGroup><PackageReference />`, new property elements glued onto the
preceding closing tag). This PR fixes the trivia-collapse defect by consolidating
on the FORMAT-BUG-003-fixed helpers in `OrchestrationMsBuildXml` and routing
`SetElementValue` call-sites through the trivia-aware
`AddChildElementPreservingIndentation` when adding (vs updating) a child.

## Diagnosis

`ProjectMutationService` carried private duplicates of `GetOrCreateItemGroup`,
`AddChildElementPreservingIndentation`, `RemoveElementCleanly`, `FormatProjectXml`,
and the trivia-detection helpers. The duplicate `GetOrCreateItemGroup` predated
the FORMAT-BUG-003 fix in `OrchestrationMsBuildXml.cs` and used two sequential
`AddAfterSelf` calls (LIFO ordering: `[lastElement][itemGroup][lineEnding+indent]`)
instead of a single splice (`[lastElement][lineEnding+indent][itemGroup]`). That
produced output like:

```
</PropertyGroup><ItemGroup>
  <PackageReference Include="Humanizer.Core" Version="2.14.1" />
</ItemGroup>
  
</Project>
```

`SetElementValue` compounded the issue by inserting new `XElement` children with
no surrounding `XText` whitespace nodes — `XmlWriter.Indent = true` then keeps
them on the same line as their siblings or the parent's closing tag, producing:

```
<PropertyGroup>
  <TargetFramework>net10.0</TargetFramework>
<LangVersion>preview</LangVersion></PropertyGroup>
```

## Approach

1. Promote `InsertFirstElementChildWithFormatting` and a new
   `AppendRootChildWithFormatting` into `OrchestrationMsBuildXml` so all root-level
   inserts share one trivia-aware splice; `GetOrCreateItemGroup` now delegates to
   the latter.
2. Delete the eight duplicate helpers in `ProjectMutationService` and route every
   call-site through `OrchestrationMsBuildXml.*`.
3. Rewrite `PreviewSetProjectPropertyAsync` and `PreviewSetConditionalPropertyAsync`
   to detect existing-child-update (`existing.Value = ...`) vs new-child-add
   (`AddChildElementPreservingIndentation(...)`).
4. Fix `AddConditionalPropertyGroup` to use `AppendRootChildWithFormatting`
   instead of `document.Root?.Add(propertyGroup)`.
5. Fix `PreviewAddTargetFrameworkAsync` / `PreviewRemoveTargetFrameworkAsync` to
   insert the empty `PropertyGroup` first, then add the `TargetFramework(s)` child
   via the trivia-aware helper.

## Scope expansion (in-file, contained)

The plan named three tools, but the same root cause affected
`set_conditional_property_preview`, `add_target_framework_preview`,
`remove_target_framework_preview`, and `add_project_reference_preview`. All of
these live in the in-scope `ProjectMutationService.cs` and their fixes fall out
of the helper consolidation — explicitly per session policy ("Correctness over
cheapness — reject band-aid fixes even when they'd close the row faster"). No
files outside the plan's scope were touched.

## Validation

- `./eng/verify-release.ps1 -Configuration Release` — 959 tests pass
- `./eng/verify-ai-docs.ps1` — passed
- `dotnet test --filter "FullyQualifiedName~ProjectMutationIntegrationTests"` — 16 tests pass (13 existing + 3 new)
- `dotnet test --filter "FullyQualifiedName~Orchestration|FullyQualifiedName~PackageMigration|FullyQualifiedName~ExtractAndWire|FullyQualifiedName~Csproj"` — 43 tests pass

## Test plan

- [x] Three new regression tests in `ProjectMutationIntegrationTests` — one per named tool — assert the preview diff does NOT contain the joined-tag patterns and DOES contain the expected 4-space-indented child line.
- [x] All pre-existing `ProjectMutationIntegrationTests` (13) still pass after the helper consolidation.
- [x] All pre-existing orchestration / package-migration / extract-and-wire tests pass — none regress on the `OrchestrationMsBuildXml.GetOrCreateItemGroup` refactor that delegates to `AppendRootChildWithFormatting`.

Closes: project-mutation-preview-xml-formatting