### PR TITLE
feat(audit): wire promotion-only scorecard JSON into /publish-preflight gate

### DIFF
--- a/.claude/skills/publish-preflight/SKILL.md
+++ b/.claude/skills/publish-preflight/SKILL.md
@@ -96,6 +96,44 @@ Check that both `.nupkg` and `.snupkg` are produced. Verify the `.nupkg` contain
 
 **Pass** if both packages exist with expected content. **Fail** with details.
 
+### Step 8: Promotion Scorecard Gate (advisory, non-blocking)
+
+This step consumes the promotion scorecard emitted by `/audit-deep mode=promotion-only`. It surfaces — but does not auto-apply — recommendations to promote experimental tools to stable in the upcoming release.
+
+Read `ai_docs/audit-reports/_latest-promotion-scorecard.json`.
+
+**Branch on file presence + freshness:**
+
+| State | Decision | Output |
+|---|---|---|
+| File missing | INFO (not a fail) | "No promotion scorecard on file. Run `/audit-deep mode=promotion-only` if you want a promotion gate this release. Otherwise no action needed." |
+| `generatedAt` ≤ 30 days old | PROCEED to inspection | Move to next bullet |
+| `generatedAt` 30–90 days old | WARN | "Promotion scorecard is N days stale. Consider re-running `/audit-deep mode=promotion-only` before release; proceeding with stale data." |
+| `generatedAt` > 90 days old | TREAT AS MISSING | "Promotion scorecard is older than 90 days; ignoring. Re-run `/audit-deep mode=promotion-only` if a promotion gate is desired this release." |
+| File malformed / wrong `schemaVersion` | WARN | "Promotion scorecard exists but is unparseable (schemaVersion=N expected 1, or JSON parse error). Treating as absent." |
+
+**When the scorecard is fresh:** filter `scorecard[]` to entries with `recommendation == "promote"`. For each:
+
+1. Note the entry's `name`, `kind`, `category`, `currentTier`.
+2. Locate the source-of-truth tier marker. For tools, this is the `[McpToolMetadata("category", "experimental", ...)]` attribute on the tool's method **plus** the matching entry in `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.<Category>.cs`. (For resources, `src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs`. For prompts, `src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.*.cs`.)
+3. Build a checklist for the maintainer:
+
+   ```
+   Promotion candidates from <generatedAt>:
+   - <name> (<kind>, <category>) — currentTier=experimental, recommendation=promote, evidence=N items
+       Edit: src/RoslynMcp.Host.Stdio/Tools/<file>.cs   — flip "experimental" → "stable" on the [McpToolMetadata] for <name>
+       Edit: src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.<Category>.cs   — flip "experimental" → "stable" on the catalog entry for <name>
+       Verify: dotnet test --filter SurfaceCatalogTests   — parity check passes after both edits
+   ```
+
+4. Ask the user explicitly: *"N tools recommended for promotion in this release. Apply now (manual edits, then re-run `/publish-preflight`), defer to a follow-up release, or skip the gate?"*
+
+5. Whatever the user chooses, log the decision in the summary report. Promotion is **not** a precondition for publish — a maintainer can ship without acting on the scorecard. The gate's purpose is visibility, not enforcement.
+
+**Pass** when the scorecard was either absent, treated-as-absent, or read cleanly. **Fail** is reserved for: scorecard present + fresh + malformed in a way that prevents reading recommendations (e.g. truncated JSON). Stale-but-readable is WARN, not FAIL.
+
+**(Future automation — backlog `audit-deep-release-cut-promotion-gate`: a `/promote-tier <tool> stable` skill will replace the manual edits in step 3 with one tool call. Until that ships, the manual checklist is the contract.)**
+
 ## Summary Report
 
 After all steps, display a table:
@@ -103,17 +141,18 @@ After all steps, display a table:
 ```
 Pre-flight Summary for vX.Y.Z
 ─────────────────────────────
-Step 1: Version Drift      ✓ PASS / ✗ FAIL
-Step 2: AI Docs             ✓ PASS / ✗ FAIL
-Step 3: Build/Test/Publish  ✓ PASS / ✗ FAIL (N tests, N passed)
-Step 4: CHANGELOG Entry     ✓ PASS / ✗ FAIL
-Step 5: SECURITY Versions   ✓ PASS / ✗ FAIL
-Step 6: Doc-Audit           ✓ PASS / ✗ FAIL
-Step 7: Package Build       ✓ PASS / ✗ FAIL
+Step 1: Version Drift            ✓ PASS / ✗ FAIL
+Step 2: AI Docs                   ✓ PASS / ✗ FAIL
+Step 3: Build/Test/Publish        ✓ PASS / ✗ FAIL (N tests, N passed)
+Step 4: CHANGELOG Entry           ✓ PASS / ✗ FAIL
+Step 5: SECURITY Versions         ✓ PASS / ✗ FAIL
+Step 6: Doc-Audit                 ✓ PASS / ✗ FAIL
+Step 7: Package Build             ✓ PASS / ✗ FAIL
+Step 8: Promotion Scorecard Gate  ✓ PASS / ⚠ WARN / ℹ INFO  (N candidates surfaced, M accepted, K deferred)
 
 Overall: READY TO PUBLISH / NOT READY (N issues)
 ```
 
 If all pass, tell the user: "All checks passed. To publish: create a GitHub Release (which triggers the publish-nuget workflow) or run `eng/publish-nuget.ps1` manually."
 
-If any fail, list the failures with remediation steps.
+If any fail, list the failures with remediation steps. Step 8's WARN/INFO never blocks publish — it only changes the wording of the overall summary line.

--- a/ai_docs/prompts/deep-review-and-refactor.md
+++ b/ai_docs/prompts/deep-review-and-refactor.md
@@ -664,6 +664,89 @@ This prompt writes **raw per-run evidence only**. Multi-repo campaigns synthesiz
 - When the run happens outside Roslyn-Backed-MCP, copy the raw file into the sibling repo's `ai_docs/audit-reports/` so `eng/stage-review-inbox.ps1` discovers it on the next `/backlog-intake` pass (or pass an explicit source path via the skill's `--sibling-parent` flag).
 - Do **not** place raw audit files under `ai_docs/reports/` — that directory is for synthesized rollups.
 
+### Promotion scorecard JSON (sibling artifact — MANDATORY when `mode=promotion-only` or `mode=full`)
+
+In addition to the human-readable `.md` report, write a machine-readable scorecard at:
+
+**`<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/_latest-promotion-scorecard.json`**
+
+This file is **overwritten** each run. Schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-05T18:36:19Z",
+  "mode": "promotion-only",
+  "auditedRepo": "roslyn-backed-mcp",
+  "auditReportPath": "ai_docs/audit-reports/20260505T183619Z_roslyn-backed-mcp_mcp-server-audit.md",
+  "serverVersion": "1.33.2",
+  "catalogVersion": "2026.04",
+  "experimentalSurface": {
+    "tools": 56,
+    "resources": 4,
+    "prompts": 20
+  },
+  "scorecard": [
+    {
+      "kind": "tool",
+      "name": "scaffold_test_apply",
+      "category": "scaffolding",
+      "currentTier": "experimental",
+      "recommendation": "promote",
+      "evidenceCount": 8,
+      "evidence": [
+        "phase-12 apply round-trip clean (preview-token honored, post-apply compile_check green)",
+        "phase-17 negative probe — stale token rejected with actionable error",
+        "phase-8 test_discover finds new test, test_run green",
+        "p50 elapsedMs=1240ms (within writer budget 30s)",
+        "schema accurate vs. live behavior",
+        "no entries in phase-1 debug log",
+        "skill `generate-tests` consumes it cleanly (Phase 16b)",
+        "no relevant backlog rows"
+      ],
+      "blockers": []
+    },
+    {
+      "kind": "tool",
+      "name": "split_class_preview",
+      "category": "refactoring",
+      "currentTier": "experimental",
+      "recommendation": "needs-more-evidence",
+      "evidenceCount": 2,
+      "evidence": [
+        "phase-10 preview emitted valid partial classes",
+        "p50 elapsedMs=480ms"
+      ],
+      "blockers": [
+        "no apply round-trip exercised (apply sibling skipped-safety in conservative mode)",
+        "no negative-probe evidence on shared-state across the split"
+      ]
+    }
+  ],
+  "summary": {
+    "promote": 1,
+    "keep-experimental": 0,
+    "needs-more-evidence": 1,
+    "deprecate": 0,
+    "blocked": 0
+  }
+}
+```
+
+**Field rules:**
+
+- `recommendation` ∈ `"promote" | "keep-experimental" | "needs-more-evidence" | "deprecate"`. Mirror the per-call recommendation captured in the `.md` report's *Experimental promotion scorecard* section. Do not invent recommendations beyond what the human-readable scorecard contains.
+- `currentTier` is the live value from `roslyn://server/catalog` per entry. Do **not** infer it from the prompt.
+- `evidence` is a flat string array — one short sentence per supporting probe. Match the per-call promotion-signal lines captured in the draft (principle #14).
+- `blockers` is empty when `recommendation == "promote"`; populated with concrete missing evidence otherwise.
+- Skip rows for entries marked `blocked` in the coverage ledger — they cannot be scored. Track them in `summary.blocked` only.
+
+**Why this exists.** `/release-cut` (via `/publish-preflight`) reads this file as a **promotion gate** — when fresh and any row is `recommendation: "promote"`, the maintainer is prompted to flip the tier in the same release. Without the JSON, promotion stays implicit and the audit's promotion lane has no operational consequence.
+
+**Staleness contract.** The JSON is a snapshot, not a journal. `/publish-preflight` warns when `generatedAt` is older than 30 days; older than 90 days, the file should be ignored entirely (recommend a fresh `/audit-deep mode=promotion-only` run).
+
+**Skip when `mode=read-only`** — read-only runs cannot exercise apply round-trips, so `recommendation` for writer tools defaults to `needs-more-evidence`. Writing a misleading scorecard is worse than writing none. Mark the run header *"promotion scorecard skipped per mode=read-only"* and proceed.
+
 ### Naming scheme (`<timestamp>_<repo-id>`)
 
 - `<timestamp>`: current UTC `yyyyMMddTHHmmssZ`.


### PR DESCRIPTION
## Summary
Implements pieces A + B of the promotion-gate concept from today's audit-deep deep-dive (S6 discussion):

- **A — Scorecard emission.** \`/audit-deep mode={promotion-only|full}\` now writes a sibling \`ai_docs/audit-reports/_latest-promotion-scorecard.json\` (schema v1) alongside the human-readable \`.md\` report. \`mode=read-only\` skips it (writer recommendations would be misleading without apply round-trips).
- **B — Gate.** \`/publish-preflight\` gains Step 8 — reads the scorecard, checks freshness (≤30 days proceed; 30–90 WARN; >90 ignore), and surfaces any \`recommendation: \"promote\"\` rows as a manual checklist with the exact \`Edit:\` instructions for the \`[McpToolMetadata]\` flip + matching \`ServerSurfaceCatalog\` entry. Advisory only — never blocks publish.

Piece C — automated \`/promote-tier <tool> stable\` skill — is queued as the existing backlog row \`audit-deep-release-cut-promotion-gate\`; this PR makes the gate operational with the manual-edit fallback so the scorecard work has immediate value.

## Test plan
- [ ] CI green (doc-only changes; verify-ai-docs gate).
- [ ] \`/audit-deep mode=promotion-only\` next run emits the JSON sibling at the documented path.
- [ ] \`/publish-preflight\` next run prints the new Step 8 line (INFO when no scorecard, WARN when stale, the candidate checklist when fresh + promote rows exist).