### PR TITLE
Reconcile symbol relationships sweep state

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -89,7 +89,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #571, 2026-05-08) |
 | Priority | Medium |
 | Backlog rows closed | `symbol-relationships-return-token-bucket-mix` |
 | Diagnosis | `src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs:144` promotes a return-type token to the declaring member for the response symbol, but `src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs:154` through `:157` still calls reference, implementation, base, and override services with the original locator. The wrapper at `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs:389` advertises the promoted-member behavior. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -84,7 +84,7 @@
     {
       "id": "symbol-relationships-return-token-bucket-mix",
       "order": 5,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["symbol-relationships-return-token-bucket-mix"],
       "productionFilesTouched": 1,
       "testFilesAdded": 1,
@@ -94,11 +94,11 @@
       "scheduleHint": null,
       "fanoutEstimate": 1,
       "fanoutOversize": false,
-      "branch": null,
-      "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": null
+      "branch": "remediation/symbol-relationships-return-token-bucket-mix",
+      "worktreePath": "C:\\Code-Repo\\Roslyn-Backed-MCP\\.worktrees\\symbol-relationships-return-token-bucket-mix",
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/571",
+      "mergedAt": "2026-05-08T19:40:48Z",
+      "notes": "Shipped as PR #571 (squash 9f662a805699469ed42694fc0781dbc16df98539). Routed symbol_relationships relationship buckets through the promoted declaring-member locator and added return-type-token promotion regression coverage."
     },
     {
       "id": "scaffold-test-batch-nullable-constructor-output",


### PR DESCRIPTION
## Summary
- Mark `symbol-relationships-return-token-bucket-mix` as merged in the active backlog-sweep plan.
- Record PR #571, merge time, and squash commit in `state.json`.

## Validation
- ./eng/verify-ai-docs.ps1
- git diff --check