### PR TITLE
feat(scaffolding): sample scaffold test names

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-05-06T21:42:46Z
+**updated_at:** 2026-05-06T22:14:44Z
 
 ## Agent contract
 
@@ -47,7 +47,6 @@
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `scaffold-test-preview-sampled-test-names` | Medium | none | Plumb `IMcpServer` into `ScaffoldingTools.PreviewScaffoldTest` (and the underlying `IScaffoldingService.PreviewScaffoldTestAsync`) and add a sampled `SuggestTestNameAsync` step gated behind a `useSampling: bool = false` parameter so non-sampling clients see no behavior change. When `useSampling=true` and the client declares the `sampling` capability, replace the placeholder `<TargetMethodName>_Needs_Test` with a model-suggested Given/When/Then test method name (e.g. `LoadIntoSessionAsync_WhenCacheMiss_FallsThroughToColdLoad`) computed from the target method's signature + sibling-test-class examples. Collapses N rename round-trips per N-test scaffold pass to 1 sampled call. Anchors: `src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs`, `src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs` (`PreviewScaffoldTestAsync` + `_Needs_Test` placeholder site at line 1887). Regression test shape: 2 — (a) `useSampling: false` returns `_Needs_Test` placeholder unchanged (default behavior preserved); (b) `useSampling: true` against a mock client that returns a string returns a non-placeholder name. Evidence: `ai_docs/items/sampling-spike.md` § Verdicts — only `go` candidate from the 2026-05-05 spike (cost $0.001–$0.003/call, latency 0.6–1.2s, equivalent-to-better quality vs outer-loop). Source: spike's "GO" verdict; sibling candidates 1+2 (XML-doc gen, refactor-summary) ruled NO-GO. |
 
 ## Low
 

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/plan.md
@@ -53,7 +53,7 @@ This follow-on plan consumes the three remaining actionable Medium backlog rows 
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | in-review |
 | Backlog rows closed | `scaffold-test-preview-sampled-test-names` |
 | Diagnosis | `scaffold_test_preview` always emits `<TargetMethodName>_Needs_Test`, pushing naming work back to the outer agent. The current design is defensible because deterministic placeholders avoid model-dependent behavior and work for clients without sampling; a gated `useSampling=false` default preserves that behavior while letting capable clients collapse rename loops. |
 | Approach | Add a nullable sampling path to `ScaffoldingTools.PreviewScaffoldTest` and `IScaffoldingService.PreviewScaffoldTestAsync`; when enabled and sampling succeeds, replace the placeholder with a sanitized sampled Given/When/Then name. |

--- a/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260506T211152Z_backlog-sweep/state.json
@@ -74,7 +74,7 @@
     {
       "id": "scaffold-test-preview-sampled-test-names",
       "order": 3,
-      "status": "pending",
+      "status": "in-review",
       "priority": "Medium",
       "backlogRowsClosed": ["scaffold-test-preview-sampled-test-names"],
       "rowsClosedCount": 1,
@@ -84,11 +84,11 @@
       "toolPolicy": "edit-only",
       "scheduleHint": null,
       "touchesHotspot": false,
-      "branch": null,
+      "branch": "remediation/scaffold-test-preview-sampled-test-names",
       "worktreePath": null,
       "prUrl": null,
       "mergedAt": null,
-      "notes": "Sampling path must be opt-in and preserve deterministic placeholder default."
+      "notes": "Implementation branch validates the opt-in sampling path and deterministic default; awaiting PR."
     }
   ]
 }

--- a/changelog.d/scaffold-test-preview-sampled-test-names.md
+++ b/changelog.d/scaffold-test-preview-sampled-test-names.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `scaffold_test_preview` can opt into MCP sampling for Given/When/Then test method names while preserving the deterministic placeholder default for non-sampling callers. Closes `scaffold-test-preview-sampled-test-names`.

--- a/src/RoslynMcp.Core/Models/ScaffoldingDtos.cs
+++ b/src/RoslynMcp.Core/Models/ScaffoldingDtos.cs
@@ -49,12 +49,17 @@ public sealed record ScaffoldTestBatchTargetDto(
 /// in the target test project and uses that as the reference. Set to the empty string to
 /// opt out of inference entirely.
 /// </param>
+/// <param name="UseSampling">
+/// When true, clients that support MCP sampling may request a model-suggested test method name.
+/// The default false path preserves the deterministic <c>&lt;TargetMethodName&gt;_Needs_Test</c> placeholder.
+/// </param>
 public sealed record ScaffoldTestDto(
     string TestProjectName,
     string TargetTypeName,
     string? TargetMethodName = null,
     string TestFramework = "auto",
-    string? ReferenceTestFile = null);
+    string? ReferenceTestFile = null,
+    bool UseSampling = false);
 
 /// <summary>
 /// Represents a request to scaffold the FIRST test file for a service that has no existing

--- a/src/RoslynMcp.Core/Services/IScaffoldingService.cs
+++ b/src/RoslynMcp.Core/Services/IScaffoldingService.cs
@@ -21,7 +21,12 @@ public interface IScaffoldingService
     /// <param name="workspaceId">The workspace session identifier.</param>
     /// <param name="request">The scaffolding parameters, including the test project name and target type.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(string workspaceId, ScaffoldTestDto request, CancellationToken ct);
+    /// <param name="testNameSuggestionProvider">Optional provider used only when <see cref="ScaffoldTestDto.UseSampling"/> is true.</param>
+    Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(
+        string workspaceId,
+        ScaffoldTestDto request,
+        CancellationToken ct,
+        ITestNameSuggestionProvider? testNameSuggestionProvider = null);
 
     /// <summary>
     /// Previews scaffolding test files for multiple target types in a single composite preview.
@@ -46,3 +51,21 @@ public interface IScaffoldingService
     /// <param name="ct">Cancellation token.</param>
     Task<RefactoringPreviewDto> PreviewScaffoldFirstTestFileAsync(string workspaceId, ScaffoldFirstTestFileDto request, CancellationToken ct);
 }
+
+/// <summary>
+/// Transport-neutral bridge for opt-in test-method-name suggestions during scaffold preview.
+/// Implementations may use MCP sampling, fixtures, or a deterministic fake in tests.
+/// </summary>
+public interface ITestNameSuggestionProvider
+{
+    Task<TestNameSuggestionResult> SuggestTestNameAsync(ScaffoldTestNameSuggestionContext context, CancellationToken ct);
+}
+
+public sealed record ScaffoldTestNameSuggestionContext(
+    string TargetTypeName,
+    string TargetMethodName,
+    string? TargetMethodSignature,
+    string? TargetNamespace,
+    IReadOnlyList<string> SiblingTestMethodNames);
+
+public sealed record TestNameSuggestionResult(string? MethodName, string? Warning = null);

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -89,6 +90,7 @@ public static class ScaffoldingTools
         "Preview scaffolding a new test file (MSTest, xUnit, or NUnit; auto-detect or specify testFramework)."),
      Description("Preview scaffolding a new test file for a target type. Supports MSTest, xUnit, and NUnit (use testFramework or auto-detect from the test project's package references). When referenceTestFile is provided (or the test project contains a sibling *Tests.cs file — auto-detected by most-recently-modified), class-level attributes, base class, and constructor-injected fixture parameters (xUnit IClassFixture<T> pattern) are replicated onto the scaffolded output so ASP.NET Core integration-test conventions carry over without manual rewrite. Pass an empty string for referenceTestFile to opt out of inference.")]
     public static Task<string> PreviewScaffoldTest(
+        RequestContext<CallToolRequestParams> requestContext,
         IWorkspaceExecutionGate gate,
         IScaffoldingService scaffoldingService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -97,15 +99,91 @@ public static class ScaffoldingTools
         [Description("Optional: target method name for the generated test stub")] string? targetMethodName = null,
         [Description("Test framework: mstest, xunit, nunit, or auto (infer from PackageReference in the test csproj)")] string testFramework = "auto",
         [Description("Optional: absolute path to an existing sibling test file whose scaffolding (class attributes, base class, IClassFixture<T> constructor) should be replicated. When omitted, the most-recently-modified *Tests.cs in the target project is used. Pass an empty string to opt out of inference.")] string? referenceTestFile = null,
+        [Description("When true, request a sampled Given/When/Then test method name from the MCP client if it supports sampling. Defaults false to preserve deterministic placeholder output.")] bool useSampling = false,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
+    {
+        var testNameSuggestionProvider = useSampling && requestContext.Server is { } server
+            ? new McpSamplingTestNameSuggestionProvider(server)
+            : null;
+
+        return ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
             c => scaffoldingService.PreviewScaffoldTestAsync(
                 workspaceId,
-                new ScaffoldTestDto(testProjectName, targetTypeName, targetMethodName, testFramework, referenceTestFile),
-                c),
+                new ScaffoldTestDto(testProjectName, targetTypeName, targetMethodName, testFramework, referenceTestFile, useSampling),
+                c,
+                testNameSuggestionProvider),
             ct);
+    }
+
+    private sealed class McpSamplingTestNameSuggestionProvider(McpServer server) : ITestNameSuggestionProvider
+    {
+        public async Task<TestNameSuggestionResult> SuggestTestNameAsync(ScaffoldTestNameSuggestionContext context, CancellationToken ct)
+        {
+            if (server.ClientCapabilities?.Sampling is null)
+            {
+                return new TestNameSuggestionResult(
+                    null,
+                    "useSampling was true but the MCP client did not advertise sampling support; emitted the deterministic placeholder test name.");
+            }
+
+            try
+            {
+                var result = await server.SampleAsync(BuildRequest(context), ct).ConfigureAwait(false);
+                var text = result.Content
+                    .OfType<TextContentBlock>()
+                    .Select(static block => block.Text)
+                    .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+                return new TestNameSuggestionResult(text);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return new TestNameSuggestionResult(
+                    null,
+                    $"Sampling test-name suggestion failed ({ex.GetType().Name}: {ex.Message}); emitted the deterministic placeholder test name.");
+            }
+        }
+
+        private static CreateMessageRequestParams BuildRequest(ScaffoldTestNameSuggestionContext context)
+            => new()
+            {
+                MaxTokens = 48,
+                Temperature = 0,
+                StopSequences = ["\n"],
+                SystemPrompt = "Return exactly one valid C# test method identifier. No markdown, no punctuation, no explanation.",
+                Messages =
+                [
+                    new SamplingMessage
+                    {
+                        Role = Role.User,
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text =
+                                    "Suggest a Given/When/Then test method name.\n" +
+                                    $"Target type: {context.TargetTypeName}\n" +
+                                    $"Target namespace: {context.TargetNamespace ?? "(global)"}\n" +
+                                    $"Target method: {context.TargetMethodName}\n" +
+                                    $"Signature: {context.TargetMethodSignature ?? context.TargetMethodName}\n" +
+                                    $"Sibling examples: {FormatSiblingExamples(context.SiblingTestMethodNames)}\n" +
+                                    "Format example: LoadIntoSessionAsync_WhenCacheMiss_FallsThroughToColdLoad"
+                            }
+                        ]
+                    }
+                ]
+            };
+
+        private static string FormatSiblingExamples(IReadOnlyList<string> siblingTestMethodNames)
+            => siblingTestMethodNames.Count == 0
+                ? "(none)"
+                : string.Join(", ", siblingTestMethodNames.Take(6));
+    }
 
     [McpServerTool(Name = "scaffold_test_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("scaffolding", "experimental", false, true,

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -326,7 +326,11 @@ public sealed class ScaffoldingService : IScaffoldingService
         return CreateResolvedTargetTypeInfo(matchedType, targetMethodName, warnOnPrivateMethod: false, nsubstituteAvailable);
     }
 
-    public async Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(string workspaceId, ScaffoldTestDto request, CancellationToken ct)
+    public async Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(
+        string workspaceId,
+        ScaffoldTestDto request,
+        CancellationToken ct,
+        ITestNameSuggestionProvider? testNameSuggestionProvider = null)
     {
         var project = ResolveProject(workspaceId, request.TestProjectName);
         ValidateIsTestProject(project);
@@ -365,14 +369,78 @@ public sealed class ScaffoldingService : IScaffoldingService
             : await testRoslynProject.GetCompilationAsync(ct).ConfigureAwait(false);
         var siblingInference = InferSiblingTestPattern(request.ReferenceTestFile, projectDirectory, testFilePath, testProjectCompilation);
         var siblingWarnings = siblingInference.Warnings;
+        var sampledTestName = await SuggestSampledTestNameAsync(
+            request,
+            simpleTypeName,
+            typeInfo.TargetNamespace,
+            typeInfo.TargetMethod,
+            projectDirectory,
+            testFilePath,
+            testNameSuggestionProvider,
+            ct).ConfigureAwait(false);
 
         var content = BuildTestContent(
             testNamespace, request, simpleTypeName, typeInfo.TargetNamespace, typeInfo.ConstructorArgs, framework,
-            typeInfo.TargetMethod, typeInfo.MatchedType, siblingInference.Pattern);
+            typeInfo.TargetMethod, typeInfo.MatchedType, siblingInference.Pattern, sampledTestName.MethodName);
         var preview = await _fileOperationService.PreviewCreateFileAsync(workspaceId, new CreateFileDto(project.Name, testFilePath, content), ct).ConfigureAwait(false);
 
-        var combinedWarnings = CombineWarnings(typeInfo.Warnings, siblingWarnings);
+        var combinedWarnings = CombineWarnings(typeInfo.Warnings, siblingWarnings, sampledTestName.Warning);
         return combinedWarnings.Count == 0 ? preview : preview with { Warnings = combinedWarnings };
+    }
+
+    private static async Task<TestNameSuggestionResult> SuggestSampledTestNameAsync(
+        ScaffoldTestDto request,
+        string simpleTypeName,
+        string targetNamespace,
+        IMethodSymbol? targetMethod,
+        string projectDirectory,
+        string testFilePath,
+        ITestNameSuggestionProvider? provider,
+        CancellationToken ct)
+    {
+        if (!request.UseSampling || string.IsNullOrWhiteSpace(request.TargetMethodName))
+        {
+            return new TestNameSuggestionResult(null);
+        }
+
+        if (provider is null)
+        {
+            return new TestNameSuggestionResult(
+                null,
+                "useSampling was true but no sampling provider was available; emitted the deterministic placeholder test name.");
+        }
+
+        try
+        {
+            var context = new ScaffoldTestNameSuggestionContext(
+                simpleTypeName,
+                request.TargetMethodName,
+                FormatMethodSignature(targetMethod),
+                string.IsNullOrWhiteSpace(targetNamespace) ? null : targetNamespace,
+                CollectSiblingTestMethodNames(projectDirectory, testFilePath, maxNames: 6));
+            var result = await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false);
+            var normalized = NormalizeSuggestedTestMethodName(result.MethodName);
+            if (normalized is not null)
+            {
+                return result with { MethodName = normalized };
+            }
+
+            return string.IsNullOrWhiteSpace(result.MethodName)
+                ? new TestNameSuggestionResult(null, result.Warning)
+                : new TestNameSuggestionResult(
+                    null,
+                    AppendWarning(result.Warning, $"Sampled test method name '{result.MethodName}' was not a valid C# identifier; emitted the deterministic placeholder test name."));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new TestNameSuggestionResult(
+                null,
+                $"Sampling test-name suggestion failed ({ex.GetType().Name}: {ex.Message}); emitted the deterministic placeholder test name.");
+        }
     }
 
     /// <summary>
@@ -859,15 +927,21 @@ public sealed class ScaffoldingService : IScaffoldingService
         return sb.ToString();
     }
 
-    private static IReadOnlyList<string> CombineWarnings(List<string>? a, IReadOnlyList<string>? b)
+    private static IReadOnlyList<string> CombineWarnings(List<string>? a, IReadOnlyList<string>? b, string? c = null)
     {
-        if ((a is null || a.Count == 0) && (b is null || b.Count == 0))
+        if ((a is null || a.Count == 0) && (b is null || b.Count == 0) && string.IsNullOrWhiteSpace(c))
             return Array.Empty<string>();
         var combined = new List<string>();
         if (a is not null) combined.AddRange(a);
         if (b is not null) combined.AddRange(b);
+        if (!string.IsNullOrWhiteSpace(c)) combined.Add(c);
         return combined;
     }
+
+    private static string AppendWarning(string? existingWarning, string warning)
+        => string.IsNullOrWhiteSpace(existingWarning)
+            ? warning
+            : $"{existingWarning} {warning}";
 
     private static string ResolveTestFramework(string? requested, string? projectFilePath)
     {
@@ -1880,11 +1954,12 @@ public sealed class ScaffoldingService : IScaffoldingService
         string framework,
         IMethodSymbol? targetMethod,
         INamedTypeSymbol? matchedType,
-        SiblingTestPattern? siblingPattern)
+        SiblingTestPattern? siblingPattern,
+        string? suggestedMethodName = null)
     {
         var methodName = string.IsNullOrWhiteSpace(request.TargetMethodName)
             ? "Generated_Test"
-            : $"{request.TargetMethodName}_Needs_Test";
+            : suggestedMethodName ?? $"{request.TargetMethodName}_Needs_Test";
 
         var usingDirective = string.IsNullOrWhiteSpace(targetNamespace)
             ? string.Empty
@@ -1906,6 +1981,130 @@ public sealed class ScaffoldingService : IScaffoldingService
             "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
             _ => BuildMSTestTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, useStaticScaffold, siblingPattern),
         };
+    }
+
+    private static string? FormatMethodSignature(IMethodSymbol? method)
+    {
+        if (method is null)
+        {
+            return null;
+        }
+
+        var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Type.ToMinimalDisplay()} {p.Name}"));
+        return $"{method.ReturnType.ToMinimalDisplay()} {method.Name}({parameters})";
+    }
+
+    private static IReadOnlyList<string> CollectSiblingTestMethodNames(
+        string projectDirectory,
+        string destinationFilePath,
+        int maxNames)
+    {
+        if (!Directory.Exists(projectDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        var destinationNormalized = Path.GetFullPath(destinationFilePath);
+        var names = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(projectDirectory, "*Tests.cs", SearchOption.AllDirectories)
+                     .Where(p =>
+                     {
+                         var normalized = Path.GetFullPath(p);
+                         if (string.Equals(normalized, destinationNormalized, StringComparison.OrdinalIgnoreCase))
+                         {
+                             return false;
+                         }
+
+                         var rel = Path.GetRelativePath(projectDirectory, normalized);
+                         return !rel.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                             .Any(seg => string.Equals(seg, "obj", StringComparison.OrdinalIgnoreCase)
+                                      || string.Equals(seg, "bin", StringComparison.OrdinalIgnoreCase));
+                     })
+                     .Select(p => new FileInfo(p))
+                     .OrderByDescending(fi => fi.LastWriteTimeUtc))
+        {
+            try
+            {
+                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file.FullName));
+                var root = tree.GetRoot();
+                foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                {
+                    if (!LooksLikeTestMethod(method))
+                    {
+                        continue;
+                    }
+
+                    names.Add(method.Identifier.Text);
+                    if (names.Count >= maxNames)
+                    {
+                        return names;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+        }
+
+        return names;
+    }
+
+    private static bool LooksLikeTestMethod(MethodDeclarationSyntax method)
+        => method.AttributeLists
+            .SelectMany(static list => list.Attributes)
+            .Select(static attr => attr.Name.ToString())
+            .Any(static name =>
+                name.Contains("TestMethod", StringComparison.Ordinal) ||
+                name.Contains("Test", StringComparison.Ordinal) ||
+                name.Contains("Fact", StringComparison.Ordinal) ||
+                name.Contains("Theory", StringComparison.Ordinal));
+
+    private static string? NormalizeSuggestedTestMethodName(string? rawName)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+        {
+            return null;
+        }
+
+        var candidate = rawName
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(line => !line.StartsWith("```", StringComparison.Ordinal));
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return null;
+        }
+
+        candidate = candidate.Trim('`', '"', '\'', ';', ' ');
+        var colon = candidate.LastIndexOf(':');
+        if (colon >= 0 && colon < candidate.Length - 1)
+        {
+            candidate = candidate[(colon + 1)..].Trim();
+        }
+        if (candidate.EndsWith("()", StringComparison.Ordinal))
+        {
+            candidate = candidate[..^2].Trim();
+        }
+        var paren = candidate.IndexOf('(');
+        if (paren > 0)
+        {
+            candidate = candidate[..paren].Trim();
+        }
+        var parts = candidate.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length > 0)
+        {
+            candidate = parts[^1];
+        }
+
+        try
+        {
+            IdentifierValidation.ThrowIfInvalidIdentifier(candidate, "sampled test method name");
+            return candidate;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -291,6 +292,83 @@ public sealed class Bar { }
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "[TestMethod]");
         StringAssert.Contains(contents, "Speak_Needs_Test");
+    }
+
+    [TestMethod]
+    public async Task Scaffold_Test_Preview_UseSamplingFalse_DoesNotCallSuggestionProvider()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var targetFilePath = workspace.GetPath("SampleLib.Tests", "DogGeneratedTests.cs");
+        var provider = new RecordingTestNameSuggestionProvider("Speak_WhenDogIsReady_ReturnsBark");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "Dog",
+                "Speak",
+                ReferenceTestFile: string.Empty,
+                UseSampling: false),
+            CancellationToken.None,
+            provider);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.AreEqual(0, provider.CallCount, "Sampling provider must not be called unless useSampling is true.");
+        var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
+        StringAssert.Contains(contents, "Speak_Needs_Test");
+        Assert.IsFalse(contents.Contains("Speak_WhenDogIsReady_ReturnsBark"),
+            "Default deterministic scaffold should not use sampled names.");
+    }
+
+    [TestMethod]
+    public async Task Scaffold_Test_Preview_UseSamplingTrue_UsesSuggestedMethodName()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var siblingPath = workspace.GetPath("SampleLib.Tests", "DogExistingTests.cs");
+        await File.WriteAllTextAsync(siblingPath, """
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SampleLib.Tests;
+
+[TestClass]
+public sealed class DogExistingTests
+{
+    [TestMethod]
+    public void Speak_WhenQuiet_ReturnsEmpty()
+    {
+    }
+}
+""", CancellationToken.None);
+        var targetFilePath = workspace.GetPath("SampleLib.Tests", "DogGeneratedTests.cs");
+        var provider = new RecordingTestNameSuggestionProvider("Speak_WhenDogIsReady_ReturnsBark");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "Dog",
+                "Speak",
+                ReferenceTestFile: string.Empty,
+                UseSampling: true),
+            CancellationToken.None,
+            provider);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.AreEqual(1, provider.CallCount, "Sampling provider should be called once for an opted-in method-focused scaffold.");
+        Assert.IsNotNull(provider.LastContext);
+        Assert.AreEqual("Dog", provider.LastContext.TargetTypeName);
+        Assert.AreEqual("Speak", provider.LastContext.TargetMethodName);
+        StringAssert.Contains(provider.LastContext.TargetMethodSignature!, "Speak(");
+        CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenQuiet_ReturnsEmpty");
+
+        var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
+        StringAssert.Contains(contents, "Speak_WhenDogIsReady_ReturnsBark");
+        Assert.IsFalse(contents.Contains("Speak_Needs_Test"),
+            "Opted-in sampled scaffold should replace the deterministic placeholder with the suggested method name.");
     }
 
     [TestMethod]
@@ -764,5 +842,22 @@ public class SnapshotContentHasher
             "Static-members-only class scaffold must NOT emit `new SnapshotContentHasher(...)` in Arrange.");
         Assert.IsFalse(contents.Contains("var subject ="),
             "Static-members-only class scaffold must NOT emit a `subject` instance.");
+    }
+
+    private sealed class RecordingTestNameSuggestionProvider(string methodName) : ITestNameSuggestionProvider
+    {
+        public int CallCount { get; private set; }
+
+        public ScaffoldTestNameSuggestionContext? LastContext { get; private set; }
+
+        public Task<TestNameSuggestionResult> SuggestTestNameAsync(
+            ScaffoldTestNameSuggestionContext context,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            CallCount++;
+            LastContext = context;
+            return Task.FromResult(new TestNameSuggestionResult(methodName));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adds opt-in `useSampling` support to `scaffold_test_preview` for sampled Given/When/Then test method names
- keeps the default deterministic `<TargetMethodName>_Needs_Test` behavior and degrades to the placeholder with warnings when sampling is unavailable or invalid
- closes backlog row `scaffold-test-preview-sampled-test-names` and records the changelog fragment

## Test strategy
- `mcp__roslyn__compile_check` — 0 errors
- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj --filter FullyQualifiedName~Scaffold_Test_Preview_UseSampling` — 2 passed
- `./eng/verify-ai-docs.ps1` — passed
- `./eng/verify-release.ps1 -Configuration Release -NoCoverage` — 1128 passed, build/publish passed
- `dotnet list RoslynMcp.slnx package --vulnerable --include-transitive` — no vulnerable packages

## Backlog and plan
- Removed open backlog row `scaffold-test-preview-sampled-test-names` per the open-work-only backlog contract.
- Marked the 20260506 backlog-sweep initiative as in-review on this branch; final merged-state reconciliation will follow after merge.