### PR TITLE
feat(tools): add responseFormat=markdown to validate_workspace (response-format-json-markdown-parameter)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs
+++ b/src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs
@@ -1,0 +1,183 @@
+using System.Globalization;
+using System.Text;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Host.Stdio.Formatters;
+
+/// <summary>
+/// response-format-json-markdown-parameter (P4 UX): renders a
+/// <see cref="WorkspaceValidationDto"/> as a compact human-readable markdown summary.
+/// Used by <c>validate_workspace</c> when the caller passes
+/// <c>responseFormat=markdown</c>; the default JSON wire shape is preserved when the
+/// parameter is omitted or set to <c>json</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Output target is roughly 30 lines vs the typical 120-line JSON envelope on
+/// medium-sized solutions. The formatter is single-pass O(N) over the diagnostics
+/// and discovered-tests lists; per-item rows are capped (configurable via
+/// <see cref="MaxDiagnosticRows"/> / <see cref="MaxTestRows"/>) so a runaway
+/// response stays bounded even when the underlying DTO does not (e.g. when
+/// <c>summary=false</c> on a large solution with many errors).
+/// </para>
+/// <para>
+/// Verdict-equivalence contract: the markdown shape MUST surface the same
+/// <c>OverallStatus</c> verdict as the JSON shape — both modes are produced from
+/// the same <see cref="WorkspaceValidationDto"/> instance, so a caller that wires
+/// the markdown table into a downstream gate gets the same pass/fail decision as
+/// a caller that parses the JSON envelope.
+/// </para>
+/// </remarks>
+internal static class ValidateWorkspaceMarkdownFormatter
+{
+    /// <summary>Cap on per-diagnostic rows in the markdown output.</summary>
+    public const int MaxDiagnosticRows = 20;
+
+    /// <summary>Cap on per-test rows in the markdown output.</summary>
+    public const int MaxTestRows = 20;
+
+    /// <summary>
+    /// Render <paramref name="dto"/> as a compact markdown summary. The returned
+    /// string is the entire tool response (no JSON envelope) and is intended to
+    /// flow straight through the MCP transport.
+    /// </summary>
+    public static string Format(WorkspaceValidationDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var sb = new StringBuilder(1024);
+
+        sb.Append("# validate_workspace — ").AppendLine(dto.OverallStatus);
+        sb.AppendLine();
+
+        sb.AppendLine("| Metric | Value |");
+        sb.AppendLine("|--------|-------|");
+        AppendRow(sb, "Overall status", dto.OverallStatus);
+        AppendRow(sb, "Compile errors", dto.CompileResult.ErrorCount.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Compile warnings", dto.CompileResult.WarningCount.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Analyzer/compile error diagnostics", dto.ErrorDiagnostics.Count.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Warning diagnostics", dto.WarningCount.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Changed file paths (resolved)", dto.ChangedFilePaths.Count.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Unknown file paths", dto.UnknownFilePaths.Count.ToString(CultureInfo.InvariantCulture));
+        AppendRow(sb, "Discovered tests", dto.DiscoveredTests.Count.ToString(CultureInfo.InvariantCulture));
+        if (dto.TestRunResult is { } run)
+        {
+            AppendRow(sb, "Tests total", run.Total.ToString(CultureInfo.InvariantCulture));
+            AppendRow(sb, "Tests passed", run.Passed.ToString(CultureInfo.InvariantCulture));
+            AppendRow(sb, "Tests failed", run.Failed.ToString(CultureInfo.InvariantCulture));
+            AppendRow(sb, "Tests skipped", run.Skipped.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (dto.ErrorDiagnostics.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Error diagnostics");
+            sb.AppendLine();
+            sb.AppendLine("| Id | File | Line | Message |");
+            sb.AppendLine("|----|------|------|---------|");
+            var shown = 0;
+            foreach (var diag in dto.ErrorDiagnostics)
+            {
+                if (shown >= MaxDiagnosticRows) break;
+                var lineText = diag.StartLine?.ToString(CultureInfo.InvariantCulture) ?? "";
+                sb.Append("| ").Append(EscapeCell(diag.Id))
+                  .Append(" | ").Append(EscapeCell(diag.FilePath ?? ""))
+                  .Append(" | ").Append(lineText)
+                  .Append(" | ").Append(EscapeCell(diag.Message))
+                  .AppendLine(" |");
+                shown++;
+            }
+            if (dto.ErrorDiagnostics.Count > MaxDiagnosticRows)
+            {
+                sb.Append("| … | (").Append((dto.ErrorDiagnostics.Count - MaxDiagnosticRows).ToString(CultureInfo.InvariantCulture))
+                  .AppendLine(" more truncated) | | |");
+            }
+        }
+
+        if (dto.DiscoveredTests.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Discovered tests");
+            sb.AppendLine();
+            sb.AppendLine("| Test | Project |");
+            sb.AppendLine("|------|---------|");
+            var shown = 0;
+            foreach (var test in dto.DiscoveredTests)
+            {
+                if (shown >= MaxTestRows) break;
+                sb.Append("| ").Append(EscapeCell(test.DisplayName))
+                  .Append(" | ").Append(EscapeCell(test.ProjectName))
+                  .AppendLine(" |");
+                shown++;
+            }
+            if (dto.DiscoveredTests.Count > MaxTestRows)
+            {
+                sb.Append("| (").Append((dto.DiscoveredTests.Count - MaxTestRows).ToString(CultureInfo.InvariantCulture))
+                  .AppendLine(" more truncated) | |");
+            }
+        }
+
+        if (dto.TestRunResult is { Failures.Count: > 0 } runResult)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Test failures");
+            sb.AppendLine();
+            sb.AppendLine("| Test | Message |");
+            sb.AppendLine("|------|---------|");
+            var shown = 0;
+            foreach (var failure in runResult.Failures)
+            {
+                if (shown >= MaxTestRows) break;
+                sb.Append("| ").Append(EscapeCell(failure.DisplayName))
+                  .Append(" | ").Append(EscapeCell(failure.Message))
+                  .AppendLine(" |");
+                shown++;
+            }
+            if (runResult.Failures.Count > MaxTestRows)
+            {
+                sb.Append("| (").Append((runResult.Failures.Count - MaxTestRows).ToString(CultureInfo.InvariantCulture))
+                  .AppendLine(" more truncated) | |");
+            }
+        }
+
+        if (dto.DotnetTestFilter is { Length: > 0 } filter)
+        {
+            sb.AppendLine();
+            sb.Append("**Re-run filter:** `dotnet test --filter ").Append(filter).AppendLine("`");
+        }
+
+        if (dto.Warnings.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Warnings");
+            foreach (var warning in dto.Warnings)
+            {
+                sb.Append("- ").AppendLine(warning);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendRow(StringBuilder sb, string metric, string value)
+    {
+        sb.Append("| ").Append(metric).Append(" | ").Append(value).AppendLine(" |");
+    }
+
+    /// <summary>
+    /// Escape a cell value for safe inclusion in a markdown table row: collapse
+    /// newlines (which would terminate the row) and escape pipe characters
+    /// (which would split the row into extra columns).
+    /// </summary>
+    private static string EscapeCell(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return "";
+        // Collapse CR/LF to spaces; replace pipe with backslash-pipe so the column
+        // boundary is preserved while still rendering the original character.
+        var collapsed = value.Replace("\r\n", " ", StringComparison.Ordinal)
+                             .Replace('\n', ' ')
+                             .Replace('\r', ' ');
+        return collapsed.Replace("|", "\\|", StringComparison.Ordinal);
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
+using System.Text.Json;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Formatters;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -19,7 +21,7 @@ public static class ValidationBundleTools
     [McpServerTool(Name = "validate_workspace", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
         "Composite post-edit validation: compile_check + project_diagnostics (errors) + test_related_files (+ optional test_run)."),
-     Description("One-call post-edit validation bundle. Runs an in-memory compile_check, harvests Error-severity compiler+analyzer diagnostics, discovers tests related to the changed file set, and (when runTests=true) executes those tests. Returns an aggregate envelope with overallStatus = clean | compile-error | analyzer-error | test-failure. Pass `summary=true` on multi-project solutions where the default response (per-diagnostic detail + per-test rows) exceeds the MCP cap (Jellyfin: 135 KB).")]
+     Description("One-call post-edit validation bundle. Runs an in-memory compile_check, harvests Error-severity compiler+analyzer diagnostics, discovers tests related to the changed file set, and (when runTests=true) executes those tests. Returns an aggregate envelope with overallStatus = clean | compile-error | analyzer-error | test-failure. Pass `summary=true` on multi-project solutions where the default response (per-diagnostic detail + per-test rows) exceeds the MCP cap (Jellyfin: 135 KB). Pass `responseFormat=\"markdown\"` for a compact ~30-line summary table when the JSON envelope is overkill — verdict (overallStatus) is preserved across both shapes.")]
     public static Task<string> ValidateWorkspace(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
@@ -27,12 +29,13 @@ public static class ValidationBundleTools
         [Description("Optional: explicit list of changed file paths. When omitted, the change tracker's session-wide change set is used. Empty list means no test discovery.")] string[]? changedFilePaths = null,
         [Description("When true, runs the discovered related tests via dotnet test --filter. Default: false (discovery only).")] bool runTests = false,
         [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default false preserves the v1.18 shape.")] bool summary = false,
+        [Description("Response shape: \"json\" (default) returns the indented JSON envelope; \"markdown\" returns a compact summary table built from the same DTO so the verdict is identical across shapes. Case-insensitive.")] string? responseFormat = null,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
-            gate,
-            workspaceId,
-            c => validationService.ValidateAsync(workspaceId, changedFilePaths, runTests, c, summary),
-            ct);
+        => gate.RunReadAsync(workspaceId, async c =>
+        {
+            var dto = await validationService.ValidateAsync(workspaceId, changedFilePaths, runTests, c, summary).ConfigureAwait(false);
+            return RenderValidationResponse(dto, responseFormat);
+        }, ct);
 
     [McpServerTool(Name = "validate_recent_git_changes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
@@ -75,5 +78,24 @@ public static class ValidationBundleTools
             var envelope = ToolErrorHandler.ClassifyAndFormat(ex, "validate_recent_git_changes");
             return ToolErrorHandler.InjectMetaIfPossible(envelope, "validate_recent_git_changes");
         }
+    }
+
+    /// <summary>
+    /// response-format-json-markdown-parameter: branch on the
+    /// <paramref name="responseFormat"/> string and serialize the DTO accordingly.
+    /// Default (null / empty / "json") preserves the indented JSON wire shape so
+    /// existing callers see no change. "markdown" returns the formatter output as
+    /// a plain string. Unknown values fall through to JSON rather than throwing,
+    /// matching the permissive contract used by other optional shape parameters
+    /// (e.g. <c>summary</c>).
+    /// </summary>
+    internal static string RenderValidationResponse(Core.Services.WorkspaceValidationDto dto, string? responseFormat)
+    {
+        if (!string.IsNullOrWhiteSpace(responseFormat)
+            && string.Equals(responseFormat, "markdown", StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidateWorkspaceMarkdownFormatter.Format(dto);
+        }
+        return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
     }
 }

--- a/tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs
@@ -1,0 +1,234 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Formatters;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// response-format-json-markdown-parameter (P4 UX): asserts the markdown formatter
+/// produces a compact summary that preserves the verdict (overallStatus) across the
+/// four canonical response shapes: clean, compile-error, test-failure, mixed
+/// (analyzer error + test failure). The formatter is a pure function over
+/// <see cref="WorkspaceValidationDto"/>; tests exercise it directly without spinning
+/// up a workspace.
+/// </summary>
+[TestClass]
+public sealed class ValidateWorkspaceMarkdownFormatterTests
+{
+    [TestMethod]
+    public void Format_CleanResponse_RendersHeaderAndZeroCounts()
+    {
+        var dto = MakeDto(overallStatus: "clean");
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        StringAssert.Contains(md, "# validate_workspace — clean");
+        StringAssert.Contains(md, "| Overall status | clean |");
+        StringAssert.Contains(md, "| Compile errors | 0 |");
+        StringAssert.Contains(md, "| Analyzer/compile error diagnostics | 0 |");
+        Assert.IsFalse(md.Contains("## Error diagnostics"), "Clean response must not emit a diagnostics section.");
+        Assert.IsFalse(md.Contains("## Discovered tests"), "Clean response with no tests must not emit a tests section.");
+        Assert.IsFalse(md.Contains("## Test failures"), "Clean response must not emit a failures section.");
+    }
+
+    [TestMethod]
+    public void Format_CompileErrorResponse_EmitsDiagnosticTableAndPreservesVerdict()
+    {
+        var diag = new DiagnosticDto(
+            Id: "CS0103",
+            Message: "The name 'foo' does not exist in the current context",
+            Severity: "Error",
+            Category: "Compiler",
+            FilePath: @"C:\src\Sample\Foo.cs",
+            StartLine: 42,
+            StartColumn: 5,
+            EndLine: 42,
+            EndColumn: 8);
+
+        var dto = MakeDto(
+            overallStatus: "compile-error",
+            compile: new CompileCheckDto(
+                Success: false,
+                ErrorCount: 1,
+                WarningCount: 0,
+                TotalDiagnostics: 1,
+                ReturnedDiagnostics: 1,
+                Offset: 0,
+                Limit: 100,
+                HasMore: false,
+                Diagnostics: new[] { diag },
+                ElapsedMs: 12),
+            errorDiagnostics: new[] { diag });
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        StringAssert.Contains(md, "# validate_workspace — compile-error");
+        StringAssert.Contains(md, "| Overall status | compile-error |");
+        StringAssert.Contains(md, "## Error diagnostics");
+        StringAssert.Contains(md, "CS0103");
+        StringAssert.Contains(md, "Foo.cs");
+        StringAssert.Contains(md, "42");
+    }
+
+    [TestMethod]
+    public void Format_TestFailureResponse_EmitsFailuresAndRerunFilter()
+    {
+        var test = new RelatedTestCaseDto(
+            DisplayName: "Sample.Tests.WidgetTests.AddsCorrectly",
+            FullyQualifiedName: "Sample.Tests.WidgetTests.AddsCorrectly",
+            ProjectName: "Sample.Tests",
+            FilePath: @"C:\src\Sample.Tests\WidgetTests.cs",
+            Line: 14,
+            TriggeredByFiles: new[] { @"C:\src\Sample\Widget.cs" });
+
+        var run = new TestRunResultDto(
+            Execution: MakeExecution(),
+            Total: 1,
+            Passed: 0,
+            Failed: 1,
+            Skipped: 0,
+            Failures: new[]
+            {
+                new TestFailureDto(
+                    DisplayName: "Sample.Tests.WidgetTests.AddsCorrectly",
+                    FullyQualifiedName: "Sample.Tests.WidgetTests.AddsCorrectly",
+                    Message: "Expected 4 but was 3",
+                    StackTrace: "  at Sample.Tests.WidgetTests.AddsCorrectly() line 17"),
+            });
+
+        var dto = MakeDto(
+            overallStatus: "test-failure",
+            discoveredTests: new[] { test },
+            dotnetTestFilter: "FullyQualifiedName=Sample.Tests.WidgetTests.AddsCorrectly",
+            testRunResult: run);
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        StringAssert.Contains(md, "# validate_workspace — test-failure");
+        StringAssert.Contains(md, "## Discovered tests");
+        StringAssert.Contains(md, "Sample.Tests.WidgetTests.AddsCorrectly");
+        StringAssert.Contains(md, "## Test failures");
+        StringAssert.Contains(md, "Expected 4 but was 3");
+        StringAssert.Contains(md, "**Re-run filter:**");
+        StringAssert.Contains(md, "FullyQualifiedName=Sample.Tests.WidgetTests.AddsCorrectly");
+        StringAssert.Contains(md, "| Tests failed | 1 |");
+    }
+
+    [TestMethod]
+    public void Format_MixedResponse_IncludesAllSections()
+    {
+        var diag = new DiagnosticDto("CA1822", "Member can be marked static", "Warning", "Performance",
+            @"C:\src\Sample\Bar.cs", 7, 1, 7, 5);
+        // Even though severity here is Warning, we put it in ErrorDiagnostics to exercise
+        // the formatter's error-table path.
+        var test = new RelatedTestCaseDto("BarTests.Works", "Sample.Tests.BarTests.Works",
+            "Sample.Tests", null, null, Array.Empty<string>());
+        var run = new TestRunResultDto(
+            MakeExecution(),
+            Total: 2, Passed: 1, Failed: 1, Skipped: 0,
+            Failures: new[] { new TestFailureDto("BarTests.Works", "Sample.Tests.BarTests.Works", "boom", null) });
+
+        var dto = MakeDto(
+            overallStatus: "test-failure",
+            errorDiagnostics: new[] { diag },
+            warningCount: 5,
+            discoveredTests: new[] { test },
+            dotnetTestFilter: "FullyQualifiedName=Sample.Tests.BarTests.Works",
+            testRunResult: run,
+            warnings: new[] { "git not on PATH; falling back to full-workspace scope" });
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        StringAssert.Contains(md, "## Error diagnostics");
+        StringAssert.Contains(md, "## Discovered tests");
+        StringAssert.Contains(md, "## Test failures");
+        StringAssert.Contains(md, "## Warnings");
+        StringAssert.Contains(md, "git not on PATH");
+        StringAssert.Contains(md, "| Warning diagnostics | 5 |");
+    }
+
+    [TestMethod]
+    public void Format_DiagnosticMessageWithPipeAndNewline_EscapedSafely()
+    {
+        // Markdown table integrity: pipes split rows, newlines terminate them.
+        var diag = new DiagnosticDto(
+            Id: "CS9999",
+            Message: "first line\nsecond | piped",
+            Severity: "Error",
+            Category: "Compiler",
+            FilePath: @"C:\x.cs",
+            StartLine: 1, StartColumn: 1, EndLine: 1, EndColumn: 2);
+        var dto = MakeDto(overallStatus: "compile-error", errorDiagnostics: new[] { diag });
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        // The escaped row must appear on a single line and not contain a literal pipe inside the message cell.
+        StringAssert.Contains(md, "first line second \\| piped");
+        Assert.IsFalse(md.Contains("first line\nsecond"), "Newline inside a cell would split the table row.");
+    }
+
+    [TestMethod]
+    public void Format_ManyDiagnostics_TruncatedToCap()
+    {
+        var diags = Enumerable.Range(0, ValidateWorkspaceMarkdownFormatter.MaxDiagnosticRows + 5)
+            .Select(i => new DiagnosticDto($"CS{i:D4}", $"msg {i}", "Error", "Compiler",
+                @"C:\f.cs", i + 1, 1, i + 1, 2))
+            .ToArray();
+        var dto = MakeDto(overallStatus: "compile-error", errorDiagnostics: diags);
+
+        var md = ValidateWorkspaceMarkdownFormatter.Format(dto);
+
+        StringAssert.Contains(md, "5 more truncated");
+        // First diagnostic kept, last one (beyond cap) NOT printed as its own row.
+        StringAssert.Contains(md, "CS0000");
+        Assert.IsFalse(md.Contains($"CS{(ValidateWorkspaceMarkdownFormatter.MaxDiagnosticRows + 4):D4}"),
+            "Diagnostic past the cap should not appear as its own row.");
+    }
+
+    private static CommandExecutionDto MakeExecution()
+        => new(
+            Command: "dotnet",
+            Arguments: new[] { "test" },
+            WorkingDirectory: ".",
+            TargetPath: ".",
+            ExitCode: 0,
+            Succeeded: true,
+            DurationMs: 100,
+            StdOut: "",
+            StdErr: "");
+
+    private static WorkspaceValidationDto MakeDto(
+        string overallStatus = "clean",
+        CompileCheckDto? compile = null,
+        IReadOnlyList<DiagnosticDto>? errorDiagnostics = null,
+        int warningCount = 0,
+        IReadOnlyList<RelatedTestCaseDto>? discoveredTests = null,
+        string? dotnetTestFilter = null,
+        TestRunResultDto? testRunResult = null,
+        IReadOnlyList<string>? warnings = null)
+    {
+        compile ??= new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 100,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 1);
+
+        return new WorkspaceValidationDto(
+            OverallStatus: overallStatus,
+            ChangedFilePaths: Array.Empty<string>(),
+            UnknownFilePaths: Array.Empty<string>(),
+            CompileResult: compile,
+            ErrorDiagnostics: errorDiagnostics ?? Array.Empty<DiagnosticDto>(),
+            WarningCount: warningCount,
+            DiscoveredTests: discoveredTests ?? Array.Empty<RelatedTestCaseDto>(),
+            DotnetTestFilter: dotnetTestFilter,
+            TestRunResult: testRunResult,
+            Warnings: warnings ?? Array.Empty<string>());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `responseFormat?: "json" | "markdown"` parameter to `validate_workspace`. Default behavior unchanged — JSON envelope is returned when omitted or set to `"json"`.
- New `ValidateWorkspaceMarkdownFormatter` renders the same `WorkspaceValidationDto` as a compact ~30-line summary table (status row + per-diagnostic / per-test rollups, capped at 20 rows each).
- Verdict-equivalence preserved across both shapes (both produced from one DTO in one gate-protected read).

## Scope

Per plan §8 Rule 3 file budget — `validate_workspace` only. Other summary-shaped tools (`server_info`, `workspace_list`, `workspace_status`, `symbol_impact_sweep`, `project_diagnostics(summary)`) are explicit out-of-scope and will get follow-up rows after this lands.

Files:
- `src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs` (+ `responseFormat` parameter; inlines gate dispatch since serialization now branches on shape)
- `src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs` (new)
- `tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs` (new — clean / compile-error / test-failure / mixed / pipe-newline-escaping / truncation)

## Test plan

- [x] `dotnet test` filtered to `ValidateWorkspaceMarkdownFormatterTests` — 6/6 pass
- [x] `dotnet test` filtered to `ValidationBundleToolsTests | ValidateWorkspaceSummaryTests | ValidateRecentGitChangesTests` — 13/13 pass (no regression on existing JSON path or error-envelope contract)
- [x] `eng/verify-ai-docs.ps1` — green
- [x] `eng/verify-release.ps1 -Configuration Release` — full Release-mode test suite green (988/988)

Closes: response-format-json-markdown-parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)