### PR TITLE
release: v1.33.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.33.0] - 2026-04-26
+
+### Added
+
+- **Added:** RMCP010 analyzer (`StdoutWriteAnalyzer`) that prevents `Console.Out.Write*` / `Trace.WriteLine` from leaking into `RoslynMcp.Host.Stdio` (would corrupt the stdio NDJSON framing). Allow-listed `Console.Out.Flush*` (protocol-required) and `Console.Error.*` (stderr-safe). Closes `stdio-host-stdout-audit`.
+- **Added:** PreToolUse guard in `hooks/hooks.json` that blocks `Edit`/`Write`/`MultiEdit` on release-managed files (`Directory.Build.props`, `BannedSymbols.txt`, the 5 version files, `.claude-plugin/{plugin,marketplace}.json`, `hooks/hooks.json`, `eng/verify-version-drift.ps1`, `eng/verify-skills-are-generic.ps1`) unless the agent's rationale contains `ack: release-managed`. Documented in `ai_docs/workflow.md`. Closes `pretooluse-block-release-critical-file-edits`.
+- **Added:** Cross-server tool aliases (`get_symbol_outline` → `document_symbols`, `find_duplicated_code` → `find_duplicated_methods`, `get_test_coverage_map` → `test_coverage`) so agents migrating from python-refactor (Jedi) land on the canonical tool. Aliases include a `deprecation.canonicalName` field on the response envelope; canonical tools include the same field with `null` value to keep the schema uniform. Closes `roslyn-mcp-sister-tool-name-aliases`.
+- **Added:** `find_type_consumers(typeName, limit) → [{filePath, kinds, count}]` MCP tool — file-granularity rollup over the existing reference index, removes the Grep fallback for "which files touch this type" workflows. Site kinds classified as `using-directive` / `ctor` / `inherit` / `field-declaration` / `local-declaration` (with `other` for unrecognized contexts). Registered in the experimental tier; surface count bumped to **166 tools** (111 stable / 55 experimental). Closes `find-type-consumers-file-granularity-rollup`.
+- **Added:** PostToolUse hook in `hooks/hooks.json` that runs `eng/verify-skills-are-generic.ps1` on every `skills/**/SKILL.md` edit, surfacing shipped-skill genericity violations the same turn instead of waiting for the CI gate. Dispatches through a thin stdin-JSON wrapper at `eng/verify-skills-on-edit.ps1` to avoid brittle inline shell quoting. Closes `posttool-verify-skills-on-shipped-skill-edits`.
+- **Added:** `validate_workspace` accepts `responseFormat: "json" | "markdown"` (default `null` → bit-for-bit identical JSON envelope; `"markdown"` returns a compact summary table with per-diagnostic / per-test rows capped at 20 each). Other summary-shaped tools (`server_info`, `workspace_list`, etc.) will adopt the pattern in follow-up rows. Closes `response-format-json-markdown-parameter`.
+- **Added:** `semantic_grep(pattern, scope=identifiers|strings|comments|all, projectFilter?) → [{filePath, line, column, tokenKind, snippet}]` MCP tool — token-aware grep over C# code, lets agents avoid false-positive matches inside string literals or comments. Walks `SyntaxTree.DescendantTokens` per workspace document and filters by `SyntaxToken.Kind()`. Capped at 500 hits per call. Registered in the experimental tier; surface count bumped to **167 tools** (111 stable / 56 experimental). Closes `semantic-grep-identifier-scoped-search`.
+
+### Maintenance
+
+- **Maintenance:** Widen `pr-reconciler` subagent's pending-checks poll budget from 1×60s retry (~120s ceiling) to 12×60s retries (~12-min ceiling) with progress notifications between attempts. Failing checks still short-circuit the early-exit path. Removes false-`not-ready` returns on slow `validate` jobs. Closes `pr-reconciler-poll-budget-tightness`.
+
 ## [1.32.0] - 2026-04-25
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.32.0</Version>
+    <Version>1.33.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/find-type-consumers-file-granularity-rollup.md
+++ b/changelog.d/find-type-consumers-file-granularity-rollup.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `find_type_consumers(typeName, limit) → [{filePath, kinds, count}]` MCP tool — file-granularity rollup over the existing reference index, removes the Grep fallback for "which files touch this type" workflows. Site kinds classified as `using-directive` / `ctor` / `inherit` / `field-declaration` / `local-declaration` (with `other` for unrecognized contexts). Registered in the experimental tier; surface count bumped to **166 tools** (111 stable / 55 experimental). Closes `find-type-consumers-file-granularity-rollup`.

--- a/changelog.d/posttool-verify-skills-on-shipped-skill-edits.md
+++ b/changelog.d/posttool-verify-skills-on-shipped-skill-edits.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** PostToolUse hook in `hooks/hooks.json` that runs `eng/verify-skills-are-generic.ps1` on every `skills/**/SKILL.md` edit, surfacing shipped-skill genericity violations the same turn instead of waiting for the CI gate. Dispatches through a thin stdin-JSON wrapper at `eng/verify-skills-on-edit.ps1` to avoid brittle inline shell quoting. Closes `posttool-verify-skills-on-shipped-skill-edits`.

--- a/changelog.d/pr-reconciler-poll-budget-tightness.md
+++ b/changelog.d/pr-reconciler-poll-budget-tightness.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Widen `pr-reconciler` subagent's pending-checks poll budget from 1×60s retry (~120s ceiling) to 12×60s retries (~12-min ceiling) with progress notifications between attempts. Failing checks still short-circuit the early-exit path. Removes false-`not-ready` returns on slow `validate` jobs. Closes `pr-reconciler-poll-budget-tightness`.

--- a/changelog.d/pretooluse-block-release-critical-file-edits.md
+++ b/changelog.d/pretooluse-block-release-critical-file-edits.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** PreToolUse guard in `hooks/hooks.json` that blocks `Edit`/`Write`/`MultiEdit` on release-managed files (`Directory.Build.props`, `BannedSymbols.txt`, the 5 version files, `.claude-plugin/{plugin,marketplace}.json`, `hooks/hooks.json`, `eng/verify-version-drift.ps1`, `eng/verify-skills-are-generic.ps1`) unless the agent's rationale contains `ack: release-managed`. Documented in `ai_docs/workflow.md`. Closes `pretooluse-block-release-critical-file-edits`.

--- a/changelog.d/response-format-json-markdown-parameter.md
+++ b/changelog.d/response-format-json-markdown-parameter.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `validate_workspace` accepts `responseFormat: "json" | "markdown"` (default `null` → bit-for-bit identical JSON envelope; `"markdown"` returns a compact summary table with per-diagnostic / per-test rows capped at 20 each). Other summary-shaped tools (`server_info`, `workspace_list`, etc.) will adopt the pattern in follow-up rows. Closes `response-format-json-markdown-parameter`.

--- a/changelog.d/roslyn-mcp-sister-tool-name-aliases.md
+++ b/changelog.d/roslyn-mcp-sister-tool-name-aliases.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** Cross-server tool aliases (`get_symbol_outline` → `document_symbols`, `find_duplicated_code` → `find_duplicated_methods`, `get_test_coverage_map` → `test_coverage`) so agents migrating from python-refactor (Jedi) land on the canonical tool. Aliases include a `deprecation.canonicalName` field on the response envelope; canonical tools include the same field with `null` value to keep the schema uniform. Closes `roslyn-mcp-sister-tool-name-aliases`.

--- a/changelog.d/semantic-grep-identifier-scoped-search.md
+++ b/changelog.d/semantic-grep-identifier-scoped-search.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `semantic_grep(pattern, scope=identifiers|strings|comments|all, projectFilter?) → [{filePath, line, column, tokenKind, snippet}]` MCP tool — token-aware grep over C# code, lets agents avoid false-positive matches inside string literals or comments. Walks `SyntaxTree.DescendantTokens` per workspace document and filters by `SyntaxToken.Kind()`. Capped at 500 hits per call. Registered in the experimental tier; surface count bumped to **167 tools** (111 stable / 56 experimental). Closes `semantic-grep-identifier-scoped-search`.

--- a/changelog.d/stdio-host-stdout-audit.md
+++ b/changelog.d/stdio-host-stdout-audit.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** RMCP010 analyzer (`StdoutWriteAnalyzer`) that prevents `Console.Out.Write*` / `Trace.WriteLine` from leaking into `RoslynMcp.Host.Stdio` (would corrupt the stdio NDJSON framing). Allow-listed `Console.Out.Flush*` (protocol-required) and `Console.Error.*` (stderr-safe). Closes `stdio-host-stdout-audit`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary
Version bump 1.32.0 → 1.33.0 (minor).

Consumes 8 `changelog.d/` fragments into the new `## [1.33.0]` section.

## Highlights (7 Added + 1 Maintenance)

**Added:**
- RMCP010 analyzer (`StdoutWriteAnalyzer`) — preventive stdio-framing guardrail
- PreToolUse guard for release-managed files (`hooks/hooks.json`)
- Cross-server tool aliases (`get_symbol_outline`, `find_duplicated_code`, `get_test_coverage_map`)
- `find_type_consumers` MCP tool — file-granularity rollup over the reference index
- PostToolUse hook running `verify-skills-are-generic.ps1` on every `skills/**/SKILL.md` edit
- `validate_workspace` accepts `responseFormat: "json" | "markdown"`
- `semantic_grep` MCP tool — token-aware grep over C# code
- Surface count: **162 → 167 tools** (108 → 111 stable, 54 → 56 experimental)

**Maintenance:**
- Widen `pr-reconciler` poll budget from 1×60s to 12×60s

See `CHANGELOG.md` for full details.

## Test plan
- [x] `eng/verify-version-drift.ps1` → all 5 files agree on 1.33.0
- [x] `eng/verify-release.ps1 -Configuration Release` → 1001/1001 tests pass
- [x] `eng/verify-skills-are-generic.ps1` → 31 SKILL.md checked, all generic
- [ ] CI green