### PR TITLE
chore(plan): reconcile formatter decomposition

### DIFF
--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
@@ -21,7 +21,7 @@ This follow-on plan consumes the three remaining actionable Medium backlog rows 
 
 | Field | Content |
 |---|---|
-| Status | in-review (PR #533, 2026-05-06) |
+| Status | merged (PR #533, 2026-05-06) |
 | Backlog rows closed | `validate-workspace-markdown-formatter-decomposition` |
 | Diagnosis | `ValidateWorkspaceMarkdownFormatter.Format` owns the verdict line plus metrics, diagnostics, discovered tests, failures, rerun-filter, and warning table branches in one method. The current design is defensible because the formatter is a small pure function with all output logic in one place; extraction still wins because the method is already a complexity hotspot and response-format changes now require reviewing unrelated table branches. |
 | Approach | Extract private section writers and small table helpers while preserving byte-stable markdown output. |

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
@@ -34,7 +34,7 @@
     {
       "id": "validate-workspace-markdown-formatter-decomposition",
       "order": 1,
-      "status": "in-review",
+      "status": "merged",
       "priority": "Medium",
       "backlogRowsClosed": ["validate-workspace-markdown-formatter-decomposition"],
       "rowsClosedCount": 1,
@@ -48,8 +48,8 @@
       "branch": "remediation/validate-workspace-markdown-formatter-decomposition",
       "worktreePath": null,
       "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/533",
-      "mergedAt": null,
-      "notes": "PR #533 opened. Pure formatter decomposition; preserve byte-stable output."
+      "mergedAt": "2026-05-06T21:35:20Z",
+      "notes": "PR #533 merged. Pure formatter decomposition; preserved byte-stable output."
     },
     {
       "id": "test-discovery-service-complexity-refactor",


### PR DESCRIPTION
## Summary
- Mark `validate-workspace-markdown-formatter-decomposition` merged in the 20260506 backlog-sweep plan/state after PR #533.

## Validation
- `./eng/verify-ai-docs.ps1`