### PR TITLE
fix(test-related): broaden service-layer refactor fallback heuristics (test-related-files-service-refactor-underreporting)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -368,6 +368,12 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         var missReasons = new List<string>();
         var anyDocumentResolved = false;
 
+        // test-related-files-service-refactor-underreporting: retain (filePath, document, root)
+        // tuples for the per-file pass so the fallback broadening (namespace-neighbor +
+        // inbound-reference expansion) can re-walk only the documents that resolved without
+        // re-running the FirstOrDefault path lookup.
+        var resolvedDocuments = new List<(string FilePath, Document Document, SyntaxNode Root)>();
+
         foreach (var filePath in filePaths)
         {
             var document = solution
@@ -390,6 +396,7 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             }
 
             anyDocumentResolved = true;
+            resolvedDocuments.Add((filePath, document, root));
 
             var searchTerms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -436,6 +443,50 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             }
         }
 
+        // test-related-files-service-refactor-underreporting: when the file-affinity pass
+        // produced zero matches across every input file but at least one document resolved,
+        // broaden via two 1-hop expansions:
+        //   - inbound-reference: walk SymbolFinder.FindReferencesAsync for each declared type
+        //     in the resolved file(s); test files containing those references are related.
+        //   - namespace-neighbor: collect other types declared in the same namespace as the
+        //     input file's types; rerun the name-affinity match against those neighbor type
+        //     names.
+        // Both run only on the empty-primary-result path so amortized cost stays low.
+        // Multi-file service refactors (e.g. MutationAnalysisService + ScaffoldingService,
+        // CodePatternAnalyzer + TestDiscoveryService) frequently miss because the test
+        // class name doesn't textually contain any input type name; the inbound-reference
+        // sweep recovers them by following actual call sites.
+        var fallbackHeuristicsAttempted = new List<string>();
+        if (testToTriggers.Count == 0 && resolvedDocuments.Count > 0 && allTests.Count > 0)
+        {
+            var testFilePaths = BuildTestFilePathSet(allTests);
+            var (referenceMatches, neighborMatches, fallbackHeuristics) =
+                await CollectFallbackMatchesAsync(resolvedDocuments, solution, allTests, testFilePaths, ct)
+                    .ConfigureAwait(false);
+
+            fallbackHeuristicsAttempted.AddRange(fallbackHeuristics);
+
+            foreach (var (filePath, test) in referenceMatches)
+            {
+                AddTrigger(testToTriggers, test.FullyQualifiedName, filePath);
+                filesThatMatched.Add(filePath);
+            }
+            foreach (var (filePath, test) in neighborMatches)
+            {
+                AddTrigger(testToTriggers, test.FullyQualifiedName, filePath);
+                filesThatMatched.Add(filePath);
+            }
+
+            if (testToTriggers.Count > 0)
+            {
+                // Broadening recovered tests that the primary heuristic missed — emit a
+                // single explanatory miss-reason rather than leaving the per-file
+                // "no name matched" reasons as the only signal.
+                missReasons.Add(
+                    $"primary type-name/file-name affinity matched zero tests; fallback broadening (heuristics: [{string.Join(", ", fallbackHeuristicsAttempted)}]) recovered {testToTriggers.Count} candidate test(s)");
+            }
+        }
+
         var projectLookup = discovery.TestProjects
             .SelectMany(p => p.Tests.Select(t => (t.FullyQualifiedName, p.ProjectName)))
             .ToDictionary(x => x.FullyQualifiedName, x => x.ProjectName, StringComparer.Ordinal);
@@ -463,8 +514,9 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
 
         var dotnetFilter = SynthesizeDotnetTestFilter(results.Select(t => t.FullyQualifiedName));
         var heuristicsAttempted = anyDocumentResolved
-            ? (IReadOnlyList<string>)["type-name", "file-name"]
-            : [];
+            ? new List<string> { "type-name", "file-name" }
+            : new List<string>();
+        heuristicsAttempted.AddRange(fallbackHeuristicsAttempted);
         var diagnostics = new RelatedTestsDiagnosticsDto(
             ScannedTestProjects: discovery.TestProjects.Count,
             HeuristicsAttempted: heuristicsAttempted,
@@ -474,6 +526,264 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
             dotnetFilter,
             new PaginationInfo(Total: total, Returned: results.Count, HasMore: total > results.Count),
             diagnostics);
+    }
+
+    private static void AddTrigger(Dictionary<string, List<string>> testToTriggers, string fqn, string filePath)
+    {
+        if (!testToTriggers.TryGetValue(fqn, out var triggers))
+        {
+            triggers = new List<string>();
+            testToTriggers[fqn] = triggers;
+        }
+        if (!triggers.Contains(filePath, StringComparer.OrdinalIgnoreCase))
+        {
+            triggers.Add(filePath);
+        }
+    }
+
+    private static HashSet<string> BuildTestFilePathSet(
+        IReadOnlyList<(string Project, TestCaseDto Test)> allTests)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (_, test) in allTests)
+        {
+            if (!string.IsNullOrWhiteSpace(test.FilePath))
+            {
+                set.Add(Path.GetFullPath(test.FilePath));
+            }
+        }
+        return set;
+    }
+
+    /// <summary>
+    /// test-related-files-service-refactor-underreporting: fallback broadening when the
+    /// primary type-name/file-name heuristic produced zero matches. Runs two 1-hop
+    /// expansions in parallel:
+    /// <list type="number">
+    ///   <item>
+    ///     <b>inbound-reference</b> — for each type declared in a resolved input file,
+    ///     <see cref="SymbolFinder.FindReferencesAsync"/> locates every call site; tests
+    ///     whose source file path appears in those references are recovered.
+    ///   </item>
+    ///   <item>
+    ///     <b>namespace-neighbor</b> — for each type declared in a resolved input file,
+    ///     other types declared in the same namespace (across the project) are added to
+    ///     the search-term set. The name-affinity match reruns over the test surface using
+    ///     those neighbor type names. Capped at one hop — neighbors of neighbors are not
+    ///     walked, to bound noise.
+    ///   </item>
+    /// </list>
+    /// Results from both expansions are de-duplicated by the caller via <c>AddTrigger</c>.
+    /// </summary>
+    private async Task<(
+        List<(string FilePath, TestCaseDto Test)> ReferenceMatches,
+        List<(string FilePath, TestCaseDto Test)> NeighborMatches,
+        List<string> Heuristics)> CollectFallbackMatchesAsync(
+            IReadOnlyList<(string FilePath, Document Document, SyntaxNode Root)> resolvedDocuments,
+            Solution solution,
+            IReadOnlyList<(string Project, TestCaseDto Test)> allTests,
+            HashSet<string> testFilePaths,
+            CancellationToken ct)
+    {
+        var referenceMatches = new List<(string FilePath, TestCaseDto Test)>();
+        var neighborMatches = new List<(string FilePath, TestCaseDto Test)>();
+        var heuristics = new List<string>();
+
+        var referenceAttempted = false;
+        var neighborAttempted = false;
+
+        foreach (var (filePath, document, root) in resolvedDocuments)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            SemanticModel? semanticModel = null;
+            try
+            {
+                semanticModel = await document.GetSemanticModelAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "FindRelatedTestsForFiles fallback: failed to obtain semantic model for '{FilePath}', skipping symbolic broadening for this file.", filePath);
+                continue;
+            }
+
+            if (semanticModel is null)
+            {
+                continue;
+            }
+
+            var declaredTypeSymbols = new List<INamedTypeSymbol>();
+            foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                if (semanticModel.GetDeclaredSymbol(typeDecl, ct) is INamedTypeSymbol typeSymbol)
+                {
+                    declaredTypeSymbols.Add(typeSymbol);
+                }
+            }
+
+            if (declaredTypeSymbols.Count == 0)
+            {
+                continue;
+            }
+
+            // ── inbound-reference expansion ────────────────────────────────────────────
+            referenceAttempted = true;
+            try
+            {
+                foreach (var typeSymbol in declaredTypeSymbols)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var references = await SymbolFinder.FindReferencesAsync(typeSymbol, solution, ct).ConfigureAwait(false);
+                    var referencedTestFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var refSet in references)
+                    {
+                        foreach (var location in refSet.Locations)
+                        {
+                            var refFilePath = location.Document?.FilePath;
+                            if (string.IsNullOrWhiteSpace(refFilePath))
+                            {
+                                continue;
+                            }
+                            var fullPath = Path.GetFullPath(refFilePath);
+                            if (testFilePaths.Contains(fullPath))
+                            {
+                                referencedTestFiles.Add(fullPath);
+                            }
+                        }
+                    }
+
+                    foreach (var (_, test) in allTests)
+                    {
+                        if (string.IsNullOrWhiteSpace(test.FilePath))
+                        {
+                            continue;
+                        }
+                        if (referencedTestFiles.Contains(Path.GetFullPath(test.FilePath)))
+                        {
+                            referenceMatches.Add((filePath, test));
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Reference sweep is best-effort. Never let it break the heuristic path.
+                _logger.LogWarning(ex, "FindRelatedTestsForFiles fallback inbound-reference sweep failed for '{FilePath}'; continuing with namespace-neighbor expansion.", filePath);
+            }
+
+            // ── namespace-neighbor expansion (1 hop) ───────────────────────────────────
+            neighborAttempted = true;
+            try
+            {
+                var neighborTerms = CollectNamespaceNeighborTerms(declaredTypeSymbols, document.Project);
+
+                if (neighborTerms.Count > 0)
+                {
+                    foreach (var (_, test) in allTests)
+                    {
+                        if (neighborTerms.Any(term =>
+                            test.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                            test.FullyQualifiedName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                            (test.FilePath?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)))
+                        {
+                            neighborMatches.Add((filePath, test));
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "FindRelatedTestsForFiles fallback namespace-neighbor expansion failed for '{FilePath}'; continuing.", filePath);
+            }
+        }
+
+        if (referenceAttempted)
+        {
+            heuristics.Add("inbound-reference");
+        }
+        if (neighborAttempted)
+        {
+            heuristics.Add("namespace-neighbor");
+        }
+
+        return (referenceMatches, neighborMatches, heuristics);
+    }
+
+    /// <summary>
+    /// Collect unqualified type names declared in the same namespace as <paramref name="declaredTypes"/>,
+    /// limited to the same project (1-hop). Excludes the input types themselves so the caller
+    /// can search the test surface for distinct neighbor names. The intent is to recover tests
+    /// for cohesive service refactors — when <c>FooService</c> ships alongside <c>BarService</c>
+    /// in the same namespace, a change touching only <c>FooService</c> should still surface
+    /// tests that exercise <c>BarService</c> if they live next door.
+    /// </summary>
+    private static HashSet<string> CollectNamespaceNeighborTerms(
+        IReadOnlyList<INamedTypeSymbol> declaredTypes,
+        Project project)
+    {
+        var inputTypeNames = new HashSet<string>(declaredTypes.Select(t => t.Name), StringComparer.Ordinal);
+        var inputNamespaceNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var typeSymbol in declaredTypes)
+        {
+            var ns = typeSymbol.ContainingNamespace;
+            if (ns is not null && !ns.IsGlobalNamespace)
+            {
+                inputNamespaceNames.Add(ns.ToDisplayString());
+            }
+        }
+
+        if (inputNamespaceNames.Count == 0)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var neighborTerms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var projectAssembly = project.TryGetCompilation(out var compilation)
+            ? compilation?.Assembly
+            : null;
+
+        if (projectAssembly is not null)
+        {
+            CollectMatchingTypeNamesFromNamespace(projectAssembly.GlobalNamespace, inputNamespaceNames, inputTypeNames, neighborTerms);
+        }
+
+        return neighborTerms;
+    }
+
+    private static void CollectMatchingTypeNamesFromNamespace(
+        INamespaceSymbol namespaceSymbol,
+        IReadOnlySet<string> targetNamespaces,
+        IReadOnlySet<string> exclude,
+        HashSet<string> neighborTerms)
+    {
+        var fullName = namespaceSymbol.IsGlobalNamespace ? string.Empty : namespaceSymbol.ToDisplayString();
+        if (!namespaceSymbol.IsGlobalNamespace && targetNamespaces.Contains(fullName))
+        {
+            foreach (var typeMember in namespaceSymbol.GetTypeMembers())
+            {
+                if (!exclude.Contains(typeMember.Name))
+                {
+                    neighborTerms.Add(typeMember.Name);
+                }
+            }
+        }
+
+        foreach (var nestedNamespace in namespaceSymbol.GetNamespaceMembers())
+        {
+            CollectMatchingTypeNamesFromNamespace(nestedNamespace, targetNamespaces, exclude, neighborTerms);
+        }
     }
 
     private static readonly HashSet<string> TestAttributeNames = new(StringComparer.Ordinal)

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -264,6 +264,106 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
             "ScannedTestProjects must be populated regardless of resolution outcome.");
     }
 
+    // test-related-files-service-refactor-underreporting: pre-fix, the file-affinity heuristic
+    // returned empty for inputs whose declared type names did not textually appear in any
+    // test method/class/file path — even though the inputs are referenced by tests via
+    // semantic dispatch. The cited 2026-04-23 sweep misses were
+    // (`MutationAnalysisService` + `ScaffoldingService`) and
+    // (`CodePatternAnalyzer` + `TestDiscoveryService`); both pairs ship related tests whose
+    // class names do not contain the input service names. Post-fix, when the primary pass
+    // produces zero candidates, the service broadens via an inbound-reference sweep
+    // (SymbolFinder.FindReferencesAsync) and a 1-hop namespace-neighbor expansion. Either
+    // expansion alone is sufficient to recover the test.
+    //
+    // Sample-fixture analogue: `IAnimal.cs` declares only `IAnimal` — no test class, method,
+    // or file path under `samples/SampleSolution/SampleLib.Tests/` contains the substring
+    // "IAnimal". But `AnimalServiceTests.cs` calls `service.GetAllAnimals()` (typed
+    // `List<IAnimal>`), so the inbound-reference sweep on `IAnimal` finds the test file.
+    // Namespace-neighbor expansion also recovers it via `AnimalService` (a sibling type in
+    // namespace `SampleLib`) which IS textually contained in `AnimalServiceTests`.
+    [TestMethod]
+    public async Task FindRelatedTestsForFiles_NameAffinityMissButReferencedByTests_FallbackRecovers()
+    {
+        var iAnimalPath = FindDocumentPath("IAnimal.cs");
+
+        // Sanity guard: pre-fix, the primary pass would produce zero matches because
+        // "IAnimal" is not a substring of any test name/path. We assert the fallback now
+        // recovers AnimalServiceTests.
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = await TestDiscoveryService.FindRelatedTestsForFilesAsync(
+            WorkspaceId,
+            new[] { iAnimalPath },
+            maxResults: 100,
+            CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.IsTrue(result.Tests.Count > 0,
+            $"Fallback broadening should surface at least one related test for IAnimal.cs; got 0. Diagnostics: " +
+            $"scanned={result.Diagnostics.ScannedTestProjects}, " +
+            $"heuristics=[{string.Join(",", result.Diagnostics.HeuristicsAttempted)}], " +
+            $"missReasons=[{string.Join(" | ", result.Diagnostics.MissReasons)}]");
+
+        Assert.IsTrue(result.Tests.Any(t =>
+                t.FilePath?.EndsWith("AnimalServiceTests.cs", StringComparison.OrdinalIgnoreCase) == true),
+            $"Expected AnimalServiceTests.cs to surface via fallback broadening; got: " +
+            $"[{string.Join(", ", result.Tests.Select(t => t.FilePath))}]");
+
+        // Heuristics envelope must report that the fallback heuristics were attempted, so
+        // callers can see why the test surfaced (and distinguish "primary hit" from
+        // "fallback recovery").
+        Assert.IsTrue(
+            result.Diagnostics.HeuristicsAttempted.Contains("inbound-reference") ||
+            result.Diagnostics.HeuristicsAttempted.Contains("namespace-neighbor"),
+            $"At least one fallback heuristic should be reported as attempted; got: " +
+            $"[{string.Join(",", result.Diagnostics.HeuristicsAttempted)}]");
+
+        // Performance guard. Reference sweep + namespace walk on a fixture-sized workspace
+        // (5 projects, ~533 docs) must finish well under 30s. Sample workspace runs with no
+        // contention here typically complete in 1-3s; the cap leaves generous headroom for
+        // CI variance without papering over a regression. The fallback path runs only on
+        // empty-primary-result, so this cost is bounded by definition.
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds < 30_000,
+            $"Fallback broadening took {stopwatch.ElapsedMilliseconds}ms which exceeds the 30s perf budget.");
+    }
+
+    // test-related-files-service-refactor-underreporting: multi-file service-refactor case.
+    // Pre-fix, passing two cohesive source files (the cited example was
+    // `MutationAnalysisService` + `ScaffoldingService`) whose declared type names matched no
+    // test name produced an empty result. Post-fix, the per-file fallback broadening still
+    // runs even when multiple input files miss together — the namespace-neighbor expansion
+    // recovers the related tests via a sibling type in the shared namespace.
+    [TestMethod]
+    public async Task FindRelatedTestsForFiles_MultiFileServiceRefactor_FallbackRecovers()
+    {
+        // Pick two cohesive sample files whose declared type names ("IAnimal", "Cat") do
+        // not textually overlap with the test class name "AnimalServiceTests" or its
+        // method names ("CountAnimals_Returns_Total_Count",
+        // "GetAllAnimals_Returns_Dog_And_Cat"). Note: "Cat" IS a substring of
+        // "GetAllAnimals_Returns_Dog_And_Cat", so the primary pass DOES match Cat.cs alone.
+        // To force the multi-file fallback path here we use IAnimal.cs (a primary-pass miss)
+        // alongside an unrelated input. Namespace-neighbor recovers AnimalServiceTests via
+        // sibling type AnimalService.
+        var iAnimalPath = FindDocumentPath("IAnimal.cs");
+        var animalExtPath = FindDocumentPath("AnimalExtensions.cs");
+
+        var result = await TestDiscoveryService.FindRelatedTestsForFilesAsync(
+            WorkspaceId,
+            new[] { iAnimalPath, animalExtPath },
+            maxResults: 100,
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Tests.Count > 0,
+            $"Multi-file service refactor (IAnimal + AnimalExtensions) should surface at " +
+            $"least one related test via fallback broadening; got 0. Diagnostics: " +
+            $"heuristics=[{string.Join(",", result.Diagnostics.HeuristicsAttempted)}], " +
+            $"missReasons=[{string.Join(" | ", result.Diagnostics.MissReasons)}]");
+
+        Assert.IsTrue(result.Tests.Any(t =>
+                t.FilePath?.EndsWith("AnimalServiceTests.cs", StringComparison.OrdinalIgnoreCase) == true),
+            $"Expected AnimalServiceTests.cs to surface via multi-file fallback broadening; got: " +
+            $"[{string.Join(", ", result.Tests.Select(t => t.FilePath))}]");
+    }
+
     private static string FindDocumentPath(string name)
     {
         var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);


### PR DESCRIPTION
## Summary

When `FindRelatedTestsForFilesAsync` produces zero matches via the primary type-name/file-name affinity heuristic and at least one input document resolved, broaden the search via two 1-hop expansions:

- **inbound-reference**: walk `SymbolFinder.FindReferencesAsync` for each declared type in the resolved input file(s); test files containing those references are recovered as related.
- **namespace-neighbor**: collect other types declared in the same namespace (within the same project) and rerun the name-affinity match against those neighbor type names. Capped at one hop — neighbors of neighbors are not walked, to bound noise.

Both expansions run only on the empty-primary-result path, so amortized cost remains low. The diagnostics envelope's `HeuristicsAttempted` list now reports `inbound-reference` / `namespace-neighbor` when broadening fired, and `MissReasons` records that broadening recovered N candidate test(s).

### Cited 2026-04-23 sweep miss cases (fixtures for this fix)

- `MutationAnalysisService` + `ScaffoldingService` — multi-file service refactor whose test class names did not textually contain either source type name.
- `CodePatternAnalyzer` + `TestDiscoveryService` — same shape.

The sample-workspace analogue used in regression tests is `IAnimal.cs` (no test name/path contains "IAnimal") which `AnimalServiceTests.cs` references via interface dispatch (`service.GetAllAnimals()` returning `List<IAnimal>`).

## Test plan

- [x] New regression test: `FindRelatedTestsForFiles_NameAffinityMissButReferencedByTests_FallbackRecovers` — single-file primary miss; asserts `AnimalServiceTests.cs` is recovered + `HeuristicsAttempted` reports `inbound-reference`/`namespace-neighbor` + 30s perf budget.
- [x] New regression test: `FindRelatedTestsForFiles_MultiFileServiceRefactor_FallbackRecovers` — two-input-file primary miss (`IAnimal.cs` + `AnimalExtensions.cs`); asserts the same recovery.
- [x] All 17 `ValidationToolsIntegrationTests` + `HardeningBehaviorTests` pass on the worktree.
- [x] `eng/verify-release.ps1 -Configuration Release -NoCoverage` passes — 966 / 966 tests green in CI-parity mode.
- [x] `eng/verify-ai-docs.ps1` passes.
- [x] No backwards-compat shims; `shims-added: 0`.

Closes: `test-related-files-service-refactor-underreporting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)