### PR TITLE
fix(tools): symbol_info not-found message names the locator field

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs
@@ -9,6 +9,21 @@ namespace RoslynMcp.Host.Stdio.Tools;
 internal static class SymbolLocatorFactory
 {
     /// <summary>
+    /// Maximum length of the metadata-name fragment echoed back in not-found error messages
+    /// (`symbol-info-not-found-message-locator-vs-location`). Long pasted metadata names — e.g.
+    /// the full <c>ToDisplayString()</c> of a generic constructed type — would otherwise leak
+    /// kilobytes of caller input into the error envelope.
+    /// </summary>
+    private const int MetadataNameMessageMaxLength = 200;
+
+    /// <summary>
+    /// Maximum length of the symbol-handle fragment echoed back in not-found error messages.
+    /// Symbol handles are opaque base64-ish blobs from the resolver; bound the echoed length
+    /// for the same payload-bloat reason as <see cref="MetadataNameMessageMaxLength"/>.
+    /// </summary>
+    private const int SymbolHandleMessageMaxLength = 120;
+
+    /// <summary>
     /// Builds a <see cref="SymbolLocator"/> from the provided parameters.
     /// </summary>
     /// <remarks>
@@ -64,5 +79,62 @@ internal static class SymbolLocatorFactory
 
         throw new ArgumentException(
             "Provide one of: filePath with line and column, symbolHandle, or metadataName.");
+    }
+
+    /// <summary>
+    /// Formats a "no symbol found" error message that names the locator field the caller
+    /// actually supplied — `symbol-info-not-found-message-locator-vs-location`. Pre-fix, every
+    /// not-found message read "No symbol found at the specified location" even when the caller
+    /// passed only <c>metadataName</c> (no location at all), pointing the caller at a non-existent
+    /// position to debug. The branch order matches the most-specific-first contract used by
+    /// callers: source location > symbol handle > metadata name. The factory's
+    /// <see cref="Create"/> populates exactly one mode, so in practice only one branch fires per
+    /// resolved locator — the explicit ordering is defense in depth in case a future caller
+    /// constructs a <see cref="SymbolLocator"/> directly with multiple modes set.
+    /// </summary>
+    /// <remarks>
+    /// Long pasted <c>metadataName</c>/<c>symbolHandle</c> values are truncated with an ellipsis
+    /// suffix so a multi-kilobyte input doesn't leak verbatim into the error envelope (Risks
+    /// field of the planning row).
+    /// </remarks>
+    public static string FormatSymbolNotFoundMessage(SymbolLocator locator)
+    {
+        ArgumentNullException.ThrowIfNull(locator);
+
+        if (locator.HasSourceLocation)
+        {
+            return $"No symbol found at {locator.FilePath}:{locator.Line}:{locator.Column}";
+        }
+
+        if (locator.HasHandle)
+        {
+            var truncatedHandle = TruncateForMessage(locator.SymbolHandle, SymbolHandleMessageMaxLength);
+            return $"No symbol found for symbol handle '{truncatedHandle}'";
+        }
+
+        if (locator.HasMetadataName)
+        {
+            var truncatedName = TruncateForMessage(locator.MetadataName, MetadataNameMessageMaxLength);
+            return $"No symbol found for metadata name '{truncatedName}'";
+        }
+
+        // The factory rejects empty locators upstream; this branch only fires if a future caller
+        // constructs a locator with all fields null/empty by hand. Keep the legacy wording so any
+        // log or alert still grepping for it on the empty-locator path keeps matching.
+        return "No symbol found at the specified location";
+    }
+
+    /// <summary>
+    /// Trims an echoed locator value to <paramref name="maxLength"/> characters, appending an
+    /// ellipsis when truncation occurred. Null/empty inputs are passed through verbatim — callers
+    /// guard the relevant <c>Has*</c> property before calling, so an empty value here means the
+    /// caller is bypassing the locator predicates and the raw empty string is the most informative
+    /// thing to surface.
+    /// </summary>
+    private static string TruncateForMessage(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value)) return value ?? string.Empty;
+        if (value.Length <= maxLength) return value;
+        return value.Substring(0, maxLength) + "...";
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -64,7 +64,13 @@ public static class SymbolTools
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var result = await symbolSearchService.GetSymbolInfoAsync(workspaceId, locator, c, allowAdjacent);
-            if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
+            if (result is null)
+            {
+                // symbol-info-not-found-message-locator-vs-location: name the locator field the
+                // caller actually supplied instead of the legacy "at the specified location" text,
+                // which misled agents who passed only metadataName (no location at all).
+                throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
+            }
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/tests/RoslynMcp.Tests/Services/SymbolInfoNotFoundMessageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/SymbolInfoNotFoundMessageTests.cs
@@ -1,0 +1,169 @@
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests.Services;
+
+/// <summary>
+/// Regression coverage for `symbol-info-not-found-message-locator-vs-location` (P4 — UX).
+/// Pre-fix, every <c>symbol_info</c> not-found error returned the verbatim string
+/// <c>"No symbol found at the specified location"</c> regardless of which locator field the
+/// caller actually supplied — including the cases where no source location was provided at all.
+/// Post-fix the message names the locator field (filePath:line:col, symbolHandle, or
+/// metadataName) so callers can correlate the failure with the input they sent.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class SymbolInfoNotFoundMessageTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// metadataName-only locator: the most common motivator for the bug — agents resolved a
+    /// fully-qualified type name (from DI registrations, document_symbols, etc.) and got told
+    /// the symbol was missing "at the specified location" they never supplied. Post-fix the
+    /// error must echo the metadata name so the agent knows what input failed to resolve.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolInfo_MetadataNameOnly_NotFound_NamesTheMetadataName()
+    {
+        const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSymbolInfo(
+                WorkspaceExecutionGate,
+                SymbolSearchService,
+                WorkspaceId,
+                metadataName: bogusName,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "metadata name",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, bogusName,
+            $"Error must echo the offending metadata name so the caller can correlate. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("at the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"at the specified location\" wording for metadataName-only callers. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// Source-location locator: the case where the legacy wording was at least directionally
+    /// correct, but still vague — "the specified location" leaves the caller guessing whether
+    /// they passed the right file. Post-fix the error must include the file:line:col literal
+    /// so the caller can verify their input round-tripped correctly.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolInfo_SourceLocationOnly_NotFound_NamesTheFileLineCol()
+    {
+        // Build an absolute path that's definitely not in the loaded workspace so the resolver
+        // returns null (no symbol). The exact path text is what we want to assert on, so the
+        // value is deterministic across machines.
+        var bogusFile = Path.Combine(Path.GetTempPath(), "definitely_not_in_workspace.cs");
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSymbolInfo(
+                WorkspaceExecutionGate,
+                SymbolSearchService,
+                WorkspaceId,
+                filePath: bogusFile,
+                line: 1,
+                column: 1,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, bogusFile,
+            $"Error must echo the file path that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, "1:1",
+            $"Error must echo the line:column position that was supplied. Got: {ex.Message}");
+        // The new message format is `"No symbol found at <file>:<line>:<col>"` — the literal
+        // `"the specified location"` phrase should be gone. Assert the substring is absent so a
+        // future caller who reverts the fix to a generic message gets caught here.
+        Assert.IsFalse(
+            ex.Message.Contains("the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"the specified location\" wording. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// symbolHandle-only locator: the third leg of the locator triad. A handle that decodes
+    /// correctly (well-formed base64+JSON payload) but points at a symbol that doesn't exist
+    /// in the loaded workspace exercises the resolver's "valid handle, symbol not found" path.
+    /// Malformed handles (non-base64, non-JSON, etc.) raise <see cref="ArgumentException"/>
+    /// upstream and never reach the not-found branch — that's a separate code path tested
+    /// elsewhere. Post-fix the not-found message must name the handle the caller supplied.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolInfo_SymbolHandleOnly_NotFound_NamesTheSymbolHandle()
+    {
+        // Construct a structurally-valid handle whose payload references a metadata name that
+        // doesn't exist in SampleSolution — the deserializer accepts the payload, the resolver
+        // looks for `SampleLib.NotARealType`, fails, and returns null. Result: the caller
+        // reaches the SymbolTools.cs throw site we're testing.
+        var validButMissingHandle = EncodeHandle("SampleLib.DefinitelyMissingType_Bogus");
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSymbolInfo(
+                WorkspaceExecutionGate,
+                SymbolSearchService,
+                WorkspaceId,
+                symbolHandle: validButMissingHandle,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "symbol handle",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, validButMissingHandle,
+            $"Error must echo the offending symbol handle so the caller can correlate. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("at the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"at the specified location\" wording for handle-only callers. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// Encodes a synthetic symbol handle whose only payload field is <c>MetadataName</c>. Matches
+    /// the on-the-wire shape of <c>SymbolHandleSerializer.SymbolHandlePayload</c> exactly enough
+    /// for <c>ParseHandlePayload</c> to accept it; the resolver then fails to find the metadata
+    /// name and returns null. Used to exercise the "valid handle, symbol not found" branch
+    /// without taking a dependency on the internal payload type.
+    /// </summary>
+    private static string EncodeHandle(string metadataName)
+    {
+        var json = $"{{\"MetadataName\":\"{metadataName}\"}}";
+        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
+    }
+
+    /// <summary>
+    /// Long pasted metadata names — e.g. the full <c>ToDisplayString()</c> of a constructed
+    /// generic type — should be truncated in the error message so the envelope doesn't leak
+    /// kilobytes of caller input. Risk called out in the planning row's Risks field.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolInfo_LongMetadataName_NotFound_TruncatesEchoedValue()
+    {
+        // 2 KB of locator text — far past any reasonable metadata-name length. The new helper
+        // truncates to 200 chars + ellipsis, so the response must NOT contain the tail of the
+        // input but MUST contain a leading prefix and the truncation marker.
+        var hugeName = "SampleLib.Bogus_" + new string('X', 2000);
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSymbolInfo(
+                WorkspaceExecutionGate,
+                SymbolSearchService,
+                WorkspaceId,
+                metadataName: hugeName,
+                ct: CancellationToken.None));
+
+        Assert.IsTrue(ex.Message.Length < hugeName.Length,
+            $"Error message must be shorter than the offending input (truncation enforced). Got len={ex.Message.Length}, input len={hugeName.Length}.");
+        StringAssert.Contains(ex.Message, "SampleLib.Bogus_",
+            $"Error must still echo the leading prefix so the caller can correlate. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, "...",
+            $"Error must surface the truncation marker so the caller knows the value was clipped. Got: {ex.Message}");
+    }
+}


### PR DESCRIPTION
## Summary

Pre-fix, every `symbol_info` not-found error returned the string *"No symbol found at the specified location"* regardless of which locator field the caller actually supplied — including the cases where no source location was provided at all (e.g. `metadataName`-only calls). The misnaming pointed callers at a non-existent position to debug.

Post-fix the throw site routes through a new `SymbolLocatorFactory.FormatSymbolNotFoundMessage` helper that branches on the populated locator field:

| Locator | Pre-fix message | Post-fix message |
|---|---|---|
| `metadataName` only | "No symbol found at the specified location" | "No symbol found for metadata name `'<name>'`" |
| `filePath`+`line`+`column` | "No symbol found at the specified location" | "No symbol found at `<file>:<line>:<col>`" |
| `symbolHandle` only | "No symbol found at the specified location" | "No symbol found for symbol handle `'<handle>'`" |

Long pasted metadata names / handles are truncated with an ellipsis suffix to keep the error envelope bounded (the planning row's Risks field called this out — agents could otherwise paste multi-kilobyte type-display strings into the locator and bloat the error response).

### Containment

The same misnaming exists in **sibling tools** as well (`symbol_relationships`, `goto_type_definition`, `find_consumers`, etc.), but per the planning row's explicit guidance ("if shared with other tools and the fix is contained to `symbol_info`, sibling tools keep the bug — surface as a spin-off backlog row instead of widening this PR"), this PR fixes only `symbol_info`. Sibling tools are candidates for a follow-up `navigation-tools-misnamed-locator-error` backlog row in the next sweep.

## Test plan

- [x] New `tests/RoslynMcp.Tests/Services/SymbolInfoNotFoundMessageTests.cs` — 4 tests covering the three locator shapes plus a long-input truncation case.
- [x] Targeted `dotnet test --filter SymbolInfoNotFoundMessage` — 4/4 pass.
- [x] CI-parity `eng/verify-release.ps1 -Configuration Release` — 1021 tests pass; build clean; publish + hash manifest produced.
- [x] CI-parity `eng/verify-ai-docs.ps1` — passes.
- [x] Adjacent test classes (`MetadataNameLocatorTests`, `IntegrationTests`, `SymbolTools*`, `AliasTools*`) — pass.

Closes: symbol-info-not-found-message-locator-vs-location

🤖 Generated with [Claude Code](https://claude.com/claude-code)