### PR TITLE
docs(items): close move-to-git-issues design after end-to-end verification

### DIFF
--- a/ai_docs/items/move-to-git-issues.md
+++ b/ai_docs/items/move-to-git-issues.md
@@ -2,7 +2,7 @@
 
 <!-- purpose: Current design note for moving the audit-finding sharing path toward GitHub Issues while keeping the maintainer-local fragment workflow. -->
 <!-- scope: in-repo -->
-<!-- status: design seed - current decisions captured; not yet a backlog row -->
+<!-- status: completed - rows 1-3 shipped (PRs #591, #592, #593) and released as v1.35.1 (PR #595); end-to-end verification passed 2026-05-10; row 4 deferred per design note -->
 
 **Created:** 2026-05-08  
 **Last reconciled:** 2026-05-09  
@@ -109,3 +109,19 @@ These are the only questions worth carrying into a future planning or sanity-che
 | `.github/ISSUE_TEMPLATE/` | Existing GitHub issue-template folder for the future `mcp-server-surface-test-finding.yml`. |
 | `AGENTS.md` | Shipped-skill genericity and bootstrap rules. |
 | `CI_POLICY.md` | Validation and merge-gating policy. |
+
+## Verification
+
+End-to-end verification per `ai_docs/items/move-to-git-issues-end-to-end-verification.md` completed on **2026-05-10**.
+
+| Step | Mode | Result |
+|---|---|---|
+| 0. Seed labels | real, idempotent | 7 area + 3 severity labels confirmed at `darylmcd/Roslyn-Backed-MCP` |
+| 1. `/mcp-server-surface-test --quick` against `C:/Code-Repo/DotNet-Firewall-Analyzer` | end-to-end | Audit report at `audit-reports/20260510T050225Z_firewallanalyzer_mcp-server-surface-test.md`; no `backlog.d/` writes; no `gh` invocations; Phase 19 = `**N/A — no actionable findings**`; wall-clock ≈2 min (budget ≤15 min). |
+| 2. Synthesized consumer Issue via shared renderer | synthesized + real `gh issue create` | Filed [#598](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/598) `verify-end-to-end-quick-auto-file-probe`; labels `area:docs` + `severity:P3`; closed in Step 6. |
+| 3. `/mcp-server-surface-test --full` | **skipped** | Per `feedback_self_hosted_runner_no_duplicate_local_run.md` — runner contention. |
+| 4. Synthesized maintainer publish path | synthesized + real `gh issue create` + real fragment delete | Filed [#599](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/599) `verify-end-to-end-publish-probe`; sibling-repo fragment at `dotnet-firewall-analyzer/backlog.d/verify-end-to-end-publish-probe.md` consumed and deleted (directory removed); backlog row was added then reverted within the verification session (no commit on `main`); closed in Step 6. |
+| 5. Refusal contract | renderer-only, no `gh` | `Test-FindingShouldRefusePublicFile` and `Render-FindingIssue.refusedPublic` both returned `True` for `severity=P0` and for `area=security`; `DO NOT FILE PUBLICLY` banner matched in both rendered bodies. |
+| 6. Cleanup | real | Both Issues closed with `not planned` reason; synthetic backlog row reverted; sibling-repo `backlog.d/` empty. |
+
+Renderer parity verified directly by diffing the bodies of [#598](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/598) (consumer auto-file path) and [#599](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/599) (maintainer publish path) — identical envelope shape and field ordering, which is the load-bearing contract Row 2 was designed to enforce.


### PR DESCRIPTION
## Summary

- Flip `move-to-git-issues.md` status from `design seed` to `completed` — Rows 1-3 shipped (PRs #591/#592/#593), released as v1.35.1 (PR #595), and end-to-end verification passed 2026-05-10.
- Append a `## Verification` section recording which steps ran end-to-end vs were synthesized, plus the closed verification Issue URLs (#598 consumer auto-file path, #599 maintainer publish path) for the audit trail.

## Verification evidence

- Renderer parity between `/mcp-server-surface-test --auto-file` (consumer) and `/backlog-intake --publish` (maintainer) confirmed by diffing the bodies of #598 and #599 — identical envelope shape and field ordering.
- Refusal contract reverified: `Test-FindingShouldRefusePublicFile` and `Render-FindingIssue.refusedPublic` both returned `True` for `severity=P0` and for `area=security`; `DO NOT FILE PUBLICLY` banner present in both rendered bodies.
- `--quick` audit against `C:/Code-Repo/DotNet-Firewall-Analyzer` produced an audit report under that repo's `audit-reports/`, made no `backlog.d/` writes, made no `gh` invocations, and Phase 19 closed with `**N/A — no actionable findings**`.
- Step 3 (`--full`) was intentionally skipped per `feedback_self_hosted_runner_no_duplicate_local_run.md` to avoid contention with the self-hosted runner.

## Test plan

- [x] `gh issue view 598` and `gh issue view 599` show identical envelope shape and both Issues are closed (`not planned`).
- [x] `gh label list --search area:` returns 7; `--search severity:` returns 3.
- [x] `git status` in `C:/Code-Repo/DotNet-Firewall-Analyzer` shows the synthetic fragment is gone (`backlog.d/` directory removed).
- [x] `ai_docs/items/move-to-git-issues.md` status comment now reads `completed`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)