### PR TITLE
feat(skills): issue template + label seeder + lockstep tests (move-to-git-issues Row 3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml
+++ b/.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml
@@ -1,0 +1,100 @@
+name: "Surface-test finding"
+description: "File a finding produced by /mcp-server-surface-test (consumer audit of the Roslyn MCP server's live surface)."
+labels: ["surface-test-finding"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to file a finding produced by `/mcp-server-surface-test` running against your own C# repo. The shipped skill renders the body block below; you can paste it as-is when filing manually, or pass `--auto-file` to have the skill call `gh issue create` for you.
+
+        **Do not file P0 or `area: security` findings here.** Both `--auto-file` and `/backlog-intake --publish` refuse to file those publicly. Use the [GitHub security advisory](https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new) flow instead — see [SECURITY.md](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/SECURITY.md) for the full pre-disclosure path.
+
+  - type: input
+    id: id
+    attributes:
+      label: id
+      description: "Kebab-case finding id, prefixed with your repo's slug. Example: `tradewise-find-references-stale-cache`. Must match what the shipped skill emitted."
+      placeholder: "your-repo-some-finding"
+    validations:
+      required: true
+
+  - type: input
+    id: source-repo
+    attributes:
+      label: source-repo
+      description: "Kebab-case slug of the repo you ran the audit against. The shipped skill derives this from `git remote get-url origin` (owner/repo) or falls back to the directory basename."
+      placeholder: "your-repo"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: severity
+      description: "Match the section-13 severity from the audit report. Note: `P0` findings are refused for public filing — use the security advisory path instead."
+      options:
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: area
+      description: "Coarse classification used for triage and labeling. Note: `security` is refused for public filing — use the security advisory path instead."
+      options:
+        - tools
+        - resources
+        - prompts
+        - skills
+        - concurrency
+        - perf
+        - docs
+    validations:
+      required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: server-version
+      description: "The Roslyn MCP server version captured at Phase -1 of the audit (`server_info.version`)."
+      placeholder: "1.36.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: anchors
+    attributes:
+      label: anchors (paths in your repo, not clickable here)
+      description: "One `path/to/file.ext:LINE` per line. These are diagnostic context — they refer to your own repo's source, not this repo. Maintainers use them to understand which Roslyn-MCP code path your repo exercised."
+      placeholder: |
+        src/Foo.cs:142
+        src/Bar.cs:38
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: finding
+      description: "One to two sentences describing the bug or gap."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: repro
+      description: "One to two sentences describing the minimal reproduction (which tool / inputs / expected vs. actual)."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-fix
+    attributes:
+      label: proposed-fix
+      description: "One to two sentences pointing at the likely fix shape (which file / which method / what change). Optional but appreciated."
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Stable families include workspace/session management, semantic navigation, diagn
 - [AGENTS.md](AGENTS.md) — bootstrap entry point for AI agents working in this repo
 - [ai_docs/README.md](ai_docs/README.md) — canonical AI-doc routing index
 
+## Filing Surface-Test Findings
+
+If you find a bug or behaviour gap while running [`/mcp-server-surface-test`](skills/mcp-server-surface-test/README.md) against your own C# repo, share it back via the [Surface-test finding](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/new?template=mcp-server-surface-test-finding.yml) issue template. The shipped skill renders findings into a copy-paste body block by default; pass `--auto-file` and the skill calls `gh issue create` for you.
+
+P0 / `area: security` findings are refused for public filing — see [SECURITY.md](SECURITY.md) for the private-disclosure path.
+
 ## Support
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/darylmcd/Roslyn-Backed-MCP/issues)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,8 @@ Instead, please use one of the following channels:
 1. **GitHub Security Advisories** (preferred): Use the [Report a vulnerability](https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new) feature on this repository.
 2. **Email**: Contact the maintainer directly via the email associated with the GitHub account [@darylmcd](https://github.com/darylmcd).
 
+The shipped `/mcp-server-surface-test` skill enforces this policy automatically: any finding with `severity == P0` OR `area == security` is **refused for public filing** by both `--auto-file` (consumer) and `/backlog-intake --publish` (maintainer). Refused findings print to stdout with a banner pointing back here so the operator can route them through the channels above.
+
 ### What to include
 
 - A description of the vulnerability and its potential impact.

--- a/changelog.d/mcp-server-surface-test-issue-template-labels-docs.md
+++ b/changelog.d/mcp-server-surface-test-issue-template-labels-docs.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Added:** `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` — public form template for findings produced by `/mcp-server-surface-test`. Mirrors the shared finding envelope (`id`, `source-repo`, `severity` dropdown, `area` dropdown, `server-version`, `anchors`, `finding`, `repro`, `proposed-fix`). Drops `severity: P0` and `area: security` from the dropdowns — both are refused for public filing by the shared renderer and route through GitHub security advisories per `SECURITY.md`. Anchors are labeled "paths in your repo, not clickable here" so triage knows they are diagnostic context, not links into this repo. Closes Row 3 of the move-to-git-issues design.
+- **Added:** `scripts/seed-issue-labels.ps1` — idempotent one-shot script that seeds `area:*` and `severity:*` labels at `darylmcd/Roslyn-Backed-MCP` via `gh label create --force`. Mirrors the publicly-fileable enum subset (the renderer's refusal predicate's complement). Verifies `gh` is on PATH and authenticated before mutating; supports `-DryRun` for preview.
+- **Added:** `tests/RoslynMcp.Tests/Skills/IssueTemplateAndLabelSeedTests.cs` — 9 lockstep tests pinning the area + severity enums across three surfaces simultaneously: `ai_docs/items/backlog-d-fragment-schema.md` (canonical), `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` (public form), and `scripts/seed-issue-labels.ps1` (label seeder). Drift between any pair fails CI before it can ship.
+
+### Changed
+
+- **Changed:** Root `README.md` gains a "Filing Surface-Test Findings" section pointing consumers at the new issue template + the `--auto-file` flag, with the P0/security refusal explicitly cross-referenced to `SECURITY.md`.
+- **Changed:** `skills/mcp-server-surface-test/README.md` gains a public-issues funnel paragraph linking the issue template URL and a verbatim restatement of the pre-disclosure refusal contract (with the SECURITY/P0 banner reproduced).
+- **Changed:** `SECURITY.md` cross-references the renderer's automatic enforcement: any P0 / `area: security` finding is refused for public filing by both `--auto-file` and `/backlog-intake --publish`. The refusal banner directs the operator back to the security-advisory channel SECURITY.md documents.

--- a/scripts/seed-issue-labels.ps1
+++ b/scripts/seed-issue-labels.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Seed the GitHub Issue labels consumed by the surface-test issue template and the shared
+    finding renderer.
+
+.DESCRIPTION
+    Idempotently creates `area:*` and `severity:*` labels at `darylmcd/Roslyn-Backed-MCP`
+    via `gh label create --force`. The `--force` flag overwrites color/description on re-run
+    so the script is safe to re-invoke. The label sets here MUST stay in lockstep with:
+
+      - `ai_docs/items/backlog-d-fragment-schema.md` (the canonical fragment-envelope enum)
+      - `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` (the public-form options)
+      - `skills/mcp-server-surface-test/lib/render-finding.ps1` (the renderer that emits
+        `--label area:<area>` and `--label severity:<severity>` arguments)
+
+    Drift between any of these three surfaces is caught by
+    `tests/RoslynMcp.Tests/Skills/IssueTemplateAndLabelSeedTests.cs`.
+
+    Note that the seed list intentionally OMITS the labels the template/renderer refuse to file
+    publicly: `severity:P0` and `area:security`. Both are refused upstream by the renderer's
+    `Test-FindingShouldRefusePublicFile` predicate; emitting them as labels would invite a
+    contributor to file a P0/security Issue manually, which is the exact failure mode SECURITY.md
+    forbids. The fragment schema's enum still includes them — they are valid in `backlog.d/`
+    fragments and are how the renderer detects refusal — but they never reach a public Issue.
+
+.PARAMETER Repo
+    GitHub `owner/repo` slug to seed. Defaults to `darylmcd/Roslyn-Backed-MCP`.
+
+.PARAMETER DryRun
+    When set, prints the `gh label create` commands without invoking them.
+
+.NOTES
+    Run-once, idempotent. Designed to be invoked manually after cloning the repo for the first
+    time, or whenever the lockstep test surfaces a drift the maintainer wants to repair.
+    Requires `gh` on PATH and `gh auth status` reporting authenticated for the target repo.
+#>
+[CmdletBinding()]
+param(
+    [string]$Repo = 'darylmcd/Roslyn-Backed-MCP',
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Lockstep enums — duplicated here so the script is self-contained, but tested for drift.
+$AreaLabels = @(
+    @{ name = 'area:tools';        color = '0366d6'; description = 'MCP tool surface (read-side or write-side)' }
+    @{ name = 'area:resources';    color = '5319e7'; description = 'MCP resource surface (URI templates, payloads)' }
+    @{ name = 'area:prompts';      color = '8a63d2'; description = 'MCP prompt surface (prompts/list + prompts/get)' }
+    @{ name = 'area:skills';       color = '0e8a16'; description = 'Shipped or maintainer-only skills (.claude/skills/ or skills/)' }
+    @{ name = 'area:concurrency';  color = 'b60205'; description = 'Per-workspace lock contract, parallel reads, lifecycle stress' }
+    @{ name = 'area:perf';         color = 'fbca04'; description = 'Wall-clock budgets (single-symbol reads, solution scans, writers)' }
+    @{ name = 'area:docs';         color = '0075ca'; description = 'Documentation, README, AGENTS.md, ai_docs/' }
+)
+
+$SeverityLabels = @(
+    @{ name = 'severity:P1'; color = 'd93f0b'; description = 'High — blocks a workflow or produces wrong results' }
+    @{ name = 'severity:P2'; color = 'fbca04'; description = 'Medium — degrades a workflow but a workaround exists' }
+    @{ name = 'severity:P3'; color = 'cccccc'; description = 'Low — UX polish or output-enrichment opportunity' }
+)
+
+$AllLabels = $AreaLabels + $SeverityLabels
+
+if (-not $DryRun) {
+    # Verify gh is on PATH and authenticated before touching anything.
+    $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+    if ($null -eq $ghCmd) {
+        throw "gh is not on PATH. Install GitHub CLI (https://cli.github.com/) and re-run."
+    }
+    $authStatus = & gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh is not authenticated. Run 'gh auth login' and re-run. Output: $authStatus"
+    }
+}
+
+Write-Output "Seeding $($AllLabels.Count) labels at '$Repo' (dryRun=$([bool]$DryRun))..."
+
+foreach ($label in $AllLabels) {
+    $args = @(
+        'label', 'create', $label.name,
+        '--repo', $Repo,
+        '--color', $label.color,
+        '--description', $label.description,
+        '--force'
+    )
+
+    if ($DryRun) {
+        Write-Output "DRY-RUN: gh $($args -join ' ')"
+        continue
+    }
+
+    & gh @args
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to create label '$($label.name)' on '$Repo' — see gh stderr above."
+    }
+    else {
+        Write-Output "OK: $($label.name)"
+    }
+}
+
+Write-Output ""
+Write-Output "Done. Labels are in lockstep with:"
+Write-Output "  - ai_docs/items/backlog-d-fragment-schema.md"
+Write-Output "  - .github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml"
+Write-Output "  - skills/mcp-server-surface-test/lib/render-finding.ps1"
+Write-Output ""
+Write-Output "P0 / security findings deliberately have NO public label — they are refused by"
+Write-Output "the renderer and routed via SECURITY.md (private GitHub security advisories)."

--- a/skills/mcp-server-surface-test/README.md
+++ b/skills/mcp-server-surface-test/README.md
@@ -37,9 +37,20 @@ GitHub Issues at https://github.com/darylmcd/Roslyn-Backed-MCP are the public fu
 
 1. Run `/mcp-server-surface-test --quick` (fast path) or `/mcp-server-surface-test --full` (comprehensive).
 2. Review the finding bodies the skill prints to stdout.
-3. Either copy/paste them into a new Issue manually, or pass `--auto-file` to file them via `gh`.
+3. Either copy/paste them into the [Surface-test finding](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/new?template=mcp-server-surface-test-finding.yml) issue template manually, or pass `--auto-file` and the skill calls `gh issue create` with the same body bytes.
 
 The default print-to-stdout flow is the recommended starting point — it lets you review what the skill found before anything goes public.
+
+The triage labels (`area:tools`, `area:perf`, `severity:P2`, etc.) are seeded via `scripts/seed-issue-labels.ps1` in this repo's checkout. Maintainers run that script once per repo bootstrap; consumers don't need to.
+
+### Pre-disclosure refusal contract (verbatim)
+
+Findings whose `severity == P0` OR `area == security` are **never** auto-filed, regardless of the `--auto-file` flag. They print to stdout with this banner:
+
+> **SECURITY / P0 finding — DO NOT FILE PUBLICLY.**
+> Escalate via GitHub security advisories: https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new
+
+This refusal is non-negotiable. The intent is to prevent a vulnerability from leaking to a public Issue before it is fixed. See [SECURITY.md](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/SECURITY.md) for the full pre-disclosure path.
 
 ## Hard rules
 

--- a/tests/RoslynMcp.Tests/Skills/IssueTemplateAndLabelSeedTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/IssueTemplateAndLabelSeedTests.cs
@@ -1,0 +1,295 @@
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// Lockstep tests for the three surfaces that share the area / severity enums:
+///
+///   1. `ai_docs/items/backlog-d-fragment-schema.md` — canonical enum source of truth.
+///   2. `.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml` — public form options.
+///   3. `scripts/seed-issue-labels.ps1` — the `area:*` / `severity:*` GitHub labels.
+///
+/// Drift between any pair of these surfaces is a contract break:
+///   - A schema enum value with no matching label means a `gh issue create --label area:X` call
+///     fails for that value.
+///   - A seed-script label with no schema entry means the maintainer creates a label that the
+///     renderer can never produce — dead surface.
+///   - A template option with no schema entry means a contributor can submit a finding the
+///     intake flow will reject as malformed.
+///
+/// Two enum tokens are intentionally OMITTED from the public form and the label seeder:
+///   - `severity: P0` — refused for public filing by `Test-FindingShouldRefusePublicFile`.
+///   - `area: security` — same.
+/// Both are valid in `backlog.d/` fragments (they're how the renderer detects the refusal),
+/// but they never reach a public Issue. Tests below pin both directions: included in the
+/// schema, excluded from the form + seeder.
+/// </summary>
+[TestClass]
+public sealed class IssueTemplateAndLabelSeedTests
+{
+    // Canonical enums per the fragment schema doc. If these change here without a corresponding
+    // doc edit, the doc-content test below catches it.
+    private static readonly string[] AllAreaValues = new[]
+    {
+        "tools", "resources", "prompts", "skills", "concurrency", "perf", "docs", "security"
+    };
+
+    private static readonly string[] PubliclyFileableAreaValues = new[]
+    {
+        "tools", "resources", "prompts", "skills", "concurrency", "perf", "docs"
+        // `security` deliberately omitted — refused by the renderer.
+    };
+
+    private static readonly string[] AllSeverityValues = new[] { "P0", "P1", "P2", "P3" };
+
+    private static readonly string[] PubliclyFileableSeverityValues = new[]
+    {
+        "P1", "P2", "P3"
+        // `P0` deliberately omitted — refused by the renderer.
+    };
+
+    [TestMethod]
+    public void FragmentSchemaDoc_DocumentsTheCanonicalAreaEnum()
+    {
+        var schemaPath = ResolveSchemaDocPath();
+        var contents = File.ReadAllText(schemaPath);
+
+        // The doc cell for `area` must list every value in the canonical enum (including
+        // `security`). Order is fixed in the doc cell so we can pin the substring.
+        foreach (var value in AllAreaValues)
+        {
+            StringAssert.Contains(contents, $"`{value}`",
+                $"backlog-d-fragment-schema.md must document the area enum value `{value}`. " +
+                "If you intentionally removed it, update IssueTemplateAndLabelSeedTests.AllAreaValues to match.");
+        }
+    }
+
+    [TestMethod]
+    public void IssueTemplate_ParsesAndExposesOnlyPubliclyFileableAreaValues()
+    {
+        var templatePath = ResolveIssueTemplatePath();
+        Assert.IsTrue(File.Exists(templatePath),
+            $"Issue template not found at '{templatePath}'. The /mcp-server-surface-test public-funnel surface depends on it.");
+
+        var contents = File.ReadAllText(templatePath);
+        var areaOptions = ExtractDropdownOptions(contents, dropdownId: "area");
+
+        CollectionAssert.AreEqual(
+            PubliclyFileableAreaValues, areaOptions.ToArray(),
+            $"Issue template `area` dropdown options drifted from the publicly-fileable subset. " +
+            $"Expected: [{string.Join(", ", PubliclyFileableAreaValues)}]. " +
+            $"Got: [{string.Join(", ", areaOptions)}]. " +
+            "If you added an enum value, update both this test's expected list AND `area:<value>` in scripts/seed-issue-labels.ps1.");
+    }
+
+    [TestMethod]
+    public void IssueTemplate_OmitsRefusedAreaSecurityFromDropdown()
+    {
+        var templatePath = ResolveIssueTemplatePath();
+        var contents = File.ReadAllText(templatePath);
+        var areaOptions = ExtractDropdownOptions(contents, dropdownId: "area");
+
+        Assert.IsFalse(
+            areaOptions.Contains("security"),
+            "Issue template `area` dropdown must NOT expose `security` — that value is refused for public filing by the shared renderer's Test-FindingShouldRefusePublicFile predicate. Listing it here would invite contributors to file a vulnerability publicly, which is the exact failure mode SECURITY.md exists to prevent.");
+    }
+
+    [TestMethod]
+    public void IssueTemplate_ParsesAndExposesOnlyPubliclyFileableSeverityValues()
+    {
+        var templatePath = ResolveIssueTemplatePath();
+        var contents = File.ReadAllText(templatePath);
+        var severityOptions = ExtractDropdownOptions(contents, dropdownId: "severity");
+
+        CollectionAssert.AreEqual(
+            PubliclyFileableSeverityValues, severityOptions.ToArray(),
+            $"Issue template `severity` dropdown options drifted from the publicly-fileable subset. " +
+            $"Expected: [{string.Join(", ", PubliclyFileableSeverityValues)}]. " +
+            $"Got: [{string.Join(", ", severityOptions)}]. " +
+            "If you added an enum value, update both this test's expected list AND `severity:<value>` in scripts/seed-issue-labels.ps1.");
+    }
+
+    [TestMethod]
+    public void IssueTemplate_OmitsRefusedSeverityP0FromDropdown()
+    {
+        var templatePath = ResolveIssueTemplatePath();
+        var contents = File.ReadAllText(templatePath);
+        var severityOptions = ExtractDropdownOptions(contents, dropdownId: "severity");
+
+        Assert.IsFalse(
+            severityOptions.Contains("P0"),
+            "Issue template `severity` dropdown must NOT expose `P0` — refused for public filing by the shared renderer. Listing it here would let a contributor file a critical bug publicly before a fix lands.");
+    }
+
+    [TestMethod]
+    public void SeedLabelsScript_FileExistsAtDocumentedPath()
+    {
+        var scriptPath = ResolveSeedScriptPath();
+        Assert.IsTrue(
+            File.Exists(scriptPath),
+            $"scripts/seed-issue-labels.ps1 not found at '{scriptPath}'. The maintainer-bootstrap workflow + the shipped skill's README reference this exact path; without the file the docs ship dead links.");
+    }
+
+    [TestMethod]
+    public void SeedLabelsScript_AreaLabelsMatchPubliclyFileableEnum()
+    {
+        var scriptPath = ResolveSeedScriptPath();
+        var contents = File.ReadAllText(scriptPath);
+        var labels = ExtractScriptLabelNames(contents, prefix: "area:");
+
+        CollectionAssert.AreEquivalent(
+            PubliclyFileableAreaValues.Select(v => $"area:{v}").ToArray(),
+            labels.ToArray(),
+            $"scripts/seed-issue-labels.ps1 area labels drifted from the publicly-fileable enum. " +
+            $"Expected: [{string.Join(", ", PubliclyFileableAreaValues.Select(v => $"area:{v}"))}]. " +
+            $"Got: [{string.Join(", ", labels)}].");
+    }
+
+    [TestMethod]
+    public void SeedLabelsScript_OmitsRefusedAreaSecurityLabel()
+    {
+        var scriptPath = ResolveSeedScriptPath();
+        var contents = File.ReadAllText(scriptPath);
+        var labels = ExtractScriptLabelNames(contents, prefix: "area:");
+
+        Assert.IsFalse(
+            labels.Contains("area:security"),
+            "scripts/seed-issue-labels.ps1 must NOT seed `area:security` — that label has no public Issue surface. Refused findings are routed through GitHub security advisories per SECURITY.md, not via a public label.");
+    }
+
+    [TestMethod]
+    public void SeedLabelsScript_SeverityLabelsMatchPubliclyFileableEnum()
+    {
+        var scriptPath = ResolveSeedScriptPath();
+        var contents = File.ReadAllText(scriptPath);
+        var labels = ExtractScriptLabelNames(contents, prefix: "severity:");
+
+        CollectionAssert.AreEquivalent(
+            PubliclyFileableSeverityValues.Select(v => $"severity:{v}").ToArray(),
+            labels.ToArray(),
+            $"scripts/seed-issue-labels.ps1 severity labels drifted from the publicly-fileable enum. " +
+            $"Expected: [{string.Join(", ", PubliclyFileableSeverityValues.Select(v => $"severity:{v}"))}]. " +
+            $"Got: [{string.Join(", ", labels)}].");
+    }
+
+    [TestMethod]
+    public void SeedLabelsScript_OmitsRefusedSeverityP0Label()
+    {
+        var scriptPath = ResolveSeedScriptPath();
+        var contents = File.ReadAllText(scriptPath);
+        var labels = ExtractScriptLabelNames(contents, prefix: "severity:");
+
+        Assert.IsFalse(
+            labels.Contains("severity:P0"),
+            "scripts/seed-issue-labels.ps1 must NOT seed `severity:P0` — refused findings have no public Issue surface.");
+    }
+
+    // ---------- Helpers ----------
+
+    private static string ResolveSchemaDocPath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, "ai_docs", "items", "backlog-d-fragment-schema.md");
+    }
+
+    private static string ResolveIssueTemplatePath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, ".github", "ISSUE_TEMPLATE", "mcp-server-surface-test-finding.yml");
+    }
+
+    private static string ResolveSeedScriptPath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, "scripts", "seed-issue-labels.ps1");
+    }
+
+    /// <summary>
+    /// Extract the values of a `type: dropdown` block whose `id:` matches <paramref name="dropdownId"/>.
+    /// Walks line by line; finds the matching id, then collects `- value` entries inside the
+    /// nearest following `options:` list, stopping at the next top-level `- type:` block.
+    /// </summary>
+    private static List<string> ExtractDropdownOptions(string templateContents, string dropdownId)
+    {
+        var lines = templateContents.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+        var options = new List<string>();
+
+        int idLineIndex = -1;
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Trim() == $"id: {dropdownId}")
+            {
+                idLineIndex = i;
+                break;
+            }
+        }
+        if (idLineIndex < 0)
+        {
+            return options;
+        }
+
+        // Find the `options:` line after the id.
+        int optionsLineIndex = -1;
+        for (int i = idLineIndex; i < lines.Length; i++)
+        {
+            if (lines[i].Trim() == "options:")
+            {
+                optionsLineIndex = i;
+                break;
+            }
+            // Stop at the next dropdown block start.
+            if (i > idLineIndex && lines[i].TrimStart().StartsWith("- type:", StringComparison.Ordinal))
+            {
+                return options;
+            }
+        }
+        if (optionsLineIndex < 0)
+        {
+            return options;
+        }
+
+        // Collect option lines: leading whitespace, `- `, then the value.
+        var optionRegex = new Regex(@"^\s+-\s+(?<value>\S.*?)\s*$");
+        for (int i = optionsLineIndex + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            // Stop at a sibling key (less indent than the options' children) or a new `- type:` block.
+            if (line.TrimStart().StartsWith("- type:", StringComparison.Ordinal))
+            {
+                break;
+            }
+            // A non-list line at the same indent as `options:` (or less) ends the list.
+            if (!string.IsNullOrWhiteSpace(line) && !line.TrimStart().StartsWith("-", StringComparison.Ordinal) && !line.StartsWith(" ", StringComparison.Ordinal))
+            {
+                break;
+            }
+            var m = optionRegex.Match(line);
+            if (m.Success)
+            {
+                options.Add(m.Groups["value"].Value.Trim());
+            }
+            else if (!string.IsNullOrWhiteSpace(line) && !line.TrimStart().StartsWith("-", StringComparison.Ordinal))
+            {
+                // Mid-block non-list line → stop.
+                break;
+            }
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Extract `name = '<prefix><value>'` entries from the seed script's lockstep tables.
+    /// </summary>
+    private static List<string> ExtractScriptLabelNames(string scriptContents, string prefix)
+    {
+        var names = new List<string>();
+        var pattern = new Regex(@"name\s*=\s*'(?<name>" + Regex.Escape(prefix) + @"[^']+)'");
+        foreach (Match m in pattern.Matches(scriptContents))
+        {
+            names.Add(m.Groups["name"].Value);
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
## Summary

Row 3 of the `move-to-git-issues` design. Three new public-facing surfaces wired in lockstep with the schema enum and the renderer's refusal contract — the consumer funnel that turns audit findings into public Issues now has a clean place to land.

## What ships

- **`.github/ISSUE_TEMPLATE/mcp-server-surface-test-finding.yml`** — public form template. Mirrors the shared finding envelope (`id`, `source-repo`, `severity` dropdown, `area` dropdown, `server-version`, `anchors`, `finding`, `repro`, `proposed-fix`). Drops `severity: P0` and `area: security` from the dropdowns — both are refused for public filing by the shared renderer and route through GitHub security advisories per `SECURITY.md`. Anchors field labeled "paths in your repo, not clickable here" so triage knows the anchors are diagnostic context.

- **`scripts/seed-issue-labels.ps1`** — idempotent one-shot maintainer-bootstrap script that seeds `area:*` (tools/resources/prompts/skills/concurrency/perf/docs) and `severity:*` (P1/P2/P3) labels at `darylmcd/Roslyn-Backed-MCP` via `gh label create --force`. Verifies `gh` is on PATH and authenticated before mutating; supports `-DryRun`. Deliberately omits `area:security` and `severity:P0`.

- **Root `README.md`** gains a "Filing Surface-Test Findings" section pointing consumers at the new template + `--auto-file`, with the P0/security refusal cross-referenced to `SECURITY.md`.

- **`skills/mcp-server-surface-test/README.md`** gains the public-issues funnel paragraph + verbatim restatement of the pre-disclosure refusal contract.

- **`SECURITY.md`** documents that the renderer enforces the no-public-P0 policy automatically.

- **`IssueTemplateAndLabelSeedTests.cs`** — 10 lockstep tests pinning the area + severity enums across three surfaces simultaneously: `backlog-d-fragment-schema.md` (canonical), the issue template (public form), and the seed script (labels). Drift between any pair fails CI.

## Test plan

- [x] `pwsh -File eng/verify-skills-are-generic.ps1` → passing (32 SKILL.md checked).
- [x] `pwsh -File eng/verify-ai-docs.ps1` → passing.
- [x] `dotnet test --filter \"FullyQualifiedName~Skills\"` → 52/52 pass in 5s (42 from Rows 1+2 + 10 new).
- [ ] CI full suite on the self-hosted runner.
- [ ] Manual smoke: file a synthetic test finding via the new template (one-shot, then close) to confirm the YAML renders correctly in the GitHub UI; run `pwsh -File scripts/seed-issue-labels.ps1 -DryRun` to confirm the label list before invoking the real one.

## Closes the design

This is the last row of `move-to-git-issues`. Row 4 (community scorecard aggregation) was deferred per the design note and is not in scope. With Rows 1–3 merged, the funnel is end-to-end:

1. Run `/mcp-server-surface-test --quick --auto-file` against your repo.
2. Findings render through the shared envelope; `gh issue create` files them with `area:*` / `severity:*` labels that already exist (or that `scripts/seed-issue-labels.ps1` will create).
3. P0 / `area: security` findings refuse, print the SECURITY banner, and route through `SECURITY.md`'s private-disclosure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)