### PR TITLE
refactor(di): consolidate host composition root via shared extension (di-graph-triple-registration-cleanup)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -31,26 +31,16 @@ var mcpLoggingProvider = new McpLoggingProvider();
 builder.Logging.AddProvider(mcpLoggingProvider);
 
 // Bind options from environment variables (hardcoded defaults used when env vars are absent)
-builder.Services.AddSingleton(BindWorkspaceManagerOptions());
-builder.Services.AddSingleton(BindValidationServiceOptions());
-builder.Services.AddSingleton(BindPreviewStoreOptions());
-builder.Services.AddSingleton(BindExecutionGateOptions());
-builder.Services.AddSingleton(BindSecurityOptions());
-builder.Services.AddSingleton(BindScriptingServiceOptions());
-
-builder.Services.AddSingleton<HttpClient>();
-// Register NuGetVersionChecker against both its concrete type and its ILatestVersionProvider
-// interface. The concrete registration is needed for anything that imports the concrete type
-// directly; the interface registration is what MCP tool methods (e.g. server_info) inject.
-// v1.19.0 shipped with only the concrete registration, which caused the MCP SDK's parameter
-// binder to fail to resolve `ILatestVersionProvider versionChecker` and leak the service
-// parameter into the tool schema as a required user-supplied argument — breaking server_info
-// (fix: di-register-latest-version-provider).
-builder.Services.AddSingleton<RoslynMcp.Host.Stdio.Services.NuGetVersionChecker>();
-builder.Services.AddSingleton<RoslynMcp.Host.Stdio.Services.ILatestVersionProvider>(
-    sp => sp.GetRequiredService<RoslynMcp.Host.Stdio.Services.NuGetVersionChecker>());
-
-builder.Services.AddRoslynServices();
+// then register the entire host composition root via AddRoslynMcpHostServices — the same
+// extension method consumed by StartupDiagnosticsTests and ToolDiResolutionTests so the
+// production and test DI graphs cannot drift.
+builder.Services.AddRoslynMcpHostServices(
+    BindWorkspaceManagerOptions(),
+    BindValidationServiceOptions(),
+    BindPreviewStoreOptions(),
+    BindExecutionGateOptions(),
+    BindSecurityOptions(),
+    BindScriptingServiceOptions());
 builder.Services
     .AddMcpServer(options =>
     {

--- a/src/RoslynMcp.Host.Stdio/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Host.Stdio/ServiceCollectionExtensions.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using RoslynMcp.Host.Stdio.Services;
+using RoslynMcp.Roslyn;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Host.Stdio;
+
+/// <summary>
+/// Extension methods for registering Host.Stdio composition-root services
+/// (host-bound options + the NuGet version checker pair). Shared between the
+/// production <c>Program.cs</c> startup path and DI test fixtures so both stay
+/// in lock-step — adding a new host-side singleton in one place means it lights
+/// up for both production and tests automatically.
+/// </summary>
+/// <remarks>
+/// di-graph-triple-registration-cleanup: prior to this refactor, the same six
+/// option singletons + <c>HttpClient</c> + <c>NuGetVersionChecker</c> +
+/// <see cref="ILatestVersionProvider"/> registrations were copy-pasted across
+/// <c>Program.cs</c>, <c>StartupDiagnosticsTests.BuildTestHost</c>, and
+/// <c>ToolDiResolutionTests.BuildHostServiceProvider</c>. The copy-paste pattern
+/// drifted (a comment in ToolDiResolutionTests explicitly warned operators
+/// "when Program.cs adds a new service, update here too — or a new tool method
+/// that injects an unregistered service will fail"). This extension consolidates
+/// the pattern.
+/// </remarks>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the host-side options bag + the NuGet version-checker pair
+    /// (both <see cref="NuGetVersionChecker"/> as a concrete singleton AND
+    /// <see cref="ILatestVersionProvider"/> bridged to the same instance).
+    /// </summary>
+    /// <param name="services">The service collection to register against.</param>
+    /// <param name="workspaceManagerOptions">Pre-bound workspace-manager options (env-var resolved in production, defaults in tests).</param>
+    /// <param name="validationServiceOptions">Pre-bound validation-service options.</param>
+    /// <param name="previewStoreOptions">Pre-bound preview-store options.</param>
+    /// <param name="executionGateOptions">Pre-bound execution-gate options.</param>
+    /// <param name="securityOptions">Pre-bound security options.</param>
+    /// <param name="scriptingServiceOptions">Pre-bound scripting-service options.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    /// <remarks>
+    /// The dual <see cref="NuGetVersionChecker"/> / <see cref="ILatestVersionProvider"/>
+    /// registration is intentional: the concrete registration is needed for code that
+    /// imports the concrete type directly; the interface registration is what MCP tool
+    /// methods (e.g. server_info) inject. v1.19.0 shipped with only the concrete
+    /// registration, which caused the MCP SDK's parameter binder to fail to resolve
+    /// <c>ILatestVersionProvider versionChecker</c> and leak the service parameter
+    /// into the tool schema as a required user-supplied argument — breaking server_info
+    /// (fix: di-register-latest-version-provider). The factory delegate guarantees the
+    /// interface and concrete views observe the same singleton instance.
+    /// </remarks>
+    public static IServiceCollection AddRoslynMcpHostServices(
+        this IServiceCollection services,
+        WorkspaceManagerOptions workspaceManagerOptions,
+        ValidationServiceOptions validationServiceOptions,
+        PreviewStoreOptions previewStoreOptions,
+        ExecutionGateOptions executionGateOptions,
+        SecurityOptions securityOptions,
+        ScriptingServiceOptions scriptingServiceOptions)
+    {
+        services.AddSingleton(workspaceManagerOptions);
+        services.AddSingleton(validationServiceOptions);
+        services.AddSingleton(previewStoreOptions);
+        services.AddSingleton(executionGateOptions);
+        services.AddSingleton(securityOptions);
+        services.AddSingleton(scriptingServiceOptions);
+
+        services.AddSingleton<HttpClient>();
+        services.AddSingleton<NuGetVersionChecker>();
+        services.AddSingleton<ILatestVersionProvider>(
+            sp => sp.GetRequiredService<NuGetVersionChecker>());
+
+        services.AddRoslynServices();
+        return services;
+    }
+}

--- a/tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Services;
 using RoslynMcp.Roslyn;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -32,5 +35,74 @@ public sealed class ServiceCollectionExtensionsTests
         Assert.IsNotNull(sp.GetRequiredService<IClassSplitOrchestrator>());
         Assert.IsNotNull(sp.GetRequiredService<IExtractAndWireOrchestrator>());
         Assert.IsNotNull(sp.GetRequiredService<ICompositeApplyOrchestrator>());
+    }
+
+    /// <summary>
+    /// di-graph-triple-registration-cleanup regression pin: each host-side option
+    /// singleton + the NuGet version-checker pair must register exactly once. Prior
+    /// to this cleanup, copy-paste between Program.cs and two test-fixture builders
+    /// surfaced 9 service types each registered three times in the cross-assembly DI
+    /// scan (last-write-wins held, but the dead lines obscured intent and risked
+    /// drift). After the consolidation into <see cref="ServiceCollectionExtensions.AddRoslynMcpHostServices"/>,
+    /// each service type has exactly one Add call inside the host extension.
+    /// </summary>
+    [TestMethod]
+    public void AddRoslynMcpHostServices_RegistersEachOptionTypeExactlyOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.ClearProviders());
+        services.AddRoslynMcpHostServices(
+            new WorkspaceManagerOptions(),
+            new ValidationServiceOptions(),
+            new PreviewStoreOptions(),
+            new ExecutionGateOptions(),
+            new SecurityOptions(),
+            new ScriptingServiceOptions());
+
+        AssertSingleRegistration<WorkspaceManagerOptions>(services);
+        AssertSingleRegistration<ValidationServiceOptions>(services);
+        AssertSingleRegistration<PreviewStoreOptions>(services);
+        AssertSingleRegistration<ExecutionGateOptions>(services);
+        AssertSingleRegistration<SecurityOptions>(services);
+        AssertSingleRegistration<ScriptingServiceOptions>(services);
+        AssertSingleRegistration<HttpClient>(services);
+        AssertSingleRegistration<NuGetVersionChecker>(services);
+        AssertSingleRegistration<ILatestVersionProvider>(services);
+    }
+
+    /// <summary>
+    /// The interface and concrete <see cref="NuGetVersionChecker"/> registrations
+    /// must resolve to the same singleton so both parameter shapes (interface vs
+    /// concrete) observe the same cached NuGet fetch state. This is the contract
+    /// the production factory in <see cref="ServiceCollectionExtensions.AddRoslynMcpHostServices"/>
+    /// upholds via <c>sp =&gt; sp.GetRequiredService&lt;NuGetVersionChecker&gt;()</c>.
+    /// </summary>
+    [TestMethod]
+    public void AddRoslynMcpHostServices_LatestVersionProvider_BridgesToConcreteSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.ClearProviders());
+        services.AddRoslynMcpHostServices(
+            new WorkspaceManagerOptions(),
+            new ValidationServiceOptions(),
+            new PreviewStoreOptions(),
+            new ExecutionGateOptions(),
+            new SecurityOptions(),
+            new ScriptingServiceOptions());
+
+        using var sp = services.BuildServiceProvider();
+        var viaInterface = sp.GetRequiredService<ILatestVersionProvider>();
+        var viaConcrete = sp.GetRequiredService<NuGetVersionChecker>();
+
+        Assert.AreSame(viaConcrete, viaInterface,
+            "Interface and concrete registrations must share the same singleton.");
+    }
+
+    private static void AssertSingleRegistration<T>(IServiceCollection services)
+    {
+        var count = services.Count(d => d.ServiceType == typeof(T));
+        Assert.AreEqual(1, count,
+            $"Service type {typeof(T).Name} must be registered exactly once via " +
+            $"AddRoslynMcpHostServices; found {count}. Triple-registration regression.");
     }
 }

--- a/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
+++ b/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Services;
@@ -196,19 +197,16 @@ public sealed class StartupDiagnosticsTests
         var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
         builder.Logging.ClearProviders();
 
-        builder.Services.AddSingleton(new WorkspaceManagerOptions());
-        builder.Services.AddSingleton(new ValidationServiceOptions());
-        builder.Services.AddSingleton(new PreviewStoreOptions());
-        builder.Services.AddSingleton(new ExecutionGateOptions());
-        builder.Services.AddSingleton(new SecurityOptions());
-        builder.Services.AddSingleton(new ScriptingServiceOptions());
-
-        builder.Services.AddSingleton<HttpClient>();
-        builder.Services.AddSingleton<NuGetVersionChecker>();
-        builder.Services.AddSingleton<ILatestVersionProvider>(
-            sp => sp.GetRequiredService<NuGetVersionChecker>());
-
-        builder.Services.AddRoslynServices();
+        // Mirror the production composition root via the shared
+        // AddRoslynMcpHostServices extension so production and test DI graphs
+        // cannot drift (di-graph-triple-registration-cleanup).
+        builder.Services.AddRoslynMcpHostServices(
+            new WorkspaceManagerOptions(),
+            new ValidationServiceOptions(),
+            new PreviewStoreOptions(),
+            new ExecutionGateOptions(),
+            new SecurityOptions(),
+            new ScriptingServiceOptions());
 
         // WithTools/Resources/PromptsFromAssembly register each attributed method as
         // a singleton McpServerTool/Resource/Prompt in DI. No transport needed for

--- a/tests/RoslynMcp.Tests/ToolDiResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDiResolutionTests.cs
@@ -2,9 +2,9 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio;
 using RoslynMcp.Host.Stdio.Services;
 using RoslynMcp.Host.Stdio.Tools;
-using RoslynMcp.Roslyn;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -118,29 +118,24 @@ public sealed class ToolDiResolutionTests
     }
 
     /// <summary>
-    /// Mirrors the service registrations in <c>src/RoslynMcp.Host.Stdio/Program.cs</c>.
-    /// When Program.cs adds a new service, update here too — or a new tool method that
-    /// injects an unregistered service will fail <see cref="EveryToolMethod_InterfaceParameter_ResolvesFromHostServiceProvider"/>
-    /// and flag the drift.
+    /// Mirrors the service registrations in <c>src/RoslynMcp.Host.Stdio/Program.cs</c>
+    /// via the shared <c>AddRoslynMcpHostServices</c> extension method, so this test
+    /// fixture stays in lock-step with production composition automatically — adding
+    /// a new host-side singleton in the extension lights it up here too
+    /// (di-graph-triple-registration-cleanup).
     /// </summary>
     private static ServiceProvider BuildHostServiceProvider()
     {
         var services = new ServiceCollection();
         services.AddLogging(b => b.ClearProviders());
 
-        services.AddSingleton(new WorkspaceManagerOptions());
-        services.AddSingleton(new ValidationServiceOptions());
-        services.AddSingleton(new PreviewStoreOptions());
-        services.AddSingleton(new ExecutionGateOptions());
-        services.AddSingleton(new SecurityOptions());
-        services.AddSingleton(new ScriptingServiceOptions());
-
-        services.AddSingleton<HttpClient>();
-        services.AddSingleton<NuGetVersionChecker>();
-        services.AddSingleton<ILatestVersionProvider>(
-            sp => sp.GetRequiredService<NuGetVersionChecker>());
-
-        services.AddRoslynServices();
+        services.AddRoslynMcpHostServices(
+            new WorkspaceManagerOptions(),
+            new ValidationServiceOptions(),
+            new PreviewStoreOptions(),
+            new ExecutionGateOptions(),
+            new SecurityOptions(),
+            new ScriptingServiceOptions());
 
         return services.BuildServiceProvider();
     }


### PR DESCRIPTION
## Summary

The cross-assembly DI scan reported 9 service types each registered 3x: 1 production registration in `Program.cs` plus 2 mirror registrations in `StartupDiagnosticsTests.BuildTestHost` and `ToolDiResolutionTests.BuildHostServiceProvider`. Per-test `ServiceCollections` are independent at runtime (last-write-wins held; `lifetimesDiffer=false`) so there was no functional bug — but the copy-paste pattern carried a documented drift hazard:

> `ToolDiResolutionTests.cs:121-124` — *Mirrors the service registrations in `src/RoslynMcp.Host.Stdio/Program.cs`. When Program.cs adds a new service, update here too — or a new tool method that injects an unregistered service will fail [...] and flag the drift.*

This refactor extracts the host-side options + NuGet version-checker pair into a new `ServiceCollectionExtensions.AddRoslynMcpHostServices(...)` extension in `RoslynMcp.Host.Stdio`. Production passes env-var-bound options; the two test fixtures pass defaults. Drift hazard eliminated — adding a new host-side singleton in the extension lights it up for both production and tests automatically.

### What changed
- `src/RoslynMcp.Host.Stdio/ServiceCollectionExtensions.cs` (new): shared `AddRoslynMcpHostServices` extension. Registers the 6 host options + `HttpClient` + `NuGetVersionChecker` + the `ILatestVersionProvider` bridge, then chains `AddRoslynServices()`.
- `src/RoslynMcp.Host.Stdio/Program.cs`: replaces 11 manual `AddSingleton` calls with one `AddRoslynMcpHostServices(...)` invocation.
- `tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs` + `ToolDiResolutionTests.cs`: same consolidation in their fixture builders.
- `tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs`: adds 2 regression tests pinning exactly-one registration per host-side type and the interface-to-concrete singleton bridge invariant.

Net: 18 dead duplicate-registration lines collapse into the new extension's 9 Add calls, plus 3 regression tests guard against re-introduction.

### Diagnosis nuance vs. the plan

The plan's diagnosis described the duplicates as living "across composition-root layers" (Roslyn + Host.Stdio + others). The actual MCP `get_di_registrations` scan revealed the 2 extra registrations per type live in **test fixtures** that re-build the DI graph for isolation tests, not in additional production composition fragments. The "Risks" section anticipated this exactly: *"If consumers test composition by mocking via a duplicated registration, those tests may break."* Removing the test mirrors directly would have broken them; the architecturally correct fix (per the user's "Correct fix over cheap fix" standing instruction) was to extract a shared composition extension that both call sites can consume — fixing the drift hazard the test fixtures had explicitly warned about.

## Validation

- `mcp__roslyn__compile_check` — RoslynMcp.Host.Stdio + RoslynMcp.Tests both clean (0 errors, 0 warnings).
- `mcp__roslyn__test_run --filter "FullyQualifiedName~ServiceCollectionExtensionsTests|FullyQualifiedName~ToolDiResolutionTests|FullyQualifiedName~StartupDiagnosticsTests"` — 11/11 passed.
- `./eng/verify-release.ps1 -Configuration Release` — Build succeeded, 0 warnings, 0 errors. **1024/1024 tests passed** in 4m4s. Publish + hash manifest produced.
- `./eng/verify-ai-docs.ps1` — passed.

## Closes

`di-graph-triple-registration-cleanup`

## Spin-offs

None observed during this refactor.