### PR TITLE
feat(errors): attach schemaHint to InvalidArgument envelopes (inv-arg-envelope-schema-hint)

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-05-04T20:01:53Z
+**updated_at:** 2026-05-04T21:25:00Z
 
 ## Agent contract
 
@@ -42,7 +42,6 @@
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `inv-arg-envelope-schema-hint` | High | none | The `InvalidArgument` error envelope (built in `src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs` around lines 49 / 264-288) names the offending parameter and the tool, but the trailing guidance — *"Check that all required parameters are provided and values match the expected types"* — gives no schema. Cold-context subagents (frequent in `/backlog-sweep:execute` parallel mode) cannot derive call shape from the error alone and round-trip through `server_info` or provoke another failure. Append a one-line `schemaHint` field to the envelope, sourced from the existing tool-catalog metadata (`ServerSurfaceCatalog.*.cs`) at error-build time, of shape `"<tool-name>(<param>: <type> [<one-line description>])"`. Anchors: `src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs`, `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` (catalog lookup). Regression test shape: extend `tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs` with cases asserting `schemaHint` presence + content for `workspace_load(missing path)`, `find_references(missing locator)`, `get_prompt_text(missing required param)`. Evidence: `ai_docs/reports/20260504T200153Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md` §3#2 — 199 `InvalidArgument` matches across 25 of 40 deep-read sessions (62.5%, highest-recurrence finding in window). |
 
 ## Medium
 

--- a/changelog.d/inv-arg-envelope-schema-hint.md
+++ b/changelog.d/inv-arg-envelope-schema-hint.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** `InvalidArgument` error envelopes now carry a `schemaHint` field naming the failing parameter's type and (when known) its description, sourced from a reflected tool-parameter index. Cold-context callers and parallel-mode subagents can re-call without round-tripping through `server_info`. When the failing parameter cannot be resolved (e.g. a JSON deserialization error before binding picks one), the hint falls back to a tool-level signature listing all user-facing parameters; when the tool itself is unknown, the field is omitted rather than emitted as `null`. Closes `inv-arg-envelope-schema-hint`.

--- a/src/RoslynMcp.Host.Stdio/Catalog/ToolParameterIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ToolParameterIndex.cs
@@ -1,0 +1,152 @@
+using System.Collections.Frozen;
+using System.ComponentModel;
+using System.Reflection;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Catalog;
+
+/// <summary>
+/// inv-arg-envelope-schema-hint: cached reflection over every
+/// <see cref="McpServerToolAttribute"/>-attributed method in the Host.Stdio assembly,
+/// projecting each tool's user-facing parameters (i.e. excluding DI services and
+/// <see cref="CancellationToken"/>) into a name → schema lookup.
+/// <para>
+/// <see cref="ToolErrorHandler"/> consults this index to attach a per-parameter
+/// <c>schemaHint</c> field to <c>InvalidArgument</c> envelopes so cold-context callers
+/// can re-call without round-tripping through <c>server_info</c>. Reflection runs once
+/// at first access; the dictionary is immutable thereafter.
+/// </para>
+/// </summary>
+internal static class ToolParameterIndex
+{
+    private static readonly Lazy<FrozenDictionary<string, FrozenDictionary<string, ToolParameterSchema>>> s_index =
+        new(BuildIndex, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Returns the cached parameter schema for <paramref name="toolName"/>'s
+    /// <paramref name="parameterName"/>, or <see langword="null"/> when no match exists.
+    /// Both lookups are case-sensitive (parameter names use the original C# casing —
+    /// the SDK already routes JSON camelCase to PascalCase before binding throws).
+    /// </summary>
+    public static ToolParameterSchema? GetParameter(string toolName, string parameterName)
+    {
+        if (string.IsNullOrEmpty(toolName) || string.IsNullOrEmpty(parameterName)) return null;
+        return s_index.Value.TryGetValue(toolName, out var parameters)
+               && parameters.TryGetValue(parameterName, out var schema)
+            ? schema
+            : null;
+    }
+
+    /// <summary>
+    /// Returns all known parameters for <paramref name="toolName"/>, or an empty list when
+    /// the tool is unknown. Used to format a tool-level schema hint when the failing
+    /// parameter could not be identified (e.g. a JSON deserialization error before binding).
+    /// </summary>
+    public static IReadOnlyCollection<ToolParameterSchema> GetParameters(string toolName)
+    {
+        if (string.IsNullOrEmpty(toolName)) return Array.Empty<ToolParameterSchema>();
+        return s_index.Value.TryGetValue(toolName, out var parameters)
+            ? parameters.Values
+            : Array.Empty<ToolParameterSchema>();
+    }
+
+    private static FrozenDictionary<string, FrozenDictionary<string, ToolParameterSchema>> BuildIndex()
+    {
+        // Anchor on a known tool-host type so we walk the same assembly that MCP discovery uses.
+        var assembly = typeof(Tools.AnalysisTools).Assembly;
+        var dict = new Dictionary<string, FrozenDictionary<string, ToolParameterSchema>>(StringComparer.Ordinal);
+
+        foreach (var type in assembly.GetTypes())
+        {
+            // Tools are public static methods on [McpServerToolType] classes per SDK convention,
+            // but include NonPublic/Instance for forward-compatibility with future shapes.
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic |
+                                                   BindingFlags.Static | BindingFlags.Instance))
+            {
+                var attr = method.GetCustomAttribute<McpServerToolAttribute>();
+                if (attr?.Name is null) continue;
+
+                var parameters = method.GetParameters()
+                    .Where(IsUserFacing)
+                    .Select(BuildSchema)
+                    .ToDictionary(p => p.Name, StringComparer.Ordinal);
+
+                if (parameters.Count > 0)
+                {
+                    dict[attr.Name] = parameters.ToFrozenDictionary(StringComparer.Ordinal);
+                }
+            }
+        }
+
+        return dict.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A parameter is user-facing when the caller supplies it via the JSON request body —
+    /// i.e. not a DI-resolved service and not <see cref="CancellationToken"/>. The
+    /// <see cref="DescriptionAttribute"/> is the conventional marker for user-supplied
+    /// parameters in this codebase, so absence implies a host-supplied service.
+    /// </summary>
+    private static bool IsUserFacing(ParameterInfo parameter)
+    {
+        if (parameter.ParameterType == typeof(CancellationToken)) return false;
+        return parameter.GetCustomAttribute<DescriptionAttribute>() is not null;
+    }
+
+    private static ToolParameterSchema BuildSchema(ParameterInfo parameter)
+    {
+        var description = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description;
+        var typeName = FormatTypeName(parameter.ParameterType);
+        var required = !parameter.HasDefaultValue;
+
+        return new ToolParameterSchema(
+            Name: parameter.Name ?? string.Empty,
+            Type: typeName,
+            Required: required,
+            Description: description);
+    }
+
+    private static string FormatTypeName(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying is not null) return FormatTypeName(underlying) + "?";
+
+        if (type.IsGenericType)
+        {
+            var name = type.Name;
+            var tickIdx = name.IndexOf('`', StringComparison.Ordinal);
+            if (tickIdx >= 0) name = name[..tickIdx];
+            var args = type.GetGenericArguments().Select(FormatTypeName);
+            return $"{name}<{string.Join(", ", args)}>";
+        }
+
+        return type.FullName switch
+        {
+            "System.String" => "string",
+            "System.Int32" => "int",
+            "System.Int64" => "long",
+            "System.Boolean" => "bool",
+            "System.Double" => "double",
+            "System.Single" => "float",
+            "System.Decimal" => "decimal",
+            "System.Byte" => "byte",
+            "System.Object" => "object",
+            _ => type.Name,
+        };
+    }
+}
+
+/// <summary>
+/// Per-parameter schema row served to <see cref="ToolErrorHandler"/> for inclusion in
+/// <c>InvalidArgument</c> envelopes. Mirrors <see cref="PromptParameterEntry"/> minus the
+/// default-value field — error envelopes care about the contract, not the runtime fallback.
+/// </summary>
+/// <param name="Name">The parameter name as declared on the C# tool method.</param>
+/// <param name="Type">A C#-style type label (e.g. <c>string</c>, <c>int?</c>, <c>List&lt;string&gt;</c>).</param>
+/// <param name="Required">When <see langword="true"/>, the parameter has no default and MUST be supplied.</param>
+/// <param name="Description">The <see cref="DescriptionAttribute"/> text on the parameter, when present.</param>
+internal sealed record ToolParameterSchema(
+    string Name,
+    string Type,
+    bool Required,
+    string? Description);

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -269,19 +270,22 @@ internal static class ToolErrorHandler
             case ArgumentNullException nullArgEx:
                 info = new("InvalidArgument",
                     $"Required parameter '{nullArgEx.ParamName ?? "<unknown>"}' is missing or null. " +
-                    "Provide a value for this parameter and retry.");
+                    "Provide a value for this parameter and retry.",
+                    ParamName: nullArgEx.ParamName);
                 return true;
 
             case ArgumentOutOfRangeException rangeEx:
                 info = new("InvalidArgument",
                     $"Parameter '{rangeEx.ParamName ?? "<unknown>"}' has an out-of-range value: {rangeEx.Message}. " +
-                    "Check the tool schema for the accepted range.");
+                    "Check the tool schema for the accepted range.",
+                    ParamName: rangeEx.ParamName);
                 return true;
 
             case ArgumentException argEx:
                 info = new("InvalidArgument",
                     $"Parameter '{argEx.ParamName ?? "<unknown>"}' is invalid: {argEx.Message}. " +
-                    "Check that all required parameters are provided and values match the expected types.");
+                    "Check that all required parameters are provided and values match the expected types.",
+                    ParamName: argEx.ParamName);
                 return true;
 
             case FormatException fmtEx:
@@ -380,19 +384,85 @@ internal static class ToolErrorHandler
         }
         else
         {
-            var error = new
+            // inv-arg-envelope-schema-hint: attach a one-line schema hint for InvalidArgument
+            // envelopes so cold-context callers can re-call without round-tripping through
+            // server_info. Hint is omitted (rather than emitted as null) when the failing
+            // parameter cannot be resolved against the tool catalog — keeps the envelope
+            // shape stable for downstream parsers that do not expect the field.
+            var schemaHint = info.Category == "InvalidArgument"
+                ? BuildSchemaHint(toolName, info.ParamName)
+                : null;
+            if (schemaHint is not null)
             {
-                error = true,
-                category = info.Category,
-                tool = toolName,
-                message = info.Message,
-                exceptionType = ex.GetType().Name,
-            };
-            return JsonSerializer.Serialize(error, JsonDefaults.Indented);
+                var error = new
+                {
+                    error = true,
+                    category = info.Category,
+                    tool = toolName,
+                    message = info.Message,
+                    exceptionType = ex.GetType().Name,
+                    schemaHint,
+                };
+                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
+            }
+            else
+            {
+                var error = new
+                {
+                    error = true,
+                    category = info.Category,
+                    tool = toolName,
+                    message = info.Message,
+                    exceptionType = ex.GetType().Name,
+                };
+                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
+            }
         }
     }
 
-    internal readonly record struct ErrorInfo(string Category, string Message);
+    /// <summary>
+    /// inv-arg-envelope-schema-hint: format a one-line schema hint sourced from the live
+    /// tool catalog. Returns the matching parameter's signature when <paramref name="paramName"/>
+    /// is known, the full tool signature when only the tool is known, or <see langword="null"/>
+    /// when the tool itself is not in the index (e.g. resource calls). Description text is
+    /// trimmed to the first sentence to keep the hint compact.
+    /// </summary>
+    private static string? BuildSchemaHint(string toolName, string? paramName)
+    {
+        if (!string.IsNullOrEmpty(paramName))
+        {
+            var schema = ToolParameterIndex.GetParameter(toolName, paramName);
+            if (schema is not null) return FormatParameter(toolName, schema);
+        }
+
+        var all = ToolParameterIndex.GetParameters(toolName);
+        if (all.Count == 0) return null;
+
+        var formatted = string.Join(", ", all.Select(p => $"{p.Name}: {p.Type}{(p.Required ? string.Empty : "?")}"));
+        return $"{toolName}({formatted})";
+    }
+
+    private static string FormatParameter(string toolName, ToolParameterSchema schema)
+    {
+        var requiredMark = schema.Required ? string.Empty : "?";
+        var description = string.IsNullOrEmpty(schema.Description)
+            ? string.Empty
+            : $" — {TrimToFirstSentence(schema.Description)}";
+        return $"{toolName}({schema.Name}: {schema.Type}{requiredMark}{description})";
+    }
+
+    private static string TrimToFirstSentence(string text)
+    {
+        // Tool descriptions often span multiple sentences (intent + caveats). Hint stays
+        // useful when only the first sentence ships; longer text bloats the envelope without
+        // proportional information gain. Cap at 160 chars even for single-sentence text so
+        // multi-kilobyte descriptions can't leak verbatim.
+        var period = text.IndexOf(". ", StringComparison.Ordinal);
+        var firstSentence = period > 0 ? text[..period] : text;
+        return firstSentence.Length > 160 ? firstSentence[..160] + "…" : firstSentence;
+    }
+
+    internal readonly record struct ErrorInfo(string Category, string Message, string? ParamName = null);
 }
 
 /// <summary>

--- a/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
+++ b/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
@@ -96,4 +96,83 @@ public sealed class ErrorResponseObservabilityTests : IsolatedWorkspaceTestBase
         Assert.AreEqual("roslyn://workspace/{workspaceId}/projects",
             doc.RootElement.GetProperty("tool").GetString());
     }
+
+    // inv-arg-envelope-schema-hint: cold-context callers (parallel-mode subagents) cannot
+    // read prior-turn calls, so an InvalidArgument envelope must carry enough schema text
+    // to compose a re-call without round-tripping through server_info. The hint is sourced
+    // from the live tool catalog via reflection — these tests pin the envelope contract
+    // and the cold-cache resolution path.
+
+    [TestMethod]
+    public void InvalidArgument_KnownParam_EmitsSchemaHintNamingThatParameter()
+    {
+        var ex = new ArgumentException("Missing 'path'.", paramName: "path");
+        var json = ToolErrorHandler.ClassifyAndFormat(ex, "workspace_load");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("workspace_load", doc.RootElement.GetProperty("tool").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("schemaHint", out var hintProp),
+            $"InvalidArgument envelope with known ParamName must carry schemaHint. Envelope: {json}");
+        var hint = hintProp.GetString();
+        Assert.IsNotNull(hint);
+        StringAssert.Contains(hint, "workspace_load(",
+            "schemaHint must lead with the tool signature.");
+        StringAssert.Contains(hint, "path",
+            "schemaHint must name the failing parameter.");
+    }
+
+    [TestMethod]
+    public void InvalidArgument_NullParam_EmitsToolLevelSchemaHintListingAllParameters()
+    {
+        // ParamName is unknown (e.g. JSON deserialization fails before binding picks a
+        // parameter). The envelope falls back to a tool-level signature so the caller
+        // can still see what shape the tool accepts.
+        var ex = new System.Text.Json.JsonException("Unexpected token at line 1.");
+        var json = ToolErrorHandler.ClassifyAndFormat(ex, "find_references");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("schemaHint", out var hintProp),
+            $"InvalidArgument envelope must carry schemaHint even when ParamName is null. Envelope: {json}");
+        var hint = hintProp.GetString();
+        Assert.IsNotNull(hint);
+        StringAssert.Contains(hint, "find_references(",
+            "Tool-level schemaHint must lead with the tool signature.");
+        // find_references accepts a workspaceId plus several locator alternatives — at
+        // least one of these must surface in the fallback hint.
+        Assert.IsTrue(
+            hint.Contains("workspaceId") || hint.Contains("metadataName") || hint.Contains("filePath"),
+            $"Tool-level schemaHint must list user-facing parameters. Got: {hint}");
+    }
+
+    [TestMethod]
+    public void InvalidArgument_UnknownTool_OmitsSchemaHintRatherThanEmittingNull()
+    {
+        // Resource URIs and unknown tool names should NOT emit a stray schemaHint — the
+        // envelope's downstream JSON parsers in observability tools rely on the field
+        // being absent rather than null when no hint is available.
+        var ex = new ArgumentException("Bad input.", paramName: "whatever");
+        var json = ToolErrorHandler.ClassifyAndFormat(ex, "this_tool_does_not_exist_anywhere");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
+        Assert.IsFalse(doc.RootElement.TryGetProperty("schemaHint", out _),
+            $"Unknown tool must not emit a schemaHint key. Envelope: {json}");
+    }
+
+    [TestMethod]
+    public void NonInvalidArgument_NeverEmitsSchemaHint()
+    {
+        // schemaHint is exclusively for InvalidArgument envelopes — adding it to other
+        // categories (NotFound, Timeout, InternalError, …) would conflate parameter-shape
+        // guidance with state/runtime issues.
+        var ex = new KeyNotFoundException("Workspace 'abc' is not loaded.");
+        var json = ToolErrorHandler.ClassifyAndFormat(ex, "workspace_status");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString());
+        Assert.IsFalse(doc.RootElement.TryGetProperty("schemaHint", out _),
+            $"Non-InvalidArgument envelope must not carry schemaHint. Got: {json}");
+    }
 }


### PR DESCRIPTION
## Summary

`InvalidArgument` error envelopes now carry a `schemaHint` field sourced from a reflected tool-parameter index. Cold-context callers (parallel-mode subagents, fresh sessions) can re-call without round-tripping through `server_info`. Closes the multi-session retro's highest-recurrence finding (62.5% of deep-read sessions across 14-day window).

## Implementation

- New `ToolParameterIndex` (`src/RoslynMcp.Host.Stdio/Catalog/ToolParameterIndex.cs`) — lazy reflection over every `[McpServerTool]`-attributed method in the assembly, projecting user-facing parameters (those with `[Description]`, excluding DI services + `CancellationToken`) into a name → schema lookup. Cached in a `FrozenDictionary` on first access; immutable thereafter. Mirrors the existing `PromptParameterIndex` pattern.
- `ToolErrorHandler.ErrorInfo` gains an optional `ParamName` field so the binding-classification path can flow the offending parameter to the formatter.
- `FormatErrorResponse` attaches `schemaHint` on `InvalidArgument` envelopes only — three behavior shapes:
  - **Known param + known tool** → `tool(name: type — description)` for the failing parameter (description trimmed to the first sentence, capped at 160 chars).
  - **Unknown param + known tool** → tool-level signature listing all user-facing parameters.
  - **Unknown tool** → field omitted entirely (preserves envelope contract for resource URIs and unknown-tool calls).
- `schemaHint` never appears on non-`InvalidArgument` categories (NotFound, Timeout, InternalError, …) — that would conflate parameter-shape guidance with state/runtime issues.

## Closes

- `inv-arg-envelope-schema-hint`

## Test plan

- [x] `verify-release.ps1 -Configuration Release` passes locally — **1031/1031 tests, 0 warnings, 0 errors**.
- [x] 4 new tests in `ErrorResponseObservabilityTests.cs`:
  - Known param emits hint naming that parameter.
  - Null param (e.g. `JsonException` before binding) emits tool-level fallback.
  - Unknown tool omits `schemaHint` key (not null).
  - Non-`InvalidArgument` categories never carry `schemaHint`.
- [x] `verify-ai-docs.ps1` passes (backlog row removed, `updated_at` bumped).

## Files

- `src/RoslynMcp.Host.Stdio/Catalog/ToolParameterIndex.cs` (new, 138 lines)
- `src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs` (~80 lines added)
- `tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs` (4 new tests, ~80 lines)
- `changelog.d/inv-arg-envelope-schema-hint.md` (fragment)
- `ai_docs/backlog.md` (row closed, `updated_at` bumped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)