### PR TITLE
docs(changelog): backfill fragment for #545 release-cut Step 6 fix

### DIFF
--- a/changelog.d/release-cut-step6-maintainer-local-update.md
+++ b/changelog.d/release-cut-step6-maintainer-local-update.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `/release-cut` Step 6 now invokes the maintainer-local `/update` override at `.claude/skills/update/` instead of the shipped `/roslyn-mcp:update`. The shipped skill's Layer 2 path falls back to chat-only instructions ("run `/plugin marketplace update` then `/plugin install`") because `verify-skills-are-generic.ps1` blocks repo-specific `eng/` references; the override calls `eng/update-claude-plugin.ps1` directly to git-pull the marketplace clone, re-sync the plugin cache, prune the old version directory, and update `installed_plugins.json`. Caught after v1.34.2's release-cut bumped successfully but Step 6 produced unexecutable instructions instead of running the actual layer-2 update. Closes the implicit follow-up to `release-cut-atomic-skill-bump-ship-tag-reinstall`.


### PR DESCRIPTION
PR #545 (release-cut Step 6 → maintainer-local /update override) shipped without a changelog fragment, so the fix is invisible to /release-cut consumption.

This PR adds the Fixed-category fragment at \`changelog.d/release-cut-step6-maintainer-local-update.md\` so /bump rolls it into the next release section alongside the 6 fragments from the 20260507T182128Z backlog sweep.

## Test plan
- [ ] verify-ai-docs.ps1 passes
- [ ] /release-cut minor (or patch) consumes 7 fragments cleanly into the new ## [X.Y.Z] section

🤖 Generated with [Claude Code](https://claude.com/claude-code)