### PR TITLE
feat(skills): /promote-tier maintainer skill (promote-tier-skill)

### DIFF
--- a/.claude/skills/promote-tier/SKILL.md
+++ b/.claude/skills/promote-tier/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: promote-tier
+description: "Flip a tool, resource, or prompt's support tier between `stable` and `experimental` atomically across both source-of-truth sites (`[McpToolMetadata]` annotation and `ServerSurfaceCatalog` partial entry). Use when: `/publish-preflight` Step 8 surfaces a `recommendation: \"promote\"` row in the promotion scorecard, a release-cut needs to flip a tier on a single tool/resource/prompt, or a tier flip needs to be reverted. Maintainer-side skill — not shipped to plugin consumers. Replaces the manual `Edit:` checklist `/publish-preflight` Step 8 surfaces today (pieces A and B shipped in PR #496; this is piece C)."
+user-invocable: true
+argument-hint: "<tool-or-resource-or-prompt-name> <stable|experimental>"
+---
+
+# Promote Tier
+
+You flip the support tier of one MCP tool, resource, or prompt atomically across BOTH source-of-truth sites: the `[McpToolMetadata("category", "tier", ...)]` attribute (or its resource/prompt equivalent on the catalog entry) AND the matching catalog row. The `SurfaceCatalogTests` parity check enforces the dual-write contract — an edit that touches one site without the other fails the test, which is the safety net for this skill.
+
+This is a **maintainer-side** skill (lives at `.claude/skills/promote-tier/`, NOT `skills/promote-tier/`). It is invoked by the maintainer at release-cut time after `/publish-preflight` Step 8 surfaces promotion candidates. It is NOT shipped to plugin consumers.
+
+## Why this exists
+
+Today `/publish-preflight` Step 8 emits a manual `Edit:` checklist for each promotion-recommended row:
+
+```
+- workspace_drift_check (tool, workspace) — currentTier=experimental, recommendation=promote
+    Edit: src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+    Edit: src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Workspace.cs
+    Verify: dotnet test --filter SurfaceCatalogTests
+```
+
+The maintainer then opens both files and hand-flips two literals. Pieces A (the `/publish-preflight` Step 8 gate) and B (the promotion scorecard JSON output) shipped in PR #496. This skill is piece C — the mechanical replacement for the hand-edit step. One invocation flips both literals and runs the parity test.
+
+## Input
+
+`$ARGUMENTS` is two space-separated tokens:
+
+1. **Name** — the tool, resource, or prompt name as it appears in `ServerSurfaceCatalog.*` (e.g. `workspace_drift_check`, `server_catalog_full`, `explain_error`). Kebab-snake, lowercase.
+2. **Target tier** — `stable` or `experimental`. The skill looks up the current tier first; if the requested tier matches the current tier, it refuses (no-op).
+
+Example: `/promote-tier workspace_drift_check stable`
+
+If either argument is missing, refuse with a one-line usage message.
+
+## Preconditions (HARD GATES — refuse if any fail)
+
+1. **Working tree is clean** for the target source files (no unstaged edits to the tool/resource/prompt file or the catalog partial). If dirty, refuse: `"Refusing: working tree has unstaged edits to <file>. Commit or stash before flipping tier."`.
+2. **Name resolves to exactly ONE entry** in `ServerSurfaceCatalog`. Zero matches → refuse with a "did you mean?" hint that lists the closest 3 names. Multiple matches → refuse with the conflicting entries (indicates a catalog-integrity bug that a human should fix).
+3. **Target tier is `stable` or `experimental`**. Any other value → refuse with the two valid values.
+4. **Current tier ≠ target tier** — already-at-target is a no-op refusal: `"Refusing: <name> is already at tier <target>. Nothing to do."`.
+
+## Workflow
+
+### Step 1 — Resolve the entry kind and category
+
+Use `mcp__roslyn__symbol_search` (preferred over `Grep`) to locate the entry in the catalog files. The `ServerSurfaceCatalog.*.cs` partials each carry an array of `Tool(...)`, `Resource(...)`, or `Prompt(...)` factory calls — find the one whose first string argument matches the input name. Capture:
+
+- **Kind**: `tool` | `resource` | `prompt` (which factory is used).
+- **Category**: 2nd argument of the factory call (e.g. `"workspace"`, `"server"`, `"prompts"`).
+- **Current tier**: 3rd argument (`"stable"` or `"experimental"`).
+- **Catalog-partial path**: e.g. `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Workspace.cs`.
+
+If the entry is not found, refuse per Precondition 2.
+
+### Step 2 — Resolve the implementation site (per kind)
+
+Three resolver paths, one per kind:
+
+#### Tools (kind == `tool`)
+
+The implementation site is a static method annotated with `[McpServerTool(Name = "<name>")]` AND `[McpToolMetadata("<category>", "<tier>", ...)]`. To find it:
+
+1. Use `mcp__roslyn__symbol_search` with the search hint `<name>` to find the static method whose `[McpServerTool]` attribute carries `Name = "<name>"`. (Method names usually mirror the tool name in PascalCase, but not always — the attribute is the source of truth.)
+2. Read the file. Locate the `[McpToolMetadata(...)]` attribute literal on that method. The tier literal is **parameter index 1** (0-based: `category`, `tier`, `readOnly`, `destructive`, `summary`).
+
+#### Resources (kind == `resource`)
+
+Resources are simpler — the tier lives ONLY in the catalog entry's 3rd argument. The `ServerResources.cs` / `WorkspaceResources.cs` files do not carry a tier marker on the `[McpServerResource]` attribute itself. Skip Step 3's "implementation-site edit" entirely; only the catalog edit applies.
+
+(Cross-check at impl time by reading `src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs` — if a future PR adds a tier marker to the resource attribute, this skill must be updated to handle it. Today: catalog-only.)
+
+#### Prompts (kind == `prompt`)
+
+Same as resources today — the tier lives only in the catalog. Implementation files are at `src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.*.cs`. Cross-check by reading the file; if a tier marker is found on the `[McpServerPrompt]` attribute or a paired metadata attribute, edit it. Today: catalog-only.
+
+### Step 3 — Edit the implementation site (tools only)
+
+For tools, use `Edit` on the source file:
+
+- `old_string`: the attribute literal anchor — `McpToolMetadata("<category>", "<currentTier>",`
+  - Note: the literal is `McpToolMetadata(...)` without a leading `[` because the attribute often appears as the second attribute in a `[Attr1, Attr2]` pair (e.g. `[McpServerTool(...), McpToolMetadata("workspace", "experimental", ...)]`). Anchoring on `[McpToolMetadata` would miss those.
+  - Include enough trailing context (typically the `<readOnly>, <destructive>,` literals plus the next-line summary) to make the match unique within the file, but stay surgical — do NOT replace the whole attribute block.
+- `new_string`: identical, with `<currentTier>` flipped to `<targetTier>`.
+
+Verify the match is unique by reading the file first (or relying on `Edit`'s uniqueness check). If the match is not unique, escalate the `old_string` with more surrounding context until it is.
+
+For resources and prompts, skip this step.
+
+### Step 4 — Edit the catalog entry
+
+Use `Edit` on the catalog partial file (e.g. `ServerSurfaceCatalog.Workspace.cs`):
+
+- `old_string`: the full factory call line, e.g.
+  `Tool("workspace_drift_check", "workspace", "experimental", true, false, "Compare the in-memory workspace snapshot...`
+  Include enough context to make the match unique (the name + category + tier prefix is usually sufficient since names are unique catalog-wide).
+- `new_string`: identical, with the tier flipped.
+
+### Step 5 — Run `SurfaceCatalogTests` to confirm parity
+
+The `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry` test asserts that every `[McpToolMetadata]` attribute matches its catalog entry on every field. This is the dual-write safety net.
+
+Run:
+
+```bash
+dotnet test --filter SurfaceCatalogTests --nologo --no-restore
+```
+
+(Or, when the workspace is loaded, prefer `mcp__roslyn__test_run --filter "SurfaceCatalogTests"` for faster feedback.)
+
+**Pass** → both edits landed correctly; the dual-write contract holds.
+
+**Fail** → one of the edits is inconsistent. Read the failure message: it names the offending tool and the field that drifted. Fix and re-run. **DO NOT proceed past this step on failure** — a half-flipped tier silently misadvertises the surface.
+
+### Step 6 — Report
+
+Emit:
+
+```
+Promoted <name> (<kind>, <category>) from <currentTier> to <targetTier>:
+  Edit: <impl-site-path>           (skipped for resource/prompt)
+  Edit: <catalog-partial-path>
+  Verify: SurfaceCatalogTests        PASS
+
+Next: stage the two edits, commit, and ship the tier flip in the next release. Run `/draft-changelog-entry` if a changelog fragment is desired.
+```
+
+## Non-goals
+
+- **Do NOT edit `CHANGELOG.md`, `changelog.d/*.md`, the README.md surface counts, or any other doc.** Tier flips are tracked in `CHANGELOG.md` only when the maintainer chooses to call them out — usually as a single-line "Maintenance" or "Changed" entry — and that's `/draft-changelog-entry`'s job.
+- **Do NOT commit, push, or open a PR.** The caller stages the edits and ships them via `/ship` (typically batched with other release-cut bookkeeping).
+- **Do NOT flip the tier of multiple entries in one invocation.** One name per call. Bulk promotion is intentionally out of scope — each promotion is a release-quality decision that warrants individual review.
+- **Do NOT touch other fields on the attribute or catalog entry.** Only the tier literal at parameter index 1. Drift in other fields is a separate concern and surfaced by a different parity test.
+
+## Refusal cases (explicit)
+
+- **Name not found** → refuse with the exact name and the closest 3 catalog names (Levenshtein-1 if any).
+- **Name found in two catalog partials** → refuse with the two file paths (catalog-integrity bug).
+- **Already at target tier** → refuse with `"<name> is already <target>. No-op."`.
+- **Working tree dirty on the target files** → refuse per Precondition 1. Do not auto-stash.
+- **Test failure post-edit** → STOP. Do not partially-revert. Report the test failure verbatim and let the maintainer decide whether to revert the edits or fix forward.
+- **Unsupported kind** → if a future entry kind appears (e.g. a hypothetical `[McpServerSlashCommand]`), refuse with: `"Unsupported entry kind '<kind>'. The promote-tier skill currently handles tool, resource, and prompt only. Add a resolver path and round-trip test before flipping this kind."`
+
+## Example
+
+**Input:** `/promote-tier workspace_drift_check stable`
+
+**Resolution:**
+
+```
+Resolved workspace_drift_check:
+  kind: tool
+  category: workspace
+  current tier: experimental
+  catalog entry: src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Workspace.cs:20
+  impl site: src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs:24 ([McpToolMetadata("workspace", "experimental", true, false, ...)])
+
+Editing impl site... ok
+Editing catalog entry... ok
+Running SurfaceCatalogTests... PASS
+
+Promoted workspace_drift_check (tool, workspace) from experimental to stable.
+```
+
+**Reverting the same flip (round-trip):**
+
+**Input:** `/promote-tier workspace_drift_check experimental`
+
+```
+Resolved workspace_drift_check:
+  kind: tool
+  ... current tier: stable
+
+Editing impl site... ok
+Editing catalog entry... ok
+Running SurfaceCatalogTests... PASS
+
+Reverted workspace_drift_check (tool, workspace) from stable to experimental.
+```
+
+The round-trip is bit-identical — the test that pairs with this skill (`tests/RoslynMcp.Tests/Skills/PromoteTierRoundTripTests.cs`) asserts this contract: a forward + reverse promotion leaves the source tree exactly as it found it.
+
+## Distinct from related skills
+
+- **`/publish-preflight`**: surfaces `recommendation: "promote"` rows in Step 8 and emits the `Edit:` checklist. This skill replaces the manual edits it suggests.
+- **`/draft-changelog-entry`**: writes ONE `changelog.d/<row-id>.md` fragment. After a tier flip ships in a release, the maintainer may invoke this to record the promotion in the changelog (optional — minor tier flips often ride in a `## [X.Y.Z]` section's "Maintenance" bullet without a dedicated fragment).
+- **`/bump`**: rolls accumulated `changelog.d/*.md` fragments into a tagged release. Tier flips are visible to consumers from this point.
+- **`/release-cut`**: the atomic release pipeline (`/bump` → `/ship` → tag → reinstall). A typical release-cut sequence is: `/publish-preflight` → `/promote-tier` (per recommended row) → `/release-cut`.
+
+## Implementation notes (for future maintainers of this skill)
+
+- The `[McpToolMetadata]` attribute's parameter shape is defined at `src/RoslynMcp.Host.Stdio/Catalog/McpToolMetadataAttribute.cs`. Today the parameter order is `(category, supportTier, readOnly, destructive, summary)` — `supportTier` is parameter index 1 (0-based). If the attribute shape ever changes, this skill's "Step 3 — Edit the implementation site" must be updated to match.
+- The catalog factory functions (`Tool`, `Resource`, `Prompt`) live in `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs`. Same parameter-shape caveat — `tier` is parameter index 2 (0-based: `name`, `category`, `tier`, ...).
+- The `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry` test is the dual-write safety net. If a future refactor splits the catalog or reshapes the attribute, that test must continue to assert dual-site parity OR this skill needs a different verification strategy.

--- a/changelog.d/promote-tier-skill.md
+++ b/changelog.d/promote-tier-skill.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** added `.claude/skills/promote-tier/` (maintainer-side) — automates the `[McpToolMetadata]` + `ServerSurfaceCatalog` tier flip the `/publish-preflight` Step 8 gate currently surfaces as a manual `Edit:` checklist. Pieces A and B of the release-cut promotion gate landed in PR #496; this is piece C. Closes `promote-tier-skill`.

--- a/tests/RoslynMcp.Tests/Skills/PromoteTierRoundTripTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/PromoteTierRoundTripTests.cs
@@ -1,0 +1,287 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// promote-tier-skill: round-trip parity test for the maintainer-side `/promote-tier` skill.
+///
+/// The skill documents two mechanical string-flip edits per tool promotion:
+///   (1) `[McpToolMetadata("category", "experimental", ...)]` -> `[McpToolMetadata("category", "stable", ...)]` on the tool source
+///   (2) `Tool("name", "category", "experimental", ...)` -> `Tool("name", "category", "stable", ...)` on the catalog partial
+/// (For resources and prompts, only the catalog partial — the McpServerResource / McpServerPrompt attributes carry no tier marker today.)
+///
+/// This test asserts the documented mechanics are bit-reversible end-to-end: a forward + reverse promotion
+/// leaves the source tree exactly as it found it. The test reads the source files, performs the flip in memory,
+/// asserts the change took effect, reverses it, and asserts byte-for-byte content equality with the original.
+/// This is the safety net that lets the skill ship without a more elaborate AST-based implementation —
+/// the dual-write contract (catalog entry vs. attribute) is enforced by SurfaceCatalogTests; the bit-reversibility
+/// contract is enforced here.
+///
+/// Choose subjects from the live catalog so the test stays correct as the catalog evolves:
+///   - Tool subject:     pick a workspace-category experimental tool (workspace_drift_check today).
+///   - Resource subject: pick an experimental resource (server_catalog_full today).
+///   - Prompt subject:   pick an experimental prompt (explain_error today; all prompts are experimental).
+/// If the chosen subject is later promoted to stable in the catalog, the test will pick a different experimental
+/// entry from the same kind via the `PickExperimentalEntry` helper. The test fails loudly with a clear message
+/// when no experimental entry of a kind exists (no false-passes).
+///
+/// HARD INVARIANT: this test NEVER writes to disk. All flips are in-memory string manipulation; the source files
+/// are only read. A failure of this invariant would pollute the catalog and is a regression to root-cause and revert.
+/// </summary>
+[TestClass]
+public sealed class PromoteTierRoundTripTests
+{
+    [TestMethod]
+    public void Tool_TierFlip_RoundTripIsBitIdentical()
+    {
+        var entry = PickExperimentalEntry(ServerSurfaceCatalog.Tools, kind: "tool");
+
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var catalogPartial = ResolveToolCatalogPartial(repoRoot, entry.Category);
+        var implFile = ResolveToolImplFile(repoRoot, entry.Name);
+
+        // Read originals.
+        var originalCatalog = File.ReadAllText(catalogPartial);
+        var originalImpl = File.ReadAllText(implFile);
+
+        // Forward flip experimental -> stable.
+        var flippedCatalog = FlipCatalogTierForTool(originalCatalog, entry.Name, entry.Category, fromTier: "experimental", toTier: "stable");
+        var flippedImpl = FlipImplTierForTool(originalImpl, entry.Category, fromTier: "experimental", toTier: "stable");
+
+        Assert.AreNotEqual(originalCatalog, flippedCatalog,
+            $"Forward flip produced no change to catalog partial '{catalogPartial}'. "
+            + $"The documented Tool(...) match for {entry.Name} did not match — has the catalog factory shape changed? "
+            + "Update the skill's Step 4 documentation and this test's FlipCatalogTierForTool helper in lockstep.");
+        Assert.AreNotEqual(originalImpl, flippedImpl,
+            $"Forward flip produced no change to impl file '{implFile}'. "
+            + $"The [McpToolMetadata(\"{entry.Category}\", \"experimental\", ...)] literal did not match — has the attribute shape changed? "
+            + "Update the skill's Step 3 documentation and this test's FlipImplTierForTool helper in lockstep.");
+
+        // Reverse flip stable -> experimental.
+        var roundTrippedCatalog = FlipCatalogTierForTool(flippedCatalog, entry.Name, entry.Category, fromTier: "stable", toTier: "experimental");
+        var roundTrippedImpl = FlipImplTierForTool(flippedImpl, entry.Category, fromTier: "stable", toTier: "experimental");
+
+        // Assert bit-identical with originals.
+        Assert.AreEqual(originalCatalog, roundTrippedCatalog,
+            $"Round-trip flip on catalog partial '{catalogPartial}' is not bit-identical. "
+            + "The skill's documented edit shape is not strictly reversible — investigate FlipCatalogTierForTool.");
+        Assert.AreEqual(originalImpl, roundTrippedImpl,
+            $"Round-trip flip on impl file '{implFile}' is not bit-identical. "
+            + "The skill's documented edit shape is not strictly reversible — investigate FlipImplTierForTool.");
+
+        // Hard invariant — no disk write occurred during the test.
+        var liveCatalogOnDisk = File.ReadAllText(catalogPartial);
+        var liveImplOnDisk = File.ReadAllText(implFile);
+        Assert.AreEqual(originalCatalog, liveCatalogOnDisk,
+            "Disk-state invariant violation: catalog partial was modified during the test. "
+            + "PromoteTierRoundTripTests must NEVER write to disk.");
+        Assert.AreEqual(originalImpl, liveImplOnDisk,
+            "Disk-state invariant violation: impl file was modified during the test. "
+            + "PromoteTierRoundTripTests must NEVER write to disk.");
+    }
+
+    [TestMethod]
+    public void Resource_TierFlip_RoundTripIsBitIdentical()
+    {
+        var entry = PickExperimentalEntry(ServerSurfaceCatalog.Resources, kind: "resource");
+
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var catalogPartial = Path.Combine(repoRoot, "src", "RoslynMcp.Host.Stdio", "Catalog", "ServerSurfaceCatalog.Resources.cs");
+        Assert.IsTrue(File.Exists(catalogPartial), $"Resource catalog partial not found at {catalogPartial}");
+
+        var originalCatalog = File.ReadAllText(catalogPartial);
+
+        // Resources are catalog-only — no impl-side tier marker today (see SKILL.md "Step 2 — Resources" path).
+        var flippedCatalog = FlipCatalogTierForResource(originalCatalog, entry.Name, entry.Category, fromTier: "experimental", toTier: "stable");
+        Assert.AreNotEqual(originalCatalog, flippedCatalog,
+            $"Forward flip produced no change to resource catalog '{catalogPartial}'. "
+            + $"The documented Resource(\"{entry.Name}\", ...) match did not fire — has the resource factory shape changed?");
+
+        var roundTrippedCatalog = FlipCatalogTierForResource(flippedCatalog, entry.Name, entry.Category, fromTier: "stable", toTier: "experimental");
+        Assert.AreEqual(originalCatalog, roundTrippedCatalog,
+            $"Round-trip flip on resource catalog '{catalogPartial}' is not bit-identical.");
+
+        // Disk-state invariant.
+        var liveCatalogOnDisk = File.ReadAllText(catalogPartial);
+        Assert.AreEqual(originalCatalog, liveCatalogOnDisk,
+            "Disk-state invariant violation: resource catalog partial was modified during the test.");
+    }
+
+    [TestMethod]
+    public void Prompt_TierFlip_RoundTripIsBitIdentical()
+    {
+        var entry = PickExperimentalEntry(ServerSurfaceCatalog.Prompts, kind: "prompt");
+
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var catalogPartial = Path.Combine(repoRoot, "src", "RoslynMcp.Host.Stdio", "Catalog", "ServerSurfaceCatalog.Prompts.cs");
+        Assert.IsTrue(File.Exists(catalogPartial), $"Prompt catalog partial not found at {catalogPartial}");
+
+        var originalCatalog = File.ReadAllText(catalogPartial);
+
+        // Prompts are catalog-only today (see SKILL.md "Step 2 — Prompts" path).
+        var flippedCatalog = FlipCatalogTierForPrompt(originalCatalog, entry.Name, entry.Category, fromTier: "experimental", toTier: "stable");
+        Assert.AreNotEqual(originalCatalog, flippedCatalog,
+            $"Forward flip produced no change to prompt catalog '{catalogPartial}'. "
+            + $"The documented Prompt(\"{entry.Name}\", ...) match did not fire — has the prompt factory shape changed?");
+
+        var roundTrippedCatalog = FlipCatalogTierForPrompt(flippedCatalog, entry.Name, entry.Category, fromTier: "stable", toTier: "experimental");
+        Assert.AreEqual(originalCatalog, roundTrippedCatalog,
+            $"Round-trip flip on prompt catalog '{catalogPartial}' is not bit-identical.");
+
+        // Disk-state invariant.
+        var liveCatalogOnDisk = File.ReadAllText(catalogPartial);
+        Assert.AreEqual(originalCatalog, liveCatalogOnDisk,
+            "Disk-state invariant violation: prompt catalog partial was modified during the test.");
+    }
+
+    [TestMethod]
+    public void Skill_FilePresent_AndDocumentsAllThreeKinds()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var skillPath = Path.Combine(repoRoot, ".claude", "skills", "promote-tier", "SKILL.md");
+        Assert.IsTrue(File.Exists(skillPath),
+            $"promote-tier SKILL.md not found at {skillPath}. The skill is the user-facing contract — its absence makes the round-trip test moot.");
+
+        var skillContents = File.ReadAllText(skillPath);
+
+        // Each of the three resolver paths must appear in the skill body — these mirror the test's per-kind round-trips.
+        Assert.IsTrue(
+            skillContents.Contains("Tools (kind == `tool`)", StringComparison.Ordinal),
+            "promote-tier SKILL.md is missing the Tools resolver path (Step 2 — `tool` heading).");
+        Assert.IsTrue(
+            skillContents.Contains("Resources (kind == `resource`)", StringComparison.Ordinal),
+            "promote-tier SKILL.md is missing the Resources resolver path (Step 2 — `resource` heading).");
+        Assert.IsTrue(
+            skillContents.Contains("Prompts (kind == `prompt`)", StringComparison.Ordinal),
+            "promote-tier SKILL.md is missing the Prompts resolver path (Step 2 — `prompt` heading).");
+
+        // The dual-write safety-net citation must be present (the SurfaceCatalogTests reference).
+        Assert.IsTrue(
+            skillContents.Contains("SurfaceCatalogTests", StringComparison.Ordinal),
+            "promote-tier SKILL.md is missing its citation of SurfaceCatalogTests as the dual-write safety net.");
+    }
+
+    /// <summary>
+    /// Pick the first experimental entry of the given kind from the live catalog. Fails loudly if none — the
+    /// test cannot run a meaningful round-trip without a real subject. This makes the test self-correcting
+    /// as the catalog evolves: as long as at least one experimental entry of each kind exists, the test runs.
+    /// </summary>
+    private static SurfaceEntry PickExperimentalEntry(IReadOnlyList<SurfaceEntry> entries, string kind)
+    {
+        var subject = entries.FirstOrDefault(e => string.Equals(e.SupportTier, "experimental", StringComparison.Ordinal));
+        Assert.IsNotNull(subject,
+            $"No experimental {kind} entries found in the live catalog. PromoteTierRoundTripTests requires at least one "
+            + $"experimental entry of each kind to exercise the round-trip. If every {kind} is now stable, this test "
+            + "needs to be skipped or rewritten to flip stable -> experimental -> stable instead.");
+        return subject!;
+    }
+
+    private static string ResolveToolCatalogPartial(string repoRoot, string category)
+    {
+        // The catalog is split by category prefix matching the partial filename suffix.
+        // Categories (today): workspace, symbols, analysis, refactoring, editing, orchestration.
+        // The map is intentionally explicit rather than dynamic — partials are stable in number.
+        var partialName = category switch
+        {
+            "workspace" or "server" => "ServerSurfaceCatalog.Workspace.cs",
+            "symbols" => "ServerSurfaceCatalog.Symbols.cs",
+            "analysis" => "ServerSurfaceCatalog.Analysis.cs",
+            "refactoring" => "ServerSurfaceCatalog.Refactoring.cs",
+            "editing" => "ServerSurfaceCatalog.Editing.cs",
+            "orchestration" => "ServerSurfaceCatalog.Orchestration.cs",
+            _ => throw new InvalidOperationException(
+                $"Unknown tool category '{category}'. Update PromoteTierRoundTripTests.ResolveToolCatalogPartial when a new partial is added.")
+        };
+        var path = Path.Combine(repoRoot, "src", "RoslynMcp.Host.Stdio", "Catalog", partialName);
+        Assert.IsTrue(File.Exists(path), $"Tool catalog partial not found at {path}");
+        return path;
+    }
+
+    /// <summary>
+    /// Find the impl file containing [McpServerTool(Name = "&lt;name&gt;")]. The skill's documented mechanics
+    /// say "use mcp__roslyn__symbol_search" — for the purposes of this test, a directory walk over Tools/*.cs
+    /// + a substring match on the [McpServerTool(Name = "&lt;name&gt;")] literal is sufficient and faster.
+    /// </summary>
+    private static string ResolveToolImplFile(string repoRoot, string toolName)
+    {
+        var toolsDir = Path.Combine(repoRoot, "src", "RoslynMcp.Host.Stdio", "Tools");
+        Assert.IsTrue(Directory.Exists(toolsDir), $"Tools directory not found at {toolsDir}");
+
+        var needle = $"Name = \"{toolName}\"";
+        foreach (var path in Directory.EnumerateFiles(toolsDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (File.ReadAllText(path).Contains(needle, StringComparison.Ordinal))
+            {
+                return path;
+            }
+        }
+        Assert.Fail($"Could not locate the impl file carrying [McpServerTool(Name = \"{toolName}\")] under {toolsDir}");
+        return null!;
+    }
+
+    private static string FlipCatalogTierForTool(string source, string name, string category, string fromTier, string toTier)
+    {
+        // Match Tool("name", "category", "fromTier", ... → Tool("name", "category", "toTier", ...
+        var oldLiteral = $"Tool(\"{name}\", \"{category}\", \"{fromTier}\"";
+        var newLiteral = $"Tool(\"{name}\", \"{category}\", \"{toTier}\"";
+        AssertSingleOccurrence(source, oldLiteral, $"Tool literal for {name} (tier={fromTier})");
+        return source.Replace(oldLiteral, newLiteral);
+    }
+
+    private static string FlipImplTierForTool(string source, string category, string fromTier, string toTier)
+    {
+        // Match McpToolMetadata("category", "fromTier", → McpToolMetadata("category", "toTier",
+        // Note: no leading '[' — the attribute often appears as the 2nd attribute in a `[Attr1, Attr2]` pair, e.g.
+        //   [McpServerTool(Name = "..."), McpToolMetadata("category", "experimental", ...)]
+        // so anchoring on '[' would miss those. The attribute name itself is unique enough on its own.
+        var oldLiteral = $"McpToolMetadata(\"{category}\", \"{fromTier}\"";
+        var newLiteral = $"McpToolMetadata(\"{category}\", \"{toTier}\"";
+        AssertSingleOccurrence(source, oldLiteral, $"McpToolMetadata literal for category={category}, tier={fromTier}");
+        return source.Replace(oldLiteral, newLiteral);
+    }
+
+    private static string FlipCatalogTierForResource(string source, string name, string category, string fromTier, string toTier)
+    {
+        var oldLiteral = $"Resource(\"{name}\", \"{category}\", \"{fromTier}\"";
+        var newLiteral = $"Resource(\"{name}\", \"{category}\", \"{toTier}\"";
+        AssertSingleOccurrence(source, oldLiteral, $"Resource literal for {name} (tier={fromTier})");
+        return source.Replace(oldLiteral, newLiteral);
+    }
+
+    private static string FlipCatalogTierForPrompt(string source, string name, string category, string fromTier, string toTier)
+    {
+        var oldLiteral = $"Prompt(\"{name}\", \"{category}\", \"{fromTier}\"";
+        var newLiteral = $"Prompt(\"{name}\", \"{category}\", \"{toTier}\"";
+        AssertSingleOccurrence(source, oldLiteral, $"Prompt literal for {name} (tier={fromTier})");
+        return source.Replace(oldLiteral, newLiteral);
+    }
+
+    /// <summary>
+    /// The skill assumes each tier-flip target literal appears EXACTLY once in its file. If it appears
+    /// zero times, the documented match is wrong — fail with a clear message. If it appears more than
+    /// once, the skill could mutate the wrong instance — fail with a clear message. Both branches point
+    /// the maintainer at the SKILL.md edit-shape contract.
+    /// </summary>
+    private static void AssertSingleOccurrence(string source, string literal, string description)
+    {
+        var occurrences = CountOccurrences(source, literal);
+        Assert.AreEqual(
+            1, occurrences,
+            $"Expected exactly 1 occurrence of {description} in source; found {occurrences}. "
+            + "If 0: the literal shape changed (update SKILL.md and the helper in lockstep). "
+            + "If >1: the skill's edit could match the wrong instance — narrow the literal with more context.");
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a maintainer-side `/promote-tier` skill at `.claude/skills/promote-tier/SKILL.md` that flips a tool, resource, or prompt's support tier atomically across both source-of-truth sites: the `[McpToolMetadata]` attribute on the tool method AND the matching `ServerSurfaceCatalog.<Category>.cs` partial entry. The `SurfaceCatalogTests` parity check enforces the dual-write contract.

This replaces the manual `Edit:` checklist `/publish-preflight` Step 8 emits today. Pieces A + B shipped in PR #496; this is piece C.

- New: `.claude/skills/promote-tier/SKILL.md` — maintainer-only (NOT in `skills/` consumer-facing directory)
- New: `tests/RoslynMcp.Tests/Skills/PromoteTierRoundTripTests.cs` — round-trip bit-reversibility contract test (4 tests, all pass; never writes to disk)
- New: `changelog.d/promote-tier-skill.md` — Maintenance fragment

## Test plan

- [x] `mcp__roslyn__compile_check` clean on the new test file
- [x] `mcp__roslyn__test_run --filter PromoteTierRoundTripTests` — 4/4 pass
- [x] `mcp__roslyn__test_run --filter SurfaceCatalogTests` — 11/11 pass (no catalog pollution)
- [x] `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` — passes
- [x] `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release` — 1081/1081 tests pass

Closes: `promote-tier-skill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)