### PR TITLE
chore(plan): add 20260506 backlog sweep plan

### DIFF
--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
@@ -1,0 +1,79 @@
+# Backlog sweep plan — 20260506T211152Z
+<!-- purpose: Backlog sweep plan for the remaining 2026-05-06 Medium initiative batch. -->
+<!-- generated_at: 2026-05-06T21:11:52Z -->
+<!-- backlog_snapshot: 2026-05-06T21:07:03Z -->
+
+## Summary
+
+This follow-on plan consumes the three remaining actionable Medium backlog rows after the 20260505T191730Z sweep completed. Deferred / Low rows remain parked because their row text explicitly requires external evidence or future trigger conditions.
+
+## Guardrails
+
+- Each initiative is one coherent backlog row.
+- Rule 3 sizing target: ≤4 production files per initiative.
+- Rule 4 sizing target: ≤3 test files per initiative.
+- Tool policy: edit-only from the main checkout; no Roslyn apply tools.
+- Backlog sync: remove rows only in the PR that ships the corresponding implementation.
+
+## Initiatives
+
+### 1. validate-workspace-markdown-formatter-decomposition
+
+| Field | Content |
+|---|---|
+| Status | pending |
+| Backlog rows closed | `validate-workspace-markdown-formatter-decomposition` |
+| Diagnosis | `ValidateWorkspaceMarkdownFormatter.Format` owns the verdict line plus metrics, diagnostics, discovered tests, failures, rerun-filter, and warning table branches in one method. The current design is defensible because the formatter is a small pure function with all output logic in one place; extraction still wins because the method is already a complexity hotspot and response-format changes now require reviewing unrelated table branches. |
+| Approach | Extract private section writers and small table helpers while preserving byte-stable markdown output. |
+| Scope | Production files: 1 — `src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs`. Test files: 1 existing — `tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs` as byte-stability guard. |
+| Tool policy | edit-only |
+| Estimated context cost | 25000 |
+| Risks | A helper could change whitespace, truncation wording, or escaped table-cell output. Keep tests focused on exact output snippets. |
+| Validation | `mcp__roslyn__compile_check`; focused `ValidateWorkspaceMarkdownFormatterTests`; `./eng/verify-release.ps1 -Configuration Release -NoCoverage`; vulnerability check. |
+| CHANGELOG category | Changed |
+| Backlog sync | Close rows: [`validate-workspace-markdown-formatter-decomposition`]. Mark obsolete: []. Update related: []. |
+
+### 2. test-discovery-service-complexity-refactor
+
+| Field | Content |
+|---|---|
+| Status | pending |
+| Backlog rows closed | `test-discovery-service-complexity-refactor` |
+| Diagnosis | `FindRelatedTestsForFilesAsync` and `CollectFallbackMatchesAsync` are large branch-heavy methods. The current design is defensible because the code keeps the test-discovery workflow linear and local; extraction still wins because the methods are measured complexity hotspots and future edge cases will otherwise keep landing inside the same two blocks. |
+| Approach | Extract cohesive helpers around input normalization, direct reference matching, fallback matching, and heuristic construction without changing public behavior. |
+| Scope | Production files: 1 — `src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs`. Test files: existing `ValidationToolsIntegrationTests` and `HardeningBehaviorTests`; no new tests if behavior remains structural. |
+| Tool policy | edit-only |
+| Estimated context cost | 40000 |
+| Risks | Accidentally changing dedupe order, max-result truncation, or cancellation propagation. Focused test-discovery fixtures must remain green. |
+| Validation | `mcp__roslyn__compile_check`; focused `ValidationToolsIntegrationTests` test-discovery cases plus hardening path; `./eng/verify-release.ps1 -Configuration Release -NoCoverage`; vulnerability check. |
+| CHANGELOG category | Changed |
+| Backlog sync | Close rows: [`test-discovery-service-complexity-refactor`]. Mark obsolete: []. Update related: []. |
+
+### 3. scaffold-test-preview-sampled-test-names
+
+| Field | Content |
+|---|---|
+| Status | pending |
+| Backlog rows closed | `scaffold-test-preview-sampled-test-names` |
+| Diagnosis | `scaffold_test_preview` always emits `<TargetMethodName>_Needs_Test`, pushing naming work back to the outer agent. The current design is defensible because deterministic placeholders avoid model-dependent behavior and work for clients without sampling; a gated `useSampling=false` default preserves that behavior while letting capable clients collapse rename loops. |
+| Approach | Add a nullable sampling path to `ScaffoldingTools.PreviewScaffoldTest` and `IScaffoldingService.PreviewScaffoldTestAsync`; when enabled and sampling succeeds, replace the placeholder with a sanitized sampled Given/When/Then name. |
+| Scope | Production files: up to 4 — `src/RoslynMcp.Core/Services/IScaffoldingService.cs`, scaffold DTO location, `src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs`, `src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs`. Test files: up to 2, centered on disabled/default behavior and enabled sampled-name behavior. |
+| Tool policy | edit-only |
+| Estimated context cost | 60000 |
+| Risks | SDK sampling call shape, capability absence, and invalid sampled identifiers. Default path must preserve placeholder output exactly; sampling failures should degrade to placeholder without hiding real non-sampling errors. |
+| Validation | `mcp__roslyn__compile_check`; focused scaffolding tests; `./eng/verify-release.ps1 -Configuration Release -NoCoverage`; vulnerability check. |
+| CHANGELOG category | Added |
+| Backlog sync | Close rows: [`scaffold-test-preview-sampled-test-names`]. Mark obsolete: []. Update related: []. |
+
+## Skipped Rows
+
+| id | Reason |
+|---|---|
+| `tool-surface-pagination-or-tool-sets` | Low / track-only; row requires small-model friction or ~200-tool threshold before implementation. |
+| `validate-locator-preflight-tool` | Defer; re-measure after 2026-05-12. |
+| `http-streamable-host-project` | Defer; requires concrete remote-deployment driver and design. |
+| `workspace-process-pool-or-daemon` | Defer; OrchardCore evidence does not justify implementation. |
+
+## Final Todo
+
+- backlog: sync ai_docs/backlog.md

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/review.md
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/review.md
@@ -1,0 +1,16 @@
+# Backlog sweep plan review — 20260506T211152Z
+<!-- purpose: Review findings for the 20260506T211152Z backlog sweep plan. -->
+<!-- generated_at: 2026-05-06T21:11:52Z -->
+
+**Plan reviewed:** `ai_docs/plans/20260506T211152Z_backlog-sweep/`
+
+## Verdict
+
+passed
+
+## Findings
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| Info | Initiative 3 depends on exact SDK sampling call shape and may need a small adapter to keep tests deterministic. | Keep implementation under the 4-production-file cap; if SDK friction expands the scope, defer rather than exceed the row. |
+

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-06T21:11:52Z",
+  "backlogSnapshot": "2026-05-06T21:07:03Z",
+  "addendaLoaded": true,
+  "reviewStatus": "passed",
+  "reviewedAt": "2026-05-06T21:11:52Z",
+  "reviewFindings": {
+    "block": 0,
+    "warn": 0,
+    "info": 1
+  },
+  "reviewArtifact": "ai_docs/plans/20260506T211152Z_backlog-sweep/review.md",
+  "vettingOverride": false,
+  "skippedRows": [
+    {
+      "rowId": "tool-surface-pagination-or-tool-sets",
+      "reason": "Low / track-only; trigger conditions not met."
+    },
+    {
+      "rowId": "validate-locator-preflight-tool",
+      "reason": "Deferred until re-measurement after 2026-05-12."
+    },
+    {
+      "rowId": "http-streamable-host-project",
+      "reason": "Deferred pending concrete remote-deployment driver."
+    },
+    {
+      "rowId": "workspace-process-pool-or-daemon",
+      "reason": "Deferred pending future worse-profile evidence."
+    }
+  ],
+  "initiatives": [
+    {
+      "id": "validate-workspace-markdown-formatter-decomposition",
+      "order": 1,
+      "status": "pending",
+      "priority": "Medium",
+      "backlogRowsClosed": ["validate-workspace-markdown-formatter-decomposition"],
+      "rowsClosedCount": 1,
+      "productionFilesTouched": 1,
+      "testFilesExtended": 1,
+      "estimatedContextTokens": 25000,
+      "toolPolicy": "edit-only",
+      "scheduleHint": null,
+      "touchesHotspot": true,
+      "hotspotFiles": ["src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs"],
+      "branch": null,
+      "worktreePath": null,
+      "prUrl": null,
+      "mergedAt": null,
+      "notes": "Pure formatter decomposition; preserve byte-stable output."
+    },
+    {
+      "id": "test-discovery-service-complexity-refactor",
+      "order": 2,
+      "status": "pending",
+      "priority": "Medium",
+      "backlogRowsClosed": ["test-discovery-service-complexity-refactor"],
+      "rowsClosedCount": 1,
+      "productionFilesTouched": 1,
+      "testFilesExtended": 2,
+      "estimatedContextTokens": 40000,
+      "toolPolicy": "edit-only",
+      "scheduleHint": null,
+      "touchesHotspot": true,
+      "hotspotFiles": ["src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs"],
+      "branch": null,
+      "worktreePath": null,
+      "prUrl": null,
+      "mergedAt": null,
+      "notes": "Structural extraction only; preserve ordering and cancellation behavior."
+    },
+    {
+      "id": "scaffold-test-preview-sampled-test-names",
+      "order": 3,
+      "status": "pending",
+      "priority": "Medium",
+      "backlogRowsClosed": ["scaffold-test-preview-sampled-test-names"],
+      "rowsClosedCount": 1,
+      "productionFilesTouched": 4,
+      "testFilesAdded": 2,
+      "estimatedContextTokens": 60000,
+      "toolPolicy": "edit-only",
+      "scheduleHint": null,
+      "touchesHotspot": false,
+      "branch": null,
+      "worktreePath": null,
+      "prUrl": null,
+      "mergedAt": null,
+      "notes": "Sampling path must be opt-in and preserve deterministic placeholder default."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a bounded follow-on backlog-sweep plan for the three remaining actionable Medium rows.
- Mark Low/Defer rows as skipped per their existing evidence gates.
- Include a review artifact and state file for execute-mode reconciliation.

## Validation
- `./eng/verify-ai-docs.ps1`