### PR TITLE
feat(skills): ship /mcp-server-surface-test as generic consumer skill (move-to-git-issues Row 1)

### DIFF
--- a/.claude/skills/backlog-intake/SKILL.md
+++ b/.claude/skills/backlog-intake/SKILL.md
@@ -58,7 +58,7 @@ Review the dry-run output. If the file list looks right:
 pwsh -File eng/stage-review-inbox.ps1
 ```
 
-If `--stage` was passed OR `review-inbox/` is empty at the start of the run, also run the real command. If the PS1 finishes with "No new artifacts found" AND `review-inbox/` is empty AND **no `backlog.d/` fragments exist anywhere**, refuse: `"Nothing to triage. Produce audits first via /mcp-server-stress (bundled prompt at .claude/skills/mcp-server-stress/prompts/prompt.md), then re-run."`
+If `--stage` was passed OR `review-inbox/` is empty at the start of the run, also run the real command. If the PS1 finishes with "No new artifacts found" AND `review-inbox/` is empty AND **no `backlog.d/` fragments exist anywhere**, refuse: `"Nothing to triage. Produce audits first via /mcp-server-stress (bundled prompt at .claude/skills/mcp-server-stress/prompts/maintainer-overlay.md), then re-run."`
 
 Record the count: `N reports + F fragments staged from M repos` for the final summary.
 

--- a/.claude/skills/mcp-server-stress/SKILL.md
+++ b/.claude/skills/mcp-server-stress/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-server-stress
-description: "Comprehensive Roslyn MCP server audit + experimental-promotion scorecard, run against a loaded C# repo. Single canonical run — always exercises apply tools against a disposable worktree the skill creates and tears down post-run, and always emits the promotion scorecard. Requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts if the server is not callable rather than running a non-MCP fallback. Maintainer-only skill (lives under `.claude/skills/`, not shipped to plugin consumers). The static SKILL.md audit (frontmatter parity + tool-reference resolution against the live catalog) is owned by `/surface-audit`, not this skill. Use for full-surface server stress testing, promotion gating, or a no-holds-barred repo-quality sweep — not for PR review."
+description: "Comprehensive Roslyn MCP server audit + experimental-promotion scorecard, run against a loaded C# repo. Maintainer-only superset of the shipped /mcp-server-surface-test skill (also lives under skills/mcp-server-surface-test/). Single canonical run — always exercises apply tools against a disposable worktree the skill creates and tears down post-run, and always emits the promotion scorecard. Adds repo-coupled phases the shipped consumer prompt does not have: host-shell `dotnet restore` precheck, ai_docs/backlog.md regression cross-check, <audited-repo-root>/backlog.d/ fragment emission for /backlog-intake, and eng/aggregate-promotion-scorecards.ps1 cross-repo aggregation. Requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts if the server is not callable rather than running a non-MCP fallback. Maintainer-only skill (lives under `.claude/skills/`, not shipped to plugin consumers). The static SKILL.md audit (frontmatter parity + tool-reference resolution against the live catalog) is owned by `/surface-audit`, not this skill. Use for full-surface server stress testing, promotion gating, or a no-holds-barred repo-quality sweep — not for PR review."
 user-invocable: true
 argument-hint: "[<target-repo-path>] [--target=<path>] [--no-worktree]"
 ---
@@ -22,7 +22,7 @@ This skill is a **null-op without the Roslyn MCP server**. The audit's entire pu
 
 ## Step 2 — Read and run the canonical audit prompt
 
-Read `${CLAUDE_PLUGIN_ROOT}/.claude/skills/mcp-server-stress/prompts/prompt.md` and run it verbatim. Always-on flags:
+Read `${CLAUDE_PLUGIN_ROOT}/.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` and run it verbatim. The overlay is the maintainer-only superset of the consumer-shipped prompt at `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/prompts/full.md` — it retains repo-coupled phases the shipped prompt does not have. Always-on flags:
 
 - **Promotion scorecard always emitted.** The `_latest-promotion-scorecard.json` sibling artifact is mandatory output.
 - **Phase 6 apply pass always exercised** against a disposable worktree the skill creates at run start and tears down at run end. The audited repo's working tree and `main` branch are never mutated by Phase 6.
@@ -97,7 +97,7 @@ The runner must return the `## Audit Phase Runner Summary` markdown table define
 
 ## Step 5 — Execute the chosen prompt
 
-Read `prompts/prompt.md` in full and follow it phase by phase. Persist the audit draft after each phase as the prompt instructs — the canonical report path lives in the prompt's *Output Format* section.
+Read `prompts/maintainer-overlay.md` in full and follow it phase by phase. Persist the audit draft after each phase as the prompt instructs — the canonical report path lives in the prompt's *Output Format* section.
 
 ### Phase 0 hand-off: prefer `/surface-audit` for live-surface drift detection
 

--- a/.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md
+++ b/.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md
@@ -1,0 +1,963 @@
+# Deep Code Review & Refactor Agent Prompt — maintainer overlay
+
+<!-- purpose: Living maintainer-only prompt for full-surface MCP audits, apply-tool exercise on a disposable worktree, and experimental→stable promotion scoring against the live Roslyn MCP server. Maintainer-only superset of the shipped consumer prompt at `skills/mcp-server-surface-test/prompts/full.md`. Output is machine-parseable (fixed tables, dense per-call evidence, promotion scorecards). -->
+<!-- DO NOT DELETE THIS FILE.
+     Living document. When tools, resources, prompts, or skills are added/removed,
+     the Phase 0 live-catalog capture + glob-based skill discovery in this prompt
+     pick up the change automatically — no appendix edit required. -->
+
+> **Maintainer-only overlay.** This prompt is the **maintainer superset** of the consumer-shipped audit prompt at `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/prompts/full.md`. It retains repo-coupled phases (host-shell `dotnet restore` precheck, `ai_docs/backlog.md` regression cross-check, `<audited-repo-root>/backlog.d/` fragment emission for `/backlog-intake`, `eng/aggregate-promotion-scorecards.ps1` cross-repo aggregation) that the shipped consumer prompt does not have. When auditing repos that maintain a `backlog.d/` ingestion path or `ai_docs/` doc taxonomy, run this overlay. For consumer audits or any repo that does **not** maintain those conventions, the shipped consumer prompt is sufficient.
+
+> **This prompt is a null-op without the Roslyn MCP server.** If `mcp__roslyn__server_info` is not callable in your current tool list, stop and ask the user to start the server. The very first step of Phase -1 verifies this as a hard gate.
+
+> **Primary purpose:** produce (1) an MCP server audit (bugs, incorrect results, gaps) and (2) an experimental-tier promotion scorecard against one loaded C# repo. **Mechanism:** real refactoring plus tool calls that exercise the full surface. The static SKILL.md audit (frontmatter parity + tool-reference resolution against the live catalog) lives in `/surface-audit`, not here.
+
+---
+
+## Prompt
+
+You are a senior .NET architect running a Roslyn-MCP audit against the loaded repo. You have **three missions** in priority order:
+
+1. **MCP server audit (primary).** For every tool, resource, and prompt, ask whether the result is correct, complete, and consistent with sibling surfaces. Record issues, coverage, per-call `_meta.elapsedMs`, and error quality.
+2. **Experimental promotion scorecard (primary).** Every experimental entry you exercise receives a rating — `promote`, `keep-experimental`, `needs-more-evidence`, or `deprecate` — with evidence citations. Feeds `docs/experimental-promotion-analysis.md` and release gating.
+3. **Apply-tool exercise on a disposable worktree (supporting).** **Phase 6 only.** Drive preview→apply→revert round-trips, verify with `compile_check` / `build_workspace` / `test_run`. Applies are test fixtures of the apply-tool surface — they run inside a disposable worktree the prompt creates at run start and tears down at run end. The audited repo's `main` branch and primary working tree are never mutated; no commit ever lands in the audited repo's history; no PR is opened.
+
+The static skills audit (SKILL.md frontmatter parity + tool-reference resolution against the live catalog) is owned by `/surface-audit`, which walks both `skills/*/SKILL.md` (shipped) and `.claude/skills/*/SKILL.md` (maintainer-local). It is a static-catalog check, not a server-execution check, and is not part of this run.
+
+### Run shape
+
+This prompt describes one canonical run. Phase 6 applies are always exercised against a disposable worktree the prompt creates at run start and tears down at run end (`dotnet build-server shutdown` + `git worktree remove --force`, in that order). The promotion scorecard is always emitted. Typical duration: 90–180 min.
+
+A single optional flag exists: `--no-worktree`, a degraded mode for environments that genuinely cannot create a git worktree (tight CI sandbox, missing `git` binary, read-only checkout). When set, Phase 6 is skipped, the *Isolation* row records `degraded — --no-worktree flag, Phase 6 applies skipped`, and writer rows whose round-trip evidence depended on the disposable worktree default to `needs-more-evidence` in the scorecard. Record `--no-worktree` in the report header so consumers know which evidence is missing.
+
+**Known issues / prior findings.** When auditing Roslyn-Backed-MCP (or any repo that has access to it), cross-check `ai_docs/backlog.md` at the audited-repo root and cite matching ids. Otherwise use the closest prior source (previous audit report, issue tracker, repro list). If none exists, the regression section is **N/A**.
+
+**Phase order.** Run in this order: **-1 → 0 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 8b → 10 → 9 → 11 → 12 → 13 → 14 → 15 → 16 → 17 → 18**. Phase 8b runs immediately after Phase 8 so it sees post-refactor state. Phase 9 runs after Phase 10 so `revert_last_apply` doesn't undo Phase 6 work.
+
+**Portability and completeness contract.**
+
+1. Runs against **any loadable C# repo**. Prefer `.sln` / `.slnx`; fall back to `.csproj`.
+2. The disposable worktree is created at run start and recorded in the *Isolation* header row before any write-capable call. `--no-worktree` opts into degraded mode where Phase 6 applies are skipped — record the rationale in the *Isolation* row.
+3. `server_info`, `roslyn://server/catalog`, and `roslyn://server/resource-templates` are the **authoritative live surface**. Any disagreement with prose in this prompt: the live catalog wins, and the drift is itself a finding.
+4. Build a live **coverage ledger** from the catalog. Every live tool, resource, and prompt ends with exactly one final status: `exercised`, `exercised-apply`, `exercised-preview-only`, `skipped-repo-shape`, `skipped-safety`, or `blocked`. Silent omissions mean the audit is incomplete. Columns: `kind`, `name`, `tier`, `category`, `status`, `phase`, `lastElapsedMs`, `notes`.
+5. If the MCP client cannot invoke a live resource/prompt family, mark those rows `blocked` with the client limitation. Blocked experimental entries score `needs-more-evidence` in the scorecard — never `promote`.
+6. Record repo-shape constraints up front: single vs multi-project, tests, analyzers, source generators, DI, `.editorconfig`, Central Package Management, multi-targeting, network/restore constraints.
+7. Do not invent applicability. If the repo has no tests, no DI, no source generators, no multi-targeting, or only one project, record that and mark dependent steps `skipped-repo-shape`.
+### Execution strategy and context conservation
+
+1. Delegate long-running/log-heavy validation to subagents or background execution where available (full-suite `test_run`, `test_coverage`, shell-based builds). Keep experimental probes inline — promotion evidence is captured per call.
+2. Helpers return structured summaries (tool, scope, pass/fail counts, failing test names, duration, coverage headline, anomalies) — never raw logs.
+3. Do not delegate preview/apply chains or workspace-version-sensitive mutations unless the helper shares the same disposable checkout and workspace state.
+
+### Cross-cutting audit principles (apply to every call)
+
+Fixed output slots in the report; capture in real time.
+
+1. **Inline severity signal.** Tag each result **PASS** / **FLAG** / **FAIL**. Accumulate for the report.
+2. **Schema vs behaviour.** Compare actual behaviour to the MCP tool schema/description. Mismatches are high-value findings. *Output slot:* *Schema vs behaviour drift*.
+3. **Performance (`_meta.elapsedMs`).** Every v1.8+ response carries `_meta.elapsedMs` (total wall-clock) plus, for workspace calls, `_meta.queuedMs` / `_meta.heldMs` / `_meta.gateMode`. Record per call. Budgets: single-symbol reads ≤5 s, solution scans ≤15 s, writers ≤30 s. The scorecard uses p50 per tool, so paged data matters. *Output slot:* *Performance baseline*.
+4. **Error message quality.** When a tool errors, rate it **actionable** / **vague** / **unhelpful**. *Output slot:* *Error message quality*.
+5. **Response-contract consistency.** Note inconsistencies across related surfaces (line-number base, field names, classification value types, pagination defaults). *Output slot:* *Response contract consistency* (conditional).
+6. **Parameter-path coverage.** Happy-path defaults are not enough. For each major family you exercise, probe at least one non-default path when the live schema exposes it. If the schema does not expose a parameter this prompt mentions, record `N/A` rather than inventing it. *Output slot:* *Parameter-path coverage*.
+7. **Precondition discipline.** Distinguish server defects from repo/environment constraints. A tool that fails because tests are absent or packages unrestored is not a server bug — record the precondition status, not a false regression.
+8. **Debug log capture.** If the MCP client surfaces `notifications/message` log entries (the `McpLoggingProvider` forwards .NET `ILogger` events with `correlationId`), keep that channel visible for the entire run. Record every `Warning` / `Error` / `Critical`, plus `Information` entries touching workspace lifecycle, gate acquisition, lock contention, rate limits, or request timeouts. If the client can't show these, record that as a client limitation in the header — do not silently drop the channel.
+9. **`evaluate_csharp` stalls — neutral diagnosis only.** The server applies a script timeout (default 10 s, env `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS`). A healthy call finishes or errors within budget + grace. Multi-minute freezes that only clear on user message: **cause = unknown — operator triages from MCP stderr + client logs.** Agents cannot reliably attribute these from inside the loop; do not speculate server-vs-client-vs-transport.
+10. **Always emit text per turn.** Every assistant turn emits at least one sentence describing what is being dispatched. Empty tool-only turns read as silent stalls.
+11. **Phases run sequentially.** Parallel within a phase for independent reads; never start phase N+1 before phase N is persisted to the draft.
+12. **Output budget per turn.** When cumulative tool-result size passes ~250 KB, persist and start a new turn. Usual culprits: `compile_check`, `project_diagnostics`, `list_analyzers`, `get_namespace_dependencies`, `get_msbuild_properties`. Use pagination (`offset`, `limit`, `severity`, `file`). The `workspace_*` summary payloads (default) keep per-phase heartbeats at ~500 B; request `verbose=true` only when you need the full project tree.
+13. **Workspace heartbeat.** Call `workspace_list` before each new phase. If the workspace is gone, reload from the recorded entrypoint — do not march on against a dead workspace.
+14. **Experimental promotion signal (per call).** For every experimental tool/resource/prompt exercised, record one line in the draft: (a) correct result, (b) schema accurate, (c) error path actionable on at least one negative probe, (d) preview→apply round-trip clean where applicable, (e) wall-clock within budget for the input scale. Do not compute the final recommendation until Final surface closure — it must reflect all phases, not just first contact.
+
+---
+
+### Phase -1: MCP server precondition (MUST run first, hard gate)
+
+This prompt is a contract with the Roslyn MCP server. Without it, nothing below is meaningful.
+
+1. **Check the tool list.** Verify `mcp__roslyn__server_info` appears in your current tool surface. If it does not, STOP and tell the user:
+
+   > *"This prompt requires the Roslyn MCP server (mcp__roslyn__* tools must be callable). Start the server — for example `dotnet tool run roslynmcp` or ensure the plugin's stdio entry is active in `.mcp.json` / `settings.json` — confirm `mcp__roslyn__server_info` is available, then rerun."*
+
+   Do **not** substitute `Read`, `Grep`, `Bash: dotnet build`, or similar host-side fallbacks. The entire point of this audit is to exercise the MCP server; a run without it produces no audit-grade evidence.
+
+2. **Call `server_info`.** Capture:
+   - `version`, `catalogVersion`, `runtime`, `os`.
+   - `surface.tools.{stable,experimental}`, `surface.resources.{stable,experimental}`, `surface.prompts.{stable,experimental}`, `surface.registered.*`, `surface.registered.parityOk` (must be `true`; `false` is a P2 finding).
+   - `connection.state` — if `initializing` or `degraded`, wait briefly and call `server_heartbeat` once before proceeding. If the state never becomes `ready`, halt and surface the diagnostic.
+
+3. **Record the live totals** from `server_info` — these are the authoritative counts the coverage ledger and scorecard will reconcile against. Any prose in this prompt that disagrees with the live numbers is drift and is itself a finding (log it in *Improvement suggestions*).
+
+4. **Sanity-check the catalog resource.** Read `roslyn://server/catalog` and confirm per-category counts match `server_info.surface`. A mismatch here is a P2 finding.
+
+5. **Workspace health probe (post-load).** After Phase 0 loads a workspace, call `workspace_health(workspaceId)` once before Phase 1's first semantic call. Capture `status` (`healthy` / `degraded` / `unhealthy`), `staleness` indicators, and any returned remediation hints. A non-`healthy` status before any mutation is a P1 finding — surface it and either reload or halt; do not march on against a degraded workspace. (`server_heartbeat` covers transport readiness; `workspace_health` covers per-workspace state.)
+
+**Hard-gate checkpoint:** Is `server_info` callable? Is `connection.state == ready`? Is `parityOk == true`? Did the catalog-resource counts match `server_info`? Did `workspace_health` (once a workspace is loaded) return `healthy`? Any `no` is a halt-or-escalate, not a silent proceed.
+
+---
+
+### Phase 0: Setup, live surface baseline, and repo shape
+
+1. Pick the entrypoint: `.sln` / `.slnx` / `.csproj`.
+2. **Create the disposable worktree** (mandatory, default mode). Run `git worktree add ../<repo-name>-audit-deep-<ts> -b audit-deep/<ts>` from the audited repo root, where `<ts>` is the same UTC `yyyyMMddTHHmmssZ` used for the report filename. Record the absolute worktree path + branch name in the *Isolation* header row before any write-capable call. Phase 6's preview→apply chains run against this checkout; the audited repo's primary working tree is never touched. **`--no-worktree` flag:** record `degraded — --no-worktree flag, Phase 6 applies skipped` in the *Isolation* row and skip worktree creation entirely.
+3. **Debug-log channel check.** Is the client surfacing `notifications/message`? Record `yes` / `partial` / `no` in the header.
+4. Read `roslyn://server/resource-templates` to capture all resource URI templates.
+5. Call `workspace_load` (lean summary default; pass `verbose=true` only if you need the full project tree).
+6. Call `workspace_list` to confirm the session; `workspace_status` to confirm clean load (look at `WorkspaceDiagnosticCount` / `WorkspaceErrorCount` / `WorkspaceWarningCount`).
+7. **`workspace_warm` (v1.28+).** Optional but recommended: call `workspace_warm(workspaceId)` immediately after load to prime `GetCompilationAsync` + semantic models. Record `projectsWarmed`, `coldCompilationCount`, `elapsedMs`. This makes every downstream perf measurement cache-hit-dominated — note whether you ran it in the report header so timings are comparable across runs.
+8. Call `project_graph`.
+9. Record repo-shape constraints (projects, tests, analyzers, source generators, DI, `.editorconfig`, CPM, multi-targeting, network/restore constraints).
+10. **Restore precheck.** Run `dotnet restore <entrypoint>` from the host shell before any Phase-1 semantic-analysis tool. Unrestored package references historically crashed `find_unused_symbols`, `type_hierarchy`, `callers_callees`, and `impact_analysis` (FLAG-A; filtered in v1.7+). Also: without restore, `compile_check`/`project_diagnostics` flood with CS0246 errors from missing types, exhausting the per-turn output budget (principle #12). If the host has no shell, mark this step `blocked` — note degradation risk in the header.
+11. **Seed the coverage ledger** from the live catalog so every tool/resource/prompt has a planned phase or a provisional skip reason. No hand-maintained list; trust `roslyn://server/catalog`.
+12. **Seed the promotion scorecard** with one row per experimental entry (tool + resource + prompt). Leave `recommendation` blank until Final surface closure.
+13. **Seed the Performance baseline** table. Every exercised read surface contributes a row; writers contribute in Phase 8b.5.
+14. **Live-surface drift detection.** After seeding the coverage ledger, diff its tool/resource/prompt name set against the names this prompt mentions in its phase guidance:
+    - **Names in catalog but never named in the prompt's phase guidance** → log under *Improvement suggestions* as `guidance gap (not coverage gap)` — the live ledger still drives coverage, but the prompt's phase mapping has missed an opportunity to give targeted treatment.
+    - **Names this prompt mentions in code-fenced examples or numbered steps but absent from the catalog** → P1 FAIL under *MCP server issues* with category `prompt drift`. The prompt is referencing a removed/renamed surface and would mislead a cold-context reader.
+    - When a separate `/surface-audit` skill is available in the host, prefer delegating this diff to it (one structured table back) rather than re-walking the catalog from scratch in the main agent.
+
+**MCP audit checkpoint:** Did `workspace_load` succeed? Does `workspace_list` show the session? Did `dotnet restore` complete (or was step 10 marked `blocked` with a reason)? Did `workspace_health` return `healthy` (Phase -1 step 5)? Were isolation path, repo shape, debug-log channel, and seeded ledger/scorecard/baseline tables all captured? Did drift detection (step 14) produce its two output buckets (or report "none")? On total load failure, mark workspace-scoped rows `blocked` and continue only with workspace-independent families (`server_info`, server resources, `analyze_snippet`, `evaluate_csharp`, prompts the client can render offline).
+
+---
+
+### Phase 1: Broad diagnostics scan
+
+1. `project_diagnostics` (no filters) for the solution-wide picture.
+2. `project_diagnostics` with at least one non-default selector (project / file / severity / `offset+limit` pagination). **v1.8+ invariant:** `TotalErrors`/`TotalWarnings`/`TotalInfo` are invariant under `severityFilter` — only the returned arrays narrow. Zero-collapsed filtered totals are a regression.
+3. `compile_check` (default `offset=0, limit=50`) — compare against `project_diagnostics`. Probe `severity=Error` and `file=<path>`.
+4. `compile_check` with `emitValidation=true` (same pagination). Compare timing and diagnostics. With unrestored packages the emit phase short-circuits — run `dotnet restore` first before flagging.
+5. `security_diagnostics` (OWASP-tagged).
+6. `security_analyzer_status` — which analyzer packages are installed / missing.
+7. `nuget_vulnerability_scan`. Requires .NET 8+ SDK and network access. Cross-reference with `security_diagnostics` (CVE vs source patterns).
+8. `list_analyzers` — total rule count; note any LOAD_ERROR entries.
+9. If the live schema exposes paging/filtering for `list_analyzers`, probe a non-default path.
+10. `diagnostic_details` on one representative error and one warning.
+
+**MCP audit checkpoint:** Do diagnostic tools agree on counts? Does the non-default `project_diagnostics` path preserve invariant totals? Does `emitValidation=true` find anything extra without hanging? Does `nuget_vulnerability_scan` fail cleanly when offline? Any analyzers fail to load? Are `diagnostic_details` locations accurate?
+
+---
+
+### Phase 2: Code quality metrics
+
+1. `get_complexity_metrics` (no filters). Flag cyclomatic > 10 or nesting > 4.
+2. `get_cohesion_metrics(minMethods=3)` to find types with LCOM4 > 1. v1.8+ ignores `[LoggerMessage]` / `[GeneratedRegex]` source-gen partials; `SharedFields` should contain only real field/property names.
+3. `get_coupling_metrics` if exposed — note if the tool returns "No such tool" (open backlog row `coupling-metrics-tool`).
+4. `find_unused_symbols(includePublic=false)`.
+5. `find_unused_symbols(includePublic=true)` — public APIs with zero internal references?
+6. `find_duplicated_methods` and `find_duplicate_helpers` — cross-check output against reads of the flagged locations; note any false positives (the BCL-wrapper false positive is tracked as `find-duplicate-helpers-framework-wrapper-false-positive`).
+7. `find_duplicated_code` — token-stream-level duplication (broader than `find_duplicated_methods`); spot-check 2–3 reported clusters against actual source ranges.
+8. `find_dead_locals` on a few chosen methods (complements `find_unused_symbols`'s symbol-level scope).
+9. `find_dead_fields` — class-field-level dead detection; complements `find_unused_symbols(includePublic=false)` with finer granularity at private/internal field scope.
+8. `get_namespace_dependencies` — circular dependencies?
+9. `get_nuget_dependencies` — audit package references.
+10. `suggest_refactorings` — ranked aggregation across complexity / cohesion / dead code. Do the recommended tool sequences match the actual tools for each category?
+
+**MCP audit checkpoint:** Are complexity scores plausible? Are LCOM4 scores sane (score=1 types actually cohesive)? Are source-gen partials correctly excluded from LCOM4? Does `find_unused_symbols` miss obvious dead code or falsely flag used symbols? Do `find_duplicated_methods` / `find_duplicate_helpers` produce an acceptable false-positive rate? Does `suggest_refactorings` rank sensibly?
+
+---
+
+### Phase 3: Deep symbol analysis (pick 3–5 key types)
+
+For each key type:
+
+1. `symbol_search` to locate by name.
+2. `symbol_info` for metadata.
+3. `document_symbols` on its file.
+4. `type_hierarchy`.
+5. `find_implementations` on any interface/abstract type discovered. Verify completeness.
+6. `find_references`.
+7. `find_consumers` — dependency-kind classification.
+7b. `find_type_consumers` on the same type — type-scoped consumer enumeration; cross-check against `find_consumers`. Discrepancies between symbol-scoped and type-scoped surfaces are FLAG worthy.
+8. `find_shared_members` — private members shared across public methods.
+9. `find_type_mutations`. v1.8+ classifies each mutating member by `MutationScope` (`FieldWrite` / `CollectionWrite` / `IO` / `Network` / `Process` / `Database`). Types whose whole purpose is IO (e.g. a snapshot store) should now report their `WriteAllText` / `Delete` methods with `MutationScope=IO`, even without instance-field reassignment.
+10. `find_type_usages` — return types, parameters, fields, casts.
+11. `callers_callees` on 2–3 methods.
+12. `find_property_writes` on settable properties (init vs post-construction).
+13. `member_hierarchy` on overrides/implements.
+14. `symbol_relationships`. v1.7+ auto-promotes a return-type-token caret to the enclosing member (`preferDeclaringMember=true` default). Point the locator at the return-type token of a known method and assert the result describes the **method**, not the type.
+15. `symbol_signature_help`. Auto-promotion applies; pass `preferDeclaringMember=false` once to confirm literal-token resolution still works when requested.
+16. `impact_analysis` on a refactor candidate. Also try `probe_position` at the same cursor to cross-check position resolution.
+17. `symbol_impact_sweep(metadataName | filePath+line+column)` — verify `references` / `nonExhaustiveSwitches` / `mapperCallsites` / `suggestedTasks` buckets. For properties (v1.18+) also expect `persistenceLayerFindings` with `To*`/`From*` mapper symmetry checks.
+
+**MCP audit checkpoint:** Does `find_implementations` return all concrete implementations? Are `find_references` and `find_consumers` consistent? Does `find_type_usages` categorize correctly? Do `callers_callees` match what you'd expect from reading code? Does `symbol_relationships` combine data correctly? Does `impact_analysis` produce a reasonable blast radius? Does `symbol_impact_sweep.references` match `find_references` on the same symbol? Does `probe_position` agree with the position your locator used?
+
+---
+
+### Phase 4: Flow analysis (pick 3–5 complex methods)
+
+For each:
+
+1. `get_source_text` to read the file.
+2. `analyze_data_flow` on the method body. **v1.8+:** expression-bodied members (`=> expr`) are supported — point the line range at the arrow or its expression and the resolver lifts the expression.
+3. `analyze_control_flow` on the same range. **v1.8+:** for expression-bodied members the result is synthesized (`Succeeded=true, StartPointIsReachable=true, EndPointIsReachable=false`, one synthetic return at the arrow).
+4. `get_operations` on key expressions (assignments, invocations, conditionals).
+5. `get_syntax_tree` on the method's line range — cross-check against the IOperation view.
+6. `trace_exception_flow` on a `throw` site inside the method (or on a known `catch` that handles downstream throws). Verify the response walks the control-flow edges and locates the nearest `catch` (or confirms an unhandled-at-boundary exit); cross-check against `find_references` on the exception type.
+
+**MCP audit checkpoint:** Does `analyze_data_flow` identify variables correctly, including `Captured` / `CapturedInside` for lambdas? Does `analyze_control_flow` correctly detect unreachable code and synthesize expression-body results? Does `get_operations` produce a sensible tree? Does `trace_exception_flow` produce a coherent throw→catch path or a clear unhandled-at-boundary signal?
+
+---
+
+### Phase 5: Snippet & script validation
+
+`analyze_snippet` / `evaluate_csharp` complete within the script timeout unless `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS` is raised. Multi-minute hangs that only clear on user message are principle-#9 territory (unknown attribution).
+
+1. `analyze_snippet(kind="expression")` on `1 + 2` — no errors.
+2. `analyze_snippet(kind="program")` on a small class — declared symbols listed.
+3. `analyze_snippet(kind="statements")` on intentionally broken code (e.g. `int x = "hello";`). Verify CS0029 and that `StartColumn` is user-relative (~9), not wrapper-relative (pre-fix this was 66 — FLAG-C, fixed v1.7+).
+4. `analyze_snippet(kind="returnExpression")` on `return 42;` — value-bearing return allowed; compare to `kind="statements"` rejecting returns by design (FLAG-007 documented behaviour).
+5. `evaluate_csharp("Enumerable.Range(1, 10).Sum()")` → 55.
+6. `evaluate_csharp` on a multi-line script.
+7. `evaluate_csharp` on code that throws at runtime (`int.Parse("abc")`) — error reported gracefully.
+8. `evaluate_csharp` on an infinite loop — timeout fires, server does not hang. Expect at most one call lasting until the configured timeout.
+
+**MCP audit checkpoint:** Do the different `kind` values wrap correctly? Are compile errors accurate and well-formatted? Does `evaluate_csharp` handle runtime errors and timeouts cleanly?
+
+---
+
+### Phase 6: Apply-tool exercise on the disposable worktree
+
+**Apply-mode mutations happen here only**, and only inside the disposable worktree created in Phase 0 step 2. Phases 10 / 12 / 13 also drive at least one preview→apply round-trip per applicable family (against the same disposable worktree). Skip Phase 6 only when `--no-worktree` was passed; in that case state **N/A — skipped per --no-worktree flag** in the Phase 6 report section and proceed.
+
+**The point of Phase 6 is to exercise the write path of the MCP server**, not to ship product changes. Applies are test fixtures: drive preview→apply→revert chains, verify behaviour with `compile_check` / `build_workspace` / `test_run` after each apply, and capture per-call evidence for the promotion scorecard. The disposable worktree is torn down at run end (see *Phase 6 teardown* below); nothing about Phase 6 produces a PR or a commit in the audited repo's history.
+
+**`try/finally` discipline.** Wrap the entire Phase 6 sub-phase chain in a `try/finally` (or your host's equivalent error-handling structure) so teardown runs even if an apply fails mid-chain. The skill's correctness contract is "the disposable worktree is gone when the run ends" — apply failures are evidence to record in the report, not reasons to leave the worktree behind.
+
+#### 6a. Fix All
+1. Pick a diagnostic with many occurrences (IDE0005, CS8600).
+2. `fix_all_preview(scope="solution", diagnosticId=…)`.
+3. Inspect — all instances found? Probe a non-default scope (e.g. `scope="project"`).
+4. `fix_all_apply(previewToken)`.
+5. `compile_check`.
+
+#### 6b. Rename
+1. Pick a poorly-named symbol.
+2. `rename_preview` with a better name.
+3. `rename_apply`. Verify the response's `MutatedSymbol` (v1.28+) carries a fresh handle for the renamed identity — chain downstream calls off `MutatedSymbol.symbolHandle` instead of re-resolving by the new name.
+4. `compile_check`; `find_references` on the new name — count matches preview.
+
+#### 6c. Extract interface (when a consumer-heavy type was found in Phase 3)
+1. `extract_interface_preview` with selected public members.
+2. `extract_interface_apply`.
+3. `bulk_replace_type_preview` to update consumers from concrete → interface.
+4. `bulk_replace_type_apply`.
+5. `compile_check`.
+
+#### 6d. Extract type (when Phase 2 found LCOM4 > 1)
+1. `find_shared_members`.
+2. `extract_type_preview` with the independent cluster's members.
+3. `extract_type_apply`.
+4. `compile_check`.
+
+#### 6e. Format & organize
+1. `format_range_preview` / `format_range_apply` on a recently-edited region.
+2. `format_document_preview` / `format_document_apply` on a heavily modified file.
+3. `organize_usings_preview` / `organize_usings_apply` on files touched by code fixes.
+4. `format_check` (solution-wide format verification) to confirm clean.
+
+#### 6f. Curated code fixes
+1. `code_fix_preview` on a specific diagnostic occurrence.
+2. `code_fix_apply`.
+3. `compile_check`.
+
+#### 6f-ii. Diagnostic suppression
+1. Pick a deliberate-pattern warning.
+2. `set_diagnostic_severity` to downgrade the severity in `.editorconfig`.
+3. `add_pragma_suppression` to insert `#pragma warning disable` at a specific site. After `apply`, call `verify_pragma_suppresses` on the site to confirm the pragma covers the intended diagnostic; if the scope is wrong, `pragma_scope_widen` to extend it.
+4. `compile_check`.
+
+#### 6g. Code actions
+1. `get_code_actions` at a position with available refactorings.
+2. `preview_code_action`.
+3. `apply_code_action`.
+
+#### 6h. Direct text edits
+1. `apply_text_edit` — one small targeted edit.
+2. `apply_multi_file_edit` — coordinated edits across two files.
+3. `preview_multi_file_edit(fileEdits=[…])` — verify per-file diffs + one token; `preview_multi_file_edit_apply(previewToken)` to commit. **Negative probe:** mutate the workspace via a separate `format_document_apply`, then retry the now-stale token — expect a "workspace moved, regenerate preview" rejection.
+4. `compile_check`.
+
+#### 6i. Dead code removal
+1. From Phase 2 `find_unused_symbols` results, pick confirmed dead symbols.
+2. `remove_dead_code_preview`.
+3. `remove_dead_code_apply`.
+4. `compile_check`.
+5. If any dead **interface** members showed up, exercise `remove_interface_member_preview(interfaceMemberHandle)`. Expect `previewToken` + `implementationCount` + implementation list, or `status=refused` with `externalCallers` populated.
+
+#### 6j. Extract method
+1. Pick a target from `suggest_refactorings` or `get_complexity_metrics` (complexity ≥ 10).
+2. `analyze_data_flow` on the target range.
+3. `extract_method_preview` with a descriptive name.
+4. Verify the preview: parameters, return type, call site.
+5. `extract_method_apply`; `compile_check`; `find_references` on the new method — ≥1 call site?
+
+#### 6k. Advanced refactor previews (experimental; promotion-relevant)
+1. **`restructure_preview`.** Pick a small idiom to normalize (e.g. `Task.Run(() => __expr__)` → `await __expr__`). Build pattern + goal as C# fragments with `__name__` placeholders. Preview on one file first, then project-wide. Apply via `preview_multi_file_edit_apply` on the returned token.
+2. **`replace_string_literals_preview`.** Find a magic string in argument/initializer position (avoid XML docs / nameof / interpolation holes). Apply via `preview_multi_file_edit_apply`.
+3. **`change_signature_preview`.** Pick a method with multiple callsites. Exercise `op=add`, `op=remove`, `op=rename` in separate previews. For `op=add`, verify the default value is spliced at every callsite (named-arg callers get a named argument). Apply via `preview_multi_file_edit_apply` (shared `IPreviewStore`; do **not** use `apply_composite_preview`). **Negative probe:** `op=reorder` must return an actionable unsupported-op error that points at `symbol_refactor_preview`. **Known limitation — backlog `change-signature-preview-callsite-summary` (P3):** preview `changes[].unifiedDiff` only enumerates the declaration-owner file; apply correctly rewrites every callsite. Verify post-apply with `compile_check` + `find_references`, not the preview diff. Do NOT re-raise.
+4. **`symbol_refactor_preview`.** Compose rename + edit + restructure in one `operations` array (max 25 / 500 affected files). Verify each op sees rewritten state from earlier ops. Apply via `preview_multi_file_edit_apply` (shared `IPreviewStore`; **not** `apply_composite_preview`, which reads `ICompositePreviewStore` — a different store used by `extract_and_wire_interface_preview` / `class_split_preview` / `migrate_package_preview`).
+5. **`change_type_namespace_preview`.** Preview moving a type's namespace while keeping its file location.
+6. **`replace_invocation_preview` / `preview_record_field_addition` / `record_field_add_with_satellites_preview` / `extract_shared_expression_to_helper_preview` / `split_service_with_di_preview`.** Exercise each if the repo shape allows; mark `skipped-repo-shape` otherwise. Verify the returned preview token is accepted by the apply tool named in the tool description.
+
+#### 6l. Atomic apply-with-verify
+1. Produce a known-good preview via `organize_usings_preview`; pass the token to `apply_with_verify(previewToken, rollbackOnError=true)`. Assert `status=applied`.
+2. Produce a known-bad preview (for example, `extract_method_preview` over a region that would introduce CS0136). On post-v1.15 repos the fix landed and this yields `status=applied`; on upstream regressions expect `status=rolled_back` with `introducedErrors` populated.
+
+#### 6m. Session change tracking
+1. After all Phase 6 applies, `workspace_changes` — verify every applied refactoring appears with correct descriptions, affected files, tool names, and timestamps; verify ordering.
+
+#### 6z. Disposable worktree teardown (mandatory, runs in `finally`)
+
+This sub-phase runs at the **end of Phase 6** as the `finally`-clause counterpart to the `try/finally` wrapping the Phase 6 chain. It also runs after Phases 10 / 12 / 13 if those phases issued additional applies inside the disposable worktree.
+
+1. **Release Windows file locks first.** Run `dotnet build-server shutdown` from the audited repo root (or the disposable worktree, equivalent). This releases `testhost.exe` / `VBCSCompiler.exe` locks on `bin/{Debug,Release}/net*/` directories. The command prints one informational line on stdout — that is normal, not an error.
+2. **Remove the worktree.** Run `git worktree remove --force <disposable-worktree-path>` from the audited repo root. The `--force` flag is required because Phase 6 leaves uncommitted apply-mode mutations in the worktree (intentionally — the point was to exercise the apply tools, not to commit their output).
+3. **Verify cleanup.** Run `git worktree list` from the audited repo root and confirm the disposable worktree is gone. Run `git status` from the audited repo's primary checkout and confirm it is clean (Phase 6 must not have leaked changes outside the worktree).
+4. **Branch cleanup.** Run `git branch -D audit-deep/<ts>` from the audited repo root to delete the disposable branch. The branch only existed to host worktree state; it has no upstream and no history worth preserving.
+5. **Record teardown outcome in the report header.** A new *Teardown* row: `clean` (worktree removed, branch deleted, primary checkout clean) / `partial — <what survived>` (e.g. `partial — branch survived; manual git branch -D required`) / `failed — <error>`.
+
+If teardown fails for an unexpected reason, surface the failure in the report's *MCP server issues* section as a P1 finding tagged `audit-deep teardown`. Do not retry blindly — the operator can clean up by hand.
+
+**`--no-worktree` mode:** sub-phase 6z is `skipped — no worktree was created`.
+
+**MCP audit checkpoint:** Does `fix_all_preview` find all instances without timing out? Does `rename_preview` catch references in comments/strings? Does `rename_apply.MutatedSymbol` resolve to the new identity? Does `bulk_replace_type_preview` miss any usages? Does `extract_type_preview` handle shared private members correctly? Does `format_range_preview` stay inside its range? Does `format_check` correctly report clean after the preceding format applies? Does `remove_dead_code_preview` touch only the targeted symbols? Does `set_diagnostic_severity` correctly create/update `.editorconfig`? Does `add_pragma_suppression` insert at the right line? Does `verify_pragma_suppresses` correctly validate scope? Does `extract_method_preview` infer correct parameters and return type? Do the advanced refactor previews each round-trip cleanly and return actionable errors on unsupported ops? Does `apply_with_verify` roll back cleanly on introduced errors? Does `workspace_changes` list every apply with correct ordering?
+
+**Cross-tool chain validation.** After `rename_apply`: `find_references` on the new name = preview count. After `extract_interface_apply`: `type_hierarchy` on the new interface shows the implementor. After `fix_all_apply`: `project_diagnostics` on that diagnostic id = 0. After `organize_usings_apply`: `get_source_text` shows sorted usings. After `extract_method_apply`: `find_references` on the new method ≥ 1. After all applies: `workspace_changes` entry count matches the apply count.
+
+**Mutation-family coverage.** By end of Phase 6 plus Phases 10 / 12 / 13, every write-capable family must be either exercised end-to-end or explicitly `skipped-safety` / `skipped-repo-shape`. A preview-only call does not cover an apply sibling unless the catalog exposes no separate apply tool.
+
+---
+
+### Phase 7: EditorConfig & MSBuild configuration
+
+1. `get_editorconfig_options` on a source file. Do the returned options match `.editorconfig`?
+2. `set_editorconfig_option` to set a benign key (e.g. `dotnet_sort_system_directives_first = true`). Verify the file was created/updated.
+3. `get_editorconfig_options` again — change reflected?
+
+#### 7b. MSBuild evaluation
+1. `get_msbuild_properties` — verify key properties (`TargetFramework`, `RootNamespace`, `OutputType`).
+2. `evaluate_msbuild_property(TargetFramework)` — matches step 1?
+3. `evaluate_msbuild_items(itemType=Compile)` — reasonable count and paths?
+
+**MCP audit checkpoint:** Are editor-config values accurate? Does `set_editorconfig_option` write the pair correctly? Are MSBuild property/item values consistent across the three tools?
+
+---
+
+### Phase 8: Build & test validation
+
+Delegate heavy validation where possible (full-suite `test_run`, `test_coverage`, shell fallbacks). Keep selection (`test_discover`, `test_related_files`, `test_related`) in the primary agent.
+
+1. `workspace_reload` — refresh post-Phase-6.
+2. `build_workspace` — full MSBuild build.
+3. `build_project` for individual projects you modified.
+4. `test_discover` — find all tests.
+5. `test_related_files` with the list of files you modified.
+6. `test_related` on a symbol you refactored.
+7. `test_run` with the filter from step 5.
+8. `test_run` with no filter — full suite.
+9. `test_coverage`.
+10. `test_reference_map(projectName?)` — verify `{ coveredSymbols, uncoveredSymbols, coveragePercent, inspectedTestProjects, notes, mockDriftWarnings? }`. For repos using NSubstitute, check `mockDriftWarnings` flags interface methods production calls that the matching test class never stubs. For repos with no test project, the response should be a clean empty-with-reason result, not an error.
+10b. `get_test_coverage_map(projectName?)` — production-symbol → covering-test-method map. Cross-check that any production symbol classified as `covered` in `test_reference_map` has at least one entry in `get_test_coverage_map`; an empty map for a `covered` symbol is a FLAG.
+11. `validate_workspace(changedFilePaths=null, runTests=false)` — verify `overallStatus ∈ {clean, compile-error, analyzer-error, test-failure}`. Probe `changedFilePaths=null` to confirm auto-scoping off `IChangeTracker`. Probe `runTests=true` on the disposable worktree. **Negative probe:** fabricated `changedFilePaths` entry → clean "no related tests" result (not a crash).
+12. `validate_recent_git_changes` — if git metadata is accessible, validate the last commit's touched files. Verify the bundle composes `compile_check` + diagnostics + related-tests correctly and reports a clean status on a passing commit.
+
+If `test_discover` returns zero, record it and distinguish: `test_run` returns a clean zero-test result, `test_run` / `test_coverage` are `skipped-repo-shape`, or the server mishandles the no-test case.
+
+**MCP audit checkpoint:** Does `build_workspace` match `compile_check` (same count / ids / locations)? Does `test_related_files` identify related tests correctly? Does `test_run` produce structured pass/fail — aggregated across projects, not just the last assembly? Does `test_coverage` produce coverage data? Does `test_reference_map.coveragePercent` agree roughly with `test_coverage`? Does `validate_workspace` produce a coherent `overallStatus`? Does `validate_recent_git_changes` succeed on a clean commit?
+
+**Do not** call `revert_last_apply` yet — it would undo the last Phase 6 apply. Continue to Phase 8b, then Phase 10, then Phase 9.
+
+---
+
+### Phase 8b: Concurrency audit (per-workspace RW lock)
+
+**Stability note.** Many AI hosts serialize MCP tool calls or cannot attribute wall-clock across truly parallel requests. That is expected. If true concurrency is unavailable, mark 8b.2 / 8b.3 / timing-sensitive parts of 8b.4 `blocked` — *client cannot issue concurrent tool calls* (or `skipped-safety` if parallel would be unsafe). Record once in the header; do not force speedup ratios against `tests/RoslynMcp.Tests/Benchmarks/WorkspaceReadConcurrencyBenchmark.cs`. Still run 8b.1 sequential baselines using `_meta.elapsedMs`.
+
+**Single lock model.** One per-workspace `AsyncReaderWriterLock` via `WorkspaceExecutionGate`. `_rw-lock_` / `_legacy-mutex_` in old audit filenames are historical artifacts only.
+
+**Purpose.** Produce a machine-readable concurrency matrix. Expected behaviour: reads overlap subject to the global throttle; writes are exclusive against in-flight readers; `workspace_close` / `workspace_reload` wait for in-flight readers.
+
+#### 8b.0 Probe set (record in the report)
+
+| Slot | Suggested probe (substitute equivalents) | Classification |
+|---|---|---|
+| R1 | `find_references` on a hot symbol used 50+ times | reader |
+| R2 | `project_diagnostics` (no filters) | reader |
+| R3 | `symbol_search` with >100 hits | reader |
+| R4 | `find_unused_symbols(includePublic=false)` | reader |
+| R5 | `get_complexity_metrics` (no filters) | reader |
+| W1 | `format_document_preview` → `format_document_apply` on a Phase-6-touched file | writer |
+| W2 | `set_editorconfig_option` with a benign key (then revert) | writer |
+
+#### 8b.1 Sequential baseline
+Call each R1–R5 once sequentially; record `_meta.elapsedMs`. Record any structured MCP log entries (correlation ids, gate warnings, rate-limit hits, timeouts).
+
+#### 8b.2 Parallel fan-out
+`N = min(4, max(2, Environment.ProcessorCount))`. The global throttle is `max(2, Environment.ProcessorCount)` (`src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs`). Record the host core count + chosen N.
+- Issue R1 ×N, R2 ×N, R3 ×N in parallel. Record wall-clock + speedup (`N × baseline / parallel`). Expected: between `0.7 × N` and `N`. < `0.7 × N` is a FLAG.
+- If the client serializes calls: `blocked — client serializes tool calls`.
+
+#### 8b.3 Read/write exclusion probe
+- Start R1; while in flight, issue W1. Expected: W1 waits.
+- Inverse: start W1; then issue R1. Expected: R1 waits.
+- Any deviation is a FLAG.
+
+#### 8b.4 Lifecycle stress
+- Start R2; while in flight, call `workspace_reload`. Label `waits-for-reader` / `runs-concurrently` / `errors`. Record whether the reader returned stale/fresh/error.
+- Start R3; call `workspace_close`. Expected: reader completes cleanly; close waits. Record the post-acquire `EnsureWorkspaceStillExists` behaviour.
+- After close, `workspace_load` again for the remaining phases.
+
+#### 8b.5 Writer reclassification
+
+| # | Tool | Verification |
+|---|---|---|
+| 1 | `apply_text_edit` | Trivial edit on a Phase-6-touched file; content changes; `compile_check` passes. |
+| 2 | `apply_multi_file_edit` | Coordinated edit across two files; both change; `compile_check` passes. |
+| 3 | `revert_last_apply` | After row 1 or 2; prior edit reverted. *Shares evidence with Phase 9 audit-only revert.* |
+| 4 | `set_editorconfig_option` | Set benign key; `get_editorconfig_options` reflects it. |
+| 5 | `set_diagnostic_severity` | Set `dotnet_diagnostic.<id>.severity = suggestion`; appears in `.editorconfig`. |
+| 6 | `add_pragma_suppression` | Insert `#pragma warning disable <id>` before a known diagnostic line; `get_source_text` shows the pragma. |
+
+Writers should be measurably slower than the reader baseline — they mutate disk.
+
+#### 8b.6 Concurrency matrix output
+Use the schema in *Output Format → Concurrency matrix*. Every cell has a value or `N/A` (with a one-line reason).
+
+**MCP audit checkpoint:** If 8b.2 was client-blocked, say so and answer **N/A — client serializes tool calls** for speedup / stability / benchmark-comparison prompts. Otherwise: did parallel reads overlap ≥ `0.7 × N`? Did the read/write probes match the documented contract? Did lifecycle stress reveal TOCTOU / stale issues? Did all six writers complete? Any gate-contention / rate-limit / deadlock entries? Is `parallel_speedup` stable across runs within ±15%?
+
+---
+
+### Phase 10: File, cross-project, and orchestration operations
+
+**Default:** inspect previews for every applicable family on the disposable worktree, and drive at least one safe preview → apply → verification → cleanup chain per family that exposes an apply sibling. Under `--no-worktree`, apply siblings are `skipped-safety — --no-worktree`.
+
+1. `move_type_to_file_preview` — move a type into its own file.
+2. `move_file_preview` — move with namespace update.
+3. `create_file_preview` — new source file.
+4. `delete_file_preview` — unused source file (safe target).
+5. Multi-project: `extract_interface_cross_project_preview`, `dependency_inversion_preview`, `move_type_to_project_preview`.
+6. If DI present: `extract_and_wire_interface_preview`.
+7. If a split candidate: `split_class_preview` and/or `split_service_with_di_preview`.
+8. If a package-migration candidate: `migrate_package_preview`.
+9. On the disposable worktree: one safe file/type preview → apply → cleanup loop with `move_type_to_file_apply` / `create_file_apply` / `move_file_apply` / `delete_file_apply`.
+10. **`apply_composite_preview` — destructive despite the name.** Only call on the disposable worktree; under `--no-worktree`, mark `skipped-safety — --no-worktree` and note the naming friction.
+
+**MCP audit checkpoint:** Do the previews produce valid diffs with correct namespace/reference updates? Does `extract_and_wire_interface_preview` correctly identify DI registrations? Does `split_class_preview` produce valid partial classes? Does `split_service_with_di_preview` produce valid DI rewires? Does the create/move/delete/apply round-trip leave the repo clean?
+
+---
+
+### Phase 9: Undo verification (run after Phase 10)
+
+**Why after Phase 10:** `revert_last_apply` immediately after Phase 8 would undo the last Phase 6 apply. Add one audit-only apply on top, then revert.
+
+1. Perform exactly one low-impact Roslyn apply whose reversal is safe — `format_document_preview` → `format_document_apply` on a single file is the canonical probe (prefer one already touched in Phase 6). This becomes the new top of the undo stack.
+2. `revert_last_apply` — only the audit-only apply is undone; Phase 6 changes remain.
+3. `compile_check`.
+4. **`revert_apply_by_sequence` — non-tip rollback.** Add a SECOND audit-only apply on top of the same Phase-6 stack (a different `format_document_apply`-style probe), then call `revert_apply_by_sequence(sequenceNumber=<the-first-audit-only-apply>)`. Verify only the targeted entry is undone; the second audit-only apply remains. Negative probe: pass an out-of-range or already-reverted sequence number — expect a clear error, not silent success. After verification, `revert_last_apply` to clear the surviving audit-only entry.
+5. `compile_check`.
+6. Only Roslyn solution-level changes are revertible. If `revert_last_apply` / `revert_apply_by_sequence` error or no-op, document it.
+
+**MCP audit checkpoint:** Does `revert_last_apply` restore the prior state? Does it report what was undone? Does it return a clear "nothing to revert" when called twice in succession? Does `revert_apply_by_sequence` correctly undo a non-tip entry without disturbing later entries? Does it reject out-of-range sequence numbers cleanly?
+
+---
+
+### Phase 11: Semantic search, discovery, and reflection/DI
+
+1. `semantic_search("async methods returning Task<bool>")`. v1.8+ HTML-decodes ingress — a client that double-encodes (`Task&lt;bool&gt;`) gets the same results as the unencoded query.
+2. `semantic_search("methods returning Task<bool>")` — broader paraphrase; explain the delta in modifier-sensitive matching.
+3. `semantic_search("classes implementing IDisposable")` — cross-check against `find_implementations(IDisposable)`.
+4. `semantic_grep` with a structural / regex-style pattern (e.g. a method-call shape or LINQ chain). Different surface from `semantic_search` — pattern-based rather than natural-language. Verify the result set is non-empty on a known-good pattern, and that an intentionally bogus pattern produces a clean empty result rather than a crash.
+5. `find_reflection_usages` — `typeof`, `GetMethod`, `Activator`, etc.
+6. `get_di_registrations` — full DI wiring audit.
+7. `source_generated_documents` — source-gen outputs listed.
+
+**MCP audit checkpoint:** Do paired `semantic_search` queries return relevant and explainable differences? Does `semantic_grep` produce sensible structural matches and reject malformed patterns cleanly? Does `find_reflection_usages` find all reflection patterns? Does `get_di_registrations` parse all registration styles? Are source-gen documents correctly listed?
+
+---
+
+### Phase 12: Scaffolding
+
+**Default:** previews on the disposable worktree, plus apply one scaffold, verify, clean up. Under `--no-worktree`: apply siblings are `skipped-safety — --no-worktree`.
+
+1. `scaffold_type_preview`. v1.8+ default is `internal sealed class`; records, interfaces, enums stay `public`. The file lands at `{projectRoot}/{namespace-folders}/T.cs` even when the namespace doesn't start with the project name. v1.17+ auto-implements interface stubs (`throw new NotImplementedException()` + required usings) when `baseType`/`interfaces` resolve to an interface with members — opt out with `implementInterface: false` and assert the body becomes empty.
+2. `scaffold_test_preview` for an existing type. v1.8+ constructor-arg expressions: `IEnumerable<T>` / `ICollection<T>` / `IList<T>` / `IReadOnlyList<T>` → `System.Array.Empty<T>()`; dictionaries → `new Dictionary<K,V>()`; `string` → `string.Empty`. Previously every parameter was `default(T)`.
+3. `scaffold_test_batch_preview(testProjectName, targets=[{targetTypeName, targetMethodName?}, …])` on 3–5 targets. Verify one composite token covers every generated file (not N tokens). Apply via `preview_multi_file_edit_apply` (**not** `apply_composite_preview`). Confirm every scaffolded test is discoverable.
+4. `scaffold_first_test_file_preview` for a project that has no test file yet — bootstraps the test project shape.
+5. Apply one scaffold via `scaffold_type_apply` (using a token from `scaffold_type_preview`) — verify the resulting file matches the preview diff and that `compile_check` passes.
+6. Apply one test scaffold via `scaffold_test_apply` (using a token from `scaffold_test_preview`) — verify the new test is discoverable via `test_discover` and runs green via `test_run`.
+
+**MCP audit checkpoint:** Does `scaffold_type_preview` infer the correct namespace and produce `internal sealed class` by default? Does the interface-stub emission toggle on `implementInterface`? Does `scaffold_type_apply` produce the file the preview promised? Does `scaffold_test_preview` produce compiling stubs that run green? Does `scaffold_test_apply` discover and run cleanly? Does `scaffold_test_batch_preview` emit one composite token? Does `scaffold_first_test_file_preview` bootstrap cleanly?
+
+---
+
+### Phase 13: Project mutation
+
+**Default:** previews on the disposable worktree, plus at least one reversible preview → `apply_project_mutation` → verify → inverse preview → reverse apply. Under `--no-worktree`: apply siblings are `skipped-safety — --no-worktree`.
+
+1. `add_package_reference_preview` / `remove_package_reference_preview`.
+2. `add_project_reference_preview` / `remove_project_reference_preview`.
+3. `set_project_property_preview` (e.g. `Nullable`, `LangVersion`).
+4. `set_conditional_property_preview` scoped to a configuration.
+5. `add_target_framework_preview` / `remove_target_framework_preview` (multi-targeting).
+6. If CPM: `add_central_package_version_preview` / `remove_central_package_version_preview`.
+7. `get_msbuild_properties` with `propertyNameFilter` / `includedNames` to probe a non-default path.
+8. Apply + reverse one reversible mutation on the disposable worktree; verify with `workspace_reload` + `build_project` / `compile_check`.
+
+**MCP audit checkpoint:** Do the previews produce correct XML diffs? Do conditional-property conditions evaluate correctly? Do framework additions/removals look right? Does the forward-reverse apply round-trip work? Are multi-targeting / CPM correctly marked `skipped-repo-shape` when unused?
+
+---
+
+### Phase 14: Navigation & completions
+
+1. `go_to_definition` on a usage → correct declaration.
+2. `goto_type_definition` on a variable → the type, not the variable declaration.
+3. `enclosing_symbol` inside a method → the method.
+4. `get_symbol_outline` on a non-trivial file (≥3 types or ≥10 members) — verify the outline tree depth, kind classification, and ordering match what `document_symbols` returns. Drift between these two surfaces (different kinds, different ordering, or one missing a member the other lists) is a FLAG.
+5. `get_completions` after a dot. v1.8+ ranks locals/parameters → type members → types → long tail. For `filterText="To"`, in-scope `ToString` should appear before namespace-qualified externals like `ToBase64Transform`.
+6. `find_references_bulk` with multiple symbol handles — batch results match individual `find_references`.
+7. `find_overrides` on a virtual method; `find_base_members` on an override.
+
+**MCP audit checkpoint:** Are navigation results accurate? Does `get_symbol_outline` agree with `document_symbols`? Does `get_completions` rank sensibly? Does `find_references_bulk` match individual calls?
+
+---
+
+### Phase 15: Resource verification
+
+1. `roslyn://server/catalog` — machine-readable surface inventory.
+2. `roslyn://server/resource-templates`.
+3. `roslyn://workspaces` (summary); `roslyn://workspaces/verbose` for the project tree.
+4. `roslyn://workspace/{id}/status` and `/status/verbose` — assert matching `WorkspaceVersion` + `SnapshotToken`.
+5. `roslyn://workspace/{id}/projects` vs `project_graph` tool output.
+6. `roslyn://workspace/{id}/diagnostics` vs `project_diagnostics` tool output.
+7. `roslyn://workspace/{id}/file/{filePath}` vs `get_source_text`.
+8. `roslyn://workspace/{id}/file/{filePath}/lines/{N-M}` — experimental line-range slice. Request a small known range (e.g. `lines/1-10`); verify the response starts with a `// roslyn://…/lines/N-M of T` marker comment and contains only the requested lines. Request an invalid range (`lines/10-5`) — expect a structured error, not a hang.
+
+**MCP audit checkpoint:** Do resources agree with their tool counterparts? Are URI templates resolved correctly? Do summary/verbose versions share `WorkspaceVersion` + `SnapshotToken`? Is the line-range slice marker present and is the invalid range rejected cleanly?
+
+---
+
+### Phase 16: Prompt verification (`prompts/list` + `prompts/get`)
+
+The live catalog is authoritative for prompt count. Exercise every live prompt unless truly `skipped-repo-shape` or `blocked`.
+
+**Per-prompt checklist:**
+
+1. **Schema sanity.** Look up the prompt in `roslyn://server/catalog`; verify argument list against `prompts/list`. Mismatch = FAIL.
+2. **Rendered output correctness.** Invoke with realistic arguments from Phases 1–3. Every tool name in the rendered text must exist in the live catalog. Hallucinated tool = FAIL.
+3. **Actionability.** Does the rendered text produce concrete tools + preview→apply chains + verification steps?
+4. **Idempotency.** Same args twice → same rendered text modulo `_meta.elapsedMs`.
+
+**Minimum exercised set:** `explain_error`, `suggest_refactoring`, `review_file`, `discover_capabilities`. Cover the remaining live prompt surface — the current snapshot includes `analyze_dependencies`, `debug_test_failure`, `refactor_and_validate`, `fix_all_diagnostics`, `guided_package_migration`, `guided_extract_interface`, `security_review`, `dead_code_audit`, `review_test_coverage`, `review_complexity`, `cohesion_analysis`, `consumer_impact`, `guided_extract_method`, `msbuild_inspection`, `session_undo`, `refactor_loop`. If the live catalog differs, trust the catalog and record prompt drift in *Improvement suggestions*.
+
+Also exercise the prompt-renderer tool:
+
+5. `get_prompt_text(promptName, parametersJson)` — verify the rendered messages array matches what `prompts/get` would have returned. Repeat for 2–3 prompts; no hallucinated tool names. **Negative probes:** unknown `promptName` (actionable error); malformed `parametersJson` (error cites the parse failure).
+
+For every exercised prompt, append one row to the *Prompt verification* table.
+
+**MCP audit checkpoint:** Do argument templates match `prompts/list`? Does every rendered prompt reference only live-catalog tools? Does `discover_capabilities` align with Phase -1's live catalog? Does `get_prompt_text` match the `prompts/get` surface?
+
+---
+
+### Phase 17: Boundary & negative testing
+
+Deliberately probe edge cases. Verify inputs validated, error messages helpful, no crashes.
+
+#### 17a. Invalid identifiers
+1. Workspace-scoped tool with a non-existent workspace id → actionable error. v1.8+: error envelope's `tool` field carries the actual tool name, not `"unknown"`.
+2. `find_references` / `symbol_info` with a fabricated symbol handle. v1.8+: structurally valid but unfindable handle (e.g. base64 of `{"MetadataName":"NonExistent.Type"}`) returns `category: NotFound`, not silent `{count:0, references:[]}`. Also applies to `find_consumers`, `find_type_usages`, `find_implementations`, `find_overrides`, `find_base_members`, `impact_analysis`, `find_type_mutations`.
+3. `rename_preview` with the same fabricated handle.
+
+#### 17b. Out-of-range positions
+1. `go_to_definition` with line beyond end-of-file.
+2. `enclosing_symbol` at line 0, column 0 (off-by-one probe).
+3. `analyze_data_flow` with `startLine > endLine`.
+4. `probe_position` on a position known to be whitespace.
+
+#### 17c. Empty / degenerate inputs
+1. `symbol_search("")` — empty result or clear error, not crash.
+2. `analyze_snippet` with empty code body.
+3. `evaluate_csharp` with empty input.
+
+#### 17d. Stale and double-apply
+1. `*_apply` with an already-consumed preview token → clear stale-token rejection.
+2. Fresh preview token → advance the workspace version with a separate low-impact mutation on the disposable worktree → attempt to apply the now-stale token → clear workspace-version/staleness rejection. Under `--no-worktree`, mark `skipped-safety — --no-worktree` (no apply available to invalidate the token).
+3. `revert_last_apply` twice in succession — second call returns clear "nothing to revert", not an error.
+
+#### 17e. Post-close operations
+1. `workspace_close`.
+2. `workspace_status` with the now-closed id → clear error.
+3. `workspace_load` to re-open (or defer reopen to end of phase if remaining phases are complete).
+
+**MCP audit checkpoint:** For each error path — actionable, vague, or unhelpful? Did stale-token / version-mismatch cases fail cleanly? Any 500-level / unhandled exceptions? Did bad input drive the server into a degraded state affecting subsequent calls?
+
+---
+
+### Phase 18: Regression verification
+
+Re-test 3–5 previously recorded issues. Prefer `ai_docs/backlog.md` at the audited-repo root when auditing Roslyn-Backed-MCP. Otherwise a prior audit report / issue tracker / saved repro list. If no prior source, `**N/A — no prior source**`.
+
+1. Read the prior source; select 3–5 items reproducible with the current workspace.
+2. For each, reproduce the exact scenario. Record **still reproduces** / **partially fixed** (describe) / **no longer reproduces — candidate for closure**.
+
+### Phase 19: Fragment emission (cross-repo backlog handoff)
+
+For each **actionable** finding in the audit report (anything that lands in section 13 *MCP server issues* or in section 14 *Improvement suggestions* with a concrete fix sketch), emit one **`backlog.d/` fragment** at:
+
+```
+<audited-repo-root>/backlog.d/<finding-id>.md
+```
+
+Schema is canonical at `<Roslyn-Backed-MCP-root>/ai_docs/items/backlog-d-fragment-schema.md` — read that file once if you have not seen it. The required frontmatter keys are: `id`, `source_audit`, `source_repo`, `severity`, `area`, `anchors`. The body is a single ≤6-sentence paragraph (finding + repro + proposed fix sketch).
+
+Steps:
+
+1. Ensure `<audited-repo-root>/backlog.d/` exists (`mkdir -p`).
+2. For each actionable finding, derive a kebab-case `<finding-id>` that prefixes the audited repo's id (e.g. `roslyn-mcp-find-references-stale-cache`, `tradewise-symbol-search-empty-query-overflow`). The filename and the frontmatter `id` must match exactly.
+3. Set `source_audit` to the basename of the prose audit report this run is producing (e.g. `20260507T203015Z_tradewise_mcp-server-audit.md`).
+4. Set `source_repo` to the audited repo's kebab-case id.
+5. Set `severity` to `P0` / `P1` / `P2` / `P3` matching the section 13 severity (or your own classification for section 14 entries: typically `P3` unless the suggestion blocks a concrete workflow, in which case `P2`).
+6. Set `area` to one of `tools` / `resources` / `prompts` / `skills` / `concurrency` / `perf` / `docs`.
+7. Set `anchors` to one or more `path/to/file.ext:LINE` strings (relative to the audited repo's root).
+
+Idempotency: if a fragment with the same filename already exists in `backlog.d/`, **do not overwrite it** — leave the existing fragment in place and skip emission for that finding. Re-running the audit on the same repo without intake-in-between is allowed; the second run is a no-op for fragments that have not changed.
+
+`**N/A — no actionable findings**` is a valid Phase 19 outcome when sections 13 + 14 are both empty.
+
+This phase replaces the prior cross-write of audit reports into `<Roslyn-MCP-root>/ai_docs/audit-reports/`. Fragments are now the only `/backlog-intake`-consumable artifact. The prose `*_mcp-server-audit.md` and the scorecard JSON stay where this run wrote them under `<audited-repo-root>/ai_docs/audit-reports/`; intake reads them only as back-references via the fragment's `source_audit` field.
+
+---
+
+### Final surface closure (mandatory before the report)
+
+1. Compare the coverage ledger against the live catalog from Phase -1 / 0.
+2. Every unaccounted tool/resource/prompt: call it now or assign a final explicit status with a one-line reason.
+3. Confirm all audit-only mutations from Phases 8b / 9–13 were reverted or cleaned up. Only intentional Phase 6 product improvements remain. (8b writer-reclassification probes + W2 `set_editorconfig_option` reverted; W1 `format_document_apply` is the audit-only apply Phase 9 reverts.)
+4. Ledger totals match live catalog; catalog summary matches `server_info`.
+5. *Concurrency matrix* fully populated (or the whole Phase 8b is `blocked` with a single reason).
+6. *Debug log capture* has at least one entry or explicitly states `client did not surface MCP log notifications`.
+7. **Compute the experimental promotion scorecard.** For each experimental entry, use this rubric:
+   - **`promote`** — ALL of: exercised end-to-end with ≥1 non-default parameter path; schema matched behaviour on every probe; zero FAIL findings in this run or prior backlog; p50 `elapsedMs` within budget (single-symbol reads ≤5 s, solution scans ≤15 s, writers ≤30 s); preview/apply round-tripped cleanly where applicable; error path actionable on ≥1 negative probe; catalog description matched actual behaviour.
+   - **`keep-experimental`** — exercised with pass signal but missing ≥1 promote criterion (typically: writer round-trip not performed, or `--no-worktree` gated the apply, or a non-default path was not probed).
+   - **`needs-more-evidence`** — not exercised (`skipped-repo-shape` / `skipped-safety` / `blocked`) OR one exercise too shallow to judge. Default for `blocked` entries.
+   - **`deprecate`** — exercised, produced FAIL findings warranting removal. Pair with an *MCP server issues* entry.
+8. *Schema vs behaviour drift*, *Error message quality*, *Parameter-path coverage*, *Performance baseline* tables populated. Every exercised tool contributes ≥1 row to *Performance baseline*; the other three can be empty-with-reason.
+9. *Prompt verification* has one row per exercised prompt.
+
+When all phases are done, `workspace_close` to release the session (if not already closed in Phase 17e).
+
+---
+
+## Output Format — MANDATORY
+
+### What goes in git (nothing from this audit)
+
+The audit run produces no commits in the audited repo's history. Phase 6 applies are exercised inside the disposable worktree the prompt creates, and the worktree is torn down at run end (sub-phase 6z). The audited repo's primary working tree and `main` branch are never mutated. The deliverable is the audit report + the promotion scorecard JSON — see below.
+
+### What goes in a file (incremental draft + final canonical output)
+
+Maintain a draft at `<canonical-path>.draft.md` and append findings after every phase. Never revisit prior phases by re-running tool calls — read from the draft. When all phases complete, atomically rename the draft to the canonical name.
+
+The audit is **not finished** until both of:
+
+1. The canonical file exists on disk at `<canonical-path>`.
+2. The draft was continuously updated per phase (no one-shot final flush from working memory).
+
+A one-shot flush from working memory is the most common cause of broken runs — the model accumulates ~1–2 MB of tool results in active context, then runs out of room when serializing the report. Persisting after each phase keeps each turn within budget and lets the next turn drop the prior phase's tool-result bulk.
+
+This prompt writes **raw per-run evidence only**. Multi-repo campaigns synthesize cross-repo findings later under `ai_docs/reports/`; do not write the raw audit file there.
+
+### Where to save the report
+
+**Canonical path:** `<audited-repo-root>/ai_docs/audit-reports/<timestamp>_<repo-id>_mcp-server-audit.md`
+
+- `<timestamp>` = current UTC `yyyyMMddTHHmmssZ`.
+- The prose `.md` report ALWAYS stays in the audited repo's own `ai_docs/audit-reports/`. Do **not** cross-write it into `<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/` — that legacy cross-write path is removed in favor of the fragment pattern (see Phase 19).
+- Cross-repo handoff to `/backlog-intake` happens via the per-finding fragments emitted in Phase 19 (`<audited-repo-root>/backlog.d/<finding-id>.md`), NOT by relocating the prose report. Intake reads the fragment's `source_audit` field to back-reference the prose report when it needs additional context.
+- Do **not** place raw audit files under `ai_docs/reports/` — that directory is for synthesized rollups.
+
+### Promotion scorecard JSON (sibling artifact — MANDATORY)
+
+In addition to the human-readable `.md` report, write a machine-readable scorecard at:
+
+**`<audited-repo-root>/ai_docs/audit-reports/_latest-promotion-scorecard.json`**
+
+The scorecard now lives **next to its source evidence** in the audited repo's
+own `ai_docs/audit-reports/` folder, alongside the prose audit report. The
+older single-file location at `<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/`
+is **deprecated** — it was a last-write-wins file across all audited
+workspaces, which let a single workspace's anomaly drive promotion
+decisions. Cross-repo aggregation (quorum across sibling repos) is now
+the consumer's job: `/publish-preflight` Step 8 gathers per-repo
+scorecards via `eng/aggregate-promotion-scorecards.ps1`.
+
+This file is **overwritten** each run. Schema:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-05T18:36:19Z",
+  "noWorktree": false,
+  "auditedRepo": "roslyn-backed-mcp",
+  "auditReportPath": "ai_docs/audit-reports/20260505T183619Z_roslyn-backed-mcp_mcp-server-audit.md",
+  "serverVersion": "1.33.2",
+  "catalogVersion": "2026.04",
+  "experimentalSurface": {
+    "tools": 56,
+    "resources": 4,
+    "prompts": 20
+  },
+  "scorecard": [
+    {
+      "kind": "tool",
+      "name": "scaffold_test_apply",
+      "category": "scaffolding",
+      "currentTier": "experimental",
+      "recommendation": "promote",
+      "evidenceCount": 7,
+      "evidence": [
+        "phase-12 apply round-trip clean (preview-token honored, post-apply compile_check green)",
+        "phase-17 negative probe — stale token rejected with actionable error",
+        "phase-8 test_discover finds new test, test_run green",
+        "p50 elapsedMs=1240ms (within writer budget 30s)",
+        "schema accurate vs. live behavior",
+        "no entries in phase-1 debug log",
+        "no relevant backlog rows"
+      ],
+      "blockers": []
+    },
+    {
+      "kind": "tool",
+      "name": "split_class_preview",
+      "category": "refactoring",
+      "currentTier": "experimental",
+      "recommendation": "needs-more-evidence",
+      "evidenceCount": 2,
+      "evidence": [
+        "phase-10 preview emitted valid partial classes",
+        "p50 elapsedMs=480ms"
+      ],
+      "blockers": [
+        "no apply round-trip exercised (apply sibling skipped-safety per --no-worktree)",
+        "no negative-probe evidence on shared-state across the split"
+      ]
+    }
+  ],
+  "summary": {
+    "promote": 1,
+    "keep-experimental": 0,
+    "needs-more-evidence": 1,
+    "deprecate": 0,
+    "blocked": 0
+  }
+}
+```
+
+**Field rules:**
+
+- `recommendation` ∈ `"promote" | "keep-experimental" | "needs-more-evidence" | "deprecate"`. Mirror the per-call recommendation captured in the `.md` report's *Experimental promotion scorecard* section. Do not invent recommendations beyond what the human-readable scorecard contains.
+- `currentTier` is the live value from `roslyn://server/catalog` per entry. Do **not** infer it from the prompt.
+- `evidence` is a flat string array — one short sentence per supporting probe. Match the per-call promotion-signal lines captured in the draft (principle #14).
+- `blockers` is empty when `recommendation == "promote"`; populated with concrete missing evidence otherwise.
+- Skip rows for entries marked `blocked` in the coverage ledger — they cannot be scored. Track them in `summary.blocked` only.
+
+**Why this exists.** `/release-cut` (via `/publish-preflight`) aggregates per-repo scorecards from configured sibling repos and applies a **quorum rule** (≥2 workspaces with `recommendation: "promote"`, no `keep-experimental` or `deprecate` blockers) before prompting the maintainer to flip a tier. Without the JSON, promotion stays implicit and the audit's promotion lane has no operational consequence. With per-repo scorecards plus quorum, single-workspace anomalies no longer drive tier decisions.
+
+**Staleness contract.** The JSON is a snapshot, not a journal. `/publish-preflight` warns when `generatedAt` is older than 30 days; older than 90 days, the file should be ignored entirely (recommend a fresh `/audit-deep` run).
+
+**`--no-worktree` runs still emit the scorecard.** Apply round-trips that depended on the disposable worktree are recorded as `skipped-safety — --no-worktree` in the coverage ledger and the affected writer tools' `recommendation` will typically default to `needs-more-evidence`, with `blockers` citing the missing worktree. The scorecard JSON is still written so consumers see a fresh artifact and can decide for themselves whether the missing-worktree evidence matters for their gate.
+
+### Naming scheme (`<timestamp>_<repo-id>`)
+
+- `<timestamp>`: current UTC `yyyyMMddTHHmmssZ`.
+- `<repo-id>`: audited solution/repo name — strip `.sln` / `.slnx` / `.csproj`; lowercase; replace spaces and dots with hyphens. Examples: `20260422T154500Z_itchatbot_mcp-server-audit.md`.
+
+### Report contents (required sections)
+
+The report is consumed by downstream agents. Dense tables, fixed schemas, one-line entries. Narrative paragraphs only when the issue genuinely requires one.
+
+**Mandatory sections (always in full):**
+
+| # | Section | Purpose |
+|---|---|---|
+| 1 | Header | Server, client, scale, mode, debug-log channel |
+| 2 | Coverage summary | Grouped by live `Kind` + `Category` |
+| 3 | Coverage ledger | One row per live tool/resource/prompt |
+| 4 | Verified tools | Tested-and-working list |
+| 5 | Phase 6 refactor summary | Applied product changes (or N/A + reason) |
+| 6 | Performance baseline | `_meta.elapsedMs` per exercised tool |
+| 7 | Schema vs behaviour drift | Principle #2 output |
+| 8 | Error message quality | Principle #4 output |
+| 9 | Parameter-path coverage | Principle #6 output |
+| 10 | Prompt verification | Phase 16 per-prompt table |
+| 11 | Experimental promotion scorecard | Per-entry recommendation |
+| 12 | Debug log capture | Phase 0 channel output |
+| 13 | MCP server issues (bugs) | Per-issue detail |
+| 14 | Improvement suggestions | Actionable UX / output enrichment |
+
+**Conditional sections (populate when data exists, otherwise `**N/A — <reason>**`):**
+
+| # | Section | Populate when |
+|---|---|---|
+| 15 | Concurrency matrix | Phase 8b ran with at least sequential baselines |
+| 16 | Writer reclassification verification | Phase 8b.5 exercised writers |
+| 17 | Response contract consistency | Principle #5 observed ≥1 inconsistency |
+| 18 | Known issue regression check | Prior source existed |
+| 19 | Known issue cross-check | New findings matched a backlog/issue id |
+
+Mandatory sections always render in full; conditional sections collapse to a single `**N/A — <reason>**` line when unpopulated.
+
+### Markdown template
+
+```markdown
+# MCP Server Audit Report
+
+## 1. Header
+- **Date:**
+- **Audited solution:**
+- **Audited revision:** (commit / branch if available)
+- **Entrypoint loaded:**
+- **Flags:** (none) / `--no-worktree`
+- **Isolation:** (absolute disposable worktree path + branch name, or `degraded — --no-worktree flag, Phase 6 applies skipped`)
+- **Teardown:** `clean` / `partial — <what survived>` / `failed — <error>` / `N/A — --no-worktree`
+- **Client:** (name/version; note if prompts or resources are client-blocked)
+- **Workspace id:**
+- **Warm-up:** `yes` / `no` (did you call `workspace_warm` after load?)
+- **Server:** (from `server_info`)
+- **Catalog version:** (from `server_info.catalogVersion`)
+- **Roslyn / .NET:** (if reported)
+- **Live surface:** `tools: <stable>/<experimental>`, `resources: <stable>/<experimental>`, `prompts: <stable>/<experimental>` (from `server_info.surface`)
+- **Scale:** ~N projects, ~M documents
+- **Repo shape:**
+- **Prior issue source:**
+- **Debug log channel:** `yes` / `partial` / `no`
+- **Report path note:** (path under the audited repo's `ai_docs/audit-reports/`; cross-repo handoff is via Phase 19 fragments, not via copying the prose report)
+
+## 2. Coverage summary
+| Kind | Category | Stable | Experimental | Exercised | Exercised-apply | Preview-only | Skipped-repo-shape | Skipped-safety | Blocked | Notes |
+|------|----------|--------|--------------|-----------|------------------|--------------|--------------------|----------------|---------|-------|
+
+## 3. Coverage ledger
+| Kind | Name | Tier | Category | Status | Phase | lastElapsedMs | Notes |
+|------|------|------|----------|--------|-------|---------------|-------|
+
+## 4. Verified tools (working)
+- `tool_name` — one-line observation (include p50 elapsedMs when available)
+
+## 5. Phase 6 apply-tool exercise summary
+- **Disposable worktree path:** absolute path (or `N/A — --no-worktree`)
+- **Disposable branch:** `audit-deep/<ts>` (or `N/A — --no-worktree`)
+- **Scope:** (which 6a–6m sub-phases ran; `**N/A — skipped per --no-worktree**` when degraded mode)
+- **Apply-tool calls:** bullets — preview→apply pairs exercised, with tool name + outcome
+- **Verification:** `compile_check` / `test_run` / `build_workspace` outcomes after applies
+- **Teardown outcome:** see header *Teardown* row; expand here if `partial` / `failed`
+
+## 6. Performance baseline (`_meta.elapsedMs`)
+| Tool | Tier | Category | Calls | p50_ms | p90_ms | max_ms | Input scale | Budget | Notes |
+|------|------|----------|-------|--------|--------|--------|-------------|--------|-------|
+
+## 7. Schema vs behaviour drift
+| Tool | Mismatch kind | Expected | Actual | Severity | Notes |
+|------|---------------|----------|--------|----------|-------|
+
+## 8. Error message quality
+| Tool | Probe input | Rating | Suggested fix | Notes |
+|------|-------------|--------|---------------|-------|
+
+## 9. Parameter-path coverage
+| Family | Non-default path tested | Status | Notes |
+|--------|--------------------------|--------|-------|
+
+## 10. Prompt verification (Phase 16)
+| Prompt | schema_ok | actionable | hallucinated_tools | idempotent | elapsedMs | recommendation_seed | Notes |
+|--------|-----------|------------|---------------------|------------|-----------|----------------------|-------|
+
+## 11. Experimental promotion scorecard
+| Kind | Name | Category | Status | p50_ms | schema_ok | error_ok | round_trip_ok | Failures | Recommendation | Evidence |
+|------|------|----------|--------|--------|-----------|----------|----------------|----------|----------------|----------|
+
+## 12. Debug log capture
+| timestamp | level | logger | correlationId | eventName | message | Phase | Tool in flight |
+|-----------|-------|--------|----------------|-----------|---------|-------|----------------|
+
+## 13. MCP server issues (bugs)
+
+### 13.1 <title or tool name>
+| Field | Detail |
+|-------|--------|
+| Tool | |
+| Input | |
+| Expected | |
+| Actual | |
+| Severity | |
+| Reproducibility | |
+
+(repeat per issue, or write `**No new issues found**` when none)
+
+## 14. Improvement suggestions
+- `tool_name` — suggestion (UX / missing feature / workflow gap / output enrichment / schema mismatch)
+
+## 15. Concurrency matrix (Phase 8b)
+
+### Concurrency probe set
+| Slot | Tool | Inputs (concise) | Classification | Notes |
+|------|------|------------------|----------------|-------|
+
+### Sequential baseline (single-call wall-clock, ms)
+| Slot | Wall-clock (ms) | Notes |
+|------|------------------|-------|
+
+### Parallel fan-out and behavioral verification
+- **Host logical cores:** _
+- **Chosen N:** _N = min(4, max(2, logical_cores))_
+
+| Slot | Parallel wall-clock (ms) | Speedup vs baseline | Expected | Pass / FLAG / FAIL | Notes |
+|------|---------------------------|----------------------|----------|---------------------|-------|
+
+### Read/write exclusion behavioral probe
+| Probe | Observed | Expected | Pass / FLAG / FAIL | Notes |
+|-------|----------|----------|---------------------|-------|
+
+### Lifecycle stress
+| Probe | Observed | Reader saw | Reader exception | correlationId | Expected | Pass / FLAG / FAIL | Notes |
+|-------|----------|-----------|------------------|---------------|----------|---------------------|-------|
+
+## 16. Writer reclassification verification (Phase 8b.5)
+| # | Tool | Status | Wall-clock (ms) | Notes |
+|---|------|--------|------------------|-------|
+
+## 17. Response contract consistency
+| Tools | Concept | Inconsistency | Notes |
+|-------|---------|---------------|-------|
+
+## 18. Known issue regression check (Phase 18)
+| Source id | Summary | Status |
+|-----------|---------|--------|
+
+## 19. Known issue cross-check
+- bullet list of newly observed issues that match a prior source
+```
+
+### Completion gate
+
+The prose `.md` report must exist at the canonical path above (under the audited repo's `ai_docs/audit-reports/`). Create the directory if missing. Phase 19 must have emitted at least one fragment under `<audited-repo-root>/backlog.d/` OR explicitly recorded `**N/A — no actionable findings**`. The task is **incomplete** without both gates passing.
+
+---
+
+## Appendix — intentionally minimal
+
+The body of this prompt **does not** embed hard-coded tool, resource, prompt, or skill counts, nor per-version change logs. Those always drift. Instead, the live surface comes from three sources the running server emits:
+
+| Source | What it gives you | When captured |
+|---|---|---|
+| `server_info` | Version, catalog version, tier counts, `surface.registered.parityOk`, connection state | Phase -1 |
+| `roslyn://server/catalog` | Per-entry `Kind`, `Category`, `SupportTier`, metadata | Phase -1 / 0 |
+| `roslyn://server/resource-templates` | All resource URI templates | Phase 0 |
+
+That is the authoritative surface for any run. Trust those captures over any prose in this prompt.
+
+### Historical notes (kept terse, rotate when obsolete)
+
+- **Script timeout.** `evaluate_csharp` honors `ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS` (default 10 s). Principle #9 governs multi-minute stalls.
+- **Write-lock model.** One per-workspace `AsyncReaderWriterLock` via `WorkspaceExecutionGate`. No dual-lock lane (historical `_rw-lock_` / `_legacy-mutex_` audit filenames are artifacts).
+- **v1.28+.** `workspace_warm` is the recommended post-`workspace_load` prime step. `rename_apply.MutatedSymbol` carries a fresh handle for chained calls.
+- **Experimental-promotion workflow.** The promotion scorecard (mandatory output of every run) replaces the deprecated standalone experimental-promotion prompt. Scorecard-only runs are no longer a separate mode — the canonical run always exercises the experimental surface and emits the scorecard.

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -78,5 +78,5 @@ This directory is the canonical AI-facing documentation tree. Use this file to f
 | Coverage baseline / CI artifacts | `../docs/coverage-baseline.md` -> `references/testing.md` |
 | Experimental -> stable promotion review | `../docs/experimental-promotion-analysis.md` |
 | Large-solution profiling method | `../docs/large-solution-profiling-baseline.md` |
-| MCP deep-review audit session | `../.claude/skills/mcp-server-stress/prompts/prompt.md` -> `audit-reports/README.md` |
-| Multi-repo MCP deep-review batch | `procedures/deep-review-program.md` -> `procedures/deep-review-command-reference.md` -> `../.claude/skills/mcp-server-stress/prompts/prompt.md` -> `audit-reports/README.md` -> `reports/README.md` |
+| MCP deep-review audit session | `../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` -> `audit-reports/README.md` |
+| Multi-repo MCP deep-review batch | `procedures/deep-review-program.md` -> `procedures/deep-review-command-reference.md` -> `../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` -> `audit-reports/README.md` -> `reports/README.md` |

--- a/ai_docs/audit-reports/README.md
+++ b/ai_docs/audit-reports/README.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Index for raw deep-review audit outputs and templates; points to baseline, static snapshots, and rollup handoff. -->
 
-Use the bundled prompt [`.claude/skills/mcp-server-stress/prompts/prompt.md`](../../.claude/skills/mcp-server-stress/prompts/prompt.md) with an MCP client connected to **roslyn-mcp** to exercise the full tool surface against a real solution. The maintainer-only `/mcp-server-stress` skill in this repo orchestrates the run end-to-end.
+Use the bundled prompt [`.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md`](../../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md) with an MCP client connected to **roslyn-mcp** to exercise the full tool surface against a real solution. The maintainer-only `/mcp-server-stress` skill in this repo orchestrates the run end-to-end.
 
 ## What belongs here
 

--- a/ai_docs/audit-reports/deep-review-session-checklist.md
+++ b/ai_docs/audit-reports/deep-review-session-checklist.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Fill-in worksheet for live deep-review runs; keep phase order aligned with the bundled mcp-server-stress prompt. -->
 
-Use with [`.claude/skills/mcp-server-stress/prompts/prompt.md`](../../.claude/skills/mcp-server-stress/prompts/prompt.md). A full PASS/FAIL matrix needs an **interactive MCP session** (e.g. Cursor) with the server running (`dotnet run --project src/RoslynMcp.Host.Stdio` or global `roslynmcp`).
+Use with [`.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md`](../../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md). A full PASS/FAIL matrix needs an **interactive MCP session** (e.g. Cursor) with the server running (`dotnet run --project src/RoslynMcp.Host.Stdio` or global `roslynmcp`).
 
 **Canonical output:** raw evidence goes to `yyyyMMddTHHmmssZ_<repo-id>_mcp-server-audit.md` in this directory (see [`README.md`](README.md)). This file is only a **worksheet** — not a substitute for that report.
 

--- a/ai_docs/items/move-to-git-issues.md
+++ b/ai_docs/items/move-to-git-issues.md
@@ -1,759 +1,111 @@
-# move-to-git-issues — design seed for the audit-finding pivot
+# move-to-git-issues - current design for external audit findings
 
-<!-- purpose: Captures the architectural rethink that surfaced at the end of the 20260507T182128Z backlog sweep — pivoting audit findings away from the local `backlog.d/` fragment pattern toward GitHub Issues so the skill can ship to consumers. Pre-brainstorm seed; not yet a backlog row. -->
+<!-- purpose: Current design note for moving the audit-finding sharing path toward GitHub Issues while keeping the maintainer-local fragment workflow. -->
 <!-- scope: in-repo -->
-<!-- status: pre-brainstorm — design discussion captured, no rows planned yet -->
+<!-- status: design seed - current decisions captured; not yet a backlog row -->
 
-**Created:** 2026-05-08
-**Trigger:** Final design conversation in the 20260507T182128Z backlog sweep session, after all 6 initiatives merged.
-**Next step:** A `/brainstorming` session that uses this doc as input to produce a sized backlog row set.
-
----
-
-## TL;DR
-
-The 20260507T182128Z sweep moved `/mcp-server-stress` (formerly `/audit-deep`) from the shipped plugin surface (`skills/audit-deep/`) to maintainer-only (`.claude/skills/mcp-server-stress/`) and built a `<audited-repo>/backlog.d/` fragment pattern for cross-repo audit findings. That pivot rationally followed from the assumption *"only the maintainer audits the server."* That assumption is wrong: the entire point of the audit is to find server bugs, and consumers running it against the C# codebases they have access to would dramatically widen the test surface. The right architectural fix is to **send actionable findings to GitHub Issues on the server's repo (`Roslyn-Backed-MCP`)**, which lets the skill go back to the shipped surface and lets consumers contribute findings. Most of the recently-shipped sweep survives; the relocate (inits 2+3) and the `backlog.d/` fragment pattern (init 5) are the parts that become partially obsolete.
+**Created:** 2026-05-08  
+**Last reconciled:** 2026-05-09  
+**Trigger:** Final design conversation after the 20260507T182128Z backlog sweep, then revised after empirical evidence from the 2026-05-08 audit run.
 
 ---
 
-## What just shipped (the 20260507T182128Z sweep)
+## Current decision snapshot
 
-Plan: `ai_docs/plans/20260507T182128Z_backlog-sweep/plan.md`. Six PRs landed, five backlog rows closed:
+The current design is **not** "replace `backlog.d/` with GitHub Issues." That earlier direction was superseded.
 
-| PR | Initiative | Closes row |
+The accepted shape is:
+
+1. **Maintainer intake stays local.** `/mcp-server-stress` continues to emit one `backlog.d/<finding-id>.md` fragment per actionable finding for maintainer-run audits. `/backlog-intake` continues to consume those fragments locally. This path is fast, offline-capable, and already validated by the 2026-05-08 audit run.
+2. **Maintainer-found accepted issues may also go public.** After local triage, valid maintainer-found findings can be filed as GitHub Issues for visibility, project-health signaling, and contributor onboarding. Do not dump every raw fragment into GitHub; curate findings first, then file issues that are real, understandable, and worth tracking publicly.
+3. **Consumer sharing becomes additive.** Consumers get a clean GitHub Issue path for findings they choose to share with `darylmcd/Roslyn-Backed-MCP`. In v1, the low-risk version is print-ready issue bodies plus an opt-in `--auto-file` path when `gh` is already authenticated. No proxy, GitHub App, telemetry endpoint, or silent filing in v1.
+4. **The shipped skill target name is `mcp-server-surface-test`.** Forward-looking surfaces use that name: skill folder, issue template, labels, docs, and commands. Historical `audit-deep` and `mcp-server-stress` references stay only where they describe already-shipped history.
+5. **The shipped skill must be generic.** Moving `.claude/skills/mcp-server-stress/` into `skills/mcp-server-surface-test/` is not a mechanical move. Shipped `./skills/**/SKILL.md` files cannot reference repo-only markers — the canonical banned-pattern set checked by `eng/verify-skills-are-generic.ps1` is `state.json`, `backlog-sweep`, `schemaVersion`, `ai_docs/`, `backlog.md`, `eng/`, `just verify-`, `Directory.Build.props`, and `BannedSymbols.txt`. Note that `backlog.d` is **not** banned: consumer-side fragments may legitimately land at `<consumer-repo>/backlog.d/`. Split consumer-generic behavior from maintainer-only repo workflow as needed.
+6. **Two run tiers are enough for v1.** `--quick` is the consumer-facing read-side tier; `--full` is the maintainer/default comprehensive tier. Defer a middle tier until there is demand.
+7. **Use one finding envelope.** The existing fragment schema is the base contract: `id`, `source_audit`, `source_repo`, `severity`, `area`, `anchors`, plus a new `server-version` field. Enrich the audit report with a structured `workspace-shape:` block instead of duplicating workspace metadata on every finding.
+8. **Public docs should be slim but explicit.** Add enough README and issue-template content that a consumer understands what `/mcp-server-surface-test` does, what each tier covers, expected runtime, privacy/safety, and how to share a finding. Include that maintainer-found issues are filed publicly to expose project quality work and create contributor entry points.
+9. **Community scorecard aggregation is stretch work.** Do not extend `publish-preflight` or `eng/aggregate-promotion-scorecards.ps1` for issue-comment input until real community scorecard data exists.
+
+## Recommended row set
+
+These are design candidates for a future planning pass, not open backlog rows yet.
+
+| Row | Scope | Notes |
 |---|---|---|
-| #547 | `audit-deep-collapse-modes` | `mcp-server-stress-single-mode` |
-| #548 | `mcp-server-stress-relocate` | (paired with #549) |
-| #549 | `mcp-server-stress-update-external-refs` | `audit-deep-relocate-and-rename` |
-| #550 | `extract-skills-audit-from-server-stress` | `extract-skills-audit-from-server-stress` |
-| #551 | `backlog-d-fragment-pattern` | `backlog-d-fragment-pattern` |
-| #552 | `per-repo-promotion-scorecard` | `per-repo-promotion-scorecard` |
+| 1. Ship as new generic skill at `skills/mcp-server-surface-test/` | Split the maintainer prompt into a generic-safe consumer half (under `skills/`) and a maintainer-only overlay (kept under `.claude/skills/`); update references and tests. | The shipped skill has never lived under `./skills/`, so this is a first-time ship, not a relocate. The genericity split is the bulk of the work — the current maintainer prompt has multiple banned-pattern hits, so this is not just `git mv`. |
+| 2. Tiered runs + shared finding envelope | Add `--quick` / `--full`, stamp `server-version`, enrich the audit report with `workspace-shape:`, and render findings through one fragment/issue envelope. | Keep `print` as the consumer default. `--auto-file` may use `gh issue create` only when explicitly requested and authenticated. Maintainer `--auto-file` should supplement local fragment emission, not replace it. |
+| 3. Slim consumer documentation + issue template | Add README guidance and `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml`. | Keep the tone factual: what the skill does, what it does not do, tier cost, privacy, where a finding goes, and how public issues can become contribution entry points. |
+| 4. Community scorecard input | Optional issue-comment or issue-body scorecard aggregation. | Stretch only. Ship after there is actual community scorecard evidence. |
 
-Plus #553 (plan-completion chore), #554 (changelog fragment for #545), and #545 (release-cut Step 6 fix) since v1.34.2.
+No v1 row should replace `/backlog-intake`'s fragment flow. Add issue intake automation only after public issue volume proves it is useful.
 
-Theme of the sweep: **maintainer-only audit-skill redesign.** Every initiative was sized around that frame.
+## Public contributor funnel
 
-## The architectural insight
+GitHub Issues should become the public-facing tracker for accepted, contributor-relevant work. This is separate from the local agent execution backlog.
 
-We rationalized the move-to-maintainer-only by claiming *"a normal `roslyn-mcp@roslyn-mcp-marketplace` consumer has no use for a skill that audits this repo's own surface, scorecard JSON, and `skills/*/SKILL.md` inventory."* That's true *if findings have to land back in this repo's local `backlog.md`* — which forces the skill to assume the auditor has commit access to `Roslyn-Backed-MCP`. The producer→consumer model we built around `<audited-repo>/backlog.d/` and `/backlog-intake` is internally consistent for the maintainer use case but doesn't generalize.
+Recommended flow:
 
-**The shape that does generalize is GitHub Issues.** Issues already have:
-- Severity (labels)
-- Dedup (search before file)
-- Comments (clarification, follow-up, repro updates)
-- Assignees (triage)
-- Repro metadata (markdown body + attached files)
-- Closed-via-PR linking
-- Cross-repo references
+1. A maintainer audit emits local fragments.
+2. The maintainer triages fragments through `/backlog-intake`.
+3. Valid findings that are worth tracking publicly get GitHub Issues.
+4. `ai_docs/backlog.md` keeps or gains the planner-ready row with a link to the GitHub Issue.
+5. Implementation PRs use `Closes #<issue>` so the public issue history shows discovery, fix, and closure.
 
-We were re-implementing a partial version of this in YAML frontmatter. The Issues-based version of the same flow is:
+Issue quality matters. A maintainer-filed issue should include:
 
-| | Old (just-shipped) | New (proposed) |
-|---|---|---|
-| Producer | `/mcp-server-stress` (maintainer-only) | `/mcp-server-stress` (shipped, runs anywhere) |
-| Per-finding scratch | `<audited-repo>/backlog.d/<id>.md` | GitHub Issue on `Roslyn-Backed-MCP` (labeled `audit-deep`) |
-| Consumer | `/backlog-intake` walks sibling repos, dedupes, deletes consumed fragments | `/backlog-intake` lists `audit-deep`-labeled issues, triages, accepts/rejects, converts accepted → backlog rows |
-| Master record | `Roslyn-Backed-MCP/ai_docs/backlog.md` | Same — populated only by triaged-and-accepted issues |
+- short title with the affected tool, prompt, or workflow;
+- concise repro or audit evidence;
+- expected vs. actual behavior;
+- likely fix area or anchor paths when known;
+- acceptance criteria that an outside contributor can verify;
+- labels for area and severity.
 
-## What survives from the recent sweep
+Use `help wanted` only when an outside PR would be welcome. Use `good first issue` only for genuinely bounded work that does not require deep Roslyn MCP internals, release-managed files, or broad workflow knowledge.
 
-Substantively right and stays:
+`ai_docs/backlog.md` remains the agent-ready execution queue. GitHub Issues are the public contribution and visibility surface, not the replacement for the structured backlog contract.
 
-- **Mode collapse (init 1)** — single canonical run with always-disposable-worktree + always-scorecard. Independent of where output goes.
-- **Disposable-worktree Phase 6 (init 1)** — applies-as-test-fixtures discipline. Audited repo's `main` is never mutated. Independent of output target.
-- **Plugin-skill audit moved to /surface-audit (init 4)** — that was a separate concern (static catalog vs runtime execution). Stays where it is.
-- **Per-repo scorecard at `<audited-repo>/ai_docs/audit-reports/_latest-promotion-scorecard.json` (init 6)** — local evidence file. What changes is whether the audit *also* posts a summary as an issue comment for community-quorum aggregation.
-- **`eng/aggregate-promotion-scorecards.ps1` (init 6)** — survives. Its input may grow to include issue-comment scorecards for community runs in addition to local file scrapes for maintainer runs.
+## Superseded decisions
 
-Roughly **~50% of inits 2+3** also survives even if we reverse the relocate: the cleanup of Phase 16b coupling, name conflicts, external references in `publish-preflight/SKILL.md` and `audit-phase-runner.md` is real cleanup that doesn't unwind.
-
-## What becomes partially obsolete
-
-- **Relocate to `.claude/skills/mcp-server-stress/` (inits 2, 3)** — needs to reverse. Skill goes back to shipped `skills/mcp-server-stress/`. The shipped surface we'd put back is *cleaner* than the original because of the cleanup work in init 3 (which still survives semantically).
-- **`backlog.d/` fragment pattern (init 5)** — the cross-repo emit-then-consolidate flow becomes redundant once findings go to issues. Specifically:
-  - **Survives:** the fragment schema at `ai_docs/items/backlog-d-fragment-schema.md` — repurposes naturally as the **issue-body template** (frontmatter fields map onto issue metadata: `severity:` → label, `area:` → label, `anchors:` → markdown bullets, body stays as-is).
-  - **Sunsets:** the discovery + delete logic in `eng/stage-review-inbox.ps1` and `/backlog-intake`'s fragment walk. Replaced by `gh issue list --label audit-deep` + maintainer triage flow.
-  - **Stays as fallback:** local fragment emit may still be useful as `--target-output=fragments` for the maintainer's own multi-repo audit if `gh` isn't authenticated. See *Fallback story* below.
-
-## The new shape (proposed)
-
-```
-/mcp-server-stress  (shipped at skills/mcp-server-stress/, invocable by any plugin consumer)
-   │
-   ├─ Loads C# workspace via Roslyn MCP (audited repo X — anywhere)
-   ├─ Runs full audit including disposable-worktree Phase 6
-   ├─ Writes prose evidence file:    <X>/ai_docs/audit-reports/<ts>_<repo>_mcp-server-audit.md
-   ├─ Writes scorecard:              <X>/ai_docs/audit-reports/_latest-promotion-scorecard.json
-   ├─ For each actionable finding:   gh issue create --repo darylmcd/Roslyn-Backed-MCP \
-   │                                   --label audit-deep,severity:P0..P3,area:tools|... \
-   │                                   --title "<title>" --body "<schema-formatted body>"
-   └─ Exits with summary + list of created issue URLs
-                  │
-                  ▼
-   GitHub Issues on Roslyn-Backed-MCP   ← producer-agnostic findings queue
-                  │
-                  ▼
-/backlog-intake   (run from Roslyn-Backed-MCP by maintainer)
-   │
-   ├─ Lists `audit-deep`-labeled open issues (`gh issue list`)
-   ├─ Triages: accept (→ backlog row), reject (→ close with comment), defer (→ keep open)
-   ├─ For accepted: drafts row in ai_docs/backlog.md, adds "Closes #<issue>" reference
-   └─ Issue stays open until the corresponding backlog row ships;
-       PR closing the row uses "Closes #<issue>" trailer, GitHub auto-closes issue.
-```
-
-The audited repo X is never mutated except for its local `ai_docs/audit-reports/` (prose evidence + scorecard). No `backlog.d/`. No commit access required to anyone else's repo. The auditor only needs `gh` authenticated against `Roslyn-Backed-MCP` (or a fallback path; see below).
-
-## Real costs / open design questions for the brainstorm
-
-### 1. Auth + fallback story
-
-**Problem:** filing issues needs `gh auth status` clean against `Roslyn-Backed-MCP` or a PAT with `repo:write` scope. Most plugin consumers won't have either.
-
-**Proposed mitigation: `--issue-mode` flag with three values.**
-
-| Mode | Behavior |
+| Superseded idea | Current replacement |
 |---|---|
-| `print` (default for community runs?) | Audit finishes, prints ready-to-paste issue body for each finding. User files manually if/when they want. No auth required. |
-| `create` | Calls `gh issue create` directly. If `gh` is unavailable or auth fails, log a clear warning and fall back to `print` mode for that finding. |
-| `preview` | Dry-run. Prints what `create` *would* do, doesn't file. Useful for the maintainer's first run on a new audited repo. |
-
-**Open question:** which is the right default? `print` is safer for first-time consumers (no auth surprises), `create` is more useful for maintainer runs. Possibly `auto` — defaults to `create` if `gh` works, falls back to `print` silently. Brainstorm should land this.
-
-### 2. Spam risk
-
-**Problem:** random consumer audits could noise the tracker.
-
-**Proposed mitigations (need to pick):**
-- **Severity gating.** Only file P0/P1 by default; require `--include-p2-p3` for the noisier classes.
-- **Confidence threshold.** Audit emits a `confidence:high|medium|low` field per finding; `--min-confidence=high` is the consumer-default. Maintainer runs with `--min-confidence=low` to see everything.
-- **Rate limit.** No more than N issues per audit run; if there are more findings, summarize the rest in a single rollup issue.
-- **Issue template.** Required fields: `server-version`, `platform`, `audited-workspace-stats` (project count, LOC). Forces enough metadata that triage is fast.
-- **`audit-deep` label as a triage filter.** Maintainer's tracker dashboard filters on this label.
-
-Brainstorm should pick the combo. My instinct: confidence threshold + required template + rate limit, no severity gating (P2/P3 are often the most actionable patterns and we shouldn't hide them).
-
-### 3. Sunset window for the existing flow
-
-**Problem:** the maintainer (you) currently audits sibling repos using the just-shipped `backlog.d/` pattern. Switching cold to issues means more friction (auth, label hygiene) for a workflow that was working.
-
-**Proposed:** keep the local-fragment path as a fallback (`--target-output=issues|fragments|both`, default `both` during the transition window, eventually `issues`). The maintainer's own multi-repo audit doesn't regress. Sunset the fragment path after — say — 3 months of community use.
-
-### 4. Issue triage discipline
-
-**Problem:** issues filed by audits accumulate. Without explicit triage workflow, the tracker fills with stale `audit-deep`-labeled issues forever.
-
-**Proposed contract:**
-- Every audit-filed issue has the `audit-deep` label and a `from-audit:<audit-id>` reference.
-- Triage SLA: maintainer reviews `audit-deep` issues weekly, decides accept/reject/defer.
-- Accepted: backlog row created, issue stays open with `triaged:accepted` label; closed when the row ships via "Closes #N" PR trailer.
-- Rejected: closed with maintainer comment explaining why. Optionally adds `triaged:not-actionable` label.
-- Deferred: stays open with `triaged:defer` + a comment explaining what evidence/condition would unblock acceptance.
-
-This needs to be written down somewhere — probably `docs/AUDIT_FINDINGS.md` or appended to `CONTRIBUTING.md`. Brainstorm should land where.
-
-### 5. Cross-forge consumers
-
-**Problem:** what about consumers using GitLab, Azure DevOps, etc.? They can still run the audit against their workspaces, but `gh issue create` against `Roslyn-Backed-MCP` only works on GitHub.
-
-**Proposed:** the audit's issue target is **always the server's repo** (`darylmcd/Roslyn-Backed-MCP`), not the audited repo. Findings are about the server, not about the audited code, so they belong in the server's tracker regardless of where the audited code lives. Consumers on non-GitHub forges still need to file against `Roslyn-Backed-MCP`'s GitHub tracker — which they likely have read access to even without contributing. Worst case: they use `print` mode and paste manually.
-
-### 6. Per-repo scorecard quorum with community evidence
-
-**Problem:** init 6's `eng/aggregate-promotion-scorecards.ps1` aggregates scorecards across configured sibling repos owned by the maintainer. Community runs would produce scorecards in random workspaces the maintainer doesn't have access to.
-
-**Proposed:** community runs optionally post their scorecard as an **issue comment** (or a structured comment on a dedicated `promotion-scorecard` rolling issue) so the maintainer can aggregate without needing access to the auditing workspaces. The aggregator script grows a mode that pulls from `gh issue` body/comments in addition to filesystem-local scorecards.
-
-This is a stretch goal; not blocking the main pivot.
-
-### 7. Issue-creation rate / GitHub API limits
-
-**Problem:** a thorough audit can produce 20+ findings. Filing 20 issues at once via `gh` is fine for personal-PAT rate limits but worth noting. 100+ findings across a community run set is more concerning.
-
-**Proposed:** rate-limit gate per run (see #2). Don't pre-engineer for the 100+ case until it's observed.
-
-## Net cost estimate (rough — for brainstorm sizing)
-
-Probably 4–6 backlog rows for the pivot. Sketch:
-
-1. **Restore shipped skill location** — reverse the maintainer-local relocate. Mostly mechanical (git mv `.claude/skills/mcp-server-stress/` → `skills/mcp-server-stress/`), update test paths back, update external refs back to shipped names. The cleanup-content from init 3 stays. ≤4 prod files + 3 tests.
-2. **GitHub Issues output mode** — add `--issue-mode=create|preview|print`, issue-body template (probably reuses `ai_docs/items/backlog-d-fragment-schema.md`'s schema, repurposed), label scheme, rate limit. Touches the audit prompt and adds a small helper script. 3-4 prod files + 1 test.
-3. **`/backlog-intake` reshape** — replace fragment-walk with `gh issue list --label audit-deep` + triage flow. The fragment-walk path stays as a degraded-mode fallback (or is moved to a separate `--input=fragments|issues` flag) until sunset. 2-3 prod files + 1 test.
-4. **Issue templates + label scheme + maintainer triage doc** — `.github/ISSUE_TEMPLATE/audit-finding.yml`, label definitions in repo settings (manual or via `gh label create`), triage doc at `docs/AUDIT_FINDINGS.md`. ≤4 prod files, 0 tests.
-5. **`/publish-preflight` Step 8 + scorecard aggregator extension** — optional issue-comment input for community-quorum scorecards. Stretch — split out as a separate row.
-6. **Sunset and cleanup** — after community use validates the pattern, remove the `backlog.d/` walk in `/backlog-intake`, remove `eng/stage-review-inbox.ps1`'s fragment-discovery branch, deprecate the `--target-output=fragments` flag. Final cleanup row, schedule for v1.36 or later.
-
-Roughly the same scope as the sweep we just shipped. Some of it is reversal of recent work, which is going to feel weird in the CHANGELOG — the entries should be honest about it.
-
-## What probably triggers the brainstorm
-
-A `/brainstorming` session should produce:
-
-1. **Decisions on the open questions in section "Real costs / open design questions"** — particularly auth fallback default (`auto` vs `print`), spam-mitigation combo, sunset window.
-2. **Sized backlog rows** for the 4–6 initiatives above, ready for `/backlog-sweep:plan`.
-3. **A short rationale doc** (`ai_docs/items/move-to-git-issues.md` updated in place, or a sibling design note) capturing the final design choices so future sessions don't re-litigate.
-
-The brainstorm should NOT:
-- Write code.
-- Touch `ai_docs/backlog.md`.
-- Start a backlog-sweep.
-
-That's all subsequent steps.
-
-## References (every artifact this discussion touched)
-
-### Recently shipped (state at 2026-05-08)
-
-- `ai_docs/plans/20260507T182128Z_backlog-sweep/plan.md` — the sweep that motivated the rethink.
-- `ai_docs/plans/20260507T182128Z_backlog-sweep/state.json` — final state, `completed: true`.
-- `ai_docs/plans/20260507T182128Z_backlog-sweep/review.md` — review-pass artifact.
-- `.claude/skills/mcp-server-stress/SKILL.md` — current home of the skill (proposed to move back to shipped).
-- `.claude/skills/mcp-server-stress/prompts/prompt.md` — the ~82KB audit body. The Phase 19 fragment-emit step is the section that gets rewritten to file issues instead.
-- `.claude/skills/mcp-server-stress/scripts/archive-old-reports.ps1` — survives, no change needed.
-- `.claude/skills/backlog-intake/SKILL.md` — has the fragment-walk logic from init 5; gets reshaped.
-- `.claude/skills/publish-preflight/SKILL.md` Step 8 — uses the scorecard aggregator; may grow issue-comment input.
-- `.claude/skills/promote-tier/SKILL.md` — accepts aggregated input format from init 6.
-- `.claude/skills/surface-audit/SKILL.md` — owns the static SKILL.md audit absorbed from init 4. Independent of this pivot.
-- `eng/aggregate-promotion-scorecards.ps1` — survives, may grow input modes.
-- `eng/stage-review-inbox.ps1` — has the fragment-discovery branch from init 5; gets sunset.
-- `ai_docs/items/backlog-d-fragment-schema.md` — the fragment schema; repurposes as issue-body template.
-- `tests/RoslynMcp.Tests/Skills/McpServerStressSkillFrontmatterTests.cs` — tests the skill's frontmatter and tool references; needs path update when skill moves back to shipped.
-- `tests/RoslynMcp.Tests/Skills/AggregatePromotionScorecardsScriptTests.cs` — tests the aggregator; may grow cases for issue-comment input.
-
-### Repo-wide context
-
-- `ai_docs/backlog.md` — master backlog (post-pivot, populated only by triaged-and-accepted issues).
-- `ai_docs/workflow.md` — workflow conventions; the triage discipline doc may be added here or sibling.
-- `ai_docs/prompts/backlog-sweep-addenda.md` — `changelog_convention: fragment` etc. The same fragment-then-consolidate pattern this pivot leaves behind for `backlog.d/`.
-- `changelog.d/` — the changelog convention that inspired the (now-being-replaced) `backlog.d/` pattern. Stays.
-- `CHANGELOG.md` — needs honest entries about the reversal when the pivot lands ("undoes part of v1.34.x's `mcp-server-stress-relocate`").
-
-### Discussion threads / sessions
-
-- The 2026-05-07 sweep planning + review + execute conversation (this session). Key turns:
-  - Initial design conversation that produced the 5-row sweep (mode collapse, relocate, fragment pattern, scorecard).
-  - Post-ship reflection on `/mcp-server-stress` invocation: "would this work as a global skill so consumers can run it from their own repo?" → led directly to the issues pivot.
-  - Architectural question: "if this is repo-specific, why are we writing fragments to the remote repo and not the local?" → exposed the hidden assumption "only the maintainer audits."
-- This very file. Future brainstorm sessions should read it first.
-
-### External / reference patterns
-
-- The `changelog.d/` + `/bump` pattern (this repo) — the *good* part of the fragment-then-consolidate model. Producer scope = single PR, consumer = release-cut. Stays.
-- GitHub Issues + `Closes #N` PR trailer pattern — standard OSS contribution flow.
-- `gh issue list --label <name>` and `gh issue create` — primitives the issues-mode skill uses.
-
----
-
-## User feedback (2026-05-08, end of capturing session)
-
-After reading the initial draft above, the user added course-corrections. These are decisions/leans, not just observations — incorporate them into the brainstorm starting position rather than re-litigating from scratch.
-
-### (1) Operator friction on consumer issue filing — `print` mode is not viable
-
-Quote: *"I dont think printing them is viable, i think a lot of issues would get lost in that process just due to the friction required. there is no real human thought around the mcp server automatically filing the issue and no real driving concern for most consumers to go through the effort of the copy and past to help us make this server better (even though they do benefit in the end). All that being said I would like to think about and find a SECURE way to allow the creation of the issues to be as seemless and pain free as possible so we get the most actionable issues as possible."*
-
-**Implication:** the `--issue-mode=print` fallback is not the answer for consumers. If consumers have to copy-paste from terminal to GitHub web UI, the data never arrives in the tracker — friction wins, the use case dies. The whole pivot's value (community findings) hinges on file-issues-without-friction. So **seamless secure filing IS the design problem to solve**, not a nice-to-have.
-
-**Design directions worth exploring in the brainstorm:**
-
-| Approach | How it works | Trade-offs |
-|---|---|---|
-| **GitHub App (canonical)** | Maintainer publishes a GitHub App; consumer installs it on `Roslyn-Backed-MCP` (one-click "Install on this repo"); audit uses the installation token from the consumer's local config to file. | Cleanest; per-consumer scoped tokens; revocable per consumer. Higher setup cost (App registration, hosting the App's OAuth dance). Best long-term shape. |
-| **Server-side proxy with maintainer PAT** | Small Cloudflare Worker / Azure Function at e.g. `audit.roslynmcp.dev/file-issue`; accepts POST with finding payload; validates schema/signature/rate; files issue using maintainer-held PAT (never leaves the proxy); returns issue URL. | Zero consumer auth; maintainer pays hosting (negligible at low volume); spam target = the endpoint, not the repo directly; rate-limit + per-IP throttling at the proxy; PAT lives in one place. Needs proxy uptime. |
-| **`gh` if present, proxy fallback** | Skill detects `gh auth status`; if authenticated, uses `gh issue create` directly (consumer's own auth); if not, falls back to proxy. | Best of both worlds for consumers who already have `gh`. Two code paths to maintain. |
-| **Anthropic-style telemetry endpoint** | The skill POSTs findings to an endpoint owned by the maintainer; endpoint can throttle, dedupe, even pre-triage before filing. | Maximum control; overkill for early-stage; possibly the right end-state if community runs become high-volume. |
-
-**Lean from this conversation:** server-side proxy is probably the right starting answer. It gives consumers zero-friction filing, keeps the auth secret in one maintainer-controlled location, and the proxy itself is a natural place to add rate-limiting + spam mitigation later (item 2). GitHub App is the more architecturally pure answer but the setup tax doesn't pay off until volume is high.
-
-**Hard requirement regardless of mechanism:** **explicit one-time consent.** First time a consumer's audit would file an issue, the skill MUST prompt: *"This audit found N actionable findings. File them as issues on `darylmcd/Roslyn-Backed-MCP`? Issues will include your finding details and audited workspace metadata (project count, server version). [Y/n/dry-run] (cached for future runs)."* Cached preference goes in plugin-local config (e.g. `~/.claude/.mcp-server-stress.json`). No silent "first run files 20 issues against a stranger's repo" surprise.
-
-### (2) Spam risk — kick the can down the road
-
-Quote: *"spam risk - this is a legitimate concern but really only affects us and our ability to 'filter the noise' and its honestly a) somewhat mitigatable and b) a can that can be kicked down the road a bit until it becomes an issue."*
-
-**Implication:** don't pre-engineer mitigations for spam volume that doesn't exist yet. The brainstorm should land minimal-viable mitigation (issue template with required fields, `mcp-server-stress` label, rate limit per audit run) and explicitly defer the rest:
-
-- **Land in v1:** required template, label, per-run rate limit (cap N issues per audit; rollup beyond that), required `audit-id` reference.
-- **Defer until observed need:** confidence-threshold filtering, severity gating, deduplication-before-file, automated triage labels, abuse-detection at the proxy.
-
-The proxy approach in (1) makes deferred mitigations easy to add server-side without re-shipping the skill.
-
-### (3) Backward compatibility — keep fragments for maintainer use
-
-Quote: *"backward compatibility - i like your lean on this. the github issue pattern is great for crowdsourcing issues but honestly overkill for us (its quicker to keep the fragments pattern local for us to consume)"*
-
-**Implication: the fragment pattern stays for maintainer use indefinitely**, not just as a transition fallback. The maintainer's own multi-repo audit gets findings into `<sibling-repo>/backlog.d/` and `/backlog-intake` consolidates locally — fast, no auth, no proxy round-trip, no GitHub API hop. The issue-filing path is the consumer flow, not a replacement for the maintainer flow.
-
-This changes the cost estimate (#3 from above is no longer "reshape `/backlog-intake`"; it's "extend `/backlog-intake` with an issues-input mode alongside the existing fragments-input mode") and changes the sunset story (no sunset for fragments; both flows coexist by design).
-
-Concrete impact on backlog row sizing:
-- `--target-output` flag now selects per-run: `fragments` (maintainer default), `issues` (consumer default), `both` (rare maintainer case).
-- `/backlog-intake` grows an `--input=fragments|issues|both` flag, defaulting to `both`. Walks both sources.
-- `eng/stage-review-inbox.ps1` keeps the fragment-discovery branch permanently. No deprecation.
-
-This is materially less work than full sunset.
-
-### (4) Issue triage discipline — agreed
-
-User confirmed the proposed triage contract (every audit-filed issue labeled, weekly maintainer review SLA, accept/reject/defer states, "Closes #N" PR trailer to auto-close). Land as proposed.
-
----
-
-## Naming convention (cross-cutting decision)
-
-Quote: *"I dont like the 'audit-deep' naming. I think we should keep the naming as consistent as posisble around mcp-server-stress or mcp-server-stress-test as possible. i think that naming CLEARLY identifies the purpose of the skill where 'audit-deep' does not. to me audit-deep is valuable but it infers actual writes to a worktree/branch that will be actioned on (not disposable)"*
-
-**Decision:** `mcp-server-stress` is the canonical name across all forward-looking surfaces. `audit-deep` only survives as historical references in:
-
-- Closed backlog row ids (`audit-deep-collapse-modes`, `audit-deep-relocate-and-rename`) — history, don't rewrite.
-- `changelog.d/audit-deep-relocate-and-rename.md` — fragment file already on disk, name preserved for fidelity.
-- CHANGELOG entries from the 20260507 sweep — written in past tense, references stay.
-
-**Forward-looking surfaces use `mcp-server-stress` consistently:**
-
-- The skill location itself (already at `skills/mcp-server-stress/` once we reverse the relocate, currently at `.claude/skills/mcp-server-stress/`).
-- Issue labels (`mcp-server-stress-finding`, NOT `audit-deep`). The label-rename in item (4)'s contract above and in the proposed issue-template scheme (#2 in *Open questions*) already used `audit-deep` — **mentally substitute `mcp-server-stress-finding` everywhere `audit-deep` appears as a label name in this doc**. The brainstorm should reflect that consistently in the row drafts.
-- Issue templates (`.github/ISSUE_TEMPLATE/mcp-server-stress-finding.yml`).
-- Proxy endpoint (if used): `mcp-server-stress.roslynmcp.dev/file-finding` or similar.
-- Triage doc filename (`docs/MCP_SERVER_STRESS_FINDINGS.md`, NOT `AUDIT_FINDINGS.md`).
-
-**Why this matters past aesthetics:** "audit-deep" semantically implies a deep audit that produces actionable persistent changes — which is exactly what we deliberately moved AWAY from with the disposable-worktree Phase 6 (audit run = no persistent change to audited repo). The new name signals "we exercise the surface and produce findings, but we don't *do* anything to your code." That's the user-facing promise we want consumers to internalize before granting auth or installing the App.
-
-`mcp-server-stress` vs `mcp-server-stress-test`: pick one and stick with it. Current shipped path is `mcp-server-stress`. Stay with that — adding `-test` is more accurate but also more verbose, and consumers typing the slash-command will appreciate the shorter form. Defer the `-test` rename unless it becomes a clarity issue in practice.
-
----
-
-## When this gets picked up
-
-Next backlog sweep planning pass, or whenever you want to schedule the brainstorm. The pivot doesn't need to happen this week — the just-shipped sweep is functionally complete and the maintainer-only audit works. The pivot is about *widening* the producer set, not about fixing a broken thing. So: after a release cycle or two, when v1.35.0 has been out long enough to gauge whether community audits would actually happen.
-
-If you decide *not* to pivot — that's fine, the just-shipped pattern is internally consistent. The cost would be that `/mcp-server-stress` stays a maintainer tool forever and the long-tail bugs that real-world consumer workspaces would surface stay invisible. Acceptable trade-off if community engagement is low.
-
----
-
-## Dissent register and final decisions (2026-05-08, second turn)
-
-After the user feedback section above was written, the user explicitly invited dissent on the resolutions. Three pushbacks landed and changed the design. **These supersede the earlier-section leans where they conflict.** Recording both the dissent and the final decision so the brainstorm starts from the resolved position, not the pre-pushback state.
-
-### D1 — Single path, not two paths (supersedes "User feedback (3)")
-
-**Original lean (above):** keep `backlog.d/` fragment pattern indefinitely for maintainer use; issues path runs alongside for consumers.
-
-**Dissent:** two parallel paths is tech debt. Costs include schema drift across 4 surfaces (2 producers, 2 consumers), duplicate test coverage, and the implicit signal that maintainer findings are architecturally different — which they aren't, they're just consumed differently. The "fragments are quicker locally" argument is workflow preference, not architectural reason. A single-path design with a *label* encoding the trust difference is cleaner.
-
-**Final decision:** **single path through GitHub Issues, with a `triaged-by-maintainer` label fast-path.**
-
-- Maintainer-filed issues land with `triaged-by-maintainer` set at creation time (the skill detects "this is the maintainer's run" via repo-local config or a `--maintainer` flag and applies the label automatically).
-- `/backlog-intake` honors the label: `triaged-by-maintainer`-labeled issues skip the human-triage step and convert directly to backlog rows.
-- All other issues go through the normal triage workflow.
-- `backlog.d/` fragment pattern + `eng/stage-review-inbox.ps1`'s fragment-discovery branch + `/backlog-intake`'s fragment walk **all retire** at v1 of this pivot. No "stays as fallback indefinitely" branch.
-
-Cost-estimate update — **drop item #6** ("sunset and cleanup" of fragments) since fragments retire as part of the v1 pivot rather than later. **Update item #3** ("`/backlog-intake` reshape") from "extend with dual input" back to "replace fragment-walk with issue-list + maintainer-label fast-path" — same scope as the original sketch above.
-
-### D2 — `print` mode IS v1, validate demand before infrastructure (supersedes "User feedback (1)")
-
-**Original lean (above):** server-side proxy is the right starting answer; consumer zero-friction filing.
-
-**Dissent:** friction also filters for engagement. The consumer willing to copy-paste a pre-formatted issue is the consumer who'll respond to triage questions and provide repro follow-up. Zero-friction automated filing produces low-context findings from people who don't even remember filing. Hosting infrastructure (Cloudflare Worker / Azure Function + secret rotation + abuse handling) is 1-2 weeks of work. Doing that *before* validating that consumers want to file findings at all is exactly the kind of premature infrastructure investment that bites later.
-
-**Final decision:** **`print` mode IS v1.** Skill outputs ready-to-paste issue body for each finding; user files manually if they care. After 3 months of v1 usage, count filed issues. If volume warrants infrastructure, build the proxy or GitHub App then with concrete signal, not speculation. If volume is low, the lower-friction path was never the bottleneck — engagement was.
-
-Cost-estimate update — **simplify item #2** ("GitHub Issues output mode") to ship `print` only. The `--issue-mode=create|preview|print` three-mode contract collapses to "skill prints issue bodies; if `gh` is authenticated AND user passes `--auto-file`, file via `gh issue create`." That's an opt-in fast path for the maintainer who already has `gh`, not a default for community runs.
-
-### D3 — `mcp-server-surface-test` is the right name target (supersedes "Naming convention")
-
-**Original lean (above):** `mcp-server-stress` is canonical; defer any further rename.
-
-**Dissent:** "stress" semantically implies *load* testing — pummel with high concurrent traffic. That's not what the skill does. It does comprehensive surface exercise + apply-tool integration check + scorecard generation. "Stress" misleads consumers about what the skill will actually do (e.g. "this will pin my CPU" or "this will bombard my MCP with concurrent requests"). User confirmed the dissent and chose `mcp-server-surface-test` as the better target.
-
-**Final decision:** **`mcp-server-surface-test` is the canonical name target.**
-
-- The pivot's first row (or a separate prep row scheduled before it) renames `.claude/skills/mcp-server-stress/` → `skills/mcp-server-surface-test/` (also reverses the maintainer-only relocate from inits 2-3 of the recent sweep).
-- All forward-looking surfaces use `mcp-server-surface-test`: the skill location, issue label (`mcp-server-surface-test-finding`), issue template (`.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml`), maintainer triage doc filename (`docs/MCP_SERVER_SURFACE_TEST_FINDINGS.md`), and any helper script names (`eng/aggregate-promotion-scorecards.ps1` is fine as-is — name doesn't reference the skill).
-- Historical references stay: backlog row ids (`audit-deep-collapse-modes`, etc.), already-shipped CHANGELOG entries, the `audit-deep-relocate-and-rename.md` fragment file. Don't rewrite history.
-- `audit-deep` is **not** a fallback or alias — gone forward. User explicitly stated: *"we arent using 'audit-deep'... i stand firm on that for now."*
-
-**Cost note:** this is the third rename for this skill in its lifetime (`audit-deep` → `mcp-server-stress` → `mcp-server-surface-test`). Worth being honest in the eventual CHANGELOG entry: *"Renamed `mcp-server-stress` to `mcp-server-surface-test` (cumulative second public rename) — 'stress' implied load testing, which the skill does not do; 'surface-test' accurately describes the comprehensive-surface-exercise + apply-tool integration shape."* Pre-empt the "why does this keep changing names" friction with a clear rationale.
-
-### D4 — Spam mitigation: minimum-viable-mitigation, not zero (clarification, not dissent — restating user's intent)
-
-User clarified: *"i never meant zero mitigation just that minimal in v1 was sufficient until we were actually noticing the spam."* The doc's existing "spam risk" section already aligns with this — landing minimum-viable-mitigation in v1 (template required fields, label scheme, audit-id reference) and deferring enforcement (rate limits, abuse detection, dedup-before-file). No design change needed; this entry exists only to make the alignment explicit.
-
-The schema lock-in piece is the part that's NOT optional in v1 — the issue-body template's required fields need to be designed once and held. Adding fields later when consumers are running old skill versions causes broken issues. Lock the schema day one even though enforcement is deferred.
-
----
-
-## Net cost estimate — REVISED after dissent register
-
-Replaces the earlier "Net cost estimate (rough — for brainstorm sizing)" section above. Same structure, applied resolutions:
-
-1. **Restore shipped skill location + rename to `mcp-server-surface-test`** — combines the relocate-reversal with the second rename. `git mv .claude/skills/mcp-server-stress/ skills/mcp-server-surface-test/`, update test paths, update external references in `publish-preflight/SKILL.md`, `audit-phase-runner.md`, and any doc references. ≤4 prod files + 3 tests. **Combined naming-and-relocation row** so we don't churn surfaces twice.
-2. **GitHub Issues output mode (print-only v1)** — Phase 19 of the prompt rewrites to print issue bodies (not file them). Optional `--auto-file` for `gh`-authenticated maintainer use. Issue-body template repurposed from `ai_docs/items/backlog-d-fragment-schema.md`. 2-3 prod files + 1 test (smaller than original estimate since we dropped the proxy + create-mode + preview-mode scope).
-3. **`/backlog-intake` reshape (single-path)** — replace fragment-walk with `gh issue list --label mcp-server-surface-test-finding` + `triaged-by-maintainer` fast-path + standard triage flow. Retire the fragment-walk branch in this same row. 2-3 prod files + 1 test.
-4. **Issue templates + label scheme + maintainer triage doc** — `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml`, label definitions (`gh label create` script), triage doc at `docs/MCP_SERVER_SURFACE_TEST_FINDINGS.md`. ≤4 prod files, 0 tests.
-5. **`/publish-preflight` Step 8 + scorecard aggregator extension** — optional issue-comment input for community-quorum scorecards. Stretch — split as a separate row, ship after #1-4 stabilize.
-
-**Total: 4 v1 rows + 1 stretch.** Down from the original 6-row estimate, primarily because the fragment-pattern sunset row goes away (single-path means it retires inline with #3) and the issue-output mode is simpler (print-only).
-
-The fragment-pattern retirement happens *as part of* row #3, not as a separate sunset row. Be honest in row #3's CHANGELOG entry: *"Retires the `<audited-repo>/backlog.d/` fragment pattern shipped in v1.34.x's `backlog-d-fragment-pattern` initiative. Single-path issue model replaces it; maintainer fast-path uses `triaged-by-maintainer` label instead of local-fragment shortcut."*
-
----
-
-## Decisions still open for the brainstorm
-
-After the dissent register, what remains genuinely undecided:
-
-1. **Issue template required-field set.** Schema lock-in is critical (D4). What fields does the template require? Probably: `audit-run-id`, `server-version`, `audited-workspace-stats` (project count, LOC), `severity`, `area`, `anchors`, `repro-steps`, `proposed-fix`. Brainstorm should land the minimal set and the rationale.
-2. **Triage SLA cadence and labels.** "Weekly maintainer review" was proposed but not confirmed. Labels: `mcp-server-surface-test-finding` (filed by audit), `triaged-by-maintainer` (auto-fast-path), `triaged:accepted` / `triaged:rejected` / `triaged:defer` (post-triage state). Confirm.
-3. **Maintainer detection.** How does the skill know "this is the maintainer's run" to apply `triaged-by-maintainer`? Options: a `--maintainer` flag (explicit), reading a config file at `~/.config/roslyn-mcp/maintainer-mode` (configured once), checking if the audited repo IS Roslyn-Backed-MCP itself (heuristic), or just trusting `gh auth status` + repo-write permission as the gate. Brainstorm should pick.
-4. **Pivot timing.** Ship after which release? v1.35.0 (the imminent release after the recent sweep) is too early — let it stabilize. Probably v1.36.x or v1.37.x. Confirm in the brainstorm.
-
-The earlier "Open design questions" section above (numbered 1-7) is partially resolved by the dissent register. What survives unresolved: items 4 (triage discipline — confirmed but specifics open), 5 (cross-forge consumers), 6 (community-quorum scorecards — stretch), 7 (rate-limits — defer per D4).
-
----
-
-## Drafted answers to open questions (2026-05-08, third turn)
-
-The four questions above were drafted with explicit recommendations and brainstorm pressure points; the user reviewed and confirmed all four with no pushbacks. Recording here as **decisions, not drafts** — the brainstorm's job is to sanity-check, not re-design. Pressure points are kept as input to that sanity check.
-
-### Q1 — Issue template required-field set
-
-**Tradeoff frame:** every required field is friction at file-time and information at triage-time. Too few → "please add X" comment for every issue. Too many → consumers abandon the file step.
-
-**Required fields (8):**
-
-| Field | Why required | Format |
-|---|---|---|
-| `audit-run-id` | Ties N findings from one audit run together; lets the maintainer see the full audit context (prose report) for any issue without searching. Mandatory because issues filed in isolation lose all context within a week. | Kebab-slug `<repo-slug>-<utc-ts>`, generated by the audit at run start, included in every issue from that run. |
-| `finding-id-within-run` | Granularity inside an audit run for cross-referencing related findings ("see also #1234, same audit run"). Trivial to generate; pays off at triage. | Integer 1..N within an `audit-run-id`. |
-| `server-version` | Half of "is this still a bug?" questions are answered by "what version were you on?" Answering at file-time eliminates a triage round-trip. | Plain string from `mcp__roslyn__server_info`. Example: `1.34.2`. |
-| `severity` | Drives triage priority. P0/P1 trigger fast-path; P2/P3 batch. Consumer-side gating depends on this. | Enum `P0`/`P1`/`P2`/`P3`. Audit assigns based on the prompt's existing severity rubric — not consumer judgment. |
-| `area` | Triage routing. Even with one maintainer, area enables search-by-area. | Enum `tools`/`resources`/`prompts`/`skills`/`concurrency`/`perf`/`docs`/`other`. |
-| `audited-workspace-shape` | Reproduces the half of bugs that are scale-dependent. "Worked on 5-project sample, broke on 200-project monorepo" is invisible without this. | Structured: `{ projectCount, totalLOC, languages, hasGenerators, targetFrameworks }`. Audit captures from `workspace_load`. |
-| `finding-summary` | Fast-skim title for the triage queue. Issue title templated from this. | One-line, ≤120 chars, sentence-case. |
-| `repro-context` | Trace of what the audit was doing when this surfaced. Without it, half of audit findings are unreproducible. | Structured: phase number, tool call sequence, last-N relevant log lines. |
-
-**Optional fields (3):**
-
-- `proposed-fix` — the audit prompt may or may not have hypotheses; don't make consumers fabricate one.
-- `anchors` — `file:line` list. Useful for tools-area findings, less for concurrency/perf. Required-by-area would be cleaner but adds template complexity; defer to v2 if triage starts asking.
-- `reproducer` — minimal repro repo or snippet. Hard to require because audits usually find things in the audited workspace, which the consumer may not be able to share.
-
-**Anti-patterns explicitly forbidden:**
-
-- Free-text "describe the bug" without structured fields. Defeats schema discipline. Template MUST surface required-field validation.
-- "Attach screenshots" — meaningless for stdio + text output.
-- "Operating system" without "MCP server platform" qualifier — consumer's OS doesn't matter; the server's runtime matters (already captured via `server-version`).
-
-**Schema-lock-in considerations (per D4):** these 8 required + 3 optional are the v1 contract. Adding a field later breaks consumers running old skill versions — so the v1 set must be high-confidence. Deferred-to-v2: client identifier (Cursor vs VS Code vs Claude Code), client-side LLM (sonnet vs gpt-4) — consumers may not even know.
-
-**Brainstorm pressure points (input to sanity-check pass):**
-
-- Is `audited-workspace-shape` really required, or "encouraged"? Lean: required. Reproducibility lives or dies on this. "You may want to fill this in" templates don't get filled in.
-- Should `anchors` be required-by-area (mandatory for `tools`/`prompts`, optional for `concurrency`/`perf`)? Cleaner contract, harder template. Lean: keep optional uniformly in v1; promote in v2 if triage demand grows.
-
-### Q2 — Triage SLA cadence and labels
-
-**Cadence:** weekly review, batched. Daily is overkill at expected volume; monthly creates a daunting backlog. Weekly batches enough volume per session for efficient processing while keeping issues responsive.
-
-Specifically: maintainer triages all `mcp-server-surface-test-finding`-labeled issues filed in the prior 7 days, on a weekly cadence (day flexible). The SLA is "no untriaged issue older than 7 days," not "must triage Monday." P0 issues escalate out-of-band via the `urgent` label.
-
-**Label scheme (12 labels):**
-
-| Label | Applied by | Meaning |
-|---|---|---|
-| `mcp-server-surface-test-finding` | Audit at file-time | Filed by an audit run. Filter for triage queue. |
-| `triaged-by-maintainer` | Audit at file-time, conditional on maintainer-mode (Q3) | Skip human triage; auto-fast-path through `/backlog-intake`. |
-| `severity:P0`/`severity:P1`/`severity:P2`/`severity:P3` | Audit at file-time | From the required `severity` field. |
-| `area:tools`/`area:resources`/`area:prompts`/`area:skills`/`area:concurrency`/`area:perf`/`area:docs`/`area:other` | Audit at file-time | From the required `area` field. |
-| `urgent` | Maintainer or consumer | Out-of-band P0 escalation; bypasses weekly cadence. |
-| `triaged:accepted` | Maintainer at triage | Will become a backlog row. Issue stays open until row ships. |
-| `triaged:rejected` | Maintainer at triage | Not a real bug or out-of-scope. Issue closes with rationale. |
-| `triaged:defer` | Maintainer at triage | Plausible but lacks evidence/repro/priority. Stays open with `defer-reason:<short>` comment. Quarterly re-evaluation. |
-| `closes-row:<row-id>` | Maintainer at backlog-row creation | Cross-references the backlog row. Lets `/backlog-intake` re-find the issue when the PR ships. |
-
-**Triage workflow:**
-
-1. Maintainer runs `/backlog-intake` weekly.
-2. Skill lists `mcp-server-surface-test-finding` issues opened in the prior 7 days, grouped by `area`, sorted by `severity`.
-3. For each issue, maintainer presses `accept`/`reject`/`defer`. Skill applies labels.
-4. For `accept`: skill drafts the backlog row, asks confirmation, applies `triaged:accepted` + `closes-row:<row-id>`, appends row to `ai_docs/backlog.md`. Issue stays open.
-5. When the row ships, the closing PR uses `Closes #<issue>` trailer. GitHub auto-closes.
-6. Quarterly: `/backlog-intake --review-deferred` walks `triaged:defer`-labeled issues. Most re-rejected (no new evidence); some promoted.
-
-**Brainstorm pressure points:**
-
-- Are 12 labels too many? Probably fine — GitHub label fatigue starts ~30+. We're at 11–13.
-- Hard expiration on `triaged:defer` (auto-close at quarter X)? Lean: no. Hard expiration produces auto-close-then-reopen churn. Quarterly review is enough.
-
-### Q3 — Maintainer detection
-
-**Decision: `gh auth status` + repo-admin-permission heuristic, with config-file override.**
-
-**Mechanism:**
-
-1. At audit start, if `--auto-file` is in play, the skill calls `gh api repos/darylmcd/Roslyn-Backed-MCP --jq .permissions.admin`. If `true`, this is a maintainer run; issues file with `triaged-by-maintainer`.
-2. Result is cached in `~/.config/roslyn-mcp/maintainer-mode-cache.json` for 24h to avoid hammering the API across multiple audit runs.
-3. Override paths:
-   - `--no-maintainer-fast-path` — explicit user override (e.g. maintainer wants to test the normal triage flow). Suppresses the label even if `gh` would grant it.
-   - `~/.config/roslyn-mcp/maintainer-mode.json` with `{ forceMaintainer: true }` — explicit opt-in for users who don't have admin permissions but ARE pre-trusted (deputy maintainers, frequent contributors). Auto-applies the label.
-
-**Edge cases:**
-
-- `gh` not installed / not authenticated → no fast-path. Issues file normally with full triage queue. This is what we want for cold-onboard consumers.
-- Maintainer's `gh` token expires → audit silently downgrades to normal triage. Maintainer notices at the next weekly review when their issue isn't pre-labeled.
-- `gh` API call fails (rate-limited, network) → use 24h cache; if cache empty, default to normal triage. Don't block the audit on `gh` flakiness.
-
-**Why this over the other options:**
-
-- **`--maintainer` flag (explicit):** zero false-positives but annoying to type 50 times/year.
-- **Config file only:** set-and-forget but copies across machines, leading to false-positives on un-authenticated machines.
-- **Heuristic "audited repo IS Roslyn-Backed-MCP":** wrong — maintainer audits siblings frequently, those wouldn't be flagged.
-- **`gh-permission` (chosen):** zero config; correct by default; degrades gracefully; one negligible API call per audit (compared to the 30+ minute audit duration).
-
-Co-maintainers added later get fast-pathed automatically. That's the right behavior.
-
-**Brainstorm pressure points:**
-
-- Does this leak signal? `triaged-by-maintainer` on a public issue tells observers the audit was filed by a maintainer. Probably not sensitive — all the audit's evidence is already public on the issue. Worth confirming.
-
-### Q4 — Pivot timing
-
-**Decision: pivot scheduled for v1.36.x or later. v1.35.0 stabilizes first.**
-
-- **v1.35.0** (imminent) — consumes the 7 fragments accumulated since v1.34.2. BREAKING due to the mode-collapse fragment, so minor bump under semver. Ships the 20260507 sweep + release-cut Step 6 fix + `--target=` contract. **No pivot work.**
-- **Pivot row #1 (rename `mcp-server-stress` → `mcp-server-surface-test` + relocate back to shipped surface)** ships separately, possibly as v1.35.x patch or held for v1.36 — decoupled from the issues-pivot rows for cleaner review. Lean: separate row, separate release.
-- **Pivot rows #2-#5 (issues-output mode, /backlog-intake reshape, templates+labels+triage doc, scorecard aggregator extension)** ship in v1.36.x or later. **Earliest 4–6 weeks after v1.35.0** to give:
-  - Time for v1.35.0 to surface its own bugs (the audit-deep redesign was big).
-  - Time for community to *try* v1.35.0 — nobody files audit findings against a version that just dropped.
-  - Calendar margin so the pivot work isn't compressed.
-
-**Why v1.36 minor and not v2.0:** semver minor with BREAKING fragments is fine; v2.0 implies a larger break than this is.
-
-**Brainstorm pressure points:**
-
-- Should rename ship decoupled from issues pivot? Lean: yes, separate row in v1.35.x or v1.36.0. Smaller PR, easier review, isolates the third-rename-fatigue concern.
-- Brainstorm itself doesn't have a deadline. Park until v1.35.0 has been out 2–3 weeks, then run the brainstorm against this doc.
-
----
-
-## Status after this turn
-
-These decisions, the dissent register (D1–D4), and the original draft sections are all the brainstorm's input. **The brainstorm's job is sanity check, not redesign** — frame the prompt explicitly as "pressure-test these decisions, look for gaps, propose alternatives if you see them, DO NOT just confirm what's there." The brainstorm pressure points listed under each question are the seed prompts.
-
-**Net cost estimate stands at 4 v1 rows + 1 stretch + 1 prep (the rename/relocate as separate row).** Roughly 5–6 rows total, depending on whether the rename rolls into the relocate or ships separately.
-
----
-
-## Fourth-turn updates (2026-05-08, fresh-eyes critique pass)
-
-After the third turn drafted answers, ran a fresh-eyes critique pass against the doc. Surfaced load-bearing concerns about the crowdsourcing premise; user pushed back substantively. The dialog produced two materially-new decisions and one scope addition. **These supersede earlier sections where they conflict.**
-
-### F1 — Floor-case justification accepted (the pivot pays off without community use)
-
-**Critique:** *"The crowdsourcing premise is unvalidated. Consumers have no incentive to run a 45-min audit. If they don't run, the pivot's ROI disappears."*
-
-**User counter:** the pivot has standalone value at zero community use:
-- Issues > fragments mechanically for the maintainer (cross-reference, search, persistence, PR auto-close linking are native to issues, bolted-on for fragments).
-- Architectural simplicity: skill back on shipped surface eliminates "where does it live, what IDE, what session" friction. Real ergonomic win regardless of audience.
-- **Credibility signal.** Active labeled-issue tracker visible from the NuGet page signals *"this server is being actively stress-tested and quality matters."* Empty trackers signal abandonment; lively trackers signal investment. Even maintainer-filed issues telegraph care.
-- Optionality: if community ever shows up, infrastructure is ready. If not, we lose nothing relative to fragments.
-
-**Decision:** the pivot pays off on **maintainer workflow + credibility alone**. Community contributions are upside, not the load-bearing case. **The fragment pattern's retirement is justified by the maintainer-side improvements alone, not by speculative community throughput.**
-
-**Anti-overbuild guard:** hold the line on infrastructure deferral (D4). No proxy / GitHub App / per-IP rate limiter / abuse detection until concrete volume signal. *"If we built more, more would come"* is famously wrong. v1 ships the cheap parts that pay off for maintainer use; the expensive parts wait for evidence.
-
-### F2 — Tiered runs (`--quick` + `--full`, defer `--mid`)
-
-**Critique:** *"45-min full run is a deal-breaker for any community use. Even the credibility signal premise breaks if nobody runs it once."*
-
-**User counter:** rethink what a run looks like — default to full, but expose tiered subsets for shorter runs.
-
-**Important architectural distinction (must be explicit in the eventual CHANGELOG):** the historical `read-only`/`promotion-only` modes (collapsed in v1.35.0's `mcp-server-stress-single-mode` initiative) were **evidence-type variants** that produced malformed scorecards. The new tiers are **time-budget slices** — strict subsets of phases, each producing a strict subset of findings, with honest contracts about what each tier covers. Same architectural axis (which phases run), different motivation (time budget vs evidence-type), different downstream contract (clearly-scoped findings, not broken scorecards).
-
-**Decision: ship two tiers in v1, defer the third.**
-
-| Tier | Phases run | What's tested | Scorecard | Default for | ETA |
-|---|---|---|---|---|---|
-| `--quick` | 0, 1, 2, 3, 4, 5, 7 | Read-side surface — `find_references`, `symbol_search`, `compile_check`, etc. The consumer-facing 80%. | Not emitted (no apply evidence) | Community runs | ~5 min |
-| `--full` (default for maintainer) | All phases | Everything — apply pass, disposable worktree, full scorecard | Emitted with full evidence | Maintainer mode | ~45 min |
-
-**Deferred to v2 (or later, if asked):** `--mid` tier (~15 min, read-side + concurrency + resources). Three tiers is more cognitive load than two; if a "between quick and full" request shows up in practice, add it then. Ship two in v1.
-
-**Honest scope note:** apply-path bugs surface only through `--full` runs, which only the maintainer does. Tiers don't crowdsource the apply-path; that stays maintainer-only structurally. The community gets credit for **read-side findings**. The design doc, the issue template, and the consumer-facing README must all be honest about this — no implied promises about apply-path coverage from quick runs.
-
-**Composes with maintainer detection (Q3):** maintainer-mode → default `--full`; consumer-mode → default `--quick`. Explicit `--tier=quick|full` overrides. Required `tier` enum field added to the issue template (Q1) so triage knows the audit's coverage scope. New label `tier:quick`/`tier:full` added to the label scheme (Q2).
-
-**Cost-estimate impact:** add ~+0.5 row (tier infrastructure folds into the issues-output mode row, doesn't need its own row). Schema changes (Q1, Q2) are minor extensions, not new rows.
-
-### F3 — Consumer-facing documentation is in scope
-
-**User addition:** *"lets make sure that we are updating the consumer side documentation that is seen from nuget/github with full explanation of the mcp-server-surface-test (why its there, what each mode does, expected time to run, why they are each important etc.)"*
-
-**Critical scope item.** F1's credibility-signal value collapses to nothing if the public docs don't explain the skill. An issue tracker full of findings, with a README that doesn't mention why or invite contribution, signals confusion not investment.
-
-**Surfaces to update (each gets a dedicated row or sub-row):**
-
-| Surface | What it carries | Audience |
-|---|---|---|
-| `README.md` (repo root, also renders on NuGet package page) | Top-level "what is this server, how do I use it, how do I help make it better" — adds a *"Quality assurance: `/mcp-server-surface-test`"* section linking to the tier explanation, the issue template, and triage SLA. | Anyone who lands on NuGet or GitHub |
-| `docs/MCP_SERVER_SURFACE_TEST.md` (NEW) | The deep-dive: why this skill exists, server-quality framing, what each tier does, expected time per tier, why each tier is important, what gets exercised, what doesn't (apply-path coverage requires `--full`), privacy/safety guarantees (disposable worktree never mutates main, no telemetry, what gets shared in an issue). | Consumers thinking about running it |
-| `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` | The structured template enforcing the 8 required fields from Q1. Each field has placeholder + explanation. | Consumers filing |
-| `docs/MCP_SERVER_SURFACE_TEST_FINDINGS.md` (NEW, the triage doc from Q2) | Triage cadence, label meanings, what happens after you file, expected response time, how decisions are made. | Consumers who filed AND maintainer reference |
-| `<csproj>` package metadata — `Description`, `PackageReleaseNotes` | NuGet page summary — must mention the audit skill exists and that quality is actively tracked. One-line pointer to README's section. | NuGet browsers |
-| `CONTRIBUTING.md` (if exists, or NEW) | Top-level "how to contribute"; audit findings section is one path among others. | Any contributor |
-
-**Required content for the deep-dive (`docs/MCP_SERVER_SURFACE_TEST.md`):**
-
-1. **Why this skill exists** — server quality matters; we audit our own surface; we want findings from real-world workspaces.
-2. **What it does** — at a high level: exercises every tool, resource, and prompt against a loaded C# workspace; produces structured findings.
-3. **What it does NOT do** — does not mutate your code (disposable worktree only), does not exfiltrate any source, does not phone home, does not require any auth from you (`print` mode default).
-4. **The two tiers** — `--quick` (~5 min, read-side surface, consumer-default) and `--full` (~45 min, full coverage, maintainer-default). Explicit honesty: quick mode does NOT cover apply-path; that's `--full`-only.
-5. **Why each tier is important** — quick is the consumer-facing 80% (the tools you actually call when refactoring); full is the maintainer-grade everything-pass that surfaces apply-path and concurrency bugs.
-6. **Expected time + resource cost** — quick is 5 min, mostly idle (one-shot tool calls). Full is 45 min, requires a disposable worktree, requires a clean-enough audited repo state to allow `git worktree add`.
-7. **What happens after a run** — prose audit report at `<your-repo>/ai_docs/audit-reports/<ts>_<repo>_mcp-server-audit.md`; for `--full` runs, scorecard JSON sibling. Findings printed in the agent session for review.
-8. **How to share findings** — link to the issue template; one-paragraph "why your findings help" framing.
-9. **Privacy/safety** — disposable worktree branches from your repo's tree but never pushes; teardown via `dotnet build-server shutdown` + `git worktree remove --force`; nothing leaves your machine unless YOU file an issue. Print mode is the v1 default specifically so you control what gets shared.
-10. **Triage and response** — link to the triage doc; weekly review cadence; what `triaged:accepted`/`rejected`/`defer` mean.
-
-**This document is the load-bearing piece for the credibility signal.** Without it, the issue tracker is just noise. With it, the tracker becomes evidence of an actively-maintained quality regime.
-
-**Cost-estimate impact:** add a new dedicated row for the consumer-doc package — call it row 3.5 or row 5b in the eventual planning. **Probably +1 row to the cost estimate.** The README and CONTRIBUTING surfaces are small edits; the deep-dive doc is the main lift (~150–250 lines of carefully-written prose).
-
-### Revised net cost estimate after fourth turn
-
-Final shape:
-
-1. **Restore shipped skill location + rename to `mcp-server-surface-test`** (combined with relocate-reversal). ~4 prod files + 3 tests.
-2. **Tiered-run + GitHub Issues output** (`--quick`/`--full`, print mode default, `--auto-file` opt-in for `gh`-authenticated maintainers; tier-aware findings; required `tier` template field; `tier:*` labels). ~4-5 prod files + 1 test. **Combines the issues-output row + tier-infrastructure work.**
-3. **`/backlog-intake` reshape** (single-path: issue-list + maintainer-fast-path + standard triage; retires fragment-walk inline). ~3 prod files + 1 test.
-4. **Issue templates + label scheme + maintainer triage doc**. ~4 prod files (template YAML, label-creation script, triage doc, label registry). 0 tests.
-5. **Consumer-facing documentation** (README section, deep-dive doc, csproj metadata, CONTRIBUTING). ~4-5 prod files (README, deep-dive .md, csproj, CONTRIBUTING). 0 tests. **NEW after fourth-turn discussion.**
-6. **`/publish-preflight` + scorecard aggregator extension** (optional issue-comment input for community-quorum scorecards). Stretch — split as separate row, ship after #1-5 stabilize.
-
-**Total: 5 v1 rows + 1 stretch.** Up by 1 (the docs row) from the third-turn estimate. Worth it — the docs row IS the credibility signal infrastructure.
-
-### Brainstorm framing reminder
-
-When the brainstorm runs (against the now-revised doc), the prompt MUST include explicit anti-rubber-stamping framing:
-
-> *"Pressure-test these decisions. Look for unvalidated assumptions, alternative shapes we didn't consider, and gaps in reasoning. Do NOT just confirm what's there — if a decision looks fine, say why; if it looks wrong, propose a concrete alternative. Treat this as adversarial review, not endorsement."*
-
-Specific brainstorm focus areas at the time it runs:
-
-- **F2 — tier scope:** is `--quick` actually useful? What if even 5 min is too much for community? Is there a `--smoke` (~30 sec) that just verifies the server responds?
-- **F3 — docs surface coverage:** are there other surfaces (NuGet README rendering, package badges, marketplace listings) we should be hitting?
-- **The schema lock-in concern from third-turn (Q1):** evidence-first review — open a recent audit report from `ai_docs/audit-reports/` and walk through it. Do the 8 required fields actually exist there in some form? Or are we declaring contracts for data the producer doesn't yet emit?
-- **Triage SLA enforcement:** what's the actual mechanism? "Weekly review" needs a forcing function or it slips.
-
----
-
-## Fifth-turn: empirical findings from 2026-05-08 audit run
-
-After the fourth-turn updates landed, an adversarial-review subagent flagged two load-bearing concerns (LB-1: D2/F1 contradiction; LB-2: schema lock-in against zero empirical samples) plus five medium concerns. The user produced empirical evidence to test the concerns: a real `/mcp-server-stress` audit run against this repo (audit-id `20260508T154415Z`) producing a 15.5KB prose report, a 11KB scorecard JSON, and 9 fragment files in `backlog.d/` (7 from the audit, 2 added by the agent reviewing its own session logs). **These supersede speculative sections above where they conflict.**
-
-### E1 — Empirical schema validation (resolves LB-2)
-
-**Evidence on disk:** 9 well-formed fragments, all using the **existing 6-field schema** (`id`, `source_audit`, `source_repo`, `severity`, `area`, `anchors`) plus a tight body paragraph (finding + repro + proposed fix). All 9 are concrete, actionable, and ready for backlog inclusion without any field expansion. The intake skill consumed them cleanly via the documented Phase 0.5 fragment path.
-
-**Decision:** **Lock the existing 6-field schema as v1.** Q1's expansion to 8 required fields is over-spec. Specifically:
-
-| Q1 proposed field | Disposition | Rationale |
-|---|---|---|
-| `audit-run-id` | DROPPED — `source_audit` already serves this role | Empirical fragments use `source_audit: <ts>_<repo>_mcp-server-audit.md`; no separate run-id field needed. |
-| `finding-id-within-run` | DROPPED — `id` (the kebab-slug) is unique within the audit context | Empirical evidence: the 9 fragments have unique kebab IDs naturally; ordering inside one run isn't a triage need. |
-| **`server-version`** | **ADDED to fragment frontmatter** | Genuinely useful for triage; cheap to capture (`mcp__roslyn__server_info` already runs at audit start). One-line audit-prompt change to stamp it. |
-| `audited-workspace-shape` | DROPPED from per-fragment; ENRICHED in audit report §2 | Per-finding it's redundant (every finding from one run has identical shape). The audit report's §2 already captures workspace info ("5 projects, 583 documents, no diagnostics"); enrich with structured `workspace-shape:` block (projectCount, totalLOC, languages, hasGenerators, targetFrameworks). Fragments reference the audit by `source_audit`; readers join. |
-| `finding-summary` | DEFERRED to v2 | Empirical fragments' first body sentence already serves this role and is consistently short + concrete (e.g. *"`find_references` can report an ambiguous metadata-name result..."*). Marginal benefit, defer until intake actually wants explicit summary metadata. |
-| `repro-context` (structured: phase number, tool call sequence, last-N log lines) | DROPPED structured form; KEPT prose form | Empirical fragments embed repro in body prose (*"Repro: load X, call Y, response Z"*). That works. Forcing structure adds audit-prompt complexity for marginal triage benefit. |
-
-**Net schema for v1:** existing 6 fields + new `server-version` = **7 required fields.** All other Q1 expansions either dropped or deferred.
-
-**Cost-estimate impact:** schema work shrinks. The audit-prompt changes needed are small:
-1. Stamp `server-version` into every emitted fragment (one line at run start, propagate to all writes).
-2. Enrich §2 of the audit report with structured `workspace-shape:` block.
-
-These are minor edits to the audit prompt, not new infrastructure. **Probably folds into the existing pivot row #2 (issues output mode) rather than spawning a new row.**
-
-### E2 — Empirical reconciliation of D2/F1 contradiction (resolves LB-1)
-
-**Evidence on disk:** the 9 fragments produced excellent maintainer-side triage signal. They were:
-- Read in place by `eng/stage-review-inbox.ps1` (no network round-trip)
-- Consumed inline by `/backlog-intake` (no `gh` API calls)
-- Deleted at source after consumption (consume-and-track contract honored)
-- Rendered as 9 backlog rows in `ai_docs/backlog.md` in one local commit
-
-The maintainer flow is empirically excellent. **Issues would have added overhead** (one `gh issue create` per fragment, one `gh issue list` per intake call, label-state management, network dependency) **for marginal gain.** This validates the reviewer's M-5 (offline-capability is architectural, not preference) and reinforces user feedback (3) (*"its quicker to keep the fragments pattern local for us to consume"*).
-
-**Decision:** **the maintainer's local-fragment workflow is now empirically validated as the right shape for the maintainer use case.** It does NOT need to be replaced.
-
-What this means for the pivot:
-- **Reverses D1 (single path).** Two paths is correct: maintainer uses fragments locally; consumers (when/if they appear) file issues. The reviewer's M-5 was right and our D1 dismissal was wrong.
-- **Honestly reframes F1's credibility-signal premise.** With D2 (print mode) holding AND maintainer using fragments locally, the issue tracker will be populated only when a consumer manually files. That MIGHT happen; it might not. F1's credibility-signal value is conditional, not guaranteed. The pivot's load-bearing case shrinks to: *"if a consumer ever files, we want a clean reception path; everything else stays as-is."*
-- **F3's docs scope shrinks dramatically.** README mention of the skill: yes. Deep-dive 150-250-line doc explaining tiers, privacy, triage SLA: only valuable if community runs are expected. With reduced expectation, F3 collapses to a 20-30-line README section + an issue template. The "load-bearing for credibility signal" framing in F3 was never quite honest; this turn corrects it.
-
-**Cost-estimate impact (significant):** the pivot shrinks from 5 v1 rows + 1 stretch to **~3 rows + 1 stretch.**
-
-Refined row set:
-
-1. **Restore shipped skill location + rename to `mcp-server-surface-test`** — unchanged. Combines relocate-reversal with the rename. ~4 prod files + 3 tests.
-2. **Tiered runs (`--quick` + `--full`) + opportunistic GitHub Issues filing** — `print` mode default; `--auto-file` opt-in for `gh`-authenticated maintainers; **`server-version` added to fragment frontmatter**; **audit report §2 enriched with `workspace-shape:` block**; tier flag handling. The "issues output" piece is a thin layer over the existing fragment-emit, not a replacement. ~3-4 prod files + 1 test.
-3. **README + issue-template package** — small README section explaining the skill exists, what tiers do, what time they take; one issue template at `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml`; no deep-dive doc, no triage doc, no csproj metadata changes (defer until volume signal). ~2 prod files + 0 tests.
-4. **`/publish-preflight` + scorecard aggregator extension (community-comment input)** — STRETCH, unchanged from prior. Defer.
-
-Dropped from prior estimate:
-- ~~`/backlog-intake` reshape (single-path)~~ — fragments stay; intake flow as-is. NO ROW.
-- ~~Maintainer triage workflow doc + label scheme~~ — issues come in irregularly; weekly batched-review-via-gh-cli is fine without infrastructure. NO ROW.
-- ~~Consumer-facing deep-dive doc~~ — collapsed into the slimmer README + issue template row.
-
-### E3 — Resolution of medium concerns from the adversarial review
-
-| Concern | Resolution |
+| Pivot all actionable findings away from `backlog.d/` and into GitHub Issues. | Keep `backlog.d/` for maintainer audits; add Issues as a consumer-sharing path. |
+| Single path through GitHub Issues with `triaged-by-maintainer` as the maintainer shortcut. | Two paths are intentional: local fragments for maintainer intake, issues for outside contributors. |
+| Sunset `eng/stage-review-inbox.ps1` fragment discovery and `/backlog-intake` fragment walking. | Keep both. They are the validated maintainer path. |
+| Require an 8-field issue schema (`audit-run-id`, `finding-id-within-run`, `audited-workspace-shape`, structured `repro-context`, etc.). | Use the existing 6-field fragment schema plus `server-version`; put workspace shape in the audit report. Defer extra fields until triage asks for them. |
+| Build a proxy, GitHub App, or telemetry endpoint for seamless filing in v1. | Defer hosted infrastructure until there is volume signal. Use print-ready bodies and optional `gh` filing first. |
+| Full consumer-facing docs package with deep-dive doc, triage SLA doc, csproj metadata, and CONTRIBUTING edits. | Start with README plus issue template. Add more surfaces only when issue volume or user confusion justifies them. |
+| Block the pivot behind the 9 findings from the 2026-05-08 audit run. | That audit batch has already been mostly shipped/reconciled. Route new work from the current `ai_docs/backlog.md`, not this historical note. |
+| Keep `audit-deep` or `mcp-server-stress` as forward-looking names. | Use `mcp-server-surface-test` for all new public surfaces. Preserve older names only in historical references. |
+| Keep maintainer-found issues only in local fragments for speed. | Keep local fragments for intake speed, but file curated accepted findings publicly when visibility or contribution value is worth it. |
+
+## Implementation constraints
+
+- Follow `AGENTS.md` shipped-skill packaging rules before moving anything under `./skills/`.
+- Run `./eng/verify-ai-docs.ps1` for doc-only changes.
+- If shipped skills change, `verify-ai-docs.ps1` also invokes `eng/verify-skills-are-generic.ps1`; treat that as a required gate, not a cleanup task.
+- If code or packaged skill behavior changes, run the release validation path from `CI_POLICY.md`.
+- Do not add pivot rows directly to `ai_docs/backlog.md` until they are sized into bounded initiatives.
+
+## Remaining questions
+
+These are the only questions worth carrying into a future planning or sanity-check pass:
+
+1. Is `--quick` enough for consumers, or should there also be a very small `--smoke` tier?
+2. Exactly how should the issue template render the shared finding envelope without requiring fields the producer does not already emit?
+3. Which labels define the initial contributor funnel (`help wanted`, `good first issue`, area, severity), and which labels should wait for real issue volume?
+4. Should the rename/relocate ship as its own row before the tier and issue-rendering work? Current lean: yes, to reduce review churn.
+
+## References
+
+| Path | Role |
 |---|---|
-| **M-1** Q3 maintainer detection forks problem | Defer until/unless we ship the auto-file path. Not load-bearing for v1 print-mode. |
-| **M-2** F3 invests in advertising friction-laden flow | Resolved by E2 — F3 scope collapsed; we're advertising "here's what this skill does" not "please file issues." |
-| **M-3** Cross-forge consumers need GitHub account | Acknowledged; print mode is the answer. Add a sentence to the README section. |
-| **M-4** Scorecard aggregator has zero community input under tier model | Resolved by E2 — community-quorum aggregation moves from "v1 with stretch" to "stretch row only, ship if ever needed." Aggregator stays single-path (maintainer scorecards). |
-| **M-5** D1 single-path assumes `gh` works for maintainer | Resolved by E2 — D1 reversed; fragments stay for maintainer. |
-
-### E4 — What did NOT survive contact with empirical evidence
-
-Being honest about prior decisions that should change:
-
-- **D1 (single path) is reversed.** Two paths: fragments for maintainer (offline-capable, fast, local), issues for consumers (when/if they file). Was the right architectural call all along; we over-rotated on tech-debt arguments in third turn.
-- **Q1 schema expansion is mostly dropped.** Schema-first design made us speculate; evidence-first review confirmed the existing 6 fields + `server-version` cover triage needs. The other 4 proposed fields were over-spec.
-- **F3 docs scope is reduced.** Big consumer-facing doc package was justified on a community-throughput premise that this run cannot validate (no community run yet, by definition). Smaller surface (README + template) covers the "we exist and we want findings if you have them" framing.
-- **Pivot cost is roughly halved.** From 5 v1 rows + 1 stretch to 3 v1 rows + 1 stretch. The work IS smaller because less of it is needed; not because we cut corners.
-
-### E5 — One new finding from this empirical pass
-
-The 2026-05-08 audit found 9 real bugs (1 P1, 8 P2) that need backlog rows independent of any design discussion. **They are concrete actionable work that's higher-priority than the pivot itself.** The P1 (`build-test-self-analyzer-file-lock`) is a self-hosting bug that breaks `build_workspace`/`test_run` for any consumer with the analyzer loaded — a production issue, not a stress-test artifact.
-
-Triage these 9 first via the next backlog sweep (or a focused mini-sweep on the P1). The pivot can wait until v1.36 or beyond. **The audit's existing pattern produced ship-ready evidence; that itself is a strong signal that the architecture is right and the pivot should be small.**
-
-### Brainstorm framing — UPDATED for fifth turn
-
-The brainstorm is no longer needed at the same scope. With LB-1 and LB-2 resolved by empirical evidence, the remaining open questions are narrower:
-
-1. **Tier scope sanity check** (F2): is `--quick` actually useful, or do we need `--smoke` (~30 sec)? Empirical run was a `--full` (~30+ min) — no quick-tier evidence yet. Worth a future test before tier infrastructure ships.
-2. **Auto-file path detail** (E2 row #2): when a `gh`-authenticated maintainer passes `--auto-file`, does it bypass the local fragment emit (issues only) or supplement it (both)? Default should probably be "supplement" — fragments AND issues — so maintainer's local intake flow is unchanged.
-3. **README section voice** (E2 row #3): "we exist; here's what we do" vs "please file findings; here's why it matters." The first is honest; the second is the credibility-signal pitch from F1 that didn't survive E2. Lean: voice #1.
-
-These can be answered without an adversarial-review session — they're scope-sanity-check questions, not architecture questions. **The brainstorm is downgraded from "required gate before sizing" to "optional sanity-check after the 9 audit findings ship."**
-
-### Net cost estimate — REVISED again after fifth turn
-
-Final shape after empirical validation:
-
-1. **Restore shipped skill location + rename to `mcp-server-surface-test`** (combined). ~4 prod files + 3 tests.
-2. **Tiered runs + opportunistic GitHub Issues filing + minor schema/§2 enrichment** (`server-version` field, structured `workspace-shape:` block). ~3-4 prod files + 1 test.
-3. **README + issue template** (slim consumer-facing surface). ~2 prod files + 0 tests.
-4. **`/publish-preflight` + scorecard aggregator community-comment input** (STRETCH). Defer until ever needed.
-
-**Total: 3 v1 rows + 1 stretch.** Down from 5 + 1 (fourth turn) and from 6 + 1 (third turn). Each shrink was honest — driven by reasoning or evidence, not by cutting corners.
-
-**Rows that fall OUT of the pivot:**
-- 9 bug-fix rows from the 2026-05-08 audit (these are NOT part of the pivot; they're concrete production work)
-- Future schema-add rows for `server-version` and §2 enrichment if they don't fold into row #2
-
-The pivot is now small enough that the brainstorm is genuinely optional. We could plan and ship it directly, or layer it after the 9 bug-fix rows ship in v1.35.x patches. Either is reasonable.
+| `ai_docs/plans/20260507T182128Z_backlog-sweep/plan.md` | Sweep that introduced the maintainer-only audit redesign and fragment pattern. |
+| `ai_docs/plans/20260508T171439Z_backlog-sweep/plan.md` | Follow-up sweep that shipped the 2026-05-08 audit findings and changed priority context. |
+| `.claude/skills/mcp-server-stress/SKILL.md` | Current maintainer-only skill entry point. |
+| `.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` | Maintainer-only superset prompt (renamed from `prompts/prompt.md` when Row 1 shipped); retains repo-coupled phases the shipped consumer prompt does not have. |
+| `.claude/skills/backlog-intake/SKILL.md` | Maintainer intake flow that consumes `backlog.d/` fragments. |
+| `ai_docs/items/backlog-d-fragment-schema.md` | Canonical fragment schema; base for the shared finding envelope. |
+| `ai_docs/backlog.md` | Current open-work source of truth. |
+| `.github/ISSUE_TEMPLATE/` | Existing GitHub issue-template folder for the future `mcp-server-surface-test-finding.yml`. |
+| `AGENTS.md` | Shipped-skill genericity and bootstrap rules. |
+| `CI_POLICY.md` | Validation and merge-gating policy. |

--- a/ai_docs/procedures/deep-review-backlog-intake.md
+++ b/ai_docs/procedures/deep-review-backlog-intake.md
@@ -53,5 +53,5 @@ If you just want files copied into `review-inbox/` without triage:
 
 - [`deep-review-program.md`](deep-review-program.md) — program context (coverage matrix, client lanes, cadence).
 - [`deep-review-command-reference.md`](deep-review-command-reference.md) — concrete commands.
-- [`../../.claude/skills/mcp-server-stress/prompts/prompt.md`](../../.claude/skills/mcp-server-stress/prompts/prompt.md) — bundled audit prompt run by `/mcp-server-stress`; produces the artifacts this skill consumes.
+- [`../../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md`](../../.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md) — bundled audit prompt run by `/mcp-server-stress`; produces the artifacts this skill consumes.
 - [`../prompts/backlog-sweep-plan.md`](../prompts/backlog-sweep-plan.md) — planner prompt that consumes the backlog this skill produces.

--- a/ai_docs/procedures/deep-review-program.md
+++ b/ai_docs/procedures/deep-review-program.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Run multi-repo deep-review audits with consistent repo/client coverage, raw evidence storage, and deduped rollup intake. -->
 
-Use this procedure when the `/mcp-server-stress` skill (bundled prompt at `.claude/skills/mcp-server-stress/prompts/prompt.md`) is being run across multiple C# repositories and the result needs to drive backlog or release decisions.
+Use this procedure when the `/mcp-server-stress` skill (bundled prompt at `.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md`) is being run across multiple C# repositories and the result needs to drive backlog or release decisions.
 
 For concrete shell examples, see `deep-review-command-reference.md`.
 
@@ -20,7 +20,7 @@ For concrete shell examples, see `deep-review-command-reference.md`.
 
 Use this flow when the audited C# repository is outside this workspace.
 
-1. Run `/mcp-server-stress` (or its bundled prompt at `.claude/skills/mcp-server-stress/prompts/prompt.md`) in the external repo.
+1. Run `/mcp-server-stress` (or its bundled prompt at `.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md`) in the external repo.
 2. Let the prompt write its raw file into that repo's `ai_docs/audit-reports/` (or copy into Roslyn-Backed-MCP when this workspace is the audit root).
 3. **Operator step:** from the Roslyn-Backed-MCP repo root, invoke the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) skill (`/backlog-intake`). It discovers sibling checkouts under the parent folder (e.g. `C:\Code-Repo\*`) via `eng/stage-review-inbox.ps1`, stages every `*_mcp-server-audit.md` / `*_experimental-promotion.md` / `*_roslyn-mcp-retro.md` into `review-inbox/`, then extracts / dedupes / anchor-verifies / ranks / splits and merges new rows into `ai_docs/backlog.md`. See [`deep-review-backlog-intake.md`](deep-review-backlog-intake.md).
 
@@ -129,7 +129,7 @@ Default intake is **driven by the [`backlog-intake`](../../.claude/skills/backlo
 ## Related
 
 - `deep-review-backlog-intake.md` — automation switches and manual follow-up
-- `.claude/skills/mcp-server-stress/prompts/prompt.md` — bundled audit prompt run by `/mcp-server-stress`
+- `.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` — bundled audit prompt run by `/mcp-server-stress`
 - `deep-review-command-reference.md` — concrete shell command examples for the workflow
 - `audit-reports/README.md` — raw audit output location
 - `reports/README.md` — synthesized rollup location

--- a/changelog.d/mcp-server-surface-test-genericity-split.md
+++ b/changelog.d/mcp-server-surface-test-genericity-split.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Added:** `/mcp-server-surface-test` shipped skill at `skills/mcp-server-surface-test/` — consumer-facing audit of the Roslyn MCP server's live surface against any loaded C# repo. Two tiers: `--quick` (read-only smoke pass, ≤15 min) and `--full` (default; comprehensive sweep including disposable-worktree apply round-trips and the experimental-promotion scorecard, 90–180 min). Findings render through one envelope and emit either to stdout (default) or as GitHub Issues at `https://github.com/darylmcd/Roslyn-Backed-MCP` via `gh issue create` when `--auto-file` is passed. P0 / `area: security` findings are never auto-filed regardless of flag — they print to stdout with a banner directing the operator to private GitHub security advisories. Closes Row 1 of the move-to-git-issues design.
+
+### Maintenance
+
+- **Maintenance:** `.claude/skills/mcp-server-stress/prompts/prompt.md` renamed to `prompts/maintainer-overlay.md`. The maintainer skill is now the maintainer-only superset of the shipped `/mcp-server-surface-test` — it retains repo-coupled phases (host-shell `dotnet restore` precheck, `ai_docs/backlog.md` regression cross-check, `<audited-repo-root>/backlog.d/` fragment emission for `/backlog-intake`, `eng/aggregate-promotion-scorecards.ps1` cross-repo aggregation) that the shipped consumer prompt does not have. SKILL.md Step 2 now routes to the renamed file. Tests updated.
+- **Maintenance:** `ai_docs/items/move-to-git-issues.md` banned-pattern list aligned to `eng/verify-skills-are-generic.ps1` (drops the false `backlog.d` entry, adds the missing `state.json` and `just verify-` entries). Row 1 wording reframed from "restore" to "ship as new generic skill" — `./skills/mcp-server-surface-test/` has never existed before.

--- a/skills/mcp-server-surface-test/README.md
+++ b/skills/mcp-server-surface-test/README.md
@@ -1,0 +1,65 @@
+# /mcp-server-surface-test
+
+Consumer-facing audit of the Roslyn MCP server's live surface against your loaded C# repo. Run when you want to verify that the server's tools, resources, and prompts behave as documented against your own codebase — and optionally share findings back upstream.
+
+## Tiers
+
+| Tier | Flag | Runtime | What it does |
+|---|---|---|---|
+| **Quick** | `--quick` | ≤15 min | Read-only smoke pass. No apply-mode mutations, no disposable worktree, no test runs, no network calls. Produces an audit report only. |
+| **Full** | *(default)* or `--full` | 90–180 min | Comprehensive sweep including disposable-worktree apply round-trips, build/test validation, and the experimental→stable promotion scorecard. |
+
+## What it does
+
+1. Verifies the Roslyn MCP server is reachable (`mcp__roslyn__server_info` returns `connection.state: ready`). Halts otherwise — there is no non-MCP fallback.
+2. Loads your C# workspace (`.sln` / `.slnx` / `.csproj`).
+3. Runs through 10–17 audit phases (depending on tier) that exercise every tool, resource, and prompt the live catalog reports. Records `_meta.elapsedMs`, schema-vs-behaviour drift, error-message quality, and parameter-path coverage.
+4. **Full tier only:** drives preview→apply→revert round-trips inside a **disposable worktree the skill creates and tears down at run end**. Your repo's `main` branch is never mutated; no commit ever lands in your repo's history; no PR is opened.
+5. Writes a structured audit report to `<your-repo>/audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md`.
+6. Renders each actionable finding through a shared envelope and emits per `--auto-file`.
+
+## Privacy and safety
+
+- **What stays local by default.** All audit evidence — the prose report and the promotion scorecard JSON (full tier only) — is written to your repo's `audit-reports/` directory. Nothing leaves your machine unless you pass `--auto-file`.
+- **What `--auto-file` sends.** The skill calls `gh issue create` against `https://github.com/darylmcd/Roslyn-Backed-MCP` with the rendered finding envelope (id, severity, area, anchors, finding/repro/proposed-fix). The body fields contain code paths and behaviour observations from your repo. **Review the printed finding bodies before passing `--auto-file` if any of that is sensitive.**
+- **No telemetry.** The skill does not phone home, does not collect usage statistics, does not call any URL other than the GitHub API on `--auto-file` (and only when you opt in).
+- **`gh` is required for `--auto-file`.** If `gh` is missing or not authenticated, the skill falls back to stdout-print and emits one warning line.
+
+### Pre-disclosure / security findings
+
+Findings whose `severity == P0` OR `area == security` are **never** auto-filed, regardless of the `--auto-file` flag. They print to stdout with a banner directing the operator to file a private disclosure via [GitHub security advisories](https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new) instead.
+
+This refusal is non-negotiable. The intent is to prevent a vulnerability from leaking to a public Issue before it is fixed.
+
+## Sharing findings
+
+GitHub Issues at https://github.com/darylmcd/Roslyn-Backed-MCP are the public funnel for accepted findings. If you find something worth sharing:
+
+1. Run `/mcp-server-surface-test --quick` (fast path) or `/mcp-server-surface-test --full` (comprehensive).
+2. Review the finding bodies the skill prints to stdout.
+3. Either copy/paste them into a new Issue manually, or pass `--auto-file` to file them via `gh`.
+
+The default print-to-stdout flow is the recommended starting point — it lets you review what the skill found before anything goes public.
+
+## Hard rules
+
+- **Server-required.** No non-MCP fallback. If the Roslyn MCP server is not callable, the skill halts.
+- **Read-only against `main`.** All apply-mode mutations confine to the disposable worktree (full tier only). The skill never pushes, never opens a PR, and never commits to your repo's history.
+- **Cite, don't summarize.** Every finding references a concrete `file:line` and a tool call.
+- **P0 / security findings are stdout-only.** See *Pre-disclosure / security findings* above.
+
+## Operational notes
+
+### Archiving old reports
+
+The skill ships a small PowerShell wrapper at `scripts/archive-old-reports.ps1` that moves `*.md` reports older than N days (default 30) into a year-stamped `archive/<YYYY>/` subdirectory.
+
+```bash
+# Preview the archive plan without mutating anything.
+pwsh -NoProfile -File ${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -DryRun
+
+# Archive reports older than 60 days.
+pwsh -NoProfile -File ${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -OlderThanDays 60
+```
+
+The script is idempotent and read-only when `-DryRun` is set.

--- a/skills/mcp-server-surface-test/SKILL.md
+++ b/skills/mcp-server-surface-test/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: mcp-server-surface-test
+description: "Consumer-facing audit of the Roslyn MCP server's live surface against a loaded C# repo. Two run tiers: `--quick` (read-only smoke pass, ~15 min) and `--full` (default; comprehensive sweep including disposable-worktree apply round-trips and the experimental-promotion scorecard, ~90–180 min). Findings print to stdout by default; pass `--auto-file` to file each finding as a GitHub Issue at https://github.com/darylmcd/Roslyn-Backed-MCP. Requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts if the server is not callable rather than running a non-MCP fallback. Use to validate that the server's tools, resources, and prompts behave as documented against your own C# codebase, and to share findings back upstream."
+user-invocable: true
+argument-hint: "[<target-repo-path>] [--quick | --full] [--auto-file] [--no-worktree]"
+---
+
+# /mcp-server-surface-test $ARGUMENTS
+
+Run a Roslyn MCP server audit against a loaded C# repo. The skill bundles two prompt files — `prompts/quick.md` for the bounded read-only tier and `prompts/full.md` for the comprehensive run — and routes between them based on `$ARGUMENTS`.
+
+## Step 1 — Hard precondition: Roslyn MCP server must be callable
+
+This skill is a **null-op without the Roslyn MCP server**. The audit's entire purpose is to exercise the server's live surface — without it, the run produces no audit-grade evidence.
+
+1. Verify `mcp__roslyn__server_info` appears in your current tool surface and call it. The response must include `connection.state: "ready"`.
+2. If the call fails, the tool is missing, or `connection.state` is `initializing` / `degraded` / absent, **stop and report**:
+
+   > *"This skill requires the Roslyn MCP server (`mcp__roslyn__*` tools must be callable, `connection.state` must be `ready`). Start the server — for example `dotnet tool run roslynmcp` or ensure the plugin's stdio entry is active in your client config — confirm `mcp__roslyn__server_info` returns `ready`, then re-invoke this skill."*
+
+   Do **not** substitute `Read`, `Grep`, `Bash: dotnet build`, or any other host-side fallback. There is no generic non-MCP audit fallback in this skill — a broken server precondition halts the run.
+
+## Step 2 — Parse $ARGUMENTS and route to a tier prompt
+
+`$ARGUMENTS` may include any combination of the following tokens, in any order. Tokens are space-separated.
+
+### Target repo (default: current Claude Code session's repo root)
+
+The audit needs a C# workspace to load via `mcp__roslyn__workspace_load`. By default the audit targets the **current session's repo root**. Override the target in two equivalent ways:
+
+- `--target=<absolute-path-or-repo-root>` — explicit flag form.
+- *(bare path)* — any single token in `$ARGUMENTS` that resolves to an existing directory containing a `.sln`/`.slnx`/`.csproj` file.
+
+Resolution rules:
+
+1. If both `--target=<path>` and a bare path appear, **stop and report the conflict** — pick one form. Do not silently prefer one over the other.
+2. The resolved target path becomes the **audited repo root** throughout the prompt — *every* output path computed by the prompt (the audit report, the disposable worktree base, finding emission) anchors here, not at the agent session's CWD.
+3. If the resolved path does not exist, contains no `.sln`/`.slnx`/`.csproj`, or is not a git working tree, **stop and report** — the audit cannot proceed without a loadable workspace and a tree the disposable-worktree step can branch from.
+4. Pass the resolved target to the prompt's Phase 0 as the `workspace_load` argument; the prompt's *Isolation* row in the report header records the resolved target path.
+
+### Tier flags
+
+- *(no flag, default)* — `--full` is the default. Read `prompts/full.md` and run it phase by phase.
+- `--quick` — read-only smoke pass. Read `prompts/quick.md` instead. Target runtime ≤15 minutes vs `--full`'s 90–180 minutes. No apply-mode mutations, no disposable worktree, no test runs, no `nuget_vulnerability_scan` (network-dependent).
+- `--full` — explicit form of the default; routes to `prompts/full.md`.
+- **Conflict:** `--quick` and `--full` together → stop and report; pick one.
+
+### `--no-worktree` (full tier only)
+
+- *(no flag, default)* — full canonical run with the disposable-worktree apply pass exercised.
+- `--no-worktree` — degraded mode for environments that genuinely cannot create a git worktree. Phase 6 sub-phases that require a worktree are marked `skipped-safety — --no-worktree`. The promotion scorecard still emits, but writer recommendations default to `needs-more-evidence` for any tool whose round-trip evidence depended on the disposable worktree. **Has no effect under `--quick`** (the quick tier already skips Phase 6); reject the combination with a one-line message.
+
+### `--auto-file` (both tiers)
+
+- *(no flag, default)* — actionable findings render to stdout as ready-to-paste GitHub Issue bodies. The skill prints the Issue title, labels, and body; the operator decides what to do with each.
+- `--auto-file` — opt-in. After the audit completes and findings are rendered, the skill calls `gh issue create` against `https://github.com/darylmcd/Roslyn-Backed-MCP` for each actionable finding. Requirements:
+  - `gh` is on `PATH`. If missing, fall back to stdout-print and emit one warning line.
+  - `gh auth status` reports an authenticated session. If not, fall back to stdout-print and emit one warning line.
+  - **Refusal contract:** the skill does **not** call `gh issue create` for any finding whose `severity == P0` or whose `area == security`. Such findings print to stdout with this header line: `**SECURITY / P0 finding — DO NOT FILE PUBLICLY.** Escalate via GitHub security advisories at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new`. The refusal applies regardless of `--auto-file` and is the load-bearing pre-disclosure safeguard.
+
+### Reject
+
+Reject any token that is neither a valid target path, `--target=<path>`, `--quick`, `--full`, `--no-worktree`, nor `--auto-file`. One-line message; ask the user to fix or drop the offending token.
+
+## Step 3 — Mutation safety: disposable worktree (full tier, default mode)
+
+The audit is **read-only against the audited repository's `main` branch**. Phase 6 of the full tier writes apply-mode mutations, but only inside a disposable worktree the prompt creates and tracks. The flow is:
+
+1. Before any Phase 6 apply, the prompt creates a disposable branch + worktree at run start and records the path in the report header (the *Isolation* row). This is **mandatory** in default full-mode — Phase 6 cannot run against the audited repo's primary checkout.
+2. Phase 6's preview → apply chains run against that disposable checkout. Applies are exercised as test fixtures of the apply-tool surface (preview→apply→revert round-trips, `compile_check` after apply, `build_workspace` + `test_run` after apply). The point is to exercise the write path of the MCP server, not to ship product changes.
+3. The disposable worktree is torn down at run end via `dotnet build-server shutdown` followed by `git worktree remove --force` (the Windows lock-release sequence is mandatory; `dotnet build-server shutdown` releases `testhost.exe` / `VBCSCompiler.exe` locks on the worktree's `bin/` dirs). Teardown runs even on apply failure — the prompt wraps the Phase 6 chain in `try/finally` discipline.
+4. The audited repo's `main` branch is **never** directly mutated. No PR is opened from the audit run. No commits land in the audited repo's history.
+
+The `--no-worktree` flag opts into a degraded mode where the disposable worktree is skipped — see Step 2 for the contract and the report-header record requirement. The `--quick` tier always skips the disposable worktree (no apply-mode phases run at all).
+
+## Step 4 — Execute the chosen prompt
+
+- `--quick`: read `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/prompts/quick.md` and run it phase by phase.
+- `--full` (default): read `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/prompts/full.md` and run it phase by phase.
+
+Persist the audit draft after each phase as the prompt instructs — the canonical report path lives in the prompt's *Output Format* section: `<audited-repo-root>/audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md`.
+
+## Step 5 — Finding emission (both tiers)
+
+After the audit phases complete, the prompt's final finding-emission phase walks every actionable finding (entries in *MCP server issues* or *Improvement suggestions* with a concrete fix sketch) and renders each through one shared envelope:
+
+- **Default (no `--auto-file`):** print each finding to stdout as a ready-to-paste GitHub Issue body. The render block is `## TITLE`, label list, and the structured body fields (`id`, `source-repo`, `severity`, `area`, `server-version`, `anchors`, `finding`, `repro`, `proposed-fix`).
+- **With `--auto-file`:** call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <title> --label <area:X,severity:Y> --body-file <tempfile>` per finding, except those refused by the P0/security refusal contract (Step 2). Refused findings still print to stdout with the security-advisory escalation banner.
+
+## Operational notes
+
+### Archiving old audit reports — `scripts/archive-old-reports.ps1`
+
+Reports written to the `audit-reports/` directory accumulate over time. The skill ships a small PowerShell wrapper at `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1` that moves `*.md` files older than N days (default 30) into a year-stamped `archive/<YYYY>/` subdirectory. The reports directory path defaults to `audit-reports` and can be overridden via `-ReportsRelativePath`.
+
+Invocation (any shell with `pwsh` on path):
+
+```bash
+# Preview the archive plan without mutating anything.
+pwsh -NoProfile -File ${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -DryRun
+
+# Archive reports older than 60 days under the default reports directory.
+pwsh -NoProfile -File ${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -OlderThanDays 60
+```
+
+Behavior contract:
+
+- **Pinned filenames are never archived** — `README.md` stays in place regardless of age.
+- **Idempotent** — running twice is safe. The destination year-subdirectory is created on demand.
+- **Read-only when `-DryRun` is set.**
+- **Independent of the Roslyn MCP server** — the archive script does not require MCP tooling.
+
+The script is invoked manually (no automatic scheduler).
+
+## Hard rules
+
+- **Server-required.** No generic non-MCP fallback exists. If `mcp__roslyn__server_info` is not callable or `connection.state` is not `ready`, halt.
+- **Read-only against `main`.** All apply-mode mutations confine to the disposable worktree the prompt creates. Never push or merge from inside this skill.
+- **No PR.** This skill produces an audit report, not a refactor PR. Phase 6 mutations are exercised as apply-tool fixtures inside the disposable worktree and torn down at run end.
+- **Cite, don't summarize.** Every finding must reference a concrete file:line and a tool call — no abstract claims.
+- **Disposable-worktree teardown is mandatory** (full tier, default mode). The Phase 6 apply chain runs inside `try/finally` so teardown executes even on apply failure. `dotnet build-server shutdown` always precedes `git worktree remove --force` on Windows.
+- **P0 / security findings are never auto-filed.** The refusal applies whether the operator passed `--auto-file` or not — those findings are stdout-only with the security-advisory escalation banner.

--- a/skills/mcp-server-surface-test/prompts/full.md
+++ b/skills/mcp-server-surface-test/prompts/full.md
@@ -28,7 +28,7 @@ This prompt describes one canonical run. Phase 6 applies are always exercised ag
 
 A single optional flag exists: `--no-worktree`, a degraded mode for environments that genuinely cannot create a git worktree (tight CI sandbox, missing `git` binary, read-only checkout). When set, Phase 6 is skipped, the *Isolation* row records `degraded — --no-worktree flag, Phase 6 applies skipped`, and writer rows whose round-trip evidence depended on the disposable worktree default to `needs-more-evidence` in the scorecard. Record `--no-worktree` in the report header so consumers know which evidence is missing.
 
-**Known issues / prior findings.** When auditing Roslyn-Backed-MCP (or any repo that has access to it), cross-check `ai_docs/backlog.md` at the audited-repo root and cite matching ids. Otherwise use the closest prior source (previous audit report, issue tracker, repro list). If none exists, the regression section is **N/A**.
+**Known issues / prior findings.** When the audited repo has a tracked backlog or issue history, cross-check it and cite matching ids — common locations include `<audited-repo-root>/backlog.md`, a project's GitHub Issues, or a prior audit report. If no prior source exists, the regression section is **N/A**.
 
 **Phase order.** Run in this order: **-1 → 0 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 8b → 10 → 9 → 11 → 12 → 13 → 14 → 15 → 16 → 17 → 18**. Phase 8b runs immediately after Phase 8 so it sees post-refactor state. Phase 9 runs after Phase 10 so `revert_last_apply` doesn't undo Phase 6 work.
 
@@ -96,7 +96,7 @@ This prompt is a contract with the Roslyn MCP server. Without it, nothing below 
 ### Phase 0: Setup, live surface baseline, and repo shape
 
 1. Pick the entrypoint: `.sln` / `.slnx` / `.csproj`.
-2. **Create the disposable worktree** (mandatory, default mode). Run `git worktree add ../<repo-name>-audit-deep-<ts> -b audit-deep/<ts>` from the audited repo root, where `<ts>` is the same UTC `yyyyMMddTHHmmssZ` used for the report filename. Record the absolute worktree path + branch name in the *Isolation* header row before any write-capable call. Phase 6's preview→apply chains run against this checkout; the audited repo's primary working tree is never touched. **`--no-worktree` flag:** record `degraded — --no-worktree flag, Phase 6 applies skipped` in the *Isolation* row and skip worktree creation entirely.
+2. **Create the disposable worktree** (mandatory, default mode). Run `git worktree add ../<repo-name>-surface-test-<ts> -b mcp-server-surface-test/<ts>` from the audited repo root, where `<ts>` is the same UTC `yyyyMMddTHHmmssZ` used for the report filename. Record the absolute worktree path + branch name in the *Isolation* header row before any write-capable call. Phase 6's preview→apply chains run against this checkout; the audited repo's primary working tree is never touched. **`--no-worktree` flag:** record `degraded — --no-worktree flag, Phase 6 applies skipped` in the *Isolation* row and skip worktree creation entirely.
 3. **Debug-log channel check.** Is the client surfacing `notifications/message`? Record `yes` / `partial` / `no` in the header.
 4. Read `roslyn://server/resource-templates` to capture all resource URI templates.
 5. Call `workspace_load` (lean summary default; pass `verbose=true` only if you need the full project tree).
@@ -310,10 +310,10 @@ This sub-phase runs at the **end of Phase 6** as the `finally`-clause counterpar
 1. **Release Windows file locks first.** Run `dotnet build-server shutdown` from the audited repo root (or the disposable worktree, equivalent). This releases `testhost.exe` / `VBCSCompiler.exe` locks on `bin/{Debug,Release}/net*/` directories. The command prints one informational line on stdout — that is normal, not an error.
 2. **Remove the worktree.** Run `git worktree remove --force <disposable-worktree-path>` from the audited repo root. The `--force` flag is required because Phase 6 leaves uncommitted apply-mode mutations in the worktree (intentionally — the point was to exercise the apply tools, not to commit their output).
 3. **Verify cleanup.** Run `git worktree list` from the audited repo root and confirm the disposable worktree is gone. Run `git status` from the audited repo's primary checkout and confirm it is clean (Phase 6 must not have leaked changes outside the worktree).
-4. **Branch cleanup.** Run `git branch -D audit-deep/<ts>` from the audited repo root to delete the disposable branch. The branch only existed to host worktree state; it has no upstream and no history worth preserving.
+4. **Branch cleanup.** Run `git branch -D mcp-server-surface-test/<ts>` from the audited repo root to delete the disposable branch. The branch only existed to host worktree state; it has no upstream and no history worth preserving.
 5. **Record teardown outcome in the report header.** A new *Teardown* row: `clean` (worktree removed, branch deleted, primary checkout clean) / `partial — <what survived>` (e.g. `partial — branch survived; manual git branch -D required`) / `failed — <error>`.
 
-If teardown fails for an unexpected reason, surface the failure in the report's *MCP server issues* section as a P1 finding tagged `audit-deep teardown`. Do not retry blindly — the operator can clean up by hand.
+If teardown fails for an unexpected reason, surface the failure in the report's *MCP server issues* section as a P1 finding tagged `surface-test teardown`. Do not retry blindly — the operator can clean up by hand.
 
 **`--no-worktree` mode:** sub-phase 6z is `skipped — no worktree was created`.
 
@@ -592,36 +592,69 @@ Deliberately probe edge cases. Verify inputs validated, error messages helpful, 
 
 ### Phase 18: Regression verification
 
-Re-test 3–5 previously recorded issues. Prefer `ai_docs/backlog.md` at the audited-repo root when auditing Roslyn-Backed-MCP. Otherwise a prior audit report / issue tracker / saved repro list. If no prior source, `**N/A — no prior source**`.
+Re-test 3–5 previously recorded issues from whichever prior source the audited repo maintains — a tracked backlog file at the repo root, a project's GitHub Issues, a prior audit report, or a saved repro list. If no prior source, `**N/A — no prior source**`.
 
 1. Read the prior source; select 3–5 items reproducible with the current workspace.
 2. For each, reproduce the exact scenario. Record **still reproduces** / **partially fixed** (describe) / **no longer reproduces — candidate for closure**.
 
-### Phase 19: Fragment emission (cross-repo backlog handoff)
+### Phase 19: Finding emission (dual-path: stdout default, opt-in `gh issue create`)
 
-For each **actionable** finding in the audit report (anything that lands in section 13 *MCP server issues* or in section 14 *Improvement suggestions* with a concrete fix sketch), emit one **`backlog.d/` fragment** at:
+For each **actionable** finding in the audit report (anything that lands in section 13 *MCP server issues* or in section 14 *Improvement suggestions* with a concrete fix sketch), render one finding envelope and emit it to **one of two destinations** depending on the `--auto-file` flag passed to the skill:
+
+**Envelope (shared across both destinations):**
+
+| Field | Source |
+|---|---|
+| `id` | kebab-case slug; prefix with the audited repo's id (derive from `git remote get-url origin` → `owner/repo` or fall back to repo dir basename). Example: `tradewise-find-references-stale-cache`. |
+| `source-repo` | audited repo's kebab-case id |
+| `severity` | `P0` / `P1` / `P2` / `P3` matching section 13 severity, or `P3`/`P2` for section-14 suggestions per their workflow blocking impact |
+| `area` | one of `tools` / `resources` / `prompts` / `skills` / `concurrency` / `perf` / `docs` |
+| `anchors` | one or more `path/to/file.ext:LINE` strings (relative to the audited repo's root) |
+| `finding` | one to two sentences describing the bug or gap |
+| `repro` | one to two sentences describing the minimal reproduction (which tool / inputs / expected vs. actual) |
+| `proposed-fix` | one to two sentences pointing at the likely fix shape |
+
+**Default (no `--auto-file`):** print each finding envelope to stdout as a ready-to-paste GitHub Issue body. Format:
 
 ```
-<audited-repo-root>/backlog.d/<finding-id>.md
+## TITLE: <id>
+Labels: area:<area>, severity:<severity>
+Body:
+- id: <id>
+- source-repo: <source-repo>
+- severity: <severity>
+- area: <area>
+- anchors:
+  - <anchor1>
+  - <anchor2>
+- finding: <finding>
+- repro: <repro>
+- proposed-fix: <proposed-fix>
 ```
 
-Schema is canonical at `<Roslyn-Backed-MCP-root>/ai_docs/items/backlog-d-fragment-schema.md` — read that file once if you have not seen it. The required frontmatter keys are: `id`, `source_audit`, `source_repo`, `severity`, `area`, `anchors`. The body is a single ≤6-sentence paragraph (finding + repro + proposed fix sketch).
+**With `--auto-file`** (and only when `gh` is on `PATH` and `gh auth status` is authenticated): for each non-refused finding, write the body block to a temp file and call:
 
-Steps:
+```
+gh issue create --repo darylmcd/Roslyn-Backed-MCP \
+  --title "<id>" \
+  --label "area:<area>" --label "severity:<severity>" \
+  --body-file <tempfile>
+```
 
-1. Ensure `<audited-repo-root>/backlog.d/` exists (`mkdir -p`).
-2. For each actionable finding, derive a kebab-case `<finding-id>` that prefixes the audited repo's id (e.g. `roslyn-mcp-find-references-stale-cache`, `tradewise-symbol-search-empty-query-overflow`). The filename and the frontmatter `id` must match exactly.
-3. Set `source_audit` to the basename of the prose audit report this run is producing (e.g. `20260507T203015Z_tradewise_mcp-server-audit.md`).
-4. Set `source_repo` to the audited repo's kebab-case id.
-5. Set `severity` to `P0` / `P1` / `P2` / `P3` matching the section 13 severity (or your own classification for section 14 entries: typically `P3` unless the suggestion blocks a concrete workflow, in which case `P2`).
-6. Set `area` to one of `tools` / `resources` / `prompts` / `skills` / `concurrency` / `perf` / `docs`.
-7. Set `anchors` to one or more `path/to/file.ext:LINE` strings (relative to the audited repo's root).
+Capture the returned Issue URL and append it to the audit report's *Finding emission* section. If `gh` is missing or unauthenticated, fall back to stdout-print and emit one warning line — do not silently drop findings.
 
-Idempotency: if a fragment with the same filename already exists in `backlog.d/`, **do not overwrite it** — leave the existing fragment in place and skip emission for that finding. Re-running the audit on the same repo without intake-in-between is allowed; the second run is a no-op for fragments that have not changed.
+**Refusal contract — load-bearing pre-disclosure safeguard:**
+
+The skill **must not** call `gh issue create` for any finding whose `severity == P0` OR `area == security`. Such findings always print to stdout, regardless of the `--auto-file` flag, prefixed with:
+
+```
+**SECURITY / P0 finding — DO NOT FILE PUBLICLY.**
+Escalate via GitHub security advisories: https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new
+```
+
+The refusal is non-negotiable and applies even when `--auto-file` is explicitly passed.
 
 `**N/A — no actionable findings**` is a valid Phase 19 outcome when sections 13 + 14 are both empty.
-
-This phase replaces the prior cross-write of audit reports into `<Roslyn-MCP-root>/ai_docs/audit-reports/`. Fragments are now the only `/backlog-intake`-consumable artifact. The prose `*_mcp-server-audit.md` and the scorecard JSON stay where this run wrote them under `<audited-repo-root>/ai_docs/audit-reports/`; intake reads them only as back-references via the fragment's `source_audit` field.
 
 ---
 
@@ -662,33 +695,22 @@ The audit is **not finished** until both of:
 
 A one-shot flush from working memory is the most common cause of broken runs — the model accumulates ~1–2 MB of tool results in active context, then runs out of room when serializing the report. Persisting after each phase keeps each turn within budget and lets the next turn drop the prior phase's tool-result bulk.
 
-This prompt writes **raw per-run evidence only**. Multi-repo campaigns synthesize cross-repo findings later under `ai_docs/reports/`; do not write the raw audit file there.
+This prompt writes **raw per-run evidence only**. The audit report belongs in the audited repo, not in any other location.
 
 ### Where to save the report
 
-**Canonical path:** `<audited-repo-root>/ai_docs/audit-reports/<timestamp>_<repo-id>_mcp-server-audit.md`
+**Canonical path:** `<audited-repo-root>/audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md`
 
 - `<timestamp>` = current UTC `yyyyMMddTHHmmssZ`.
-- The prose `.md` report ALWAYS stays in the audited repo's own `ai_docs/audit-reports/`. Do **not** cross-write it into `<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/` — that legacy cross-write path is removed in favor of the fragment pattern (see Phase 19).
-- Cross-repo handoff to `/backlog-intake` happens via the per-finding fragments emitted in Phase 19 (`<audited-repo-root>/backlog.d/<finding-id>.md`), NOT by relocating the prose report. Intake reads the fragment's `source_audit` field to back-reference the prose report when it needs additional context.
-- Do **not** place raw audit files under `ai_docs/reports/` — that directory is for synthesized rollups.
+- The prose `.md` report stays in the audited repo's own `audit-reports/` directory. Cross-repo handoff to upstream happens via the Phase 19 finding emission (stdout-print or `gh issue create`), not by relocating the prose report.
 
 ### Promotion scorecard JSON (sibling artifact — MANDATORY)
 
 In addition to the human-readable `.md` report, write a machine-readable scorecard at:
 
-**`<audited-repo-root>/ai_docs/audit-reports/_latest-promotion-scorecard.json`**
+**`<audited-repo-root>/audit-reports/_latest-promotion-scorecard.json`**
 
-The scorecard now lives **next to its source evidence** in the audited repo's
-own `ai_docs/audit-reports/` folder, alongside the prose audit report. The
-older single-file location at `<Roslyn-Backed-MCP-root>/ai_docs/audit-reports/`
-is **deprecated** — it was a last-write-wins file across all audited
-workspaces, which let a single workspace's anomaly drive promotion
-decisions. Cross-repo aggregation (quorum across sibling repos) is now
-the consumer's job: `/publish-preflight` Step 8 gathers per-repo
-scorecards via `eng/aggregate-promotion-scorecards.ps1`.
-
-This file is **overwritten** each run. Schema:
+The scorecard lives **next to its source evidence** in the audited repo's own `audit-reports/` folder, alongside the prose audit report. This file is **overwritten** each run. Schema:
 
 ```json
 {
@@ -696,7 +718,7 @@ This file is **overwritten** each run. Schema:
   "generatedAt": "2026-05-05T18:36:19Z",
   "noWorktree": false,
   "auditedRepo": "roslyn-backed-mcp",
-  "auditReportPath": "ai_docs/audit-reports/20260505T183619Z_roslyn-backed-mcp_mcp-server-audit.md",
+  "auditReportPath": "audit-reports/20260505T183619Z_roslyn-backed-mcp_mcp-server-surface-test.md",
   "serverVersion": "1.33.2",
   "catalogVersion": "2026.04",
   "experimentalSurface": {
@@ -758,16 +780,16 @@ This file is **overwritten** each run. Schema:
 - `blockers` is empty when `recommendation == "promote"`; populated with concrete missing evidence otherwise.
 - Skip rows for entries marked `blocked` in the coverage ledger — they cannot be scored. Track them in `summary.blocked` only.
 
-**Why this exists.** `/release-cut` (via `/publish-preflight`) aggregates per-repo scorecards from configured sibling repos and applies a **quorum rule** (≥2 workspaces with `recommendation: "promote"`, no `keep-experimental` or `deprecate` blockers) before prompting the maintainer to flip a tier. Without the JSON, promotion stays implicit and the audit's promotion lane has no operational consequence. With per-repo scorecards plus quorum, single-workspace anomalies no longer drive tier decisions.
+**Why this exists.** Upstream maintainers use the per-repo scorecard plus a quorum rule (≥2 workspaces with `recommendation: "promote"`, no `keep-experimental` or `deprecate` blockers) before flipping a tool's experimental → stable tier. Without the JSON the audit's promotion lane has no operational signal. With per-repo scorecards plus quorum, single-workspace anomalies no longer drive tier decisions.
 
-**Staleness contract.** The JSON is a snapshot, not a journal. `/publish-preflight` warns when `generatedAt` is older than 30 days; older than 90 days, the file should be ignored entirely (recommend a fresh `/audit-deep` run).
+**Staleness contract.** The JSON is a snapshot, not a journal. Treat it as warn-after-30-days, ignore-after-90-days; on staleness, run `/mcp-server-surface-test` again to refresh the artifact.
 
 **`--no-worktree` runs still emit the scorecard.** Apply round-trips that depended on the disposable worktree are recorded as `skipped-safety — --no-worktree` in the coverage ledger and the affected writer tools' `recommendation` will typically default to `needs-more-evidence`, with `blockers` citing the missing worktree. The scorecard JSON is still written so consumers see a fresh artifact and can decide for themselves whether the missing-worktree evidence matters for their gate.
 
 ### Naming scheme (`<timestamp>_<repo-id>`)
 
 - `<timestamp>`: current UTC `yyyyMMddTHHmmssZ`.
-- `<repo-id>`: audited solution/repo name — strip `.sln` / `.slnx` / `.csproj`; lowercase; replace spaces and dots with hyphens. Examples: `20260422T154500Z_itchatbot_mcp-server-audit.md`.
+- `<repo-id>`: audited solution/repo name — strip `.sln` / `.slnx` / `.csproj`; lowercase; replace spaces and dots with hyphens. Examples: `20260422T154500Z_itchatbot_mcp-server-surface-test.md`.
 
 ### Report contents (required sections)
 
@@ -828,7 +850,7 @@ Mandatory sections always render in full; conditional sections collapse to a sin
 - **Repo shape:**
 - **Prior issue source:**
 - **Debug log channel:** `yes` / `partial` / `no`
-- **Report path note:** (path under the audited repo's `ai_docs/audit-reports/`; cross-repo handoff is via Phase 19 fragments, not via copying the prose report)
+- **Report path note:** (path under the audited repo's `audit-reports/`; cross-repo handoff is via Phase 19 fragments, not via copying the prose report)
 
 ## 2. Coverage summary
 | Kind | Category | Stable | Experimental | Exercised | Exercised-apply | Preview-only | Skipped-repo-shape | Skipped-safety | Blocked | Notes |
@@ -843,7 +865,7 @@ Mandatory sections always render in full; conditional sections collapse to a sin
 
 ## 5. Phase 6 apply-tool exercise summary
 - **Disposable worktree path:** absolute path (or `N/A — --no-worktree`)
-- **Disposable branch:** `audit-deep/<ts>` (or `N/A — --no-worktree`)
+- **Disposable branch:** `mcp-server-surface-test/<ts>` (or `N/A — --no-worktree`)
 - **Scope:** (which 6a–6m sub-phases ran; `**N/A — skipped per --no-worktree**` when degraded mode)
 - **Apply-tool calls:** bullets — preview→apply pairs exercised, with tool name + outcome
 - **Verification:** `compile_check` / `test_run` / `build_workspace` outcomes after applies
@@ -937,7 +959,7 @@ Mandatory sections always render in full; conditional sections collapse to a sin
 
 ### Completion gate
 
-The prose `.md` report must exist at the canonical path above (under the audited repo's `ai_docs/audit-reports/`). Create the directory if missing. Phase 19 must have emitted at least one fragment under `<audited-repo-root>/backlog.d/` OR explicitly recorded `**N/A — no actionable findings**`. The task is **incomplete** without both gates passing.
+The prose `.md` report must exist at the canonical path above (under the audited repo's `audit-reports/`). Create the directory if missing. Phase 19 must have emitted at least one fragment under `<audited-repo-root>/backlog.d/` OR explicitly recorded `**N/A — no actionable findings**`. The task is **incomplete** without both gates passing.
 
 ---
 

--- a/skills/mcp-server-surface-test/prompts/quick.md
+++ b/skills/mcp-server-surface-test/prompts/quick.md
@@ -1,0 +1,211 @@
+# Roslyn MCP Server — Quick Surface-Test Prompt (`--quick` tier)
+
+<!-- purpose: Bounded read-only smoke pass for the Roslyn MCP server's live surface against a loaded C# repo. Target runtime ≤15 minutes. No apply-mode mutations, no disposable worktree, no test runs, no network-dependent calls. -->
+
+> **This prompt is a null-op without the Roslyn MCP server.** If `mcp__roslyn__server_info` is not callable in your current tool list, stop and ask the user to start the server.
+
+> **Primary purpose:** produce a fast read-only assessment of whether the loaded C# repo's Roslyn MCP surface is healthy enough that `--full` would yield clean evidence. No promotion scorecard. No apply round-trips. Findings still render through Phase 19 (dual-path emission — see *Finding emission* below).
+
+The **`--full` tier** (sibling `prompts/full.md`) is the comprehensive 90–180-minute run. Use `--quick` when you want a first-look smoke pass before committing to a full audit, when you do not have the time budget for `--full`, or when the host environment cannot create a disposable worktree (`--quick` does not need one).
+
+---
+
+## Run shape
+
+| Property | Value |
+|---|---|
+| Apply-mode mutations | **forbidden** (no `*_apply`, no `*_preview` on writers) |
+| Disposable worktree | **not created** (the prompt never invokes `git worktree add`) |
+| Test runs | **forbidden** (`test_run`, `test_coverage` are out of scope) |
+| Network calls | **forbidden** (`nuget_vulnerability_scan` is skipped) |
+| Promotion scorecard | **not emitted** (use `--full` if you need the experimental→stable signal) |
+| Target runtime | **≤15 minutes** on a loaded mid-size solution |
+
+If any phase below would require an apply or a worktree, mark it `skipped-safety — quick tier` and continue.
+
+---
+
+## Cross-cutting principles (apply to every call)
+
+1. **Inline severity signal.** Tag each result **PASS** / **FLAG** / **FAIL**.
+2. **Performance (`_meta.elapsedMs`).** Record per call. Quick-tier budget: single-symbol reads ≤5 s, solution scans ≤15 s. Slower than budget = FLAG, not FAIL (writer budgets are not relevant in this tier).
+3. **Error message quality.** Rate every observed error **actionable** / **vague** / **unhelpful**.
+4. **Cite, don't summarize.** Every finding must reference a concrete file:line and a tool call.
+5. **Always emit text per turn.** Empty tool-only turns read as silent stalls.
+6. **Workspace heartbeat.** Call `workspace_list` before each new phase. If the workspace is gone, reload from the recorded entrypoint.
+
+---
+
+### Phase -1: MCP server precondition (MUST run first, hard gate)
+
+1. **Check the tool list.** Verify `mcp__roslyn__server_info` appears in your current tool surface. If it does not, STOP and tell the user the skill requires the Roslyn MCP server to be started.
+2. **Call `server_info`.** Capture `version`, `catalogVersion`, `runtime`, `os`, `connection.state`, `surface.{tools,resources,prompts}.{stable,experimental}` counts, and `surface.registered.parityOk`. Halt if `connection.state != ready` or `parityOk == false`.
+3. **Sanity-check the catalog resource.** Read `roslyn://server/catalog` and confirm per-category counts match `server_info.surface`.
+4. **Workspace health probe (post-load).** After Phase 0 loads a workspace, call `workspace_health(workspaceId)` once. A non-`healthy` status before any further call is a P1 finding.
+
+**Hard-gate checkpoint:** Is `server_info` callable? Is `connection.state == ready`? Is `parityOk == true`? Did the catalog-resource counts match `server_info`? Did `workspace_health` return `healthy`? Any `no` is a halt-or-escalate.
+
+---
+
+### Phase 0: Setup, live surface baseline, and repo shape
+
+1. Pick the entrypoint: `.sln` / `.slnx` / `.csproj`. (Quick tier never creates a disposable worktree — Phase 6 is forbidden.)
+2. Read `roslyn://server/resource-templates` to capture all resource URI templates.
+3. Call `workspace_load` (lean summary default).
+4. Call `workspace_list` to confirm the session; `workspace_status` to confirm clean load.
+5. Call `workspace_warm(workspaceId)` (optional but recommended for stable timings).
+6. Call `project_graph`.
+7. Record repo-shape constraints (projects, tests, analyzers, source generators, DI, `.editorconfig`, CPM, multi-targeting). Do not invent applicability.
+8. **Seed the coverage ledger** from the live catalog. Every tool/resource/prompt in scope for this tier ends with one final status: `exercised`, `skipped-repo-shape`, `skipped-safety — quick tier`, or `blocked`.
+9. **Live-surface drift detection.** Diff the seeded coverage ledger against names referenced in this prompt's phase guidance. Names this prompt mentions but absent from the catalog → P1 FAIL under *MCP server issues* with category `prompt drift`.
+
+**MCP audit checkpoint:** Did `workspace_load` succeed? Does `workspace_list` show the session? Did `workspace_health` return `healthy`? Are repo shape and the seeded ledger captured?
+
+---
+
+### Phase 1: Broad diagnostics (read-only)
+
+1. `project_diagnostics` (no filters) for the solution-wide picture.
+2. `project_diagnostics` with at least one non-default selector (project / file / severity / `offset+limit`). **Invariant check:** `TotalErrors`/`TotalWarnings`/`TotalInfo` must be invariant under `severityFilter` — only the returned arrays narrow.
+3. `compile_check` (default `offset=0, limit=50`). Compare against `project_diagnostics`. Probe `severity=Error` and `file=<path>`.
+4. `security_diagnostics` (OWASP-tagged).
+5. `security_analyzer_status` — which analyzer packages are installed / missing.
+6. `list_analyzers` — total rule count; note any LOAD_ERROR entries.
+7. `diagnostic_details` on one representative error and one warning.
+
+**Skipped in this tier:** `compile_check(emitValidation=true)` (slower variant), `nuget_vulnerability_scan` (network-dependent — mark `skipped-safety — quick tier`).
+
+**MCP audit checkpoint:** Do diagnostic tools agree on counts? Does the non-default `project_diagnostics` path preserve invariant totals? Are `diagnostic_details` locations accurate?
+
+---
+
+### Phase 2: Code quality metrics (read-only)
+
+1. `get_complexity_metrics` (no filters). Flag cyclomatic > 10 or nesting > 4.
+2. `get_cohesion_metrics(minMethods=3)` to find types with LCOM4 > 1.
+3. `get_coupling_metrics` if exposed; if it returns "No such tool" record the gap.
+4. `find_unused_symbols(includePublic=false)`.
+5. `find_dead_locals` on a few chosen methods.
+6. `find_dead_fields`.
+7. `get_namespace_dependencies` — circular dependencies?
+8. `get_nuget_dependencies` — audit package references.
+9. `suggest_refactorings` — ranked aggregation.
+
+**Skipped in this tier:** `find_duplicated_methods`, `find_duplicate_helpers`, `find_duplicated_code` (heavier scans — defer to `--full`).
+
+**MCP audit checkpoint:** Are complexity scores plausible? Are LCOM4 scores sane? Does `find_unused_symbols` miss obvious dead code or falsely flag used symbols? Does `suggest_refactorings` rank sensibly?
+
+---
+
+### Phase 3: Deep symbol analysis (one key type)
+
+Pick ONE type that surfaces from Phase 2 (high complexity, LCOM4 > 1, or central in the project graph). Quick tier intentionally narrows from the full tier's 3–5 types.
+
+1. `symbol_search` to locate by name.
+2. `symbol_info` for metadata.
+3. `document_symbols` on its file.
+4. `type_hierarchy`.
+5. `find_implementations` on any interface/abstract type discovered.
+6. `find_references`.
+7. `find_consumers` — dependency-kind classification.
+8. `member_hierarchy` on overrides/implements.
+
+**Skipped in this tier:** flow analysis (Phase 4 of `--full`), snippet/script validation (Phase 5), apply-tool exercise (Phase 6), build-and-test validation (Phase 8), concurrency audit (Phase 8b), undo verification (Phase 9), file/cross-project orchestration (Phase 10), scaffolding (Phase 12), project mutation (Phase 13). Mark each `skipped-safety — quick tier`.
+
+**MCP audit checkpoint:** Does `find_implementations` return all concrete implementations? Are `find_references` and `find_consumers` consistent? Does `member_hierarchy` look right?
+
+---
+
+### Phase 11: Semantic search, discovery, and reflection/DI
+
+1. `semantic_search("async methods returning Task<bool>")`.
+2. `semantic_search("classes implementing IDisposable")` — cross-check against `find_implementations(IDisposable)`.
+3. `semantic_grep` with a structural pattern. Verify the result set is non-empty on a known-good pattern, and that an intentionally bogus pattern produces a clean empty result.
+4. `find_reflection_usages` — `typeof`, `GetMethod`, `Activator`, etc.
+5. `get_di_registrations` — DI wiring audit.
+
+**MCP audit checkpoint:** Do paired `semantic_search` queries return relevant differences? Does `semantic_grep` produce sensible structural matches and reject malformed patterns cleanly? Does `find_reflection_usages` find all reflection patterns? Does `get_di_registrations` parse all registration styles?
+
+---
+
+### Phase 14: Navigation & completions
+
+1. `go_to_definition` on a usage → correct declaration.
+2. `goto_type_definition` on a variable → the type, not the variable declaration.
+3. `enclosing_symbol` inside a method → the method.
+4. `get_symbol_outline` on a non-trivial file (≥3 types or ≥10 members).
+5. `get_completions` after a dot.
+6. `find_overrides` on a virtual method; `find_base_members` on an override.
+
+**MCP audit checkpoint:** Are navigation results accurate? Does `get_symbol_outline` agree with `document_symbols`? Does `get_completions` rank sensibly?
+
+---
+
+### Phase 15: Resource verification
+
+1. `roslyn://server/catalog` — machine-readable surface inventory.
+2. `roslyn://server/resource-templates`.
+3. `roslyn://workspaces` (summary).
+4. `roslyn://workspace/{id}/status` — assert `WorkspaceVersion` + `SnapshotToken`.
+5. `roslyn://workspace/{id}/projects` vs `project_graph` tool output.
+6. `roslyn://workspace/{id}/diagnostics` vs `project_diagnostics` tool output.
+7. `roslyn://workspace/{id}/file/{filePath}/lines/{N-M}` — small known range; verify the `// roslyn://…/lines/N-M of T` marker; reject `lines/10-5` cleanly.
+
+**MCP audit checkpoint:** Do resources agree with their tool counterparts? Are URI templates resolved correctly? Is the line-range slice marker present and the invalid range rejected cleanly?
+
+---
+
+### Phase 16: Prompt verification (4 prompts)
+
+Quick tier exercises a representative subset, not the full prompt surface.
+
+1. `explain_error` — invoke with realistic arguments from Phase 1's diagnostics.
+2. `suggest_refactoring` — invoke with a concrete tool sequence from Phase 2's `suggest_refactorings`.
+3. `discover_capabilities` — must align with Phase -1's live catalog.
+4. `review_file` — invoke against one file from Phase 3.
+
+For each prompt: schema sanity (argument list against `prompts/list`), rendered output correctness (every tool name in the rendered text exists in the live catalog), idempotency (same args twice → same rendered text modulo `_meta.elapsedMs`).
+
+**MCP audit checkpoint:** Do argument templates match `prompts/list`? Does every rendered prompt reference only live-catalog tools?
+
+---
+
+### Final surface closure (mandatory before the report)
+
+1. Compare the coverage ledger against the live catalog from Phase -1 / 0.
+2. Every unaccounted tool/resource/prompt: assign a final explicit status with a one-line reason. The vast majority will be `skipped-safety — quick tier`.
+3. *Schema vs behaviour drift*, *Error message quality*, *Performance baseline* tables populated. Every exercised tool contributes ≥1 row to *Performance baseline*.
+4. *Prompt verification* has one row per exercised prompt (4).
+
+When all phases are done, leave the workspace loaded — do not call `workspace_close` (the operator may want to follow up with `--full`).
+
+---
+
+## Output Format — MANDATORY
+
+### Where to save the report
+
+**Canonical path:** `<audited-repo-root>/audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md`
+
+- `<timestamp>` = current UTC `yyyyMMddTHHmmssZ`.
+- `<repo-id>` = audited solution/repo name — strip `.sln` / `.slnx` / `.csproj`; lowercase; replace spaces and dots with hyphens.
+
+The quick-tier report is structurally identical to the full-tier report but omits sections 5 (Phase 6 refactor summary), 11 (Experimental promotion scorecard), 15 (Concurrency matrix), and 16 (Writer reclassification). Those sections collapse to `**N/A — quick tier**` lines.
+
+### Promotion scorecard JSON
+
+Quick tier does **not** emit `_latest-promotion-scorecard.json`. Promotion-tier signal requires the apply-mode round-trips the quick tier intentionally skips. Use `--full` for promotion evidence.
+
+### Phase 19: Finding emission
+
+Identical to the `--full` tier's Phase 19 contract — see `prompts/full.md` *Phase 19: Finding emission (dual-path)*. Quick summary:
+
+- **Default:** print each actionable finding's envelope to stdout as a ready-to-paste GitHub Issue body. Required envelope fields: `id`, `source-repo`, `severity`, `area`, `anchors`, `finding`, `repro`, `proposed-fix`.
+- **`--auto-file`:** call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <id> --label "area:<area>" --label "severity:<severity>" --body-file <tempfile>` per non-refused finding. Fall back to stdout-print if `gh` is missing or unauthenticated.
+- **Refusal contract:** P0 or `area: security` findings are **never** auto-filed, regardless of the `--auto-file` flag. Print to stdout with the security-advisory escalation banner pointing at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new.
+
+`**N/A — no actionable findings**` is a valid Phase 19 outcome.
+
+### Completion gate
+
+The prose `.md` report must exist at the canonical path. Phase 19 must have either emitted at least one finding (stdout or `gh issue create`) OR explicitly recorded `**N/A — no actionable findings**`. The task is **incomplete** without both gates passing.

--- a/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1
+++ b/skills/mcp-server-surface-test/scripts/archive-old-reports.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Archive old audit reports under audit-reports/ into year-stamped subdirectories.
+
+.DESCRIPTION
+    Moves *.md files in <RepoRoot>/<ReportsRelativePath>/ that are older than -OlderThanDays days
+    into <RepoRoot>/<ReportsRelativePath>/archive/<YYYY>/, where <YYYY> is the file's
+    LastWriteTime year. Files already inside the `archive/` subtree are left untouched.
+
+    README.md is pinned by name and is never archived regardless of age.
+
+    The script is idempotent: running it twice is safe. The destination year-subdirectory is
+    created on demand. If a destination file with the same name already exists, the move is
+    skipped and a warning is emitted (the operator can resolve the collision manually).
+
+.PARAMETER RepoRoot
+    Repository root path. Defaults to the directory three levels above this script
+    (skills/mcp-server-surface-test/scripts/ -> skills/mcp-server-surface-test/ -> skills/ -> repo root).
+
+.PARAMETER ReportsRelativePath
+    Path (relative to RepoRoot) of the audit-reports directory to archive. Defaults to
+    the /mcp-server-surface-test convention. Override when the host repo writes
+    audit drafts to a different relative path.
+
+.PARAMETER OlderThanDays
+    Minimum age in days for a report to be archived. Defaults to 30. Files with
+    LastWriteTime newer than (now - OlderThanDays) are left in place.
+
+.PARAMETER DryRun
+    When set, the script reports what it would do but performs no filesystem mutations.
+    Use this in tests and to preview the archive plan before committing.
+
+.EXAMPLE
+    pwsh -NoProfile -File skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -DryRun
+        Reports which files would be archived without moving anything.
+
+.EXAMPLE
+    pwsh -NoProfile -File skills/mcp-server-surface-test/scripts/archive-old-reports.ps1 -OlderThanDays 60
+        Archives reports older than 60 days into <ReportsRelativePath>/archive/<YYYY>/.
+
+.NOTES
+    Designed to be invoked from PowerShell 7+ (pwsh) on Windows or Linux/macOS via
+    `pwsh -NoProfile -File <path>`. The script does not require the Roslyn MCP server.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot,
+
+    [string]$ReportsRelativePath = 'audit-reports',
+
+    [ValidateRange(0, 36500)]
+    [int]$OlderThanDays = 30,
+
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    # script -> skills/audit-deep/scripts/ -> skills/audit-deep/ -> skills/ -> repo root
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).ProviderPath
+}
+
+if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) {
+    throw "RepoRoot '$RepoRoot' does not exist or is not a directory."
+}
+
+$reportsDir = Join-Path $RepoRoot $ReportsRelativePath
+if (-not (Test-Path -LiteralPath $reportsDir -PathType Container)) {
+    Write-Output "audit-reports directory not present at '$reportsDir' — nothing to archive."
+    return
+}
+
+$archiveRoot = Join-Path $reportsDir 'archive'
+$cutoff = (Get-Date).AddDays(-1 * $OlderThanDays)
+
+# Files pinned by name — never archived even if old.
+$pinnedNames = @('README.md')
+
+$candidates = Get-ChildItem -LiteralPath $reportsDir -Filter '*.md' -File |
+    Where-Object {
+        # Skip pinned filenames.
+        if ($pinnedNames -contains $_.Name) { return $false }
+        # Skip anything already under the archive/ subtree (Get-ChildItem with no -Recurse
+        # won't enter it anyway, but belt-and-suspenders against future call-site changes).
+        if ($_.FullName.StartsWith($archiveRoot, [System.StringComparison]::OrdinalIgnoreCase)) { return $false }
+        return $_.LastWriteTime -lt $cutoff
+    }
+
+$summary = [ordered]@{
+    repoRoot       = $RepoRoot
+    reportsDir     = $reportsDir
+    archiveRoot    = $archiveRoot
+    olderThanDays  = $OlderThanDays
+    cutoff         = $cutoff.ToString('o')
+    dryRun         = [bool]$DryRun
+    candidateCount = $candidates.Count
+    moved          = New-Object System.Collections.Generic.List[string]
+    skipped        = New-Object System.Collections.Generic.List[string]
+}
+
+if ($candidates.Count -eq 0) {
+    Write-Output "No reports older than $OlderThanDays days under '$reportsDir'."
+    return [pscustomobject]$summary
+}
+
+foreach ($file in $candidates) {
+    $year = $file.LastWriteTime.Year.ToString('D4')
+    $destDir = Join-Path $archiveRoot $year
+    $destPath = Join-Path $destDir $file.Name
+
+    if (Test-Path -LiteralPath $destPath) {
+        $msg = "SKIP '$($file.Name)' -> '$destPath' (destination already exists)"
+        Write-Warning $msg
+        $summary.skipped.Add($msg)
+        continue
+    }
+
+    if ($DryRun) {
+        Write-Output "DRY-RUN move: $($file.FullName) -> $destPath"
+        $summary.moved.Add("$($file.FullName) -> $destPath")
+        continue
+    }
+
+    if (-not (Test-Path -LiteralPath $destDir)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+
+    Move-Item -LiteralPath $file.FullName -Destination $destPath
+    Write-Output "Moved: $($file.FullName) -> $destPath"
+    $summary.moved.Add("$($file.FullName) -> $destPath")
+}
+
+Write-Output ""
+Write-Output "Archive summary: candidates=$($summary.candidateCount), moved=$($summary.moved.Count), skipped=$($summary.skipped.Count), dryRun=$($summary.dryRun)"
+
+return [pscustomobject]$summary

--- a/tests/RoslynMcp.Tests/Skills/McpServerStressSkillFrontmatterTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/McpServerStressSkillFrontmatterTests.cs
@@ -72,10 +72,13 @@ public sealed class McpServerStressSkillFrontmatterTests
         var skillPath = ResolveSkillPath();
         var contents = File.ReadAllText(skillPath);
 
-        // SKILL.md must route to the single-prompt path.
+        // SKILL.md must route to the single-prompt path. The prompt was renamed from `prompts/prompt.md`
+        // to `prompts/maintainer-overlay.md` when /mcp-server-stress became the maintainer-only superset
+        // of the shipped /mcp-server-surface-test skill — the file's role is now an overlay over the
+        // shipped consumer prompt rather than a standalone document.
         Assert.IsTrue(
-            contents.Contains("prompts/prompt.md", StringComparison.Ordinal),
-            "mcp-server-stress SKILL.md must reference `prompts/prompt.md` — that is the single canonical prompt file. " +
+            contents.Contains("prompts/maintainer-overlay.md", StringComparison.Ordinal),
+            "mcp-server-stress SKILL.md must reference `prompts/maintainer-overlay.md` — that is the single canonical maintainer prompt file. " +
             "If you renamed the prompt, update the route in Step 2.");
 
         // Negative assertions — the historical mode tokens must not survive the collapse.
@@ -109,7 +112,7 @@ public sealed class McpServerStressSkillFrontmatterTests
         var skillContents = File.ReadAllText(skillPath);
 
         var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
-        var promptPath = Path.Combine(repoRoot, ".claude", "skills", SkillName, "prompts", "prompt.md");
+        var promptPath = Path.Combine(repoRoot, ".claude", "skills", SkillName, "prompts", "maintainer-overlay.md");
         var promptContents = File.ReadAllText(promptPath);
 
         Assert.IsFalse(
@@ -117,25 +120,43 @@ public sealed class McpServerStressSkillFrontmatterTests
             "mcp-server-stress SKILL.md must not contain `Phase 16b` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
         Assert.IsFalse(
             promptContents.Contains("Phase 16b", StringComparison.Ordinal),
-            "mcp-server-stress prompts/prompt.md must not contain `Phase 16b` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
+            "mcp-server-stress prompts/maintainer-overlay.md must not contain `Phase 16b` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
 
         Assert.IsFalse(
             skillContents.Contains("plugin-skill", StringComparison.Ordinal),
             "mcp-server-stress SKILL.md must not contain `plugin-skill` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
         Assert.IsFalse(
             promptContents.Contains("plugin-skill", StringComparison.Ordinal),
-            "mcp-server-stress prompts/prompt.md must not contain `plugin-skill` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
+            "mcp-server-stress prompts/maintainer-overlay.md must not contain `plugin-skill` — the plugin-skill audit was extracted into /surface-audit by `extract-skills-audit-from-server-stress`.");
     }
 
     [TestMethod]
     public void Skill_PromptFile_ExistsAtDocumentedPath()
     {
         var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
-        var promptPath = Path.Combine(repoRoot, ".claude", "skills", SkillName, "prompts", "prompt.md");
+        var promptPath = Path.Combine(repoRoot, ".claude", "skills", SkillName, "prompts", "maintainer-overlay.md");
 
         Assert.IsTrue(File.Exists(promptPath),
             $"mcp-server-stress canonical prompt not found at {promptPath}. SKILL.md Step 2 routes to this single file; " +
             "missing it breaks every invocation of /mcp-server-stress.");
+    }
+
+    [TestMethod]
+    public void Skill_OverlayPrompt_ReferencesShippedConsumerPrompt()
+    {
+        // The maintainer overlay must point at the shipped consumer prompt to make the layering relationship
+        // explicit. If a future edit drops the reference, the maintainer would lose the breadcrumb pointing
+        // at the canonical generic-safe half — and a follow-up Row 2 consolidation would have nothing to
+        // reduce against.
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var promptPath = Path.Combine(repoRoot, ".claude", "skills", SkillName, "prompts", "maintainer-overlay.md");
+        var promptContents = File.ReadAllText(promptPath);
+
+        Assert.IsTrue(
+            promptContents.Contains("skills/mcp-server-surface-test/prompts/full.md", StringComparison.Ordinal),
+            "mcp-server-stress prompts/maintainer-overlay.md must reference the shipped consumer prompt at " +
+            "`skills/mcp-server-surface-test/prompts/full.md`. The overlay is the maintainer superset; " +
+            "without the breadcrumb, future readers cannot tell which content is consumer-generic and which is overlay-only.");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/Skills/McpServerSurfaceTestSkillTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/McpServerSurfaceTestSkillTests.cs
@@ -1,0 +1,227 @@
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// Structural + tool-reference parity for the shipped consumer-facing `mcp-server-surface-test` skill
+/// (lives under `skills/mcp-server-surface-test/`, bundled by `plugin.json` and distributed to every
+/// installer). This is the consumer-generic half of the maintainer-only `/mcp-server-stress` skill;
+/// the genericity gate at `eng/verify-skills-are-generic.ps1` enforces that no banned repo-only marker
+/// reaches the SKILL.md.
+///
+/// Contract enforced here:
+///   1. SKILL.md exists at `skills/mcp-server-surface-test/SKILL.md` and has the expected frontmatter
+///      fields (`name`, `description`, `user-invocable`, `argument-hint`).
+///   2. Both prompt files exist — `prompts/quick.md` (≤15-min read-only smoke pass) and
+///      `prompts/full.md` (90–180-min comprehensive sweep). The argument-hint advertises both tiers.
+///   3. Every `mcp__roslyn__&lt;tool&gt;` reference in the SKILL.md body resolves to a name in the live
+///      `ServerSurfaceCatalog.Tools` list.
+///   4. The SKILL.md body and frontmatter contain none of the banned repo-only markers
+///      (`ai_docs/`, `backlog.md`, `eng/`, etc.) — a redundant in-process echo of the
+///      `verify-skills-are-generic.ps1` gate, kept here so a build-only contributor (no `pwsh`) still
+///      catches genericity drift.
+///
+/// The prompt bodies (`prompts/quick.md`, `prompts/full.md`) are intentionally NOT scanned for tool
+/// names here — the maintainer prompt has the same exemption (the prompt's "live catalog wins"
+/// contract is verified at runtime via Phase 0 drift detection, not statically).
+/// </summary>
+[TestClass]
+public sealed class McpServerSurfaceTestSkillTests
+{
+    private const string SkillName = "mcp-server-surface-test";
+
+    [TestMethod]
+    public void Skill_FilePresent_AtExpectedPath()
+    {
+        var skillPath = ResolveSkillPath();
+        Assert.IsTrue(
+            File.Exists(skillPath),
+            $"mcp-server-surface-test SKILL.md not found at {skillPath}. The shipped skill is the consumer-facing entry point — its absence makes /mcp-server-surface-test moot.");
+    }
+
+    [TestMethod]
+    public void Skill_Frontmatter_HasExpectedFields()
+    {
+        var skillPath = ResolveSkillPath();
+        var contents = File.ReadAllText(skillPath);
+        var frontmatter = ExtractFrontmatter(contents, skillPath);
+
+        AssertFrontmatterField(frontmatter, "name", expectedValue: SkillName, skillPath);
+        AssertFrontmatterField(frontmatter, "description", expectedValue: null, skillPath);
+        AssertFrontmatterField(frontmatter, "user-invocable", expectedValue: "true", skillPath);
+        AssertFrontmatterField(frontmatter, "argument-hint", expectedValue: null, skillPath);
+
+        // The argument-hint must advertise both tier flags so the consumer skill router has a usable
+        // surface description in the slash-command picker.
+        var argumentHint = frontmatter["argument-hint"];
+        Assert.IsTrue(
+            argumentHint.Contains("--quick", StringComparison.Ordinal) && argumentHint.Contains("--full", StringComparison.Ordinal),
+            $"mcp-server-surface-test argument-hint must advertise both `--quick` and `--full` tier flags. Actual: {argumentHint}");
+        Assert.IsTrue(
+            argumentHint.Contains("--auto-file", StringComparison.Ordinal),
+            $"mcp-server-surface-test argument-hint must advertise the `--auto-file` opt-in. Actual: {argumentHint}");
+    }
+
+    [TestMethod]
+    public void Skill_Body_DocumentsTiersAndPrecondition()
+    {
+        var skillPath = ResolveSkillPath();
+        var contents = File.ReadAllText(skillPath);
+
+        // SKILL.md must route to both prompt paths so the tier picker has a destination.
+        Assert.IsTrue(
+            contents.Contains("prompts/quick.md", StringComparison.Ordinal),
+            "mcp-server-surface-test SKILL.md must reference `prompts/quick.md` — that is the bounded read-only tier prompt.");
+        Assert.IsTrue(
+            contents.Contains("prompts/full.md", StringComparison.Ordinal),
+            "mcp-server-surface-test SKILL.md must reference `prompts/full.md` — that is the comprehensive tier prompt.");
+
+        // The hard precondition — server-or-halt — must be unambiguous.
+        Assert.IsTrue(
+            contents.Contains("mcp__roslyn__server_info", StringComparison.Ordinal),
+            "mcp-server-surface-test SKILL.md must require `mcp__roslyn__server_info` as the hard precondition. " +
+            "Without this gate, the skill could fall back to a non-MCP audit and produce no audit-grade evidence.");
+
+        // The P0/security refusal contract is the load-bearing pre-disclosure safeguard. Pin it.
+        Assert.IsTrue(
+            contents.Contains("P0", StringComparison.Ordinal) && contents.Contains("security", StringComparison.Ordinal),
+            "mcp-server-surface-test SKILL.md must document the P0 / security refusal contract for `--auto-file`. " +
+            "Without it, the skill could file a vulnerability to a public Issue before the fix lands.");
+    }
+
+    [TestMethod]
+    public void Skill_PromptFiles_ExistAtDocumentedPaths()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var quickPath = Path.Combine(repoRoot, "skills", SkillName, "prompts", "quick.md");
+        var fullPath = Path.Combine(repoRoot, "skills", SkillName, "prompts", "full.md");
+
+        Assert.IsTrue(File.Exists(quickPath),
+            $"mcp-server-surface-test quick-tier prompt not found at {quickPath}. SKILL.md Step 4 routes to this file when `--quick` is passed.");
+        Assert.IsTrue(File.Exists(fullPath),
+            $"mcp-server-surface-test full-tier prompt not found at {fullPath}. SKILL.md Step 4 routes to this file by default and on `--full`.");
+    }
+
+    [TestMethod]
+    public void Skill_Body_ContainsNoBannedRepoMarkers()
+    {
+        // Mirror of `eng/verify-skills-are-generic.ps1`. The gate is the canonical check; this is a
+        // build-only echo so `dotnet test` catches genericity drift without invoking pwsh.
+        var skillPath = ResolveSkillPath();
+        var contents = File.ReadAllText(skillPath);
+
+        // Strip URLs before scanning — GitHub links to this repo's public docs legitimately contain
+        // `ai_docs/` and are explicitly allowed by the gate.
+        var stripped = Regex.Replace(contents, @"https?://[^\s)]+", string.Empty);
+
+        var bannedPatterns = new[]
+        {
+            @"state\.json",
+            @"backlog-sweep",
+            @"schemaVersion",
+            @"\bai_docs/",
+            @"\bbacklog\.md\b",
+            @"\beng/",
+            @"just verify-",
+            @"Directory\.Build\.props",
+            @"BannedSymbols\.txt",
+        };
+
+        var violations = new List<string>();
+        foreach (var pattern in bannedPatterns)
+        {
+            if (Regex.IsMatch(stripped, pattern))
+            {
+                violations.Add(pattern);
+            }
+        }
+
+        Assert.AreEqual(
+            0, violations.Count,
+            $"mcp-server-surface-test SKILL.md contains banned repo-only marker(s): {string.Join(", ", violations)}. " +
+            "Shipped skills must be generic. Move repo-coupled content to the `.claude/skills/mcp-server-stress/` overlay.");
+    }
+
+    [TestMethod]
+    public void Skill_ToolReferences_AllResolveToLiveCatalog()
+    {
+        var skillPath = ResolveSkillPath();
+        var contents = File.ReadAllText(skillPath);
+
+        var matches = Regex.Matches(contents, @"mcp__roslyn__([a-zA-Z_][a-zA-Z0-9_]*)");
+        if (matches.Count == 0)
+        {
+            return;
+        }
+
+        var liveToolNames = new HashSet<string>(
+            ServerSurfaceCatalog.Tools.Select(t => t.Name),
+            StringComparer.Ordinal);
+
+        var unknown = new List<string>();
+        foreach (Match m in matches)
+        {
+            var name = m.Groups[1].Value;
+            if (!liveToolNames.Contains(name))
+            {
+                unknown.Add(name);
+            }
+        }
+
+        Assert.AreEqual(
+            0, unknown.Count,
+            $"mcp-server-surface-test SKILL.md references {unknown.Count} tool name(s) that do not exist in the live ServerSurfaceCatalog: " +
+            string.Join(", ", unknown.Distinct()) + ". " +
+            "Shipped skills must not reference renamed/removed tools.");
+    }
+
+    private static string ResolveSkillPath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, "skills", SkillName, "SKILL.md");
+    }
+
+    private static Dictionary<string, string> ExtractFrontmatter(string contents, string skillPath)
+    {
+        var match = Regex.Match(contents, @"^---\s*\r?\n(?<body>.*?)\r?\n---\s*\r?\n", RegexOptions.Singleline);
+        Assert.IsTrue(match.Success,
+            $"mcp-server-surface-test SKILL.md at {skillPath} is missing a `---`-delimited frontmatter block at the file head.");
+
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in match.Groups["body"].Value.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var colon = line.IndexOf(':');
+            if (colon < 0) continue;
+            var key = line[..colon].Trim();
+            var value = line[(colon + 1)..].Trim();
+            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            {
+                value = value[1..^1];
+            }
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    private static void AssertFrontmatterField(
+        Dictionary<string, string> frontmatter,
+        string field,
+        string? expectedValue,
+        string skillPath)
+    {
+        Assert.IsTrue(frontmatter.ContainsKey(field),
+            $"mcp-server-surface-test frontmatter at {skillPath} is missing the `{field}` field.");
+        var actual = frontmatter[field];
+        Assert.IsFalse(string.IsNullOrWhiteSpace(actual),
+            $"mcp-server-surface-test frontmatter field `{field}` at {skillPath} is empty.");
+        if (expectedValue is not null)
+        {
+            Assert.AreEqual(expectedValue, actual,
+                $"mcp-server-surface-test frontmatter field `{field}` at {skillPath} must equal `{expectedValue}`.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Row 1 of the `move-to-git-issues` design (`ai_docs/items/move-to-git-issues.md`).

- Splits the 961-line maintainer prompt into a generic-safe shipped half at `skills/mcp-server-surface-test/` and a maintainer-only overlay at `.claude/skills/mcp-server-stress/prompts/maintainer-overlay.md` (renamed via `git mv` from `prompts/prompt.md`).
- New `/mcp-server-surface-test` skill ships two tiers: `--quick` (read-only smoke pass, ≤15 min) and `--full` (default; comprehensive sweep with disposable-worktree apply round-trips and the experimental-promotion scorecard, 90–180 min).
- Findings render through one envelope: stdout-print by default; opt-in `gh issue create --repo darylmcd/Roslyn-Backed-MCP` when `--auto-file` is passed and `gh` is authenticated.
- **P0 / `area: security` findings are NEVER auto-filed**, regardless of flag — they print to stdout with a banner directing the operator to GitHub security advisories. Load-bearing pre-disclosure safeguard.

## What ships

| Path | Action |
|---|---|
| `skills/mcp-server-surface-test/SKILL.md` | new (≤200 lines, fully generic, passes `eng/verify-skills-are-generic.ps1`) |
| `skills/mcp-server-surface-test/prompts/full.md` | new (961-line maintainer prompt scrubbed; Phase 19 replaced with dual-path emission) |
| `skills/mcp-server-surface-test/prompts/quick.md` | new (bounded read-only tier) |
| `skills/mcp-server-surface-test/scripts/archive-old-reports.ps1` | new (paths + pinned-name list updated for shipped context) |
| `skills/mcp-server-surface-test/README.md` | new (consumer-facing privacy + refusal contract) |
| `.claude/skills/mcp-server-stress/prompts/prompt.md` → `prompts/maintainer-overlay.md` | rename + relationship-note header |
| `.claude/skills/mcp-server-stress/SKILL.md` | description + routing updated |
| `tests/RoslynMcp.Tests/Skills/McpServerSurfaceTestSkillTests.cs` | new (6 tests including in-process echo of the genericity gate) |
| `tests/RoslynMcp.Tests/Skills/McpServerStressSkillFrontmatterTests.cs` | path constants + new overlay-references-shipped test |
| 8 cross-doc references | updated for the prompt rename |
| `ai_docs/items/move-to-git-issues.md` | banned-pattern list aligned to `eng/verify-skills-are-generic.ps1`; row-1 wording reframed |
| `changelog.d/mcp-server-surface-test-genericity-split.md` | new fragment |

Zero production code touched — docs, prompts, and tests only.

## Test plan

- [x] `pwsh -File eng/verify-skills-are-generic.ps1` → passing (32 SKILL.md checked, +1 vs. main)
- [x] `pwsh -File eng/verify-ai-docs.ps1` → passing (no broken links after the rename)
- [x] `dotnet test RoslynMcp.slnx --filter "FullyQualifiedName~Skills"` → 31/31 in 3s
- [ ] CI full suite (the local full-suite run was aborted by a `Stop-Process` intervention on a thrashing testhost; CI is the canonical gate)
- [ ] Manual smoke: invoke `/mcp-server-surface-test --quick` against this repo with the live MCP server up; confirm `audit-reports/<ts>_roslyn-backed-mcp_mcp-server-surface-test.md` lands and prints zero banned patterns

## Follow-ups (separate PRs per approved plan)

- **Row 2** — tiered runs + shared finding envelope + `--publish` flag on `/backlog-intake` + `server_version` envelope field + `lib/render-finding.ps1` shared renderer + tier-routing tests + P0 refusal tests.
- **Row 3** — `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` + `SECURITY.md` + `scripts/seed-issue-labels.ps1` + slim consumer docs in root README + lockstep schema/template/seed test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)