### PR TITLE
Reconcile find references duplicate candidates initiative

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -32,7 +32,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #565, 2026-05-08) |
 | Priority | Medium |
 | Backlog rows closed | `find-references-duplicate-metadata-candidates` |
 | Diagnosis | `find_references` delegates metadata-name disambiguation through `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs:190` and then calls `ReferenceService.FindReferencesAsync` at `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs:202`. Candidate enumeration in `src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs:197` dedupes with `SymbolEqualityComparer.Default`, which can still treat equivalent source declarations from separate project compilations as distinct. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -27,7 +27,7 @@
     {
       "id": "find-references-duplicate-metadata-candidates",
       "order": 2,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["find-references-duplicate-metadata-candidates"],
       "productionFilesTouched": 2,
       "testFilesAdded": 1,
@@ -39,9 +39,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": null
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/565",
+      "mergedAt": "2026-05-08T18:26:58Z",
+      "notes": "Shipped as PR #565 (squash f017338d79a8927c248d32cd82d8d178b1de6517). Fixed false metadata-name ambiguity by deduping candidates with stable source-span keys."
     },
     {
       "id": "add-project-reference-self-reference-preview",


### PR DESCRIPTION
## Summary
- Mark initiative 2 (`find-references-duplicate-metadata-candidates`) as merged in the active backlog-sweep plan and state.
- Record PR #565, merge time, and squash commit in `state.json`.

## Validation
- ./eng/verify-ai-docs.ps1
- git diff --check