### PR TITLE
feat(symbols): projectFilter on find_references and find_consumers (find-references-project-filter)

### DIFF
--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
@@ -69,7 +69,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | in-progress (branch: remediation/navigation-tools-misnamed-locator-error, worktree: .worktrees/navigation-tools-misnamed-locator-error) |
+| Status | merged (PR #488, 2026-05-05) |
 | Backlog rows closed | `navigation-tools-misnamed-locator-error` |
 | Diagnosis | Verified live (per yesterday's planning verification, re-verified today): 4 throw sites with the legacy literal `"No symbol found at the specified location"` across 3 files — `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs:258` (callers_callees), `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs:308` (find_consumers), `src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs:32`, `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs:330`. Each site has a `SymbolLocator` in scope (built one or two lines above the throw). Helper `SymbolLocatorFactory.FormatSymbolNotFoundMessage(SymbolLocator)` exists at `src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs:100` (added by PR #474). Backlog row text cites lines `232/258/308/358` in `AnalysisTools.cs` and tool names `symbol_relationships`, `goto_type_definition`, `find_consumers`; live grep finds throws only at 258/308 in `AnalysisTools.cs`. Executor should ship against live throw sites regardless of backlog text drift. |
 | Approach | Replace the literal at each of the 4 throw sites with `SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator)`. Where the locator local is named differently, hoist or rename to a local before the service call. No service-layer changes. |
@@ -87,7 +87,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | in-progress (branch: remediation/find-references-project-filter, worktree: .worktrees/find-references-project-filter) |
 | Backlog rows closed | `find-references-project-filter` |
 | Diagnosis | Verified live. `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs` carries the `find_references` and `find_consumers` tool wrappers (4 mentions confirmed via grep). The backlog row's anchor `src/RoslynMcp.Roslyn/Services/SymbolReferenceService.cs` is **stale** — actual file is `src/RoslynMcp.Roslyn/Services/ReferenceService.cs` (verified via `ls src/RoslynMcp.Roslyn/Services/`). `src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs` exists as cited. `semantic_grep` already accepts a `projectFilter` parameter — established precedent for the param shape. |
 | Approach | (a) Add optional `projectFilter: string?` (single project name; comma-separated for multi) to `find_references` and `find_consumers` `[McpServerTool]` wrappers in `AnalysisTools.cs`. (b) Thread the filter through to `ReferenceService.FindReferencesAsync` and `ConsumerAnalysisService` — accept an optional `IReadOnlyCollection<string>?` of project names; when non-null, filter the result enumeration by `Project.Name`. (c) Match `semantic_grep`'s parameter description text for consistency. |

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
@@ -85,7 +85,7 @@
     {
       "id": "navigation-tools-misnamed-locator-error",
       "order": 4,
-      "status": "in-progress",
+      "status": "merged",
       "priority": "Low",
       "backlogRowsClosed": ["navigation-tools-misnamed-locator-error"],
       "rowsClosedCount": 1,
@@ -97,14 +97,14 @@
       "touchesHotspot": false,
       "branch": "remediation/navigation-tools-misnamed-locator-error",
       "worktreePath": ".worktrees/navigation-tools-misnamed-locator-error",
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": "Mechanical replacement at 4 throw sites with SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator). Live throw sites differ from backlog-row text — executor uses live grep."
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/488",
+      "mergedAt": "2026-05-05T14:24:12Z",
+      "notes": "Mechanical replacement at 4 throw sites with SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator). find_consumers handle-only test omitted — handle resolver throws ArgumentException upstream before reaching the not-found branch."
     },
     {
       "id": "find-references-project-filter",
       "order": 5,
-      "status": "pending",
+      "status": "in-progress",
       "priority": "Low",
       "backlogRowsClosed": ["find-references-project-filter"],
       "rowsClosedCount": 1,
@@ -116,8 +116,8 @@
       "scheduleHint": null,
       "touchesHotspot": true,
       "hotspotFiles": ["src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs"],
-      "branch": null,
-      "worktreePath": null,
+      "branch": "remediation/find-references-project-filter",
+      "worktreePath": ".worktrees/find-references-project-filter",
       "prUrl": null,
       "mergedAt": null,
       "notes": "Catalog touch is description-only (no new tool registration). Backlog row's anchor 'SymbolReferenceService.cs' is stale — actual file is 'ReferenceService.cs'."

--- a/src/RoslynMcp.Core/Services/IConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Core/Services/IConsumerAnalysisService.cs
@@ -12,6 +12,13 @@ public interface IConsumerAnalysisService
     /// Finds all types that consume (depend on) the type identified by <paramref name="locator"/>,
     /// classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable).
     /// </summary>
+    /// <param name="projectFilter">
+    /// Optional case-sensitive set of <c>Project.Name</c> values used to scope the reference
+    /// walk. When non-null and non-empty, references whose document belongs to a non-matching
+    /// project are dropped before consumer classification (matches <c>semantic_grep</c>'s
+    /// <c>projectFilter</c> semantics). When null/empty, behavior is byte-identical to the
+    /// unfiltered call.
+    /// </param>
     Task<ConsumerAnalysisDto?> FindConsumersAsync(
-        string workspaceId, SymbolLocator locator, CancellationToken ct);
+        string workspaceId, SymbolLocator locator, CancellationToken ct, IReadOnlyCollection<string>? projectFilter = null);
 }

--- a/src/RoslynMcp.Core/Services/IReferenceService.cs
+++ b/src/RoslynMcp.Core/Services/IReferenceService.cs
@@ -17,7 +17,13 @@ public interface IReferenceService
     /// <see cref="LocationDto"/> has <c>PreviewText = null</c>; file path + line + column
     /// + classification still populated. Default <c>false</c> preserves the v1.18.2 shape.
     /// </param>
-    Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool summary = false);
+    /// <param name="projectFilter">
+    /// Optional case-sensitive set of <c>Project.Name</c> values to scope the result to.
+    /// When non-null and non-empty, only references whose document belongs to a matching
+    /// project are returned (matches <c>semantic_grep</c>'s <c>projectFilter</c> semantics).
+    /// When null/empty, behavior is byte-identical to the unfiltered call.
+    /// </param>
+    Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool summary = false, IReadOnlyCollection<string>? projectFilter = null);
     /// <summary>
     /// Finds every implementation of an interface or abstract member resolved at
     /// <paramref name="locator"/>.

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs
@@ -34,7 +34,7 @@ public static partial class ServerSurfaceCatalog
         Tool("validate_workspace", "validation", "experimental", true, false, "Composite post-edit validation: compile_check + project_diagnostics (errors) + test_related_files (+ optional test_run)."),
         Tool("validate_recent_git_changes", "validation", "experimental", true, false, "post-edit-validate-workspace-scoped-to-touched-files: auto-scoped validation companion that derives changedFilePaths from git status --porcelain, falls back to full-workspace scope with a warning when git is unavailable or the solution is outside a git repo."),
         Tool("test_coverage", "validation", "stable", false, false, "Run coverage collection for test execution."),
-        Tool("find_consumers", "analysis", "stable", true, false, "Find all types that depend on a given type or interface, classified by dependency kind."),
+        Tool("find_consumers", "analysis", "stable", true, false, "Find all types that depend on a given type or interface, classified by dependency kind. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated)."),
         Tool("get_cohesion_metrics", "analysis", "stable", true, false, "Measure type cohesion via LCOM4 metrics, identifying independent method clusters."),
         Tool("get_coupling_metrics", "analysis", "stable", true, false, "Measure per-type afferent/efferent coupling + Martin's instability index."),
         Tool("preview_record_field_addition", "analysis", "experimental", true, false, "Pre-flight audit: every site impacted by adding a positional field to a record."),

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
@@ -7,7 +7,7 @@ public static partial class ServerSurfaceCatalog
         Tool("symbol_search", "symbols", "stable", true, false, "Search symbols by name across the workspace."),
         Tool("symbol_info", "symbols", "stable", true, false, "Inspect the symbol at a source location."),
         Tool("go_to_definition", "symbols", "stable", true, false, "Navigate to the symbol definition."),
-        Tool("find_references", "symbols", "stable", true, false, "Find references to a symbol."),
+        Tool("find_references", "symbols", "stable", true, false, "Find references to a symbol. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated)."),
         Tool("find_implementations", "symbols", "stable", true, false, "Find implementations of an interface or abstract member."),
         Tool("document_symbols", "symbols", "stable", true, false, "List declared symbols in a document."),
         Tool("find_overrides", "symbols", "stable", true, false, "Find overrides of a virtual or abstract member."),

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -12,8 +12,8 @@ public static class ConsumerAnalysisTools
 
     [McpServerTool(Name = "find_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
-        "Find all types that depend on a given type or interface, classified by dependency kind."),
-     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument)")]
+        "Find all types that depend on a given type or interface, classified by dependency kind. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated)."),
+     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the consumer walk to the listed project(s) — matches semantic_grep's filter semantics.")]
     public static Task<string> FindConsumers(
         IWorkspaceExecutionGate gate,
         IConsumerAnalysisService consumerAnalysisService,
@@ -23,12 +23,14 @@ public static class ConsumerAnalysisTools
         [Description("Optional: 1-based column number")] int? column = null,
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         [Description("Optional: fully qualified metadata name, e.g. Namespace.IMyInterface")] string? metadataName = null,
+        [Description("Optional: case-sensitive Project.Name filter to scope the consumer walk; comma-separated for multiple projects (e.g. 'Foo.Core,Foo.Tests'). Null/empty preserves the unfiltered solution-wide walk.")] string? projectFilter = null,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
-            var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, c);
+            var filterSet = SymbolTools.ParseProjectFilter(projectFilter);
+            var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, c, filterSet);
             if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -98,9 +98,9 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_references", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all references to a symbol at the given position across the entire solution. Response shape: { count, totalCount, hasMore, offset, limit, items } where items is the paged LocationDto list. Pass `summary=true` to drop per-ref preview text — useful for high-fan-out symbols where the default payload exceeds the MCP cap (Jellyfin's IUserManager: 154 KB on 233 refs).")]
+    [McpServerTool(Name = "find_references", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all references to a symbol at the given position across the entire solution. Response shape: { count, totalCount, hasMore, offset, limit, items } where items is the paged LocationDto list. Pass `summary=true` to drop per-ref preview text — useful for high-fan-out symbols where the default payload exceeds the MCP cap (Jellyfin's IUserManager: 154 KB on 233 refs). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the result to references hosted in the listed project(s) — matches semantic_grep's filter semantics.")]
     [McpToolMetadata("symbols", "stable", true, false,
-        "Find references to a symbol.")]
+        "Find references to a symbol. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated).")]
     public static Task<string> FindReferences(
         IWorkspaceExecutionGate gate,
         IReferenceService referenceService,
@@ -113,13 +113,15 @@ public static class SymbolTools
         [Description("Maximum number of references to return (default: 100)")] int limit = 100,
         [Description("Number of references to skip before returning results (default: 0)")] int offset = 0,
         [Description("When true, drops per-ref preview text to keep the response small for high-fan-out symbols. File path + line + column + classification still populated. Default false preserves the v1.18.2 shape.")] bool summary = false,
+        [Description("Optional: case-sensitive Project.Name filter to scope the result; comma-separated for multiple projects (e.g. 'Foo.Core,Foo.Tests'). Null/empty preserves the unfiltered solution-wide walk.")] string? projectFilter = null,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             ParameterValidation.ValidatePagination(offset, limit);
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
-            var results = await referenceService.FindReferencesAsync(workspaceId, locator, c, summary);
+            var filterSet = ParseProjectFilter(projectFilter);
+            var results = await referenceService.FindReferencesAsync(workspaceId, locator, c, summary, filterSet);
             var paged = results.Skip(offset).Take(limit).ToList();
             var hasMore = offset + paged.Count < results.Count;
             return JsonSerializer.Serialize(new
@@ -571,6 +573,22 @@ public static class SymbolTools
             var result = await completionService.GetCompletionsAsync(workspaceId, filePath, line, column, filterText, maxItems, c);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
+    }
+
+    /// <summary>
+    /// find-references-project-filter: parses the comma-separated <c>projectFilter</c> wire
+    /// parameter into the <see cref="IReadOnlyCollection{T}"/> shape consumed by
+    /// <see cref="IReferenceService.FindReferencesAsync"/> and
+    /// <see cref="IConsumerAnalysisService.FindConsumersAsync"/>. Whitespace around each
+    /// entry is trimmed and empty fragments are dropped; null / whitespace-only input maps to
+    /// <c>null</c> so the underlying services skip the filter pass entirely.
+    /// </summary>
+    internal static IReadOnlyCollection<string>? ParseProjectFilter(string? projectFilter)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilter)) return null;
+        var entries = projectFilter
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return entries.Length == 0 ? null : entries;
     }
 
 }

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -17,7 +17,7 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
     }
 
     public async Task<ConsumerAnalysisDto?> FindConsumersAsync(
-        string workspaceId, SymbolLocator locator, CancellationToken ct)
+        string workspaceId, SymbolLocator locator, CancellationToken ct, IReadOnlyCollection<string>? projectFilter = null)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         // Throw on unresolved symbol so callers see a structured NotFound envelope
@@ -26,6 +26,16 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
+        // find-references-project-filter: scope consumer classification to the supplied projects.
+        // Case-sensitive Project.Name match (matches semantic_grep + ReferenceService semantics).
+        // Null/empty filter preserves unfiltered behavior byte-for-byte.
+        if (projectFilter is { Count: > 0 })
+        {
+            var filterSet = new HashSet<string>(projectFilter, StringComparer.Ordinal);
+            refLocations = refLocations
+                .Where(r => r.Document?.Project.Name is { } name && filterSet.Contains(name))
+                .ToList();
+        }
 
         // The materializer fetches syntax roots + semantic models in parallel under a bounded
         // semaphore. This is the dominant cost for high-fanout types like IWorkspaceManager.

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -18,7 +18,7 @@ public sealed class ReferenceService : IReferenceService
         _logger = logger;
     }
 
-    public async Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool summary = false)
+    public async Task<IReadOnlyList<LocationDto>> FindReferencesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool summary = false, IReadOnlyCollection<string>? projectFilter = null)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
         // Throw on unresolved symbol so callers get a structured NotFound envelope
@@ -27,6 +27,18 @@ public sealed class ReferenceService : IReferenceService
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
+        // find-references-project-filter: when projectFilter is supplied, drop reference locations
+        // whose document does not belong to a named project before materializing (saves the per-ref
+        // syntax-root + preview-text fetches for filtered-out hits). Case-sensitive Project.Name
+        // match — matches semantic_grep's existing projectFilter semantics. Null/empty filter is a
+        // no-op so unfiltered behavior remains byte-identical.
+        if (projectFilter is { Count: > 0 })
+        {
+            var filterSet = new HashSet<string>(projectFilter, StringComparer.Ordinal);
+            refLocations = refLocations
+                .Where(r => r.Document?.Project.Name is { } name && filterSet.Contains(name))
+                .ToList();
+        }
         var dtos = await ReferenceLocationMaterializer.MaterializeDtosAsync(refLocations, ct, summary).ConfigureAwait(false);
         // FLAG-8b-A: stable sort by (FilePath, StartLine, StartColumn) so parallel callers get
         // identical ordering. Roslyn's symbol-enumeration walker may otherwise produce different

--- a/tests/RoslynMcp.Tests/ProjectFilterTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectFilterTests.cs
@@ -1,0 +1,143 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// find-references-project-filter regression coverage.
+///
+/// Verifies that the new <c>projectFilter</c> parameter on
+/// <c>IReferenceService.FindReferencesAsync</c> and
+/// <c>IConsumerAnalysisService.FindConsumersAsync</c> behaves as documented:
+///
+///   * Null/empty filter returns the same result set as the unfiltered (legacy) call —
+///     byte-identical regression baseline.
+///   * Single-project filter narrows the result to references whose document belongs to
+///     that project (case-sensitive Project.Name match — matches semantic_grep semantics).
+///
+/// Fixture: <c>IAnimal</c> in <c>SampleLib</c> has consumers across multiple projects in
+/// the SampleSolution layout (<c>SampleLib</c>, <c>SampleApp</c>, <c>SampleLib.Tests</c>),
+/// so a project-name filter is observable.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class ProjectFilterTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task FindReferences_NullProjectFilter_MatchesUnfilteredBaseline()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+
+        // Legacy two-arg-style call (no projectFilter argument): the IReadOnlyCollection<string>?
+        // default of null must produce the same set as an explicit null pass.
+        var baseline = await ReferenceService.FindReferencesAsync(WorkspaceId, locator, CancellationToken.None);
+        var explicitNull = await ReferenceService.FindReferencesAsync(WorkspaceId, locator, CancellationToken.None, summary: false, projectFilter: null);
+        var explicitEmpty = await ReferenceService.FindReferencesAsync(WorkspaceId, locator, CancellationToken.None, summary: false, projectFilter: Array.Empty<string>());
+
+        Assert.AreEqual(baseline.Count, explicitNull.Count, "explicit null projectFilter must match the legacy default");
+        Assert.AreEqual(baseline.Count, explicitEmpty.Count, "empty projectFilter must match the legacy default");
+        // Stable ordering is documented on the service; pairwise compare by (FilePath, line, column).
+        for (var i = 0; i < baseline.Count; i++)
+        {
+            Assert.AreEqual(baseline[i].FilePath, explicitNull[i].FilePath);
+            Assert.AreEqual(baseline[i].StartLine, explicitNull[i].StartLine);
+            Assert.AreEqual(baseline[i].StartColumn, explicitNull[i].StartColumn);
+        }
+    }
+
+    [TestMethod]
+    public async Task FindReferences_SingleProjectFilter_NarrowsToThatProject()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+
+        var unfiltered = await ReferenceService.FindReferencesAsync(WorkspaceId, locator, CancellationToken.None);
+        var filtered = await ReferenceService.FindReferencesAsync(
+            WorkspaceId, locator, CancellationToken.None, summary: false, projectFilter: new[] { "SampleLib" });
+
+        Assert.IsTrue(filtered.Count > 0, "Expected at least one reference inside SampleLib");
+        Assert.IsTrue(filtered.Count <= unfiltered.Count,
+            $"Filtered result must be a subset (filtered={filtered.Count}, unfiltered={unfiltered.Count})");
+
+        // Every filtered hit must live under the SampleLib project directory. We can't read
+        // Project.Name back out of LocationDto directly, so anchor on the path segment that
+        // every SampleLib document shares: '\\SampleLib\\' (or '/SampleLib/' on POSIX).
+        foreach (var dto in filtered)
+        {
+            var path = dto.FilePath ?? string.Empty;
+            var inSampleLib = path.Contains($"{Path.DirectorySeparatorChar}SampleLib{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || path.Contains("/SampleLib/", StringComparison.Ordinal);
+            Assert.IsTrue(inSampleLib, $"Filtered hit not inside SampleLib: {path}");
+        }
+    }
+
+    [TestMethod]
+    public async Task FindReferences_NonexistentProjectFilter_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+        var filtered = await ReferenceService.FindReferencesAsync(
+            WorkspaceId, locator, CancellationToken.None, summary: false, projectFilter: new[] { "DoesNotExist" });
+        Assert.AreEqual(0, filtered.Count, "filter pointing at a non-existent project name must yield zero hits");
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_NullProjectFilter_MatchesUnfilteredBaseline()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+
+        var baseline = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+        var explicitNull = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None, projectFilter: null);
+        var explicitEmpty = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None, projectFilter: Array.Empty<string>());
+
+        Assert.IsNotNull(baseline);
+        Assert.IsNotNull(explicitNull);
+        Assert.IsNotNull(explicitEmpty);
+        Assert.AreEqual(baseline.Consumers.Count, explicitNull.Consumers.Count, "explicit null filter must equal legacy default");
+        Assert.AreEqual(baseline.Consumers.Count, explicitEmpty.Consumers.Count, "empty filter must equal legacy default");
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_SingleProjectFilter_NarrowsToThatProject()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+
+        var unfiltered = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+        Assert.IsNotNull(unfiltered);
+
+        var filtered = await ConsumerAnalysisService.FindConsumersAsync(
+            WorkspaceId, locator, CancellationToken.None, projectFilter: new[] { "SampleLib" });
+        Assert.IsNotNull(filtered);
+
+        Assert.IsTrue(filtered.Consumers.Count > 0, "Expected at least one IAnimal consumer inside SampleLib (Dog, Cat, AnimalService)");
+        Assert.IsTrue(filtered.Consumers.Count <= unfiltered.Consumers.Count,
+            $"Filtered consumer set must be a subset (filtered={filtered.Consumers.Count}, unfiltered={unfiltered.Consumers.Count})");
+
+        // Every filtered consumer's containing-type Project.Name (carried on TypeConsumerDto.ProjectName)
+        // must match the filter — that's the contract the wrapper exposes to MCP callers.
+        foreach (var consumer in filtered.Consumers)
+        {
+            Assert.AreEqual("SampleLib", consumer.ProjectName,
+                $"Filtered consumer leaked from non-SampleLib project: {consumer.TypeName} ({consumer.ProjectName})");
+        }
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_NonexistentProjectFilter_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimal");
+        var filtered = await ConsumerAnalysisService.FindConsumersAsync(
+            WorkspaceId, locator, CancellationToken.None, projectFilter: new[] { "DoesNotExist" });
+        Assert.IsNotNull(filtered);
+        Assert.AreEqual(0, filtered.Consumers.Count, "filter pointing at a non-existent project name must yield zero consumers");
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `projectFilter` parameter (case-sensitive `Project.Name`; comma-separated for multi) to the `find_references` and `find_consumers` MCP tool wrappers, matching `semantic_grep`'s existing filter shape.
- Thread the filter through to `ReferenceService.FindReferencesAsync` and `ConsumerAnalysisService.FindConsumersAsync` as an optional `IReadOnlyCollection<string>?`. When non-null and non-empty, reference locations whose `Document.Project.Name` does not match are dropped before materialization (saves the per-ref syntax-root + preview-text fetches for filtered-out hits).
- Null/empty filter preserves byte-identical legacy behavior — covered by a regression-baseline test.

## Test plan

- [x] `dotnet test` (Release) — 1045/1045 passing including 6 new `ProjectFilterTests` cases (null filter ≡ baseline, single-project filter narrows correctly, non-existent project name yields zero results — for both `find_references` and `find_consumers`).
- [x] `./eng/verify-release.ps1 -Configuration Release` (CI parity).
- [x] `./eng/verify-ai-docs.ps1`.
- [x] Catalog `Summary` strings updated to keep `[McpToolMetadata]` ↔ `ServerSurfaceCatalog` parity (caught by `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry`).

Closes: find-references-project-filter