### PR TITLE
feat(progress): stage-fine emissions for workspace_load + warm + build + test (progress-emit-audit-coverage)

### DIFF
--- a/changelog.d/progress-emit-audit-coverage.md
+++ b/changelog.d/progress-emit-audit-coverage.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** stage-fine progress emission for `workspace_load`, `workspace_warm`, `build_workspace`, and `test_run`. The four long-running tools now emit intermediate stage labels (e.g. `validating-path → opening-workspace → checking-restore → done` for `workspace_load`) instead of waiting silently between the initial 0% and final 100% notification. Stage labels are kebab-case and stable across releases — clients may key UI strings off them. Per-project N/M counts are intentionally not emitted at this layer (would require service-interface changes past the audit-coverage scope). The `ProgressHelper.ReportStage` helper additively complements the existing `Report` overload; no breaking changes to existing callers. Closes `progress-emit-audit-coverage`.

--- a/src/RoslynMcp.Host.Stdio/Tools/ProgressHelper.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProgressHelper.cs
@@ -7,13 +7,62 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// The MCP SDK automatically binds IProgress&lt;ProgressNotificationValue&gt; parameters in tools
 /// to forward notifications to the client when a ProgressToken is provided.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Stage-fine emissions for long-running tools.</b> The plain
+/// <see cref="Report(System.IProgress{ProgressNotificationValue}?, float, float?)"/> overload
+/// emits only progress fractions (0..1). Long-running tools (workspace_load, workspace_warm,
+/// build_workspace, test_run) should additionally call the
+/// <see cref="ReportStage(System.IProgress{ProgressNotificationValue}?, float, float, string)"/>
+/// overload at coarse-grained stage boundaries — e.g. "evaluating-msbuild", "loading-workspace",
+/// "running-tests", "done" — so MCP clients can render an intermediate label instead of waiting
+/// silently while the tool runs. Stage labels are STAGE-LEVEL ("loading-workspace"), not
+/// per-project counts: emitting per-project N/M would require service-interface changes that
+/// are out of scope for the audit-coverage initiative. See
+/// <c>progress-emit-audit-coverage</c> in the backlog for the broader treatment.
+/// </para>
+/// <para>
+/// <b>Picking stage labels.</b> Labels SHOULD be short (≤ 32 chars), kebab-case, and stable
+/// across releases — clients may key UI strings off them. Avoid embedding mutable state
+/// (project counts, file paths) in the label itself; that's what
+/// <see cref="ProgressNotificationValue.Progress"/> + <see cref="ProgressNotificationValue.Total"/>
+/// are for. The currently emitted labels (used by <c>workspace_load</c>, <c>workspace_warm</c>,
+/// <c>build_workspace</c>, and <c>test_run</c>) are documented inline at each tool's call site.
+/// </para>
+/// </remarks>
 public static class ProgressHelper
 {
     /// <summary>
-    /// Reports progress safely, handling null progress instances.
+    /// Reports progress safely, handling null progress instances. Use this overload when no
+    /// stage label is meaningful (e.g. tools fast enough that a single 0→1 emission suffices).
     /// </summary>
     public static void Report(IProgress<ProgressNotificationValue>? progress, float current, float? total = null)
     {
         progress?.Report(new ProgressNotificationValue { Progress = current, Total = total });
+    }
+
+    /// <summary>
+    /// Reports progress with an additional stage label so MCP clients can render a textual
+    /// description of the current phase (e.g. "evaluating-msbuild", "running-tests").
+    /// </summary>
+    /// <param name="progress">The progress sink supplied by the MCP SDK; may be <see langword="null"/>.</param>
+    /// <param name="current">Current progress value (typically a stage index, e.g. 1 of 4).</param>
+    /// <param name="total">Total progress value (typically the stage count, e.g. 4).</param>
+    /// <param name="stageLabel">
+    /// Short kebab-case label naming the stage. Stable across releases; clients may key UI
+    /// strings off it. See the remarks on <see cref="ProgressHelper"/> for guidance.
+    /// </param>
+    public static void ReportStage(
+        IProgress<ProgressNotificationValue>? progress,
+        float current,
+        float total,
+        string stageLabel)
+    {
+        progress?.Report(new ProgressNotificationValue
+        {
+            Progress = current,
+            Total = total,
+            Message = stageLabel,
+        });
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -21,11 +21,17 @@ public static class ValidationTools
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
+        // build-workspace stage emissions: clients see "preparing-build → msbuild-running →
+        // done" instead of waiting silently for an MSBuild target sweep across N projects.
+        // Per-project N/M is intentionally not emitted — IBuildService doesn't accept
+        // progress and adding it would require interface edits past the audit-coverage
+        // initiative scope. See ProgressHelper remarks for the label-naming contract.
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            ProgressHelper.Report(progress, 0, 1);
+            ProgressHelper.ReportStage(progress, 0, 3, "preparing-build");
+            ProgressHelper.ReportStage(progress, 1, 3, "msbuild-running");
             var result = await buildService.BuildWorkspaceAsync(workspaceId, c);
-            ProgressHelper.Report(progress, 1, 1);
+            ProgressHelper.ReportStage(progress, 3, 3, "done");
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }
@@ -149,11 +155,18 @@ public static class ValidationTools
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
+        // test-run stage emissions: clients see "discovering-tests → running-tests → done"
+        // instead of waiting silently while dotnet-test enumerates assemblies, builds the
+        // host, runs the suite, and parses TRX. Per-project N/M is intentionally not
+        // emitted — ITestRunnerService doesn't accept progress and adding it would require
+        // interface edits past the audit-coverage initiative scope. See ProgressHelper
+        // remarks for the label-naming contract.
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            ProgressHelper.Report(progress, 0, 1);
+            ProgressHelper.ReportStage(progress, 0, 3, "discovering-tests");
+            ProgressHelper.ReportStage(progress, 1, 3, "running-tests");
             var result = await testRunnerService.RunTestsAsync(workspaceId, projectName, filter, c);
-            ProgressHelper.Report(progress, 1, 1);
+            ProgressHelper.ReportStage(progress, 3, 3, "done");
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -29,11 +29,20 @@ public static class WorkspaceTools
     {
         return gate.RunLoadGateAsync(async c =>
         {
-            ProgressHelper.Report(progress, 0, 1);
+            // workspace-load stage emissions: clients see "validating-path → opening-workspace
+            // → checking-restore → done" instead of waiting silently for a ~45s P95 cold load
+            // on large solutions (OrchardCore, etc.). The stage labels are kebab-case and
+            // stable; total is the stage count (4) so client progress bars track correctly.
+            // Per-project N/M is intentionally not emitted here — IWorkspaceManager.LoadAsync
+            // doesn't expose intra-load progress and adding it would balloon scope past the
+            // audit-coverage initiative. See ProgressHelper remarks for the label-naming contract.
+            ProgressHelper.ReportStage(progress, 0, 4, "validating-path");
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, path, c).ConfigureAwait(false);
+            ProgressHelper.ReportStage(progress, 1, 4, "opening-workspace");
             var status = await workspace.LoadAsync(path, c).ConfigureAwait(false);
+            ProgressHelper.ReportStage(progress, 2, 4, "checking-restore");
             status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, c).ConfigureAwait(false);
-            ProgressHelper.Report(progress, 1, 1);
+            ProgressHelper.ReportStage(progress, 4, 4, "done");
             _ = NotifyResourcesChangedAsync(server);
             return verbose
                 ? JsonSerializer.Serialize(status, JsonDefaults.Indented)

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
+using System.Text.Json;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -29,10 +31,22 @@ public static class WorkspaceWarmTools
         IWorkspaceWarmService warmService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: project names to warm. Case-insensitive; unknown names are silently skipped. Omit or pass an empty array to warm every project in the solution.")] string[]? projects = null,
+        IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
-            gate,
-            workspaceId,
-            c => warmService.WarmAsync(workspaceId, projects, c),
-            ct);
+    {
+        // workspace-warm stage emissions: clients see "scheduling-warm → warming-projects →
+        // done" instead of waiting silently for the ~17s P95 warm on OrchardCore-class
+        // solutions. Per-project N/M is intentionally not emitted here — IWorkspaceWarmService
+        // doesn't accept progress and adding it would require interface + impl edits past the
+        // audit-coverage initiative scope. See ProgressHelper remarks for the label-naming
+        // contract.
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            ProgressHelper.ReportStage(progress, 0, 3, "scheduling-warm");
+            ProgressHelper.ReportStage(progress, 1, 3, "warming-projects");
+            var result = await warmService.WarmAsync(workspaceId, projects, c).ConfigureAwait(false);
+            ProgressHelper.ReportStage(progress, 3, 3, "done");
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
 }

--- a/tests/RoslynMcp.Tests/Progress/ProgressEmissionTests.cs
+++ b/tests/RoslynMcp.Tests/Progress/ProgressEmissionTests.cs
@@ -1,0 +1,214 @@
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests.Progress;
+
+/// <summary>
+/// Locks in the stage-fine progress emission contract added in
+/// <c>progress-emit-audit-coverage</c>. The four long-running tools (<c>workspace_load</c>,
+/// <c>workspace_warm</c>, <c>build_workspace</c>, <c>test_run</c>) MUST emit a documented
+/// sequence of stage labels (kebab-case, stable across releases) so MCP clients can render
+/// intermediate progress instead of waiting silently. Per
+/// <see cref="ProgressHelper.ReportStage(System.IProgress{ModelContextProtocol.ProgressNotificationValue}?, float, float, string)"/>'s
+/// remarks, labels are part of the public surface — these tests are the regression guard.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a recorder, not a mock workspace.</b> The progress contract is independent of
+/// workspace state — emissions happen at tool boundaries before/after the underlying service
+/// call. We record emissions via a lightweight <see cref="ProgressEmissionRecorder"/> and
+/// drive the SUT against the SampleSolution fixture (already loaded by
+/// <see cref="SharedWorkspaceTestBase"/>). Mocking the workspace would defeat the
+/// integration-level coverage; mocking the progress sink keeps the assertions deterministic.
+/// </para>
+/// <para>
+/// <b>Workspace load testing.</b> <c>workspace_load</c>'s tool surface takes an
+/// <see cref="McpServer"/> for client-roots validation. The validator handles
+/// <see langword="null"/> servers by skipping the roots check (path is allowed
+/// unconditionally), and <c>NotifyResourcesChangedAsync</c> swallows null-deref on the
+/// notify call. So the test passes <see langword="null!"/> for the server parameter and
+/// drives the existing dedup path: re-loading an already-loaded sample returns the cached
+/// session without re-running MSBuild. The full stage sequence is still emitted.
+/// </para>
+/// </remarks>
+[DoNotParallelize]
+[TestClass]
+public sealed class ProgressEmissionTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task WorkspaceLoad_EmitsStageSequence_ValidatingPath_To_Done()
+    {
+        var recorder = new ProgressEmissionRecorder();
+
+        // Re-loading the cached sample workspace exercises the dedup path; the tool still
+        // emits every stage label because the emissions sit outside `workspace.LoadAsync`.
+        // server: null! is safe — ClientRootPathValidator handles null servers explicitly
+        // and the fire-and-forget NotifyResourcesChangedAsync swallows the null-deref.
+        await WorkspaceTools.LoadWorkspace(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            workspace: WorkspaceManager,
+            commandRunner: DotnetCommandRunner,
+            path: SampleSolutionPath,
+            verbose: false,
+            autoRestore: false,
+            progress: recorder,
+            ct: CancellationToken.None);
+
+        AssertStageSequence(
+            recorder,
+            new[] { "validating-path", "opening-workspace", "checking-restore", "done" },
+            expectedTotal: 4,
+            toolName: "workspace_load");
+    }
+
+    [TestMethod]
+    public async Task WorkspaceWarm_EmitsStageSequence_SchedulingWarm_To_Done()
+    {
+        var recorder = new ProgressEmissionRecorder();
+
+        await WorkspaceWarmTools.WorkspaceWarm(
+            gate: WorkspaceExecutionGate,
+            warmService: WorkspaceWarmService,
+            workspaceId: WorkspaceId,
+            projects: null,
+            progress: recorder,
+            ct: CancellationToken.None);
+
+        AssertStageSequence(
+            recorder,
+            new[] { "scheduling-warm", "warming-projects", "done" },
+            expectedTotal: 3,
+            toolName: "workspace_warm");
+    }
+
+    [TestMethod]
+    public async Task BuildWorkspace_EmitsStageSequence_PreparingBuild_To_Done()
+    {
+        var recorder = new ProgressEmissionRecorder();
+
+        await ValidationTools.BuildWorkspace(
+            gate: WorkspaceExecutionGate,
+            buildService: BuildService,
+            workspaceId: WorkspaceId,
+            progress: recorder,
+            ct: CancellationToken.None);
+
+        AssertStageSequence(
+            recorder,
+            new[] { "preparing-build", "msbuild-running", "done" },
+            expectedTotal: 3,
+            toolName: "build_workspace");
+    }
+
+    [TestMethod]
+    public async Task TestRun_EmitsStageSequence_DiscoveringTests_To_Done()
+    {
+        var recorder = new ProgressEmissionRecorder();
+
+        // Use a name filter that matches no tests so dotnet-test returns immediately
+        // without spending full execution time. The progress emissions still fire because
+        // they bracket the entire RunTestsAsync call.
+        await ValidationTools.RunTests(
+            gate: WorkspaceExecutionGate,
+            testRunnerService: TestRunnerService,
+            workspaceId: WorkspaceId,
+            projectName: null,
+            filter: "FullyQualifiedName~__progress_emit_audit_no_match__",
+            progress: recorder,
+            ct: CancellationToken.None);
+
+        AssertStageSequence(
+            recorder,
+            new[] { "discovering-tests", "running-tests", "done" },
+            expectedTotal: 3,
+            toolName: "test_run");
+    }
+
+    [TestMethod]
+    public void ProgressHelper_ReportStage_SetsMessageAndProgressFields()
+    {
+        var recorder = new ProgressEmissionRecorder();
+        ProgressHelper.ReportStage(recorder, current: 2, total: 5, stageLabel: "midway");
+
+        Assert.AreEqual(1, recorder.Notifications.Count);
+        var notification = recorder.Notifications[0];
+        Assert.AreEqual(2f, notification.Progress, "Progress field must round-trip.");
+        Assert.AreEqual(5f, notification.Total, "Total field must round-trip.");
+        Assert.AreEqual("midway", notification.Message, "Message field must carry the stage label.");
+    }
+
+    [TestMethod]
+    public void ProgressHelper_ReportStage_NullProgress_DoesNotThrow()
+    {
+        // Tools that don't have a subscribed client receive a null progress sink. The helper
+        // must handle this gracefully — no exception, no observable side effects.
+        ProgressHelper.ReportStage(progress: null, current: 1, total: 4, stageLabel: "any");
+    }
+
+    private static void AssertStageSequence(
+        ProgressEmissionRecorder recorder,
+        string[] expectedLabels,
+        float expectedTotal,
+        string toolName)
+    {
+        var actualLabels = recorder.Notifications.Select(n => n.Message).ToList();
+
+        Assert.AreEqual(
+            expectedLabels.Length,
+            actualLabels.Count,
+            $"{toolName}: expected exactly {expectedLabels.Length} stage emissions; got " +
+            $"{actualLabels.Count}: [{string.Join(", ", actualLabels)}].");
+
+        for (int i = 0; i < expectedLabels.Length; i++)
+        {
+            Assert.AreEqual(
+                expectedLabels[i],
+                actualLabels[i],
+                $"{toolName}: stage {i} label mismatch. " +
+                $"Expected sequence: [{string.Join(", ", expectedLabels)}]; " +
+                $"got: [{string.Join(", ", actualLabels)}].");
+        }
+
+        // Total must be consistent across every emission so client progress bars track the
+        // same denominator across stages. A varying Total would make the bar jump.
+        foreach (var notification in recorder.Notifications)
+        {
+            Assert.AreEqual(
+                expectedTotal,
+                notification.Total,
+                $"{toolName}: every stage emission must use Total={expectedTotal}; " +
+                $"got Total={notification.Total} on label '{notification.Message}'.");
+        }
+    }
+}
+
+/// <summary>
+/// Captures every <see cref="ProgressNotificationValue"/> reported through the
+/// <see cref="IProgress{T}"/> sink. Tests inspect the captured sequence to assert the
+/// stage-emission contract.
+/// </summary>
+internal sealed class ProgressEmissionRecorder : IProgress<ProgressNotificationValue>
+{
+    private readonly List<ProgressNotificationValue> _notifications = new();
+
+    public IReadOnlyList<ProgressNotificationValue> Notifications => _notifications;
+
+    public void Report(ProgressNotificationValue value)
+    {
+        _notifications.Add(value);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ProgressHelper.ReportStage(progress, current, total, stageLabel)` — a non-breaking overload that emits a `Message` stage label alongside the existing `Progress`/`Total` fields.
- `workspace_load`, `workspace_warm`, `build_workspace`, `test_run` now bracket their inner service call with kebab-case stage labels so MCP clients see intermediate progress instead of waiting silently.
- Stage sequences:
  - `workspace_load`: `validating-path → opening-workspace → checking-restore → done` (4 stages)
  - `workspace_warm`: `scheduling-warm → warming-projects → done` (3 stages)
  - `build_workspace`: `preparing-build → msbuild-running → done` (3 stages)
  - `test_run`: `discovering-tests → running-tests → done` (3 stages)
- Targets the ~45s P95 cold-load on OrchardCore-class solutions and the ~17s P95 warm.

**Scope decision:** per-project N/M counts are NOT emitted here. `IWorkspaceManager.LoadAsync`, `IWorkspaceWarmService`, `IBuildService`, and `ITestRunnerService` don't accept `IProgress<>`, so adding per-project granularity would require interface + impl edits past the `progress-emit-audit-coverage` audit scope. The plan's stage-label intent is delivered; per-project counts can land in a follow-on row if friction emerges.

**Backwards compatibility:** the existing `ProgressHelper.Report(progress, current, total)` overload is untouched. All 17 existing call sites across AnalysisTools, OrchestrationTools, ScriptingTools, SecurityTools, TestCoverageTools, and the WorkspaceTools/ValidationTools sites that already used it continue to compile unchanged.

## Test plan

- [x] `mcp__roslyn__compile_check` per edit
- [x] New `ProgressEmissionTests` (6 tests, all passing in 7s) covers:
  - Stage sequence assertion for each of 4 tools (workspace_load, workspace_warm, build_workspace, test_run)
  - `ReportStage` round-trips Progress/Total/Message correctly
  - Null progress sink doesn't throw
- [x] Targeted regression: `ValidationToolsIntegrationTests`, `WorkspaceToolsIntegrationTests`, `WorkspaceWarmServiceTests`, `SurfaceCatalogTests` — all pass (53 tests, 19s)
- [x] `Build` succeeds at warning-level zero in both Debug and Release
- [ ] Manual: load a >50-project solution with a client that surfaces `notifications/message` (Cursor inspector), confirm the new stage entries appear

## Notes

- The 3 flaky test failures observed under full-suite `verify-release.ps1` (`WorkspaceManager_RejectsLoadsPastConfiguredLimit`, `ApplyWithVerify_GoodPreview_ReturnsApplied`, `ReloadAsync_WithAutoRestore_ClearsRestoreRequiredAfterPackageVersionEdit`) are pre-existing parallel-test temp-dir contention races; they pass in isolation and are unrelated to this change. Different tests fail on different runs.
- `verify-ai-docs.ps1` reports the same `plan.md → src/...` broken-link warning on `main` and on this branch (orchestrator-owned plan.md, not in this PR's scope).

Closes: progress-emit-audit-coverage