### PR TITLE
feat(tools): cross-MCP-server tool aliases (roslyn-mcp-sister-tool-name-aliases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **162 tools** (108 stable / 54 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **165 tools** (111 stable / 54 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
@@ -47,5 +47,7 @@ public static partial class ServerSurfaceCatalog
         Tool("get_operations", "advanced-analysis", "stable", true, false, "Get the IOperation tree for behavioral analysis at a source position."),
         Tool("analyze_snippet", "analysis", "stable", true, false, "Analyze a C# code snippet in an ephemeral workspace without loading a solution."),
         Tool("verify_pragma_suppresses", "validation", "stable", true, false, "Verify an existing #pragma warning disable/restore pair covers a fire line."),
+        Tool("find_duplicated_code", "advanced-analysis", "stable", true, false, "Alias for find_duplicated_methods (cross-MCP-server name compatibility)."),
+        Tool("get_test_coverage_map", "validation", "stable", false, false, "Alias for test_coverage (cross-MCP-server name compatibility)."),
     ];
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
@@ -21,5 +21,6 @@ public static partial class ServerSurfaceCatalog
         Tool("enclosing_symbol", "symbols", "stable", true, false, "Return the enclosing symbol for a source position."),
         Tool("goto_type_definition", "symbols", "stable", true, false, "Navigate from a symbol usage to its type definition."),
         Tool("get_completions", "symbols", "stable", true, false, "Return IntelliSense-style completion items at a position."),
+        Tool("get_symbol_outline", "symbols", "stable", true, false, "Alias for document_symbols (cross-MCP-server name compatibility)."),
     ];
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -263,7 +263,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicated_methods", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find clusters of near-duplicate method bodies by AST-normalized hash."),
-     Description("Find clusters of method bodies whose AST-normalized structure is identical (or very close) — surfaces internal copy-paste that should be extracted to a shared helper. Normalization strips trivia, renames locals/parameters to ordinal placeholders, and compares the canonical SyntaxKind sequence, so cosmetic differences (formatting, local names, parameter names) don't affect bucketing. Overloads with identical bodies cluster; overloads with different bodies do not (bucketing is by body-shape, not method name). Auto-generated files (.g.cs, .Designer.cs, obj/), abstract declarations, and partial methods without bodies are excluded. Tune `minLines` up to reduce noise (default 10); narrow `projectFilter` for large solutions. `similarityThreshold` gates exact-structural matches only in the current implementation — near-miss bucketing is reserved for a future iteration, so any value in [0,1] behaves the same as 1.0.")]
+     Description("Find clusters of method bodies whose AST-normalized structure is identical (or very close) — surfaces internal copy-paste that should be extracted to a shared helper. Normalization strips trivia, renames locals/parameters to ordinal placeholders, and compares the canonical SyntaxKind sequence, so cosmetic differences (formatting, local names, parameter names) don't affect bucketing. Overloads with identical bodies cluster; overloads with different bodies do not (bucketing is by body-shape, not method name). Auto-generated files (.g.cs, .Designer.cs, obj/), abstract declarations, and partial methods without bodies are excluded. Tune `minLines` up to reduce noise (default 10); narrow `projectFilter` for large solutions. `similarityThreshold` gates exact-structural matches only in the current implementation — near-miss bucketing is reserved for a future iteration, so any value in [0,1] behaves the same as 1.0. Response shape: { count, groups, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. find_duplicated_code).")]
     public static Task<string> FindDuplicatedMethods(
         IWorkspaceExecutionGate gate,
         IDuplicateMethodDetectorService duplicateMethodDetectorService,
@@ -272,6 +272,22 @@ public static class AdvancedAnalysisTools
         [Description("Structural similarity threshold in [0.0, 1.0] (default: 0.85). Exact structural duplicates score 1.0; the current implementation reports only exact-structural matches, so any value <= 1.0 behaves identically.")] double similarityThreshold = 0.85,
         [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
         [Description("Maximum number of groups to return (default: 50).")] int limit = 50,
+        CancellationToken ct = default)
+    {
+        return FindDuplicatedMethodsCore(gate, duplicateMethodDetectorService, workspaceId, minLines, similarityThreshold, projectFilter, limit, deprecation: null, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: shared core invoked by both the canonical
+    // `find_duplicated_methods` tool and the `find_duplicated_code` alias.
+    internal static Task<string> FindDuplicatedMethodsCore(
+        IWorkspaceExecutionGate gate,
+        IDuplicateMethodDetectorService duplicateMethodDetectorService,
+        string workspaceId,
+        int minLines,
+        double similarityThreshold,
+        string? projectFilter,
+        int limit,
+        ToolAliasDeprecation? deprecation,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
@@ -286,8 +302,40 @@ public static class AdvancedAnalysisTools
                     Limit = limit
                 },
                 c);
-            return JsonSerializer.Serialize(new { count = results.Count, groups = results }, JsonDefaults.Indented);
+            return JsonSerializer.Serialize(new { count = results.Count, groups = results, deprecation }, JsonDefaults.Indented);
         }, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
+    // (Jedi) tool name `find_duplicated_code`. The plan-document evidence cites both
+    // `find_duplicated_methods` and `find_duplicate_helpers` as candidate canonicals; the
+    // broader semantic match is `find_duplicated_methods` (clusters of internal copy-paste),
+    // so the alias delegates there. Callers wanting the BCL/NuGet-wrapper detection should
+    // call `find_duplicate_helpers` directly.
+    [McpServerTool(Name = "find_duplicated_code", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("advanced-analysis", "stable", true, false,
+        "Alias for find_duplicated_methods (cross-MCP-server name compatibility)."),
+     Description("Alias for `find_duplicated_methods` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical find_duplicated_methods response envelope ({ count, groups, deprecation }) with deprecation.canonicalName populated. Note: the python-refactor server has only one duplicate-detection tool while this server has two — `find_duplicated_methods` (clusters of internal copy-paste, picked here as the broader match) and `find_duplicate_helpers` (private/internal helpers that re-wrap a BCL/NuGet symbol). Call those canonicals directly when you need the targeted shape.")]
+    public static Task<string> FindDuplicatedCode(
+        IWorkspaceExecutionGate gate,
+        IDuplicateMethodDetectorService duplicateMethodDetectorService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Minimum body line count for a method to be considered (default: 10).")] int minLines = 10,
+        [Description("Structural similarity threshold in [0.0, 1.0] (default: 0.85).")] double similarityThreshold = 0.85,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Maximum number of groups to return (default: 50).")] int limit = 50,
+        CancellationToken ct = default)
+    {
+        return FindDuplicatedMethodsCore(
+            gate,
+            duplicateMethodDetectorService,
+            workspaceId,
+            minLines,
+            similarityThreshold,
+            projectFilter,
+            limit,
+            ToolAliasDeprecation.ForSisterAlias("find_duplicated_methods"),
+            ct);
     }
 
     [McpServerTool(Name = "semantic_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -152,7 +152,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree")]
+    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree. Response shape: { count, symbols, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. get_symbol_outline).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "List declared symbols in a document.")]
     public static Task<string> GetDocumentSymbols(
@@ -163,12 +163,52 @@ public static class SymbolTools
         [Description("Absolute path to the source file")] string filePath,
         CancellationToken ct = default)
     {
+        return GetDocumentSymbolsCore(server, gate, symbolSearchService, workspaceId, filePath, deprecation: null, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: shared core invoked by both the canonical
+    // `document_symbols` tool and the `get_symbol_outline` alias. The alias passes a populated
+    // `deprecation` envelope so callers can see the canonical name inline; the canonical method
+    // passes `null` so the response schema always carries the field.
+    internal static Task<string> GetDocumentSymbolsCore(
+        McpServer server,
+        IWorkspaceExecutionGate gate,
+        ISymbolSearchService symbolSearchService,
+        string workspaceId,
+        string filePath,
+        ToolAliasDeprecation? deprecation,
+        CancellationToken ct = default)
+    {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
             var results = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, c);
-            return JsonSerializer.Serialize(new { count = results.Count, symbols = results }, JsonDefaults.Indented);
+            return JsonSerializer.Serialize(new { count = results.Count, symbols = results, deprecation }, JsonDefaults.Indented);
         }, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
+    // (Jedi) tool name `get_symbol_outline`. Delegates to the canonical `document_symbols`
+    // implementation and surfaces the migration path inline via the `deprecation` envelope.
+    [McpServerTool(Name = "get_symbol_outline", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Alias for `document_symbols` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical document_symbols response envelope ({ count, symbols, deprecation }) with deprecation.canonicalName populated. Prefer `document_symbols` directly in new code.")]
+    [McpToolMetadata("symbols", "stable", true, false,
+        "Alias for document_symbols (cross-MCP-server name compatibility).")]
+    public static Task<string> GetSymbolOutline(
+        McpServer server,
+        IWorkspaceExecutionGate gate,
+        ISymbolSearchService symbolSearchService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Absolute path to the source file")] string filePath,
+        CancellationToken ct = default)
+    {
+        return GetDocumentSymbolsCore(
+            server,
+            gate,
+            symbolSearchService,
+            workspaceId,
+            filePath,
+            ToolAliasDeprecation.ForSisterAlias("document_symbols"),
+            ct);
     }
 
     [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find overriding members for a virtual, abstract, or interface member. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) now surface with FilePath=null so count matches member_hierarchy.")]

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -16,13 +16,31 @@ public static class TestCoverageTools
     [McpServerTool(Name = "test_coverage", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("validation", "stable", false, false,
         "Run coverage collection for test execution."),
-     Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires coverlet.collector NuGet package in test projects.")]
+     Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires coverlet.collector NuGet package in test projects. Response shape is the TestCoverageResultDto fields (success, error, lineCoveragePercent, branchCoveragePercent, modules, failureEnvelope) with an additional top-level `deprecation` field — null on the canonical tool, populated on aliases (e.g. get_test_coverage_map).")]
     public static Task<string> RunTestCoverage(
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
         IDotnetCommandRunner commandRunner,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: specific test project name")] string? projectName = null,
+        IProgress<ProgressNotificationValue>? progress = null,
+        CancellationToken ct = default)
+    {
+        return RunTestCoverageCore(gate, workspace, commandRunner, workspaceId, projectName, deprecation: null, progress, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: shared core invoked by both the canonical
+    // `test_coverage` tool and the `get_test_coverage_map` alias. Wraps the
+    // <see cref="TestCoverageResultDto"/> in an anonymous envelope so the same JSON shape
+    // can carry the `deprecation` field on every emit path (success, coverlet-missing
+    // short-circuit, post-run no-coverage-file fallback).
+    internal static Task<string> RunTestCoverageCore(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceManager workspace,
+        IDotnetCommandRunner commandRunner,
+        string workspaceId,
+        string? projectName,
+        ToolAliasDeprecation? deprecation,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
@@ -49,7 +67,7 @@ public static class TestCoverageTools
                 ProgressHelper.Report(progress, 1, 1);
                 var summary = $"Coverlet missing: {testProjectsLackingCoverlet.Count} test project(s) don't reference coverlet.collector. " +
                     $"Install via `dotnet add package coverlet.collector` in: {string.Join(", ", testProjectsLackingCoverlet)}.";
-                return JsonSerializer.Serialize(new TestCoverageResultDto(
+                return SerializeWithDeprecation(new TestCoverageResultDto(
                     Success: false,
                     Error: summary,
                     LineCoveragePercent: null,
@@ -59,7 +77,7 @@ public static class TestCoverageTools
                         ErrorKind: "CoverletMissing",
                         IsRetryable: false,
                         Summary: summary,
-                        MissingPackages: testProjectsLackingCoverlet)), JsonDefaults.Indented);
+                        MissingPackages: testProjectsLackingCoverlet)), deprecation);
             }
 
             var arguments = new List<string>
@@ -87,7 +105,7 @@ public static class TestCoverageTools
                 var summary = !execution.Succeeded
                     ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found."
                     : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.";
-                return JsonSerializer.Serialize(new TestCoverageResultDto(
+                return SerializeWithDeprecation(new TestCoverageResultDto(
                     Success: false,
                     Error: summary,
                     LineCoveragePercent: null,
@@ -96,14 +114,59 @@ public static class TestCoverageTools
                     FailureEnvelope: new TestCoverageFailureEnvelopeDto(
                         ErrorKind: errorKind,
                         IsRetryable: errorKind == "TestFailure",
-                        Summary: summary)), JsonDefaults.Indented);
+                        Summary: summary)), deprecation);
             }
 
             var latestCoverage = coverageFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
             var result = ParseCoberturaXml(latestCoverage);
             ProgressHelper.Report(progress, 1, 1);
-            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            return SerializeWithDeprecation(result, deprecation);
         }, ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
+    // (Jedi) tool name `get_test_coverage_map`. Delegates to the canonical `test_coverage`
+    // implementation and surfaces the migration path inline via the `deprecation` envelope.
+    [McpServerTool(Name = "get_test_coverage_map", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
+     McpToolMetadata("validation", "stable", false, false,
+        "Alias for test_coverage (cross-MCP-server name compatibility)."),
+     Description("Alias for `test_coverage` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical test_coverage response envelope with deprecation.canonicalName populated. Prefer `test_coverage` directly in new code.")]
+    public static Task<string> GetTestCoverageMap(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceManager workspace,
+        IDotnetCommandRunner commandRunner,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: specific test project name")] string? projectName = null,
+        IProgress<ProgressNotificationValue>? progress = null,
+        CancellationToken ct = default)
+    {
+        return RunTestCoverageCore(
+            gate,
+            workspace,
+            commandRunner,
+            workspaceId,
+            projectName,
+            ToolAliasDeprecation.ForSisterAlias("test_coverage"),
+            progress,
+            ct);
+    }
+
+    // roslyn-mcp-sister-tool-name-aliases: project the TestCoverageResultDto's record fields
+    // onto an anonymous envelope so we can splice the top-level `deprecation` field without
+    // mutating the DTO record (which is part of the Core models surface). Field names are
+    // emitted lower-camel-cased to match the rest of the JSON the tool emits via JsonDefaults.
+    private static string SerializeWithDeprecation(TestCoverageResultDto result, ToolAliasDeprecation? deprecation)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            success = result.Success,
+            error = result.Error,
+            lineCoveragePercent = result.LineCoveragePercent,
+            branchCoveragePercent = result.BranchCoveragePercent,
+            modules = result.Modules,
+            failureEnvelope = result.FailureEnvelope,
+            deprecation,
+        }, JsonDefaults.Indented);
     }
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolAliasDeprecation.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolAliasDeprecation.cs
@@ -1,0 +1,24 @@
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// roslyn-mcp-sister-tool-name-aliases: response-envelope payload published on every alias-tool
+/// JSON response (and emitted as <c>null</c> on the canonical tool's response so the schema
+/// always carries the field). When non-null, <see cref="CanonicalName"/> is the underlying
+/// MCP tool the agent should migrate to; <see cref="Reason"/> documents why the alias exists.
+/// </summary>
+/// <param name="CanonicalName">The canonical MCP tool name the alias delegates to.</param>
+/// <param name="Reason">Short human-readable explanation of why the alias is published.</param>
+internal sealed record ToolAliasDeprecation(string CanonicalName, string Reason)
+{
+    /// <summary>
+    /// Standard reason text for sister-server-name aliases. Centralized so every alias method
+    /// emits the same message and a single edit propagates to the whole alias surface.
+    /// </summary>
+    public const string SisterServerReason = "alias for cross-MCP-server name compatibility";
+
+    /// <summary>
+    /// Build a sister-server alias deprecation envelope for the given canonical tool name.
+    /// </summary>
+    public static ToolAliasDeprecation ForSisterAlias(string canonicalName) =>
+        new(canonicalName, SisterServerReason);
+}

--- a/tests/RoslynMcp.Tests/AliasToolsTests.cs
+++ b/tests/RoslynMcp.Tests/AliasToolsTests.cs
@@ -1,0 +1,269 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// roslyn-mcp-sister-tool-name-aliases: covers the cross-MCP-server alias tools
+/// (<c>get_symbol_outline</c>, <c>find_duplicated_code</c>, <c>get_test_coverage_map</c>)
+/// that delegate to canonical Roslyn MCP tools (<c>document_symbols</c>,
+/// <c>find_duplicated_methods</c>, <c>test_coverage</c>).
+///
+/// Two-part contract:
+///   1. The alias's response payload (minus <c>deprecation</c>) is byte-identical to the
+///      canonical's response payload (minus <c>deprecation</c>) — so callers see no
+///      observable behavior difference.
+///   2. The <c>deprecation</c> field is always present in the schema. It is
+///      <c>{ canonicalName, reason }</c> on the alias and JSON <c>null</c> on the canonical.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class AliasToolsTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    private static string FindDocumentPath(string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        return solution.Projects
+            .SelectMany(project => project.Documents)
+            .First(document => document.Name == name).FilePath!;
+    }
+
+    [TestMethod]
+    public async Task GetSymbolOutline_Alias_ReturnsSamePayloadAsDocumentSymbols_PlusDeprecation()
+    {
+        var dogFile = FindDocumentPath("Dog.cs");
+
+        var canonicalJson = await SymbolTools.GetDocumentSymbols(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            filePath: dogFile,
+            ct: CancellationToken.None);
+
+        var aliasJson = await SymbolTools.GetSymbolOutline(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            filePath: dogFile,
+            ct: CancellationToken.None);
+
+        AssertAliasParity(
+            canonicalJson,
+            aliasJson,
+            sharedFields: ["count", "symbols"],
+            expectedCanonicalName: "document_symbols");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicatedCode_Alias_ReturnsSamePayloadAsFindDuplicatedMethods_PlusDeprecation()
+    {
+        var canonicalJson = await AdvancedAnalysisTools.FindDuplicatedMethods(
+            gate: WorkspaceExecutionGate,
+            duplicateMethodDetectorService: ServiceContainer.DuplicateMethodDetectorService,
+            workspaceId: WorkspaceId,
+            minLines: 10,
+            similarityThreshold: 0.85,
+            projectFilter: null,
+            limit: 50,
+            ct: CancellationToken.None);
+
+        var aliasJson = await AdvancedAnalysisTools.FindDuplicatedCode(
+            gate: WorkspaceExecutionGate,
+            duplicateMethodDetectorService: ServiceContainer.DuplicateMethodDetectorService,
+            workspaceId: WorkspaceId,
+            minLines: 10,
+            similarityThreshold: 0.85,
+            projectFilter: null,
+            limit: 50,
+            ct: CancellationToken.None);
+
+        AssertAliasParity(
+            canonicalJson,
+            aliasJson,
+            sharedFields: ["count", "groups"],
+            expectedCanonicalName: "find_duplicated_methods");
+    }
+
+    [TestMethod]
+    public async Task GetTestCoverageMap_Alias_ReturnsSamePayloadAsTestCoverage_PlusDeprecation()
+    {
+        // The sample test project does not reference coverlet.collector — both calls hit the
+        // CoverletMissing short-circuit BEFORE invoking `dotnet test`, so this stays a fast
+        // deterministic comparison instead of running the actual test suite twice.
+        var canonicalJson = await TestCoverageTools.RunTestCoverage(
+            gate: WorkspaceExecutionGate,
+            workspace: WorkspaceManager,
+            commandRunner: DotnetCommandRunner,
+            workspaceId: WorkspaceId,
+            projectName: "SampleLib.Tests",
+            progress: null,
+            ct: CancellationToken.None);
+
+        var aliasJson = await TestCoverageTools.GetTestCoverageMap(
+            gate: WorkspaceExecutionGate,
+            workspace: WorkspaceManager,
+            commandRunner: DotnetCommandRunner,
+            workspaceId: WorkspaceId,
+            projectName: "SampleLib.Tests",
+            progress: null,
+            ct: CancellationToken.None);
+
+        AssertAliasParity(
+            canonicalJson,
+            aliasJson,
+            sharedFields: ["success", "error", "lineCoveragePercent", "branchCoveragePercent", "modules", "failureEnvelope"],
+            expectedCanonicalName: "test_coverage");
+    }
+
+    [TestMethod]
+    public void Catalog_RegistersAllThreeAliases()
+    {
+        // The catalog-parity test (SurfaceCatalogTests) confirms the [McpServerTool] surface
+        // matches ServerSurfaceCatalog.Tools by name. This test pins the existence + tier of
+        // each alias so a refactor that drops one fails here with a focused message instead
+        // of a "set differs" message buried in the parity test.
+        var aliases = new[]
+        {
+            ("get_symbol_outline", "symbols"),
+            ("find_duplicated_code", "advanced-analysis"),
+            ("get_test_coverage_map", "validation"),
+        };
+
+        foreach (var (name, category) in aliases)
+        {
+            var entry = RoslynMcp.Host.Stdio.Catalog.ServerSurfaceCatalog.Tools
+                .SingleOrDefault(t => t.Name == name);
+            Assert.IsNotNull(entry, $"Alias tool '{name}' missing from ServerSurfaceCatalog.");
+            Assert.AreEqual("stable", entry!.SupportTier,
+                $"Alias '{name}' must be stable (matches the canonical tool's tier).");
+            Assert.AreEqual(category, entry.Category,
+                $"Alias '{name}' must land in the canonical tool's catalog category.");
+        }
+    }
+
+    [TestMethod]
+    public async Task DocumentSymbols_Canonical_ReturnsDeprecationNull()
+    {
+        // The canonical tool MUST emit `deprecation: null` so the response schema is
+        // identical to the alias shape — clients can read deprecation unconditionally.
+        var dogFile = FindDocumentPath("Dog.cs");
+
+        var json = await SymbolTools.GetDocumentSymbols(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            filePath: dogFile,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("deprecation", out var deprecation),
+            "Canonical document_symbols must publish a `deprecation` field (even when null).");
+        Assert.AreEqual(JsonValueKind.Null, deprecation.ValueKind,
+            "Canonical document_symbols `deprecation` must serialize as JSON null.");
+    }
+
+    [TestMethod]
+    public async Task GetSymbolOutline_Alias_DeprecationFieldShape()
+    {
+        // Pin the deprecation envelope shape: { canonicalName, reason }.
+        var dogFile = FindDocumentPath("Dog.cs");
+
+        var json = await SymbolTools.GetSymbolOutline(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            filePath: dogFile,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("deprecation", out var deprecation));
+        Assert.AreEqual(JsonValueKind.Object, deprecation.ValueKind);
+        Assert.AreEqual("document_symbols", deprecation.GetProperty("canonicalName").GetString());
+        Assert.AreEqual(
+            "alias for cross-MCP-server name compatibility",
+            deprecation.GetProperty("reason").GetString());
+    }
+
+    /// <summary>
+    /// Project the canonical and alias payloads onto only the shared (non-deprecation) fields
+    /// and assert the JSON is byte-equal. This pins the contract that "the alias is the
+    /// canonical plus a deprecation envelope" — no semantic divergence is allowed.
+    /// </summary>
+    private static void AssertAliasParity(
+        string canonicalJson,
+        string aliasJson,
+        string[] sharedFields,
+        string expectedCanonicalName)
+    {
+        using var canonicalDoc = JsonDocument.Parse(canonicalJson);
+        using var aliasDoc = JsonDocument.Parse(aliasJson);
+
+        // Field-by-field equality on the shared subset. Comparing rendered RawText avoids
+        // floating-point/format jitter and matches what the wire delivers.
+        foreach (var field in sharedFields)
+        {
+            Assert.IsTrue(canonicalDoc.RootElement.TryGetProperty(field, out var canonicalField),
+                $"Canonical response missing expected field '{field}'.");
+            Assert.IsTrue(aliasDoc.RootElement.TryGetProperty(field, out var aliasField),
+                $"Alias response missing expected field '{field}'.");
+            Assert.AreEqual(
+                canonicalField.GetRawText(),
+                aliasField.GetRawText(),
+                $"Field '{field}' diverges between canonical and alias responses.");
+        }
+
+        // Canonical must publish deprecation=null; alias must publish a populated envelope.
+        Assert.IsTrue(canonicalDoc.RootElement.TryGetProperty("deprecation", out var canonicalDep));
+        Assert.AreEqual(JsonValueKind.Null, canonicalDep.ValueKind,
+            "Canonical response must emit deprecation=null.");
+
+        Assert.IsTrue(aliasDoc.RootElement.TryGetProperty("deprecation", out var aliasDep));
+        Assert.AreEqual(JsonValueKind.Object, aliasDep.ValueKind,
+            "Alias response must emit a populated deprecation object.");
+        Assert.AreEqual(expectedCanonicalName,
+            aliasDep.GetProperty("canonicalName").GetString());
+        Assert.AreEqual(
+            "alias for cross-MCP-server name compatibility",
+            aliasDep.GetProperty("reason").GetString());
+    }
+
+    /// <summary>
+    /// The shared <see cref="TestServiceContainer"/> doesn't currently publish
+    /// <see cref="DuplicateMethodDetectorService"/> (it's only consumed by the
+    /// <see cref="DuplicateMethodDetectorTests"/> set, which builds its own AdhocWorkspace).
+    /// Construct it locally against the existing shared <see cref="TestBase.WorkspaceManager"/>
+    /// so the alias parity test can invoke the canonical tool wrapper without changing the
+    /// shared infrastructure.
+    /// </summary>
+    private static class ServiceContainer
+    {
+        private static readonly Lazy<DuplicateMethodDetectorService> s_dup = new(() =>
+        {
+            var compilationCache = new CompilationCache(WorkspaceManager);
+            return new DuplicateMethodDetectorService(
+                WorkspaceManager,
+                compilationCache,
+                NullLogger<DuplicateMethodDetectorService>.Instance);
+        });
+
+        public static DuplicateMethodDetectorService DuplicateMethodDetectorService => s_dup.Value;
+    }
+}


### PR DESCRIPTION
## Summary

Closes: `roslyn-mcp-sister-tool-name-aliases`

Register three first-class `[McpServerTool]` aliases that delegate to existing canonical Roslyn MCP tools, so agents migrating from the python-refactor (Jedi) MCP server land on the right tool instead of hitting `<tool_use_error>No such tool available: mcp__roslyn__<name>`:

| Alias                  | Canonical                | Tools file               | Catalog partial                            |
| ---------------------- | ------------------------ | ------------------------ | ------------------------------------------ |
| `get_symbol_outline`   | `document_symbols`       | `SymbolTools.cs`         | `ServerSurfaceCatalog.Symbols.cs`          |
| `find_duplicated_code` | `find_duplicated_methods` | `AdvancedAnalysisTools.cs` | `ServerSurfaceCatalog.Analysis.cs`        |
| `get_test_coverage_map` | `test_coverage`          | `TestCoverageTools.cs`   | `ServerSurfaceCatalog.Analysis.cs`        |

`find_duplicated_code` could plausibly map to either `find_duplicated_methods` or `find_duplicate_helpers`. Per the plan brief, the broader semantic match (`find_duplicated_methods` — clusters of internal copy-paste) was chosen; the tool description points callers at `find_duplicate_helpers` directly when they need the BCL/NuGet-wrapper detection shape.

### Response envelope contract

Every alias response carries a top-level `deprecation: { canonicalName, reason }` field. Canonical responses also publish the field as JSON `null`, so the schema is identical:

```json
{
  "count": 3,
  "symbols": [ ... ],
  "deprecation": null            // canonical
}
{
  "count": 3,
  "symbols": [ ... ],
  "deprecation": {                // alias
    "canonicalName": "document_symbols",
    "reason": "alias for cross-MCP-server name compatibility"
  }
}
```

This is a versioned API field on the response envelope, NOT a wrapper or shim. Clients can read `deprecation` unconditionally instead of guarding for absence vs null.

### Implementation pattern

Each canonical method now delegates to a shared `*Core` helper that takes a nullable `ToolAliasDeprecation`. The alias methods call the same helper with a populated deprecation envelope. Zero behavior divergence — the new `AliasToolsTests.AssertAliasParity` helper asserts byte-equal JSON for the shared (non-deprecation) fields between each alias and its canonical.

A small `ToolAliasDeprecation` record (~25 lines) lives next to the tools to avoid duplicating the deprecation envelope shape and reason text across three tool files.

### Surface count addendum

`README.md` "Live Surface" line updated: **162 tools (108 stable / 54 experimental) -> 165 tools (111 stable / 54 experimental)**. Required to keep `ReadmeSurfaceCountTests.ReadmeCounts_MatchLiveServerSurfaceCatalog` green; counted as a documentation addendum to this initiative per plan brief.

### Scope deviation

Plan brief said "Production: <=3 file modifications (Catalog partials + Tools/ files)." Actual count: 5 modified production files (2 catalog partials + 3 distinct Tools files — `SymbolTools.cs`, `AdvancedAnalysisTools.cs`, `TestCoverageTools.cs`) + 1 new helper (`ToolAliasDeprecation.cs`) + README addendum.

The plan undercounted: `find_duplicated_methods` lives in `AdvancedAnalysisTools.cs` (not the assumed `AnalysisTools.cs`), and `test_coverage` lives in its own `TestCoverageTools.cs`. So 3 distinct Tools files are unavoidable. The 1 helper file prevents 3-way duplication of the same record declaration. No genuine scope creep.

### Shims-added: 0

The new alias methods are first-class `[McpServerTool]` methods, NOT shims. Each one is registered in the catalog, has its own `McpToolMetadata` attribute, and is exposed on the wire as a peer tool. The `deprecation` field is a versioned API field on the response envelope (always present, null on canonicals). No backwards-compat constructors, no overload shims, no null-gated degraded paths.

## Test plan

- [x] All 6 new `AliasToolsTests` methods pass (parity for all 3 aliases + canonical-emits-null + alias-envelope-shape + catalog registration)
- [x] `SurfaceCatalogTests` (catalog-attribute parity, `[McpToolMetadata]` matches catalog row) — 5 passing
- [x] `ReadmeSurfaceCountTests` — passes against the new 165-tool count
- [x] `ServerSurfaceCatalogAnalyzerTests` — analyzer doesn't flag the new aliases
- [x] `AnalysisToolsTests` — 12 existing tool-wrapper tests unaffected
- [x] `DuplicateMethodDetectorTests` — 9 service-level tests pass (canonical service unchanged)
- [x] `ExpandedSurfaceIntegrationTests` test_coverage tests pass (`TestCoverageTool_Returns_Structured_Response`, `TestCoverageTool_WhenCoverletMissing_ReturnsStructuredErrorBeforeRunning`) — confirms the anonymous-envelope rewrite preserved the JSON wire shape
- [x] `eng/verify-ai-docs.ps1` passes
- [x] `mcp__roslyn__validate_workspace` returns `overallStatus: clean` for all 6 changed prod files
- [x] `eng/verify-release.ps1 -Configuration Release` — 952 of 972 tests pass; 20 failures are pre-existing flakes per plan initiative 12 (`ci-test-parallelization-audit`), all in unrelated services (ExtractMethod, NamespaceRelocation, RecordFieldAddition, package-mutation tests) — none touch alias / catalog / coverage / duplicate-detection code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)