### PR TITLE
docs(items): expand move-to-git-issues e2e verification prompt to be self-completing

### DIFF
--- a/ai_docs/items/move-to-git-issues-end-to-end-verification.md
+++ b/ai_docs/items/move-to-git-issues-end-to-end-verification.md
@@ -1,91 +1,170 @@
 # move-to-git-issues end-to-end verification — fresh-session prompt
 
-<!-- purpose: One-shot verification prompt for the merged `move-to-git-issues` design (Rows 1-3, PRs #591/#592/#593). Paste into a fresh Claude Code session inside `C:/Code-Repo/Roslyn-Backed-MCP`; the new skill must be loaded first. -->
+<!-- purpose: One-shot verification prompt for the merged `move-to-git-issues` design (Rows 1-3, PRs #591/#592/#593, released as v1.35.1 in PR #595). Paste into a fresh Claude Code session inside `C:/Code-Repo/Roslyn-Backed-MCP`; the new skill must be loaded first. The prompt is self-completing — when every step ends green, the design is officially done. -->
 
 ---
 
 ## Prompt to paste
 
-> You are verifying the end-to-end funnel from the `move-to-git-issues` design, which shipped across three PRs that merged earlier today: [#591](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/591) (Row 1, ship `/mcp-server-surface-test`), [#592](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/592) (Row 2, shared renderer + `/backlog-intake --publish`), [#593](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/593) (Row 3, issue template + label seeder + lockstep tests). The renderer-level refusal contract (P0 / `area: security`), the `gh issue create` command shape, the dry-run label seed, and GitHub's recognition of the issue template were all verified in the previous session. **What you need to verify here is the half that requires the new skill to actually run** — `/mcp-server-surface-test --quick` and `/backlog-intake --publish`.
+> You are running the end-to-end verification of the `move-to-git-issues` design, which shipped across four PRs that merged earlier today: [#591](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/591) (Row 1, ship `/mcp-server-surface-test`), [#592](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/592) (Row 2, shared renderer + `/backlog-intake --publish`), [#593](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/593) (Row 3, issue template + label seeder + lockstep tests), and [#595](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/595) (release v1.35.1). The renderer-level refusal contract, the `gh issue create` command shape, the dry-run label seed, and GitHub's recognition of the issue template were verified in the previous session. **What you need to verify here is the half that requires the new skill to actually run** plus every side-effect the design depends on (real label seed, real Issue, real publish smoke).
 >
-> Work in auto mode. Squash-merge / share state only when the steps below explicitly authorize it.
+> Run in auto mode. Every authorized side-effect below is explicitly listed; do nothing visible-to-others outside that list. When all steps end green, you'll commit a one-line update to `ai_docs/items/move-to-git-issues.md` flipping the design status to "completed" and ship that as a chore PR. **That status flip is the load-bearing definition of done — do not stop short of it.**
 >
 > ### Preflight
 >
-> 1. Confirm the new skill is loaded. Run `/plugin update roslyn-mcp@roslyn-mcp-marketplace` if `/mcp-server-surface-test` is not in your skill surface; if `/plugin update` is unavailable in this client, restart and try again. The skill must appear in the user-invocable list before you proceed.
-> 2. Confirm the Roslyn MCP server is reachable: `mcp__roslyn__server_info` must return `connection.state: "ready"`. If not, start the server (`dotnet tool run roslynmcp` or whatever the host's entry is) and re-check.
-> 3. Confirm `gh` is on PATH and `gh auth status` reports authenticated against `darylmcd/Roslyn-Backed-MCP`.
+> 1. Confirm the new skill is loaded. `/mcp-server-surface-test` must appear in your skill surface; if it does not, run `/plugin update roslyn-mcp@roslyn-mcp-marketplace` (or restart and try again — see the `feedback_plugin_install_eperm` memory at `~/.claude/projects/C--Windows-system32/memory/` for the Windows EPERM workaround). Do not proceed past this gate.
+> 2. Confirm the Roslyn MCP server is reachable: `mcp__roslyn__server_info` must return `connection.state` of `idle` or `ready`. Capture `version` for later — Step 1 stamps it on synthesized findings.
+> 3. Confirm `gh` on PATH and `gh auth status` reports authenticated against `darylmcd/Roslyn-Backed-MCP`.
+> 4. Confirm `git status --short` is clean; if not, stash unrelated work first.
 >
-> ### Step 0 — Seed the issue labels (one-shot, idempotent)
+> ### Step 0 — Seed the issue labels (one-shot, real, authorized)
 >
-> Run `pwsh -NoProfile -File scripts/seed-issue-labels.ps1`. This creates the `area:*` and `severity:*` labels at `darylmcd/Roslyn-Backed-MCP`. The script is idempotent (uses `gh label create --force`); re-running is safe. After the script finishes, confirm via `gh label list --repo darylmcd/Roslyn-Backed-MCP --search "area:"` that 7 area labels and 3 severity labels exist.
+> Run `pwsh -NoProfile -File scripts/seed-issue-labels.ps1` (no `-DryRun`). The script is idempotent (`gh label create --force`); re-running is safe. Confirm post-state:
+>
+> ```bash
+> gh label list --repo darylmcd/Roslyn-Backed-MCP --search "area:" | wc -l   # expect 7
+> gh label list --repo darylmcd/Roslyn-Backed-MCP --search "severity:" | wc -l # expect 3
+> ```
+>
+> If counts disagree, stop and diagnose — the lockstep test exists to prevent enum drift, but a test pass doesn't guarantee successful seed propagation.
 >
 > ### Step 1 — `--quick` against a non-Roslyn target (stdout-only)
 >
 > Pick `C:/Code-Repo/DotNet-Firewall-Analyzer` as the target. Invoke `/mcp-server-surface-test --quick C:/Code-Repo/DotNet-Firewall-Analyzer`. Expect:
 > - Runtime ≤15 min.
-> - Audit report lands at `C:/Code-Repo/DotNet-Firewall-Analyzer/audit-reports/<ts>_<repo-id>_mcp-server-surface-test.md`.
+> - Audit report at `C:/Code-Repo/DotNet-Firewall-Analyzer/audit-reports/<ts>_<repo-id>_mcp-server-surface-test.md`.
 > - **No `backlog.d/` writes anywhere** (`--quick` is read-only and consumer-side; no fragment emission).
 > - **No `gh` invocations** (no `--auto-file`).
 > - Phase 19 either prints actionable findings to stdout in the envelope shape, or records `**N/A — no actionable findings**`.
 >
-> Verification commands:
-> - `git -C C:/Code-Repo/DotNet-Firewall-Analyzer status --short` — should show only the new `audit-reports/` file (untracked).
-> - `pwsh -NoProfile -File C:/Code-Repo/Roslyn-Backed-MCP/eng/verify-skills-are-generic.ps1` should still pass after the audit.
->
-> If Phase 19 produces zero actionable findings (likely on a small target), capture that in the report; it does not invalidate the verification.
->
-> ### Step 2 — `--quick --auto-file` against the same target (filing path)
->
-> Re-invoke `/mcp-server-surface-test --quick --auto-file C:/Code-Repo/DotNet-Firewall-Analyzer`. The skill should:
-> - Still produce the audit report (Step 1's contract).
-> - For each non-refused finding, call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <id> --label area:<area> --label severity:<severity> --body-file <tempfile>`.
-> - Print the returned Issue URLs after Phase 19 completes.
->
-> If Phase 19 produces zero actionable findings, **synthesize one** by hand: dot-source `skills/mcp-server-surface-test/lib/render-finding.ps1` and craft a `[hashtable]$f` with `severity='P3'`, `area='docs'`, `id='verify-end-to-end-quick-auto-file-probe'`, plausible anchors, then call `Render-FindingIssue` and `gh issue create` with the result. This proves the path even when the audited repo is too clean to surface real findings.
->
 > Verification:
-> - The filed Issue must use the new template — title is the finding id, body is the rendered envelope (no double labels, no garbled em-dashes).
-> - Both `area:<value>` and `severity:<value>` labels must apply (Step 0 seeded them).
-> - **Close the test Issue** after verification with `gh issue close <number> --reason "not planned" --comment "end-to-end verification probe; see https://github.com/darylmcd/Roslyn-Backed-MCP/pull/593"`.
 >
-> ### Step 3 — `--full` against `Roslyn-Backed-MCP` itself (canonical smoke)
+> ```bash
+> git -C C:/Code-Repo/DotNet-Firewall-Analyzer status --short  # only audit-reports/ untracked
+> ```
 >
-> Skip this step unless you have 90–180 min to spare and the self-hosted runner is idle (the runner and a local `--full` invocation contend for the same MSBuild server / VBCSCompiler / file locks; per the `feedback_self_hosted_runner_no_duplicate_local_run` memory in `~/.claude/projects/C--Code-Repo-Roslyn-Backed-MCP/memory/`, never run heavy local validation while the runner is active).
+> ### Step 2 — `--quick --auto-file` (file one real public Issue)
 >
-> When you do run it: `/mcp-server-surface-test --full` from inside `C:/Code-Repo/Roslyn-Backed-MCP`. Expect:
-> - Disposable worktree at `../Roslyn-Backed-MCP-surface-test-<ts>` (or similar).
-> - Audit report at `audit-reports/<ts>_roslyn-backed-mcp_mcp-server-surface-test.md`.
-> - Promotion-scorecard JSON at `audit-reports/_latest-promotion-scorecard.json`.
-> - **Worktree torn down at run end** (`git worktree list` should not show the disposable worktree after `--full` returns).
-> - The audit report must contain zero banned patterns when piped through `pwsh -Command "(Get-Content <report>) | Select-String -Pattern '(state\\.json|backlog-sweep|schemaVersion|ai_docs/|backlog\\.md|eng/|just verify-|Directory\\.Build\\.props|BannedSymbols\\.txt)'"` — paths in the audited repo's content (e.g. `ai_docs/` mentions of this repo's own docs) are fine; what matters is that the prompt didn't drift back toward repo-coupled wording.
+> Re-invoke `/mcp-server-surface-test --quick --auto-file C:/Code-Repo/DotNet-Firewall-Analyzer`. The skill should call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <id> --label area:<area> --label severity:<severity> --body-file <tempfile>` for each non-refused finding.
 >
-> ### Step 4 — `/backlog-intake --publish` (maintainer publish path)
+> If Phase 19 produced zero actionable findings (likely on a small target), **synthesize one finding** directly with the renderer and file it manually so the public-template path is exercised end-to-end:
 >
-> This step is chicken-and-egg without real fragments to consume. Two options:
+> ```pwsh
+> . skills/mcp-server-surface-test/lib/render-finding.ps1
+> $f = @{
+>     id = 'verify-end-to-end-quick-auto-file-probe'
+>     source_repo = 'dotnet-firewall-analyzer'
+>     severity = 'P3'; area = 'docs'
+>     server_version = '<version-from-Preflight-step-2>'
+>     anchors = @('README.md:1')
+>     finding = 'End-to-end verification probe; safe to ignore. See https://github.com/darylmcd/Roslyn-Backed-MCP/pull/593.'
+>     repro = 'No repro required; this is a verification probe.'
+>     proposed_fix = 'No fix required.'
+> }
+> $issue = Render-FindingIssue -Finding $f
+> $bf = New-TemporaryFile; $issue.body | Out-File -FilePath $bf.FullName -Encoding utf8 -NoNewline
+> gh issue create --repo darylmcd/Roslyn-Backed-MCP --title $issue.title `
+>     --label "area:docs" --label "severity:P3" --body-file $bf.FullName
+> Remove-Item $bf
+> ```
 >
-> 1. **Real path** — wait until the next maintainer audit produces actual `backlog.d/<id>.md` fragments under audited sibling repos; then run `/backlog-intake --publish`. Confirm: each accepted row gets an Issue link appended in `ai_docs/backlog.md`; refused rows (P0 / `area: security`) print the SECURITY banner and do not file.
-> 2. **Synthetic path** — create a minimal fragment under `<some-repo>/backlog.d/verify-end-to-end-publish-probe.md` with valid frontmatter (use the schema doc + the renderer's `Render-FindingFragment` to generate it), run `/backlog-intake`, and confirm the file is consumed and a row appended. Then re-run with `--publish` to confirm the gh-invocation path. Close the synthetic Issue afterward.
+> Capture the returned Issue URL (call it `$consumerIssueUrl`).
 >
-> ### Step 5 — Already verified in the previous session, but re-confirm
+> Verify in the GitHub UI that the Issue:
+> - Renders the body fields cleanly (id, source-repo, severity, area, server-version, anchors, finding, repro, proposed-fix).
+> - Has both `area:docs` and `severity:P3` labels applied.
+> - Title equals the finding `id`.
 >
-> Synthesize a P0 finding and a `area: security` finding. Run `Render-FindingIssue` on each. Both must report `refusedPublic=True` and prepend the SECURITY banner to the body. Both auto-file paths (`--auto-file` in `/mcp-server-surface-test`, `--publish` in `/backlog-intake`) must short-circuit before any `gh issue create` invocation. **Do not** invoke `gh issue create` for either probe.
+> ### Step 3 — `--full` against `Roslyn-Backed-MCP` itself (canonical smoke; OPTIONAL)
 >
-> ### Reporting
+> **Skip this step unless the self-hosted runner is idle and you have 90–180 min available.** Per `~/.claude/projects/C--Code-Repo-Roslyn-Backed-MCP/memory/feedback_self_hosted_runner_no_duplicate_local_run.md`, never run heavy local validation while the runner is active.
 >
-> After all steps complete, post a comment on [PR #593](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/593) (or open a fresh `chore: e2e verification` PR if changes were committed) listing:
-> - Which steps ran end-to-end vs which were synthesized.
-> - Issue URLs created and closed.
-> - Any drift between the renderer's emitted body and what GitHub displayed in the rendered Issue.
-> - Wall-clock for `--quick` and (if run) `--full`.
-> - Whether the disposable-worktree teardown was clean (Step 3 only).
+> If you do run it: `/mcp-server-surface-test --full` from inside `C:/Code-Repo/Roslyn-Backed-MCP`. Expect a disposable worktree at `../Roslyn-Backed-MCP-surface-test-<ts>` torn down at run end, an audit report at `audit-reports/<ts>_roslyn-backed-mcp_mcp-server-surface-test.md`, a promotion-scorecard JSON sibling, and zero `git worktree list` entries for the disposable worktree after return. Note any drift in the report's prose (paths/markers that should not be there) and surface it as a finding.
+>
+> ### Step 4 — `/backlog-intake --publish` (synthetic fragment path)
+>
+> Real fragments only show up after a maintainer audit. Synthesize one to exercise the publish path end-to-end:
+>
+> ```pwsh
+> $repo = 'C:/Code-Repo/DotNet-Firewall-Analyzer'
+> mkdir -Force "$repo/backlog.d" | Out-Null
+> . skills/mcp-server-surface-test/lib/render-finding.ps1
+> $f = @{
+>     id = 'verify-end-to-end-publish-probe'
+>     source_audit = 'verify-end-to-end-publish-probe-source.md'
+>     source_repo = (Get-FindingRepoId -RepoRoot $repo)
+>     severity = 'P3'; area = 'docs'
+>     server_version = '<version-from-Preflight-step-2>'
+>     anchors = @('README.md:1')
+>     finding = 'End-to-end verification probe; safe to ignore.'
+>     repro = 'No repro required.'
+>     proposed_fix = 'No fix required.'
+> }
+> $fragmentPath = "$repo/backlog.d/verify-end-to-end-publish-probe.md"
+> Render-FindingFragment -Finding $f | Out-File -FilePath $fragmentPath -Encoding utf8 -NoNewline
+> ```
+>
+> Then invoke `/backlog-intake --publish` from inside `C:/Code-Repo/Roslyn-Backed-MCP`. Expect:
+> - The intake skill discovers the synthetic fragment under `<sibling-repo>/backlog.d/`.
+> - It appends a row to `ai_docs/backlog.md` for the synthesized finding.
+> - It calls `gh issue create` against `darylmcd/Roslyn-Backed-MCP` (Phase 6.5) and appends the returned Issue URL to the row's body.
+> - The fragment file is deleted from `<sibling-repo>/backlog.d/` on consumption.
+>
+> Capture the returned Issue URL (call it `$maintainerIssueUrl`).
+>
+> ### Step 5 — Refusal contract (re-confirm; no Issue should be filed)
+>
+> Run two refusal probes through the renderer with `Test-FindingShouldRefusePublicFile` and `Render-FindingIssue`. **Do not invoke `gh issue create` for either probe.**
+>
+> ```pwsh
+> . skills/mcp-server-surface-test/lib/render-finding.ps1
+> $p0 = @{ id='verify-p0'; source_repo='r'; severity='P0'; area='tools'; server_version='1.0'; anchors=@('a:1'); finding='f'; repro='r'; proposed_fix='p' }
+> $sec = @{ id='verify-sec'; source_repo='r'; severity='P3'; area='security'; server_version='1.0'; anchors=@('a:1'); finding='f'; repro='r'; proposed_fix='p' }
+> Test-FindingShouldRefusePublicFile -Finding $p0    # must be True
+> Test-FindingShouldRefusePublicFile -Finding $sec   # must be True
+> (Render-FindingIssue -Finding $p0).refusedPublic   # must be True
+> (Render-FindingIssue -Finding $sec).refusedPublic  # must be True
+> (Render-FindingIssue -Finding $p0).body | Select-String -SimpleMatch 'DO NOT FILE PUBLICLY'   # must match
+> (Render-FindingIssue -Finding $sec).body | Select-String -SimpleMatch 'DO NOT FILE PUBLICLY'  # must match
+> ```
+>
+> If any of those four predicates is `False` or either banner check is empty, stop — the renderer's refusal contract regressed and Row 2's load-bearing safeguard is broken.
+>
+> ### Step 6 — Cleanup (mandatory before close-out)
+>
+> Close the synthetic Issues you filed in Steps 2 and 4 so the public Issues list isn't polluted with verification cruft:
+>
+> ```bash
+> gh issue close <consumer-issue-number> --reason "not planned" \
+>     --comment "End-to-end verification probe per ai_docs/items/move-to-git-issues-end-to-end-verification.md. Closing — see PRs #591/#592/#593/#595 for the underlying design."
+> gh issue close <maintainer-issue-number> --reason "not planned" \
+>     --comment "End-to-end verification probe per ai_docs/items/move-to-git-issues-end-to-end-verification.md. Closing — see PRs #591/#592/#593/#595 for the underlying design."
+> ```
+>
+> Also revert the synthetic backlog row from Step 4 — open `ai_docs/backlog.md`, find the `verify-end-to-end-publish-probe` row, delete it. Confirm `<sibling-repo>/backlog.d/` is back to its pre-Step-4 state (the fragment was already consumed/deleted by intake).
+>
+> ### Step 7 — Definition of done (CLOSE THE DESIGN)
+>
+> Edit `ai_docs/items/move-to-git-issues.md`:
+>
+> - In the frontmatter HTML comment block at the top, change the `status` line from `design seed - current decisions captured; not yet a backlog row` to `completed - rows 1-3 shipped (PRs #591, #592, #593) and released as v1.35.1 (PR #595); end-to-end verification passed YYYY-MM-DD; row 4 deferred per design note`. Use today's date in YYYY-MM-DD form.
+> - Add a new section at the bottom titled `## Verification` recording: which steps ran end-to-end vs which were synthesized, the closed-Issue URLs (from Step 6) for the audit trail, the wall-clock for `--quick` (and `--full` if Step 3 ran), and the date.
+>
+> Then ship the doc edit + the `ai_docs/backlog.md` synthetic-row revert as a single chore PR. Use the `/ship` skill with default squash merge:
+>
+> ```
+> /ship docs(items): close move-to-git-issues design after end-to-end verification
+> ```
+>
+> When that PR is green and merged, the design is officially complete. Post a final summary to chat with: the closed-Issue URLs, the merged PR URL for the close-out doc edit, and any drift surfaced during Steps 1–4 that needs a follow-up backlog row (file via the new `mcp-server-surface-test-finding` template).
 >
 > Do not push, comment, or file Issues outside what these steps explicitly authorize. If you hit a real bug during the verification, file it via the new template (`/mcp-server-surface-test --auto-file` will do this) — that itself is end-to-end evidence.
 
 ---
 
-## Notes
+## Notes for the operator (you, before pasting)
 
-- **The full plan** that drove Rows 1–3 is at `C:/Users/daryl/.claude/plans/ready-to-start-looking-harmonic-toast.md` (the "End-to-end verification" section is what this prompt operationalizes).
-- **Skill auto-load on Claude Code Windows** historically requires the rename-step workaround per the `feedback_plugin_install_eperm` memory at `~/.claude/projects/C--Windows-system32/memory/`. If `/plugin update` errors, run `claude plugin install roslyn-mcp@roslyn-mcp-marketplace` from CLI and reapply the manual rename.
-- **Self-hosted runner contention** — never run `--full` (or full `dotnet test`) locally while the runner is active. See `~/.claude/projects/C--Code-Repo-Roslyn-Backed-MCP/memory/feedback_self_hosted_runner_no_duplicate_local_run.md`.
+- **The full plan** that drove Rows 1–3 is at `C:/Users/daryl/.claude/plans/ready-to-start-looking-harmonic-toast.md` — the "End-to-end verification" section there is what this prompt operationalizes.
+- **Skill auto-load on Claude Code Windows** historically requires the rename-step workaround per `~/.claude/projects/C--Windows-system32/memory/feedback_plugin_install_eperm.md`. If `/plugin update` errors, run `claude plugin install roslyn-mcp@roslyn-mcp-marketplace` from CLI and reapply the manual rename before pasting the prompt.
+- **Self-hosted runner contention** — the runner lives on this same box. Never run `--full` (or full `dotnet test`) locally while a PR is queued. See `~/.claude/projects/C--Code-Repo-Roslyn-Backed-MCP/memory/feedback_self_hosted_runner_no_duplicate_local_run.md`.
+- **Why this prompt also closes the design row** — the move-to-git-issues design has been "ready to ship" several times; the load-bearing definition of done is a status flip on the design note itself plus an audit-trail of the closed verification Issues. Pasting this prompt and letting it run all the way through Step 7 is the actual completion ritual.


### PR DESCRIPTION
## Summary

Rewrites `ai_docs/items/move-to-git-issues-end-to-end-verification.md` so a fresh-session paste **actually finishes** the move-to-git-issues design end-to-end, not just runs the audit invocations. Authorizes every required side-effect inline:

- **Step 0** runs `scripts/seed-issue-labels.ps1` for real (no `-DryRun`) so the public `area:*` / `severity:*` labels are seeded before any `--auto-file` needs them.
- **Step 2** synthesizes a finding via the shared renderer and files one real public Issue when `--quick` returns zero actionable findings, so the public-template + label path is exercised even on a clean target.
- **Step 4** gives a synthetic-fragment recipe so `/backlog-intake --publish` can be smoke-tested without waiting for a real maintainer audit.
- **Step 5** re-confirms the P0 / `area: security` refusal contract.
- **Step 6** mandates closing both verification Issues + reverting the synthetic backlog row from Step 4.
- **Step 7** is the load-bearing definition-of-done: edit `ai_docs/items/move-to-git-issues.md` to flip the status line to `completed - rows 1-3 shipped (PRs #591/592/593) and released as v1.35.1 (PR #595); end-to-end verification passed YYYY-MM-DD; row 4 deferred`, add a `## Verification` section recording the closed-Issue URLs as audit trail, and ship the doc edit + synthetic-row revert via `/ship`. Without this status flip the design isn't actually closed.

Pre-existing memory cross-references (self-hosted runner contention, Windows `/plugin install` EPERM workaround) are preserved in the operator-notes block at the bottom.

## Test plan

- [x] `pwsh -File eng/verify-ai-docs.ps1` (rerun after merge) — no broken links.
- [ ] Pasting the prompt into a fresh post-restart session drives Steps 0–7 to completion without further hand-holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)