### PR TITLE
chore(backlog): add P4 row for pr-reconciler poll-budget tightness

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-04-25T21:39:34Z
+**updated_at:** 2026-04-25T22:00:36Z
 
 ## Agent contract
 
@@ -52,6 +52,7 @@
 |----|-----|------|-----|
 | `workspace-process-pool-or-daemon` | P4 | `large-solution profile` | Do not start a daemon/process-pool implementation blindly. First capture representative 50+ project timings per `docs/large-solution-profiling-baseline.md`; only if `workspace_load` / reload P95 still blocks daily use after `workspace_warm` should the next plan produce a bounded design note comparing daemon, process-pool, and shared-workspace approaches, including lifecycle and failure-isolation hooks. |
 | `semantic-grep-identifier-scoped-search` | P4 | — | Agents want to grep inside C# code but exclude string/comment matches — current Grep returns hits inside CHANGELOG, markdown, and string literals (3 Roslyn-self-audit sessions in the 2026-04-10→04-24 retro: 57a0d696, 08adc1f1, cf2d0b85). Add `semantic_grep(pattern, scope=identifiers|strings|comments|all, projectFilter?) → [{filePath, line, column, tokenKind, snippet}]` as a thin wrapper on `SyntaxTree.DescendantTokens` + `SyntaxToken.Kind()` + regex match. Anchors: new service under `src/RoslynMcp.Roslyn/Services/`, new tool in `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`. Weaker evidence (3 sessions, all self-audit) — P4 until an external-repo session reproduces the pattern. |
+| `pr-reconciler-poll-budget-tightness` | P4 | — | The `pr-reconciler` subagent's `BLOCKED-with-pending-checks` rule (`.claude/agents/pr-reconciler.md:38`) is "wait 60s, retry once; if still not green, emit STATUS: not-ready and exit" — this gives a ~120s effective ceiling, but this repo's `validate` job (full Release-mode test run) routinely takes 8-12 min. The reconciler returns `not-ready` on every initiative-PR's first dispatch, forcing the orchestrator to bash-poll then re-dispatch (observed twice in the 2026-04-25 sweep: PRs #441 and #442). Either lengthen the poll loop with bounded backoff (e.g. 60s × 12 retries with progress notifications) or replace the early exit with a `gh pr checks --watch`-style block. Anchors: `.claude/agents/pr-reconciler.md` (rule table at L38; gh-failure rule at L107). Keep the early-exit path for genuinely-failing checks — only widen the budget for `IN_PROGRESS`. |
 
 ## Refs
 
@@ -67,6 +68,6 @@
 | `docs/large-solution-profiling-baseline.md` | Evidence gate for daemon/process-pool performance work. |
 | `ai_docs/procedures/deep-review-backlog-intake.md` | Intake procedure for future audit batches. |
 | `ai_docs/plans/20260422T223000Z_backlog-sweep/plan.md` | Prior sweep (20260422T223000Z). Shipped 14 initiatives across 14 PRs; closed 9 backlog rows (P2: 0, P3: 4, P4: 5). |
-| `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | Active sweep against the 44-initiative audit-intake batch (5 P2 + 29 P3 + 10 P4). 41 merged / 3 pending as of 2026-04-25; remaining rows above are the open carry-overs. |
+| `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | Closed sweep against the 44-initiative audit-intake batch (5 P2 + 29 P3 + 10 P4). 42 merged / 2 deferred as of 2026-04-25 — `ci-test-parallelization-audit` (dedicated phased plan) and `workspace-process-pool-or-daemon` (heroic-last, profile-evidence gated). Remaining open rows above are carry-overs from the audit batch + new entries. |
 | `review-inbox/` | Staging folder for the NEXT audit batch (flat directory; `/backlog-intake` reads here). |
 | `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches — one subdirectory per successful intake, named by the intake commit's UTC timestamp. Backlog rows citing specific files are anchored here. Batch `20260424T031936Z` holds the 14-file cross-repo audit + retro batch that produced the current rows. Keep until every row sourced from a batch is closed or superseded, then delete that subdirectory. |


### PR DESCRIPTION
## Summary

Adds backlog row `pr-reconciler-poll-budget-tightness` (P4) capturing the recurring friction observed in the 2026-04-25 backlog sweep: the `pr-reconciler` subagent's BLOCKED-with-pending-checks rule (`wait 60s, retry once`) gives a ~120s effective ceiling, but this repo's `validate` job routinely takes 8-12 min. Forces a bash-poll + re-dispatch round-trip on every initiative-PR.

Also refreshes the Refs row for the 20260424T041204Z sweep — now closed at 42 merged / 2 deferred.

## Test plan

- [x] `git diff` confirms doc-only edit (one P4 row + one Refs line + `updated_at` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)