### PR TITLE
fix(scaffolding): handle nullable constructor args (scaffold-test-batch-nullable-constructor-output)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -1166,6 +1166,9 @@ public sealed class ScaffoldingService : IScaffoldingService
     internal static string BuildArgExpression(ITypeSymbol parameterType, bool nsubstituteAvailable = false)
     {
         var displayName = parameterType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var constructibleDisplayName = parameterType
+            .WithNullableAnnotation(NullableAnnotation.NotAnnotated)
+            .ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
         if (parameterType.SpecialType == SpecialType.System_String)
         {
@@ -1203,7 +1206,7 @@ public sealed class ScaffoldingService : IScaffoldingService
             (parameterType.TypeKind == TypeKind.Class && parameterType.IsAbstract))
         {
             return nsubstituteAvailable
-                ? $"NSubstitute.Substitute.For<{displayName}>()"
+                ? $"NSubstitute.Substitute.For<{constructibleDisplayName}>()"
                 : $"default({displayName})! /* TODO: provide a test double for {displayName} */";
         }
 
@@ -1214,7 +1217,7 @@ public sealed class ScaffoldingService : IScaffoldingService
             !concrete.IsAbstract &&
             HasAccessibleParameterlessCtor(concrete))
         {
-            return $"new {displayName}()";
+            return $"new {constructibleDisplayName}()";
         }
 
         // Concrete class without a parameterless ctor: can't safely construct. Emit a TODO so
@@ -1224,7 +1227,7 @@ public sealed class ScaffoldingService : IScaffoldingService
             !concreteNoCtor.IsAbstract)
         {
             return nsubstituteAvailable
-                ? $"NSubstitute.Substitute.For<{displayName}>()"
+                ? $"NSubstitute.Substitute.For<{constructibleDisplayName}>()"
                 : $"default({displayName})! /* TODO: provide a test double for {displayName} */";
         }
 

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -631,6 +631,88 @@ public class PlaywrightFlowTests
     }
 
     [TestMethod]
+    public async Task Scaffold_Test_Batch_NullableCtorArgs_EmitCompileSafeExpressions()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var fixturePath = workspace.GetPath("SampleLib", "Dog.cs");
+        await File.AppendAllTextAsync(fixturePath, """
+
+public interface INullableSink
+{
+    void Record(string value);
+}
+
+public sealed class NullableOption
+{
+    public string Value { get; } = string.Empty;
+}
+
+public sealed class RequiredOption
+{
+    public RequiredOption(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+}
+
+public sealed class NullableConstructorTarget
+{
+    private readonly NullableOption? _option;
+    private readonly RequiredOption? _required;
+    private readonly INullableSink? _sink;
+
+    public NullableConstructorTarget(
+        NullableOption? option,
+        RequiredOption? required,
+        INullableSink? sink)
+    {
+        _option = option;
+        _required = required;
+        _sink = sink;
+    }
+
+    public string Describe()
+    {
+        _sink?.Record(_option?.Value ?? _required?.Value ?? string.Empty);
+        return _option?.Value ?? _required?.Value ?? string.Empty;
+    }
+}
+""", CancellationToken.None);
+
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestBatchAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestBatchDto(
+                "SampleLib.Tests",
+                [new ScaffoldTestBatchTargetDto("NullableConstructorTarget", "Describe")],
+                "auto"),
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken,
+            "scaffold_test_batch_apply",
+            CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var generatedPath = workspace.GetPath("SampleLib.Tests", "NullableConstructorTargetGeneratedTests.cs");
+        var contents = await File.ReadAllTextAsync(generatedPath, CancellationToken.None);
+
+        StringAssert.Contains(contents, "new NullableOption()",
+            "Nullable concrete ctor arg with an accessible parameterless ctor should unwrap the annotation before object creation.");
+        Assert.IsFalse(contents.Contains("new NullableOption?()"),
+            "Scaffold must not emit invalid nullable object creation syntax.");
+        StringAssert.Contains(contents, "default(RequiredOption?)!",
+            "Nullable concrete ctor arg without a parameterless ctor should stay compile-safe and keep the nullable annotation.");
+        StringAssert.Contains(contents, "default(INullableSink?)!",
+            "Nullable interface ctor arg should use the existing compile-safe TODO placeholder shape.");
+    }
+
+    [TestMethod]
     public async Task Scaffold_Test_DottedTargetTypeName_TopLevel_Yields_SingleIdentifier_ClassName()
     {
         // Regression for scaffold-test-preview-dotted-identifier: callers who hit the


### PR DESCRIPTION
## Summary
- Normalize top-level nullable annotations before emitting constructible constructor-argument expressions.
- Add batch scaffold regression coverage for nullable concrete args with and without parameterless constructors, plus a nullable interface arg.

Closes: scaffold-test-batch-nullable-constructor-output

## Validation
- mcp__roslyn__compile_check: 0 errors
- mcp__roslyn__test_run --filter FullyQualifiedName=RoslynMcp.Tests.ScaffoldingIntegrationTests.Scaffold_Test_Batch_NullableCtorArgs_EmitCompileSafeExpressions: passed (1/1)
- ./eng/verify-ai-docs.ps1: passed
- ./eng/verify-release.ps1 -Configuration Release -NoCoverage: passed (1140/1140 tests)
- dotnet package list --project RoslynMcp.slnx --vulnerable --include-transitive: no vulnerable packages