### PR TITLE
feat(tools): add semantic_grep MCP tool (semantic-grep-identifier-scoped-search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **166 tools** (111 stable / 55 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **167 tools** (111 stable / 56 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/src/RoslynMcp.Core/Models/SemanticGrepResultDto.cs
+++ b/src/RoslynMcp.Core/Models/SemanticGrepResultDto.cs
@@ -1,0 +1,27 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Single hit returned by the <c>semantic_grep</c> MCP tool — one row per token whose
+/// text matches the supplied regex pattern, scoped by syntactic category (identifier vs
+/// string literal vs comment trivia).
+/// </summary>
+/// <remarks>
+/// semantic-grep-identifier-scoped-search: produced by <c>semantic_grep</c>. The token
+/// walk filters by <see cref="Microsoft.CodeAnalysis.SyntaxToken"/> kind so callers can
+/// avoid false-positive matches that plain text grep returns inside string literals or
+/// comments. <see cref="TokenKind"/> is one of <c>identifier</c>, <c>string</c>, or
+/// <c>comment</c>.
+/// </remarks>
+/// <param name="FilePath">Absolute path of the source file containing the hit.</param>
+/// <param name="Line">1-based line number of the matching token.</param>
+/// <param name="Column">1-based column number of the matching token.</param>
+/// <param name="TokenKind">
+/// Bucketed kind of the matched token: <c>identifier</c>, <c>string</c>, or <c>comment</c>.
+/// </param>
+/// <param name="Snippet">Single-line excerpt containing the match (token text or trivia text).</param>
+public sealed record SemanticGrepHitDto(
+    string FilePath,
+    int Line,
+    int Column,
+    string TokenKind,
+    string Snippet);

--- a/src/RoslynMcp.Core/Services/ISemanticGrepService.cs
+++ b/src/RoslynMcp.Core/Services/ISemanticGrepService.cs
@@ -1,0 +1,48 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Token-aware regex search across a loaded workspace. Walks each document's syntax tokens
+/// and trivia, filters by syntactic category, and returns regex matches as ranked hits.
+/// </summary>
+/// <remarks>
+/// semantic-grep-identifier-scoped-search: backs the <c>semantic_grep</c> MCP tool. Lets
+/// callers exclude string-literal and comment matches that plain text grep would return.
+/// </remarks>
+public interface ISemanticGrepService
+{
+    /// <summary>
+    /// Walks every document in the workspace, filters tokens/trivia by <paramref name="scope"/>,
+    /// runs <paramref name="pattern"/> as a .NET regex against each candidate's text, and
+    /// returns matching hits up to <paramref name="limit"/>.
+    /// </summary>
+    /// <param name="workspaceId">Workspace session identifier.</param>
+    /// <param name="pattern">.NET regex pattern. Must be non-empty.</param>
+    /// <param name="scope">
+    /// One of <c>identifiers</c> (identifier tokens only), <c>strings</c> (string-literal
+    /// tokens only — includes verbatim, interpolated text components, and raw strings),
+    /// <c>comments</c> (single-line and multi-line comment trivia), or <c>all</c> (the
+    /// union of all three buckets).
+    /// </param>
+    /// <param name="projectFilter">
+    /// Optional case-sensitive project name filter. When supplied, only documents owned by
+    /// projects whose <see cref="Microsoft.CodeAnalysis.Project.Name"/> matches are walked.
+    /// </param>
+    /// <param name="limit">
+    /// Hard cap on the number of returned hits (default 500). The token walk stops as soon
+    /// as the cap is reached so large solutions cannot produce runaway responses.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// Hits in deterministic order: ascending file path, then ascending line, then ascending
+    /// column. The list length never exceeds <paramref name="limit"/>.
+    /// </returns>
+    Task<IReadOnlyList<SemanticGrepHitDto>> SearchAsync(
+        string workspaceId,
+        string pattern,
+        string scope,
+        string? projectFilter,
+        int limit,
+        CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
@@ -49,5 +49,6 @@ public static partial class ServerSurfaceCatalog
         Tool("verify_pragma_suppresses", "validation", "stable", true, false, "Verify an existing #pragma warning disable/restore pair covers a fire line."),
         Tool("find_duplicated_code", "advanced-analysis", "stable", true, false, "Alias for find_duplicated_methods (cross-MCP-server name compatibility)."),
         Tool("get_test_coverage_map", "validation", "stable", false, false, "Alias for test_coverage (cross-MCP-server name compatibility)."),
+        Tool("semantic_grep", "analysis", "experimental", true, false, "Token-aware regex search over C# code (identifier / string / comment scopes)."),
     ];
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -409,4 +409,24 @@ public static class AnalysisTools
             }, JsonDefaults.Indented);
         }, ct);
     }
+
+    [McpServerTool(Name = "semantic_grep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Token-aware regex search over the loaded C# workspace. Walks every document's syntax tokens (and comment trivia) and applies the supplied .NET regex to the text of tokens whose syntactic kind matches `scope`. Lets callers exclude false-positive matches that plain text grep would return inside string literals or comments. Scopes: `identifiers` (identifier tokens only), `strings` (string-literal tokens — verbatim, interpolated text, raw, char, utf8), `comments` (single-line, multi-line, and doc-comment trivia), or `all` (the union). Optional `projectFilter` restricts the walk by Project.Name. Hard-capped at 500 hits per call to bound response size — narrow `pattern` or `projectFilter` if hits are truncated. Response shape: { count, items: [{ filePath, line, column, tokenKind, snippet }] } sorted by ascending file/line/column.")]
+    [McpToolMetadata("analysis", "experimental", true, false,
+        "Token-aware regex search over C# code (identifier / string / comment scopes).")]
+    public static Task<string> SemanticGrep(
+        IWorkspaceExecutionGate gate,
+        ISemanticGrepService semanticGrepService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description(".NET regex pattern to match against token text.")] string pattern,
+        [Description("Token-kind scope: 'identifiers' | 'strings' | 'comments' | 'all'.")] string scope = "identifiers",
+        [Description("Optional: case-sensitive Project.Name filter to scope the walk.")] string? projectFilter = null,
+        [Description("Maximum hits to return (default 500; hard cap to bound response size).")] int limit = 500,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var results = await semanticGrepService.SearchAsync(workspaceId, pattern, scope, projectFilter, limit, c);
+            return JsonSerializer.Serialize(new { count = results.Count, items = results }, JsonDefaults.Indented);
+        }, ct);
+    }
 }

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISymbolRelationshipService, SymbolRelationshipService>();
         services.AddSingleton<IMutationAnalysisService, MutationAnalysisService>();
         services.AddSingleton<ITypeConsumersService, TypeConsumersService>();
+        services.AddSingleton<ISemanticGrepService, SemanticGrepService>();
         services.AddSingleton<IDiagnosticService, DiagnosticService>();
         services.AddSingleton<IBuildService, BuildService>();
         services.AddSingleton<ITestRunnerService, TestRunnerService>();

--- a/src/RoslynMcp.Roslyn/Services/SemanticGrepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SemanticGrepService.cs
@@ -1,0 +1,255 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// semantic-grep-identifier-scoped-search: token-aware regex search backing the
+/// <c>semantic_grep</c> MCP tool. Walks every C# document in the loaded workspace, filters
+/// tokens (and trivia for the comment scope) by syntactic kind, and applies the supplied
+/// regex against the token text. Capped result count protects against runaway responses
+/// on large solutions.
+/// </summary>
+public sealed class SemanticGrepService : ISemanticGrepService
+{
+    /// <summary>Hard cap on per-pattern regex evaluation time per document, in milliseconds.</summary>
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    public const string ScopeIdentifiers = "identifiers";
+    public const string ScopeStrings = "strings";
+    public const string ScopeComments = "comments";
+    public const string ScopeAll = "all";
+
+    private static readonly HashSet<string> ValidScopes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ScopeIdentifiers, ScopeStrings, ScopeComments, ScopeAll,
+    };
+
+    private readonly IWorkspaceManager _workspace;
+    private readonly ILogger<SemanticGrepService> _logger;
+
+    public SemanticGrepService(IWorkspaceManager workspace, ILogger<SemanticGrepService> logger)
+    {
+        _workspace = workspace;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<SemanticGrepHitDto>> SearchAsync(
+        string workspaceId,
+        string pattern,
+        string scope,
+        string? projectFilter,
+        int limit,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(pattern))
+        {
+            throw new ArgumentException("pattern must be non-empty.", nameof(pattern));
+        }
+        if (string.IsNullOrWhiteSpace(scope) || !ValidScopes.Contains(scope))
+        {
+            throw new ArgumentException(
+                $"scope must be one of: {ScopeIdentifiers}, {ScopeStrings}, {ScopeComments}, {ScopeAll}.",
+                nameof(scope));
+        }
+        if (limit < 1)
+        {
+            throw new ArgumentException("limit must be >= 1.", nameof(limit));
+        }
+
+        Regex regex;
+        try
+        {
+            regex = new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"Invalid regex pattern: {ex.Message}", nameof(pattern), ex);
+        }
+
+        var includeIdentifiers = scope is ScopeAll || string.Equals(scope, ScopeIdentifiers, StringComparison.OrdinalIgnoreCase);
+        var includeStrings = scope is ScopeAll || string.Equals(scope, ScopeStrings, StringComparison.OrdinalIgnoreCase);
+        var includeComments = scope is ScopeAll || string.Equals(scope, ScopeComments, StringComparison.OrdinalIgnoreCase);
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var hits = new List<SemanticGrepHitDto>();
+
+        foreach (var project in solution.Projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!string.IsNullOrEmpty(projectFilter)
+                && !string.Equals(project.Name, projectFilter, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var document in project.Documents)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (document.FilePath is null)
+                {
+                    continue;
+                }
+
+                var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                if (root is null)
+                {
+                    continue;
+                }
+
+                CollectFromDocument(
+                    root,
+                    document.FilePath,
+                    regex,
+                    includeIdentifiers,
+                    includeStrings,
+                    includeComments,
+                    limit,
+                    hits);
+
+                if (hits.Count >= limit)
+                {
+                    break;
+                }
+            }
+
+            if (hits.Count >= limit)
+            {
+                break;
+            }
+        }
+
+        return hits
+            .OrderBy(h => h.FilePath, StringComparer.Ordinal)
+            .ThenBy(h => h.Line)
+            .ThenBy(h => h.Column)
+            .Take(limit)
+            .ToList();
+    }
+
+    private static void CollectFromDocument(
+        SyntaxNode root,
+        string filePath,
+        Regex regex,
+        bool includeIdentifiers,
+        bool includeStrings,
+        bool includeComments,
+        int limit,
+        List<SemanticGrepHitDto> hits)
+    {
+        foreach (var token in root.DescendantTokens(descendIntoTrivia: false))
+        {
+            if (hits.Count >= limit)
+            {
+                return;
+            }
+
+            var kind = token.Kind();
+
+            if (includeIdentifiers && kind == SyntaxKind.IdentifierToken)
+            {
+                TryAddMatch(token.ValueText, token.GetLocation(), filePath, "identifier", regex, hits);
+            }
+            else if (includeStrings && IsStringToken(kind))
+            {
+                // For string-literal tokens we match against the actual literal value (ValueText
+                // strips surrounding quotes/prefix and unescapes), which is what callers most
+                // often want when searching for "Console.Write" inside a logged string.
+                TryAddMatch(token.ValueText, token.GetLocation(), filePath, "string", regex, hits);
+            }
+
+            if (includeComments)
+            {
+                CollectCommentsFromTriviaList(token.LeadingTrivia, filePath, regex, limit, hits);
+                if (hits.Count >= limit) return;
+                CollectCommentsFromTriviaList(token.TrailingTrivia, filePath, regex, limit, hits);
+                if (hits.Count >= limit) return;
+            }
+        }
+    }
+
+    private static void CollectCommentsFromTriviaList(
+        SyntaxTriviaList trivia,
+        string filePath,
+        Regex regex,
+        int limit,
+        List<SemanticGrepHitDto> hits)
+    {
+        foreach (var t in trivia)
+        {
+            if (hits.Count >= limit) return;
+            if (!IsCommentTrivia(t.Kind()))
+            {
+                continue;
+            }
+            TryAddMatch(t.ToString(), t.GetLocation(), filePath, "comment", regex, hits);
+        }
+    }
+
+    private static void TryAddMatch(
+        string text,
+        Location location,
+        string filePath,
+        string tokenKind,
+        Regex regex,
+        List<SemanticGrepHitDto> hits)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+        try
+        {
+            if (!regex.IsMatch(text))
+            {
+                return;
+            }
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Skip pathological inputs rather than fail the whole sweep.
+            return;
+        }
+
+        var lineSpan = location.GetLineSpan();
+        // GetLineSpan returns 0-based; expose 1-based to callers (matches every other tool).
+        var line = lineSpan.StartLinePosition.Line + 1;
+        var column = lineSpan.StartLinePosition.Character + 1;
+
+        // Snippet: collapse to single line and trim length so a giant string literal does not
+        // bloat the response.
+        var snippet = text.Replace('\r', ' ').Replace('\n', ' ');
+        if (snippet.Length > 200)
+        {
+            snippet = snippet[..200];
+        }
+
+        hits.Add(new SemanticGrepHitDto(filePath, line, column, tokenKind, snippet));
+    }
+
+    private static bool IsStringToken(SyntaxKind kind) => kind switch
+    {
+        SyntaxKind.StringLiteralToken => true,
+        SyntaxKind.InterpolatedStringTextToken => true,
+        SyntaxKind.SingleLineRawStringLiteralToken => true,
+        SyntaxKind.MultiLineRawStringLiteralToken => true,
+        SyntaxKind.Utf8StringLiteralToken => true,
+        SyntaxKind.Utf8SingleLineRawStringLiteralToken => true,
+        SyntaxKind.Utf8MultiLineRawStringLiteralToken => true,
+        SyntaxKind.CharacterLiteralToken => true,
+        _ => false,
+    };
+
+    private static bool IsCommentTrivia(SyntaxKind kind) => kind switch
+    {
+        SyntaxKind.SingleLineCommentTrivia => true,
+        SyntaxKind.MultiLineCommentTrivia => true,
+        SyntaxKind.SingleLineDocumentationCommentTrivia => true,
+        SyntaxKind.MultiLineDocumentationCommentTrivia => true,
+        _ => false,
+    };
+}

--- a/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
@@ -1,0 +1,122 @@
+namespace RoslynMcp.Tests;
+
+[DoNotParallelize]
+[TestClass]
+public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task SemanticGrep_Identifiers_FindsConsoleInvocationsButNotStringContent()
+    {
+        // AnimalService.cs contains `Console.WriteLine($"{animal.Name} says {sound}")` —
+        // identifier scope must hit `Console`, but must NOT hit a string literal that
+        // happens to contain the word "Console".
+        var hits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @"^Console$", "identifiers", projectFilter: null, limit: 500, CancellationToken.None);
+
+        Assert.IsTrue(hits.Count >= 1, $"Expected at least one identifier hit for 'Console', got {hits.Count}.");
+        Assert.IsTrue(hits.All(h => h.TokenKind == "identifier"),
+            $"All hits must be identifier-kind. Got: {string.Join(",", hits.Select(h => h.TokenKind).Distinct())}");
+        Assert.IsTrue(hits.Any(h => h.FilePath.EndsWith("AnimalService.cs", StringComparison.OrdinalIgnoreCase)),
+            "Expected an identifier hit for 'Console' in AnimalService.cs.");
+
+        // 1-based line/column.
+        foreach (var h in hits)
+        {
+            Assert.IsTrue(h.Line >= 1, $"Line number must be 1-based; got {h.Line}.");
+            Assert.IsTrue(h.Column >= 1, $"Column number must be 1-based; got {h.Column}.");
+        }
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_Strings_FindsLiteralContentButNotIdentifiers()
+    {
+        // AnimalService.cs has the interpolated string with text " says " between holes.
+        // String scope should hit the literal text, not the surrounding identifiers.
+        var hits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @"says", "strings", projectFilter: null, limit: 500, CancellationToken.None);
+
+        Assert.IsTrue(hits.All(h => h.TokenKind == "string"),
+            $"All hits must be string-kind. Got: {string.Join(",", hits.Select(h => h.TokenKind).Distinct())}");
+        Assert.IsTrue(hits.Any(h => h.FilePath.EndsWith("AnimalService.cs", StringComparison.OrdinalIgnoreCase)),
+            "Expected a string-literal hit for 'says' in AnimalService.cs.");
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_Comments_DoesNotMatchIdentifiersOrStrings()
+    {
+        // Run identifiers + strings scope and assert NO comment-kind hits leak in.
+        var idHits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @"Animal", "identifiers", projectFilter: null, limit: 500, CancellationToken.None);
+        Assert.IsTrue(idHits.All(h => h.TokenKind == "identifier"),
+            "Identifier-scope must not return string or comment hits.");
+
+        // Comment scope should never return identifier-kind hits.
+        var commentHits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @".+", "comments", projectFilter: null, limit: 500, CancellationToken.None);
+        Assert.IsTrue(commentHits.All(h => h.TokenKind == "comment"),
+            "Comment-scope must only return comment-kind hits.");
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_All_UnionsAllThreeBuckets()
+    {
+        var allHits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @"Animal", "all", projectFilter: null, limit: 500, CancellationToken.None);
+        var idHits = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @"Animal", "identifiers", projectFilter: null, limit: 500, CancellationToken.None);
+
+        Assert.IsTrue(allHits.Count >= idHits.Count,
+            $"Scope='all' must return at least as many hits as 'identifiers'. all={allHits.Count}, identifiers={idHits.Count}.");
+
+        var distinctKinds = allHits.Select(h => h.TokenKind).Distinct().ToList();
+        foreach (var kind in distinctKinds)
+        {
+            CollectionAssert.Contains(new[] { "identifier", "string", "comment" }, kind,
+                $"Unexpected token kind '{kind}' under scope='all'.");
+        }
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_Limit_CapsResultCount()
+    {
+        var capped = await SemanticGrepService.SearchAsync(
+            WorkspaceId, @".", "identifiers", projectFilter: null, limit: 5, CancellationToken.None);
+        Assert.IsTrue(capped.Count <= 5, $"limit=5 must cap result list; got {capped.Count}.");
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_InvalidScope_Throws()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(
+            () => SemanticGrepService.SearchAsync(
+                WorkspaceId, @"x", "definitely-not-a-scope", projectFilter: null, limit: 10, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_EmptyPattern_Throws()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(
+            () => SemanticGrepService.SearchAsync(
+                WorkspaceId, "", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task SemanticGrep_InvalidRegex_Throws()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(
+            () => SemanticGrepService.SearchAsync(
+                WorkspaceId, "(unclosed", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -28,6 +28,7 @@ public abstract class TestBase
     protected static SymbolRelationshipService SymbolRelationshipService { get; private set; } = null!;
     protected static MutationAnalysisService MutationAnalysisService { get; private set; } = null!;
     protected static TypeConsumersService TypeConsumersService { get; private set; } = null!;
+    protected static SemanticGrepService SemanticGrepService { get; private set; } = null!;
     protected static DiagnosticService DiagnosticService { get; private set; } = null!;
     protected static RefactoringService RefactoringService { get; private set; } = null!;
     protected static BuildService BuildService { get; private set; } = null!;
@@ -126,6 +127,7 @@ public abstract class TestBase
         SymbolRelationshipService = services.SymbolRelationshipService;
         MutationAnalysisService = services.MutationAnalysisService;
         TypeConsumersService = services.TypeConsumersService;
+        SemanticGrepService = services.SemanticGrepService;
         DiagnosticService = services.DiagnosticService;
         RefactoringService = services.RefactoringService;
         BuildService = services.BuildService;

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -15,6 +15,7 @@ internal sealed class TestServiceContainer
     public required SymbolRelationshipService SymbolRelationshipService { get; init; }
     public required MutationAnalysisService MutationAnalysisService { get; init; }
     public required TypeConsumersService TypeConsumersService { get; init; }
+    public required SemanticGrepService SemanticGrepService { get; init; }
     public required DiagnosticService DiagnosticService { get; init; }
     public required RefactoringService RefactoringService { get; init; }
     public required BuildService BuildService { get; init; }
@@ -147,6 +148,9 @@ internal sealed class TestServiceContainer
             TypeConsumersService = new TypeConsumersService(
                 workspaceManager,
                 NullLogger<TypeConsumersService>.Instance),
+            SemanticGrepService = new SemanticGrepService(
+                workspaceManager,
+                NullLogger<SemanticGrepService>.Instance),
             SymbolRelationshipService = new SymbolRelationshipService(
                 workspaceManager,
                 referenceService,


### PR DESCRIPTION
## Summary
- New `semantic_grep(pattern, scope, projectFilter?, limit)` MCP tool — token-aware regex search over every C# document in the loaded workspace. Walks `SyntaxTree.DescendantTokens` (and comment trivia for the `comments` scope) and filters by `SyntaxToken.Kind()` so callers can exclude false-positive matches inside string literals or comments.
- Scopes: `identifiers` (identifier tokens) | `strings` (string-literal tokens — verbatim, interpolated text, raw, char, utf8) | `comments` (single-line, multi-line, doc-comment trivia) | `all` (union).
- Hard-capped at 500 hits per call to bound response size on large solutions; results sorted by ascending file/line/column.
- Registered as **experimental** (new tool, soak before promotion). Surface bumped to **167 tools** (111 stable / 56 experimental).

## Test plan
- [x] `SemanticGrepServiceTests` — 8 tests covering each scope value (identifiers, strings, comments, all), limit cap, invalid scope/pattern/regex
- [x] `ReadmeSurfaceCountTests` green after surface bump (`166 → 167`)
- [x] `eng/verify-release.ps1 -Configuration Release` — 1001/1001 tests green
- [x] `eng/verify-ai-docs.ps1` green
- [x] Identifier scope finds `Console` invocations in `AnimalService.cs` but not string content; string scope finds literal text but not identifiers; comment scope only returns `comment`-kind hits

Closes: semantic-grep-identifier-scoped-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)