### PR TITLE
feat(workspace): workspace_drift_check tool — surface stale-snapshot risk before reads (workspace-drift-check-tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **167 tools** (111 stable / 56 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **168 tools** (111 stable / 57 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/changelog.d/workspace-drift-check-tool.md
+++ b/changelog.d/workspace-drift-check-tool.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `workspace_drift_check` tool — fast comparison of in-memory MSBuildWorkspace snapshot against filesystem mtimes. Returns `{ stale, files_drifted[], recommended }` so agents can conditionally `workspace_reload` before reads instead of always-reloading or never-reloading. Eliminates silent stale-snapshot reads after out-of-band `Edit`/`Write` mutations. Closes `workspace-drift-check-tool`.

--- a/src/RoslynMcp.Core/Models/WorkspaceDriftResult.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceDriftResult.cs
@@ -1,0 +1,23 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Result of <see cref="Services.IWorkspaceDriftService.CheckDriftAsync"/>: the diff
+/// between the in-memory MSBuildWorkspace snapshot and current on-disk state.
+/// </summary>
+/// <param name="Stale">
+/// <see langword="true"/> when at least one tracked document file's last-write time
+/// (UTC) is past the workspace's load timestamp, or the file no longer exists on disk.
+/// </param>
+/// <param name="FilesDrifted">
+/// Absolute paths of documents whose disk state has drifted past the workspace snapshot,
+/// sorted alphabetically (case-insensitive on Windows, ordinal). Empty when
+/// <paramref name="Stale"/> is <see langword="false"/>.
+/// </param>
+/// <param name="Recommended">
+/// <c>"reload"</c> when drift is detected, <c>"noop"</c> when the workspace is already
+/// in sync with disk. Strings are stable contract — agents branch on the literal value.
+/// </param>
+public sealed record WorkspaceDriftResult(
+    bool Stale,
+    IReadOnlyList<string> FilesDrifted,
+    string Recommended);

--- a/src/RoslynMcp.Core/Services/IWorkspaceDriftService.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceDriftService.cs
@@ -1,0 +1,40 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Compares an in-memory MSBuildWorkspace snapshot against filesystem mtimes so callers
+/// can branch — invoke <c>workspace_reload</c> only when the on-disk state has actually
+/// drifted past the workspace's load timestamp instead of either always-reloading
+/// (slow) or never-reloading (silent stale reads after out-of-band <c>Edit</c>/<c>Write</c>
+/// mutations).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The drift check compares <see cref="System.IO.File.GetLastWriteTimeUtc"/> for every
+/// document in the workspace's solution against the workspace's <c>LoadedAtUtc</c>
+/// timestamp from <see cref="WorkspaceStatusDto"/>. Files whose mtime exceeds the load
+/// time, or whose path no longer exists on disk, are reported as drifted.
+/// </para>
+/// <para>
+/// This is intentionally a thin, deterministic probe — no semantic-model resolution, no
+/// project loading. Callers use the resulting recommendation to decide whether to take
+/// the cost of <c>workspace_reload</c> before issuing a read.
+/// </para>
+/// </remarks>
+public interface IWorkspaceDriftService
+{
+    /// <summary>
+    /// Probes the loaded workspace for drift between its in-memory snapshot and the
+    /// current filesystem state.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier returned by <c>workspace_load</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="WorkspaceDriftResult"/> with <c>Stale=false</c> and
+    /// <c>Recommended="noop"</c> when no document file's mtime exceeds the workspace's
+    /// load timestamp. Otherwise <c>Stale=true</c>, <c>FilesDrifted</c> populated with
+    /// the affected paths in stable alphabetical order, and <c>Recommended="reload"</c>.
+    /// </returns>
+    Task<WorkspaceDriftResult> CheckDriftAsync(string workspaceId, CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Workspace.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Workspace.cs
@@ -17,5 +17,6 @@ public static partial class ServerSurfaceCatalog
         Tool("source_generated_documents", "workspace", "stable", true, false, "List source-generated documents for a workspace or project."),
         Tool("get_source_text", "workspace", "stable", true, false, "Read source text as the Roslyn workspace currently sees it (may differ from disk if workspace hasn't been reloaded)."),
         Tool("workspace_changes", "workspace", "stable", true, false, "List all mutations applied to a workspace during this session, with descriptions, affected files, tool names, and timestamps."),
+        Tool("workspace_drift_check", "workspace", "experimental", true, false, "Compare the in-memory workspace snapshot against filesystem mtimes; return drift status, drifted file paths, and a reload/noop recommendation."),
     ];
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// MCP tool entry point for <c>workspace_drift_check</c>. Wraps
+/// <see cref="IWorkspaceDriftService.CheckDriftAsync"/> with the standard read-gated
+/// dispatch so multiple drift checks run concurrently against the same workspace and so
+/// an in-flight write (<c>*_apply</c>) blocks the check until it completes.
+/// </summary>
+/// <remarks>
+/// Marked experimental on first ship: the response shape (Stale / FilesDrifted /
+/// Recommended) and the recommendation string vocabulary may evolve as agents start
+/// branching on it (e.g. adding a third "partial-reload" recommendation if/when the
+/// reload path supports per-document refresh).
+/// </remarks>
+[McpServerToolType]
+public static class WorkspaceDriftTool
+{
+    [McpServerTool(Name = "workspace_drift_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
+     McpToolMetadata("workspace", "experimental", true, false,
+        "Compare the in-memory workspace snapshot against filesystem mtimes; return drift status, drifted file paths, and a reload/noop recommendation."),
+     Description("Fast probe that compares the in-memory MSBuildWorkspace snapshot for `workspaceId` against the current on-disk last-write times of every tracked document. Returns `{ stale: bool, files_drifted: string[], recommended: 'reload' | 'noop' }`. A document drifts when its mtime is past the workspace's loadedAtUtc, or when the file no longer exists on disk (deletion is also drift). Agents call this BEFORE a read tool to decide whether `workspace_reload` is needed — eliminates the dilemma between always-reloading (slow) and never-reloading (silent stale reads after out-of-band Edit/Write mutations). Source-generated documents have no file path and are skipped. Output is deterministic: the `files_drifted` list is sorted ordinally and deduped across linked documents.")]
+    public static Task<string> WorkspaceDriftCheck(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceDriftService driftService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        CancellationToken ct = default)
+        => ToolDispatch.ReadByWorkspaceIdAsync(
+            gate,
+            workspaceId,
+            c => driftService.CheckDriftAsync(workspaceId, c),
+            ct);
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ITestReferenceMapService, TestReferenceMapService>();
         services.AddSingleton<IWorkspaceValidationService, WorkspaceValidationService>();
         services.AddSingleton<IWorkspaceWarmService, WorkspaceWarmService>();
+        services.AddSingleton<IWorkspaceDriftService, WorkspaceDriftService>();
         services.AddSingleton<IChangeSignatureService, ChangeSignatureService>();
         services.AddSingleton<ISymbolRefactorService, SymbolRefactorService>();
         services.AddSingleton<IExceptionFlowService, ExceptionFlowService>();

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceDriftService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceDriftService.cs
@@ -1,0 +1,100 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Default <see cref="IWorkspaceDriftService"/> implementation. Iterates every document
+/// in the workspace's current <see cref="Microsoft.CodeAnalysis.Solution"/> and compares
+/// the on-disk last-write time against the workspace's <see cref="WorkspaceStatusDto.LoadedAtUtc"/>
+/// timestamp.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> Out-of-band <c>Edit</c>/<c>Write</c> mutations (an editor or a
+/// peer agent writing a <c>.cs</c> file directly) silently break Roslyn reads — the
+/// workspace continues to serve the stale <see cref="Microsoft.CodeAnalysis.SourceText"/>
+/// it loaded into memory at <c>workspace_load</c> time. Agents had two options before
+/// this tool: always call <c>workspace_reload</c> before reads (slow) or never call it
+/// (silent staleness). <see cref="CheckDriftAsync"/> turns that into a fast probe so the
+/// reload only happens when it would actually change something.
+/// </para>
+/// <para>
+/// <b>Drift definition.</b> A document is drifted when either (a) its on-disk
+/// <see cref="System.IO.File.GetLastWriteTimeUtc"/> exceeds the workspace's
+/// <c>LoadedAtUtc</c>, or (b) the file no longer exists on disk (treated as drift so
+/// callers reload to surface the deletion through normal Roslyn diagnostics).
+/// </para>
+/// <para>
+/// <b>Determinism.</b> The returned <see cref="WorkspaceDriftResult.FilesDrifted"/>
+/// list is sorted ordinally so repeated calls on the same drifted state produce identical
+/// JSON — important for snapshot tests and for agents that key on the list.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceDriftService : IWorkspaceDriftService
+{
+    private readonly IWorkspaceManager _workspace;
+
+    public WorkspaceDriftService(IWorkspaceManager workspace)
+    {
+        _workspace = workspace;
+    }
+
+    public async Task<WorkspaceDriftResult> CheckDriftAsync(string workspaceId, CancellationToken ct)
+    {
+        var status = await _workspace.GetStatusAsync(workspaceId, ct).ConfigureAwait(false);
+        var loadedAtUtc = status.LoadedAtUtc.UtcDateTime;
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        var drifted = new List<string>();
+
+        foreach (var project in solution.Projects)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            foreach (var document in project.Documents)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                var path = document.FilePath;
+                if (string.IsNullOrEmpty(path))
+                {
+                    // In-memory documents (e.g. source-generated) have no file path —
+                    // there is nothing on disk to drift against, skip cleanly.
+                    continue;
+                }
+
+                if (!File.Exists(path))
+                {
+                    // Deleted on disk while still in the workspace's snapshot. Treat as
+                    // drift so the caller reloads and the deletion surfaces through the
+                    // normal Roslyn diagnostic path rather than as a stale read.
+                    drifted.Add(path);
+                    continue;
+                }
+
+                var mtime = File.GetLastWriteTimeUtc(path);
+                if (mtime > loadedAtUtc)
+                {
+                    drifted.Add(path);
+                }
+            }
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        // Dedupe (the same file can appear in multiple projects via linked documents) and
+        // sort for deterministic output.
+        var orderedUnique = drifted
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        var stale = orderedUnique.Length > 0;
+        return new WorkspaceDriftResult(
+            Stale: stale,
+            FilesDrifted: orderedUnique,
+            Recommended: stale ? "reload" : "noop");
+    }
+}

--- a/tests/RoslynMcp.Tests/Services/WorkspaceDriftServiceTests.cs
+++ b/tests/RoslynMcp.Tests/Services/WorkspaceDriftServiceTests.cs
@@ -1,0 +1,146 @@
+namespace RoslynMcp.Tests.Services;
+
+/// <summary>
+/// Integration tests for <see cref="Roslyn.Services.WorkspaceDriftService"/>. Uses
+/// <see cref="IsolatedWorkspaceTestBase"/> so each test has a private on-disk solution
+/// copy that can be mutated (overwrite, delete) without polluting the shared SampleSolution
+/// fixture used by other test classes.
+/// </summary>
+[TestClass]
+public sealed class WorkspaceDriftServiceTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// Clean workspace: no on-disk changes since load → drift check returns
+    /// <c>{ stale: false, files_drifted: [], recommended: "noop" }</c>. This is the
+    /// hot-path agents will hit most often when the workspace and disk are in sync.
+    /// </summary>
+    [TestMethod]
+    public async Task CheckDriftAsync_CleanWorkspace_ReturnsNotStale()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var result = await WorkspaceDriftService.CheckDriftAsync(
+            workspace.WorkspaceId,
+            CancellationToken.None);
+
+        Assert.IsFalse(result.Stale, "Fresh workspace with no on-disk edits should not be stale.");
+        Assert.AreEqual(0, result.FilesDrifted.Count, "files_drifted should be empty when not stale.");
+        Assert.AreEqual("noop", result.Recommended, "Recommendation should be 'noop' when not stale.");
+    }
+
+    /// <summary>
+    /// Out-of-band edit after load → drift detected, the touched file appears in
+    /// <c>files_drifted</c>, recommendation is <c>"reload"</c>. This is the central
+    /// motivator for the tool: agents that <c>Edit</c>/<c>Write</c> a tracked .cs file
+    /// directly need to know the workspace's in-memory copy is now stale.
+    /// </summary>
+    [TestMethod]
+    public async Task CheckDriftAsync_FileEditedAfterLoad_ReturnsStaleWithPath()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        // Pick any tracked .cs file in the loaded solution and bump its mtime past the
+        // workspace's LoadedAtUtc. The workspace was loaded synchronously above; a small
+        // delay guarantees the post-load mtime is strictly greater on every filesystem
+        // (NTFS resolves to ~100ns but the WriteAllText / GetLastWriteTimeUtc round-trip
+        // is observed at >50ms in practice).
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var targetPath = solution.Projects
+            .SelectMany(p => p.Documents)
+            .Select(d => d.FilePath)
+            .First(p => !string.IsNullOrEmpty(p) && p!.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))!;
+
+        await Task.Delay(50, CancellationToken.None);
+        var original = File.ReadAllText(targetPath);
+        File.WriteAllText(targetPath, original + "\n// drift-test\n");
+
+        var result = await WorkspaceDriftService.CheckDriftAsync(
+            workspace.WorkspaceId,
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Stale, "Workspace should be stale after an out-of-band edit to a tracked file.");
+        Assert.AreEqual("reload", result.Recommended, "Recommendation should be 'reload' when drifted.");
+        CollectionAssert.Contains(
+            result.FilesDrifted.ToArray(),
+            targetPath,
+            $"files_drifted should include the edited path. Got: [{string.Join(", ", result.FilesDrifted)}]");
+    }
+
+    /// <summary>
+    /// Tracked file deleted from disk after load → still treated as drift so the caller
+    /// reloads and the deletion surfaces through the normal Roslyn diagnostic path
+    /// rather than as a stale read against an in-memory <c>SourceText</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task CheckDriftAsync_FileDeletedAfterLoad_ReturnsStaleWithPath()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var targetPath = solution.Projects
+            .SelectMany(p => p.Documents)
+            .Select(d => d.FilePath)
+            .First(p => !string.IsNullOrEmpty(p) && p!.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))!;
+
+        File.Delete(targetPath);
+
+        var result = await WorkspaceDriftService.CheckDriftAsync(
+            workspace.WorkspaceId,
+            CancellationToken.None);
+
+        Assert.IsTrue(result.Stale, "Workspace should be stale after a tracked file is deleted.");
+        Assert.AreEqual("reload", result.Recommended, "Recommendation should be 'reload' when a tracked file vanishes.");
+        CollectionAssert.Contains(
+            result.FilesDrifted.ToArray(),
+            targetPath,
+            $"files_drifted should include the deleted path. Got: [{string.Join(", ", result.FilesDrifted)}]");
+    }
+
+    /// <summary>
+    /// Output determinism: the <c>files_drifted</c> list must be sorted ordinally so
+    /// repeat calls on the same drifted state produce byte-identical JSON. Agents and
+    /// snapshot tests key on this — an unordered diff would break their caching.
+    /// </summary>
+    [TestMethod]
+    public async Task CheckDriftAsync_MultipleDrifts_ReturnsSortedList()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var paths = solution.Projects
+            .SelectMany(p => p.Documents)
+            .Select(d => d.FilePath)
+            .Where(p => !string.IsNullOrEmpty(p) && p!.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .Cast<string>()
+            .Take(2)
+            .ToArray();
+
+        // Need at least 2 drifted files for the sort assertion to be meaningful.
+        if (paths.Length < 2)
+        {
+            Assert.Inconclusive("SampleSolution does not expose enough .cs files to validate sort order.");
+        }
+
+        await Task.Delay(50, CancellationToken.None);
+        foreach (var path in paths)
+        {
+            File.WriteAllText(path, File.ReadAllText(path) + "\n// drift-test\n");
+        }
+
+        var result = await WorkspaceDriftService.CheckDriftAsync(
+            workspace.WorkspaceId,
+            CancellationToken.None);
+
+        var expected = result.FilesDrifted.OrderBy(p => p, StringComparer.Ordinal).ToArray();
+        CollectionAssert.AreEqual(
+            expected,
+            result.FilesDrifted.ToArray(),
+            "files_drifted must be sorted ordinally for deterministic output.");
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -80,6 +80,7 @@ public abstract class TestBase
     protected static InterfaceExtractionService InterfaceExtractionService { get; private set; } = null!;
     protected static ExceptionFlowService ExceptionFlowService { get; private set; } = null!;
     protected static WorkspaceWarmService WorkspaceWarmService { get; private set; } = null!;
+    protected static WorkspaceDriftService WorkspaceDriftService { get; private set; } = null!;
     protected static string RepositoryRootPath { get; private set; } = null!;
     protected static string SampleSolutionPath { get; private set; } = null!;
     protected static string BuildFailureSolutionPath { get; private set; } = null!;
@@ -179,6 +180,7 @@ public abstract class TestBase
         InterfaceExtractionService = services.InterfaceExtractionService;
         ExceptionFlowService = services.ExceptionFlowService;
         WorkspaceWarmService = services.WorkspaceWarmService;
+        WorkspaceDriftService = services.WorkspaceDriftService;
 
         RepositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
         SampleSolutionPath = TestFixtureFileSystem.FindFixturePath(RepositoryRootPath, "SampleSolution", "SampleSolution.slnx", "SampleSolution.sln");

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -67,6 +67,7 @@ internal sealed class TestServiceContainer
     public required InterfaceExtractionService InterfaceExtractionService { get; init; }
     public required ExceptionFlowService ExceptionFlowService { get; init; }
     public required WorkspaceWarmService WorkspaceWarmService { get; init; }
+    public required WorkspaceDriftService WorkspaceDriftService { get; init; }
 
     public static TestServiceContainer Create(ValidationServiceOptions validationOptions)
     {
@@ -286,7 +287,8 @@ internal sealed class TestServiceContainer
                 NullLogger<ExceptionFlowService>.Instance),
             WorkspaceWarmService = new WorkspaceWarmService(
                 workspaceManager,
-                NullLogger<WorkspaceWarmService>.Instance)
+                NullLogger<WorkspaceWarmService>.Instance),
+            WorkspaceDriftService = new WorkspaceDriftService(workspaceManager)
         };
     }
 }


### PR DESCRIPTION
## Summary

New experimental MCP tool `workspace_drift_check` that compares the in-memory MSBuildWorkspace snapshot against filesystem mtimes and returns `{ stale, files_drifted[], recommended }` so agents can branch — call `workspace_reload` only when on-disk state has actually drifted past the workspace's load timestamp instead of either always-reloading (slow) or never-reloading (silent stale reads after out-of-band `Edit`/`Write` mutations).

## What changed

Structural-unit shape (Rule 3 exemption — 4 units, 6 prod files):

- **Core contract (1 unit)** — `IWorkspaceDriftService` + `WorkspaceDriftResult` DTO
- **Roslyn impl (1 unit)** — `WorkspaceDriftService` iterates `solution.Projects.Documents`, compares `File.GetLastWriteTimeUtc(document.FilePath)` against `WorkspaceStatusDto.LoadedAtUtc`. Deleted files are treated as drift so reload surfaces them. Output deduped (linked documents) + sorted ordinally for determinism.
- **Host.Stdio surface (1 unit)** — `WorkspaceDriftTool` with read-gated dispatch, `ReadOnly=true`, marked **experimental** on first ship.
- **Registration (1 unit)** — `ServerSurfaceCatalog.Workspace.cs` row + DI binding in `RoslynMcp.Roslyn.ServiceCollectionExtensions`.

**No `WorkspaceManager` hotspot touch** — `WorkspaceStatusDto` already exposes `LoadedAtUtc`, so the service goes through `GetStatusAsync` + `GetCurrentSolution` only. Read-only by construction.

## Addenda (counted in 6-file budget)

- `tests/RoslynMcp.Tests/TestBase.cs` + `TestInfrastructure/TestServiceContainer.cs` — test fixture DI registration so existing tests resolve the new service.
- `README.md` — live-surface count bumped 167 → 168 (experimental 56 → 57). `ReadmeSurfaceCountTests` would otherwise fail.

## Test plan

- [x] `WorkspaceDriftServiceTests` (new, 4 cases) all pass — clean workspace → `noop`, file edited after load → `stale + reload`, file deleted from disk → `stale + reload`, multiple drifts → sorted output.
- [x] `ReadmeSurfaceCountTests` passes against the bumped counts.
- [x] `eng/verify-release.ps1 -Configuration Release` — 1035/1035 tests pass.
- [x] `eng/verify-ai-docs.ps1` — clean.
- [x] RMCP001/RMCP002 (catalog↔attribute) analyzers green — tool registered in `ServerSurfaceCatalog.Workspace.cs`.

Closes: workspace-drift-check-tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)