### PR TITLE
Reconcile add project reference initiative

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -51,7 +51,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #567, 2026-05-08) |
 | Priority | Medium |
 | Backlog rows closed | `add-project-reference-self-reference-preview` |
 | Diagnosis | `src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs:112` resolves both projects and only checks whether the relative `ProjectReference` already exists; it does not reject `project.Id == referencedProject.Id` before diff creation. The tool wrapper at `src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs:70` forwards the request directly. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -46,7 +46,7 @@
     {
       "id": "add-project-reference-self-reference-preview",
       "order": 3,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["add-project-reference-self-reference-preview"],
       "productionFilesTouched": 1,
       "testFilesAdded": 1,
@@ -58,9 +58,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": null
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/567",
+      "mergedAt": "2026-05-08T18:49:08Z",
+      "notes": "Shipped as PR #567 (squash 1ef971fba344d6ffa506f2060f5b41fdb18be7dd). Rejected add_project_reference_preview self-references and project-reference cycles before diff generation."
     },
     {
       "id": "find-overrides-interface-root-empty",


### PR DESCRIPTION
## Summary
- Mark initiative 3 (`add-project-reference-self-reference-preview`) as merged in the active backlog-sweep plan and state.
- Record PR #567, merge time, and squash commit in `state.json`.

## Validation
- ./eng/verify-ai-docs.ps1
- git diff --check