### PR TITLE
release: v1.34.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.34.0",
+      "version": "1.34.1",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.34.1] - 2026-05-06
+
+### Fixed
+
+- **Fixed:** `WorkspaceLoadCacheFastPathTests.ColdThenWarm_*` no longer fails the release-publish workflow on a noise-margin stopwatch comparison. The previous timing assertion (`warmElapsedMs < coldElapsedMs`) was a flaky proxy for "warm-cache fast path engaged" against the 3-project SampleSolution fixture — wall-clock was dominated by MSBuild SDK resolution and shared-runner jitter routinely flipped the inequality (v1.34.0's publish-nuget runs failed twice for this reason). Replaced with cold-load behavioral assertion (`AmbientGateMetrics.CacheHit == false`), functional parity check, and entry-persistence check; warm-load `CacheHit == true` is intentionally not asserted yet because the probe-stage entry lookup in `WorkspaceManager.TryEnumerateNewestCacheEntryAsync` currently double-hashes its third key component (tracked as `workspace-cache-probe-double-hash-segment`). Closes `cache-fastpath-test-flakiness`.
+
+### Added
+
+- **Added:** `/roslyn-mcp:audit-deep` plugin skill — the comprehensive Roslyn MCP server audit + experimental-promotion scorecard + plugin-skill audit, now shipped with the plugin instead of relying on each consuming repo to keep `ai_docs/prompts/deep-review-and-refactor.md` current. Three modes: `full`, `promotion-only`, `read-only`. Skill requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts with a clear message when absent rather than running a non-MCP fallback. Phase 6 mutations confined to disposable worktrees the prompt creates (read-only against the audited repo's main). Closes (split A) `audit-deep-skill-migration` — paired with the archive-and-surface-audit-integration follow-on.
+- **Added:** `/roslyn-mcp:audit-deep` Phase 0 delegates drift detection to `/surface-audit` when available, and ships `skills/audit-deep/scripts/archive-old-reports.ps1` (with `-OlderThanDays`, `-DryRun`, `-ReportsRelativePath` flags) that moves audit-report markdown files older than 30 days into `archive/<YYYY>/`. `-ReportsRelativePath` keeps the shipped skill generic (consumer repos can point it anywhere). Closes the (S2) + (S5) follow-on pieces of `audit-deep-skill-migration` (paired with initiative #12).
+- **Added:** `symbol_search`, `find_references`, and `go_to_definition` invoke MCP `elicitation/create` when the resolved name is ambiguous (overloads, partial classes, inherited members) and the client declares the `elicitation` capability. The agent is asked to pick a candidate via a labeled select-from-N prompt; clients without elicitation continue to receive the existing disambiguation-list response (purely additive, no breaking change). Closes `elicit-disambiguation-on-multi-symbol-resolve`.
+- **Added:** MCP 2025-06-18 `outputSchema` + `structuredContent` infrastructure — `[McpToolMetadata]` accepts an optional `outputSchemaTypeRef`, schemas generate from existing DTO records via `System.Text.Json` `JsonSchemaExporter`, `StructuredCallToolFilter` emits both `content[].text` and `structuredContent` channels with a single `_meta` payload (no duplication). New `ToolOutputSchemaIndex` reflection cache mirrors the `PromptParameterIndex` pattern. No tools opted in this PR — per-tool batches follow. Closes `tool-output-schema-infrastructure`.
+- **Added:** `outputSchema` + `structuredContent` channel for 6 high-traffic read tools (`server_info`, `server_heartbeat`, `workspace_status`, `workspace_list`, `workspace_health`, `workspace_drift_check`). Clients with MCP 2025-06-18 support get typed structured payloads; clients without continue to receive the existing text-channel JSON unchanged. `server_info`, `server_heartbeat`, and `workspace_list` were refactored from anonymous-object response bodies to typed DTOs (new `ServerToolDtos.cs`) so `typeof(...)` is reachable in the `[McpToolMetadata]` annotation; on-the-wire JSON shape is preserved bit-for-bit. Closes `tool-output-schema-batch-1-server-info-workspace`.
+
 ## [1.34.0] - 2026-05-06
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.34.0</Version>
+    <Version>1.34.1</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/audit-deep-archive-and-surface-audit-integration.md
+++ b/changelog.d/audit-deep-archive-and-surface-audit-integration.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `/roslyn-mcp:audit-deep` Phase 0 delegates drift detection to `/surface-audit` when available, and ships `skills/audit-deep/scripts/archive-old-reports.ps1` (with `-OlderThanDays`, `-DryRun`, `-ReportsRelativePath` flags) that moves audit-report markdown files older than 30 days into `archive/<YYYY>/`. `-ReportsRelativePath` keeps the shipped skill generic (consumer repos can point it anywhere). Closes the (S2) + (S5) follow-on pieces of `audit-deep-skill-migration` (paired with initiative #12).

--- a/changelog.d/audit-deep-skill-create-and-mode-split.md
+++ b/changelog.d/audit-deep-skill-create-and-mode-split.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `/roslyn-mcp:audit-deep` plugin skill — the comprehensive Roslyn MCP server audit + experimental-promotion scorecard + plugin-skill audit, now shipped with the plugin instead of relying on each consuming repo to keep `ai_docs/prompts/deep-review-and-refactor.md` current. Three modes: `full`, `promotion-only`, `read-only`. Skill requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts with a clear message when absent rather than running a non-MCP fallback. Phase 6 mutations confined to disposable worktrees the prompt creates (read-only against the audited repo's main). Closes (split A) `audit-deep-skill-migration` — paired with the archive-and-surface-audit-integration follow-on.

--- a/changelog.d/cache-fastpath-test-flakiness.md
+++ b/changelog.d/cache-fastpath-test-flakiness.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `WorkspaceLoadCacheFastPathTests.ColdThenWarm_*` no longer fails the release-publish workflow on a noise-margin stopwatch comparison. The previous timing assertion (`warmElapsedMs < coldElapsedMs`) was a flaky proxy for "warm-cache fast path engaged" against the 3-project SampleSolution fixture — wall-clock was dominated by MSBuild SDK resolution and shared-runner jitter routinely flipped the inequality (v1.34.0's publish-nuget runs failed twice for this reason). Replaced with cold-load behavioral assertion (`AmbientGateMetrics.CacheHit == false`), functional parity check, and entry-persistence check; warm-load `CacheHit == true` is intentionally not asserted yet because the probe-stage entry lookup in `WorkspaceManager.TryEnumerateNewestCacheEntryAsync` currently double-hashes its third key component (tracked as `workspace-cache-probe-double-hash-segment`). Closes `cache-fastpath-test-flakiness`.

--- a/changelog.d/elicit-disambiguation-on-multi-symbol-resolve.md
+++ b/changelog.d/elicit-disambiguation-on-multi-symbol-resolve.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `symbol_search`, `find_references`, and `go_to_definition` invoke MCP `elicitation/create` when the resolved name is ambiguous (overloads, partial classes, inherited members) and the client declares the `elicitation` capability. The agent is asked to pick a candidate via a labeled select-from-N prompt; clients without elicitation continue to receive the existing disambiguation-list response (purely additive, no breaking change). Closes `elicit-disambiguation-on-multi-symbol-resolve`.

--- a/changelog.d/tool-output-schema-batch-1-server-info-workspace.md
+++ b/changelog.d/tool-output-schema-batch-1-server-info-workspace.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `outputSchema` + `structuredContent` channel for 6 high-traffic read tools (`server_info`, `server_heartbeat`, `workspace_status`, `workspace_list`, `workspace_health`, `workspace_drift_check`). Clients with MCP 2025-06-18 support get typed structured payloads; clients without continue to receive the existing text-channel JSON unchanged. `server_info`, `server_heartbeat`, and `workspace_list` were refactored from anonymous-object response bodies to typed DTOs (new `ServerToolDtos.cs`) so `typeof(...)` is reachable in the `[McpToolMetadata]` annotation; on-the-wire JSON shape is preserved bit-for-bit. Closes `tool-output-schema-batch-1-server-info-workspace`.

--- a/changelog.d/tool-output-schema-infrastructure.md
+++ b/changelog.d/tool-output-schema-infrastructure.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** MCP 2025-06-18 `outputSchema` + `structuredContent` infrastructure — `[McpToolMetadata]` accepts an optional `outputSchemaTypeRef`, schemas generate from existing DTO records via `System.Text.Json` `JsonSchemaExporter`, `StructuredCallToolFilter` emits both `content[].text` and `structuredContent` channels with a single `_meta` payload (no duplication). New `ToolOutputSchemaIndex` reflection cache mirrors the `PromptParameterIndex` pattern. No tools opted in this PR — per-tool batches follow. Closes `tool-output-schema-infrastructure`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Patch release v1.34.1. Carries the test-flakiness fix from PR #522 plus the 5 features merged after the v1.34.0 tag (cache-fastpath test de-flake, audit-deep plugin skill + Phase 0 archive integration, elicit disambiguation on multi-symbol resolves, MCP `outputSchema`/`structuredContent` infrastructure + batch 1).

Replaces v1.34.0 on NuGet — that version's publish-nuget workflow failed twice on the now-fixed flaky timing test (runs [25415271368](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/runs/25415271368), [25447475476](https://github.com/darylmcd/Roslyn-Backed-MCP/actions/runs/25447475476)).

## What changed

- 4 version files bumped 1.34.0 → 1.34.1 (`Directory.Build.props`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `manifest.json`).
- `CHANGELOG.md`: new `## [1.34.1] - 2026-05-06` section consuming 6 fragments (1 Fixed, 5 Added).
- `changelog.d/`: 6 fragments removed (consumed).

## Test plan

- [x] `eng/verify-release.ps1 -Configuration Release` — 1115/1115 tests pass locally
- [x] `eng/verify-ai-docs.ps1` — passed (32 skills generic)
- [x] `eng/verify-version-drift.ps1` — all 5 files agree on 1.34.1
- [ ] CI green
- [ ] post-merge: tag v1.34.1 + publish-nuget workflow ships package

🤖 Generated with [Claude Code](https://claude.com/claude-code)