### PR TITLE
fix(refactoring): change_signature_preview rejects parenthesized metadataName with actionable error (change-signature-preview-metadataname-shape-error-actionability)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
@@ -30,7 +30,7 @@ public static class ChangeSignatureTools
         [Description("Optional: 1-based line number of the method declaration")] int? line = null,
         [Description("Optional: 1-based column number of the method declaration")] int? column = null,
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
-        [Description("Optional: fully qualified metadata name of the method")] string? metadataName = null,
+        [Description("Optional: bare fully-qualified method name without parentheses (e.g. 'Foo.Bar.Baz'). For overloaded methods supply file/line/column to disambiguate, or use symbolHandle from symbol_search. Parenthesized signatures like 'Foo.Bar.Baz(string)' are NOT accepted.")] string? metadataName = null,
         [Description("Parameter name. For op='add': the new parameter's name. For op='remove': the existing parameter to drop (or use position). For op='rename': the current name.")] string? name = null,
         [Description("op='rename' only: the new parameter name.")] string? newName = null,
         [Description("op='add' only: the parameter type (e.g. 'string', 'IReadOnlyList<int>', 'CancellationToken').")] string? parameterType = null,

--- a/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
@@ -37,6 +37,28 @@ public sealed class ChangeSignatureService : IChangeSignatureService
         if (string.IsNullOrWhiteSpace(request.Op))
             throw new ArgumentException("ChangeSignatureRequest.Op is required.", nameof(request));
 
+        // change-signature-preview-metadataname-shape-error-actionability:
+        // Reject parenthesized metadataName up-front with an actionable error. The shape
+        // `Namespace.Type.Method(string)` is what an agent that copy/pastes a Roslyn
+        // ToDisplayString() output naturally produces, but `compilation.GetTypeByMetadataName`
+        // does NOT accept parentheses — it returns null, the fallback "split-at-last-dot"
+        // path also fails (containing-type-name still contains parens), and the service
+        // ultimately surfaces the misleading "requires a method symbol; resolved null"
+        // error which names the wrong cause. Pre-check is method-style-scoped (this
+        // service ONLY accepts method symbols, so the rejection cannot swallow a
+        // legitimate property-indexer-accessor or other non-method kind that
+        // `SymbolResolver.ResolveByMetadataNameAsync` is shared with from non-method
+        // tools). Plan rationale: ai_docs/plans/20260428T124405Z_backlog-sweep/plan.md
+        // initiative `change-signature-preview-metadataname-shape-error-actionability`.
+        if (locator.HasMetadataName && locator.MetadataName!.Contains('('))
+        {
+            throw new ArgumentException(
+                $"metadataName must be a bare method name (e.g. 'Foo.Bar.Baz') with file/line/column for disambiguation, " +
+                $"OR a symbolHandle from symbol_search; received '{locator.MetadataName}' which contains a parenthesized " +
+                $"signature. Drop the '(...)' or use symbolHandle.",
+                nameof(locator));
+        }
+
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
 

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
@@ -1,0 +1,149 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for `change-signature-preview-metadataname-shape-error-actionability` (P3).
+/// Pre-fix, calling `change_signature_preview` with a parenthesized metadata name like
+/// <c>SampleLib.AnimalService.GetAllAnimals(string)</c> failed with the misleading
+/// <c>"requires a method symbol; resolved null"</c> error. The cause was actually shape
+/// mismatch (parens are not part of a metadata name) but the message named "method symbol
+/// resolution" — pointing the agent at the wrong cure. Post-fix the service rejects the
+/// parenthesized shape up-front with an actionable message that names the supported
+/// alternatives (bare method name + position-disambiguator, or `symbolHandle` from
+/// `symbol_search`).
+/// </summary>
+[TestClass]
+public sealed class ChangeSignaturePreviewMetadataNameShapeTests : TestBase
+{
+    private static ChangeSignatureService _changeSignatureService = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        InitializeServices();
+        _changeSignatureService = new ChangeSignatureService(
+            WorkspaceManager,
+            PreviewStore,
+            RefactoringService);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Parenthesized metadata names — the shape an agent gets when copy/pasting a Roslyn
+    /// <c>ToDisplayString()</c> output — must produce an actionable rejection that names
+    /// the shape mismatch and points at the supported alternatives. Pre-fix the error read
+    /// "requires a method symbol; resolved null", which incorrectly described the cause as
+    /// resolution failure rather than as shape mismatch. The new message must contain
+    /// "parenthesized" (so the agent learns the shape is wrong) and "symbolHandle" (the
+    /// supported alternative).
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_MetadataNameWithParens_RejectsWithActionableError()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            // Parenthesized metadata name — exactly the shape an agent that pastes a
+            // Roslyn `ToDisplayString()` output naturally produces. Pre-fix this throws
+            // `InvalidOperationException("requires a method symbol; resolved null")` —
+            // misleading. Post-fix it throws `ArgumentException` whose message names the
+            // shape mismatch and the supported alternatives.
+            var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals(string)");
+            var request = new ChangeSignatureRequest(
+                Op: "remove",
+                Name: null,
+                ParameterType: null,
+                Position: 0,
+                NewName: null,
+                DefaultValue: null);
+
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, request, CancellationToken.None));
+
+            // Error must name the shape mismatch (the actual cause) so the agent knows what
+            // to fix.
+            StringAssert.Contains(ex.Message, "parenthesized",
+                $"error must call out the parenthesized signature as the cause; got: {ex.Message}");
+
+            // Error must point at the supported alternative.
+            StringAssert.Contains(ex.Message, "symbolHandle",
+                $"error must name `symbolHandle` as the alternative; got: {ex.Message}");
+
+            // Error must echo back the offending input so the agent can correlate with
+            // its own request payload.
+            StringAssert.Contains(ex.Message, "SampleLib.AnimalService.GetAllAnimals(string)",
+                $"error must echo the offending metadata name input; got: {ex.Message}");
+
+            // Error must NOT use the misleading pre-fix wording.
+            Assert.IsFalse(ex.Message.Contains("requires a method symbol", StringComparison.Ordinal),
+                $"error must NOT use the pre-fix 'requires a method symbol' wording; got: {ex.Message}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// Negative-case complement: the supported bare-method-name shape must continue to
+    /// resolve cleanly. This exercises the rejection branch's negation — if the new
+    /// pre-check accidentally rejected non-parenthesized inputs the supported path would
+    /// regress. SampleLib.AnimalService.GetAllAnimals is a real method on the sample
+    /// solution; locating it by bare name and removing parameter 0 must succeed. (The
+    /// method is parameterless in the sample, so `op=remove Position=0` itself raises
+    /// a different error — but that error must NOT be the new shape-mismatch error.)
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_BareMetadataName_DoesNotHitShapeMismatchPath()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            // Bare fully-qualified method name — the supported shape. The resolver must
+            // accept this and proceed past the new shape-rejection branch. The downstream
+            // service may still surface a different error (e.g. method has no parameters,
+            // or position out of range), but that error must NOT contain the new
+            // shape-mismatch wording.
+            var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals");
+            var request = new ChangeSignatureRequest(
+                Op: "remove",
+                Name: null,
+                ParameterType: null,
+                Position: 99, // genuinely out of range — exercises the post-resolution path
+                NewName: null,
+                DefaultValue: null);
+
+            // The bare name resolves and the pipeline proceeds past the parenthesis check.
+            // The downstream behavior may succeed or fail, but it must NOT raise the new
+            // shape-mismatch error.
+            try
+            {
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, request, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                // Whatever the downstream raises, it must NOT be the shape-mismatch error.
+                Assert.IsFalse(ex.Message.Contains("parenthesized", StringComparison.Ordinal),
+                    $"bare name must not be flagged as parenthesized; got: {ex.Message}");
+            }
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pre-fix, calling `change_signature_preview` with a fully-qualified metadata name of shape `Namespace.Type.Method(string)` — the natural shape an agent gets when copy/pasting a Roslyn `ToDisplayString()` output — failed with the misleading error *"requires a method symbol; resolved null"*. The parenthesized signature is not a valid metadata name (`compilation.GetTypeByMetadataName` does not accept parens), and the fallback "split-at-last-dot" path also fails because the containing-type half still contains parens. The downstream error named "method symbol resolution" as the cause, which is wrong and points the agent at the wrong cure.

This PR adds a method-style-scoped pre-check in `ChangeSignatureService.PreviewChangeSignatureAsync`: if `locator.MetadataName` contains `(`, throw `ArgumentException` with a message that names the shape mismatch (`"parenthesized signature"`) and points at the supported alternatives (`"bare method name + file/line/column"` or `"symbolHandle from symbol_search"`).

## Why the change is in the service, not the shared resolver

The plan's risk note flagged that the shared `SymbolResolver.ResolveByMetadataNameAsync` is also used by non-method tools (`find_references`, `find_consumers`, etc.) which could legitimately receive non-method symbol kinds. Narrowing the rejection to the method-only `ChangeSignatureService` prevents collateral damage to those tools — `find_references` against a property indexer with parens (rare but not impossible to imagine future-shape) is unaffected.

## Files changed

- `src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs` — pre-check that throws `ArgumentException` for parenthesized metadata names; comment links rationale back to the backlog row.
- `src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs` — tightened `[Description]` on the `metadataName` parameter to include a one-line shape example so the catalog/JSON-schema surface tells agents what's expected.
- `tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs` (new) — 2 regression tests:
  1. Parenthesized name -> `ArgumentException` with `"parenthesized"` and `"symbolHandle"` in the message; must NOT contain pre-fix wording `"requires a method symbol"`.
  2. Bare name (supported shape) -> exercises the rejection branch's negation; whatever the downstream raises must NOT contain the new shape-mismatch wording.

## Test plan

- [x] `mcp__roslyn__compile_check` clean for both production files
- [x] `mcp__roslyn__test_run --filter ChangeSignaturePreviewMetadataNameShape` -> 2/2 passed
- [x] `mcp__roslyn__test_run --filter ChangeSignaturePreview` -> 12/12 passed (existing 10 + new 2)
- [x] `./eng/verify-release.ps1 -Configuration Release` -> 1009 passed, 0 failed, build clean

Closes: change-signature-preview-metadataname-shape-error-actionability

🤖 Generated with [Claude Code](https://claude.com/claude-code)