### PR TITLE
refactor(roslyn-services): drop dead ILogger<T> fields from 4 services (batch 1)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -13,13 +12,11 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
-    private readonly ILogger<BulkRefactoringService> _logger;
 
-    public BulkRefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<BulkRefactoringService> logger)
+    public BulkRefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore)
     {
         _workspace = workspace;
         _previewStore = previewStore;
-        _logger = logger;
     }
 
     public async Task<RefactoringPreviewDto> PreviewBulkReplaceTypeAsync(

--- a/src/RoslynMcp.Roslyn/Services/CodeMetricsService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodeMetricsService.cs
@@ -4,19 +4,16 @@ using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class CodeMetricsService : ICodeMetricsService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<CodeMetricsService> _logger;
 
-    public CodeMetricsService(IWorkspaceManager workspace, ILogger<CodeMetricsService> logger)
+    public CodeMetricsService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _logger = logger;
     }
 
     public async Task<IReadOnlyList<ComplexityMetricsDto>> GetComplexityMetricsAsync(

--- a/src/RoslynMcp.Roslyn/Services/CompletionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompletionService.cs
@@ -3,19 +3,16 @@ using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class CompletionService : ICompletionService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<CompletionService> _logger;
 
-    public CompletionService(IWorkspaceManager workspace, ILogger<CompletionService> logger)
+    public CompletionService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _logger = logger;
     }
 
     public async Task<CompletionResultDto> GetCompletionsAsync(

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -4,19 +4,16 @@ using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class ConsumerAnalysisService : IConsumerAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<ConsumerAnalysisService> _logger;
 
-    public ConsumerAnalysisService(IWorkspaceManager workspace, ILogger<ConsumerAnalysisService> logger)
+    public ConsumerAnalysisService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _logger = logger;
     }
 
     public async Task<ConsumerAnalysisDto?> FindConsumersAsync(

--- a/tests/RoslynMcp.Tests/CodeMetricsNestingTests.cs
+++ b/tests/RoslynMcp.Tests/CodeMetricsNestingTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
@@ -281,7 +280,7 @@ public sealed class CodeMetricsNestingTests
                     fullPath))));
 
         var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
-        var service = new CodeMetricsService(wsManager, NullLogger<CodeMetricsService>.Instance);
+        var service = new CodeMetricsService(wsManager);
 
         var results = await service.GetComplexityMetricsAsync(
             WorkspaceId,

--- a/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
+++ b/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for backlog row <c>dead-logger-fields-roslyn-services-batch-1</c>.
+///
+/// Four services in <see cref="RoslynMcp.Roslyn.Services"/> previously declared a
+/// <c>private readonly ILogger&lt;T&gt; _logger</c> field that was assigned in the
+/// constructor but never read by any method. This test asserts that the field has
+/// been removed (and is not reintroduced) by reflecting on the type and confirming
+/// no instance field named <c>_logger</c> exists.
+///
+/// If a future change legitimately needs a logger on one of these services, prefer
+/// adding it back together with the call sites that actually emit log records — and
+/// then update this test to drop the type from <c>TypesThatMustNotHaveDeadLoggerFields</c>.
+/// </summary>
+[TestClass]
+public sealed class DeadLoggerFieldsTests
+{
+    private static readonly Type[] TypesThatMustNotHaveDeadLoggerFields =
+    [
+        typeof(BulkRefactoringService),
+        typeof(CodeMetricsService),
+        typeof(CompletionService),
+        typeof(ConsumerAnalysisService),
+    ];
+
+    [TestMethod]
+    public void GuardedServices_DoNotDeclareDeadLoggerField()
+    {
+        foreach (var type in TypesThatMustNotHaveDeadLoggerFields)
+        {
+            var field = type.GetField(
+                "_logger",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.IsNull(
+                field,
+                $"{type.FullName} declares a '_logger' field. The dead-logger-fields-roslyn-services-batch-1 sweep removed this field because no method ever read it. If a logger is now genuinely needed, drop {type.Name} from TypesThatMustNotHaveDeadLoggerFields and add the call sites in the same change.");
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -179,9 +179,7 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 NullLogger<TestDiscoveryService>.Instance,
                 validationOptions),
-            CompletionService = new CompletionService(
-                workspaceManager,
-                NullLogger<CompletionService>.Instance),
+            CompletionService = new CompletionService(workspaceManager),
             CodeActionService = new CodeActionService(
                 workspaceManager,
                 previewStore,
@@ -190,9 +188,7 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 compilationCache,
                 NullLogger<UnusedCodeAnalyzer>.Instance),
-            CodeMetricsService = new CodeMetricsService(
-                workspaceManager,
-                NullLogger<CodeMetricsService>.Instance),
+            CodeMetricsService = new CodeMetricsService(workspaceManager),
             NamespaceDependencyService = namespaceDependencyService,
             DiRegistrationService = diRegistrationService,
             NuGetDependencyService = nuGetDependencyService,
@@ -232,8 +228,7 @@ internal sealed class TestServiceContainer
             SyntaxService = new SyntaxService(workspaceManager),
             BulkRefactoringService = new BulkRefactoringService(
                 workspaceManager,
-                previewStore,
-                NullLogger<BulkRefactoringService>.Instance),
+                previewStore),
             CohesionAnalysisService = new CohesionAnalysisService(
                 workspaceManager,
                 NullLogger<CohesionAnalysisService>.Instance),
@@ -243,9 +238,7 @@ internal sealed class TestServiceContainer
             RecordFieldAdditionService = new RecordFieldAdditionService(
                 workspaceManager,
                 NullLogger<RecordFieldAdditionService>.Instance),
-            ConsumerAnalysisService = new ConsumerAnalysisService(
-                workspaceManager,
-                NullLogger<ConsumerAnalysisService>.Instance),
+            ConsumerAnalysisService = new ConsumerAnalysisService(workspaceManager),
             TypeExtractionService = new TypeExtractionService(
                 workspaceManager,
                 previewStore,
@@ -289,7 +282,7 @@ internal sealed class TestServiceContainer
                 NullLogger<ExtractMethodService>.Instance),
             ChangeTracker = changeTracker,
             RefactoringSuggestionService = new RefactoringSuggestionService(
-                new CodeMetricsService(workspaceManager, NullLogger<CodeMetricsService>.Instance),
+                new CodeMetricsService(workspaceManager),
                 new CohesionAnalysisService(workspaceManager, NullLogger<CohesionAnalysisService>.Instance),
                 new UnusedCodeAnalyzer(workspaceManager, compilationCache, NullLogger<UnusedCodeAnalyzer>.Instance),
                 NullLogger<RefactoringSuggestionService>.Instance),


### PR DESCRIPTION
## Summary

Closes: `dead-logger-fields-roslyn-services-batch-1`

Four services in `RoslynMcp.Roslyn.Services` declared a `private readonly ILogger<T> _logger` field that was assigned by the constructor but never read by any method. Verified with grep: write count = 1 (assignment), read count = 0. Drops the dead field, ctor parameter, ctor assignment, and the now-unused `using Microsoft.Extensions.Logging;` import from each:

- `BulkRefactoringService`
- `CodeMetricsService`
- `CompletionService`
- `ConsumerAnalysisService`

Updates 6 direct-`new` test call sites under `tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs` and `tests/RoslynMcp.Tests/CodeMetricsNestingTests.cs` to match the new ctor signatures (also drops the now-unused `Microsoft.Extensions.Logging.Abstractions` using from the latter). DI registrations in `ServiceCollectionExtensions.cs` use framework auto-resolution so no DI changes are required.

Adds `tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs` as a reflection-based regression guard that asserts no `_logger` instance field is reintroduced on the four guarded service types. If a logger is genuinely needed on one of these in the future, the test message instructs how to drop the type from the guard list and add real call sites in the same change.

This is batch 1 of 3.

## Test plan

- [x] `mcp__roslyn__compile_check` — all 5 projects, zero compiler errors and zero compiler warnings on edited files
- [x] `mcp__roslyn__test_run` — targeted run of `BulkRefactoringTests | CodeMetricsNestingTests | ConsumerAnalysisTests | DeadLoggerFieldsTests` — 13/13 pass
- [x] `./eng/verify-release.ps1 -Configuration Release` — 1018/1018 tests pass after `dotnet build-server shutdown` (an earlier run had 21 fixture-temp-path flakes from a stale build server; clean rerun is green)
- [x] `./eng/verify-ai-docs.ps1` — passed
- [x] DI sanity — `mcp__roslyn__get_di_registrations` shows the four services still resolve via the unchanged `ServiceCollectionExtensions.cs` AddSingleton lines

Note: plan called for `tests/RoslynMcp.Tests/Services/DeadLoggerFieldsTests.cs`; placed at `tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs` to match repo convention (the test project is flat — no `Services/` subdir). Same file count, same contents, same Validation step semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)