### PR TITLE
refactor(roslyn): remove duplicate detector dead deps

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-05-02T14:24:45Z
+**updated_at:** 2026-05-03T14:20:21Z
 
 ## Agent contract
 
@@ -52,7 +52,6 @@
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `dead-logger-fields-roslyn-services-batch-3` | Low | none | Last service in the dead-`_logger` cluster: `DuplicateMethodDetectorService` declares both a never-read `_logger` AND a never-read `_compilationCache` (both written once by the primary constructor). Drop both parameters from the constructor signature. Single-file change. Anchors: `src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs:24` (`_compilationCache`) + `:25` (`_logger`). Regression test shape: extend the batch-1/2 reflection assertion to cover the 9th service AND assert `_compilationCache` is gone. Evidence: `review-inbox/archive/20260427T202515Z/20260427T202515Z_roslyn-backed-mcp_mcp-server-audit.md` §14.1 (split per Rule 3). |
 | `navigation-tools-misnamed-locator-error` | Low | none | After PR #474 fixed `symbol_info`'s misnamed-error message branch, sibling navigation tools still return the legacy *"No symbol found at the specified location"* text regardless of which locator field was supplied. Apply the same locator-aware branching at the resolver layer (or via the new `SymbolLocatorFactory` helper from PR #474) so all navigation tools surface the supplied-field name. Affected sites cited by PR #474 author: `symbol_relationships`, `goto_type_definition`, `find_consumers`; `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs` lines 232/258/308/358. Anchors: `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`, plus the resolvers behind `symbol_relationships`, `goto_type_definition`, `find_consumers`. Regression test shape: 3 tests per affected tool (one per locator shape) asserting message names supplied field. Evidence: PR #474 (closed `symbol-info-not-found-message-locator-vs-location` with deliberate containment to symbol_info per Rule 1; sibling tools deferred to this row). |
 
 ## Defer

--- a/changelog.d/dead-logger-fields-roslyn-services-batch-3.md
+++ b/changelog.d/dead-logger-fields-roslyn-services-batch-3.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** dropped never-read `ILogger<T>` and `ICompilationCache` constructor dependencies from `DuplicateMethodDetectorService`. Closes `dead-logger-fields-roslyn-services-batch-3`.

--- a/src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs
@@ -4,7 +4,6 @@ using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -21,17 +20,10 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class DuplicateMethodDetectorService : IDuplicateMethodDetectorService
 {
     private readonly IWorkspaceManager _workspace;
-    private readonly ICompilationCache _compilationCache;
-    private readonly ILogger<DuplicateMethodDetectorService> _logger;
 
-    public DuplicateMethodDetectorService(
-        IWorkspaceManager workspace,
-        ICompilationCache compilationCache,
-        ILogger<DuplicateMethodDetectorService> logger)
+    public DuplicateMethodDetectorService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
-        _compilationCache = compilationCache;
-        _logger = logger;
     }
 
     public async Task<IReadOnlyList<DuplicatedMethodGroupDto>> FindDuplicatedMethodsAsync(

--- a/tests/RoslynMcp.Tests/AliasToolsTests.cs
+++ b/tests/RoslynMcp.Tests/AliasToolsTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
 
@@ -256,13 +255,7 @@ public sealed class AliasToolsTests : SharedWorkspaceTestBase
     private static class ServiceContainer
     {
         private static readonly Lazy<DuplicateMethodDetectorService> s_dup = new(() =>
-        {
-            var compilationCache = new CompilationCache(WorkspaceManager);
-            return new DuplicateMethodDetectorService(
-                WorkspaceManager,
-                compilationCache,
-                NullLogger<DuplicateMethodDetectorService>.Instance);
-        });
+            new DuplicateMethodDetectorService(WorkspaceManager));
 
         public static DuplicateMethodDetectorService DuplicateMethodDetectorService => s_dup.Value;
     }

--- a/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
+++ b/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
@@ -4,10 +4,11 @@ using RoslynMcp.Roslyn.Services;
 namespace RoslynMcp.Tests;
 
 /// <summary>
-/// Regression guard for backlog rows <c>dead-logger-fields-roslyn-services-batch-1</c>
-/// and <c>dead-logger-fields-roslyn-services-batch-2</c>.
+/// Regression guard for backlog rows <c>dead-logger-fields-roslyn-services-batch-1</c>,
+/// <c>dead-logger-fields-roslyn-services-batch-2</c>, and
+/// <c>dead-logger-fields-roslyn-services-batch-3</c>.
 ///
-/// Eight services in <see cref="RoslynMcp.Roslyn.Services"/> previously declared a
+/// Nine services in <see cref="RoslynMcp.Roslyn.Services"/> previously declared a
 /// <c>private readonly ILogger&lt;T&gt; _logger</c> field that was assigned in the
 /// constructor but never read by any method. This test asserts that the field has
 /// been removed (and is not reintroduced) by reflecting on the type and confirming
@@ -30,6 +31,7 @@ public sealed class DeadLoggerFieldsTests
         typeof(EditorConfigService),
         typeof(FlowAnalysisService),
         typeof(MutationAnalysisService),
+        typeof(DuplicateMethodDetectorService),
     ];
 
     [TestMethod]
@@ -45,5 +47,17 @@ public sealed class DeadLoggerFieldsTests
                 field,
                 $"{type.FullName} declares a '_logger' field. The dead-logger-fields-roslyn-services sweeps removed this field because no method ever read it. If a logger is now genuinely needed, drop {type.Name} from TypesThatMustNotHaveDeadLoggerFields and add the call sites in the same change.");
         }
+    }
+
+    [TestMethod]
+    public void DuplicateMethodDetector_DoesNotDeclareDeadCompilationCacheField()
+    {
+        var field = typeof(DuplicateMethodDetectorService).GetField(
+            "_compilationCache",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNull(
+            field,
+            $"{typeof(DuplicateMethodDetectorService).FullName} declares a '_compilationCache' field. The duplicate-method detector is syntax-only and does not need a compilation cache dependency.");
     }
 }

--- a/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
@@ -421,11 +420,7 @@ public sealed class DuplicateMethodDetectorTests
         }
 
         var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
-        var cache = new CompilationCache(wsManager);
-        return new DuplicateMethodDetectorService(
-            wsManager,
-            cache,
-            NullLogger<DuplicateMethodDetectorService>.Instance);
+        return new DuplicateMethodDetectorService(wsManager);
     }
 
     /// <summary>
@@ -475,11 +470,7 @@ public sealed class DuplicateMethodDetectorTests
         }
 
         var wsManager = new TestWorkspaceManager(WorkspaceId, adhoc);
-        var cache = new CompilationCache(wsManager);
-        var service = new DuplicateMethodDetectorService(
-            wsManager,
-            cache,
-            NullLogger<DuplicateMethodDetectorService>.Instance);
+        var service = new DuplicateMethodDetectorService(wsManager);
         return (service, adhoc);
     }
 


### PR DESCRIPTION
## Summary
- Remove unused `ILogger<DuplicateMethodDetectorService>` and `ICompilationCache` constructor dependencies from `DuplicateMethodDetectorService`.
- Update duplicate detector and alias tests for the simpler constructor.
- Extend dead-field regression coverage and close `dead-logger-fields-roslyn-services-batch-3` with a changelog fragment.

## Test plan
- [x] `./eng/verify-ai-docs.ps1`
- [x] `./eng/verify-release.ps1 -NoCoverage`
- [x] `dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive`

Generated with [Codex](https://Codex.com/Codex)