### PR TITLE
chore(plan): reconcile test discovery refactor

### DIFF
--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
@@ -37,7 +37,7 @@ This follow-on plan consumes the three remaining actionable Medium backlog rows 
 
 | Field | Content |
 |---|---|
-| Status | in-review (PR #535, 2026-05-06) |
+| Status | merged (PR #535, 2026-05-06) |
 | Backlog rows closed | `test-discovery-service-complexity-refactor` |
 | Diagnosis | `FindRelatedTestsForFilesAsync` and `CollectFallbackMatchesAsync` are large branch-heavy methods. The current design is defensible because the code keeps the test-discovery workflow linear and local; extraction still wins because the methods are measured complexity hotspots and future edge cases will otherwise keep landing inside the same two blocks. |
 | Approach | Extract cohesive helpers around input normalization, direct reference matching, fallback matching, and heuristic construction without changing public behavior. |

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
@@ -54,7 +54,7 @@
     {
       "id": "test-discovery-service-complexity-refactor",
       "order": 2,
-      "status": "in-review",
+      "status": "merged",
       "priority": "Medium",
       "backlogRowsClosed": ["test-discovery-service-complexity-refactor"],
       "rowsClosedCount": 1,
@@ -68,8 +68,8 @@
       "branch": "remediation/test-discovery-service-complexity-refactor",
       "worktreePath": null,
       "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/535",
-      "mergedAt": null,
-      "notes": "PR #535 opened. Structural extraction only; preserve ordering and cancellation behavior."
+      "mergedAt": "2026-05-06T22:00:10Z",
+      "notes": "PR #535 merged. Structural extraction only; preserved ordering and cancellation behavior."
     },
     {
       "id": "scaffold-test-preview-sampled-test-names",


### PR DESCRIPTION
## Summary
- Mark `test-discovery-service-complexity-refactor` merged in the 20260506 backlog-sweep plan/state after PR #535.

## Validation
- `./eng/verify-ai-docs.ps1`