### PR TITLE
release: v1.34.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.34.1",
+      "version": "1.34.2",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.34.2] - 2026-05-07
+
+### Changed
+
+- **Changed:** split related-file test discovery into primary match, fallback broadening, and result-building helpers while preserving existing discovery behavior. Closes `test-discovery-service-complexity-refactor`.
+- **Changed:** split `ValidateWorkspaceMarkdownFormatter.Format` into focused section writers while preserving the existing markdown response contract. Closes `validate-workspace-markdown-formatter-decomposition`.
+- **Changed:** `WorkspaceEvicted` envelopes now carry the originally-loaded solution path and an exact `recovery=workspace_load(path: "...")` retry shape when the eviction was a same-process trim (path was retained on the in-memory eviction record). Cross-process recycle envelopes still omit both fields because the prior process's session metadata is unrecoverable. Typoed-`workspaceId` lookups remain `category=NotFound`. `WorkspaceEvictedException.LoadedPath` is the new typed surface; the `WorkspaceManager._evictedWorkspaces` value type is now an `EvictedSessionRecord(LoadedAtUtc, LoadedPath)` record struct. Closes `workspace-id-recovery-hints`.
+- **Changed:** `workspace_load` now auto-runs `workspace_warm` for omitted `prewarm` on solutions with more than 50 projects, while explicit `prewarm: false` keeps the cold-load profile. Closes `workspace-warm-default-above-50-projects`.
+
+### Added
+
+- **Added:** `/roslyn-mcp:audit-deep` now documents a repo-local `audit-phase-runner` handoff for log-heavy read-side phases, keeping Phase 6 and preview/apply mutation chains inline. Closes `audit-deep-subagent-orchestration`.
+- **Added:** Design note `ai_docs/items/parameter-object-preview-design.md` for a future `parameter_object_preview` MCP tool. Specifies the tool contract, generated-DTO conventions (positional `record`), call-site rewrite policy (refuse default-value sites and `ref`/`out`/`in`/`params`/`this`/local-function targets; warn on reflective sites), cross-project pre-flight check, and Rule-3 file-count estimate (4 structural units / 6 prod files + 3 addenda + 1 test). Closes `parameter-object-preview-design`; opens follow-on row `parameter-object-preview-tool`.
+- **Added:** `scaffold_test_preview` can opt into MCP sampling for Given/When/Then test method names while preserving the deterministic placeholder default for non-sampling callers. Closes `scaffold-test-preview-sampled-test-names`.
+- **Added:** `workspace_load(prewarm: true)` now runs `workspace_warm` after a successful load and returns the warm result alongside the load summary; omitted or `false` preserves the cold-load profile. Closes `workspace-cache-prewarm-on-load`.
+
 ## [1.34.1] - 2026-05-06
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.34.1</Version>
+    <Version>1.34.2</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/audit-deep-subagent-orchestration.md
+++ b/changelog.d/audit-deep-subagent-orchestration.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `/roslyn-mcp:audit-deep` now documents a repo-local `audit-phase-runner` handoff for log-heavy read-side phases, keeping Phase 6 and preview/apply mutation chains inline. Closes `audit-deep-subagent-orchestration`.

--- a/changelog.d/parameter-object-preview-design.md
+++ b/changelog.d/parameter-object-preview-design.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** Design note `ai_docs/items/parameter-object-preview-design.md` for a future `parameter_object_preview` MCP tool. Specifies the tool contract, generated-DTO conventions (positional `record`), call-site rewrite policy (refuse default-value sites and `ref`/`out`/`in`/`params`/`this`/local-function targets; warn on reflective sites), cross-project pre-flight check, and Rule-3 file-count estimate (4 structural units / 6 prod files + 3 addenda + 1 test). Closes `parameter-object-preview-design`; opens follow-on row `parameter-object-preview-tool`.

--- a/changelog.d/scaffold-test-preview-sampled-test-names.md
+++ b/changelog.d/scaffold-test-preview-sampled-test-names.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `scaffold_test_preview` can opt into MCP sampling for Given/When/Then test method names while preserving the deterministic placeholder default for non-sampling callers. Closes `scaffold-test-preview-sampled-test-names`.

--- a/changelog.d/test-discovery-service-complexity-refactor.md
+++ b/changelog.d/test-discovery-service-complexity-refactor.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** split related-file test discovery into primary match, fallback broadening, and result-building helpers while preserving existing discovery behavior. Closes `test-discovery-service-complexity-refactor`.

--- a/changelog.d/validate-workspace-markdown-formatter-decomposition.md
+++ b/changelog.d/validate-workspace-markdown-formatter-decomposition.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** split `ValidateWorkspaceMarkdownFormatter.Format` into focused section writers while preserving the existing markdown response contract. Closes `validate-workspace-markdown-formatter-decomposition`.

--- a/changelog.d/workspace-cache-prewarm-on-load.md
+++ b/changelog.d/workspace-cache-prewarm-on-load.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `workspace_load(prewarm: true)` now runs `workspace_warm` after a successful load and returns the warm result alongside the load summary; omitted or `false` preserves the cold-load profile. Closes `workspace-cache-prewarm-on-load`.

--- a/changelog.d/workspace-id-recovery-hints.md
+++ b/changelog.d/workspace-id-recovery-hints.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** `WorkspaceEvicted` envelopes now carry the originally-loaded solution path and an exact `recovery=workspace_load(path: "...")` retry shape when the eviction was a same-process trim (path was retained on the in-memory eviction record). Cross-process recycle envelopes still omit both fields because the prior process's session metadata is unrecoverable. Typoed-`workspaceId` lookups remain `category=NotFound`. `WorkspaceEvictedException.LoadedPath` is the new typed surface; the `WorkspaceManager._evictedWorkspaces` value type is now an `EvictedSessionRecord(LoadedAtUtc, LoadedPath)` record struct. Closes `workspace-id-recovery-hints`.

--- a/changelog.d/workspace-warm-default-above-50-projects.md
+++ b/changelog.d/workspace-warm-default-above-50-projects.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** `workspace_load` now auto-runs `workspace_warm` for omitted `prewarm` on solutions with more than 50 projects, while explicit `prewarm: false` keeps the cold-load profile. Closes `workspace-warm-default-above-50-projects`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Patch release rolling up 8 changelog fragments since v1.34.1.

### Changed
- Test discovery service split into focused helpers (`test-discovery-service-complexity-refactor`)
- `ValidateWorkspaceMarkdownFormatter` decomposition (`validate-workspace-markdown-formatter-decomposition`)
- `WorkspaceEvicted` envelopes carry `loadedPath` + `recovery=workspace_load(path: "...")` hint (`workspace-id-recovery-hints`)
- `workspace_load` auto-warms solutions > 50 projects (`workspace-warm-default-above-50-projects`)

### Added
- `/roslyn-mcp:audit-deep` audit-phase-runner handoff (`audit-deep-subagent-orchestration`)
- Design note for `parameter_object_preview` MCP tool (`parameter-object-preview-design`)
- `scaffold_test_preview` MCP-sampling opt-in for test names (`scaffold-test-preview-sampled-test-names`)
- `workspace_load(prewarm: true)` (`workspace-cache-prewarm-on-load`)

See `CHANGELOG.md` for the full grouped entries.

## Test plan

- [x] All 5 version files agree on 1.34.2 (`eng/verify-version-drift.ps1`)
- [x] `eng/verify-release.ps1 -Configuration Release` — 1129 / 1129 tests passing
- [x] `eng/verify-ai-docs.ps1` — clean
- [ ] CI green