### PR TITLE
docs: refresh doc-audit context

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -9,9 +9,9 @@
 - **Name:** Roslyn-Backed MCP Server
 - **Path:** Roslyn-Backed-MCP
 - **Repo class:** public
-- **Repo class signals:** GitHub origin under the project owner, live public CI badge in `README.md`, published .NET global tool (`PackAsTool` in `src/RoslynMcp.Host.Stdio.csproj`), and public Docker/plugin installation docs.
+- **Repo class signals:** GitHub origin under the project owner, live public CI badge in `README.md`, published .NET global tool (`PackAsTool` in `src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj`), and public Docker/plugin installation docs.
 - **Tech stack:** C# / .NET 10 SDK / Roslyn 5.x / Microsoft.CodeAnalysis / stdio MCP host
-- **Ecosystem role:** Local stdio MCP server for semantic C# analysis, navigation, and refactoring used by AI coding clients.
+- **Ecosystem role:** Local stdio MCP server for semantic C# analysis, navigation, validation, refactoring, and bundled Claude Code skills used by AI coding clients.
 - **Integration brief:** none
 - **Session-start overrides:** `AGENTS.md` uses a repo-specific ordered bootstrap: `CI_POLICY.md` -> `ai_docs/README.md` -> `ai_docs/workflow.md` -> `ai_docs/runtime.md` -> `ai_docs/bootstrap-read-tool-primer.md` -> `ai_docs/backlog.md` -> `.github/copilot-instructions.md` -> `.cursor/rules/operational-essentials.md`; after that, agents use `ai_docs/planning_index.md` for next-step routing.
 - **MCP servers declared:** `roslyn` in `.mcp.json`
@@ -19,10 +19,10 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-04-26 (targeted plan cleanup refresh)
-- **Last audit mode:** refresh
-- **Next recommended mode:** refresh
-- **ai_docs/ file count:** 38
+- **Last audit:** 2026-05-06
+- **Last audit mode:** initial
+- **Next recommended mode:** initial
+- **ai_docs/ file count:** 55
 - **docs/ file count:** 16
 - **Agent instruction files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/operational-essentials.md`, `CI_POLICY.md`
 
@@ -32,15 +32,15 @@
 |-----------|--------|-------|
 | AGENTS.md | present | Canonical bootstrap with repo-local MCP bootstrap and in-repo planning-scope routing; Next-step protocol matches `planning_index.md` verbatim. |
 | CLAUDE.md | present-pointer | Collapsed pointer to `AGENTS.md`. |
-| .github/copilot-instructions.md | present | Canonical implementation-quality and safety rules. |
-| .cursor/rules/operational-essentials.md | present | Cursor-specific operational overlay still aligned with repo runner/docs flow. |
-| CI_POLICY.md | present | Validation and merge-gating policy. |
+| .github/copilot-instructions.md | present | Implementation-quality and safety rules; plugin skill count refreshed to 32. |
+| .cursor/rules/operational-essentials.md | present | Cursor-specific operational overlay aligned with repo runner/docs flow. |
+| CI_POLICY.md | present | Validation and merge-gating policy; documents docs-only PR gate and CodeQL default setup. |
 | .mcp.json | present | Declares `roslyn`; AGENTS bootstrap distinguishes declared config from live availability. |
-| ai_docs/README.md | present | Index covers planning, reports, rollups, prompts, and audit-support files. |
-| ai_docs/architecture.md | present | Current-state architecture; skill count (31) matches `skills/`. |
-| ai_docs/backlog.md | present | v5 single-table format with `Critical|High|Medium|Low|Defer` sections, `pri` column, anchors + evidence on every row. |
+| ai_docs/README.md | present | Core index is current, but active `ai_docs/plans/` artifacts are discoverable mainly through backlog refs rather than a plan sub-index. |
+| ai_docs/architecture.md | present | Current-state architecture. |
+| ai_docs/backlog.md | present | v5 single-table format with `Critical|High|Medium|Low|Defer` sections, `pri` column, anchors + evidence on every row; near hard size cap. |
 | ai_docs/workflow.md | present | Workflow and backlog-closure contract current. |
-| ai_docs/runtime.md | present | Runner-first runtime reference; env-var table accurate against `Program.cs`. |
+| ai_docs/runtime.md | present | Runner-first runtime reference; env-var table accurate against `Program.cs`; above warn size threshold. |
 | ai_docs/planning_index.md | present | In-repo planning router with Agent contract, Next-step protocol, and scope routing table. |
 | ai_docs/domains/ | present | Domain references match the source layout. |
 | ai_docs/references/ | present | Cross-cutting references indexed and current. |
@@ -52,17 +52,22 @@
 
 | File | Approx tokens | Warn/Cap | Status |
 |------|---------------|----------|--------|
-| README.md | 1260 | 2500/5000 | ok |
-| ai_docs/README.md | 1281 | 2500/4000 | ok |
-| ai_docs/architecture.md | 867 | 2500/6000 | ok |
-| ai_docs/backlog.md | 1523 | 1500/4000 | warn |
-| ai_docs/workflow.md | 1171 | 1500/4000 | ok |
-| ai_docs/runtime.md | 2099 | 1500/4000 | warn |
-| ai_docs/planning_index.md | 613 | 2500/5000 | ok |
+| README.md | 1472 | 2500/5000 | ok |
+| ai_docs/README.md | 1307 | 2500/4000 | ok |
+| ai_docs/architecture.md | 866 | 2500/6000 | ok |
+| ai_docs/backlog.md | 3978 | 1500/4000 | warn-near-cap |
+| ai_docs/workflow.md | 1373 | 1500/4000 | ok |
+| ai_docs/runtime.md | 2098 | 1500/4000 | warn |
+| ai_docs/planning_index.md | 612 | 2500/5000 | ok |
 | ai_docs/bootstrap-read-tool-primer.md | 2298 | 2500/5000 | ok |
-| docs/README.md | 563 | 800/1600 | ok |
+| docs/README.md | 562 | 800/1600 | ok |
+| ai_docs/plans/20260428T124405Z_backlog-sweep/plan.md | 6761 | 2500/5000 | over |
+| ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md | 6329 | 2500/5000 | over |
+| ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md | 14797 | 2500/5000 | over |
+| ai_docs/procedures/audit-21-implementation-plan.md | 12161 | 2500/5000 | over |
+| ai_docs/prompts/backlog-sweep-execute.md | 10261 | 5000/10000 | over |
 
-Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback.
+Tokens estimated via `char_count / 4` per STANDARD size-matrix fallback.
 
 ## Runner
 
@@ -75,59 +80,63 @@ Tokens estimated via `char_count / 4` per STANDARD §Size-Matrix fallback.
 - **Legacy runners coexisting:** none
 - **runtime.md references runner:** yes
 
-## Live Surface (verified 2026-04-26)
+## Live Surface (verified 2026-05-06)
 
 | Component | Stable | Experimental | Total |
 |-----------|--------|--------------|-------|
-| Tools | 111 | 56 | 167 |
+| Tools | 111 | 57 | 168 |
 | Resources | 9 | 4 | 13 |
 | Prompts | 0 | 20 | 20 |
-| Bundled skills | — | — | 31 |
+| Bundled skills | - | - | 32 |
 
-Source: `README.md` live-surface line guarded by `ReadmeSurfaceCountTests`; `skills/` directory listing.
+Source: `README.md` live-surface line guarded by `ReadmeSurfaceCountTests`; `skills/**/SKILL.md` directory listing.
 
 ## Known Gaps
 
-- `ai_docs/backlog.md` (~1523 tokens) is slightly over the 1500-token warn threshold but well under the 4000-token hard cap. Each row carries planner-ready anchors + evidence; further compression risks losing the signal that keeps rows planner-ready.
-- `ai_docs/runtime.md` (~2101 tokens) is stable above the 1500-token warn threshold. Future additions should land in `ai_docs/references/` rather than the runtime page.
-- This repo has no local `ai_docs/ecosystem/` planning router. Cross-project planning requests must rely on explicit external context named by the user (planning_index.md and AGENTS.md already say so verbatim).
+- `ai_docs/backlog.md` is 3978 tokens against a 4000-token hard cap. Do not add rows without trimming shipped/deferred detail into reports or moving long evidence out of the table.
+- Active and retained plan artifacts exceed the AI-doc hard cap, especially `ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md` (~14797 tokens). Prune completed initiative bodies or move stable history out of active routing with user approval.
+- `ai_docs/plans/20260504T191653Z_backlog-sweep/` is superseded by `20260504T203132Z_backlog-sweep/` but still present. It is not yet 30 days old; decide whether to prune early or retain until the standard retention window expires.
+- `ai_docs/prompts/backlog-sweep-execute.md` is slightly over the prompt hard cap (~10261 / 10000). Trim duplicated execution guidance before adding more prompt content.
+- `ai_docs/procedures/audit-21-implementation-plan.md` is far over the generic AI-doc hard cap (~12161 / 5000). Confirm whether it is still active reference material; otherwise archive or compress.
+- `ai_docs/runtime.md` remains above warn threshold (~2098 / 1500). Future additions should land in focused `ai_docs/references/` pages.
+- There is no `ai_docs/plans/README.md` or equivalent plan sub-index. Current plan discovery relies on `ai_docs/backlog.md` refs and `state.json` files.
+- The bundled `doc-audit` skill standard still declares schema 4 while this repo's audit context is schema 5 from the 2026-04-26 migration. Preserve schema 5 unless the standard is explicitly upgraded or reconciled.
 
 ## Findings from Last Audit
 
-- **2026-04-26 (targeted plan cleanup refresh):** Deleted all remaining `ai_docs/plans/` plan directories after auditing their state files. Valid deferred work was reconciled back to `ai_docs/backlog.md`: kept `pretooluse-apply-preview-token-invariant` as a Medium re-review/design row and kept `workspace-process-pool-or-daemon` as Defer pending 50+ project profiling evidence. Closed stale or already-satisfied rows instead of preserving plan mirrors: removed `ci-test-parallelization-audit` after the 25-run no-repro triage, and removed `tool-annotation-population-audit` after confirming all 167 current `[McpServerTool]` attributes carry `ReadOnly`, `Destructive`, `Idempotent`, and `OpenWorld`. Removed deleted-plan references from `ai_docs/README.md` and `ai_docs/backlog.md`; bumped backlog `updated_at` to `2026-04-26T20:38:05Z`.
-- **2026-04-26 (initial, schema 4 → 5 migration):** 32 commits since the 2026-04-25 second pass, including release v1.32.0, finalization of the 20260424T041204Z sweep (batches 8–13 + final reconcile), and the new active sweep plan `20260426T025255Z_backlog-sweep`. Migration actions: (1) bumped `.ai-doc-audit.md` schema 4 → 5; (2) rewrote `ai_docs/backlog.md` from legacy P2/P3/P4 section/pri labels to the v5 canonical `Critical | High | Medium | Low | Defer` taxonomy — corrected 4 rows that were sectioned under `P3` while tagged `pri = P4` (skills-remove-server-heartbeat-polling, tool-annotation-population-audit, response-format-json-markdown-parameter, posttool-verify-skills-on-shipped-skill-edits → all moved to `Low`); promoted the 3 prior P3 rows to `Medium`; demoted `workspace-process-pool-or-daemon` to `Defer` (it has an explicit evidence-gated dependency); (3) added the missing v5 standing-rules lines (`Weak-evidence flag`, `Priority tiers: Critical > High > Medium > Low > Defer`); (4) added the active sweep plan to `## Refs`; (5) bumped backlog `updated_at` to `2026-04-26T16:00:00Z`. Backlog format contract checks (purpose + scope tags, ISO datetime, Agent contract MUST/MUST NOT, no body sections, kebab-case ids, anchors + evidence per code-touching row, ≤4 prod / ≤3 test sizing) all pass post-rewrite. AGENTS.md `## Planning Scope` still matches `planning_index.md` Next-step protocol verbatim; MCP Bootstrap intact; runner smoke (`just --list`) passed.
-- **2026-04-25 (initial, second pass):** 0 commits since the earlier 2026-04-25 initial pass. Caught two contamination findings: missing scope tag on `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` and orphaned `ai_docs/prompts/roslyn-mcp-multisession-retro.md` — both auto-fixed.
-- **2026-04-25 (initial):** 31 commits since the 2026-04-24 refresh, including release v1.31.0 and 12 backlog-sweep reconcile batches. Surface counts re-verified against `ServerSurfaceCatalog*.cs`. Restored `ai_docs/plans/20260424T041204Z_backlog-sweep/plan.md` to backlog.md Refs.
-- **2026-04-24 (refresh):** Detected 57 new commits and a 6972-token backlog after the audit-intake batch, escalated next-mode to `initial`.
-- **2026-04-22 (initial):** Migrated `.ai-doc-audit.md` to schema 4; rewrote AGENTS.md to canonical shape with MCP Bootstrap; replaced CLAUDE.md with collapsed-pointer; added `ai_docs/planning_index.md`; tagged plan/backlog/reference files with scope metadata.
+- **2026-05-06 (initial):** Auto-detected initial mode because 65 commits landed since the last recorded audit and `ai_docs/` grew from 38 to 55 files. Shipped PR #524 first, then refreshed documentation state. Updated stale shipped-skill counts from 31/11 to 32 in root and human docs, added missing `purpose` comments and in-repo `scope` tags to current plan/review/report artifacts, refreshed live surface counts to 168 tools (111 stable / 57 experimental), and preserved repo-local schema 5 despite the bundled skill standard still documenting schema 4. `just verify-docs` passed after edits.
+- **2026-04-26 (targeted plan cleanup refresh):** Deleted stale plan directories after reconciling valid deferred work back to `ai_docs/backlog.md`; removed stale plan refs; kept evidence-gated rows in backlog.
+- **2026-04-26 (initial, schema 4 -> 5 migration):** Rewrote backlog to v5 priority taxonomy (`Critical | High | Medium | Low | Defer`), added standing-rule lines, and refreshed audit context.
+- **2026-04-25 to 2026-04-24:** Prior doc-audit passes added planning-scope tags, restored active sweep refs, and escalated to initial when backlog size and commit drift exceeded refresh limits.
 
 ## Pruning Summary
 
 | Action | Files affected | Approval |
 |--------|----------------|----------|
-| Deleted completed/stale plan directories after valid deferred work was reconciled to `ai_docs/backlog.md` | `ai_docs/plans/20260422T170500Z_test-parallelization-audit/`, `ai_docs/plans/20260422T223000Z_backlog-sweep/`, `ai_docs/plans/20260424T041204Z_backlog-sweep/`, `ai_docs/plans/20260426T025255Z_backlog-sweep/` | user-approved |
-| Removed stale plan refs and closed invalid/satisfied backlog rows | `ai_docs/backlog.md`, `ai_docs/README.md` | user-approved |
-| Migrated `.ai-doc-audit.md` schema 4 → 5 | `.ai-doc-audit.md` | auto (schema migration) |
-| Rewrote `ai_docs/backlog.md` to v5 canonical priority sections (`Critical | High | Medium | Low | Defer`); fixed 4 section/pri mismatches; added v5 standing-rules lines; added active sweep plan to Refs; bumped `updated_at` | `ai_docs/backlog.md` | auto (mechanical v5 conformance — no semantic content lost; row text preserved verbatim; pri-column relabel only) |
-| Refreshed audit context with current state, sizes, surface | `.ai-doc-audit.md` | auto (skill maintenance) |
+| Added missing purpose comments and in-repo scope tags to plan/review/report artifacts | `ai_docs/items/sampling-spike.md`, `ai_docs/plans/**/{plan,review}.md`, selected `ai_docs/prompts/` and `ai_docs/reports/` files | auto (mechanical standard conformance) |
+| Refreshed stale shipped-skill counts from 31/11 to 32 | `README.md`, `.github/copilot-instructions.md`, `docs/product-contract.md`, `docs/roadmap.md` | auto (stale fact correction) |
+| Refreshed audit context with current counts, sizes, live surface, and known gaps | `.ai-doc-audit.md` | auto (skill maintenance) |
 
 ## Retention State
 
-- **Audit reports:** 0 audit-report files (limit: 3) — `ai_docs/audit-reports/` contains only persistent reference docs.
-- **Reports rollups:** 8 report files under `ai_docs/reports/`, including deep-review rollups, the 2026-04-26 multi-session retro, and the retained test-parallelization no-repro triage. No retention rule defined for `reports/` in STANDARD.md; oldest is the 2026-04-06 example file kept intentionally.
-- **Shipped plans pending archival:** none — `ai_docs/plans/` has no tracked plan files after the user-approved 2026-04-26 cleanup.
-- **Shipped reviews pending archival:** none.
-- **README.md token budget:** 1260 / 2500 warn / 5000 hard.
-- **review-inbox/:** empty (only `archive/` subfolder for processed batches).
+- **Audit reports:** 0 raw audit-report files beyond persistent reference docs (limit: latest 3).
+- **Reports rollups:** 10 report files under `ai_docs/reports/`; no retention rule defined for synthesized reports.
+- **Shipped plans pending archival:** `ai_docs/plans/20260428T124405Z_backlog-sweep/` and `ai_docs/plans/20260504T203132Z_backlog-sweep/` are completed but less than 30 days old.
+- **Superseded plans pending decision:** `ai_docs/plans/20260504T191653Z_backlog-sweep/`.
+- **Active plans:** `ai_docs/plans/20260505T191730Z_backlog-sweep/` has pending initiatives in `state.json`.
+- **Shipped reviews pending archival:** matching reviews for completed plans are retained with their plan directories.
+- **README.md token budget:** 1472 / 2500 warn / 5000 hard.
+- **review-inbox/:** empty except processed archive subdirectories.
 
 ## Codebase Domains
 
 | Domain | Source path | ai_docs/ coverage | Notes |
 |--------|-------------|-------------------|-------|
-| Host / Transport | `src/RoslynMcp.Host.Stdio/` | `domains/host-stdio/reference.md` | MCP transport, startup, and DI wiring. |
-| Core Contracts | `src/RoslynMcp.Core/` | `domains/core-contracts/reference.md` | Shared DTOs and abstractions. |
-| Roslyn Services | `src/RoslynMcp.Roslyn/` | `domains/roslyn-services/reference.md` | Workspace, analysis, navigation, and refactoring services. |
+| Host / Transport | `src/RoslynMcp.Host.Stdio/` | `domains/host-stdio/reference.md` | MCP transport, tool/resource/prompt wiring, logging, filters, and DI. |
+| Core Contracts | `src/RoslynMcp.Core/` | `domains/core-contracts/reference.md` | DTOs and abstractions. |
+| Roslyn Services | `src/RoslynMcp.Roslyn/` | `domains/roslyn-services/reference.md` | Workspace, analysis, navigation, validation, and refactoring services. |
 | Tests | `tests/RoslynMcp.Tests/` | `references/testing.md` | Integration-heavy validation surface. |
+| Plugin Skills | `skills/` | `docs/product-contract.md`, `docs/setup.md`, `ai_docs/runtime.md` | 32 shipped skill definitions plus hooks and plugin manifests. |
 
 ## Build/Test/Run Commands
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ For session bootstrap and workflow, follow `AGENTS.md` first.
 
 ## Claude Code Plugin
 
-The server ships as a Claude Code plugin with 11 skills and safety hooks. When modifying plugin artifacts:
+The server ships as a Claude Code plugin with 32 skills and safety hooks. When modifying plugin artifacts:
 
 - **Skills** (`skills/*/SKILL.md`): Reference MCP tools by their tool names. Skills are orchestration prompts, not code — they compose existing tools into workflows.
 - **Hooks** (`hooks/hooks.json`): Matchers use regex against tool names prefixed with `mcp__roslyn__`. Keep matchers in sync when tools are renamed or added.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dotnet run --project src/RoslynMcp.Host.Stdio
 /plugin install roslyn-mcp@roslyn-mcp-marketplace
 ```
 
-The plugin bundles the MCP server, 31 skills, and safety hooks. For packaging, reinstall, and local plugin-dev details, see [docs/setup.md](docs/setup.md) and [docs/reinstall.md](docs/reinstall.md).
+The plugin bundles the MCP server, 32 skills, and safety hooks. For packaging, reinstall, and local plugin-dev details, see [docs/setup.md](docs/setup.md) and [docs/reinstall.md](docs/reinstall.md).
 
 ### Any Stdio MCP Client
 

--- a/ai_docs/items/sampling-spike.md
+++ b/ai_docs/items/sampling-spike.md
@@ -1,4 +1,5 @@
 # Sampling-driven tool flows — spike note
+<!-- purpose: Spike results for sampling-driven MCP tool flows. -->
 
 **Initiative:** `sampling-driven-tool-flows-spike`
 **Date:** 2026-05-05

--- a/ai_docs/plans/20260428T124405Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260428T124405Z_backlog-sweep/plan.md
@@ -1,4 +1,6 @@
 # Backlog sweep plan — 20260428T124405Z
+<!-- purpose: Backlog sweep plan for the 20260428T124405Z initiative batch. -->
+<!-- scope: in-repo -->
 
 **Generated:** 2026-04-28T12:44:05Z
 **Backlog snapshot:** 2026-04-27T21:03:46Z

--- a/ai_docs/plans/20260428T124405Z_backlog-sweep/review.md
+++ b/ai_docs/plans/20260428T124405Z_backlog-sweep/review.md
@@ -1,4 +1,6 @@
 # Plan review — 2026-04-28T12:50:00Z
+<!-- purpose: Review findings for the 20260428T124405Z backlog sweep plan. -->
+<!-- scope: in-repo -->
 
 **Plan reviewed:** `ai_docs/plans/20260428T124405Z_backlog-sweep/`
 **Reviewer mode:** /backlog-sweep:review

--- a/ai_docs/plans/20260504T191653Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T191653Z_backlog-sweep/plan.md
@@ -1,4 +1,6 @@
 # Backlog sweep plan — 20260504T191653Z
+<!-- purpose: Backlog sweep plan for the 20260504T191653Z initiative batch. -->
+<!-- scope: in-repo -->
 
 **Generated:** 2026-05-04T19:16:53Z
 **Backlog snapshot:** 2026-05-03T14:20:21Z

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/plan.md
@@ -1,4 +1,6 @@
 # Backlog sweep plan — 20260504T203132Z
+<!-- purpose: Backlog sweep plan for the 20260504T203132Z initiative batch. -->
+<!-- scope: in-repo -->
 
 **Generated:** 2026-05-04T20:31:32Z
 **Backlog snapshot:** 2026-05-04T20:01:53Z

--- a/ai_docs/plans/20260504T203132Z_backlog-sweep/review.md
+++ b/ai_docs/plans/20260504T203132Z_backlog-sweep/review.md
@@ -1,4 +1,6 @@
 # Plan review — 2026-05-04T20:42:00Z
+<!-- purpose: Review findings for the 20260504T203132Z backlog sweep plan. -->
+<!-- scope: in-repo -->
 
 **Plan reviewed:** `ai_docs/plans/20260504T203132Z_backlog-sweep/`
 **Reviewer mode:** /backlog-sweep:review

--- a/ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md
@@ -1,4 +1,6 @@
 # Backlog sweep plan — 20260505T191730Z
+<!-- purpose: Backlog sweep plan for the 20260505T191730Z initiative batch. -->
+<!-- scope: in-repo -->
 
 **Generated:** 2026-05-05T19:17:30Z
 **Backlog snapshot:** 2026-05-05T19:30:00Z

--- a/ai_docs/plans/20260505T191730Z_backlog-sweep/review.md
+++ b/ai_docs/plans/20260505T191730Z_backlog-sweep/review.md
@@ -1,4 +1,6 @@
 # Plan review — 2026-05-05T19:50:00Z
+<!-- purpose: Review findings for the 20260505T191730Z backlog sweep plan. -->
+<!-- scope: in-repo -->
 
 **Plan reviewed:** `ai_docs/plans/20260505T191730Z_backlog-sweep/`
 **Reviewer mode:** /backlog-sweep:review

--- a/ai_docs/prompts/roslyn-mcp-multisession-retro.md
+++ b/ai_docs/prompts/roslyn-mcp-multisession-retro.md
@@ -1,4 +1,5 @@
 # Multi-session retrospective — Roslyn MCP issues, gaps, and recommendations (cross-repo, last N days)
+<!-- purpose: Prompt for producing a multi-session Roslyn MCP retrospective report. -->
 
 Review **recent Claude Code sessions across all repos** and produce a structured retrospective **report file** that captures Roslyn MCP server issues, missing-tool gaps, and recommendations worth fixing. The report is saved **locally** in the Roslyn MCP repo as a self-contained artifact — it is not pushed, appended, or synced to any external backlog. The maintainer can read the file directly when they want to triage findings.
 

--- a/ai_docs/reports/20260426T162740Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md
+++ b/ai_docs/reports/20260426T162740Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md
@@ -26,6 +26,7 @@ truncated: false
 ---
 
 # Roslyn MCP multi-session retrospective - 2026-04-26 - 14-day window
+<!-- purpose: Multi-session Roslyn MCP retrospective report generated on 2026-04-26. -->
 
 ## 1. Session classification
 
@@ -353,4 +354,3 @@ JSON-aware scan found 1,294 actual mcp__roslyn__* calls. The raw extractor marke
 The window is mixed-heavy: 42 refactoring / 21 release-operational / 37 planning-docs / 98 mixed across 198 included sessions. Friction concentrates in reliability and ergonomics: preview/apply gating, workspace lifecycle, catalog/schema drift, and low-friction verification, rather than pure absence of semantic read tools. Repo skew is significant: 94 of 198 included sessions came from roslyn-backed-mcp, and many findings are self-edit or audit-prompt shaped, so future retros should compare a consumer-heavy window before promoting every item. Next time I would default to workspace_load + read-only Roslyn verification earlier in self-edit sessions and reserve shell dotnet build/test for CI parity. The 14-day window was long enough for recurring patterns, but several proposed gaps still lean on 1-2 high-signal sessions; widening to 30 days would improve priority confidence.
 
 MCP availability note for this run: .mcp.json declares a roslyn stdio server via roslynmcp, ai_docs/runtime.md documents Roslyn MCP as the default C# tool surface, and the live current session verified server_info for roslyn-mcp 1.33.0 with zero loaded workspaces.
-

--- a/ai_docs/reports/20260504T200153Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md
+++ b/ai_docs/reports/20260504T200153Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md
@@ -26,6 +26,7 @@ truncated_reason: "Capped at 40 largest-by-Roslyn-MCP-mention out of 209 relevan
 ---
 
 # Roslyn MCP multi-session retrospective — 2026-05-04 — 14-day window
+<!-- purpose: Multi-session Roslyn MCP retrospective report generated on 2026-05-04. -->
 
 ## 1. Session classification
 

--- a/ai_docs/reports/20260505T131500Z_apply-verify-rollback-audit.md
+++ b/ai_docs/reports/20260505T131500Z_apply-verify-rollback-audit.md
@@ -11,6 +11,7 @@ recommendation: close-obsolete (with optional spin-off for line-shift fingerprin
 ---
 
 # `apply_with_verify` rollback false-positive audit
+<!-- purpose: Audit report for the apply_with_verify rollback false-positive backlog row. -->
 
 ## Trigger
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -82,7 +82,7 @@ Current experimental families:
 The server is also distributed as a Claude Code plugin (`roslyn-mcp`) providing:
 
 - **MCP server**: `roslynmcp` via stdio with user-configurable env vars
-- **31 bundled skills** across analysis, refactoring, search, testing, workspace/session, documentation, and release workflows
+- **32 bundled skills** across analysis, refactoring, search, testing, workspace/session, documentation, and release workflows
 - **Safety hooks**: PreToolUse guard (blocks apply without prior preview) and PostToolUse reminder (compile-check after structural refactoring)
 
 Skills compose multiple Roslyn MCP tools into guided workflows. They are not part of the MCP protocol surface — they are Claude Code-specific orchestration on top of the stable and experimental tool tiers documented above.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ Reason:
 Delivered:
 
 - `.claude-plugin/plugin.json` and `marketplace.json` for distribution via GitHub
-- 31 bundled skills spanning analysis, refactoring, search, testing, workspace/session, documentation, and release workflows
+- 32 bundled skills spanning analysis, refactoring, search, testing, workspace/session, documentation, and release workflows
 - Safety hooks: PreToolUse apply guard, PostToolUse compile-check reminder
 
 Future direction:


### PR DESCRIPTION
## Summary
- refresh `.ai-doc-audit.md` after the 65-commit doc-audit drift gate forced initial mode
- update stale bundled-skill counts from 31/11 to 32 across README, docs, and Copilot guidance
- add missing purpose/scope metadata to current AI-doc plan, review, prompt, and report artifacts
- record remaining doc-audit gaps around backlog size, oversized plan/prompt files, and schema-version drift

## Test plan
- [x] `just verify-docs`
- [x] `git diff --check`

Generated with [Codex](https://Codex.com/Codex)