### PR TITLE
feat(change-signature): support op=reorder with callsite rewrites

### DIFF
--- a/src/RoslynMcp.Core/Services/IChangeSignatureService.cs
+++ b/src/RoslynMcp.Core/Services/IChangeSignatureService.cs
@@ -22,9 +22,8 @@ public interface IChangeSignatureService
 ///   <item><description><c>add</c> — insert a new parameter at <see cref="Position"/> (or trailing if null). Requires <see cref="Name"/>, <see cref="ParameterType"/>; uses <see cref="DefaultValue"/> at every callsite.</description></item>
 ///   <item><description><c>remove</c> — drop the parameter at <see cref="Position"/>. Updates callsites by removing the matching positional or named argument.</description></item>
 ///   <item><description><c>rename</c> — change the parameter name (delegate to rename engine for callsites using named args). Requires <see cref="Name"/> (current) and <see cref="NewName"/>.</description></item>
+///   <item><description><c>reorder</c> — permute parameters via <see cref="NewOrder"/> (comma-separated list of parameter names OR 0-based indices that must be a permutation of the existing parameters). Declaration is reordered, positional callsites are reordered to match, named-only callsites are left as-is, and mixed positional+named callsites raise an actionable error.</description></item>
 /// </list>
-/// Parameter reordering is not supported — callers that need it should issue a sequence of
-/// remove + add ops via <c>symbol_refactor_preview</c>, or fall back to a multi-file edit.
 /// </summary>
 public sealed record ChangeSignatureRequest(
     string Op,
@@ -32,4 +31,5 @@ public sealed record ChangeSignatureRequest(
     string? NewName = null,
     string? ParameterType = null,
     string? DefaultValue = null,
-    int? Position = null);
+    int? Position = null,
+    string? NewOrder = null);

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Refactoring.cs
@@ -15,7 +15,7 @@ public static partial class ServerSurfaceCatalog
         Tool("code_fix_apply", "refactoring", "stable", false, true, "Apply a previously previewed curated code fix."),
         Tool("restructure_preview", "refactoring", "experimental", true, false, "Preview a syntax-tree pattern-based find-and-replace using __placeholder__ captures."),
         Tool("replace_string_literals_preview", "refactoring", "experimental", true, false, "Preview replacing string literals in argument/initializer position with a constant expression."),
-        Tool("change_signature_preview", "refactoring", "experimental", true, false, "Preview adding/removing/renaming a method parameter with all callsites updated atomically."),
+        Tool("change_signature_preview", "refactoring", "experimental", true, false, "Preview adding/removing/renaming/reordering a method parameter with all callsites updated atomically."),
         Tool("parameter_object_preview", "refactoring", "experimental", true, false, "Preview grouping N parameters of a method into a positional sealed record DTO with all callsites updated atomically."),
         Tool("symbol_refactor_preview", "refactoring", "experimental", true, false, "Composite preview chaining rename + edit + restructure operations into a single token."),
         Tool("split_service_with_di_preview", "refactoring", "experimental", true, false, "Composite preview splitting a service into partitions + forwarding facade + DI-registration deltas."),

--- a/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
@@ -19,13 +19,13 @@ public static class ChangeSignatureTools
 {
     [McpServerTool(Name = "change_signature_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
-        "Preview adding/removing/renaming a method parameter with all callsites updated atomically."),
-     Description("Preview a change to a method's signature: add, remove, or rename a parameter. The declaration AND every callsite are rewritten in one preview token. For 'add', supply Name + ParameterType + DefaultValue (default value is spliced into every existing callsite). For 'remove', supply Name OR Position. For 'rename', supply Name (current) + NewName. Reordering is not supported — stage a remove + add pair via symbol_refactor_preview if you need it.")]
+        "Preview adding/removing/renaming/reordering a method parameter with all callsites updated atomically."),
+     Description("Preview a change to a method's signature: add, remove, rename, or reorder parameters. The declaration AND every callsite are rewritten in one preview token. For 'add', supply Name + ParameterType + DefaultValue. For 'remove', supply Name OR Position. For 'rename', supply Name (current) + NewName. For 'reorder', supply NewOrder as a comma-separated permutation of parameter names or 0-based indices (e.g. 'b,a,c' or '1,0,2'); positional callsites are reordered, all-named callsites are left as-is, mixed callsites are refused.")]
     public static Task<string> PreviewChangeSignature(
         IWorkspaceExecutionGate gate,
         IChangeSignatureService changeSignatureService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Operation: 'add', 'remove', or 'rename'. Reordering parameters is not supported.")] string op,
+        [Description("Operation: 'add', 'remove', 'rename', or 'reorder'.")] string op,
         [Description("Optional: absolute path to the source file containing the method declaration")] string? filePath = null,
         [Description("Optional: 1-based line number of the method declaration")] int? line = null,
         [Description("Optional: 1-based column number of the method declaration")] int? column = null,
@@ -36,13 +36,14 @@ public static class ChangeSignatureTools
         [Description("op='add' only: the parameter type (e.g. 'string', 'IReadOnlyList<int>', 'CancellationToken').")] string? parameterType = null,
         [Description("op='add' only: the default value spliced into every existing callsite (e.g. 'null', 'default', '\"\"', '0').")] string? defaultValue = null,
         [Description("Optional position (0-based) of the parameter. For op='add': insertion index (defaults to trailing). For op='remove': index to drop.")] int? position = null,
+        [Description("op='reorder' only: comma-separated permutation of parameter names or 0-based indices (e.g. 'b,a,c' or '1,0,2'). Must list every parameter exactly once.")] string? newOrder = null,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var locator = new SymbolLocator(filePath, line, column, symbolHandle, metadataName);
             locator.Validate();
-            var request = new ChangeSignatureRequest(op, name, newName, parameterType, defaultValue, position);
+            var request = new ChangeSignatureRequest(op, name, newName, parameterType, defaultValue, position, newOrder);
             var dto = await changeSignatureService.PreviewChangeSignatureAsync(workspaceId, locator, request, c).ConfigureAwait(false);
             return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
         }, ct);

--- a/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ChangeSignatureService.cs
@@ -9,10 +9,10 @@ using RoslynMcp.Roslyn.Helpers;
 namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
-/// Item 3 implementation. Supports <c>add</c>, <c>remove</c>, and <c>rename</c> ops by
-/// rewriting both the method declaration and every callsite in one atomic preview.
-/// Reordering parameters is not supported — callers that need it should stage a
-/// remove + add pair via <c>symbol_refactor_preview</c>.
+/// Item 3 implementation. Supports <c>add</c>, <c>remove</c>, <c>rename</c>, and
+/// <c>reorder</c> ops by rewriting both the method declaration and every callsite in one
+/// atomic preview. Reorder accepts a <c>NewOrder</c> permutation of parameter names or
+/// 0-based indices; mixed positional+named callsites raise an actionable error.
 /// </summary>
 public sealed class ChangeSignatureService : IChangeSignatureService
 {
@@ -91,10 +91,9 @@ public sealed class ChangeSignatureService : IChangeSignatureService
             "add" => await PreviewAddParameterAsync(workspaceId, solution, method, request, ct).ConfigureAwait(false),
             "remove" => await PreviewRemoveParameterAsync(workspaceId, solution, method, request, ct).ConfigureAwait(false),
             "rename" => await PreviewRenameParameterAsync(workspaceId, method, request, ct).ConfigureAwait(false),
+            "reorder" => await PreviewReorderParametersAsync(workspaceId, solution, method, request, ct).ConfigureAwait(false),
             _ => throw new ArgumentException(
-                $"Unsupported op '{request.Op}'. Valid values: add, remove, rename. " +
-                "Parameter reordering is not supported — stage a remove + add pair via symbol_refactor_preview " +
-                "or fall back to preview_multi_file_edit.",
+                $"Unsupported op '{request.Op}'. Valid values: add, remove, rename, reorder.",
                 nameof(request)),
         };
     }
@@ -259,6 +258,183 @@ public sealed class ChangeSignatureService : IChangeSignatureService
         var lineSpan = loc.GetLineSpan();
         var renameLocator = SymbolLocator.BySource(loc.SourceTree!.FilePath, lineSpan.StartLinePosition.Line + 1, lineSpan.StartLinePosition.Character + 1);
         return await _refactoringService.PreviewRenameAsync(workspaceId, renameLocator, request.NewName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reorder method parameters according to <see cref="ChangeSignatureRequest.NewOrder"/>.
+    /// <para>
+    /// <c>NewOrder</c> is a comma-separated list that must be a permutation of the existing
+    /// parameters: each token is either a parameter name or a 0-based index. The declaration
+    /// is rewritten to match. Per-callsite handling:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>All-positional callsite — arguments are reordered to match the new permutation.</description></item>
+    ///   <item><description>All-named callsite — left untouched (named args carry the binding by name; reorder has no semantic effect).</description></item>
+    ///   <item><description>Mixed positional + named callsite — refused with an actionable error citing the callsite location, because remapping the positional prefix can silently change which parameter a positional argument binds to.</description></item>
+    /// </list>
+    /// <para>
+    /// <c>params</c> arrays MUST remain in the trailing position (otherwise the C# parser
+    /// rejects them); we refuse if the new order moves a <c>params</c> parameter off the
+    /// trailing slot.
+    /// </para>
+    /// </summary>
+    private async Task<RefactoringPreviewDto> PreviewReorderParametersAsync(
+        string workspaceId, Solution solution, IMethodSymbol method, ChangeSignatureRequest request, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.NewOrder))
+            throw new ArgumentException(
+                "op='reorder' requires NewOrder — a comma-separated permutation of the existing parameters " +
+                "(by name or 0-based index, e.g. 'b,a,c' or '1,0,2').",
+                nameof(request));
+
+        var permutation = ParseAndValidatePermutation(method, request.NewOrder!);
+
+        // Check params trailing-slot invariant. params must stay last.
+        for (var newIdx = 0; newIdx < permutation.Length; newIdx++)
+        {
+            var origIdx = permutation[newIdx];
+            if (method.Parameters[origIdx].IsParams && newIdx != permutation.Length - 1)
+            {
+                throw new ArgumentException(
+                    $"op='reorder' cannot move the params parameter '{method.Parameters[origIdx].Name}' off the " +
+                    $"trailing slot — C# requires params to be the last parameter. Keep '{method.Parameters[origIdx].Name}' " +
+                    $"at the end of NewOrder.",
+                    nameof(request));
+            }
+        }
+
+        // Identity permutation = no-op; refuse so we don't produce an empty preview.
+        var isIdentity = true;
+        for (var i = 0; i < permutation.Length; i++)
+        {
+            if (permutation[i] != i) { isIdentity = false; break; }
+        }
+        if (isIdentity)
+            throw new ArgumentException(
+                $"op='reorder' NewOrder='{request.NewOrder}' is the identity permutation — no change to apply.",
+                nameof(request));
+
+        var (accumulator, changes, callsiteUpdates) = await ApplyAddRemoveAsync(
+            solution, method,
+            updateDeclaration: existingList => BuildReorderedParameterList(existingList, permutation),
+            updateCallsite: (args, isPositional) =>
+            {
+                if (args.Count == 0) return args;
+
+                // All-named callsite: leave untouched (named args bind by name regardless of order).
+                var allNamed = args.All(a => a.NameColon is not null);
+                if (allNamed) return args;
+
+                // Mixed positional + named: refuse via sentinel exception so the caller sees an
+                // actionable error rather than a silently-wrong rewrite.
+                if (!isPositional)
+                {
+                    throw new InvalidOperationException(
+                        "op='reorder' refuses to rewrite a callsite that mixes positional and named arguments " +
+                        "because remapping the positional prefix can change which parameter each positional " +
+                        "argument binds to. Convert the callsite to all-positional or all-named, then retry.");
+                }
+
+                // All-positional: build new list by walking permutation.
+                // If callsite passes fewer args than the method declares (default-valued tail),
+                // only reorder the indices that exist; trailing missing slots stay omitted.
+                // For simplicity: if any permuted index is >= args.Count, those are dropped
+                // (they were already absent at the callsite). Reordering otherwise.
+                var newArgs = SyntaxFactory.SeparatedList<ArgumentSyntax>();
+                for (var i = 0; i < permutation.Length; i++)
+                {
+                    var srcIdx = permutation[i];
+                    if (srcIdx < args.Count)
+                    {
+                        var arg = args[srcIdx];
+                        // Strip leading trivia from the source arg, then add a single space
+                        // separator (except for the first).
+                        var clean = arg.WithLeadingTrivia(i == 0 ? default : SyntaxFactory.Space);
+                        newArgs = newArgs.Add(clean);
+                    }
+                }
+                return newArgs;
+            },
+            ct).ConfigureAwait(false);
+
+        var orderDescription = string.Join(", ",
+            permutation.Select(i => method.Parameters[i].Name));
+        return BuildPreviewDto(workspaceId, accumulator, changes, callsiteUpdates,
+            $"Reorder parameters of {method.ToDisplayString()} to ({orderDescription})");
+    }
+
+    /// <summary>
+    /// Parses <paramref name="newOrder"/> into a permutation array. Each entry maps a new
+    /// position to the original parameter index. Tokens may be parameter names or 0-based
+    /// indices; the result must be a strict permutation of <c>[0..method.Parameters.Length)</c>.
+    /// </summary>
+    private static int[] ParseAndValidatePermutation(IMethodSymbol method, string newOrder)
+    {
+        var tokens = newOrder.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length != method.Parameters.Length)
+            throw new ArgumentException(
+                $"op='reorder' NewOrder must list every parameter exactly once. " +
+                $"Method {method.ToDisplayString()} has {method.Parameters.Length} parameter(s) " +
+                $"({string.Join(", ", method.Parameters.Select(p => p.Name))}); NewOrder supplied " +
+                $"{tokens.Length} token(s).",
+                nameof(newOrder));
+
+        var permutation = new int[tokens.Length];
+        var seen = new HashSet<int>();
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            var token = tokens[i];
+            int origIdx;
+            if (int.TryParse(token, out var asIndex))
+            {
+                if (asIndex < 0 || asIndex >= method.Parameters.Length)
+                    throw new ArgumentException(
+                        $"op='reorder' NewOrder index {asIndex} is out of range (valid 0..{method.Parameters.Length - 1}).",
+                        nameof(newOrder));
+                origIdx = asIndex;
+            }
+            else
+            {
+                origIdx = -1;
+                for (var p = 0; p < method.Parameters.Length; p++)
+                {
+                    if (string.Equals(method.Parameters[p].Name, token, StringComparison.Ordinal))
+                    {
+                        origIdx = p;
+                        break;
+                    }
+                }
+                if (origIdx < 0)
+                    throw new ArgumentException(
+                        $"op='reorder' NewOrder token '{token}' does not match any parameter on " +
+                        $"{method.ToDisplayString()} (parameters: {string.Join(", ", method.Parameters.Select(p => p.Name))}).",
+                        nameof(newOrder));
+            }
+            if (!seen.Add(origIdx))
+                throw new ArgumentException(
+                    $"op='reorder' NewOrder lists parameter '{method.Parameters[origIdx].Name}' more than once.",
+                    nameof(newOrder));
+            permutation[i] = origIdx;
+        }
+        return permutation;
+    }
+
+    /// <summary>
+    /// Build a new <see cref="ParameterListSyntax"/> by reordering the existing parameters
+    /// according to <paramref name="permutation"/>. Reuses the parse-from-text approach from
+    /// add/remove so the comma+space trivia and enclosing parens trivia are correct.
+    /// </summary>
+    private static ParameterListSyntax BuildReorderedParameterList(
+        ParameterListSyntax existingList, int[] permutation)
+    {
+        var paramTexts = new List<string>(permutation.Length);
+        for (var i = 0; i < permutation.Length; i++)
+        {
+            paramTexts.Add(existingList.Parameters[permutation[i]].ToString());
+        }
+        var newListText = "(" + string.Join(", ", paramTexts) + ")";
+        var newList = SyntaxFactory.ParseParameterList(newListText);
+        return newList.WithTriviaFrom(existingList);
     }
 
     private static int ResolveParameterIndex(IMethodSymbol method, ChangeSignatureRequest request)

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
@@ -712,6 +712,265 @@ public sealed class ChangeSignaturePreviewTests : TestBase
         }
     }
 
+    /// <summary>
+    /// change-signature-reorder-preview: op='reorder' with a positional callsite reorders
+    /// both the declaration parameters and the callsite arguments to match the new
+    /// permutation supplied via NewOrder (parameter names).
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_ReorderOp_PositionalCallsite_ReordersDeclarationAndArgs()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureReorderFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureReorderFixture",
+            "{",
+            "    public int Compute(int a, int b, int c)",
+            "    {",
+            "        return a + b + c;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(1, 2, 3);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+            // Reorder (a, b, c) -> (c, a, b). Validates name-token parsing too.
+            var request = new ChangeSignatureRequest(
+                Op: "reorder",
+                NewOrder: "c, a, b");
+
+            var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspaceId, locator, request, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+
+            // Declaration reordered.
+            StringAssert.Contains(postApplyText, "public int Compute(int c, int a, int b)",
+                $"declaration must be reordered to (c, a, b); got:\n{postApplyText}");
+            // Body brace stays on its own line (uses the same parse-from-text trivia path).
+            StringAssert.Contains(postApplyText, "public int Compute(int c, int a, int b)\r\n    {",
+                $"body brace must stay on its own line; got:\n{postApplyText}");
+            // Positional callsite Compute(1, 2, 3) was reordered to Compute(3, 1, 2).
+            StringAssert.Contains(postApplyText, "Compute(3, 1, 2)",
+                $"positional callsite arguments must be reordered to (3, 1, 2); got:\n{postApplyText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-reorder-preview: op='reorder' accepts a 0-based index permutation
+    /// and leaves all-named callsites untouched (named arguments bind by name regardless of
+    /// the declaration order).
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_ReorderOp_NamedCallsite_LeftUntouched_IndexPermutation()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureReorderNamedFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureReorderNamedFixture",
+            "{",
+            "    public int Compute(int a, int b)",
+            "    {",
+            "        return a + b;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(a: 1, b: 2);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+            // Index-form permutation: (a, b) -> (b, a).
+            var request = new ChangeSignatureRequest(
+                Op: "reorder",
+                NewOrder: "1,0");
+
+            var preview = await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspaceId, locator, request, CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken!, "test_apply", CancellationToken.None);
+            Assert.IsTrue(applyResult.Success, $"apply must succeed: {applyResult.Error}");
+
+            var postApplyText = await File.ReadAllTextAsync(fixturePath);
+
+            StringAssert.Contains(postApplyText, "public int Compute(int b, int a)",
+                $"declaration must be reordered via index permutation; got:\n{postApplyText}");
+            // Named callsite must remain untouched — args bind by name.
+            StringAssert.Contains(postApplyText, "Compute(a: 1, b: 2)",
+                $"all-named callsite must remain unchanged after reorder; got:\n{postApplyText}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-reorder-preview: invalid NewOrder inputs surface actionable errors
+    /// rather than internal exceptions. Covers wrong arity, unknown name token, duplicate
+    /// token, and identity-permutation no-op.
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_ReorderOp_InvalidNewOrder_EmitsActionableError()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureReorderInvalidFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureReorderInvalidFixture",
+            "{",
+            "    public int Compute(int a, int b, int c)",
+            "    {",
+            "        return a + b + c;",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+
+            // Missing NewOrder.
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, new ChangeSignatureRequest(Op: "reorder"), CancellationToken.None));
+            StringAssert.Contains(ex.Message, "NewOrder",
+                $"missing-NewOrder error must cite 'NewOrder'; got: {ex.Message}");
+
+            // Wrong arity (2 tokens for 3-param method).
+            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b"), CancellationToken.None));
+            StringAssert.Contains(ex.Message, "exactly once",
+                $"wrong-arity error must explain that every parameter must appear exactly once; got: {ex.Message}");
+
+            // Unknown name token.
+            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b,zz"), CancellationToken.None));
+            StringAssert.Contains(ex.Message, "zz",
+                $"unknown-token error must cite the offending token; got: {ex.Message}");
+
+            // Duplicate token.
+            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,a,b"), CancellationToken.None));
+            StringAssert.Contains(ex.Message, "more than once",
+                $"duplicate-token error must explain the parameter is listed twice; got: {ex.Message}");
+
+            // Identity permutation (no-op).
+            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b,c"), CancellationToken.None));
+            StringAssert.Contains(ex.Message, "identity",
+                $"identity-permutation error must call out the no-op; got: {ex.Message}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// change-signature-reorder-preview: callsite that mixes positional and named arguments
+    /// is refused with an actionable message because reordering the positional prefix can
+    /// silently change which parameter each positional argument binds to.
+    /// </summary>
+    [TestMethod]
+    public async Task ChangeSignaturePreview_ReorderOp_MixedPositionalAndNamedCallsite_Refused()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+
+        var fixturePath = Path.Combine(sampleLibDir, "ChangeSignatureReorderMixedFixture.cs");
+        var content = string.Join("\r\n", new[]
+        {
+            "namespace SampleLib;",
+            "",
+            "public class ChangeSignatureReorderMixedFixture",
+            "{",
+            "    public int Compute(int a, int b, int c)",
+            "    {",
+            "        return a + b + c;",
+            "    }",
+            "",
+            "    public int CallCompute()",
+            "    {",
+            "        return Compute(1, b: 2, c: 3);",
+            "    }",
+            "}",
+            "",
+        });
+        await File.WriteAllTextAsync(fixturePath, content);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
+            var request = new ChangeSignatureRequest(Op: "reorder", NewOrder: "c,a,b");
+
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+                await _changeSignatureService.PreviewChangeSignatureAsync(
+                    workspaceId, locator, request, CancellationToken.None));
+            StringAssert.Contains(ex.Message, "mixes positional and named",
+                $"mixed-callsite refusal must explain why; got: {ex.Message}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
     [TestMethod]
     public async Task ChangeSignaturePreview_RemoveOp_CaretOnParameter_ExplicitPositionOverridesAutoResolve()
     {


### PR DESCRIPTION
## Summary

Implement `op=reorder` for `change_signature_preview`. Accepts a `NewOrder` parameter (comma-separated list of parameter names OR 0-based indices) that must be a strict permutation of the existing parameters.

- Declaration is rewritten via the same `ParseParameterList`-from-text path used by add/remove (preserves comma+space trivia and body-brace line breaks).
- All-positional callsites are reordered to match the permutation.
- All-named callsites are left untouched (named arguments bind by name).
- Mixed positional+named callsites are refused with an actionable error.
- `params` parameters must remain in the trailing slot (C# parser invariant).
- Identity permutations are refused as a no-op.

Scope expanded by 1 file: `ServerSurfaceCatalog.Refactoring.cs` was updated to keep the surface-catalog summary in sync with the tool's new `Description` (required by `McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry`).

Closes: change-signature-reorder-preview

## Test plan

- [x] 4 new tests in `ChangeSignaturePreviewTests.cs` cover positional reorder, all-named no-op, invalid `NewOrder` inputs, and mixed-callsite refusal.
- [x] `mcp__roslyn__compile_check` clean.
- [x] `mcp__roslyn__test_run --filter ChangeSignaturePreviewTests`: 14 passed (10 existing + 4 new).
- [x] `eng/verify-release.ps1 -Configuration Release`: 1150/1150 pass.
- [x] `eng/verify-ai-docs.ps1`: pass.