### PR TITLE
chore(plan): reconcile scaffold-test-internal-target-accessibility (#584)

### DIFF
--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md
@@ -127,7 +127,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #584, 2026-05-09) |
 | Priority | Medium |
 | Backlog rows closed | `scaffold-test-internal-target-accessibility` |
 | Diagnosis | `src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs:329` builds a scaffold for the requested target, and `ResolveTargetMethod` only warns for private methods at `src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs:1121`. Internal target types and methods are treated as directly callable even when the test assembly lacks `InternalsVisibleTo`, leading to CS0122 after apply. |

--- a/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260508T171439Z_backlog-sweep/state.json
@@ -122,7 +122,7 @@
     {
       "id": "scaffold-test-internal-target-accessibility",
       "order": 7,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": ["scaffold-test-internal-target-accessibility"],
       "productionFilesTouched": 1,
       "testFilesAdded": 1,
@@ -134,9 +134,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": null
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/584",
+      "mergedAt": "2026-05-09T14:25:00Z",
+      "notes": "Shipped as PR #584 (squash 57a34bb3e41e181f102e3ecab6ff40e7c8b80d92). Added IsAccessibleFromAssembly accessibility helper walking containing types + InternalsVisibleTo via IAssemblySymbol.GivesAccessTo; emits structured warning + Assert.Inconclusive placeholder when target type/method is internal-not-visible to the test assembly. Private-on-public-type continues through existing reflection-scaffold path. 1146/1146 tests pass."
     },
     {
       "id": "validate-recent-git-changes-timeout",


### PR DESCRIPTION
Mark backlog-sweep order 7 (`scaffold-test-internal-target-accessibility`) as `merged` after PR #584 landed.

- `state.json`: status → merged, prUrl + mergedAt + notes populated
- `plan.md`: Status row → merged (PR #584, 2026-05-09)

Closes the post-merge state-flip per `ai_docs/prompts/backlog-sweep-execute.md` Step 11. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)