### PR TITLE
chore(plan): reconcile workspace warm default

### DIFF
--- a/ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260505T191730Z_backlog-sweep/plan.md
@@ -199,7 +199,7 @@ Sort: priority band (High → Medium → Low), cost ASC within band, deps respec
 
 | Field | Content |
 |---|---|
-| Status | in-review (PR #528, branch: `remediation/workspace-warm-default-above-50-projects`) |
+| Status | merged (PR #528, 2026-05-06) |
 | Backlog rows closed | `workspace-warm-default-above-50-projects` |
 | Diagnosis | Verified live. The row's own `do` text says "may be obsoleted by `workspace-cache-prewarm-on-load`". After initiative #10 ships, this row collapses to a one-line default flip: `prewarm: true` becomes the default when the loaded solution exceeds a project-count threshold. **Pre-flight at execute time:** if the default flip is genuinely 1 line, ship as a small initiative; if `prewarm`'s implementation makes the default-flip risky (cache-write contention on first load, cold-start regression on small solutions), mark `obsolete (subsumed by initiative #10)` and skip. |
 | Approach | (a) After initiative #10 lands, set `prewarm: true` as the default in `workspace_load` when `LoadedSolution.ProjectCount > 50` and the caller did not pass `prewarm` explicitly. (b) Add `warm: false` opt-out semantics if not already provided by initiative #10 (single-flag opt-out is required by the row). |

--- a/ai_docs/plans/20260505T191730Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260505T191730Z_backlog-sweep/state.json
@@ -234,7 +234,7 @@
     {
       "id": "workspace-warm-default-above-50-projects",
       "order": 11,
-      "status": "in-review",
+      "status": "merged",
       "priority": "Medium",
       "backlogRowsClosed": ["workspace-warm-default-above-50-projects"],
       "rowsClosedCount": 1,
@@ -248,7 +248,7 @@
       "branch": "remediation/workspace-warm-default-above-50-projects",
       "worktreePath": null,
       "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/528",
-      "mergedAt": null,
+      "mergedAt": "2026-05-06T20:40:44Z",
       "notes": "PR #528 opened. The implementation resolves omitted prewarm after load because project count is only known from WorkspaceStatusDto; explicit prewarm=false remains the opt-out."
     },
     {


### PR DESCRIPTION
## Summary
- Step 1b reconciliation for `ai_docs/plans/20260505T191730Z_backlog-sweep/`.
- Transitions `workspace-warm-default-above-50-projects` from `in-review` to `merged` based on PR #528.

## Transitions
- `workspace-warm-default-above-50-projects`: `in-review` -> `merged` (PR #528, merged 2026-05-06T20:40:44Z)

## Test plan
- [x] `./eng/verify-ai-docs.ps1`
- [x] `state.json` `schemaVersion` remains 2
- [x] `plan.md` status row mirrors `state.json`