### PR TITLE
docs(pr-reconciler): widen pending-checks poll budget to 12×60s

### DIFF
--- a/.claude/agents/pr-reconciler.md
+++ b/.claude/agents/pr-reconciler.md
@@ -35,7 +35,7 @@ Decision table:
 | Condition | Action | `MERGED_BY` in report |
 |---|---|---|
 | `state == "OPEN"` AND `mergeable == "MERGEABLE"` AND `mergeStateStatus == "CLEAN"` | proceed to step 2 | `pr-reconciler` |
-| `mergeStateStatus == "BLOCKED"` due to pending checks | wait 60s, retry once; if still not green, emit `STATUS: not-ready` and exit | — |
+| `mergeStateStatus == "BLOCKED"` due to pending checks | wait 60s, retry up to 12 times (12-min ceiling) with a one-line progress notification between attempts (e.g. `still pending after Nm — retry K/12`); if still not green after 12 retries, emit `STATUS: not-ready` and exit. Any check transitioning to `fail`/`error` during the loop short-circuits to the failing-check row below — the 12×60s budget is ONLY for `IN_PROGRESS` / `PENDING` checks. | — |
 | Any check is failing | emit `STATUS: not-ready` with the failing check names and exit | — |
 | `reviewDecision == "CHANGES_REQUESTED"` | emit `STATUS: not-ready` (review gate) and exit | — |
 | `state == "MERGED"` (pre-existing) | **skip the `gh pr merge` call entirely**; proceed to step 3 (cleanup only) | `preexisting` (capture `mergeCommit.oid` as `MERGE_SHA`) |


### PR DESCRIPTION
## Summary

Replaces the `BLOCKED-with-pending-checks` rule in `.claude/agents/pr-reconciler.md`'s decision table with a bounded backoff loop:

- **Before:** "wait 60s, retry once; if still not green, emit `STATUS: not-ready` and exit" → ~120s effective ceiling.
- **After:** "wait 60s, retry up to 12 times (12-min ceiling) with a one-line progress notification between attempts; if still not green after 12 retries, emit `STATUS: not-ready`."

The old 120s ceiling was too tight for typical CI on this repo — `verify-release.ps1` + `verify-ai-docs.ps1` commonly run 3-8 min in sequence — causing reconcilers to bail with `not-ready` while CI was still healthy and progressing. 12 minutes covers the realistic upper bound while still bounding the wait.

The early-exit path for failing checks is unchanged: any check transitioning to `fail`/`error` short-circuits to the existing `Any check is failing` row immediately below — the 12×60s budget applies ONLY to `IN_PROGRESS` / `PENDING` checks. The new row text now spells this out explicitly.

## Scope

- **Touched:** 1 file, 1 line.
  - `.claude/agents/pr-reconciler.md` — single rule-table row updated (L38).
- **Verified untouched:** L107 (`gh-failure rule`) — that rule covers `gh pr view` itself failing (network / auth / rate limit), a distinct concern from check-pending polling, so its `retry once after 5s` semantics correctly remain.

## Test plan

- [x] YAML frontmatter still parses (lines 1-5 intact).
- [x] Markdown table structure preserved (3-column, header separator on L36, 6 data rows L37-42 — unchanged count).
- [x] Grep sweep — no leftover `retry once` / `120s` / similar stale text in the pending-checks context.
- [x] Manual diff inspection — single-line change, exactly the row called out in the plan.
- [ ] Live verification of the new 12-retry behavior will occur naturally when the next pr-reconciler subagent runs against a PR with pending checks. No code-path test exists for prose-only agent definitions.

Closes: pr-reconciler-poll-budget-tightness