### PR TITLE
fix(errors): name locator field in navigation-tool not-found messages (navigation-tools-misnamed-locator-error)

### DIFF
--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
@@ -69,7 +69,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | in-progress (branch: remediation/navigation-tools-misnamed-locator-error, worktree: .worktrees/navigation-tools-misnamed-locator-error) |
 | Backlog rows closed | `navigation-tools-misnamed-locator-error` |
 | Diagnosis | Verified live (per yesterday's planning verification, re-verified today): 4 throw sites with the legacy literal `"No symbol found at the specified location"` across 3 files — `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs:258` (callers_callees), `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs:308` (find_consumers), `src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs:32`, `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs:330`. Each site has a `SymbolLocator` in scope (built one or two lines above the throw). Helper `SymbolLocatorFactory.FormatSymbolNotFoundMessage(SymbolLocator)` exists at `src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs:100` (added by PR #474). Backlog row text cites lines `232/258/308/358` in `AnalysisTools.cs` and tool names `symbol_relationships`, `goto_type_definition`, `find_consumers`; live grep finds throws only at 258/308 in `AnalysisTools.cs`. Executor should ship against live throw sites regardless of backlog text drift. |
 | Approach | Replace the literal at each of the 4 throw sites with `SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator)`. Where the locator local is named differently, hoist or rename to a local before the service call. No service-layer changes. |

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
@@ -85,7 +85,7 @@
     {
       "id": "navigation-tools-misnamed-locator-error",
       "order": 4,
-      "status": "pending",
+      "status": "in-progress",
       "priority": "Low",
       "backlogRowsClosed": ["navigation-tools-misnamed-locator-error"],
       "rowsClosedCount": 1,
@@ -95,8 +95,8 @@
       "toolPolicy": "edit-only",
       "scheduleHint": null,
       "touchesHotspot": false,
-      "branch": null,
-      "worktreePath": null,
+      "branch": "remediation/navigation-tools-misnamed-locator-error",
+      "worktreePath": ".worktrees/navigation-tools-misnamed-locator-error",
       "prUrl": null,
       "mergedAt": null,
       "notes": "Mechanical replacement at 4 throw sites with SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator). Live throw sites differ from backlog-row text — executor uses live grep."

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -254,8 +254,9 @@ public static class AnalysisTools
         {
             ParameterValidation.ValidatePagination(0, callersLimit);
             ParameterValidation.ValidatePagination(0, calleesLimit);
-            var result = await symbolRelationshipService.GetCallersCalleesAsync(workspaceId, SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName), c);
-            if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
+            var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
+            var result = await symbolRelationshipService.GetCallersCalleesAsync(workspaceId, locator, c);
+            if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
 
             var callers = result.Callers.Take(callersLimit).ToList();
             var callees = result.Callees.Take(calleesLimit).ToList();
@@ -300,12 +301,13 @@ public static class AnalysisTools
             ParameterValidation.ValidatePagination(referencesOffset, referencesLimit);
             if (declarationsLimit < 1) throw new ArgumentException("declarationsLimit must be >= 1.", nameof(declarationsLimit));
             var paging = new ImpactAnalysisPaging(referencesOffset, referencesLimit, declarationsLimit);
+            var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var result = await mutationAnalysisService.AnalyzeImpactAsync(
                 workspaceId,
-                SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName),
+                locator,
                 paging,
                 c);
-            if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
+            if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
 
             // Summary mode drops the materialized per-ref / per-decl arrays. Paging knobs
             // are still echoed so callers paging follow-up requests get the same envelope

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -29,7 +29,7 @@ public static class ConsumerAnalysisTools
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, c);
-            if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
+            if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -327,7 +327,7 @@ public static class SymbolTools
             ParameterValidation.ValidatePagination(0, limit);
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var result = await symbolRelationshipService.GetSymbolRelationshipsAsync(workspaceId, locator, preferDeclaringMember, c);
-            if (result is null) throw new KeyNotFoundException("No symbol found at the specified location");
+            if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
             var references = result.References.Take(limit).ToList();
             var implementations = result.Implementations.Take(limit).ToList();
             var baseMembers = result.BaseMembers.Take(limit).ToList();

--- a/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
@@ -1,0 +1,147 @@
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests.Services;
+
+/// <summary>
+/// Regression coverage for `navigation-tools-misnamed-locator-error` (P4 — UX). Pre-fix the four
+/// navigation/analysis tools (<c>callers_callees</c>, <c>impact_analysis</c>, <c>find_consumers</c>,
+/// <c>symbol_relationships</c>) all threw the verbatim string
+/// <c>"No symbol found at the specified location"</c> when the resolver returned null — even when
+/// the caller had supplied <c>metadataName</c> or <c>symbolHandle</c> and never passed a location
+/// at all. Post-fix every site routes through <see cref="SymbolLocatorFactory.FormatSymbolNotFoundMessage"/>
+/// so the error names the locator field that was actually supplied. Mirrors the shape of
+/// <see cref="SymbolInfoNotFoundMessageTests"/> — one test per (tool x locator-mode) cell that
+/// exercises a not-found path and asserts the locator field appears in the message and the legacy
+/// "at the specified location" wording is gone.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    /// <summary>
+    /// <c>callers_callees</c> with a <c>metadataName</c>-only locator that does not resolve.
+    /// Pre-fix the message claimed the symbol was missing "at the specified location" — there was
+    /// no location supplied. Post-fix the message must echo the metadata name.
+    /// </summary>
+    [TestMethod]
+    public async Task CallersCallees_MetadataNameOnly_NotFound_NamesTheMetadataName()
+    {
+        const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await AnalysisTools.GetCallersCallees(
+                WorkspaceExecutionGate,
+                SymbolRelationshipService,
+                WorkspaceId,
+                metadataName: bogusName,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "metadata name",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, bogusName,
+            $"Error must echo the offending metadata name so the caller can correlate. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("at the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"at the specified location\" wording. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// <c>impact_analysis</c> with a <c>metadataName</c>-only locator that does not resolve. Same
+    /// motivator as the callers_callees case — agents resolved a fully-qualified name and got a
+    /// message about a location they never supplied.
+    /// </summary>
+    [TestMethod]
+    public async Task ImpactAnalysis_MetadataNameOnly_NotFound_NamesTheMetadataName()
+    {
+        const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await AnalysisTools.AnalyzeImpact(
+                WorkspaceExecutionGate,
+                MutationAnalysisService,
+                WorkspaceId,
+                metadataName: bogusName,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "metadata name",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, bogusName,
+            $"Error must echo the offending metadata name so the caller can correlate. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("at the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"at the specified location\" wording. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// <c>find_consumers</c> with a <c>metadataName</c>-only locator that does not resolve. Covers
+    /// the consumer-analysis throw site previously sharing the misleading "at the specified
+    /// location" wording. (A symbolHandle-only variant for the same tool is not exercised here:
+    /// well-formed-but-missing handles are rejected upstream by the handle resolver with its own
+    /// targeted error message before reaching the not-found branch — that path stays informative
+    /// without going through <see cref="SymbolLocatorFactory.FormatSymbolNotFoundMessage"/>.)
+    /// </summary>
+    [TestMethod]
+    public async Task FindConsumers_MetadataNameOnly_NotFound_NamesTheMetadataName()
+    {
+        const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await ConsumerAnalysisTools.FindConsumers(
+                WorkspaceExecutionGate,
+                ConsumerAnalysisService,
+                WorkspaceId,
+                metadataName: bogusName,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "metadata name",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, bogusName,
+            $"Error must echo the offending metadata name so the caller can correlate. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("at the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"at the specified location\" wording. Got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// <c>symbol_relationships</c> with a source-location-only locator pointing at a file that's
+    /// not in the loaded workspace. Pre-fix the message was "No symbol found at the specified
+    /// location" — directionally correct but vague. Post-fix the message must include the
+    /// file:line:col literal so the caller can verify their input round-tripped correctly.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolRelationships_SourceLocationOnly_NotFound_NamesTheFileLineCol()
+    {
+        var bogusFile = Path.Combine(Path.GetTempPath(), "definitely_not_in_workspace.cs");
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSymbolRelationships(
+                WorkspaceExecutionGate,
+                SymbolRelationshipService,
+                WorkspaceId,
+                filePath: bogusFile,
+                line: 1,
+                column: 1,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, bogusFile,
+            $"Error must echo the file path that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, "1:1",
+            $"Error must echo the line:column position that was supplied. Got: {ex.Message}");
+        Assert.IsFalse(
+            ex.Message.Contains("the specified location", StringComparison.Ordinal),
+            $"Error must NOT use the legacy \"the specified location\" wording. Got: {ex.Message}");
+    }
+
+}


### PR DESCRIPTION
## Summary

- Replace the literal `"No symbol found at the specified location"` in `callers_callees`, `impact_analysis`, `find_consumers`, and `symbol_relationships` with `SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator)`. The new message echoes the `filePath:line:col`, `symbolHandle`, or `metadataName` the caller supplied so a `metadataName`-only or `symbolHandle`-only failure no longer points the agent at a non-existent location.
- Add `tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs` modeled on the existing `SymbolInfoNotFoundMessageTests` — one cell per tool x at least one locator-mode (4 tests). The `find_consumers` handle-only path is intentionally left out: the handle resolver throws its own targeted `ArgumentException` upstream before the not-found branch fires, so that path is already informative.

Closes: navigation-tools-misnamed-locator-error

## Test plan

- [x] `compile_check` clean on all 4 touched files
- [x] `dotnet test --filter NavigationToolsNotFoundMessageTests` — 4/4 pass
- [x] `eng/verify-release.ps1 -Configuration Release` — 1039/1039 pass
- [x] `eng/verify-ai-docs.ps1` — pass