### PR TITLE
chore(plan): reconcile inv-arg-envelope-schema-hint merged via #483

### DIFF
--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
@@ -15,7 +15,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | in-progress (branch: remediation/inv-arg-envelope-schema-hint, worktree: .worktrees/inv-arg-envelope-schema-hint) |
+| Status | merged (PR #483, 2026-05-05) |
 | Backlog rows closed | `inv-arg-envelope-schema-hint` |
 | Diagnosis | Verified live. `src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs` line 49 maps `ArgumentException → "InvalidArgument"` envelope; lines 264–288 build envelopes for `MissingFieldException` / `FormatException` shapes. The current envelope shape is `{ category, tool, message, exceptionType }` — no `schemaHint` or schema reference. Cold-context subagents (frequent in `/backlog-sweep:execute` parallel mode) cannot reference prior turns and re-derive the call shape from the error alone. The catalog (`src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.*.cs` partials) carries the full parameter list per tool — sourcing a one-line hint at error-build time is a single catalog lookup. |
 | Approach | (a) Extend the envelope record/anonymous-object shape in `ToolErrorHandler.cs` to include `schemaHint: string?`. (b) Where the failing parameter is known (the `ArgumentException` and `Missing*` paths already capture the parameter name), look up the tool's catalog entry, find the matching parameter, and format `"<tool-name>(<param>: <type> [<one-line description>])"`. (c) Where parameter name is not known, omit `schemaHint` (don't emit an empty key — keep the envelope shape stable for downstream parsers). (d) Cache the catalog → tool-name lookup in a static `FrozenDictionary` to avoid per-error overhead. |

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
@@ -23,7 +23,7 @@
     {
       "id": "inv-arg-envelope-schema-hint",
       "order": 1,
-      "status": "in-progress",
+      "status": "merged",
       "priority": "High",
       "backlogRowsClosed": ["inv-arg-envelope-schema-hint"],
       "rowsClosedCount": 1,
@@ -37,8 +37,8 @@
       "hotspotFiles": ["src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs"],
       "branch": "remediation/inv-arg-envelope-schema-hint",
       "worktreePath": ".worktrees/inv-arg-envelope-schema-hint",
-      "prUrl": null,
-      "mergedAt": null,
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/483",
+      "mergedAt": "2026-05-05T13:07:24Z",
       "notes": "Catalog touch is read-only lookup helper consumption; aim to avoid adding new public catalog API. May influence whether initiative #6 (validate-locator-preflight-tool) closes obsolete after re-measurement."
     },
     {


### PR DESCRIPTION
## Summary

Plan-state reconcile for the merge of #483 (squash-merged 2026-05-05T13:07:24Z, commit \`8e9a444\`):

- \`state.json\`: initiative #1 \`inv-arg-envelope-schema-hint\` → \`status: merged\`, \`prUrl\` + \`mergedAt\` set.
- \`plan.md\`: Status row → \`merged (PR #483, 2026-05-05)\`.

Initiative #1 of 6 in \`ai_docs/plans/20260504T203132Z_backlog-sweep\` complete. Five pending initiatives remain (#2–#6); next-in-queue is \`apply-with-verify-false-positive-audit\`.

## Test plan

- [x] No production code changed — pure plan-state reconcile.
- [x] No CI gate triggered (state.json + plan.md edits only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)