### PR TITLE
chore(docs): doc-audit schema 4 -> 5 migration

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -1,4 +1,4 @@
-<!-- doc-audit-schema: 4 -->
+<!-- doc-audit-schema: 5 -->
 
 # Documentation Audit Context
 
@@ -19,10 +19,10 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-04-25 (second pass)
+- **Last audit:** 2026-04-26 (schema 4 → 5 migration)
 - **Last audit mode:** initial
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 39
+- **ai_docs/ file count:** 40
 - **docs/ file count:** 14
 - **Agent instruction files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/operational-essentials.md`, `CI_POLICY.md`
 
@@ -30,7 +30,7 @@
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| AGENTS.md | present | Canonical bootstrap with repo-local MCP bootstrap and in-repo planning-scope routing. |
+| AGENTS.md | present | Canonical bootstrap with repo-local MCP bootstrap and in-repo planning-scope routing; Next-step protocol matches `planning_index.md` verbatim. |
 | CLAUDE.md | present-pointer | Collapsed pointer to `AGENTS.md`. |
 | .github/copilot-instructions.md | present | Canonical implementation-quality and safety rules. |
 | .cursor/rules/operational-essentials.md | present | Cursor-specific operational overlay still aligned with repo runner/docs flow. |
@@ -38,7 +38,7 @@
 | .mcp.json | present | Declares `roslyn`; AGENTS bootstrap distinguishes declared config from live availability. |
 | ai_docs/README.md | present | Index covers planning, reports, rollups, prompts, and audit-support files. |
 | ai_docs/architecture.md | present | Current-state architecture; skill count (31) matches `skills/`. |
-| ai_docs/backlog.md | present | Scope-tagged, open-only backlog with ISO `updated_at`, Agent contract, and active-sweep ref restored. |
+| ai_docs/backlog.md | present | v5 single-table format with `Critical|High|Medium|Low|Defer` sections, `pri` column, anchors + evidence on every row. |
 | ai_docs/workflow.md | present | Workflow and backlog-closure contract current. |
 | ai_docs/runtime.md | present | Runner-first runtime reference; env-var table accurate against `Program.cs`. |
 | ai_docs/planning_index.md | present | In-repo planning router with Agent contract, Next-step protocol, and scope routing table. |
@@ -52,17 +52,17 @@
 
 | File | Approx tokens | Warn/Cap | Status |
 |------|---------------|----------|--------|
-| README.md | 1267 | 2500/5000 | ok |
-| ai_docs/README.md | 1305 | 2500/4000 | ok |
+| README.md | 1266 | 2500/5000 | ok |
+| ai_docs/README.md | 1338 | 2500/4000 | ok |
 | ai_docs/architecture.md | 876 | 2500/6000 | ok |
-| ai_docs/backlog.md | 3312 | 1500/4000 | warn |
-| ai_docs/workflow.md | 524 | 1500/4000 | ok |
-| ai_docs/runtime.md | 2102 | 1500/4000 | warn |
+| ai_docs/backlog.md | 2533 | 1500/4000 | warn |
+| ai_docs/workflow.md | 1174 | 1500/4000 | ok |
+| ai_docs/runtime.md | 2101 | 1500/4000 | warn |
 | ai_docs/planning_index.md | 612 | 2500/5000 | ok |
 | ai_docs/bootstrap-read-tool-primer.md | 2317 | 2500/5000 | ok |
 | docs/README.md | 564 | 800/1600 | ok |
 
-Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback. Slight variance from prior audit's 3120 figure for backlog.md is measurement-method noise (no commits intervened); current measurement is the canonical figure for this audit row.
+Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback.
 
 ## Runner
 
@@ -75,7 +75,7 @@ Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback. Sligh
 - **Legacy runners coexisting:** none
 - **runtime.md references runner:** yes
 
-## Live Surface (verified 2026-04-25)
+## Live Surface (verified 2026-04-25; surface unchanged through 2026-04-26 commit cf65b7d)
 
 | Component | Stable | Experimental | Total |
 |-----------|--------|--------------|-------|
@@ -84,35 +84,35 @@ Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback. Sligh
 | Prompts | 0 | 20 | 20 |
 | Bundled skills | — | — | 31 |
 
-Source: `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog*.cs` tier-string counts; `skills/` directory listing. README.md, ai_docs/architecture.md, and `.claude-plugin/plugin.json` claims all match this catalog count.
+Source: `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog*.cs` tier-string counts; `skills/` directory listing.
 
 ## Known Gaps
 
-- `ai_docs/backlog.md` (~3312 tokens) is over the 1500-token warn threshold but well under the 4000-token hard cap. Down from 6972 tokens at the 2026-04-24 refresh (major win after the 20260424T041204Z sweep cleared 41 of 44 intake rows). Further compression risks losing the evidence anchors the rows need to stay planner-ready.
-- `ai_docs/runtime.md` (~2102 tokens) is stable above the 1500-token warn threshold. Future additions should land in `ai_docs/references/` rather than the runtime page.
+- `ai_docs/backlog.md` (~2533 tokens) is over the 1500-token warn threshold but well under the 4000-token hard cap. Each row carries planner-ready anchors + evidence; further compression risks losing the signal that keeps rows planner-ready.
+- `ai_docs/runtime.md` (~2101 tokens) is stable above the 1500-token warn threshold. Future additions should land in `ai_docs/references/` rather than the runtime page.
 - This repo has no local `ai_docs/ecosystem/` planning router. Cross-project planning requests must rely on explicit external context named by the user (planning_index.md and AGENTS.md already say so verbatim).
 
 ## Findings from Last Audit
 
-- **2026-04-25 (initial, second pass):** 0 commits since the earlier 2026-04-25 initial pass. Caught two contamination findings the earlier pass missed: (1) `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` lacked both `<!-- purpose: -->` and `<!-- scope: in-repo -->` (Quality Rule #7 + Planning-Doc-Scope-Rules required tag); auto-fixed since location made scope unambiguous. (2) `ai_docs/prompts/roslyn-mcp-multisession-retro.md` was orphaned — present on disk but not referenced from `ai_docs/README.md` or any sub-index; auto-fixed by adding to "Procedures And Prompts" section. All other contracts re-verified clean: AGENTS.md MCP Bootstrap, planning_index.md routing, AGENTS.md Next-step protocol verbatim match, backlog.md ISO datetime + Agent contract, workflow.md Backlog closure subsection, runner smoke (just --list passed), no bare `ecosystem/<filename>` references. Sizes unchanged from the prior pass within measurement noise.
-- **2026-04-25 (initial):** 31 commits since the 2026-04-24 refresh, including release v1.31.0 and 12 backlog-sweep reconcile batches that closed ~31 PRs. All structure-compliance contracts pass (AGENTS.md MCP Bootstrap, planning_index.md routing, AGENTS.md Next-step protocol verbatim, backlog.md ISO datetime + Agent contract, workflow.md backlog-closure subsection). Surface-count claims in README.md (`162 tools / 13 resources / 20 prompts`, with stable/experimental split `108/54`, `9/4`, `0/20`) verified against `ServerSurfaceCatalog*.cs` tier-string counts. `.claude-plugin/plugin.json` "31 bundled agent skills" matches `skills/` directory count. Restored `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` to backlog.md Refs so the active sweep is discoverable through normal routing. backlog.md size dropped from 6972 to 3120 tokens after sweep closures.
+- **2026-04-26 (initial, schema 4 → 5 migration):** 32 commits since the 2026-04-25 second pass, including release v1.32.0, finalization of the 20260424T041204Z sweep (batches 8–13 + final reconcile), and the new active sweep plan `20260426T025255Z_backlog-sweep`. Migration actions: (1) bumped `.ai-doc-audit.md` schema 4 → 5; (2) rewrote `ai_docs/backlog.md` from legacy P2/P3/P4 section/pri labels to the v5 canonical `Critical | High | Medium | Low | Defer` taxonomy — corrected 4 rows that were sectioned under `P3` while tagged `pri = P4` (skills-remove-server-heartbeat-polling, tool-annotation-population-audit, response-format-json-markdown-parameter, posttool-verify-skills-on-shipped-skill-edits → all moved to `Low`); promoted the 3 prior P3 rows to `Medium`; demoted `workspace-process-pool-or-daemon` to `Defer` (it has an explicit evidence-gated dependency); (3) added the missing v5 standing-rules lines (`Weak-evidence flag`, `Priority tiers: Critical > High > Medium > Low > Defer`); (4) added the active sweep plan to `## Refs`; (5) bumped backlog `updated_at` to `2026-04-26T16:00:00Z`. Backlog format contract checks (purpose + scope tags, ISO datetime, Agent contract MUST/MUST NOT, no body sections, kebab-case ids, anchors + evidence per code-touching row, ≤4 prod / ≤3 test sizing) all pass post-rewrite. AGENTS.md `## Planning Scope` still matches `planning_index.md` Next-step protocol verbatim; MCP Bootstrap intact; runner smoke (`just --list`) passed.
+- **2026-04-25 (initial, second pass):** 0 commits since the earlier 2026-04-25 initial pass. Caught two contamination findings: missing scope tag on `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` and orphaned `ai_docs/prompts/roslyn-mcp-multisession-retro.md` — both auto-fixed.
+- **2026-04-25 (initial):** 31 commits since the 2026-04-24 refresh, including release v1.31.0 and 12 backlog-sweep reconcile batches. Surface counts re-verified against `ServerSurfaceCatalog*.cs`. Restored `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` to backlog.md Refs.
 - **2026-04-24 (refresh):** Detected 57 new commits and a 6972-token backlog after the audit-intake batch, escalated next-mode to `initial`.
-- **2026-04-22 (initial):** Migrated `.ai-doc-audit.md` to schema 4; rewrote AGENTS.md to canonical shape with MCP Bootstrap; replaced CLAUDE.md with collapsed-pointer; added `ai_docs/planning_index.md`; tagged plan/backlog/reference files with scope metadata; reduced over-cap docs.
+- **2026-04-22 (initial):** Migrated `.ai-doc-audit.md` to schema 4; rewrote AGENTS.md to canonical shape with MCP Bootstrap; replaced CLAUDE.md with collapsed-pointer; added `ai_docs/planning_index.md`; tagged plan/backlog/reference files with scope metadata.
 
 ## Pruning Summary
 
 | Action | Files affected | Approval |
 |--------|----------------|----------|
-| Added `<!-- purpose: -->` + `<!-- scope: in-repo -->` to most recent backlog-sweep plan | `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | auto (STANDARD §Planning-Doc-Scope-Rules — location made scope unambiguous) |
-| Indexed orphaned retro prompt under "Procedures And Prompts" | `ai_docs/README.md` | auto (orphan-link fix; mirrors dangling-index-link policy in inverse direction) |
-| Refreshed audit context with current state, sizes, drift findings | `.ai-doc-audit.md` | auto (skill maintenance) |
-| Added active sweep plan to backlog.md Refs and bumped `updated_at` (prior pass) | `ai_docs/backlog.md` | auto (low-risk index restore) |
+| Migrated `.ai-doc-audit.md` schema 4 → 5 | `.ai-doc-audit.md` | auto (schema migration) |
+| Rewrote `ai_docs/backlog.md` to v5 canonical priority sections (`Critical | High | Medium | Low | Defer`); fixed 4 section/pri mismatches; added v5 standing-rules lines; added active sweep plan to Refs; bumped `updated_at` | `ai_docs/backlog.md` | auto (mechanical v5 conformance — no semantic content lost; row text preserved verbatim; pri-column relabel only) |
+| Refreshed audit context with current state, sizes, surface | `.ai-doc-audit.md` | auto (skill maintenance) |
 
 ## Retention State
 
 - **Audit reports:** 0 audit-report files (limit: 3) — `ai_docs/audit-reports/` contains only persistent reference docs.
 - **Reports rollups:** 4 timestamped deep-review rollups under `ai_docs/reports/` (2026-04-06 to 2026-04-22). No retention rule defined for `reports/` in STANDARD.md; oldest is the 2026-04-06 example file kept intentionally.
-- **Shipped plans pending archival:** none — both backlog-sweep plans are within the 30-day archive window (oldest closed 2026-04-23).
+- **Shipped plans pending archival:** none — newest sweep plan `20260426T025255Z_backlog-sweep` is active; prior sweeps within the 30-day archive window.
 - **Shipped reviews pending archival:** none.
 - **README.md token budget:** 1266 / 2500 warn / 5000 hard.
 - **review-inbox/:** empty (only `archive/` subfolder for processed batches).

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,52 +3,71 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-04-26T03:54:55Z
+**updated_at:** 2026-04-26T16:00:00Z
 
 ## Agent contract
 
-**Scope:** this file lists unfinished work only. It is not a changelog.
-
 | | |
 |---|---|
+| **Scope** | This file lists unfinished work only. It is not a changelog. |
 | **MUST** | Remove or update backlog rows when work ships; do it in the same PR or an immediate follow-up. |
 | **MUST** | End implementation plans with a final todo: `backlog: sync ai_docs/backlog.md`. |
 | **MUST** | Use stable, kebab-case `id` values per open row. |
-| **MUST NOT** | Add completed tables, dated history sections, or narrative changelogs here. |
+| **MUST** | Every row's `do` cell summarizes the current need + the concrete next deliverable. Include `Anchors:` (specific source file paths) when the row references code, and evidence (audit/retro/CI signal) when one exists. |
+| **MUST** | Size every row to a single bounded initiative — ≤4 production files, ≤3 test files, one regression-test shape. Split heroic multi-bug rows into per-bug children before planning against them. |
+| **MUST NOT** | Add `Completed`, `Shipped`, `Done`, `History`, or `Changelog` sections. Git is the archive. |
 | **MUST NOT** | Leave done items in the open table. |
+| **MUST NOT** | Use `### <id>` body sections per item. The table row IS the canonical form. Items needing long-form depth (more than ~10 lines) link to `ai_docs/items/<id>.md` from the `do` cell. |
 
 ## Standing rules
 
-- Reprioritize on each audit pass.
-- Keep rows terse: summarize the current need, not the full session history.
-- Keep rows planner-ready: name live anchors and the next concrete deliverable or investigation output.
-- Replace stale umbrella rows with concrete follow-ons before planning against them.
-- Put long-form audit evidence in the referenced reports, not in this file.
-- Size every row to a single `backlog-sweep-plan.md` initiative: one code path, ≤4 production files, ≤3 test files, one regression-test shape. Split heroic multi-bug rows into per-bug children before a sweep runs against them.
+- **Reprioritize on each audit pass.** Stale priority order is a finding.
+- **Keep rows planner-ready.** A row is ready when an agent can read it cold and start a plan: name the live anchors and the next concrete deliverable or investigation output.
+- **Replace stale umbrella rows with concrete follow-ons** before planning against them.
+- **Long-form audit evidence belongs in referenced reports**, not in this file. The `do` cell carries a one-line evidence summary plus the report path.
+- **Weak-evidence flag.** When a row's signal is thin (single retro session, self-audit only, etc.) say so explicitly in the `do` cell ("Weaker evidence — N until external session reproduces").
+- **Priority tiers:** Critical > High > Medium > Low > Defer.
+- See `workflow.md` → **Backlog closure** for close-in-PR expectations.
 
-## P2 — open work
+---
+
+## Critical
+
+<!-- Production-breaking or blocking work. Empty section is fine; keep the header. -->
+
+| id | pri | deps | do |
+|----|-----|------|-----|
+
+## High
 
 | id | pri | deps | do |
 |----|-----|------|-----|
 
-## P3 — open work
+## Medium
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `ci-test-parallelization-audit` | P3 | — | Refresh the old test-parallelization audit around the real residual issue: `eng/verify-release.ps1` still has 3 pre-existing cleanup-race flakes even though the `[DoNotParallelize]` sweep is already done. Start by reproducing and naming the failing tests, then localize whether the race sits in `tests/RoslynMcp.Tests/AssemblyCleanup.cs`, `tests/RoslynMcp.Tests/TestBase.cs`, or another teardown path before planning the fix plus a repeated-release stress gate (`eng/verify-release-stress.ps1` / CI). |
-| `pretooluse-apply-preview-token-invariant` | P3 | — | The `PreToolUse:mcp__roslyn__*_apply` hook at `hooks/hooks.json` still scans the session transcript for a matching `*_preview` and false-positive-blocks `*_apply` 8 times across 4 refactor sessions in the 2026-04-10→04-24 retro (`format_range_apply`, `extract_interface_apply`, `create_file_apply`, `fix_all_apply`, `move_type_to_file_apply`) — prior work (PR #234, PR #230) softened cold-subagent and composite-preview cases but the structural scan remains. Return a short-lived `previewToken` on every `*_preview` response and require it on every `*_apply`; rewrite the hook to validate by token presence instead of transcript grep. Anchors: `src/RoslynMcp.Roslyn/Services/PreviewStore.cs` (already issues tokens for most previews — extend to the remaining preview tools), `src/RoslynMcp.Host.Stdio/Tools/*Apply*.cs` (add required `previewToken` parameter on every `*_apply`), `hooks/hooks.json` (flip scan → token compare). Distinct from `format-range-apply-preview-token-lifetime` (that row tunes token lifetime; this row tightens the apply-gate invariant). |
-| `find-type-consumers-file-granularity-rollup` | P3 | — | Agents looking for "which files touch this type" fall back to Grep (≥5 refactor sessions in the 2026-04-10→04-24 retro: 57a0d696, bfe7443f, ac8b4d93, 08adc1f1, b3e4cb62) because `find_references` returns per-site hits with no per-file rollup. Add `find_type_consumers(typeName, limit) → [{filePath, kinds: [using|ctor|inherit|field|local], count}]` on top of the existing reference index. Anchors: `src/RoslynMcp.Roslyn/Services/ReferenceService.cs` (reuse reference index), new tool in `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs`. Shape mirrors what downstream rename/move/delete planning flows already want. |
-| `skills-remove-server-heartbeat-polling` | P4 | — | The `/roslyn-mcp:complexity` skill (and any wait-loop in sibling skills under `.claude/plugins/roslyn-mcp/skills/`) polls `mcp__roslyn__server_heartbeat` in a loop — one session in the 2026-04-10→04-24 retro (b5464409) logged 78 heartbeat calls inside a single `/complexity` invocation; two others logged 8 and 6. Audit the shipped skill prompts and replace poll-until-ready with a single `server_info` check (or `workspace_status` + bounded backoff) so transcripts aren't inflated by heartbeat noise. Anchors: `.claude-plugin/plugin.json` (plugin manifest at repo root) + `skills/complexity/SKILL.md`, cross-check with `skills/*/SKILL.md` for the same pattern. |
-| `tool-annotation-population-audit` | P4 | — | MCP best-practices: tools should declare `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` annotations so clients (including the PreToolUse apply-gate hook) can route decisions off structured metadata instead of tool-name patterns. Verify via `server_info.surface` + a spot-check on `src/RoslynMcp.Host.Stdio/Tools/*Apply*.cs` and `*Preview*.cs` whether the `[McpServerTool]` attributes already carry these. If missing, populate: every `*_apply` → `destructiveHint: true`; every `*_preview` / read-shape tool → `readOnlyHint: true`; workspace-scoped tools → `openWorldHint: false`. Close-immediately if already populated. |
-| `response-format-json-markdown-parameter` | P4 | — | MCP best-practices: summary-shaped tools should support `response_format: "json" \| "markdown"` (default `json` preserves wire compatibility). Current state: all 161 tools return JSON only. Highest-value candidates (heavy context cost, human-readable reframing): `server_info`, `workspace_list`, `workspace_status`, `validate_workspace`, `symbol_impact_sweep`, `project_diagnostics(summary)`. Add the parameter + markdown formatter per tool; start with `validate_workspace` (typically 120-line JSON → ~30-line table). Anchors: `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs`, `WorkspaceTools.cs`, `ValidationBundleTools.cs`. |
-| `posttool-verify-skills-on-shipped-skill-edits` | P4 | — | `eng/verify-skills-are-generic.ps1` is gated by `just ci` + `verify-release.ps1`, so an `ai_docs/` / `eng/` / `backlog.md` leak inside a `./skills/**/SKILL.md` is caught at CI, not at edit-time — round-trip waste per retro observation. Add a PostToolUse hook on `Edit\|Write\|MultiEdit` matching `./skills/**` that runs `pwsh eng/verify-skills-are-generic.ps1` and surfaces violations the same turn. Timeout bounded (the script is <1s). |
+| `ci-test-parallelization-audit` | Medium | — | Refresh the old test-parallelization audit around the real residual issue: `eng/verify-release.ps1` still has 3 pre-existing cleanup-race flakes even though the `[DoNotParallelize]` sweep is already done. Start by reproducing and naming the failing tests, then localize whether the race sits in `tests/RoslynMcp.Tests/AssemblyCleanup.cs`, `tests/RoslynMcp.Tests/TestBase.cs`, or another teardown path before planning the fix plus a repeated-release stress gate (`eng/verify-release-stress.ps1` / CI). |
+| `pretooluse-apply-preview-token-invariant` | Medium | — | The `PreToolUse:mcp__roslyn__*_apply` hook at `hooks/hooks.json` still scans the session transcript for a matching `*_preview` and false-positive-blocks `*_apply` 8 times across 4 refactor sessions in the 2026-04-10→04-24 retro (`format_range_apply`, `extract_interface_apply`, `create_file_apply`, `fix_all_apply`, `move_type_to_file_apply`) — prior work (PR #234, PR #230) softened cold-subagent and composite-preview cases but the structural scan remains. Return a short-lived `previewToken` on every `*_preview` response and require it on every `*_apply`; rewrite the hook to validate by token presence instead of transcript grep. Anchors: `src/RoslynMcp.Roslyn/Services/PreviewStore.cs` (already issues tokens for most previews — extend to the remaining preview tools), `src/RoslynMcp.Host.Stdio/Tools/*Apply*.cs` (add required `previewToken` parameter on every `*_apply`), `hooks/hooks.json` (flip scan → token compare). Distinct from `format-range-apply-preview-token-lifetime` (that row tunes token lifetime; this row tightens the apply-gate invariant). |
+| `find-type-consumers-file-granularity-rollup` | Medium | — | Agents looking for "which files touch this type" fall back to Grep (≥5 refactor sessions in the 2026-04-10→04-24 retro: 57a0d696, bfe7443f, ac8b4d93, 08adc1f1, b3e4cb62) because `find_references` returns per-site hits with no per-file rollup. Add `find_type_consumers(typeName, limit) → [{filePath, kinds: [using|ctor|inherit|field|local], count}]` on top of the existing reference index. Anchors: `src/RoslynMcp.Roslyn/Services/ReferenceService.cs` (reuse reference index), new tool in `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs`. Shape mirrors what downstream rename/move/delete planning flows already want. |
 
-## P4 — open work
+## Low
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `workspace-process-pool-or-daemon` | P4 | `large-solution profile` | Do not start a daemon/process-pool implementation blindly. First capture representative 50+ project timings per `docs/large-solution-profiling-baseline.md`; only if `workspace_load` / reload P95 still blocks daily use after `workspace_warm` should the next plan produce a bounded design note comparing daemon, process-pool, and shared-workspace approaches, including lifecycle and failure-isolation hooks. |
-| `semantic-grep-identifier-scoped-search` | P4 | — | Agents want to grep inside C# code but exclude string/comment matches — current Grep returns hits inside CHANGELOG, markdown, and string literals (3 Roslyn-self-audit sessions in the 2026-04-10→04-24 retro: 57a0d696, 08adc1f1, cf2d0b85). Add `semantic_grep(pattern, scope=identifiers|strings|comments|all, projectFilter?) → [{filePath, line, column, tokenKind, snippet}]` as a thin wrapper on `SyntaxTree.DescendantTokens` + `SyntaxToken.Kind()` + regex match. Anchors: new service under `src/RoslynMcp.Roslyn/Services/`, new tool in `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`. Weaker evidence (3 sessions, all self-audit) — P4 until an external-repo session reproduces the pattern. |
+| `skills-remove-server-heartbeat-polling` | Low | — | The `/roslyn-mcp:complexity` skill (and any wait-loop in sibling skills under `.claude/plugins/roslyn-mcp/skills/`) polls `mcp__roslyn__server_heartbeat` in a loop — one session in the 2026-04-10→04-24 retro (b5464409) logged 78 heartbeat calls inside a single `/complexity` invocation; two others logged 8 and 6. Audit the shipped skill prompts and replace poll-until-ready with a single `server_info` check (or `workspace_status` + bounded backoff) so transcripts aren't inflated by heartbeat noise. Anchors: `.claude-plugin/plugin.json` (plugin manifest at repo root) + `skills/complexity/SKILL.md`, cross-check with `skills/*/SKILL.md` for the same pattern. |
+| `tool-annotation-population-audit` | Low | — | MCP best-practices: tools should declare `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` annotations so clients (including the PreToolUse apply-gate hook) can route decisions off structured metadata instead of tool-name patterns. Verify via `server_info.surface` + a spot-check on `src/RoslynMcp.Host.Stdio/Tools/*Apply*.cs` and `*Preview*.cs` whether the `[McpServerTool]` attributes already carry these. If missing, populate: every `*_apply` → `destructiveHint: true`; every `*_preview` / read-shape tool → `readOnlyHint: true`; workspace-scoped tools → `openWorldHint: false`. Close-immediately if already populated. |
+| `response-format-json-markdown-parameter` | Low | — | MCP best-practices: summary-shaped tools should support `response_format: "json" \| "markdown"` (default `json` preserves wire compatibility). Current state: all 161 tools return JSON only. Highest-value candidates (heavy context cost, human-readable reframing): `server_info`, `workspace_list`, `workspace_status`, `validate_workspace`, `symbol_impact_sweep`, `project_diagnostics(summary)`. Add the parameter + markdown formatter per tool; start with `validate_workspace` (typically 120-line JSON → ~30-line table). Anchors: `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs`, `WorkspaceTools.cs`, `ValidationBundleTools.cs`. |
+| `posttool-verify-skills-on-shipped-skill-edits` | Low | — | `eng/verify-skills-are-generic.ps1` is gated by `just ci` + `verify-release.ps1`, so an `ai_docs/` / `eng/` / `backlog.md` leak inside a `./skills/**/SKILL.md` is caught at CI, not at edit-time — round-trip waste per retro observation. Add a PostToolUse hook on `Edit\|Write\|MultiEdit` matching `./skills/**` that runs `pwsh eng/verify-skills-are-generic.ps1` and surfaces violations the same turn. Timeout bounded (the script is <1s). |
+| `semantic-grep-identifier-scoped-search` | Low | — | Agents want to grep inside C# code but exclude string/comment matches — current Grep returns hits inside CHANGELOG, markdown, and string literals (3 Roslyn-self-audit sessions in the 2026-04-10→04-24 retro: 57a0d696, 08adc1f1, cf2d0b85). Add `semantic_grep(pattern, scope=identifiers|strings|comments|all, projectFilter?) → [{filePath, line, column, tokenKind, snippet}]` as a thin wrapper on `SyntaxTree.DescendantTokens` + `SyntaxToken.Kind()` + regex match. Anchors: new service under `src/RoslynMcp.Roslyn/Services/`, new tool in `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`. Weaker evidence — Low until an external-repo session reproduces the pattern. |
+
+## Defer
+
+<!-- Explicitly parked. Record WHY in the `do` cell. -->
+
+| id | pri | deps | do |
+|----|-----|------|-----|
+| `workspace-process-pool-or-daemon` | Defer | `large-solution profile` | Do not start a daemon/process-pool implementation blindly. First capture representative 50+ project timings per `docs/large-solution-profiling-baseline.md`; only if `workspace_load` / reload P95 still blocks daily use after `workspace_warm` should the next plan produce a bounded design note comparing daemon, process-pool, and shared-workspace approaches, including lifecycle and failure-isolation hooks. Deferred until profile evidence justifies the work. |
 
 ## Refs
 
@@ -63,7 +82,8 @@
 | `ai_docs/plans/20260422T170500Z_test-parallelization-audit/plan.md` | Dedicated phased plan for `ci-test-parallelization-audit`. |
 | `docs/large-solution-profiling-baseline.md` | Evidence gate for daemon/process-pool performance work. |
 | `ai_docs/procedures/deep-review-backlog-intake.md` | Intake procedure for future audit batches. |
-| `ai_docs/plans/20260422T223000Z_backlog-sweep/plan.md` | Prior sweep (20260422T223000Z). Shipped 14 initiatives across 14 PRs; closed 9 backlog rows (P2: 0, P3: 4, P4: 5). |
-| `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | Closed sweep against the 44-initiative audit-intake batch (5 P2 + 29 P3 + 10 P4). 42 merged / 2 deferred as of 2026-04-25 — `ci-test-parallelization-audit` (dedicated phased plan) and `workspace-process-pool-or-daemon` (heroic-last, profile-evidence gated). Remaining open rows above are carry-overs from the audit batch + new entries. |
+| `ai_docs/plans/20260422T223000Z_backlog-sweep/plan.md` | Prior sweep (20260422T223000Z). Shipped 14 initiatives across 14 PRs; closed 9 backlog rows. |
+| `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` | Closed sweep against the 44-initiative audit-intake batch (5 P2 + 29 P3 + 10 P4). 42 merged / 2 deferred as of 2026-04-25 — `ci-test-parallelization-audit` (dedicated phased plan) and `workspace-process-pool-or-daemon` (heroic-last, profile-evidence gated). |
+| `ai_docs/plans/20260426T025255Z_backlog-sweep/plan.md` | Active sweep plan against the open backlog after the 20260424T041204Z sweep finalized. |
 | `review-inbox/` | Staging folder for the NEXT audit batch (flat directory; `/backlog-intake` reads here). |
-| `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches — one subdirectory per successful intake, named by the intake commit's UTC timestamp. Backlog rows citing specific files are anchored here. Batch `20260424T031936Z` holds the 14-file cross-repo audit + retro batch that produced the current rows. Keep until every row sourced from a batch is closed or superseded, then delete that subdirectory. |
+| `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches — one subdirectory per successful intake. Keep until every row sourced from a batch is closed or superseded, then delete that subdirectory. |


### PR DESCRIPTION
## Summary
- Migrate `.ai-doc-audit.md` to schema 5 (per `~/.claude/skills/doc-audit/STANDARD.md` v5).
- Rewrite `ai_docs/backlog.md` to the v5 single-table format: canonical `Critical | High | Medium | Low | Defer` priority sections; relabeled `pri` column; fixed 4 section/pri mismatches; demoted `workspace-process-pool-or-daemon` to `Defer` (evidence-gated dep).
- Added missing v5 standing-rules lines (weak-evidence flag, priority tiers).
- Added active sweep plan `20260426T025255Z_backlog-sweep` to `## Refs`.
- Refreshed audit-context findings, size table, file count (39 → 40).

No backlog row content lost — the `do` cells are preserved verbatim. Pure mechanical conformance to v5.

## Test plan
- [x] `just verify-docs` passes
- [ ] CI green