### PR TITLE
refactor(roslyn): remove dead logger fields batch 2

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-04-28T19:57:35Z
+**updated_at:** 2026-05-02T14:24:45Z
 
 ## Agent contract
 
@@ -52,8 +52,7 @@
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `dead-logger-fields-roslyn-services-batch-2` | Low | `dead-logger-fields-roslyn-services-batch-1` | Same fix as batch-1 applied to the next 4 services in `RoslynMcp.Roslyn.Services`. Anchors: `src/RoslynMcp.Roslyn/Services/DiagnosticService.cs:18`, `src/RoslynMcp.Roslyn/Services/EditorConfigService.cs:13`, `src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs:12`, `src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs:16`. Regression test shape: extend the batch-1 reflection assertion to cover these 4 service types. Evidence: `review-inbox/archive/20260427T202515Z/20260427T202515Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 (split per Rule 3). |
-| `dead-logger-fields-roslyn-services-batch-3` | Low | `dead-logger-fields-roslyn-services-batch-2` | Last service in the dead-`_logger` cluster: `DuplicateMethodDetectorService` declares both a never-read `_logger` AND a never-read `_compilationCache` (both written once by the primary constructor). Drop both parameters from the constructor signature. Single-file change. Anchors: `src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs:24` (`_compilationCache`) + `:25` (`_logger`). Regression test shape: extend the batch-1/2 reflection assertion to cover the 9th service AND assert `_compilationCache` is gone. Evidence: `review-inbox/archive/20260427T202515Z/20260427T202515Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 (split per Rule 3). |
+| `dead-logger-fields-roslyn-services-batch-3` | Low | none | Last service in the dead-`_logger` cluster: `DuplicateMethodDetectorService` declares both a never-read `_logger` AND a never-read `_compilationCache` (both written once by the primary constructor). Drop both parameters from the constructor signature. Single-file change. Anchors: `src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs:24` (`_compilationCache`) + `:25` (`_logger`). Regression test shape: extend the batch-1/2 reflection assertion to cover the 9th service AND assert `_compilationCache` is gone. Evidence: `review-inbox/archive/20260427T202515Z/20260427T202515Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 (split per Rule 3). |
 | `navigation-tools-misnamed-locator-error` | Low | none | After PR #474 fixed `symbol_info`'s misnamed-error message branch, sibling navigation tools still return the legacy *"No symbol found at the specified location"* text regardless of which locator field was supplied. Apply the same locator-aware branching at the resolver layer (or via the new `SymbolLocatorFactory` helper from PR #474) so all navigation tools surface the supplied-field name. Affected sites cited by PR #474 author: `symbol_relationships`, `goto_type_definition`, `find_consumers`; `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs` lines 232/258/308/358. Anchors: `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`, plus the resolvers behind `symbol_relationships`, `goto_type_definition`, `find_consumers`. Regression test shape: 3 tests per affected tool (one per locator shape) asserting message names supplied field. Evidence: PR #474 (closed `symbol-info-not-found-message-locator-vs-location` with deliberate containment to symbol_info per Rule 1; sibling tools deferred to this row). |
 
 ## Defer

--- a/changelog.d/dead-logger-fields-roslyn-services-batch-2.md
+++ b/changelog.d/dead-logger-fields-roslyn-services-batch-2.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** dropped never-read `ILogger<T>` fields and constructor parameters from `DiagnosticService`, `EditorConfigService`, `FlowAnalysisService`, and `MutationAnalysisService`. Closes `dead-logger-fields-roslyn-services-batch-2`.

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -15,7 +14,6 @@ public sealed class DiagnosticService : IDiagnosticService
     private readonly IWorkspaceManager _workspace;
     private readonly ICompilationCache _compilationCache;
     private readonly ICodeFixProviderRegistry _codeFixRegistry;
-    private readonly ILogger<DiagnosticService> _logger;
 
     /// <summary>
     /// Cache of full per-project diagnostic lists, keyed by workspaceId. The detail-lookup
@@ -46,13 +44,11 @@ public sealed class DiagnosticService : IDiagnosticService
     public DiagnosticService(
         IWorkspaceManager workspace,
         ICompilationCache compilationCache,
-        ICodeFixProviderRegistry codeFixRegistry,
-        ILogger<DiagnosticService> logger)
+        ICodeFixProviderRegistry codeFixRegistry)
     {
         _workspace = workspace;
         _compilationCache = compilationCache;
         _codeFixRegistry = codeFixRegistry;
-        _logger = logger;
         _workspace.WorkspaceClosed += InvalidateWorkspaceCaches;
         // Item #7: `compile-check-stale-assembly-refs-post-reload` — drop cached analyzer
         // results synchronously on reload. The version check on read still catches stale

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -3,25 +3,21 @@ using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class EditorConfigService : IEditorConfigService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<EditorConfigService> _logger;
     private readonly IUndoService? _undoService;
     private readonly IChangeTracker? _changeTracker;
 
     public EditorConfigService(
         IWorkspaceManager workspace,
-        ILogger<EditorConfigService> logger,
         IUndoService? undoService = null,
         IChangeTracker? changeTracker = null)
     {
         _workspace = workspace;
-        _logger = logger;
         _undoService = undoService;
         _changeTracker = changeTracker;
     }

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
@@ -2,19 +2,16 @@ using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class FlowAnalysisService : IFlowAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<FlowAnalysisService> _logger;
 
-    public FlowAnalysisService(IWorkspaceManager workspace, ILogger<FlowAnalysisService> logger)
+    public FlowAnalysisService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _logger = logger;
     }
 
     public async Task<DataFlowAnalysisDto> AnalyzeDataFlowAsync(

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -6,19 +6,16 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class MutationAnalysisService : IMutationAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ILogger<MutationAnalysisService> _logger;
 
-    public MutationAnalysisService(IWorkspaceManager workspace, ILogger<MutationAnalysisService> logger)
+    public MutationAnalysisService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _logger = logger;
     }
 
     public async Task<ImpactAnalysisDto?> AnalyzeImpactAsync(

--- a/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
+++ b/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
@@ -4,9 +4,10 @@ using RoslynMcp.Roslyn.Services;
 namespace RoslynMcp.Tests;
 
 /// <summary>
-/// Regression guard for backlog row <c>dead-logger-fields-roslyn-services-batch-1</c>.
+/// Regression guard for backlog rows <c>dead-logger-fields-roslyn-services-batch-1</c>
+/// and <c>dead-logger-fields-roslyn-services-batch-2</c>.
 ///
-/// Four services in <see cref="RoslynMcp.Roslyn.Services"/> previously declared a
+/// Eight services in <see cref="RoslynMcp.Roslyn.Services"/> previously declared a
 /// <c>private readonly ILogger&lt;T&gt; _logger</c> field that was assigned in the
 /// constructor but never read by any method. This test asserts that the field has
 /// been removed (and is not reintroduced) by reflecting on the type and confirming
@@ -25,6 +26,10 @@ public sealed class DeadLoggerFieldsTests
         typeof(CodeMetricsService),
         typeof(CompletionService),
         typeof(ConsumerAnalysisService),
+        typeof(DiagnosticService),
+        typeof(EditorConfigService),
+        typeof(FlowAnalysisService),
+        typeof(MutationAnalysisService),
     ];
 
     [TestMethod]
@@ -38,7 +43,7 @@ public sealed class DeadLoggerFieldsTests
 
             Assert.IsNull(
                 field,
-                $"{type.FullName} declares a '_logger' field. The dead-logger-fields-roslyn-services-batch-1 sweep removed this field because no method ever read it. If a logger is now genuinely needed, drop {type.Name} from TypesThatMustNotHaveDeadLoggerFields and add the call sites in the same change.");
+                $"{type.FullName} declares a '_logger' field. The dead-logger-fields-roslyn-services sweeps removed this field because no method ever read it. If a logger is now genuinely needed, drop {type.Name} from TypesThatMustNotHaveDeadLoggerFields and add the call sites in the same change.");
         }
     }
 }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -87,15 +87,12 @@ internal sealed class TestServiceContainer
         var referenceService = new ReferenceService(
             workspaceManager,
             NullLogger<ReferenceService>.Instance);
-        var mutationAnalysisService = new MutationAnalysisService(
-            workspaceManager,
-            NullLogger<MutationAnalysisService>.Instance);
+        var mutationAnalysisService = new MutationAnalysisService(workspaceManager);
         var codeFixRegistry = new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance);
         var diagnosticService = new DiagnosticService(
             workspaceManager,
             compilationCache,
-            codeFixRegistry,
-            NullLogger<DiagnosticService>.Instance);
+            codeFixRegistry);
         var changeTracker = new ChangeTracker(workspaceManager);
         var undoService = new UndoService(NullLogger<UndoService>.Instance, workspaceManager, changeTracker);
         var msBuildEvaluationService = new MsBuildEvaluationService(workspaceManager);
@@ -251,9 +248,7 @@ internal sealed class TestServiceContainer
                 workspaceManager,
                 previewStore,
                 NullLogger<TypeMoveService>.Instance),
-            FlowAnalysisService = new FlowAnalysisService(
-                workspaceManager,
-                NullLogger<FlowAnalysisService>.Instance),
+            FlowAnalysisService = new FlowAnalysisService(workspaceManager),
             CompileCheckService = compileCheckService,
             AnalyzerInfoService = new AnalyzerInfoService(
                 workspaceManager,
@@ -272,7 +267,6 @@ internal sealed class TestServiceContainer
                 new ScriptingServiceOptions()),
             EditorConfigService = new EditorConfigService(
                 workspaceManager,
-                NullLogger<EditorConfigService>.Instance,
                 undoService,
                 changeTracker),
             MsBuildEvaluationService = msBuildEvaluationService,


### PR DESCRIPTION
## Summary
- Removed never-read `ILogger<T>` fields and constructor parameters from four Roslyn service classes.
- Updated the test service container for the simplified constructor signatures.
- Extended the reflection regression guard to cover the batch-2 services.
- Closed `dead-logger-fields-roslyn-services-batch-2` in the backlog and added a changelog fragment.

## Test plan
- [x] Roslyn `compile_check`: 0 errors
- [x] Focused related tests: 20/20 passed
- [x] `./eng/verify-ai-docs.ps1`
- [x] `./eng/verify-release.ps1 -NoCoverage`
- [x] `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`

Generated with [Codex](https://Codex.com/Codex)