### PR TITLE
Reconcile find overrides initiative

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -70,7 +70,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #569, 2026-05-08) |
 | Priority | Medium |
 | Backlog rows closed | `find-overrides-interface-root-empty` |
 | Diagnosis | `src/RoslynMcp.Roslyn/Services/ReferenceService.cs:141` promotes implementation-site symbols before `SymbolFinder.FindOverridesAsync`, and `src/RoslynMcp.Roslyn/Services/ReferenceService.cs:242` maps implicit implementation symbols back to their interface member. The interface-member root itself still passes directly to `SymbolFinder.FindOverridesAsync`, which can miss implicit implementations in the audit fixture even though `find_base_members` can see the reverse relation. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -65,7 +65,7 @@
     {
       "id": "find-overrides-interface-root-empty",
       "order": 4,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["find-overrides-interface-root-empty"],
       "productionFilesTouched": 1,
       "testFilesAdded": 1,
@@ -77,9 +77,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": null
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/569",
+      "mergedAt": "2026-05-08T19:17:19Z",
+      "notes": "Shipped as PR #569 (squash abf99c939d9a7aa0ae0b8fd4f2508e1d8113b1ed). Included implicit interface implementations for interface-member find_overrides roots and aligned member_hierarchy overrides with that path."
     },
     {
       "id": "symbol-relationships-return-token-bucket-mix",


### PR DESCRIPTION
## Summary
- Mark initiative 4 (`find-overrides-interface-root-empty`) as merged in the active backlog-sweep plan and state.
- Record PR #569, merge time, and squash commit in `state.json`.

## Validation
- ./eng/verify-ai-docs.ps1
- git diff --check