### PR TITLE
fix(catalog): apply_composite_preview leads with DESTRUCTIVE warning (apply-composite-preview-name-friction)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Orchestration.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Orchestration.cs
@@ -28,7 +28,7 @@ public static partial class ServerSurfaceCatalog
         Tool("migrate_package_preview", "orchestration", "experimental", true, false, "Preview migrating a package across affected projects."),
         Tool("split_class_preview", "orchestration", "experimental", true, false, "Preview splitting a class into a new partial file."),
         Tool("extract_and_wire_interface_preview", "orchestration", "experimental", true, false, "Preview extracting an interface and updating DI registrations."),
-        Tool("apply_composite_preview", "orchestration", "experimental", false, true, "Apply a previously previewed orchestration operation."),
+        Tool("apply_composite_preview", "orchestration", "experimental", false, true, "DESTRUCTIVE — applies a previously-previewed orchestration operation to disk. Pair with a *_preview call in the same session."),
         Tool("get_syntax_tree", "syntax", "stable", true, false, "Return a structured syntax tree for a document or range."),
         Tool("security_diagnostics", "security", "stable", true, false, "Return security-relevant diagnostics with OWASP categorization and fix hints."),
         Tool("security_analyzer_status", "security", "stable", true, false, "Check which security analyzer packages are present and recommend missing ones."),

--- a/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs
@@ -93,8 +93,8 @@ public static class OrchestrationTools
 
     [McpServerTool(Name = "apply_composite_preview", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("orchestration", "experimental", false, true,
-        "Apply a previously previewed orchestration operation."),
-     Description("Apply a previously previewed orchestration operation using its preview token.")]
+        "DESTRUCTIVE — applies a previously-previewed orchestration operation to disk. Pair with a *_preview call in the same session."),
+     Description("DESTRUCTIVE — applies a previously-previewed orchestration operation to disk using its preview token. Pair with an orchestration *_preview call in the same session before invoking.")]
     public static Task<string> ApplyCompositePreview(
         IWorkspaceExecutionGate gate,
         ICompositeApplyOrchestrator compositeApplyOrchestrator,

--- a/tests/RoslynMcp.Tests/CatalogDestructiveWarningTests.cs
+++ b/tests/RoslynMcp.Tests/CatalogDestructiveWarningTests.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System.Reflection;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class CatalogDestructiveWarningTests
+{
+    private const string DestructiveMarker = "DESTRUCTIVE";
+
+    [TestMethod]
+    public void Catalog_ApplyCompositePreview_SummaryLeadsWithDestructiveMarker()
+    {
+        var entry = ServerSurfaceCatalog.Tools.SingleOrDefault(t => t.Name == "apply_composite_preview");
+        Assert.IsNotNull(entry, "apply_composite_preview must be present in the tool catalog.");
+        Assert.IsTrue(entry.Destructive, "Catalog entry must classify the tool as destructive.");
+        Assert.IsTrue(
+            entry.Summary.StartsWith(DestructiveMarker, StringComparison.Ordinal),
+            $"Catalog summary must lead with '{DestructiveMarker}' so agents reading discover_capabilities see the warning before invoking. Actual: '{entry.Summary}'");
+    }
+
+    [TestMethod]
+    public void Tool_ApplyCompositePreview_DescriptionLeadsWithDestructiveMarker()
+    {
+        var method = typeof(OrchestrationTools).GetMethod(
+            nameof(OrchestrationTools.ApplyCompositePreview),
+            BindingFlags.Public | BindingFlags.Static);
+        Assert.IsNotNull(method, "OrchestrationTools.ApplyCompositePreview must exist.");
+
+        var description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
+        Assert.IsNotNull(description, "ApplyCompositePreview must carry a [Description] attribute for tool-schema rendering.");
+        Assert.IsTrue(
+            description.Description.StartsWith(DestructiveMarker, StringComparison.Ordinal),
+            $"Tool [Description] must lead with '{DestructiveMarker}' to mirror the catalog summary. Actual: '{description.Description}'");
+    }
+}


### PR DESCRIPTION
## Summary

Tool name `apply_composite_preview` reads as a preview but the tool is **destructive** — it applies a previously-staged composite preview to disk. Agents reading `discover_capabilities` had no warning marker, so misuse was plausible. Two text changes lead the description with `DESTRUCTIVE —`:

- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Orchestration.cs:31` — catalog `summary`.
- `src/RoslynMcp.Host.Stdio/Tools/OrchestrationTools.cs` `ApplyCompositePreview` `[Description]` — mirrors the warning for MCP clients that render the schema description.

Regression test (new file, `tests/RoslynMcp.Tests/CatalogDestructiveWarningTests.cs`):
- Asserts `ServerSurfaceCatalog.Tools["apply_composite_preview"].Summary.StartsWith("DESTRUCTIVE")`.
- Asserts `OrchestrationTools.ApplyCompositePreview` `[System.ComponentModel.Description]` starts with `DESTRUCTIVE`.

Rule 3 exemption: tool-surface-only, 2 files. `toolPolicy: edit-only`. Hotspot file: `ServerSurfaceCatalog.Orchestration.cs` (this batch's sole hotspot-touching initiative).

## Closes

- `apply-composite-preview-name-friction`

## Validation

- [x] `pwsh -File ./eng/verify-ai-docs.ps1` — passed
- [x] `pwsh -File ./eng/verify-release.ps1 -Configuration Release` — passed (1017 tests, 0 failed, 5 min 2s)
- [x] Targeted `dotnet test --filter CatalogDestructiveWarning|SurfaceCatalogTests` — 13/13 passed (2 new tests + 11 existing catalog tests still green)

## Note on origin

Originally spawned via the parallel-mode wave 2 of `/backlog-sweep:execute mode=parallel count=2`. The subagent (`initiative-executor`) made the 2 production-file edits before hitting the account's "extra usage" limit at 12:40pm Central reset window. The orchestrator session inherited the partial work, added the regression test (the missing piece), ran full CI-parity validation, and shipped.

The sibling initiative #3 (`symbol-info-not-found-message-locator-vs-location`) clean-abandoned in the same wave (no partial work to recover) and is deferred to the next sweep session after the usage reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)