### PR TITLE
feat(mcp-output-schema): add outputSchema + structuredContent infrastructure (tool-output-schema-infrastructure)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Catalog/McpToolMetadataAttribute.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/McpToolMetadataAttribute.cs
@@ -12,6 +12,14 @@ namespace RoslynMcp.Host.Stdio.Catalog;
 /// and run fine and the name-level parity check continues to catch missing catalog rows. A
 /// future cleanup PR will annotate the remaining tools so the entire surface is enforced.
 /// </para>
+/// <para>
+/// tool-output-schema-infrastructure: the optional <see cref="OutputSchemaTypeRef"/> parameter
+/// names the DTO record whose JSON-Schema representation describes a tool's
+/// <c>structuredContent</c> channel per MCP 2025-06-18 § Tools / Structured Content. Tools that
+/// do not set this parameter remain text-only and unchanged; tools that do are emitted via
+/// both the <c>content[].text</c> and <c>structuredContent</c> channels by
+/// <c>StructuredCallToolFilter</c>. No tools opt in this PR — wiring only.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class McpToolMetadataAttribute : Attribute
@@ -21,13 +29,15 @@ public sealed class McpToolMetadataAttribute : Attribute
         string supportTier,
         bool readOnly,
         bool destructive,
-        string summary)
+        string summary,
+        Type? outputSchemaTypeRef = null)
     {
         Category = category ?? throw new ArgumentNullException(nameof(category));
         SupportTier = supportTier ?? throw new ArgumentNullException(nameof(supportTier));
         ReadOnly = readOnly;
         Destructive = destructive;
         Summary = summary ?? throw new ArgumentNullException(nameof(summary));
+        OutputSchemaTypeRef = outputSchemaTypeRef;
     }
 
     public string Category { get; }
@@ -35,4 +45,15 @@ public sealed class McpToolMetadataAttribute : Attribute
     public bool ReadOnly { get; }
     public bool Destructive { get; }
     public string Summary { get; }
+
+    /// <summary>
+    /// tool-output-schema-infrastructure: optional CLR type whose JSON-Schema (generated via
+    /// <see cref="System.Text.Json.Schema.JsonSchemaExporter"/>) describes the tool's
+    /// <c>structuredContent</c> channel. <see langword="null"/> means the tool returns
+    /// text-only content (legacy contract, unchanged behavior). When set, the dispatch
+    /// pipeline emits both <c>content[].text</c> (serialized JSON of the same payload) and
+    /// the <c>structuredContent</c> channel — the MCP spec requires both channels coexist
+    /// when <c>structuredContent</c> is populated.
+    /// </summary>
+    public Type? OutputSchemaTypeRef { get; }
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -133,11 +133,19 @@ public static partial class ServerSurfaceCatalog
     private static int CountByTier(IReadOnlyList<SurfaceEntry> entries, string tier) =>
         entries.Count(entry => string.Equals(entry.SupportTier, tier, StringComparison.Ordinal));
 
+    // tool-output-schema-infrastructure: tool factory consults ToolOutputSchemaIndex so that
+    // any [McpToolMetadata(outputSchemaTypeRef: ...)]-annotated method publishes a JSON-Schema
+    // on its catalog entry without per-row plumbing in the partial-class files. Tools without
+    // an opt-in stay schema-less (OutputSchema == null) — the existing text-only contract.
     private static SurfaceEntry Tool(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
-        new("tool", name, category, supportTier, readOnly, destructive, summary, UriTemplate: null, Parameters: null);
+        new("tool", name, category, supportTier, readOnly, destructive, summary,
+            UriTemplate: null,
+            Parameters: null,
+            OutputSchema: ToolOutputSchemaIndex.GetSchema(name));
 
     private static SurfaceEntry Resource(string name, string category, string supportTier, bool readOnly, bool destructive, string summary, string uriTemplate) =>
-        new("resource", name, category, supportTier, readOnly, destructive, summary, uriTemplate, Parameters: null);
+        new("resource", name, category, supportTier, readOnly, destructive, summary, uriTemplate,
+            Parameters: null, OutputSchema: null);
 
     // get-prompt-text-publish-parameter-schema: the prompt factory always splices the
     // PromptParameterIndex's reflected parameter list onto the entry. Reflection runs once at
@@ -145,7 +153,8 @@ public static partial class ServerSurfaceCatalog
     private static SurfaceEntry Prompt(string name, string category, string supportTier, bool readOnly, bool destructive, string summary) =>
         new("prompt", name, category, supportTier, readOnly, destructive, summary,
             UriTemplate: null,
-            Parameters: PromptParameterIndex.GetParameters(name));
+            Parameters: PromptParameterIndex.GetParameters(name),
+            OutputSchema: null);
 }
 
 /// <summary>
@@ -165,6 +174,15 @@ public static partial class ServerSurfaceCatalog
 /// Excludes DI-resolved services and <see cref="CancellationToken"/> — only the values an agent
 /// must supply via <c>parametersJson</c> on <c>get_prompt_text</c>.
 /// </param>
+/// <param name="OutputSchema">
+/// tool-output-schema-infrastructure: the JSON-Schema describing the tool's
+/// <c>structuredContent</c> channel per MCP 2025-06-18 § Tools / Structured Content.
+/// <see langword="null"/> for tools without an <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/>
+/// declaration (legacy text-only contract; structuredContent stays absent), and always
+/// <see langword="null"/> for resource and prompt entries. Generated lazily from the declared
+/// CLR type via <see cref="ToolOutputSchemaIndex"/>; the cache is shared across the catalog,
+/// the dispatch filter, and the catalog-document resource serializer.
+/// </param>
 public sealed record SurfaceEntry(
     string Kind,
     string Name,
@@ -174,7 +192,8 @@ public sealed record SurfaceEntry(
     bool Destructive,
     string Summary,
     string? UriTemplate,
-    IReadOnlyList<PromptParameterEntry>? Parameters);
+    IReadOnlyList<PromptParameterEntry>? Parameters,
+    System.Text.Json.Nodes.JsonNode? OutputSchema = null);
 
 /// <summary>
 /// get-prompt-text-publish-parameter-schema: per-parameter schema row published on each

--- a/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Catalog;
+
+/// <summary>
+/// tool-output-schema-infrastructure: cached reflection over every
+/// <see cref="McpToolMetadataAttribute"/>-attributed method that declares an
+/// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/>, projecting each tool's
+/// declared DTO type into a JSON-Schema document via
+/// <see cref="System.Text.Json.Schema.JsonSchemaExporter"/>.
+/// <para>
+/// The catalog publishes the generated schema per tool on <see cref="SurfaceEntry.OutputSchema"/>
+/// so MCP clients (and the dual-channel <c>StructuredCallToolFilter</c>) can know in advance
+/// what shape to expect on the <c>structuredContent</c> channel. Reflection runs once at first
+/// access; the dictionary is immutable thereafter — schema generation per type is deterministic
+/// so the cache is safe across the server's lifetime.
+/// </para>
+/// <para>
+/// Tools without an <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/> are absent from
+/// the dictionary and <see cref="GetSchema"/> returns <see langword="null"/>. No tools opt in
+/// during the initial infrastructure PR — per-tool batches follow.
+/// </para>
+/// </summary>
+internal static class ToolOutputSchemaIndex
+{
+    /// <summary>
+    /// Schema-export options matched to the server's runtime serializer. We do NOT include
+    /// reference handling or polymorphic discriminators because tool outputs are flat DTOs by
+    /// convention; if a tool ever needs deeper shape, the contract opt-in is to add the
+    /// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/> on a properly-shaped record.
+    /// </summary>
+    private static readonly JsonSchemaExporterOptions s_exportOptions = new()
+    {
+        TreatNullObliviousAsNonNullable = true,
+    };
+
+    private static readonly Lazy<IReadOnlyDictionary<string, JsonNode>> s_index =
+        new(BuildIndex, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Returns the cached JSON-Schema node for <paramref name="toolName"/>, or
+    /// <see langword="null"/> when the tool has no declared output schema (the legacy
+    /// text-only contract; structuredContent stays absent).
+    /// </summary>
+    public static JsonNode? GetSchema(string toolName)
+    {
+        if (string.IsNullOrEmpty(toolName)) return null;
+        return s_index.Value.TryGetValue(toolName, out var schema)
+            // Return a deep clone so callers cannot mutate the cached node.
+            ? schema.DeepClone()
+            : null;
+    }
+
+    /// <summary>
+    /// Returns the cached set of tool names that have an opted-in output schema. Used by tests
+    /// to spot the surface count without re-running the schema generation pipeline.
+    /// </summary>
+    public static IReadOnlyCollection<string> RegisteredToolNames => s_index.Value.Keys.ToArray();
+
+    /// <summary>
+    /// Generates a JSON-Schema node for the given CLR type using the runtime's default
+    /// serializer options. Exposed <see langword="internal"/> so the dual-channel filter can
+    /// also use it ad-hoc when the tool's response object is built but the cached schema is
+    /// keyed off the tool name (cache hit) — both paths produce identical output for the same
+    /// type.
+    /// </summary>
+    internal static JsonNode GenerateSchema(Type type) =>
+        JsonSchemaExporter.GetJsonSchemaAsNode(JsonSerializerOptions.Default, type, s_exportOptions);
+
+    private static IReadOnlyDictionary<string, JsonNode> BuildIndex()
+    {
+        // Anchor on a known tool-host type so we walk the same assembly that MCP discovery uses.
+        var assembly = typeof(Tools.ServerTools).Assembly;
+        var dict = new Dictionary<string, JsonNode>(StringComparer.Ordinal);
+
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var method in type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            {
+                var toolAttr = method.GetCustomAttribute<McpServerToolAttribute>();
+                if (toolAttr?.Name is null) continue;
+
+                var metadataAttr = method.GetCustomAttribute<McpToolMetadataAttribute>();
+                var schemaType = metadataAttr?.OutputSchemaTypeRef;
+                if (schemaType is null) continue;
+
+                try
+                {
+                    dict[toolAttr.Name] = GenerateSchema(schemaType);
+                }
+                catch (Exception ex)
+                {
+                    // Schema generation failure is recorded but does not crash the server.
+                    // The tool falls back to text-only output (legacy contract).
+                    System.Diagnostics.Trace.TraceWarning(
+                        "Output-schema generation failed for tool '{0}' (type {1}): {2}",
+                        toolAttr.Name, schemaType.FullName, ex.Message);
+                }
+            }
+        }
+
+        return dict;
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
@@ -411,8 +413,30 @@ internal static class StructuredCallToolFilter
     /// historical contract that e.g. <c>source_generated_documents</c>'s bare-array
     /// response shape remains stable across the filter migration. Exposed <c>internal</c>
     /// so tests can assert meta-injection behavior directly.
+    ///
+    /// <para><b>tool-output-schema-infrastructure (MCP 2025-06-18 § Tools / Structured Content):</b></para>
+    /// <para>
+    /// When the tool has a registered <c>outputSchema</c> via
+    /// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/>, this method ALSO populates
+    /// <see cref="CallToolResult.StructuredContent"/> with the same payload (sans <c>_meta</c>) so
+    /// the structured-content channel is non-empty. Per spec, when <c>structuredContent</c> is
+    /// emitted the server MUST also emit a serialized JSON copy in the <c>content[].text</c>
+    /// channel — both channels coexist; <c>_meta</c> lives only in the text channel so clients
+    /// never see two observability blobs (defense against the dedupe risk noted in the
+    /// initiative plan).
+    /// </para>
     /// </summary>
-    internal static CallToolResult InjectMetaIntoContent(CallToolResult result, string toolName)
+    internal static CallToolResult InjectMetaIntoContent(CallToolResult result, string toolName) =>
+        InjectMetaIntoContent(result, toolName, ToolOutputSchemaIndex.GetSchema);
+
+    /// <summary>
+    /// Test seam: same as <see cref="InjectMetaIntoContent(CallToolResult, string)"/> but lets
+    /// the caller supply a custom schema resolver so dual-channel behavior can be exercised
+    /// without needing a live <c>[McpToolMetadata(outputSchemaTypeRef:)]</c> opt-in. The
+    /// production path always uses the static <see cref="ToolOutputSchemaIndex"/>.
+    /// </summary>
+    internal static CallToolResult InjectMetaIntoContent(
+        CallToolResult result, string toolName, Func<string, JsonNode?> schemaResolver)
     {
         if (result.Content is null || result.Content.Count == 0)
         {
@@ -424,8 +448,36 @@ internal static class StructuredCallToolFilter
             return result;
         }
 
+        // Parse once so both the meta-injection path and the structuredContent path can share
+        // a single JsonNode tree. Non-JSON / array-rooted responses bail out early as before.
+        JsonNode? parsedRoot = null;
+        try
+        {
+            parsedRoot = JsonNode.Parse(text.Text);
+        }
+        catch (JsonException)
+        {
+            // Fall through to the original best-effort path; non-JSON responses pass through.
+        }
+
+        var schema = schemaResolver(toolName);
+        // structuredContent is only emitted when (a) the tool opted in via OutputSchemaTypeRef
+        // and (b) the response is an object-rooted JSON document we can mirror. Arrays, scalars,
+        // and non-JSON responses leave structuredContent absent — matching the spec's "MAY"
+        // semantics rather than fabricating a structured shape that doesn't match the schema.
+        // CallToolResult.StructuredContent is a JsonElement? — convert from JsonNode via the
+        // round-trip text. The body is small (already serialized once for the text channel)
+        // so the extra parse is bounded; deep-clone to detach from the parsed tree.
+        JsonElement? structuredFromBody = null;
+        if (schema is not null && parsedRoot is JsonObject bodyObj)
+        {
+            structuredFromBody = JsonDocument.Parse(bodyObj.ToJsonString()).RootElement.Clone();
+        }
+
         var injected = ToolErrorHandler.InjectMetaIfPossible(text.Text, toolName);
-        if (ReferenceEquals(injected, text.Text) || injected == text.Text)
+        var textChanged = !(ReferenceEquals(injected, text.Text) || injected == text.Text);
+
+        if (!textChanged && structuredFromBody is null)
         {
             // Nothing to change — skip the allocation so array-rooted and non-JSON
             // responses pass through byte-for-byte identical.
@@ -434,7 +486,7 @@ internal static class StructuredCallToolFilter
 
         var newContent = new List<ContentBlock>(result.Content.Count)
         {
-            new TextContentBlock { Text = injected }
+            new TextContentBlock { Text = textChanged ? injected : text.Text }
         };
         for (var i = 1; i < result.Content.Count; i++)
         {
@@ -445,7 +497,9 @@ internal static class StructuredCallToolFilter
         {
             IsError = result.IsError,
             Content = newContent,
-            StructuredContent = result.StructuredContent,
+            // Preserve any pre-existing StructuredContent (a tool may have set it directly);
+            // otherwise emit the schema-mirrored body when the tool has opted in.
+            StructuredContent = result.StructuredContent ?? structuredFromBody,
         };
     }
 

--- a/tests/RoslynMcp.Tests/StructuredContentRoundTripTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredContentRoundTripTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// tool-output-schema-infrastructure: locks in MCP 2025-06-18 § Tools / Structured Content
+/// behavior. Tools that declare an output schema via
+/// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/> emit BOTH the legacy
+/// <c>content[].text</c> channel AND the new <c>structuredContent</c> channel; tools that do
+/// not declare a schema continue to emit text-only (unchanged contract). The <c>_meta</c>
+/// observability blob lives only in the text channel — clients never see two of them.
+/// </summary>
+[TestClass]
+public sealed class StructuredContentRoundTripTests
+{
+    private sealed record SampleDto(string Name, int Count, bool Loaded);
+
+    private static JsonNode? ResolveSchemaForSample(string toolName) =>
+        toolName == "sample_tool"
+            ? ToolOutputSchemaIndex.GenerateSchema(typeof(SampleDto))
+            : null;
+
+    private static JsonNode? AlwaysNull(string _) => null;
+
+    [TestMethod]
+    public void GenerateSchema_RecordWithInitOnlyProperties_RoundTripsCleanly()
+    {
+        // Risk (2) from the plan: confirm DTO records (init-only, nested) round-trip cleanly
+        // through System.Text.Json.Schema.JsonSchemaExporter. If this assertion ever fails,
+        // the JsonSchema.Net package must be added per the Approach addendum.
+        var schema = ToolOutputSchemaIndex.GenerateSchema(typeof(SampleDto));
+
+        Assert.IsNotNull(schema);
+        var schemaObj = schema.AsObject();
+        Assert.AreEqual("object", schemaObj["type"]!.GetValue<string>(),
+            "Top-level schema for a record must be of type 'object'.");
+
+        var properties = schemaObj["properties"]!.AsObject();
+        Assert.IsTrue(properties.ContainsKey("Name"), "Record's Name property must be in schema.");
+        Assert.IsTrue(properties.ContainsKey("Count"), "Record's Count property must be in schema.");
+        Assert.IsTrue(properties.ContainsKey("Loaded"), "Record's Loaded property must be in schema.");
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ToolWithSchema_EmitsBothChannelsWithSingleMeta()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var bodyJson = JsonSerializer.Serialize(
+            new { name = "ws-1", count = 42, loaded = true },
+            JsonDefaults.Indented);
+
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+        };
+
+        var result = StructuredCallToolFilter.InjectMetaIntoContent(
+            input, "sample_tool", ResolveSchemaForSample);
+
+        // Channel 1: text content carries the JSON body PLUS _meta.
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var textPayload = JsonDocument.Parse(text).RootElement;
+        Assert.IsTrue(textPayload.TryGetProperty("name", out _),
+            "Text channel must still carry the response body for legacy clients.");
+        Assert.IsTrue(textPayload.TryGetProperty("_meta", out _),
+            "Text channel must carry _meta for observability — this is the dedupe site.");
+
+        // Channel 2: structuredContent carries the same body MINUS _meta.
+        Assert.IsNotNull(result.StructuredContent,
+            "Tools with a registered output schema MUST populate structuredContent " +
+            "per MCP 2025-06-18 § Tools / Structured Content.");
+        var structured = result.StructuredContent.Value;
+        Assert.IsTrue(structured.TryGetProperty("name", out var nameProp));
+        Assert.AreEqual("ws-1", nameProp.GetString());
+        Assert.IsFalse(structured.TryGetProperty("_meta", out _),
+            "_meta MUST live ONLY in the text channel — duplicating it into structuredContent " +
+            "would surface two observability blobs to the client (dedupe risk per plan).");
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ToolWithoutSchema_TextOnlyContractPreserved()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var bodyJson = JsonSerializer.Serialize(
+            new { name = "ws-1", count = 42 }, JsonDefaults.Indented);
+
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+        };
+
+        var result = StructuredCallToolFilter.InjectMetaIntoContent(
+            input, "no_schema_tool", AlwaysNull);
+
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var payload = JsonDocument.Parse(text).RootElement;
+        Assert.IsTrue(payload.TryGetProperty("_meta", out _),
+            "Tools without a schema still get _meta on the text channel — the legacy contract.");
+        Assert.IsNull(result.StructuredContent,
+            "Tools without a registered output schema MUST NOT populate structuredContent — " +
+            "emitting an unconstrained body there would violate the spec's schema-conformance " +
+            "expectation and break clients that rely on the absence as a signal.");
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ArrayRootedJson_StaysTextOnlyEvenWithSchema()
+    {
+        // Defensive: even if a schema is registered, an array-rooted body cannot be mirrored
+        // into structuredContent (which is object-shaped per spec). The filter must NOT
+        // fabricate a wrapper — the legacy bare-array contract wins, matching the
+        // source_generated_documents pass-through behavior.
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = "[1,2,3]" }],
+        };
+
+        var result = StructuredCallToolFilter.InjectMetaIntoContent(
+            input, "sample_tool", ResolveSchemaForSample);
+
+        Assert.AreSame(input, result,
+            "Array-rooted responses pass through unchanged regardless of schema registration.");
+        Assert.IsNull(result.StructuredContent);
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_PreExistingStructuredContent_NotOverwritten()
+    {
+        // If a tool ever sets StructuredContent itself (current production tools don't, but
+        // the SDK contract permits it), the filter must NOT clobber it. The dual-channel
+        // injection only fills in when the tool left it null.
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var bodyJson = JsonSerializer.Serialize(
+            new { name = "ws-1" }, JsonDefaults.Indented);
+        var preset = JsonDocument.Parse("""{"preset":true}""").RootElement.Clone();
+
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+            StructuredContent = preset,
+        };
+
+        var result = StructuredCallToolFilter.InjectMetaIntoContent(
+            input, "sample_tool", ResolveSchemaForSample);
+
+        Assert.IsNotNull(result.StructuredContent);
+        Assert.IsTrue(result.StructuredContent.Value.TryGetProperty("preset", out _),
+            "Pre-existing StructuredContent must be preserved verbatim.");
+        Assert.IsFalse(result.StructuredContent.Value.TryGetProperty("name", out _),
+            "Filter must NOT overwrite a tool's own StructuredContent.");
+    }
+}


### PR DESCRIPTION
## Summary

Wires MCP 2025-06-18 § Tools / Structured Content support without opting any tool in yet — per-tool batches follow.

- `[McpToolMetadata]` gains an optional `outputSchemaTypeRef: Type?` parameter (positional optional; the 53 existing usages remain unchanged).
- New `ToolOutputSchemaIndex` reflects over `[McpServerTool]`+`[McpToolMetadata]` pairs and generates schemas via `System.Text.Json.Schema.JsonSchemaExporter` (.NET 9+ built-in; no `JsonSchema.Net` package needed). Reflection runs once at first access — same `Lazy<>`-cached pattern as `PromptParameterIndex`.
- `ServerSurfaceCatalog.SurfaceEntry` exposes a new optional `OutputSchema` field (`JsonNode?`). The `Tool` factory consults the index so any opted-in tool publishes its schema with no per-row plumbing in the partial-class files.
- `StructuredCallToolFilter.InjectMetaIntoContent` emits BOTH `content[].text` and `StructuredContent` when a schema is registered. The `_meta` observability blob lives ONLY in the text channel — clients never see two of them (dedupe risk noted in the plan). Pre-existing `StructuredContent` set directly by a tool is preserved.

## Scope note

The Approach in plan.md anticipated 3 production files; I added a 4th — `src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs`. This is the reflection cache the `Tool` factory consults; it mirrors the existing `PromptParameterIndex.cs` shape. It is wiring, not per-tool entries — no tools opted in this PR. Within the Rule 3 cap.

## Validation

- New `StructuredContentRoundTripTests` (5 tests): schema generation for a record DTO, dual-channel emission with single `_meta`, no-schema text-only contract preserved, array-rooted pass-through stays text-only even with schema, pre-existing `StructuredContent` not overwritten. All passing.
- Focused regression suite (62 tests across `StructuredCallToolFilter`, `SurfaceCatalog`, `ServerSurfaceCatalogAnalyzer`, `ReadmeSurfaceCount`, `CatalogDestructive`, `ToolErrorHandler`) green.
- Full 1101-test sweep green on a clean run. Two subsequent `verify-release.ps1` invocations surfaced 1–8 transient failures in unrelated tests (`FlowAnalysisServiceTests`, `IntegrationTests.Format_Document_Apply_Normalizes_Isolated_Copy`, `Add_Package_Reference_Preview_Rejects_Package_Already_Imported_From_Directory_Build_Props`, `ColdThenWarm_WritesEntry_AndSecondLoadIsMeasurablyFaster`, `PreviewMultiFile_F17NamespaceCommentBrace_ThrowsWhenSyntaxCheckEnabled`, `Scaffold_Test_Preview_ConstantsOnlyClass_Omits_NewT_InArrange`). Different tests fail each run — confirmed flakiness in parallel temp-dir collisions (commit 294ed9d moved to class-level parallel for this reason). When run in isolation all suspect tests pass; my change does not touch any of those code paths.
- `verify-ai-docs.ps1` clean.

## Test plan

- [x] New `StructuredContentRoundTripTests` cover dual-channel emission and dedupe
- [x] Existing `StructuredCallToolFilterTests` still green (catalog wiring is additive)
- [x] `ReadmeSurfaceCountTests` unaffected (per-tool entries unchanged)
- [x] `verify-release.ps1` build + publish stages green; transient parallel-test flake unrelated to this change

Closes: tool-output-schema-infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)