### PR TITLE
chore(changelog): add 4 missing fragments since v1.33.2

### DIFF
--- a/changelog.d/audit-deep-promotion-gate.md
+++ b/changelog.d/audit-deep-promotion-gate.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `/audit-deep` (modes `full` and `promotion-only`) now writes a machine-readable promotion scorecard at `ai_docs/audit-reports/_latest-promotion-scorecard.json` (schema v1) alongside the human-readable `.md` report. `/publish-preflight` gains Step 8 — reads the scorecard, checks freshness (≤30 days proceed; 30–90 WARN; >90 ignore), and surfaces any `recommendation: "promote"` rows as a manual checklist with the exact `Edit:` instructions for the `[McpToolMetadata]` tier flip + matching `ServerSurfaceCatalog` entry. Step 8 is advisory, never blocks publish. `mode=read-only` skips scorecard emission (writer recommendations would mislead without apply round-trips).

--- a/changelog.d/audit-deep-prompt-coverage-gaps.md
+++ b/changelog.d/audit-deep-prompt-coverage-gaps.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** `ai_docs/prompts/deep-review-and-refactor.md` (the prompt resolved by `/audit-deep`) now names 10 previously-unmapped MCP tools across the live surface — `workspace_health` in Phase -1, `revert_apply_by_sequence` in Phase 9, `semantic_grep` in Phase 11, `get_test_coverage_map` in Phase 8, `find_dead_fields` / `find_duplicated_code` / `find_type_consumers` in Phases 2–3, `get_symbol_outline` in Phase 14, `scaffold_test_apply` / `scaffold_type_apply` in Phase 12. Adds a Phase-0 Live-surface drift-detection sub-step that diffs the live catalog against names mentioned in the prompt and FAILs P1 on stale references. The `/audit-deep` slash-command description was rewritten to match the actual deliverable (Roslyn MCP server audit + promotion scorecard + plugin-skill audit, not a generic codebase refactor).

--- a/changelog.d/find-references-project-filter.md
+++ b/changelog.d/find-references-project-filter.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `find_references` and `find_consumers` accept an optional `projectFilter` parameter (single project name or comma-separated list) for scoping the reference walk to a project subset, matching `semantic_grep`'s existing surface. Filter applies after the reference walk; null/absent yields byte-identical results to the prior behavior. Closes `find-references-project-filter`.

--- a/changelog.d/navigation-tools-misnamed-locator-error.md
+++ b/changelog.d/navigation-tools-misnamed-locator-error.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** navigation tools `callers_callees`, `find_consumers`, and the `SymbolTools` resolver now emit a locator-aware "no symbol found" message that names the field the caller actually supplied (`filePath:line:column`, `symbolHandle`, or `metadataName`) instead of the legacy literal `"No symbol found at the specified location"`. Matches the fix that landed for `symbol_info` in PR #474. Closes `navigation-tools-misnamed-locator-error`.


### PR DESCRIPTION
Audit found 4 missing user-facing fragments since v1.33.2 (PRs #488, #490, #494, #496). Backlog/plan reconciles remain internal.