### PR TITLE
fix(semantic-search): dedupe by symbolHandle and surface debug + matchKind

### DIFF
--- a/src/RoslynMcp.Core/Models/SemanticSearchResultDto.cs
+++ b/src/RoslynMcp.Core/Models/SemanticSearchResultDto.cs
@@ -3,6 +3,21 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents a semantic search match.
 /// </summary>
+/// <param name="SymbolName">Short symbol name (e.g. <c>"JobProcessor"</c>).</param>
+/// <param name="SymbolKind">The Roslyn <see cref="Microsoft.CodeAnalysis.SymbolKind"/> name (e.g. <c>"NamedType"</c>, <c>"Method"</c>).</param>
+/// <param name="FilePath">Absolute path to the source file containing the declaration.</param>
+/// <param name="Line">1-based line number of the declaration.</param>
+/// <param name="Signature">Fully qualified display string of the symbol.</param>
+/// <param name="ContainingType">Containing type's short name, when applicable.</param>
+/// <param name="Namespace">Containing namespace's display string, when applicable.</param>
+/// <param name="SymbolHandle">Opaque handle for symbol resolution by other MCP tools. Also serves as the dedupe key for semantic search results.</param>
+/// <param name="MatchKind">
+/// Which matching strategy produced this result. One of:
+/// <c>"structured"</c> (matched a parsed predicate),
+/// <c>"name-substring"</c> (whole-query name substring fallback),
+/// <c>"token-or-match"</c> (verbose-query stopword-stripped token-OR fallback).
+/// Documented under <c>semantic-search-duplicate-results-and-fallback-signal</c>.
+/// </param>
 public sealed record SemanticSearchResultDto(
     string SymbolName,
     string SymbolKind,
@@ -11,4 +26,5 @@ public sealed record SemanticSearchResultDto(
     string Signature,
     string? ContainingType,
     string? Namespace,
-    string? SymbolHandle);
+    string? SymbolHandle,
+    string MatchKind);

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -306,11 +306,16 @@ public static class AdvancedAnalysisTools
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var response = await codePatternAnalyzer.SemanticSearchAsync(workspaceId, query, projectName, limit, c);
+            // semantic-search-duplicate-results-and-fallback-signal: project the Debug
+            // payload (parsedTokens / appliedPredicates / fallbackStrategy) so callers
+            // can decode why a verbose natural-language query landed on a particular
+            // strategy. Per-result MatchKind is part of the result rows themselves.
             return JsonSerializer.Serialize(new
             {
                 count = response.Results.Count,
                 results = response.Results,
-                warning = response.Warning
+                warning = response.Warning,
+                debug = response.Debug
             }, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -141,11 +141,19 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var results = new List<SemanticSearchResultDto>();
+        // BUG fix (semantic-search-duplicate-results-and-fallback-signal): partial classes,
+        // multi-targeted projects, and linked source files cause the same ISymbol to be
+        // surfaced via multiple syntax trees / declarations. Walking MemberDeclarationSyntax
+        // node-by-node would emit one row per declaration site. Dedupe by SymbolHandle (the
+        // canonical identifier we already publish) so callers never see the same symbol twice.
+        var seenHandles = new HashSet<string>(StringComparer.Ordinal);
         var projects = ProjectFilterHelper.FilterProjects(solution, projectFilter);
 
         var parse = ParseSemanticQuery(decodedQuery);
         bool Combined(ISymbol s) => parse.Predicates.All(p => p(s));
-        await CollectSemanticSearchMatchesAsync(solution, projects, Combined, limit, results, ct).ConfigureAwait(false);
+        await CollectSemanticSearchMatchesAsync(
+            solution, projects, Combined, limit, results, seenHandles, "structured", ct)
+            .ConfigureAwait(false);
 
         string? warning = null;
         var fallbackStrategy = results.Count > 0 ? "structured" : "none";
@@ -155,7 +163,8 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         {
             var term = decodedQuery.Trim();
             bool NameMatch(ISymbol s) => s.Name.Contains(term, StringComparison.OrdinalIgnoreCase);
-            await CollectSemanticSearchMatchesAsync(solution, projects, NameMatch, limit, results, ct)
+            await CollectSemanticSearchMatchesAsync(
+                solution, projects, NameMatch, limit, results, seenHandles, "name-substring", ct)
                 .ConfigureAwait(false);
             if (results.Count > 0)
             {
@@ -180,7 +189,8 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
                 }
                 return false;
             }
-            await CollectSemanticSearchMatchesAsync(solution, projects, TokenOrMatch, limit, results, ct)
+            await CollectSemanticSearchMatchesAsync(
+                solution, projects, TokenOrMatch, limit, results, seenHandles, "token-or-match", ct)
                 .ConfigureAwait(false);
             if (results.Count > 0)
             {
@@ -208,6 +218,8 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         Func<ISymbol, bool> symbolMatches,
         int limit,
         List<SemanticSearchResultDto> results,
+        HashSet<string> seenHandles,
+        string matchKind,
         CancellationToken ct)
     {
         foreach (var project in projects)
@@ -239,6 +251,9 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
                     if (location is null) continue;
                     var lineSpan = location.GetLineSpan();
 
+                    var handle = SymbolHandleSerializer.CreateHandle(symbol);
+                    if (!seenHandles.Add(handle)) continue;
+
                     results.Add(new SemanticSearchResultDto(
                         symbol.Name,
                         symbol.Kind.ToString(),
@@ -247,7 +262,8 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
                         symbol.ToDisplayString(),
                         symbol.ContainingType?.Name,
                         symbol.ContainingNamespace?.ToDisplayString(),
-                        SymbolHandleSerializer.CreateHandle(symbol)));
+                        handle,
+                        matchKind));
                 }
             }
         }

--- a/tests/RoslynMcp.Tests/SemanticSearchFallbackTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticSearchFallbackTests.cs
@@ -113,4 +113,73 @@ public sealed class SemanticSearchFallbackTests : SharedWorkspaceTestBase
             CollectionAssert.DoesNotContain(response.Debug.ParsedTokens.ToList(), stopword);
         }
     }
+
+    // ── semantic-search-duplicate-results-and-fallback-signal ──
+
+    /// <summary>
+    /// Regression for <c>semantic-search-duplicate-results-and-fallback-signal</c>: partial
+    /// classes, multi-targeted projects, and nested-type traversal previously caused the same
+    /// symbol to be surfaced twice (identical fully-qualified name + identical SymbolHandle).
+    /// The dedupe-by-handle guard added in <c>CollectSemanticSearchMatchesAsync</c> must
+    /// guarantee all returned handles are unique for any query.
+    /// </summary>
+    [TestMethod]
+    public async Task SemanticSearch_StructuredQuery_ResultHandlesAreUnique()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        // Query that exercises the structured path with multiple predicates ("classes" +
+        // "implementing interface"), which is the exact scenario the backlog row called out
+        // (`semantic_search("classes implementing IDisposable")` used to return JobProcessor
+        // twice with identical SymbolHandle).
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId, "classes implementing IDisposable", "SampleLib", 50, CancellationToken.None);
+
+        Assert.IsTrue(response.Results.Count > 0, "Expected at least one IDisposable class.");
+        var handles = response.Results.Select(r => r.SymbolHandle).ToList();
+        var distinct = handles.Distinct(StringComparer.Ordinal).ToList();
+        Assert.AreEqual(handles.Count, distinct.Count,
+            "Each semantic-search result must have a unique SymbolHandle (dedupe guard).");
+    }
+
+    /// <summary>
+    /// Each result must declare which matching strategy produced it via <c>MatchKind</c>.
+    /// Structured-predicate hits report "structured".
+    /// </summary>
+    [TestMethod]
+    public async Task SemanticSearch_StructuredQuery_PerResultMatchKindIsStructured()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId, "classes implementing IDisposable", "SampleLib", 50, CancellationToken.None);
+
+        Assert.IsTrue(response.Results.Count > 0);
+        Assert.IsTrue(
+            response.Results.All(r => r.MatchKind == "structured"),
+            "All structured-query results must report MatchKind == 'structured'.");
+    }
+
+    /// <summary>
+    /// Verbose-query fallback path must propagate "token-or-match" as the per-result MatchKind
+    /// so the caller can see why a particular row showed up.
+    /// </summary>
+    [TestMethod]
+    public async Task SemanticSearch_VerboseQuery_PerResultMatchKindIsTokenOrMatch()
+    {
+        var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+
+        var response = await CodePatternAnalyzer.SemanticSearchAsync(
+            workspaceId,
+            "tell me about the Dog animal type inside the SampleLib namespace please",
+            "SampleLib",
+            50,
+            CancellationToken.None);
+
+        Assert.IsTrue(response.Results.Count > 0);
+        Assert.AreEqual("token-or-match", response.Debug!.FallbackStrategy);
+        Assert.IsTrue(
+            response.Results.All(r => r.MatchKind == "token-or-match"),
+            "All token-or-fallback results must report MatchKind == 'token-or-match'.");
+    }
 }


### PR DESCRIPTION
## Summary
- `semantic_search` now dedupes results by canonical `SymbolHandle` so partial classes / multi-targeted projects / linked files no longer surface the same `ISymbol` twice (the original report: `semantic_search("classes implementing IDisposable")` returned `JobProcessor` twice with identical `fullyQualifiedName` + `symbolHandle`).
- Per-result `MatchKind` (`"structured"` | `"name-substring"` | `"token-or-match"`) added to `SemanticSearchResultDto` so callers can decode which strategy produced each row.
- `AdvancedAnalysisTools.SemanticSearch` now projects the `Debug` payload (`parsedTokens` / `appliedPredicates` / `fallbackStrategy`) into the JSON output — the analyzer already populated it; the tool wrapper was dropping it on the floor.

## Implementation notes
- Dedup key is `SymbolHandle` (the same canonical identifier already returned to callers), shared across all three fallback passes via a single `HashSet<string>`. A symbol that matches both the structured pass AND a fallback pass surfaces only via its first match — and the per-row `MatchKind` reports that.
- DTO field addition is breaking per session policy (no backwards-compat shims); single internal caller updated in the same PR.

## Files
- `src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs` — dedupe HashSet + propagate `matchKind` per fallback pass
- `src/RoslynMcp.Core/Models/SemanticSearchResultDto.cs` — add `MatchKind` (with XML doc)
- `src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs` — project `Debug` to JSON output
- `tests/RoslynMcp.Tests/SemanticSearchFallbackTests.cs` — three regression tests (unique-handle invariant, structured `MatchKind`, token-or-match `MatchKind`)

## Test plan
- [x] `compile_check` clean across `RoslynMcp.Roslyn`, `RoslynMcp.Host.Stdio`, `RoslynMcp.Tests` (Debug)
- [x] Targeted SemanticSearch tests pass (Debug + Release): 13/13
- [x] `verify-ai-docs.ps1` passes
- [ ] CI gate — `verify-release.ps1 -Configuration Release -NoCoverage` on Linux runner (local Windows reruns hit pre-existing flakes in `OrganizeUsings_Preview_Succeeds_After_MidSequence_WorkspaceReload`, `Rename_Summary_Apply_Still_Rewrites_All_References`, `ValidateAsync_SummaryMode_ResponseSmallerThanFullMode`, `LoadAsync_SamePathTenTimes_OnlyOneWorkspaceIsTracked`, `PreviewMultiFile_F17NamespaceCommentBrace_ThrowsWhenSyntaxCheckEnabled` — different subset each run, all pass in isolation, none touch the modified files; main is green on the same Linux gate)

Closes: semantic-search-duplicate-results-and-fallback-signal