### PR TITLE
fix(workspace): pass MSBuild Configuration on self-hosted analyzer-load test

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at: 2026-05-08T22:50:00Z**
+**updated_at: 2026-05-09T00:00:00Z**
 
 ## Agent contract
 
@@ -42,7 +42,6 @@
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `selfhosted-shadow-copy-analyzer-reference-test-fails` | High | none | The Windows-only test `SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy` (added in PR #563 to guard the analyzer-DLL file-lock fix) fails on the self-hosted Windows runner activated 2026-05-08 (PR #580). Failure is at the test's first precondition (`tests/RoslynMcp.Tests/ValidationIntegrationTests.cs:80`): `hostProject.AnalyzerReferences.OfType<AnalyzerFileReference>().FirstOrDefault(...)` returns null despite a successful build that produced `analyzers/ServerSurfaceCatalogAnalyzer/bin/Release/netstandard2.0/RoslynMcp.Analyzers.ServerSurfaceCatalog.dll`. The test has been silently skipping on every prior hosted-Linux CI run via `if (!OperatingSystem.IsWindows()) return;` at line 63 — so this latent issue has been hidden for the entire post-#563 history. **Higher than Medium because** every PR landing on the self-hosted runner now fails this single test, requiring admin-override merges until fixed; the override pattern needs to stop quickly. Two hypotheses: (a) MSBuildWorkspace.LoadAsync timing — analyzer reference may not refresh if load happens immediately after build; (b) LocalSystem service-account env differences (PATH, MSBuild property evaluation) cause the AnalyzerFileReference to not be populated. Next deliverable: investigate via `dotnet test --filter SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy` on the runner machine (manually invoke the same test outside CI to isolate runner-vs-CI vs LocalSystem-vs-user); if reproducible interactively under LocalSystem, add diagnostic logging to enumerate `hostProject.AnalyzerReferences` regardless of type filter; root-cause and patch. Anchors: `tests/RoslynMcp.Tests/ValidationIntegrationTests.cs:60-104` (the test), `src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs` LoadAsync, `analyzers/ServerSurfaceCatalogAnalyzer/ServerSurfaceCatalogAnalyzer.csproj`, `src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj` (`<ProjectReference OutputItemType="Analyzer">`). Regression test shape: existing test passes on self-hosted runner under LocalSystem service account. Evidence: `gh run view 25582580116 --log-failed | tail -50` from PR #580 first-self-hosted-run on 2026-05-08; failed in 2s at the IsNotNull on line 80 with message "Expected Host.Stdio to carry the server-surface catalog analyzer reference." Build had succeeded 1s prior with no errors. |
 
 ## Medium
 

--- a/changelog.d/selfhosted-shadow-copy-analyzer-reference-test-fails.md
+++ b/changelog.d/selfhosted-shadow-copy-analyzer-reference-test-fails.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `WorkspaceManager.LoadAsync` now accepts an optional `IDictionary<string,string> globalProperties` parameter that flows MSBuild global property overrides (e.g. `Configuration=Release`) into `MSBuildWorkspace.Create`. Without this, `MSBuildWorkspace` defaulted to `Configuration=Debug` evaluation, which dropped `ProjectReference OutputItemType="Analyzer"` entries on Release-only checkouts (such as the self-hosted Windows CI runner) because the Debug `TargetPath` did not exist on disk. The new `SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy` test detects the host's actual build configuration from `AppContext.BaseDirectory` and passes it through. When global properties are set, the load also opts out of session deduplication and the cache fast-path so the new evaluation always runs. Closes `selfhosted-shadow-copy-analyzer-reference-test-fails`.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -154,7 +154,13 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         return null;
     }
 
-    public async Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct)
+    public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct)
+        => LoadAsync(path, globalProperties: null, ct);
+
+    public async Task<WorkspaceStatusDto> LoadAsync(
+        string path,
+        IDictionary<string, string>? globalProperties,
+        CancellationToken ct)
     {
         var fullPath = ValidateWorkspacePath(path);
 
@@ -164,15 +170,23 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         // pattern from the 2026-04-08 roslyn-backed-mcp audit and keeps workspace_list aligned
         // with operator expectations. Matches the "idempotent for repeated loads" language
         // already in the workspace_load tool description.
-        var existing = FindSessionByLoadedPath(fullPath);
-        if (existing is not null)
+        //
+        // When the caller passes MSBuild global properties (e.g. Configuration=Release), skip
+        // dedup so the new evaluation actually runs — an existing session was loaded with
+        // different globals and would not satisfy the caller's request.
+        var skipDedup = globalProperties is { Count: > 0 };
+        if (!skipDedup)
         {
-            existing.TouchAccess();
-            _logger.LogInformation(
-                "workspace_load: returning existing workspace '{WorkspaceId}' for path '{Path}' (idempotent)",
-                existing.WorkspaceId,
-                fullPath);
-            return BuildStatus(existing);
+            var existing = FindSessionByLoadedPath(fullPath);
+            if (existing is not null)
+            {
+                existing.TouchAccess();
+                _logger.LogInformation(
+                    "workspace_load: returning existing workspace '{WorkspaceId}' for path '{Path}' (idempotent)",
+                    existing.WorkspaceId,
+                    fullPath);
+                return BuildStatus(existing);
+            }
         }
 
         if (!await _workspaceSlots.WaitAsync(0, ct).ConfigureAwait(false))
@@ -185,23 +199,27 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         var sessionAdded = false;
         try
         {
-            await LoadIntoSessionAsync(session, fullPath, ct).ConfigureAwait(false);
+            await LoadIntoSessionAsync(session, fullPath, globalProperties, ct).ConfigureAwait(false);
 
             // Second dedup check, this time for the race window between our scan above and
             // another concurrent LoadAsync call that won the semaphore with the same path.
             // Whichever caller lost the race returns the winner's session and releases its
-            // slot in the finally block so we do not leak a slot per racing caller.
-            var raceWinner = FindSessionByLoadedPath(fullPath);
-            if (raceWinner is not null)
+            // slot in the finally block so we do not leak a slot per racing caller. Skipped
+            // under global-property overrides for the same reason as the pre-load dedup above.
+            if (!skipDedup)
             {
-                _logger.LogInformation(
-                    "workspace_load: race lost; returning winner '{WorkspaceId}' for path '{Path}' instead of new '{NewId}'",
-                    raceWinner.WorkspaceId,
-                    fullPath,
-                    workspaceId);
-                session.Dispose();
-                raceWinner.TouchAccess();
-                return BuildStatus(raceWinner);
+                var raceWinner = FindSessionByLoadedPath(fullPath);
+                if (raceWinner is not null)
+                {
+                    _logger.LogInformation(
+                        "workspace_load: race lost; returning winner '{WorkspaceId}' for path '{Path}' instead of new '{NewId}'",
+                        raceWinner.WorkspaceId,
+                        fullPath,
+                        workspaceId);
+                    session.Dispose();
+                    raceWinner.TouchAccess();
+                    return BuildStatus(raceWinner);
+                }
             }
 
             if (!_sessions.TryAdd(workspaceId, session))
@@ -1063,7 +1081,14 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         WorkspaceCacheEntry? CachedEntry,
         bool MetadataReferencesStillStable);
 
-    private async Task LoadIntoSessionAsync(WorkspaceSession session, string path, CancellationToken ct)
+    private Task LoadIntoSessionAsync(WorkspaceSession session, string path, CancellationToken ct)
+        => LoadIntoSessionAsync(session, path, globalProperties: null, ct);
+
+    private async Task LoadIntoSessionAsync(
+        WorkspaceSession session,
+        string path,
+        IDictionary<string, string>? globalProperties,
+        CancellationToken ct)
     {
         await session.LoadLock.WaitAsync(ct).ConfigureAwait(false);
         // autoreload-cascade-stdio-host-crash: build the new workspace + diagnostics queue into
@@ -1081,7 +1106,23 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         try
         {
             MsBuildInitializer.EnsureInitialized();
-            newWorkspace = MSBuildWorkspace.Create();
+            // selfhosted-shadow-copy-analyzer-reference-test-fails: when caller passes MSBuild
+            // global properties (e.g. Configuration=Release), thread them into MSBuildWorkspace
+            // so ProjectReference OutputItemType="Analyzer" entries resolve against the right
+            // bin/<config>/ tree. Without this, the default Configuration=Debug evaluation
+            // drops analyzer references on Release-only checkouts (CI runners) because the
+            // Debug TargetPath does not exist on disk.
+            newWorkspace = (globalProperties is { Count: > 0 })
+                ? MSBuildWorkspace.Create(globalProperties)
+                : MSBuildWorkspace.Create();
+            if (globalProperties is { Count: > 0 })
+            {
+                _logger.LogInformation(
+                    "Workspace {WorkspaceId}: created MSBuildWorkspace with {Count} global property override(s): {Properties}",
+                    session.WorkspaceId,
+                    globalProperties.Count,
+                    string.Join(", ", globalProperties.Select(kv => $"{kv.Key}={kv.Value}")));
+            }
             newDiagnostics = new ConcurrentQueue<DiagnosticDto>();
             var fullPath = path;
             var diagnosticsRef = newDiagnostics; // capture for the handler closure below
@@ -1124,7 +1165,12 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // by (solution, sdk) here as a candidate-set probe. The probe is best-effort: any
             // failure leaves cachedCandidate null and the cold path runs unchanged.
             CachedSolutionProbe? cachedProbe = null;
-            if (_cacheStore is not null)
+            // Skip cache probe when caller passed global property overrides — different
+            // Configuration / RuntimeIdentifier / etc. produce different MSBuild graph hashes
+            // and the post-load comparison would invalidate any hit anyway. Probing under
+            // overrides also risks short-circuiting the restore-race wait against a graph that
+            // was captured under different globals.
+            if (_cacheStore is not null && globalProperties is not { Count: > 0 })
             {
                 cachedProbe = await TryProbeWorkspaceCacheAsync(fullPath, ct).ConfigureAwait(false);
             }

--- a/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
@@ -66,7 +66,27 @@ public class ValidationIntegrationTests : SharedWorkspaceTestBase
         }
 
         var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
-        var loaded = await WorkspaceManager.LoadAsync(repositorySolutionPath, CancellationToken.None);
+
+        // selfhosted-shadow-copy-analyzer-reference-test-fails: detect the host's actual
+        // build configuration from AppContext.BaseDirectory and pass it to MSBuildWorkspace
+        // as a Configuration global property. Without this, MSBuildWorkspace defaults to
+        // Configuration=Debug evaluation; on the self-hosted Windows runner CI builds only
+        // Release, so the analyzer ProjectReference resolves to a Debug TargetPath that
+        // does not exist on disk and Roslyn drops the AnalyzerFileReference. Passing
+        // global properties also opts the load out of session deduplication, guaranteeing
+        // a fresh evaluation even if another test has already cached a session for the
+        // same path under default globals.
+        var configuration = AppContext.BaseDirectory.Contains(
+            Path.DirectorySeparatorChar + "Release" + Path.DirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase) ? "Release" : "Debug";
+        var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Configuration"] = configuration,
+        };
+        var loaded = await WorkspaceManager.LoadAsync(
+            repositorySolutionPath,
+            globalProperties,
+            CancellationToken.None);
 
         try
         {


### PR DESCRIPTION
## Summary

- Adds `LoadAsync(path, IDictionary<string,string> globalProperties, ct)` overload on `WorkspaceManager` that flows MSBuild global property overrides (e.g. `Configuration=Release`) into `MSBuildWorkspace.Create`. When set, the load also opts out of session deduplication and the cache fast-path so the new evaluation always runs. The existing 2-arg overload is unchanged for production callers.
- Updates `SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy` to detect the host's actual build configuration from `AppContext.BaseDirectory` and pass it through. Without this, `MSBuildWorkspace` defaulted to `Configuration=Debug` evaluation; on the new self-hosted Windows runner CI builds only Release, so the analyzer ProjectReference resolved to a non-existent Debug `TargetPath` and Roslyn dropped the `AnalyzerFileReference` — failing every PR with an admin-override merge.
- Closes `selfhosted-shadow-copy-analyzer-reference-test-fails` (backlog row removed; changelog fragment added).

## Test plan

- [x] `dotnet build RoslynMcp.slnx -c Release` — clean (0 warnings, 0 errors).
- [x] `dotnet test ./tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy"` — passes (8s).
- [x] `dotnet test ./RoslynMcp.slnx -c Release --no-build --filter "TestCategory!=Benchmark"` — 1143 passed, 0 failed.
- [ ] CI on the self-hosted Windows runner under LocalSystem (this PR's own run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)