### PR TITLE
feat(refactoring): add parameter_object_preview tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [SECURITY.md](SECURITY.md) for disclosure policy.
 
 ## Live Surface
 
-The current release exposes **168 tools** (111 stable / 57 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
+The current release exposes **169 tools** (111 stable / 58 experimental), **13 resources** (9 stable / 4 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/src/RoslynMcp.Core/Models/ParameterObjectPreviewRequest.cs
+++ b/src/RoslynMcp.Core/Models/ParameterObjectPreviewRequest.cs
@@ -1,0 +1,46 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// Request payload for <c>parameter_object_preview</c>: groups N parameters of a target
+/// method into a generated positional <c>record</c> DTO and rewrites every call site so
+/// the original argument values flow through the new record's primary constructor.
+/// </summary>
+/// <remarks>
+/// v1 is opinionated: the generated DTO is always a <c>sealed record</c> with positional
+/// primary-constructor parameters mirroring <see cref="ParameterNames"/> in caller-supplied
+/// order. Default-value omissions and by-ref parameters refuse the preview rather than
+/// risk semantic drift. See <c>ai_docs/items/parameter-object-preview-design.md</c> for
+/// the full contract.
+/// </remarks>
+/// <param name="ParameterNames">
+/// Ordered list of parameter names on the target method to group into the new record.
+/// Must contain at least two entries; each must exist on the target. Order is preserved
+/// in the generated record's primary constructor.
+/// </param>
+/// <param name="NewTypeName">PascalCase identifier for the generated record type.</param>
+/// <param name="DtoProjectName">
+/// Optional override for the project the new record lands in. When omitted the record
+/// is added to the same project as the target method. When supplied and different from
+/// the method's project, every project containing a call site MUST already reference
+/// the override project — v1 does not auto-insert <c>&lt;ProjectReference&gt;</c> entries.
+/// </param>
+/// <param name="DtoNamespace">
+/// Optional namespace override for the generated record. Defaults to the method's
+/// containing namespace.
+/// </param>
+/// <param name="DtoFolders">
+/// Optional folder override (relative to the target project root). Defaults to folders
+/// derived from <see cref="DtoNamespace"/> via the same convention as
+/// <c>scaffold_type_preview</c>.
+/// </param>
+/// <param name="ParameterName">
+/// Optional name for the new single parameter on the rewritten method. Defaults to
+/// <see cref="NewTypeName"/> camelCased.
+/// </param>
+public sealed record ParameterObjectPreviewRequest(
+    IReadOnlyList<string> ParameterNames,
+    string NewTypeName,
+    string? DtoProjectName = null,
+    string? DtoNamespace = null,
+    IReadOnlyList<string>? DtoFolders = null,
+    string? ParameterName = null);

--- a/src/RoslynMcp.Core/Services/IParameterObjectService.cs
+++ b/src/RoslynMcp.Core/Services/IParameterObjectService.cs
@@ -1,0 +1,28 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// <c>parameter-object-preview-tool</c> (v1, experimental): groups N parameters of a
+/// target method into a positional <c>record</c> DTO and rewrites every call site to
+/// pass a single <c>new Dto(...)</c> argument in place of the grouped parameters. The
+/// preview adds the new record file and rewrites both the method declaration and every
+/// caller in one atomic snapshot, redeemable through the standard
+/// <see cref="IRefactoringService.ApplyRefactoringAsync(string, string, System.Threading.CancellationToken)"/>
+/// path. See <c>ai_docs/items/parameter-object-preview-design.md</c> for the contract.
+/// </summary>
+public interface IParameterObjectService
+{
+    /// <summary>
+    /// Builds a preview that synthesizes a positional record DTO and atomically rewrites
+    /// the target method's signature plus every call site to flow grouped argument values
+    /// through the new record. Refuses the preview structurally for default-value,
+    /// <c>ref</c>/<c>out</c>/<c>in</c>/<c>params</c>, extension <c>this</c>, local-function,
+    /// and missing cross-project-reference cases — see the design note for the full list.
+    /// </summary>
+    Task<RefactoringPreviewDto> PreviewParameterObjectAsync(
+        string workspaceId,
+        SymbolLocator target,
+        ParameterObjectPreviewRequest request,
+        CancellationToken ct);
+}

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
@@ -16,6 +16,7 @@ public static partial class ServerSurfaceCatalog
         Tool("restructure_preview", "refactoring", "experimental", true, false, "Preview a syntax-tree pattern-based find-and-replace using __placeholder__ captures."),
         Tool("replace_string_literals_preview", "refactoring", "experimental", true, false, "Preview replacing string literals in argument/initializer position with a constant expression."),
         Tool("change_signature_preview", "refactoring", "experimental", true, false, "Preview adding/removing/renaming a method parameter with all callsites updated atomically."),
+        Tool("parameter_object_preview", "refactoring", "experimental", true, false, "Preview grouping N parameters of a method into a positional sealed record DTO with all callsites updated atomically."),
         Tool("symbol_refactor_preview", "refactoring", "experimental", true, false, "Composite preview chaining rename + edit + restructure operations into a single token."),
         Tool("split_service_with_di_preview", "refactoring", "experimental", true, false, "Composite preview splitting a service into partitions + forwarding facade + DI-registration deltas."),
         Tool("record_field_add_with_satellites_preview", "refactoring", "experimental", true, false, "Composite preview synthesizing coordinated edits for satellite members when a type gains a new field."),

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Text.Json;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// <c>parameter-object-preview-tool</c> v1 (experimental): groups N parameters of a
+/// method into a positional <c>sealed record</c> and rewrites every call site to flow
+/// the grouped argument values through the new record's primary constructor. Apply via
+/// the standard <c>apply_refactoring</c> path. See
+/// <c>ai_docs/items/parameter-object-preview-design.md</c> for the contract.
+/// </summary>
+[McpServerToolType]
+public static class ParameterObjectTools
+{
+    [McpServerTool(Name = "parameter_object_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
+     McpToolMetadata("refactoring", "experimental", true, false,
+        "Preview grouping N parameters of a method into a positional sealed record DTO with all callsites updated atomically."),
+     Description("Preview replacing N parameters of a method with a single record DTO. Synthesizes a `public sealed record NewType(...)` (or `internal` when same-project + non-public containing type) and rewrites every call site so grouped arguments flow through `new NewType(...)`. Refuses (does not partially proceed) for: default-value omissions at any call site, ref/out/in/params parameters, the extension-method `this` receiver, local-function targets, and cross-project call sites where the caller project does not already reference the DTO project. Apply via apply_refactoring. v1 always emits a positional record; class/struct generation is out of scope.")]
+    public static Task<string> PreviewParameterObject(
+        IWorkspaceExecutionGate gate,
+        IParameterObjectService parameterObjectService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Names of method parameters to group, in the order they should appear on the new record's primary constructor. Must contain at least two entries.")] string[] parameterNames,
+        [Description("PascalCase name of the new record type (e.g. 'OrderRequest').")] string newTypeName,
+        [Description("Optional: absolute path to the source file containing the method declaration")] string? filePath = null,
+        [Description("Optional: 1-based line number of the method declaration")] int? line = null,
+        [Description("Optional: 1-based column number of the method declaration")] int? column = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        [Description("Optional: bare fully-qualified method name without parentheses (e.g. 'Foo.Bar.Baz').")] string? metadataName = null,
+        [Description("Optional override project for the new record. Defaults to the method's project. When different, every caller project must already reference it (no auto-add of <ProjectReference> in v1).")] string? dtoProjectName = null,
+        [Description("Optional namespace for the new record. Defaults to the method's containing namespace.")] string? dtoNamespace = null,
+        [Description("Optional folder segments under the project root for the new record file. Defaults to folders derived from the namespace.")] string[]? dtoFolders = null,
+        [Description("Optional name for the new single record-typed parameter on the rewritten method. Defaults to the camelCased newTypeName.")] string? parameterName = null,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var locator = new SymbolLocator(filePath, line, column, symbolHandle, metadataName);
+            locator.Validate();
+            var request = new ParameterObjectPreviewRequest(
+                parameterNames,
+                newTypeName,
+                dtoProjectName,
+                dtoNamespace,
+                dtoFolders,
+                parameterName);
+            var dto = await parameterObjectService.PreviewParameterObjectAsync(workspaceId, locator, request, c).ConfigureAwait(false);
+            return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
+        }, ct);
+    }
+}

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -121,6 +121,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IWorkspaceWarmService, WorkspaceWarmService>();
         services.AddSingleton<IWorkspaceDriftService, WorkspaceDriftService>();
         services.AddSingleton<IChangeSignatureService, ChangeSignatureService>();
+        services.AddSingleton<IParameterObjectService, ParameterObjectService>();
         services.AddSingleton<ISymbolRefactorService, SymbolRefactorService>();
         services.AddSingleton<IExceptionFlowService, ExceptionFlowService>();
         services.AddSingleton<IPostApplySymbolResolver, PostApplySymbolResolver>();

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -1,0 +1,635 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// <c>parameter-object-preview-tool</c> implementation. Synthesizes a positional
+/// <c>sealed record</c> DTO for a chosen subset of a method's parameters and rewrites
+/// every call site to flow grouped argument values through the new record's primary
+/// constructor. See <c>ai_docs/items/parameter-object-preview-design.md</c> for the
+/// authoritative contract (refusal cases, cross-project policy, generated-DTO shape).
+/// </summary>
+public sealed class ParameterObjectService : IParameterObjectService
+{
+    private readonly IWorkspaceManager _workspace;
+    private readonly IPreviewStore _previewStore;
+
+    public ParameterObjectService(IWorkspaceManager workspace, IPreviewStore previewStore)
+    {
+        _workspace = workspace;
+        _previewStore = previewStore;
+    }
+
+    public async Task<RefactoringPreviewDto> PreviewParameterObjectAsync(
+        string workspaceId,
+        SymbolLocator target,
+        ParameterObjectPreviewRequest request,
+        CancellationToken ct)
+    {
+        target.Validate();
+        ValidateRequest(request);
+        IdentifierValidation.ThrowIfInvalidIdentifier(request.NewTypeName, "newTypeName");
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveAsync(solution, target, ct).ConfigureAwait(false);
+        if (symbol is not IMethodSymbol method)
+            throw new InvalidOperationException(
+                $"parameter_object_preview requires a method symbol; resolved {symbol?.Kind.ToString() ?? "null"} instead.");
+
+        if (method.MethodKind == MethodKind.LocalFunction)
+            throw new ArgumentException(
+                $"parameter_object_preview does not support local functions ({method.ToDisplayString()}); v1 scope is intra-class methods only.",
+                nameof(target));
+
+        var groupedParameters = ResolveGroupedParameters(method, request);
+        EnforceParameterShapeRefusals(method, groupedParameters);
+
+        var (dtoProject, dtoVisibilityIsPublic) = ResolveDtoProject(solution, method, request);
+
+        var callerLocations = await CollectCallerSpansAsync(solution, method, ct).ConfigureAwait(false);
+        var methodProject = solution.GetProject(method.ContainingAssembly)!;
+        EnforceCrossProjectReferences(solution, methodProject, dtoProject, callerLocations);
+
+        var defaultValueWarnings = await CollectDefaultValueWarningsAsync(
+            solution, method, groupedParameters, callerLocations, ct).ConfigureAwait(false);
+        if (defaultValueWarnings.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "parameter_object_preview refuses: one or more call sites omit a grouped parameter and rely on its default value. " +
+                "Either add the explicit argument at every site first, or remove the omitted parameter from parameterNames. " +
+                "Affected sites: " + string.Join("; ", defaultValueWarnings));
+        }
+
+        var (dtoNamespace, dtoFolders) = ResolveDtoLocation(dtoProject, request, method);
+        var dtoFilePath = ResolveDtoFilePath(dtoProject, dtoFolders, request.NewTypeName);
+        var dtoSource = BuildDtoSource(dtoNamespace, request.NewTypeName, groupedParameters, dtoVisibilityIsPublic);
+
+        var newParameterName = request.ParameterName ?? CamelCase(request.NewTypeName);
+
+        var originalTexts = new Dictionary<DocumentId, string>();
+        var perFileCallsites = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        var accumulator = await RewriteMethodDeclarationAsync(
+            solution, method, groupedParameters, request.NewTypeName, newParameterName, originalTexts, ct).ConfigureAwait(false);
+
+        accumulator = await RewriteCallSitesAsync(
+            accumulator, solution, method, groupedParameters, request.NewTypeName, callerLocations,
+            originalTexts, perFileCallsites, ct).ConfigureAwait(false);
+
+        // Add the new DTO document last so its diff is appended cleanly; we capture no
+        // pre-existing text for it (it's an Added file).
+        var dtoFolderArray = dtoFolders.Count == 0 ? null : (IEnumerable<string>)dtoFolders;
+        var targetProject = accumulator.GetProject(dtoProject.Id)!;
+        var newDoc = targetProject.AddDocument(
+            $"{request.NewTypeName}.cs",
+            dtoSource,
+            folders: dtoFolderArray,
+            filePath: dtoFilePath);
+        accumulator = newDoc.Project.Solution;
+
+        var changes = await BuildFileChangesAsync(accumulator, solution, originalTexts, newDoc.Id, ct).ConfigureAwait(false);
+        if (changes.Count == 0)
+            throw new InvalidOperationException(
+                "parameter_object_preview produced no changes — verify the target method actually has parameters to group.");
+
+        var description = $"Group {groupedParameters.Count} parameter(s) of {method.ToDisplayString()} into new record '{request.NewTypeName}'";
+        var token = _previewStore.Store(workspaceId, accumulator, _workspace.GetCurrentVersion(workspaceId), description, changes);
+
+        var callsiteUpdates = perFileCallsites
+            .Select(kvp => new CallsiteUpdateDto(kvp.Key, kvp.Value))
+            .OrderBy(u => u.FilePath, StringComparer.Ordinal)
+            .ToList();
+
+        return new RefactoringPreviewDto(
+            token,
+            description,
+            changes,
+            Warnings: null,
+            CallsiteUpdates: callsiteUpdates.Count == 0 ? null : callsiteUpdates);
+    }
+
+    private static void ValidateRequest(ParameterObjectPreviewRequest request)
+    {
+        if (request.ParameterNames is null || request.ParameterNames.Count < 2)
+            throw new ArgumentException(
+                "parameter_object_preview requires at least two parameter names to group.",
+                nameof(request));
+        if (string.IsNullOrWhiteSpace(request.NewTypeName))
+            throw new ArgumentException("parameter_object_preview requires newTypeName.", nameof(request));
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in request.ParameterNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException(
+                    "parameterNames entries must be non-empty.", nameof(request));
+            if (!seen.Add(name))
+                throw new ArgumentException(
+                    $"parameterNames contains a duplicate entry: '{name}'.", nameof(request));
+        }
+    }
+
+    private static IReadOnlyList<IParameterSymbol> ResolveGroupedParameters(
+        IMethodSymbol method, ParameterObjectPreviewRequest request)
+    {
+        var byName = method.Parameters.ToDictionary(p => p.Name, p => p, StringComparer.Ordinal);
+        var grouped = new List<IParameterSymbol>(request.ParameterNames.Count);
+        foreach (var name in request.ParameterNames)
+        {
+            if (!byName.TryGetValue(name, out var p))
+                throw new ArgumentException(
+                    $"Parameter '{name}' not found on {method.ToDisplayString()}. Existing parameters: " +
+                    string.Join(", ", method.Parameters.Select(q => q.Name)),
+                    nameof(request));
+            grouped.Add(p);
+        }
+        return grouped;
+    }
+
+    private static void EnforceParameterShapeRefusals(IMethodSymbol method, IReadOnlyList<IParameterSymbol> grouped)
+    {
+        foreach (var p in grouped)
+        {
+            if (p.RefKind != RefKind.None)
+                throw new ArgumentException(
+                    $"parameter_object_preview refuses: parameter '{p.Name}' has by-ref kind '{p.RefKind}'. " +
+                    "Positional records cannot carry ref/out/in semantics; remove it from parameterNames.",
+                    nameof(grouped));
+            if (p.IsParams)
+                throw new ArgumentException(
+                    $"parameter_object_preview refuses: parameter '{p.Name}' is a 'params' array. " +
+                    "Variadic call shape does not survive grouping; remove it from parameterNames.",
+                    nameof(grouped));
+            if (p.IsThis)
+                throw new ArgumentException(
+                    $"parameter_object_preview refuses: parameter '{p.Name}' is the extension-method 'this' receiver. " +
+                    "Drop it from parameterNames; other parameters of the extension method remain eligible.",
+                    nameof(grouped));
+        }
+    }
+
+    private static (Project DtoProject, bool VisibilityIsPublic) ResolveDtoProject(
+        Solution solution, IMethodSymbol method, ParameterObjectPreviewRequest request)
+    {
+        var methodProject = solution.GetProject(method.ContainingAssembly)
+            ?? throw new InvalidOperationException(
+                $"Could not resolve a project for the method's containing assembly '{method.ContainingAssembly?.Name}'.");
+
+        if (string.IsNullOrWhiteSpace(request.DtoProjectName))
+        {
+            var sameProjectVisibility = method.ContainingType.DeclaredAccessibility == Accessibility.Public;
+            return (methodProject, sameProjectVisibility);
+        }
+
+        var dtoProject = solution.Projects.FirstOrDefault(p =>
+            string.Equals(p.Name, request.DtoProjectName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException(
+                $"dtoProjectName '{request.DtoProjectName}' was not found in the loaded solution.",
+                nameof(request));
+
+        var crossProject = dtoProject.Id != methodProject.Id;
+        // Cross-project: force public so the method's signature can reference it from another assembly.
+        var visibility = crossProject || method.ContainingType.DeclaredAccessibility == Accessibility.Public;
+        return (dtoProject, visibility);
+    }
+
+    private static async Task<Dictionary<DocumentId, List<TextSpan>>> CollectCallerSpansAsync(
+        Solution solution, IMethodSymbol method, CancellationToken ct)
+    {
+        var locations = new Dictionary<DocumentId, List<TextSpan>>();
+        var callers = await SymbolFinder.FindCallersAsync(method, solution, ct).ConfigureAwait(false);
+        foreach (var caller in callers)
+        {
+            foreach (var location in caller.Locations)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (!location.IsInSource) continue;
+                var doc = solution.GetDocument(location.SourceTree);
+                if (doc is null) continue;
+                if (!locations.TryGetValue(doc.Id, out var spans))
+                {
+                    spans = [];
+                    locations[doc.Id] = spans;
+                }
+                if (!spans.Contains(location.SourceSpan))
+                    spans.Add(location.SourceSpan);
+            }
+        }
+        return locations;
+    }
+
+    private static void EnforceCrossProjectReferences(
+        Solution solution,
+        Project methodProject,
+        Project dtoProject,
+        Dictionary<DocumentId, List<TextSpan>> callerLocations)
+    {
+        var missing = new List<string>();
+        var seenProjects = new HashSet<ProjectId>();
+
+        // The declaring project must reference the DTO project so the rewritten signature
+        // (which now mentions the new record type) compiles. Same-project case is the no-op.
+        void Check(Project p)
+        {
+            if (p.Id == dtoProject.Id) return;
+            if (!seenProjects.Add(p.Id)) return;
+            var hasReference = p.AllProjectReferences.Any(r => r.ProjectId == dtoProject.Id);
+            if (!hasReference) missing.Add($"{p.Name} -> {dtoProject.Name}");
+        }
+
+        Check(methodProject);
+        foreach (var docId in callerLocations.Keys)
+        {
+            var callerProject = solution.GetProject(docId.ProjectId);
+            if (callerProject is null) continue;
+            Check(callerProject);
+        }
+
+        if (missing.Count > 0)
+            throw new ArgumentException(
+                "parameter_object_preview refuses: one or more caller projects do not reference the DTO project. " +
+                "Add a project reference (use add_project_reference_preview) for each entry, then retry. " +
+                "Missing references: " + string.Join("; ", missing));
+    }
+
+    private static async Task<List<string>> CollectDefaultValueWarningsAsync(
+        Solution solution,
+        IMethodSymbol method,
+        IReadOnlyList<IParameterSymbol> grouped,
+        Dictionary<DocumentId, List<TextSpan>> callerLocations,
+        CancellationToken ct)
+    {
+        var groupedSet = new HashSet<string>(grouped.Select(p => p.Name), StringComparer.Ordinal);
+        var warnings = new List<string>();
+
+        foreach (var (docId, spans) in callerLocations)
+        {
+            var doc = solution.GetDocument(docId);
+            if (doc is null) continue;
+            var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            if (root is null) continue;
+            foreach (var span in spans)
+            {
+                var node = root.FindNode(span);
+                var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                if (invocation is null) continue;
+
+                var providedNames = CollectProvidedParameterNames(invocation, method);
+                foreach (var groupedName in groupedSet)
+                {
+                    if (providedNames.Contains(groupedName)) continue;
+                    var lineSpan = invocation.GetLocation().GetLineSpan();
+                    var filePath = doc.FilePath ?? doc.Name;
+                    warnings.Add($"{filePath}:{lineSpan.StartLinePosition.Line + 1} omits '{groupedName}'");
+                }
+            }
+        }
+        return warnings;
+    }
+
+    private static HashSet<string> CollectProvidedParameterNames(InvocationExpressionSyntax invocation, IMethodSymbol method)
+    {
+        // Build the set of parameter names actually supplied at this call site, accounting
+        // for both positional prefix and named-argument suffix. Anything missing relied on
+        // a default value and triggers the refusal path.
+        var args = invocation.ArgumentList.Arguments;
+        var provided = new HashSet<string>(StringComparer.Ordinal);
+        var positionalIndex = 0;
+        foreach (var arg in args)
+        {
+            if (arg.NameColon is null)
+            {
+                if (positionalIndex < method.Parameters.Length)
+                    provided.Add(method.Parameters[positionalIndex].Name);
+                positionalIndex++;
+            }
+            else
+            {
+                provided.Add(arg.NameColon.Name.Identifier.ValueText);
+            }
+        }
+        return provided;
+    }
+
+    private static (string Namespace, IReadOnlyList<string> Folders) ResolveDtoLocation(
+        Project dtoProject, ParameterObjectPreviewRequest request, IMethodSymbol method)
+    {
+        var ns = request.DtoNamespace;
+        if (string.IsNullOrWhiteSpace(ns))
+        {
+            ns = method.ContainingNamespace?.IsGlobalNamespace == false
+                ? method.ContainingNamespace.ToDisplayString()
+                : dtoProject.Name;
+        }
+
+        IReadOnlyList<string> folders;
+        if (request.DtoFolders is { Count: > 0 })
+        {
+            folders = request.DtoFolders;
+        }
+        else
+        {
+            folders = ResolveFolderSegmentsForNamespace(ns!, dtoProject.Name);
+        }
+        return (ns!, folders);
+    }
+
+    private static IReadOnlyList<string> ResolveFolderSegmentsForNamespace(string typeNamespace, string projectName)
+    {
+        // Mirrors ScaffoldingService.ResolveFolderSegmentsForNamespace — kept private to
+        // avoid widening that helper's visibility for a single new caller.
+        if (string.IsNullOrWhiteSpace(typeNamespace) || string.Equals(typeNamespace, projectName, StringComparison.Ordinal))
+            return Array.Empty<string>();
+        var working = typeNamespace.StartsWith(projectName + ".", StringComparison.Ordinal)
+            ? typeNamespace[(projectName.Length + 1)..]
+            : typeNamespace;
+        return working.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static string ResolveDtoFilePath(Project dtoProject, IReadOnlyList<string> folders, string typeName)
+    {
+        var projectDir = Path.GetDirectoryName(dtoProject.FilePath)
+            ?? throw new InvalidOperationException(
+                $"DTO project '{dtoProject.Name}' has no resolvable directory (FilePath='{dtoProject.FilePath}').");
+        return Path.Combine([projectDir, .. folders, $"{typeName}.cs"]);
+    }
+
+    private static string BuildDtoSource(
+        string ns, string typeName, IReadOnlyList<IParameterSymbol> grouped, bool isPublic)
+    {
+        var visibility = isPublic ? "public" : "internal";
+        var sb = new StringBuilder();
+        sb.Append("namespace ").Append(ns).AppendLine(";");
+        sb.AppendLine();
+        sb.Append(visibility).Append(" sealed record ").Append(typeName).Append('(');
+        for (var i = 0; i < grouped.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(grouped[i].Type.ToDisplayString()).Append(' ').Append(Capitalize(grouped[i].Name));
+        }
+        sb.AppendLine(");");
+        return sb.ToString();
+    }
+
+    private static string Capitalize(string name) =>
+        string.IsNullOrEmpty(name) ? name : char.ToUpperInvariant(name[0]) + name[1..];
+
+    private static string CamelCase(string name) =>
+        string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name[1..];
+
+    private static async Task<Solution> RewriteMethodDeclarationAsync(
+        Solution solution,
+        IMethodSymbol method,
+        IReadOnlyList<IParameterSymbol> grouped,
+        string newTypeName,
+        string newParameterName,
+        Dictionary<DocumentId, string> originalTexts,
+        CancellationToken ct)
+    {
+        var accumulator = solution;
+        var groupedNames = new HashSet<string>(grouped.Select(p => p.Name), StringComparer.Ordinal);
+
+        foreach (var declRef in method.DeclaringSyntaxReferences)
+        {
+            var node = await declRef.GetSyntaxAsync(ct).ConfigureAwait(false);
+            if (node is not BaseMethodDeclarationSyntax mds) continue;
+            var doc = accumulator.GetDocument(node.SyntaxTree);
+            if (doc is null) continue;
+
+            await CaptureOriginalTextAsync(originalTexts, solution, doc.Id, ct).ConfigureAwait(false);
+            var oldRoot = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            if (oldRoot is null) continue;
+
+            var currentMds = oldRoot.FindNode(mds.Span).FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+            if (currentMds is null) continue;
+
+            var existingList = currentMds.ParameterList;
+            var newParamTexts = new List<string>(existingList.Parameters.Count);
+            var insertedDtoParam = false;
+            foreach (var p in existingList.Parameters)
+            {
+                if (groupedNames.Contains(p.Identifier.ValueText))
+                {
+                    if (!insertedDtoParam)
+                    {
+                        newParamTexts.Add($"{newTypeName} {newParameterName}");
+                        insertedDtoParam = true;
+                    }
+                    continue;
+                }
+                newParamTexts.Add(p.ToString());
+            }
+            if (!insertedDtoParam)
+                newParamTexts.Add($"{newTypeName} {newParameterName}");
+
+            var newListText = "(" + string.Join(", ", newParamTexts) + ")";
+            var newList = SyntaxFactory.ParseParameterList(newListText).WithTriviaFrom(existingList);
+            var newRoot = oldRoot.ReplaceNode(existingList, newList);
+            accumulator = accumulator.WithDocumentText(doc.Id, SourceText.From(newRoot.ToFullString()));
+        }
+        return accumulator;
+    }
+
+    private static async Task<Solution> RewriteCallSitesAsync(
+        Solution accumulator,
+        Solution baselineSolution,
+        IMethodSymbol method,
+        IReadOnlyList<IParameterSymbol> grouped,
+        string newTypeName,
+        Dictionary<DocumentId, List<TextSpan>> callerLocations,
+        Dictionary<DocumentId, string> originalTexts,
+        Dictionary<string, int> perFileCallsites,
+        CancellationToken ct)
+    {
+        var groupedNameToOrder = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < grouped.Count; i++) groupedNameToOrder[grouped[i].Name] = i;
+        var firstGroupedParameterIndex = method.Parameters
+            .Select((p, idx) => (p.Name, idx))
+            .Where(t => groupedNameToOrder.ContainsKey(t.Name))
+            .Select(t => (int?)t.idx)
+            .FirstOrDefault() ?? 0;
+
+        foreach (var (docId, spans) in callerLocations)
+        {
+            ct.ThrowIfCancellationRequested();
+            await CaptureOriginalTextAsync(originalTexts, baselineSolution, docId, ct).ConfigureAwait(false);
+
+            // Sort spans descending so earlier replacements don't shift later spans.
+            spans.Sort((a, b) => b.Start.CompareTo(a.Start));
+            foreach (var span in spans)
+            {
+                ct.ThrowIfCancellationRequested();
+                var doc = accumulator.GetDocument(docId);
+                if (doc is null) break;
+                var oldRoot = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                if (oldRoot is null) break;
+
+                var node = oldRoot.FindNode(span);
+                var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                if (invocation is null) continue;
+
+                var newArgList = BuildRewrittenArgumentList(
+                    invocation.ArgumentList, method, grouped, groupedNameToOrder, firstGroupedParameterIndex, newTypeName);
+                if (newArgList is null) continue;
+
+                var newInvocation = invocation.WithArgumentList(newArgList);
+                var newRoot = oldRoot.ReplaceNode(invocation, newInvocation);
+                accumulator = accumulator.WithDocumentText(docId, SourceText.From(newRoot.ToFullString()));
+
+                var filePath = doc.FilePath ?? doc.Name;
+                perFileCallsites[filePath] = perFileCallsites.TryGetValue(filePath, out var c) ? c + 1 : 1;
+            }
+        }
+        return accumulator;
+    }
+
+    private static ArgumentListSyntax? BuildRewrittenArgumentList(
+        ArgumentListSyntax argList,
+        IMethodSymbol method,
+        IReadOnlyList<IParameterSymbol> grouped,
+        Dictionary<string, int> groupedNameToOrder,
+        int spliceIndex,
+        string newTypeName)
+    {
+        // Materialize the lexical args into a semantic slot array indexed by the original
+        // method's parameter order. NameColon args land in the named slot; positional args
+        // fill the prefix lexically. Missing slots indicate default-value omission — already
+        // refused upstream for grouped parameters; for non-grouped ones we leave the
+        // omission as-is (the rewritten call still relies on the same default).
+        var args = argList.Arguments;
+        var semanticArgs = new ArgumentSyntax?[method.Parameters.Length];
+        var positionalIndex = 0;
+        foreach (var arg in args)
+        {
+            if (arg.NameColon is null)
+            {
+                if (positionalIndex < semanticArgs.Length) semanticArgs[positionalIndex] = arg;
+                positionalIndex++;
+            }
+            else
+            {
+                var name = arg.NameColon.Name.Identifier.ValueText;
+                for (var k = 0; k < method.Parameters.Length; k++)
+                {
+                    if (string.Equals(method.Parameters[k].Name, name, StringComparison.Ordinal))
+                    {
+                        semanticArgs[k] = arg;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Build the DTO constructor args in `parameterNames` order, stripping NameColon
+        // (positional-record primary ctor takes positional args).
+        var dtoArgs = new List<ArgumentSyntax>(grouped.Count);
+        for (var i = 0; i < grouped.Count; i++)
+        {
+            // grouped[i] is the i-th parameterName. Find its index on the original method.
+            var paramName = grouped[i].Name;
+            var paramIndex = -1;
+            for (var k = 0; k < method.Parameters.Length; k++)
+            {
+                if (string.Equals(method.Parameters[k].Name, paramName, StringComparison.Ordinal))
+                {
+                    paramIndex = k;
+                    break;
+                }
+            }
+            if (paramIndex < 0) return null;
+            var src = semanticArgs[paramIndex];
+            if (src is null) return null; // would have been caught upstream as default-value refusal
+            var stripped = SyntaxFactory.Argument(src.Expression.WithoutTrivia());
+            dtoArgs.Add(i == 0 ? stripped : stripped.WithLeadingTrivia(SyntaxFactory.Space));
+        }
+
+        var dtoCreation = SyntaxFactory.ObjectCreationExpression(
+            SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+            SyntaxFactory.IdentifierName(newTypeName),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(dtoArgs)),
+            initializer: null);
+
+        // Build the rewritten outer call's argument list. Walk the original method's
+        // parameters in order; emit a single Argument(dtoCreation) at the first grouped
+        // index, skip the rest of the grouped params, and emit non-grouped args
+        // unchanged (preserving their original NameColon shape if any).
+        var outerArgs = new List<ArgumentSyntax>();
+        var emittedDto = false;
+        for (var k = 0; k < method.Parameters.Length; k++)
+        {
+            var paramName = method.Parameters[k].Name;
+            if (groupedNameToOrder.ContainsKey(paramName))
+            {
+                if (!emittedDto)
+                {
+                    outerArgs.Add(SyntaxFactory.Argument(dtoCreation));
+                    emittedDto = true;
+                }
+                continue;
+            }
+            var src = semanticArgs[k];
+            if (src is null) continue; // omitted, relies on original default — fine for non-grouped
+            outerArgs.Add(SyntaxFactory.Argument(src.NameColon, src.RefKindKeyword, src.Expression.WithoutTrivia()));
+        }
+        if (!emittedDto)
+            outerArgs.Add(SyntaxFactory.Argument(dtoCreation));
+
+        // Add canonical inter-arg leading-space trivia.
+        for (var i = 1; i < outerArgs.Count; i++)
+            outerArgs[i] = outerArgs[i].WithLeadingTrivia(SyntaxFactory.Space);
+
+        return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(outerArgs))
+            .WithTriviaFrom(argList);
+    }
+
+    private static async Task<string> CaptureOriginalTextAsync(
+        Dictionary<DocumentId, string> originalTexts,
+        Solution solution,
+        DocumentId docId,
+        CancellationToken ct)
+    {
+        if (originalTexts.TryGetValue(docId, out var cached)) return cached;
+        var doc = solution.GetDocument(docId);
+        if (doc is null) return string.Empty;
+        var text = (await doc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+        originalTexts[docId] = text;
+        return text;
+    }
+
+    private static async Task<List<FileChangeDto>> BuildFileChangesAsync(
+        Solution accumulator,
+        Solution baseline,
+        Dictionary<DocumentId, string> originalTexts,
+        DocumentId addedDocId,
+        CancellationToken ct)
+    {
+        var changes = new List<FileChangeDto>();
+        foreach (var (docId, originalText) in originalTexts)
+        {
+            var finalDoc = accumulator.GetDocument(docId);
+            if (finalDoc is null) continue;
+            var finalText = (await finalDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+            if (string.Equals(finalText, originalText, StringComparison.Ordinal)) continue;
+            var filePath = finalDoc.FilePath ?? finalDoc.Name;
+            changes.Add(new FileChangeDto(filePath, DiffGenerator.GenerateUnifiedDiff(originalText, finalText, filePath)));
+        }
+
+        var addedDoc = accumulator.GetDocument(addedDocId);
+        if (addedDoc is not null)
+        {
+            var addedText = (await addedDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+            var addedPath = addedDoc.FilePath ?? addedDoc.Name;
+            changes.Add(new FileChangeDto(addedPath, DiffGenerator.GenerateUnifiedDiff(string.Empty, addedText, addedPath)));
+        }
+        return changes;
+    }
+}

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -1,0 +1,321 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the v1 <c>parameter_object_preview</c> tool. The seven cases mirror the
+/// regression set named in <c>ai_docs/items/parameter-object-preview-design.md</c> §(f):
+/// (1) positional grouping, (2) named + mixed call sites, (3) default-value refusal,
+/// (4) ref/out refusal, (5) cross-project success, (6) cross-project missing-reference
+/// refusal, (7) end-to-end apply via <c>RefactoringService.ApplyRefactoringAsync</c>.
+/// </summary>
+[TestClass]
+public sealed class ParameterObjectPreviewTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task PositionalGrouping_SingleProject_RewritesBothDeclarationAndCallsite()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class POPosFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int Caller() => Sum(1, 2, 3);
+            }
+            """,
+            "POPosFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16), // 'Sum'
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                CancellationToken.None);
+
+            Assert.IsNotNull(preview.PreviewToken);
+            var fixtureDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("POPosFixture.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(fixtureDiff);
+            StringAssert.Contains(fixtureDiff, "SumArgs sumArgs", "declaration should take the new record param");
+            StringAssert.Contains(fixtureDiff, "new SumArgs(1, 2, 3)", "callsite should wrap grouped args in new SumArgs(...)");
+
+            var addedDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("SumArgs.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(addedDiff, "preview must include the new DTO file");
+            StringAssert.Contains(addedDiff, "public sealed record SumArgs(int A, int B, int C)");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task NamedAndMixedCallSites_RewriteToPositionalDtoConstructor()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class PONamedFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int CallNamed() => Sum(c: 3, a: 1, b: 2);
+                public int CallMixed() => Sum(1, c: 3, b: 2);
+            }
+            """,
+            "PONamedFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                CancellationToken.None);
+
+            var diff = preview.Changes.First(c => c.FilePath.EndsWith("PONamedFixture.cs", StringComparison.OrdinalIgnoreCase)).UnifiedDiff;
+            // Both call sites must collapse to the same positional `new SumArgs(1, 2, 3)`.
+            var occurrences = CountOccurrences(diff, "new SumArgs(1, 2, 3)");
+            Assert.AreEqual(2, occurrences, $"Expected both call sites rewritten to positional. Diff:\n{diff}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task DefaultValueOmissionAtCallSite_RefusesPreview()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class PODefaultFixture
+            {
+                public int Sum(int a, int b = 0, int c = 0) => a + b + c;
+
+                public int Caller() => Sum(a: 1, c: 3); // omits 'b'
+            }
+            """,
+            "PODefaultFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "omits 'b'");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task RefOutParameter_RefusesEntirePreview()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class PORefFixture
+            {
+                public void Compute(int a, ref int b) { b = a; }
+
+                public void Caller() { int x = 0; Compute(1, ref x); }
+            }
+            """,
+            "PORefFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 17),
+                    new ParameterObjectPreviewRequest(["a", "b"], "ComputeArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "by-ref kind");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task CrossProject_RewritesCallSiteWhenReferenceExists()
+    {
+        // SampleApp already references SampleLib in the SampleSolution fixture, so a method
+        // declared in SampleLib with a SampleApp call site exercises the reference-present path.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var libDir = Path.Combine(solutionDir, "SampleLib");
+        var appDir = Path.Combine(solutionDir, "SampleApp");
+
+        var libFile = Path.Combine(libDir, "POCrossLib.cs");
+        await File.WriteAllTextAsync(libFile,
+            """
+            namespace SampleLib;
+
+            public class POCrossLib
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+            }
+            """);
+        var appFile = Path.Combine(appDir, "POCrossApp.cs");
+        await File.WriteAllTextAsync(appFile,
+            """
+            using SampleLib;
+
+            namespace SampleApp;
+
+            public static class POCrossApp
+            {
+                public static int Run() => new POCrossLib().Sum(1, 2, 3);
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(libFile, line: 5, column: 16),
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                CancellationToken.None);
+
+            Assert.IsNotNull(preview.PreviewToken);
+            Assert.IsTrue(preview.Changes.Any(c => c.FilePath.EndsWith("POCrossLib.cs", StringComparison.OrdinalIgnoreCase)));
+            var appDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("POCrossApp.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(appDiff, "cross-project caller must be rewritten");
+            StringAssert.Contains(appDiff, "new SumArgs(1, 2, 3)");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task CrossProject_RefusesWhenCallerProjectMissingReference()
+    {
+        // Place the method in SampleApp (which is NOT referenced by SampleLib.Tests) and
+        // request the DTO to land in SampleApp; then create a caller in SampleLib.Tests that
+        // can compile against SampleApp's type *only via* a fixture-lib reference. To keep the
+        // setup simple, we instead place the method in SampleLib.Tests (which references both)
+        // and request the DTO to live in SampleApp — SampleLib.Tests references SampleApp? Let's
+        // verify by inverse: method in SampleLib, dtoProjectName=SampleApp. SampleLib does NOT
+        // reference SampleApp, so the SampleLib declaration's project is missing the reference.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var libDir = Path.Combine(solutionDir, "SampleLib");
+
+        var libFile = Path.Combine(libDir, "POCrossMissingLib.cs");
+        await File.WriteAllTextAsync(libFile,
+            """
+            namespace SampleLib;
+
+            public class POCrossMissingLib
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(libFile, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoProjectName: "SampleApp"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "SampleLib -> SampleApp");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ApplyRefactoring_WritesNewFileAndRewritesCallSitesOnDisk()
+    {
+        var (workspaceId, fixturePath, fixtureDir) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class POApplyFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int Caller() => Sum(1, 2, 3);
+            }
+            """,
+            "POApplyFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                CancellationToken.None);
+
+            var apply = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+            Assert.IsTrue(apply.Success, $"Apply must succeed: {apply.Error}");
+
+            var dtoPath = Path.Combine(fixtureDir, "SumArgs.cs");
+            Assert.IsTrue(File.Exists(dtoPath), "DTO file must be written to disk");
+            var dtoText = await File.ReadAllTextAsync(dtoPath);
+            StringAssert.Contains(dtoText, "public sealed record SumArgs(int A, int B, int C);");
+
+            var fixtureText = await File.ReadAllTextAsync(fixturePath);
+            StringAssert.Contains(fixtureText, "Sum(SumArgs sumArgs)");
+            StringAssert.Contains(fixtureText, "new SumArgs(1, 2, 3)");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    private static async Task<(string WorkspaceId, string FixturePath, string FixtureDir)> SetupSingleProjectFixtureAsync(
+        string content, string fileName)
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var libDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(libDir, fileName);
+        await File.WriteAllTextAsync(fixturePath, content);
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        return (loadResult.WorkspaceId, fixturePath, libDir);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { count++; i += needle.Length; }
+        return count;
+    }
+}

--- a/tests/RoslynMcp.Tests/TestBase.cs
+++ b/tests/RoslynMcp.Tests/TestBase.cs
@@ -81,6 +81,7 @@ public abstract class TestBase
     protected static ExceptionFlowService ExceptionFlowService { get; private set; } = null!;
     protected static WorkspaceWarmService WorkspaceWarmService { get; private set; } = null!;
     protected static WorkspaceDriftService WorkspaceDriftService { get; private set; } = null!;
+    protected static ParameterObjectService ParameterObjectService { get; private set; } = null!;
 
     /// <summary>
     /// On-disk workspace cache store rooted under the test temp tree. Internal infrastructure
@@ -191,6 +192,7 @@ public abstract class TestBase
         ExceptionFlowService = services.ExceptionFlowService;
         WorkspaceWarmService = services.WorkspaceWarmService;
         WorkspaceDriftService = services.WorkspaceDriftService;
+        ParameterObjectService = services.ParameterObjectService;
 
         // workspace-cache-store-infrastructure: rooted in a per-assembly temp directory so
         // shared-fixture tests don't pollute the user's real ~/.roslyn-mcp/cache during runs.

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -68,6 +68,7 @@ internal sealed class TestServiceContainer
     public required ExceptionFlowService ExceptionFlowService { get; init; }
     public required WorkspaceWarmService WorkspaceWarmService { get; init; }
     public required WorkspaceDriftService WorkspaceDriftService { get; init; }
+    public required ParameterObjectService ParameterObjectService { get; init; }
 
     public static TestServiceContainer Create(ValidationServiceOptions validationOptions)
     {
@@ -281,7 +282,8 @@ internal sealed class TestServiceContainer
             WorkspaceWarmService = new WorkspaceWarmService(
                 workspaceManager,
                 NullLogger<WorkspaceWarmService>.Instance),
-            WorkspaceDriftService = new WorkspaceDriftService(workspaceManager)
+            WorkspaceDriftService = new WorkspaceDriftService(workspaceManager),
+            ParameterObjectService = new ParameterObjectService(workspaceManager, previewStore)
         };
     }
 }


### PR DESCRIPTION
## Summary

Implements v1 of the `parameter_object_preview` MCP tool per `ai_docs/items/parameter-object-preview-design.md`. Groups N parameters of a target method into a positional `sealed record` DTO and rewrites every call site atomically. The preview produces an Added file (the new record) plus declaration and call-site rewrites, redeemable through the existing `apply_refactoring` path.

- Core contract (`IParameterObjectService` + `ParameterObjectPreviewRequest`)
- Roslyn implementation (`ParameterObjectService`) — pre-flight refuses default-value omissions, ref/out/in/params, extension `this`, local functions, and missing cross-project references
- Host.Stdio tool surface + catalog entry (`refactoring` / `experimental`)
- DI registration in `RoslynMcp.Roslyn.ServiceCollectionExtensions`
- README live-surface count bumped: 168 -> 169 tools, 57 -> 58 experimental

## Test plan

Seven-case regression set in `ParameterObjectPreviewTests`:

- [x] positional grouping single project
- [x] named + mixed call sites collapse to positional `new Dto(...)`
- [x] default-value omission refused with structured warning naming the missing parameter
- [x] ref/out parameter refused with `ArgumentException`
- [x] cross-project rewrite when reference exists (SampleApp -> SampleLib)
- [x] cross-project refused when caller-or-declarer project does not reference dtoProject
- [x] `apply_refactoring` writes the new file AND rewrites call sites on disk
- [x] `verify-ai-docs.ps1` passes
- [x] `verify-release.ps1 -Configuration Release -NoCoverage` passes (1153/1153 tests)

Closes: parameter-object-preview-tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)