### PR TITLE
chore(docs): refresh doc-audit state + restore active sweep ref

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -19,12 +19,11 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-04-24
-- **Last audit mode:** refresh
-- **Next recommended mode:** initial
-- **Next-mode rationale:** 57 commits since last audit (> 50 escalation threshold) AND `ai_docs/backlog.md` now breaches the 4000-token hard cap at ~6972 tokens after the 2026-04-24 audit-intake commit (`233288f`, 44 initiatives). Full initial-mode pass should right-size the backlog (split by priority/owner or archive already-shipped rows) and re-inventory post-1.29.1 doc drift.
+- **Last audit:** 2026-04-25
+- **Last audit mode:** initial
+- **Next recommended mode:** refresh
 - **ai_docs/ file count:** 39
-- **docs/ file count:** 16
+- **docs/ file count:** 14
 - **Agent instruction files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/operational-essentials.md`, `CI_POLICY.md`
 
 ## Structure Compliance
@@ -32,34 +31,35 @@
 | Component | Status | Notes |
 |-----------|--------|-------|
 | AGENTS.md | present | Canonical bootstrap with repo-local MCP bootstrap and in-repo planning-scope routing. |
-| CLAUDE.md | present-pointer | Collapsed pointer to `AGENTS.md`; mirror form removed. |
+| CLAUDE.md | present-pointer | Collapsed pointer to `AGENTS.md`. |
 | .github/copilot-instructions.md | present | Canonical implementation-quality and safety rules. |
 | .cursor/rules/operational-essentials.md | present | Cursor-specific operational overlay still aligned with repo runner/docs flow. |
 | CI_POLICY.md | present | Validation and merge-gating policy. |
 | .mcp.json | present | Declares `roslyn`; AGENTS bootstrap distinguishes declared config from live availability. |
-| ai_docs/README.md | present | Index now covers planning, reports, rollups, prompts, and audit-support files. |
-| ai_docs/architecture.md | present | Current-state architecture reference remains within budget. |
-| ai_docs/backlog.md | present | Scope-tagged, open-only backlog with ISO `updated_at` and Agent contract. |
-| ai_docs/workflow.md | present | Workflow and backlog-closure contract remain current. |
-| ai_docs/runtime.md | present | Runner-first runtime reference; stale fixed-count prose removed. |
+| ai_docs/README.md | present | Index covers planning, reports, rollups, prompts, and audit-support files. |
+| ai_docs/architecture.md | present | Current-state architecture; skill count (31) matches `skills/`. |
+| ai_docs/backlog.md | present | Scope-tagged, open-only backlog with ISO `updated_at`, Agent contract, and active-sweep ref restored. |
+| ai_docs/workflow.md | present | Workflow and backlog-closure contract current. |
+| ai_docs/runtime.md | present | Runner-first runtime reference; env-var table accurate against `Program.cs`. |
 | ai_docs/planning_index.md | present | In-repo planning router with Agent contract, Next-step protocol, and scope routing table. |
-| ai_docs/domains/ | present | Domain references still match the source layout. |
-| ai_docs/references/ | present | Cross-cutting references remain indexed and current. |
+| ai_docs/domains/ | present | Domain references match the source layout. |
+| ai_docs/references/ | present | Cross-cutting references indexed and current. |
 | docs/ | present | Human docs index covers topic files and `.mcp.json` examples. |
 | docs/adr/ | not-needed | No ADR directory in the current docs layout. |
-| runner | present | tool: `just` |
+| runner | present | tool: `just`; required commands (build/test/ci/list) all present. |
 
 ## Size Compliance
 
 | File | Approx tokens | Warn/Cap | Status |
 |------|---------------|----------|--------|
-| README.md | 1224 | 2500/5000 | ok |
-| ai_docs/README.md | 1314 | 2500/4000 | ok |
+| README.md | 1266 | 2500/5000 | ok |
+| ai_docs/README.md | 1291 | 2500/4000 | ok |
 | ai_docs/architecture.md | 876 | 2500/6000 | ok |
-| ai_docs/backlog.md | 6972 | 1500/4000 | **over** |
+| ai_docs/backlog.md | 3120 | 1500/4000 | warn |
 | ai_docs/workflow.md | 524 | 1500/4000 | ok |
 | ai_docs/runtime.md | 2101 | 1500/4000 | warn |
 | ai_docs/planning_index.md | 612 | 2500/5000 | ok |
+| ai_docs/bootstrap-read-tool-primer.md | 2317 | 2500/5000 | ok |
 | docs/README.md | 564 | 800/1600 | ok |
 
 ## Runner
@@ -73,37 +73,44 @@
 - **Legacy runners coexisting:** none
 - **runtime.md references runner:** yes
 
+## Live Surface (verified 2026-04-25)
+
+| Component | Stable | Experimental | Total |
+|-----------|--------|--------------|-------|
+| Tools | 108 | 54 | 162 |
+| Resources | 9 | 4 | 13 |
+| Prompts | 0 | 20 | 20 |
+| Bundled skills | — | — | 31 |
+
+Source: `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog*.cs` tier-string counts; `skills/` directory listing. README.md, ai_docs/architecture.md, and `.claude-plugin/plugin.json` claims all match this catalog count.
+
 ## Known Gaps
 
-- `ai_docs/backlog.md` now exceeds the 4000-token hard cap (~6972 tokens) after the 2026-04-24 audit-intake (commit `233288f`) added 44 initiative rows plus the retro follow-ons. Mitigation options for the next `initial` pass: (a) split by priority (P2/P3/P4 into separate files indexed from the main `backlog.md`), (b) archive already-shipped rows that leaked past the sweep reconcile, (c) compress multi-sentence rows into the terse shape the contract asks for.
-- `ai_docs/runtime.md` is still above the 1500-token warn threshold (~2101 tokens, up from 1892 at the last audit). Keep future additions pointer-heavy or split detailed appendices into `ai_docs/references/`.
-- This repo has no local `ai_docs/ecosystem/` planning router. Cross-project planning requests must rely on explicit external context named by the user.
+- `ai_docs/backlog.md` (~3120 tokens) is over the 1500-token warn threshold but well under the 4000-token hard cap. Down from 6972 tokens at the prior audit (major win after the 20260424T041204Z sweep cleared 41 of 44 intake rows). Further compression risks losing the evidence anchors the rows need to stay planner-ready.
+- `ai_docs/runtime.md` (~2101 tokens) is stable above the 1500-token warn threshold. Future additions should land in `ai_docs/references/` rather than the runtime page.
+- This repo has no local `ai_docs/ecosystem/` planning router. Cross-project planning requests must rely on explicit external context named by the user (planning_index.md and AGENTS.md already say so verbatim).
 
 ## Findings from Last Audit
 
-- **2026-04-24 (refresh):** 57 commits landed since 2026-04-22 (including release 1.29.0 + 1.29.1 and a 44-initiative audit intake). Contract checks pass: AGENTS.md MCP Bootstrap section present, planning_index.md structure intact, AGENTS.md Next-step protocol verbatim with planning_index, backlog `updated_at` is ISO datetime, `just --list` parses cleanly with all 4 required commands (build/test/ci/list). Runner smoke OK. Size check flagged `ai_docs/backlog.md` as newly over the 4000-token hard cap (~6972 tokens, up from 836). Escalated next-mode to `initial`; working tree was dirty so no auto-fixes were applied.
-- **2026-04-22 (initial):** Migrated `.ai-doc-audit.md` to schema 4 and refreshed it to the current repo state, including repo class, declared MCP servers, token budgets, and runner facts.
-- **2026-04-22 (initial):** Rewrote `AGENTS.md` to the canonical bootstrap shape with repo-local `.mcp.json` guidance, planning-scope routing, and explicit conflict precedence; replaced `CLAUDE.md` with the collapsed-pointer form.
-- **2026-04-22 (initial):** Added `ai_docs/planning_index.md`, tagged plan/backlog/reference planning files with scope metadata, added missing purpose comments on live rollups/plans, and aligned sub-indexes so `ai_docs/README.md` and `docs/README.md` cover the current file set.
-- **2026-04-22 (initial):** Reduced `README.md`, `ai_docs/backlog.md`, and `ai_docs/runtime.md` below hard caps; removed stale fixed tool/resource/skill counts from human docs and plugin metadata in favor of live-catalog guidance.
-- **2026-04-22 (initial):** Added repo-local editor MCP config files (`.cursor/mcp.json`, `.vscode/mcp.json`) and ignored `.worktrees/` so local worktree state stays out of future commits.
+- **2026-04-25 (initial):** 31 commits since the 2026-04-24 refresh, including release v1.31.0 and 12 backlog-sweep reconcile batches that closed ~31 PRs. All structure-compliance contracts pass (AGENTS.md MCP Bootstrap, planning_index.md routing, AGENTS.md Next-step protocol verbatim, backlog.md ISO datetime + Agent contract, workflow.md backlog-closure subsection). Surface-count claims in README.md (`162 tools / 13 resources / 20 prompts`, with stable/experimental split `108/54`, `9/4`, `0/20`) verified against `ServerSurfaceCatalog*.cs` tier-string counts. `.claude-plugin/plugin.json` "31 bundled agent skills" matches `skills/` directory count. Restored `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` to backlog.md Refs so the active sweep is discoverable through normal routing. backlog.md size dropped from 6972 to 3120 tokens after sweep closures.
+- **2026-04-24 (refresh):** Detected 57 new commits and a 6972-token backlog after the audit-intake batch, escalated next-mode to `initial`.
+- **2026-04-22 (initial):** Migrated `.ai-doc-audit.md` to schema 4; rewrote AGENTS.md to canonical shape with MCP Bootstrap; replaced CLAUDE.md with collapsed-pointer; added `ai_docs/planning_index.md`; tagged plan/backlog/reference files with scope metadata; reduced over-cap docs.
 
 ## Pruning Summary
 
 | Action | Files affected | Approval |
 |--------|----------------|----------|
-| Replaced deprecated bootstrap chain and mirror form | `AGENTS.md`, `CLAUDE.md` | user-approved |
-| Added planning router plus scope/purpose metadata | `ai_docs/planning_index.md`, `ai_docs/backlog.md`, `ai_docs/plans/**`, `ai_docs/prompts/*backlog*.md`, `ai_docs/prompts/standardize-backlog-hygiene.md`, `ai_docs/procedures/*.md`, `ai_docs/reports/*.md` | user-approved |
-| Rewrote oversize landing/reference docs into budget-compliant forms | `README.md`, `ai_docs/backlog.md`, `ai_docs/runtime.md`, `docs/README.md`, `ai_docs/README.md` | user-approved |
-| Removed stale fixed-count surface claims from docs and plugin metadata | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `docs/setup.md`, `docs/product-contract.md`, `docs/roadmap.md`, `docs/stdio-client-integration.md`, `docs/experimental-promotion-analysis.md`, `ai_docs/references/**` | user-approved |
-| Added editor-local MCP config and ignored local worktree admin directories | `.cursor/mcp.json`, `.vscode/mcp.json`, `.gitignore` | user-approved |
+| Added active sweep plan to backlog.md Refs and bumped `updated_at` | `ai_docs/backlog.md` | auto (low-risk index restore) |
+| Refreshed audit context with current state, sizes, drift findings | `.ai-doc-audit.md` | auto (skill maintenance) |
 
 ## Retention State
 
-- **Audit reports:** 0 files (limit: 3)
-- **Shipped plans pending archival:** none
-- **Shipped reviews pending archival:** none
-- **README.md token budget:** 1224 / 2500 warn / 5000 hard
+- **Audit reports:** 0 audit-report files (limit: 3) — `ai_docs/audit-reports/` contains only persistent reference docs.
+- **Reports rollups:** 4 timestamped deep-review rollups under `ai_docs/reports/` (2026-04-06 to 2026-04-22). No retention rule defined for `reports/` in STANDARD.md; oldest is the 2026-04-06 example file kept intentionally.
+- **Shipped plans pending archival:** none — both backlog-sweep plans are within the 30-day archive window (oldest closed 2026-04-23).
+- **Shipped reviews pending archival:** none.
+- **README.md token budget:** 1266 / 2500 warn / 5000 hard.
+- **review-inbox/:** empty (only `archive/` subfolder for processed batches).
 
 ## Codebase Domains
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-04-25T20:16:32Z
+**updated_at:** 2026-04-25T22:00:00Z
 
 ## Agent contract
 
@@ -68,5 +68,6 @@
 | `docs/large-solution-profiling-baseline.md` | Evidence gate for daemon/process-pool performance work. |
 | `ai_docs/procedures/deep-review-backlog-intake.md` | Intake procedure for future audit batches. |
 | `ai_docs/plans/20260422T223000Z_backlog-sweep/plan.md` | Prior sweep (20260422T223000Z). Shipped 14 initiatives across 14 PRs; closed 9 backlog rows (P2: 0, P3: 4, P4: 5). |
+| `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | Active sweep against the 44-initiative audit-intake batch (5 P2 + 29 P3 + 10 P4). 41 merged / 3 pending as of 2026-04-25; remaining rows above are the open carry-overs. |
 | `review-inbox/` | Staging folder for the NEXT audit batch (flat directory; `/backlog-intake` reads here). |
 | `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches — one subdirectory per successful intake, named by the intake commit's UTC timestamp. Backlog rows citing specific files are anchored here. Batch `20260424T031936Z` holds the 14-file cross-repo audit + retro batch that produced the current rows. Keep until every row sourced from a batch is closed or superseded, then delete that subdirectory. |


### PR DESCRIPTION
## Summary
- Bumps `ai_docs/backlog.md` `updated_at` and adds the active 20260424T041204Z sweep plan to the Refs table.
- Refreshes `.ai-doc-audit.md` findings, sizes, and retention state to reflect the v1.31.0 release + 12-batch sweep landings (backlog dropped 6972 → 3120 tokens).
- Adds verified live-surface count table (108 stable / 54 experimental tools, 9/4 resources, 0/20 prompts, 31 bundled skills) sourced from `ServerSurfaceCatalog*.cs`.

## Test plan
- [x] `git diff` review confirms doc-only edits, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)