### PR TITLE
chore(plan): reconcile build-test analyzer lock initiative

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -13,7 +13,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #563, 2026-05-08) |
 | Priority | High |
 | Backlog rows closed | `build-test-self-analyzer-file-lock` |
 | Diagnosis | Confirmed the validation entry points shell out through loaded workspace state: `src/RoslynMcp.Roslyn/Services/BuildService.cs:28` calls `dotnet build`, and `src/RoslynMcp.Roslyn/Services/TestRunnerService.cs:44` calls `dotnet test` with existing MSB3027/MSB3021 fast-fail handling. The analyzer is wired into Host.Stdio via `src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj:59` with `OutputItemType="Analyzer"` and `ReferenceOutputAssembly="false"`, so a self-hosted workspace can hold the analyzer output DLL while a child build/test process tries to overwrite it. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -8,7 +8,7 @@
     {
       "id": "build-test-self-analyzer-file-lock",
       "order": 1,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["build-test-self-analyzer-file-lock"],
       "productionFilesTouched": 3,
       "testFilesAdded": 1,
@@ -20,9 +20,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": "High priority self-hosting validator lock. Prefer fixing analyzer-reference lock root during workspace load, not only shell retry behavior."
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/563",
+      "mergedAt": "2026-05-08T18:02:24Z",
+      "notes": "Shipped as PR #563 (squash 20b517e4ea76e131998521573b43dc4a0b544f6d). Fixed the self-hosted analyzer lock by retargeting AnalyzerFileReference loaders to shadow-copy on Windows."
     },
     {
       "id": "find-references-duplicate-metadata-candidates",


### PR DESCRIPTION
## Summary
- Marks `build-test-self-analyzer-file-lock` as merged in the 20260508 backlog-sweep state.
- Records PR #563 merge metadata and updates the human-readable plan status row.

## Test plan
- [x] `./eng/verify-ai-docs.ps1`

Generated with Codex