### PR TITLE
feat(hooks): surface shipped-skill genericity violations at edit-time

### DIFF
--- a/eng/verify-skills-on-edit.ps1
+++ b/eng/verify-skills-on-edit.ps1
@@ -1,0 +1,42 @@
+# PostToolUse hook dispatcher.
+# Reads Claude Code's hook-input JSON from stdin and, when the edited path is a
+# shipped skill (skills/<name>/SKILL.md or any *.md under skills/), invokes the
+# generic-skills linter so violations surface in the same turn as the edit
+# instead of waiting for CI.
+#
+# Hook config: hooks/hooks.json -> PostToolUse -> Edit|Write|MultiEdit.
+# Verifier:    eng/verify-skills-are-generic.ps1.
+#
+# Silent on non-skill paths and on clean skill edits (the verifier prints a
+# one-line success message; that is fine — the user sees confirmation that the
+# guard ran). Exits with the verifier's exit code so Claude surfaces failures.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+
+try {
+    $payload = $raw | ConvertFrom-Json
+} catch {
+    # Malformed payload — do not block the edit.
+    exit 0
+}
+
+$filePath = $payload.tool_input.file_path
+if (-not $filePath) { exit 0 }
+
+# Normalize Windows backslashes to forward slashes for the regex.
+$normalized = $filePath -replace '\\', '/'
+if ($normalized -notmatch '/skills/[^/]+/.*\.md$') { exit 0 }
+
+$repoRoot = $env:CLAUDE_PROJECT_DIR
+if (-not $repoRoot) { $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path }
+
+$verifier = Join-Path $repoRoot 'eng/verify-skills-are-generic.ps1'
+if (-not (Test-Path $verifier)) { exit 0 }
+
+& pwsh -NoProfile -NonInteractive -File $verifier -RepoRoot $repoRoot
+exit $LASTEXITCODE

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,16 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -NonInteractive -File ${CLAUDE_PROJECT_DIR}/eng/verify-skills-on-edit.ps1",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "mcp__roslyn__server_info",
         "hooks": [
           {


### PR DESCRIPTION
## Summary
- Add a `PostToolUse` hook on `Edit|Write|MultiEdit` that runs `eng/verify-skills-are-generic.ps1` whenever the edited file matches `skills/<name>/*.md`. Leaks of repo-coupled tokens (`ai_docs/`, `backlog.md`, `eng/`, `state.json`, `schemaVersion`, `just verify-`, etc.) into shipped `SKILL.md` files now surface in the same turn as the edit instead of waiting for `just ci` / `verify-release.ps1`.
- New dispatcher script `eng/verify-skills-on-edit.ps1` reads Claude's hook-input JSON from stdin, normalizes `tool_input.file_path`, applies the skill-path filter, and forwards to the existing verifier — no logic duplication. The dispatcher exists to avoid brittle nested shell-quoting of an inline pwsh one-liner inside `hooks.json`'s `command` string.
- 10s timeout (script runtime is <1s on 31 shipped `SKILL.md` files).

## Implementation notes
- `hooks/hooks.json` is on the release-managed-file list (PR #448). The commit message includes `ack: release-managed` as required by the PreToolUse guard.
- Hook uses `${CLAUDE_PROJECT_DIR}` for the script path so it works regardless of cwd.
- Dispatcher is silent on non-skill paths and non-skill markdown; exits 0 on clean skill edits with the verifier's one-line confirmation; exits 1 with the violation list on dirty edits.

## Test plan
- [x] `pwsh -NoProfile -Command "Get-Content hooks/hooks.json -Raw | ConvertFrom-Json"` — JSON parses
- [x] `just verify-skills` — clean
- [x] `just verify-docs` — clean
- [x] Dispatcher tested with a skill path → verifier runs, exit 0
- [x] Dispatcher tested with a non-skill path → silent, exit 0
- [x] Dispatcher tested with empty stdin → silent, exit 0
- [x] Manual injection: appended `see ai_docs/foo.md` to `skills/analyze/SKILL.md` → hook reported `skills/analyze/SKILL.md:122: banned pattern '\bai_docs/'`, exited 1; restoration confirmed clean.

Closes: posttool-verify-skills-on-shipped-skill-edits

Plan: ai_docs/plans/20260426T025255Z_backlog-sweep/plan.md §6