### PR TITLE
chore(plan): finalize 20260504T203132Z backlog sweep (5 merged, 1 deferred)

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-05-05T13:15:00Z
+**updated_at:** 2026-05-05T15:05:00Z
 
 ## Agent contract
 
@@ -80,3 +80,4 @@
 | `review-inbox/` | Staging folder for the NEXT audit batch (flat directory; `/backlog-intake` reads here). |
 | `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches — one subdirectory per successful intake. Keep until every row sourced from a batch is closed or superseded, then delete that subdirectory. |
 | `ai_docs/plans/20260428T124405Z_backlog-sweep/plan.md` | Backlog sweep (20260428T124405Z). Shipped 7 initiatives across 7 PRs (#467, #468, #471, #473, #474, #476, #477); closed 7 backlog rows. |
+| `ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md` | Backlog sweep (20260504T203132Z). Shipped 5 initiatives across 5 PRs (#483, #485, #486, #488, #490); closed 5 backlog rows. Initiative #6 (`validate-locator-preflight-tool`) deferred pending re-measurement of locator-shape error rate after #1's `schemaHint` lands — re-evaluate after 2026-05-12. |

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
@@ -87,7 +87,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | in-progress (branch: remediation/find-references-project-filter, worktree: .worktrees/find-references-project-filter) |
+| Status | merged (PR #490, 2026-05-05) |
 | Backlog rows closed | `find-references-project-filter` |
 | Diagnosis | Verified live. `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs` carries the `find_references` and `find_consumers` tool wrappers (4 mentions confirmed via grep). The backlog row's anchor `src/RoslynMcp.Roslyn/Services/SymbolReferenceService.cs` is **stale** — actual file is `src/RoslynMcp.Roslyn/Services/ReferenceService.cs` (verified via `ls src/RoslynMcp.Roslyn/Services/`). `src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs` exists as cited. `semantic_grep` already accepts a `projectFilter` parameter — established precedent for the param shape. |
 | Approach | (a) Add optional `projectFilter: string?` (single project name; comma-separated for multi) to `find_references` and `find_consumers` `[McpServerTool]` wrappers in `AnalysisTools.cs`. (b) Thread the filter through to `ReferenceService.FindReferencesAsync` and `ConsumerAnalysisService` — accept an optional `IReadOnlyCollection<string>?` of project names; when non-null, filter the result enumeration by `Project.Name`. (c) Match `semantic_grep`'s parameter description text for consistency. |
@@ -105,7 +105,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, hotspot-tou
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | deferred (re-measurement window not elapsed; re-evaluate after 2026-05-12 — see state.json notes) |
 | Backlog rows closed | `validate-locator-preflight-tool` |
 | Diagnosis | Verified live. `src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorFactory.cs` exists (added by PR #474) with `Create(...)` factory and `FormatSymbolNotFoundMessage(locator)` helper — both reusable. The retro (§4#4) cites 6 sessions that hit post-hoc shape errors and would have benefited from pre-flight validation. **Deps note:** This row depends on initiative #1 (`inv-arg-envelope-schema-hint`) — if `schemaHint` lets agents self-correct from `find_references` errors directly, this row may close obsolete and never ship. Plan-time recommendation: ship initiative #1 first, re-measure error-recovery patterns over a 7-day window, then decide whether to ship this row. **If re-measurement closes this obsolete, skip with `obsolete:` rather than ship.** |
 | Approach | New read-only tool following the structural-unit shape: (a) `src/RoslynMcp.Core/Services/ISymbolLocatorValidator.cs` — interface. (b) `src/RoslynMcp.Core/Models/SymbolLocatorValidationResult.cs` — DTO `{ valid: bool, mode: "filePath" \| "metadataName" \| "symbolHandle" \| null, normalized: string?, hint: string? }`. (c) `src/RoslynMcp.Roslyn/Services/SymbolLocatorValidator.cs` — implementation; reuses `SymbolLocatorFactory.Create()` in a try/catch and returns shape rather than throwing. Validates parseability of `metadataName` against Roslyn's `SymbolKey`/`MetadataName` parser — does NOT resolve the symbol (that's `find_references`' job). (d) `src/RoslynMcp.Host.Stdio/Tools/SymbolLocatorTool.cs` — `[McpServerTool]` wrapper. (e) Catalog registration in `ServerSurfaceCatalog.Symbols.cs` partial. (f) DI in `ServiceCollectionExtensions.cs`. |

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/state.json
@@ -1,5 +1,7 @@
 {
   "schemaVersion": 2,
+  "completed": true,
+  "completedAt": "2026-05-05T15:05:00Z",
   "generatedAt": "2026-05-04T20:31:32Z",
   "backlogSnapshot": "2026-05-04T20:01:53Z",
   "addendaLoaded": true,
@@ -104,7 +106,7 @@
     {
       "id": "find-references-project-filter",
       "order": 5,
-      "status": "in-progress",
+      "status": "merged",
       "priority": "Low",
       "backlogRowsClosed": ["find-references-project-filter"],
       "rowsClosedCount": 1,
@@ -118,14 +120,14 @@
       "hotspotFiles": ["src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Analysis.cs"],
       "branch": "remediation/find-references-project-filter",
       "worktreePath": ".worktrees/find-references-project-filter",
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": "Catalog touch is description-only (no new tool registration). Backlog row's anchor 'SymbolReferenceService.cs' is stale — actual file is 'ReferenceService.cs'."
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/490",
+      "mergedAt": "2026-05-05T15:00:16Z",
+      "notes": "Catalog touch landed in both ServerSurfaceCatalog.Analysis.cs (find_consumers) and ServerSurfaceCatalog.Symbols.cs (find_references) — required for [McpToolMetadata] ↔ catalog parity per SurfaceCatalogTests. Backlog row's anchor 'SymbolReferenceService.cs' was stale — actual file is 'ReferenceService.cs'."
     },
     {
       "id": "validate-locator-preflight-tool",
       "order": 6,
-      "status": "pending",
+      "status": "deferred",
       "priority": "Low",
       "backlogRowsClosed": ["validate-locator-preflight-tool"],
       "rowsClosedCount": 1,
@@ -143,7 +145,7 @@
       "worktreePath": null,
       "prUrl": null,
       "mergedAt": null,
-      "notes": "Rule 3 structural-unit exemption: 4 units. After initiative #1 ships, re-measure InvalidArgument-on-locator-tools rate; if rate drops ≥80%, mark obsolete and skip. Hotspot non-adjacent to #3 (positions 3 and 6)."
+      "notes": "Deferred 2026-05-05 by /backlog-sweep:execute orchestrator. Plan-time recommendation requires re-measuring InvalidArgument-on-locator-tools rate over a 7-day window after initiative #1 (inv-arg-envelope-schema-hint, merged 2026-05-05T13:07Z) ships. Window has not elapsed (~2h since #1 merged at decision time) and no automated telemetry pipeline exists for the orchestrator to query. Re-evaluate after 2026-05-12: if schemaHint reduces locator-shape errors ≥80%, mark obsolete; otherwise re-plan and ship. Rule 3 structural-unit exemption: 4 units. Hotspot non-adjacent to #3 (positions 3 and 6)."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Final reconcile for the 20260504T203132Z backlog-sweep plan.
- Initiative #5 (find-references-project-filter) → merged via #490.
- Initiative #6 (validate-locator-preflight-tool) → deferred. The plan-time recommendation (plan.md L110, L115) requires re-measuring InvalidArgument-on-locator-tools rate over a 7-day window after #1 (`inv-arg-envelope-schema-hint`, merged at 2026-05-05T13:07Z) ships. Window is ~2h elapsed at this commit and there is no automated telemetry pipeline. Re-evaluate after 2026-05-12.
- Adds a Refs entry to `ai_docs/backlog.md` pointing at the completed plan; bumps `updated_at`.

## Test plan
- [ ] CI green (state/plan/backlog edits only — no source changes).