### PR TITLE
chore(registry): draft MCP Registry server.json + README badge (mcp-registry-publication)

### DIFF
--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.darylmcd/roslyn-mcp",
+  "description": "Local-first MCP server for semantic C# analysis, navigation, validation, and refactoring on real .sln / .slnx / .csproj workspaces. Powered by Roslyn and MSBuildWorkspace; runs over stdio; ships as a .NET global tool.",
+  "repository": {
+    "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
+    "source": "github"
+  },
+  "version": "1.33.2",
+  "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "Darylmcd.RoslynMcp",
+      "version": "1.33.2",
+      "runtimeHint": "dnx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "github.com/darylmcd/Roslyn-Backed-MCP",
+      "license": "MIT",
+      "keywords": ["csharp", "dotnet", "roslyn", "refactoring", "analysis", "mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Roslyn-Backed MCP Server
 
 [![CI](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/workflows/ci.yml)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-submission%20pending-lightgrey)](https://registry.modelcontextprotocol.io/)
 
 Local-first MCP (Model Context Protocol) server for semantic C# analysis, navigation, validation, and refactoring on real `.sln` / `.slnx` / `.csproj` workspaces. It uses Roslyn and `MSBuildWorkspace`, runs over stdio, and does not require Visual Studio.
 
@@ -59,6 +60,14 @@ Point the client at the installed tool:
 ```
 
 For NDJSON framing, handshake order, and minimal Python/C# client examples, see [docs/stdio-client-integration.md](docs/stdio-client-integration.md).
+
+### MCP Registry (submission pending)
+
+The server is also being published to the public [MCP Registry](https://registry.modelcontextprotocol.io/). Once the submission is approved, MCP-Registry-aware clients will be able to discover and install the server by name.
+
+Draft manifest: [`.claude-plugin/server.json`](.claude-plugin/server.json) — published name `io.github.darylmcd/roslyn-mcp`, NuGet package `Darylmcd.RoslynMcp`, runtime `dnx`.
+
+Until the submission is approved, prefer the [Global Tool](#install-as-a-global-tool) or [Claude Code Plugin](#claude-code-plugin) install paths above. After approval, this section will be updated with the registry URL and the registry-aware client install snippet.
 
 ## Configuration
 

--- a/changelog.d/mcp-registry-publication.md
+++ b/changelog.d/mcp-registry-publication.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** drafted MCP Registry submission manifest at `.claude-plugin/server.json` (canonical filename per the 2025-12-11 server.schema.json) and added a "submission pending" badge + section to root `README.md` referencing the new file. Actual external submission via `mcp-publisher` and post-approval URL flip remain a maintainer follow-up. Closes `mcp-registry-publication`.


### PR DESCRIPTION
## Summary

Authors the MCP Registry submission manifest for the Roslyn-Backed MCP server and adds a registry-pending badge / install-section placeholder to the root README. Pure outreach + manifest work; no `src/` changes.

Closes: `mcp-registry-publication`

## What this PR does (subagent-completed)

- **`.claude-plugin/server.json` (new)** — Draft submission manifest matching the [2025-12-11 server.schema.json](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json):
  - `name`: `io.github.darylmcd/roslyn-mcp` (matches the GitHub-auth namespace path the registry's `mcp-publisher` CLI requires)
  - `packages[0]`: `registryType: nuget`, `identifier: Darylmcd.RoslynMcp`, `version: 1.33.2`, `runtimeHint: dnx`, `transport: stdio` — the canonical pattern for .NET-tool MCP servers per the registry's [generic-server-json reference](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md)
  - `_meta.io.modelcontextprotocol.registry/publisher-provided`: license, keywords, tool URL
- **`README.md`** — Adds:
  - A `MCP Registry — submission pending` shields.io badge next to the existing CI badge
  - A new `### MCP Registry (submission pending)` subsection under `## Quick Start` linking to the draft manifest, naming the published server name + NuGet package, and steering current users to the existing Global Tool / Claude Code Plugin paths until the submission is approved

## What this PR intentionally does NOT do (maintainer follow-up)

The row's scope draft says "Author manifest changes + a registry-pending badge/section in README. The actual external registry submission and any post-approval URL update are MAINTAINER actions (after merge), NOT subagent actions." The following remain for the maintainer:

1. **Submit to the MCP Registry** — install [`mcp-publisher`](https://github.com/modelcontextprotocol/registry/releases/latest), run `mcp-publisher login github` from this checkout, then `mcp-publisher publish` against `.claude-plugin/server.json`. (The registry verifies the GitHub namespace; the maintainer's GitHub account `darylmcd` matches `io.github.darylmcd/...`.)
2. **Update README post-approval** — replace `submission pending` badge color/text with `live` and update the badge URL to point at the registry listing (e.g. `https://registry.modelcontextprotocol.io/servers/io.github.darylmcd/roslyn-mcp`). Replace the "Until the submission is approved..." paragraph with the registry-aware client install snippet.
3. **(Optional) Add a `dotnet tool install` verification step** — once the submission is live, verify a clean-account install from the registry matches the existing `dotnet tool install -g Darylmcd.RoslynMcp` install path.

## Why `plugin.json` and `marketplace.json` are unchanged

Per the row's risk #3 ("Don't break `plugin.json` schema when adding a registry field") and per the [Claude Code Plugins reference](https://code.claude.com/docs/en/plugins-reference) as of 2026-05, the official `plugin.json` manifest schema declares these top-level fields: `$schema`, `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `skills`, `commands`, `agents`, `hooks`, `mcpServers`, `outputStyles`, `themes`, `lspServers`, `monitors`, `userConfig`, `channels`, `dependencies`. There is no MCP-Registry-link field and no precedent for a placeholder one. Same for `marketplace.json`. Adding a non-spec field would risk failing `claude plugin validate`. The README badge + dedicated draft manifest at `.claude-plugin/server.json` covers the row's discoverability intent without breaking the plugin-manifest contract.

## Test plan

- [x] `python -c "import json; json.load(...)"` confirms `.claude-plugin/server.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` all parse as valid JSON.
- [x] `eng/verify-ai-docs.ps1` — README's new relative link `[`.claude-plugin/server.json`](.claude-plugin/server.json)` resolves to a real on-disk file. Only pre-existing error (broken `src/...` link in `ai_docs/plans/.../plan.md`) is unrelated to this PR and present on `main`.
- [x] `eng/verify-release.ps1 -Configuration Release` — full CI-parity gate: 0 warnings, 0 errors, 1045 tests pass.
- [x] `ReadmeSurfaceCountTests` — confirmed the new badge/section don't introduce a `**N tools**` phrase that would trip the regex.
- [ ] **Maintainer:** install `mcp-publisher` and submit (see follow-up #1 above).
- [ ] **Maintainer:** verify a clean-account `mcp-publisher publish` succeeds and post-approval, edit README to flip the badge to `live` (see follow-up #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)