### PR TITLE
Streamline audit-report pipeline + maintainer auto-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -502,3 +502,12 @@ $RECYCLE.BIN/
 
 # Release-managed edit override sentinel (created by /bump, /release-cut, /ship; transient)
 .release-managed-edit-allowed
+
+# Per-run audit output from /mcp-server-surface-test (prose reports + scorecards).
+# Findings consolidate via eng/process-audit-reports.ps1 -> review-inbox/ -> /backlog-intake.
+audit-reports/
+
+# Flat staging directory for /backlog-intake. Prose reports stage here from sibling
+# repos and get archived into review-inbox/archive/<batch-id>/ after intake. The flat
+# files are transient; the archive (with citation paths from backlog rows) is tracked.
+review-inbox/*.md

--- a/eng/aggregate-promotion-scorecards.ps1
+++ b/eng/aggregate-promotion-scorecards.ps1
@@ -26,7 +26,11 @@
     init 5 of the same backlog sweep established): walk every immediate
     subdirectory under `$SiblingRepoParent` (defaults to the parent of this
     repo), skip the running repo itself unless `-IncludeSelf`, and probe
-    each candidate's `ai_docs/audit-reports/_latest-promotion-scorecard.json`.
+    each candidate for `_latest-promotion-scorecard.json` under any of the
+    paths in `$ScorecardSearchPaths`. Defaults cover both the canonical
+    `ai_docs/audit-reports/` location (deep-review pipeline convention) and
+    the top-level `audit-reports/` location used by the consumer-facing
+    `/mcp-server-surface-test` skill. First match wins per repo.
 
     Missing scorecards are NOT errors. The aggregator simply notes
     `missingFromRepos`. Empty configured sibling sets emit a clean
@@ -76,9 +80,11 @@
     pattern means scorecards land under each *audited* repo, and this repo
     typically only audits siblings.
 
-.PARAMETER ScorecardRelativePath
-    Per-repo path to the scorecard. Defaults to
-    `ai_docs/audit-reports/_latest-promotion-scorecard.json`.
+.PARAMETER ScorecardSearchPaths
+    Per-repo relative paths to probe for `_latest-promotion-scorecard.json`.
+    First match wins per repo. Defaults cover both the canonical
+    `ai_docs/audit-reports/` (deep-review pipeline) and top-level
+    `audit-reports/` (consumer-facing /mcp-server-surface-test skill).
 
 .PARAMETER OutputFile
     Optional file path. When set, the JSON is written to this path in addition
@@ -101,7 +107,10 @@ param(
     [string]$SiblingRepoParent = '',
     [string[]]$ExcludeRepoFolders = @(),
     [switch]$IncludeSelf,
-    [string]$ScorecardRelativePath = 'ai_docs/audit-reports/_latest-promotion-scorecard.json',
+    [string[]]$ScorecardSearchPaths = @(
+        'ai_docs/audit-reports/_latest-promotion-scorecard.json',
+        'audit-reports/_latest-promotion-scorecard.json'
+    ),
     [string]$OutputFile = ''
 )
 
@@ -141,8 +150,17 @@ $entries = @{}
 
 foreach ($root in $roots) {
     $siblingReposScanned.Add($root.Name) | Out-Null
-    $scorecardPath = Join-Path $root.Path $ScorecardRelativePath
-    if (-not (Test-Path -LiteralPath $scorecardPath)) {
+
+    # Probe each candidate path; first existing scorecard wins. Mirrors
+    # stage-review-inbox's defensive multi-path discovery so consumer-facing
+    # repos that write to top-level `audit-reports/` are included alongside
+    # deep-review repos using `ai_docs/audit-reports/`.
+    $scorecardPath = $null
+    foreach ($candidate in $ScorecardSearchPaths) {
+        $probe = Join-Path $root.Path $candidate
+        if (Test-Path -LiteralPath $probe) { $scorecardPath = $probe; break }
+    }
+    if ($null -eq $scorecardPath) {
         $siblingReposMissingScorecard.Add($root.Name) | Out-Null
         continue
     }

--- a/eng/process-audit-reports.ps1
+++ b/eng/process-audit-reports.ps1
@@ -1,0 +1,137 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    One-file end-to-end workflow for processing audit reports across this repo + sibling repos.
+
+.DESCRIPTION
+    Wraps the two existing maintenance scripts into a single invocation so the
+    full audit-report consolidation pipeline runs from one command:
+
+      1. eng/stage-review-inbox.ps1
+         Discovers `*_mcp-server-audit.md`, `*_mcp-server-surface-test.md`,
+         `*_experimental-promotion.md`, and `*_roslyn-mcp-retro.md` under
+         either `audit-reports/` or `ai_docs/audit-reports/` across this
+         repo and every sibling under the parent folder. Self -> COPY,
+         siblings -> MOVE (defaults). Reports land in `review-inbox/`.
+
+      2. eng/aggregate-promotion-scorecards.ps1
+         Probes both `ai_docs/audit-reports/` and top-level `audit-reports/`
+         for `_latest-promotion-scorecard.json` per repo, applies the quorum
+         rule, writes the consolidated JSON to `audit-reports/_aggregated-promotion-scorecard.json`.
+
+      3. Prints the next step — invoke `/backlog-intake` (or `/backlog-intake --publish`)
+         to triage `review-inbox/` into `ai_docs/backlog.md` rows and (optionally)
+         file Issues via the shared renderer. The intake skill archives processed
+         files into `review-inbox/archive/<batch-id>/` automatically.
+
+    No fully-automated /backlog-intake step exists because /backlog-intake is a
+    Claude Code skill (judgment work) rather than a CLI script (mechanical work).
+    This wrapper handles every mechanical phase and leaves the judgment phase
+    for the operator to invoke explicitly.
+
+.PARAMETER DryRun
+    Pass-through: forwards -DryRun to stage-review-inbox.ps1 (aggregate is read-only
+    and always safe to run).
+
+.PARAMETER CopyFromSiblings
+    Pass-through: forwards -CopyFromSiblings to stage-review-inbox.ps1. Use when
+    sibling audits are still mid-flight and you want a snapshot without disturbing
+    the source repos.
+
+.PARAMETER SkipAggregate
+    Skip the aggregate-promotion-scorecards step (e.g., when only staging is wanted).
+
+.PARAMETER SkipStage
+    Skip the stage-review-inbox step (e.g., when reports are already in review-inbox/
+    and only the scorecard rollup is needed).
+
+.PARAMETER SiblingRepoParent
+    Forwarded to both child scripts. Defaults to the parent of this repo.
+
+.EXAMPLE
+    pwsh ./eng/process-audit-reports.ps1
+
+    Run the full pipeline: stage (move-from-siblings + copy-from-self), aggregate,
+    print next step.
+
+.EXAMPLE
+    pwsh ./eng/process-audit-reports.ps1 -DryRun
+
+    Show what would be staged without copying / moving anything. Aggregate still
+    runs (read-only).
+#>
+[CmdletBinding()]
+param(
+    [string]$SiblingRepoParent = '',
+    [switch]$DryRun,
+    [switch]$CopyFromSiblings,
+    [switch]$SkipAggregate,
+    [switch]$SkipStage
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot   = Split-Path -Parent $PSScriptRoot
+$stageScript    = Join-Path $PSScriptRoot 'stage-review-inbox.ps1'
+$aggregateScript = Join-Path $PSScriptRoot 'aggregate-promotion-scorecards.ps1'
+
+if (-not (Test-Path -LiteralPath $stageScript))     { throw "Missing dependency: $stageScript" }
+if (-not (Test-Path -LiteralPath $aggregateScript)) { throw "Missing dependency: $aggregateScript" }
+
+# ---------- Step 1: stage ----------
+if (-not $SkipStage) {
+    Write-Host "=== Step 1/3: stage-review-inbox ===" -ForegroundColor Cyan
+    $stageArgs = @{}
+    if ($DryRun)            { $stageArgs['DryRun'] = $true }
+    if ($CopyFromSiblings)  { $stageArgs['CopyFromSiblings'] = $true }
+    if ($SiblingRepoParent) { $stageArgs['SiblingRepoParent'] = $SiblingRepoParent }
+    & $stageScript @stageArgs
+    Write-Host ""
+} else {
+    Write-Host "=== Step 1/3: stage-review-inbox SKIPPED (-SkipStage) ===" -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+# ---------- Step 2: aggregate ----------
+if (-not $SkipAggregate) {
+    Write-Host "=== Step 2/3: aggregate-promotion-scorecards ===" -ForegroundColor Cyan
+    $aggregatedDir = Join-Path $repoRoot 'audit-reports'
+    if (-not (Test-Path -LiteralPath $aggregatedDir)) {
+        if ($DryRun) {
+            Write-Host "[DryRun] Would create $aggregatedDir"
+        } else {
+            New-Item -ItemType Directory -Path $aggregatedDir | Out-Null
+        }
+    }
+    $aggregatedFile = Join-Path $aggregatedDir '_aggregated-promotion-scorecard.json'
+
+    $aggregateArgs = @{}
+    if ($SiblingRepoParent) { $aggregateArgs['SiblingRepoParent'] = $SiblingRepoParent }
+    if (-not $DryRun)       { $aggregateArgs['OutputFile'] = $aggregatedFile }
+
+    $json = & $aggregateScript @aggregateArgs
+    $parsed = $json | ConvertFrom-Json
+    $summary = $parsed.summary
+    $with    = $parsed.siblingReposWithScorecard.Count
+    $missing = $parsed.siblingReposMissingScorecard.Count
+
+    Write-Host "  Sibling scorecards found: $with (missing: $missing)"
+    Write-Host "  Verdict counts: promoteReady=$($summary.promoteReady) promoteBlocked=$($summary.promoteBlocked) needsMoreEvidence=$($summary.needsMoreEvidence)"
+    if (-not $DryRun) {
+        Write-Host "  Wrote: $aggregatedFile" -ForegroundColor Green
+    }
+    Write-Host ""
+} else {
+    Write-Host "=== Step 2/3: aggregate-promotion-scorecards SKIPPED (-SkipAggregate) ===" -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+# ---------- Step 3: next-step pointer ----------
+Write-Host "=== Step 3/3: invoke /backlog-intake ===" -ForegroundColor Cyan
+Write-Host "  In Claude Code, run:"
+Write-Host "    /backlog-intake             # extract -> backlog.md rows; archives processed files"
+Write-Host "    /backlog-intake --publish   # also files Issues via the shared renderer"
+Write-Host ""
+Write-Host "  /backlog-intake archives consumed reports into review-inbox/archive/<batch-id>/"
+Write-Host "  automatically — no manual cleanup needed."

--- a/eng/stage-review-inbox.ps1
+++ b/eng/stage-review-inbox.ps1
@@ -9,14 +9,24 @@
     already carry a repo-id prefix (e.g. 20260424T030145Z_roslyn-backed-mcp_roslyn-mcp-retro.md)
     so no renaming is needed.
 
-    The default behavior is COPY (not move) so the canonical
-    <repo>/ai_docs/audit-reports/<ts>_<repo>_mcp-server-audit.md path stays
-    populated as the audit prompt promises. Pass -Move to revert to the older
-    move-to-inbox behavior (typically only useful when re-running on the same
-    artifacts and you want the source removed).
+    Default behavior is **per-source**:
+      - Sibling repos: MOVE (delete after staging). Sibling repos shouldn't
+        accumulate stale audit reports — once handed off to the upstream
+        review-inbox, the source is no longer the canonical copy.
+      - This repo (self): COPY (preserve in place). The canonical
+        <repo>/ai_docs/audit-reports/ path stays populated as the audit
+        prompt promises.
+
+    Overrides:
+      -Move                    Force MOVE for both self and siblings (legacy
+                               behavior). Useful for full-cleanup re-runs.
+      -CopyFromSiblings        Force COPY from siblings too. Useful when an
+                               audit pass is mid-flight and you want to stage
+                               without disturbing the source repos yet.
 
     Recognized shapes:
       *_mcp-server-audit.md         Server audit from the deep-review prompt
+      *_mcp-server-surface-test.md  Consumer-facing audit from /mcp-server-surface-test
       *_experimental-promotion.md   Experimental tool/prompt promotion audit
       *_roslyn-mcp-retro.md         Session retro on Roslyn-MCP tool quality
       backlog.d/<finding-id>.md     Per-finding fragments emitted by /mcp-server-stress
@@ -54,9 +64,13 @@
     Show what would be staged without moving files.
 
 .PARAMETER Move
-    Move instead of copy (the default). Removes the source file after staging.
-    Use only when you explicitly want the canonical
-    <repo>/ai_docs/audit-reports/ location cleared — typically a re-run scenario.
+    Force MOVE from both self AND siblings (legacy behavior). Without this
+    flag, the per-source default is move-from-siblings, copy-from-self.
+
+.PARAMETER CopyFromSiblings
+    Force COPY from siblings (override the move-from-siblings default).
+    Useful when sibling audits are mid-flight and you want to stage a
+    snapshot without disturbing the source repos.
 
 .PARAMETER SkipSelf
     Do not scan this repo's own ai_docs/audit-reports or ai_docs/reports
@@ -95,6 +109,7 @@ param(
     ),
     [switch]$DryRun,
     [switch]$Move,
+    [switch]$CopyFromSiblings,
     [switch]$SkipSelf
 )
 
@@ -109,7 +124,12 @@ if (-not $SiblingRepoParent) {
     $SiblingRepoParent = Split-Path -Parent $repoRoot
 }
 
-$filePatterns = @('*_mcp-server-audit.md', '*_experimental-promotion.md', '*_roslyn-mcp-retro.md')
+$filePatterns = @(
+    '*_mcp-server-audit.md',
+    '*_mcp-server-surface-test.md',
+    '*_experimental-promotion.md',
+    '*_roslyn-mcp-retro.md'
+)
 
 # Fragment-discovery contract: any .md under <repo-root>/backlog.d/ whose
 # YAML frontmatter contains a `severity:` key. Audit-report .md files NEVER
@@ -130,14 +150,16 @@ function Test-IsBacklogFragment {
     return $false
 }
 
-$roots = New-Object System.Collections.Generic.List[string]
-if (-not $SkipSelf) { $roots.Add($repoRoot) | Out-Null }
+$roots = New-Object System.Collections.Generic.List[pscustomobject]
+if (-not $SkipSelf) {
+    $roots.Add([pscustomobject]@{ Path = $repoRoot; IsSibling = $false }) | Out-Null
+}
 
 if (Test-Path $SiblingRepoParent) {
     $excludeSet = @{ $repoName = $true }
     foreach ($x in $ExcludeRepoFolders) { $excludeSet[$x] = $true }
     Get-ChildItem -Path $SiblingRepoParent -Directory | Where-Object { -not $excludeSet.ContainsKey($_.Name) } | ForEach-Object {
-        $roots.Add($_.FullName) | Out-Null
+        $roots.Add([pscustomobject]@{ Path = $_.FullName; IsSibling = $true }) | Out-Null
     }
 }
 
@@ -146,8 +168,19 @@ $skipped = New-Object System.Collections.Generic.List[pscustomobject]
 $fragments = New-Object System.Collections.Generic.List[pscustomobject]
 
 foreach ($root in $roots) {
+    # Per-source action: legacy -Move forces move everywhere; otherwise siblings move
+    # (unless -CopyFromSiblings opts out), self always copies. Self-move would clear the
+    # canonical audit-reports/ source — only -Move asks for that explicitly.
+    if ($Move) {
+        $action = 'Move'
+    } elseif ($root.IsSibling -and -not $CopyFromSiblings) {
+        $action = 'Move'
+    } else {
+        $action = 'Copy'
+    }
+
     foreach ($rel in $SearchPaths) {
-        $dir = Join-Path $root $rel
+        $dir = Join-Path $root.Path $rel
         if (-not (Test-Path $dir)) { continue }
         foreach ($pat in $filePatterns) {
             Get-ChildItem -Path $dir -Filter $pat -File -ErrorAction SilentlyContinue | ForEach-Object {
@@ -155,7 +188,7 @@ foreach ($root in $roots) {
                 if (Test-Path $dest) {
                     $skipped.Add([pscustomobject]@{ Source = $_.FullName; Reason = 'already in review-inbox' })
                 } else {
-                    $staged.Add([pscustomobject]@{ Source = $_.FullName; Dest = $dest })
+                    $staged.Add([pscustomobject]@{ Source = $_.FullName; Dest = $dest; Action = $action })
                 }
             }
         }
@@ -164,11 +197,11 @@ foreach ($root in $roots) {
     # Fragment discovery — backlog.d/*.md per <root>. Reported only; not moved.
     # /backlog-intake reads them in place from the source repo and deletes after
     # consumption. Disambiguation pins on `severity:` frontmatter key.
-    $fragmentDir = Join-Path $root 'backlog.d'
+    $fragmentDir = Join-Path $root.Path 'backlog.d'
     if (Test-Path $fragmentDir) {
         Get-ChildItem -Path $fragmentDir -Filter '*.md' -File -ErrorAction SilentlyContinue | ForEach-Object {
             if (Test-IsBacklogFragment -Path $_.FullName) {
-                $fragments.Add([pscustomobject]@{ Source = $_.FullName; Repo = (Split-Path -Leaf $root) })
+                $fragments.Add([pscustomobject]@{ Source = $_.FullName; Repo = (Split-Path -Leaf $root.Path) })
             }
         }
     }
@@ -187,21 +220,22 @@ if ($staged.Count -gt 0 -and -not (Test-Path $inbox)) {
     }
 }
 
-$verb = if ($Move) { 'Move' } else { 'Copy' }
 if ($staged.Count -gt 0) {
-    Write-Host "Staging $($staged.Count) artifact(s) -> $inbox ($verb)" -ForegroundColor Cyan
+    $copyCount = ($staged | Where-Object { $_.Action -eq 'Copy' }).Count
+    $moveCount = ($staged | Where-Object { $_.Action -eq 'Move' }).Count
+    Write-Host "Staging $($staged.Count) artifact(s) -> $inbox (Copy: $copyCount, Move: $moveCount)" -ForegroundColor Cyan
 
     foreach ($item in $staged) {
         if ($DryRun) {
-            Write-Host "  [DryRun] $verb $($item.Source) -> $($item.Dest)"
+            Write-Host "  [DryRun] $($item.Action) $($item.Source) -> $($item.Dest)"
             continue
         }
-        if ($Move) {
+        if ($item.Action -eq 'Move') {
             Move-Item -LiteralPath $item.Source -Destination $item.Dest
         } else {
             Copy-Item -LiteralPath $item.Source -Destination $item.Dest
         }
-        Write-Host "  $verb $(Split-Path -Leaf $item.Source)"
+        Write-Host "  $($item.Action) $(Split-Path -Leaf $item.Source)"
     }
 }
 

--- a/skills/mcp-server-surface-test/SKILL.md
+++ b/skills/mcp-server-surface-test/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mcp-server-surface-test
-description: "Consumer-facing audit of the Roslyn MCP server's live surface against a loaded C# repo. Two run tiers: `--quick` (read-only smoke pass, ~15 min) and `--full` (default; comprehensive sweep including disposable-worktree apply round-trips and the experimental-promotion scorecard, ~90–180 min). Findings print to stdout by default; pass `--auto-file` to file each finding as a GitHub Issue at https://github.com/darylmcd/Roslyn-Backed-MCP. Requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts if the server is not callable rather than running a non-MCP fallback. Use to validate that the server's tools, resources, and prompts behave as documented against your own C# codebase, and to share findings back upstream."
+description: "Consumer-facing audit of the Roslyn MCP server's live surface against a loaded C# repo. Two run tiers: `--quick` (read-only smoke pass, ~15 min) and `--full` (default; comprehensive sweep including disposable-worktree apply round-trips and the experimental-promotion scorecard, ~90–180 min). Findings print to stdout by default for non-maintainers; the repo owner (`darylmcd`) auto-files each finding as a GitHub Issue at https://github.com/darylmcd/Roslyn-Backed-MCP. Pass `--auto-file` to force-enable or `--no-auto-file` to force-disable. Requires the Roslyn MCP server (`mcp__roslyn__server_info`); halts if the server is not callable rather than running a non-MCP fallback. Use to validate that the server's tools, resources, and prompts behave as documented against your own C# codebase, and to share findings back upstream."
 user-invocable: true
-argument-hint: "[<target-repo-path>] [--quick | --full] [--auto-file] [--no-worktree]"
+argument-hint: "[<target-repo-path>] [--quick | --full] [--auto-file | --no-auto-file] [--no-worktree] [--single-agent]"
 ---
 
 # /mcp-server-surface-test $ARGUMENTS
@@ -45,22 +45,41 @@ Resolution rules:
 - `--full` — explicit form of the default; routes to `prompts/full.md`.
 - **Conflict:** `--quick` and `--full` together → stop and report; pick one.
 
+### `--single-agent` (full tier only)
+
+- *(no flag, default)* — the full tier dispatches phase groups to `audit-phase-runner` subagents per the prompt's *Phase 0.5: Subagent dispatch plan*. The orchestrator owns workspace lifecycle, the disposable worktree's `try/finally`, all report-file writes, and finding emission; subagents return compact structured summaries the orchestrator pastes in. This is the only way the `--full` tier achieves its 250+ tool-call coverage without burning through a single agent's context window.
+- `--single-agent` — opt out of the dispatch plan and run every phase in the orchestrator's own context. Use only when (a) the host environment cannot spawn subagents, or (b) the operator wants a one-shot run and accepts that long phases may surface as `phase-failed-budget` in the coverage summary. The completion gate (no silent `skipped-budget` truncation) still applies — partial runs surface as P1 audit defects, not as quiet ledger entries.
+- **Has no effect under `--quick`** (the quick tier is bounded enough to run in a single agent by design); reject the combination with a one-line message.
+
 ### `--no-worktree` (full tier only)
 
 - *(no flag, default)* — full canonical run with the disposable-worktree apply pass exercised.
 - `--no-worktree` — degraded mode for environments that genuinely cannot create a git worktree. Phase 6 sub-phases that require a worktree are marked `skipped-safety — --no-worktree`. The promotion scorecard still emits, but writer recommendations default to `needs-more-evidence` for any tool whose round-trip evidence depended on the disposable worktree. **Has no effect under `--quick`** (the quick tier already skips Phase 6); reject the combination with a one-line message.
 
-### `--auto-file` (both tiers)
+### `--auto-file` / `--no-auto-file` (both tiers)
 
-- *(no flag, default)* — actionable findings render to stdout as ready-to-paste GitHub Issue bodies. The skill prints the Issue title, labels, and body; the operator decides what to do with each.
-- `--auto-file` — opt-in. After the audit completes and findings are rendered, the skill calls `gh issue create` against `https://github.com/darylmcd/Roslyn-Backed-MCP` for each actionable finding. Requirements:
-  - `gh` is on `PATH`. If missing, fall back to stdout-print and emit one warning line.
-  - `gh auth status` reports an authenticated session. If not, fall back to stdout-print and emit one warning line.
-  - **Refusal contract:** the skill does **not** call `gh issue create` for any finding whose `severity == P0` or whose `area == security`. Such findings print to stdout with this header line: `**SECURITY / P0 finding — DO NOT FILE PUBLICLY.** Escalate via GitHub security advisories at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new`. The refusal applies regardless of `--auto-file` and is the load-bearing pre-disclosure safeguard.
+The auto-file default is **maintainer-aware**: the skill probes the operator's GitHub identity and auto-files when the operator owns the upstream repo. Findings always go to `https://github.com/darylmcd/Roslyn-Backed-MCP` regardless of the audited repo, since findings are about the MCP server itself and the audited repo is just a fixture.
+
+**Maintainer detection (run once per invocation, before Phase 19):**
+
+Dot-source `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/lib/render-finding.ps1` and call `Test-IsMaintainer`. It wraps `gh api user --jq .login` and compares against the maintainer login derived from the single `$script:UpstreamRepo` constant — that one literal in `lib/render-finding.ps1` is the source of truth for "who is the maintainer" and "where do auto-filed Issues land." Any failure mode (`gh` missing, unauthenticated, network failure, login mismatch) returns `$false` and is treated as **not the maintainer**.
+
+**Default (no flag):**
+
+- **Maintainer detected** (`gh api user --jq .login` == `darylmcd`): auto-file each non-refused finding via `gh issue create` (same call as the explicit `--auto-file` path).
+- **Otherwise**: print each finding to stdout as a ready-to-paste GitHub Issue body. The operator decides what to do with each.
+
+**Explicit overrides:**
+
+- `--auto-file` — force-enable auto-filing regardless of detected identity. Still subject to the `gh`-available + authenticated requirement (falls back to stdout-print with one warning line if either is missing); still subject to the P0/security refusal contract below.
+- `--no-auto-file` — force-disable auto-filing. Always emit to stdout, even when the maintainer is detected. Use this for a dry-run on the maintainer's own machine.
+- **Conflict:** `--auto-file` and `--no-auto-file` together → stop and report; pick one.
+
+**Refusal contract — load-bearing pre-disclosure safeguard:** the skill does **not** call `gh issue create` for any finding whose `severity == P0` or whose `area == security`. Such findings print to stdout with this header line: `**SECURITY / P0 finding — DO NOT FILE PUBLICLY.** Escalate via GitHub security advisories at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new`. The refusal applies regardless of detected identity, `--auto-file`, or `--no-auto-file`.
 
 ### Reject
 
-Reject any token that is neither a valid target path, `--target=<path>`, `--quick`, `--full`, `--no-worktree`, nor `--auto-file`. One-line message; ask the user to fix or drop the offending token.
+Reject any token that is neither a valid target path, `--target=<path>`, `--quick`, `--full`, `--no-worktree`, `--single-agent`, `--auto-file`, nor `--no-auto-file`. One-line message; ask the user to fix or drop the offending token.
 
 ## Step 3 — Mutation safety: disposable worktree (full tier, default mode)
 
@@ -84,8 +103,8 @@ Persist the audit draft after each phase as the prompt instructs — the canonic
 
 After the audit phases complete, the prompt's final finding-emission phase walks every actionable finding (entries in *MCP server issues* or *Improvement suggestions* with a concrete fix sketch) and renders each through one shared envelope:
 
-- **Default (no `--auto-file`):** print each finding to stdout as a ready-to-paste GitHub Issue body. The render block is `## TITLE`, label list, and the structured body fields (`id`, `source-repo`, `severity`, `area`, `server-version`, `anchors`, `finding`, `repro`, `proposed-fix`).
-- **With `--auto-file`:** call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <title> --label <area:X,severity:Y> --body-file <tempfile>` per finding, except those refused by the P0/security refusal contract (Step 2). Refused findings still print to stdout with the security-advisory escalation banner.
+- **Stdout-print path** (non-maintainer default, or when `--no-auto-file` is passed): print each finding to stdout as a ready-to-paste GitHub Issue body. The render block is `## TITLE`, label list, and the structured body fields (`id`, `source-repo`, `severity`, `area`, `server-version`, `anchors`, `finding`, `repro`, `proposed-fix`).
+- **Auto-file path** (maintainer default — `gh api user --jq .login` == `darylmcd` — or when `--auto-file` is passed): call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <title> --label <area:X,severity:Y> --body-file <tempfile>` per finding, except those refused by the P0/security refusal contract (Step 2). Refused findings still print to stdout with the security-advisory escalation banner.
 
 ## Operational notes
 
@@ -119,4 +138,4 @@ The script is invoked manually (no automatic scheduler).
 - **No PR.** This skill produces an audit report, not a refactor PR. Phase 6 mutations are exercised as apply-tool fixtures inside the disposable worktree and torn down at run end.
 - **Cite, don't summarize.** Every finding must reference a concrete file:line and a tool call — no abstract claims.
 - **Disposable-worktree teardown is mandatory** (full tier, default mode). The Phase 6 apply chain runs inside `try/finally` so teardown executes even on apply failure. `dotnet build-server shutdown` always precedes `git worktree remove --force` on Windows.
-- **P0 / security findings are never auto-filed.** The refusal applies whether the operator passed `--auto-file` or not — those findings are stdout-only with the security-advisory escalation banner.
+- **P0 / security findings are never auto-filed.** The refusal applies whether the operator is the detected maintainer, passed `--auto-file`, or passed `--no-auto-file` — those findings are stdout-only with the security-advisory escalation banner.

--- a/skills/mcp-server-surface-test/lib/render-finding.ps1
+++ b/skills/mcp-server-surface-test/lib/render-finding.ps1
@@ -53,6 +53,53 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
+# ---------- Constants (single source of truth) ----------
+#
+# `$script:UpstreamRepo` is the only place the upstream repo name is hardcoded inside the
+# executable surface of this skill. The maintainer login is derived from it. If the repo is
+# renamed or transferred, update this one literal — every probe, refusal banner, and
+# `gh issue create --repo` call sourced through this lib follows.
+#
+# Documentation files (SKILL.md, prompts/*.md, README.md) carry their own literal copies
+# of the string for readability; those need a separate doc-edit pass on rename, but the
+# load-bearing routing logic stays correct from this constant alone.
+
+$script:UpstreamRepo     = 'darylmcd/Roslyn-Backed-MCP'
+$script:MaintainerLogin  = ($script:UpstreamRepo -split '/', 2)[0]
+$script:SecurityAdvisoryUrl = "https://github.com/$($script:UpstreamRepo)/security/advisories/new"
+
+function Get-UpstreamRepo     { return $script:UpstreamRepo }
+function Get-MaintainerLogin  { return $script:MaintainerLogin }
+
+function Test-IsMaintainer {
+    <#
+    .SYNOPSIS
+        Probe the operator's GitHub identity and return $true when it matches the upstream
+        repo owner. Used by Phase 19 routing to decide whether to auto-file by default.
+    .DESCRIPTION
+        Runs `gh api user --jq .login`. Treats any of {gh missing, gh unauthenticated,
+        network failure, login mismatch} as **not maintainer** — the safe default. Never
+        throws; the worst outcome is `$false`.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    $gh = Get-Command -Name 'gh' -ErrorAction SilentlyContinue
+    if ($null -eq $gh) { return $false }
+
+    try {
+        $login = (& gh api user --jq .login 2>$null) | Select-Object -First 1
+    }
+    catch {
+        return $false
+    }
+    if ($LASTEXITCODE -ne 0) { return $false }
+    if ([string]::IsNullOrWhiteSpace($login)) { return $false }
+
+    return ($login.Trim() -eq $script:MaintainerLogin)
+}
+
 # ---------- Internal helpers ----------
 
 function Get-FindingFieldString {
@@ -251,7 +298,7 @@ function Render-FindingIssue {
         # the caller MUST also short-circuit before invoking `gh issue create`.
         $bodyHeader = @(
             '**SECURITY / P0 finding — DO NOT FILE PUBLICLY.**',
-            'Escalate via GitHub security advisories: https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new',
+            "Escalate via GitHub security advisories: $($script:SecurityAdvisoryUrl)",
             ''
         ) -join [Environment]::NewLine
     }

--- a/skills/mcp-server-surface-test/prompts/full.md
+++ b/skills/mcp-server-surface-test/prompts/full.md
@@ -117,6 +117,49 @@ This prompt is a contract with the Roslyn MCP server. Without it, nothing below 
 
 ---
 
+### Phase 0.5: Subagent dispatch plan (MANDATORY for `--full`, skip when `--single-agent`)
+
+The full tier exercises 250+ MCP tool calls across 19 phases. A single agent that tries to run them all in one context will burn through its window long before Phase 19 and silently truncate to a "representative probe" — that is a contract violation of the `--full` tier, not a feature. The fix is structural: the **orchestrator owns coordination** (workspace lifecycle, worktree lifecycle, report writes, finding emission) and **dispatches phase groups to `audit-phase-runner` subagents** that each return a compact structured summary the orchestrator pastes into the report.
+
+**Orchestrator-owned phases (never dispatched):**
+
+- Phase -1, 0 — already complete by the time you reach this section.
+- Phase 6 **setup** (`git worktree add`, branch creation) and **teardown** (`dotnet build-server shutdown` → `git worktree remove --force`). The `try/finally` discipline must be owned by a single, surviving caller — a crashed subagent cannot leak the worktree.
+- Phase 18 — depends on synthesizing prior phase outputs.
+- Phase 19 — finding emission (routing decision via `Test-IsMaintainer`, `gh issue create` calls).
+- All writes to `audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md` and `_latest-promotion-scorecard.json`. Subagents return structured summaries; the orchestrator alone touches the files (no concurrent-writer hazard).
+
+**Subagent dispatch groups (run via `audit-phase-runner`, parallel where independent):**
+
+Group all dispatches in a single message with multiple `Agent` tool-use blocks where the listed groups are independent. Phases inside a group are run by the same subagent in sequence so they can share intermediate analysis (e.g., the diagnostic IDs Phase 1 surfaces feed the metric thresholds in Phase 2).
+
+| Group | Phases | Parallel-safe with | Notes |
+|---|---|---|---|
+| **G1** | 1, 2 | G2, G3, G5 | diagnostics + metrics — read-only, workspace-scoped, no shared state with other groups |
+| **G2** | 3, 4 | G1, G3, G5 | symbol + flow analysis on selected types/methods |
+| **G3** | 5, 9 (Phase 9 if Phase 10 already complete) | G1, G2, G5 | snippet/script + undo verification |
+| **G4** | 6 sub-phases (after orchestrator creates worktree) | — | runs serially against the disposable worktree; orchestrator passes the worktree path; subagent must NOT call `git worktree remove` |
+| **G5** | 7, 8, 8b | G1, G2, G3 | configuration + build/test + concurrency stress; the heaviest group, give it the biggest context budget |
+| **G6** | 10, 11, 12 | G7 | file/cross-project ops + semantic search + scaffolding |
+| **G7** | 13, 14 | G6 | project mutation + navigation/completions |
+| **G8** | 15, 16, 17 | — | resources + prompts + negative testing; run after G6/G7 so the coverage ledger is mostly populated |
+
+**Dispatch contract per group:**
+
+Each subagent prompt must include: (a) the workspace `workspaceId` (already loaded — subagents reuse the orchestrator's MCP session, no `workspace_load` needed), (b) the audit report path (read-only — for context only, do not write), (c) the disposable worktree path when relevant (G4 only), (d) the explicit phase numbers + the relevant prompt section excerpt, (e) "return a compact structured summary in <RESULT> envelope" instruction. The orchestrator pastes each returned summary into the report under the matching phase heading.
+
+**Completion gate (load-bearing — replaces the soft `skipped-budget` fallback):**
+
+Any subagent that returns `skipped-budget`, `skipped-context`, `truncated`, or any equivalent self-imposed-limit marker for a phase is a **hard FAIL** of the `--full` contract. The orchestrator must either (a) re-dispatch that phase to a fresh subagent with a smaller scope, or (b) record `phase-failed-budget` in the coverage ledger and surface it in the report's *Coverage summary* as a P1 audit defect. Silent truncation labeled as "representative probe" is no longer an acceptable outcome — `--full` means full or it means honest failure with a named cause.
+
+**Escape hatch — `--single-agent`:**
+
+When the SKILL receives `--single-agent`, skip this dispatch plan and run all phases in the orchestrator's own context. The operator has accepted the truncation tradeoff explicitly. The completion gate above still applies — `skipped-budget` markers must surface as P1 audit defects in the coverage summary, not get buried in the ledger.
+
+**MCP audit checkpoint:** Has the orchestrator decided which groups it will dispatch (default) or recorded `--single-agent` in the report header? Are subagent prompts ready to send with the workspaceId, report path, and per-group phase scopes?
+
+---
+
 ### Phase 1: Broad diagnostics scan
 
 1. `project_diagnostics` (no filters) for the solution-wide picture.
@@ -597,9 +640,17 @@ Re-test 3–5 previously recorded issues from whichever prior source the audited
 1. Read the prior source; select 3–5 items reproducible with the current workspace.
 2. For each, reproduce the exact scenario. Record **still reproduces** / **partially fixed** (describe) / **no longer reproduces — candidate for closure**.
 
-### Phase 19: Finding emission (dual-path: stdout default, opt-in `gh issue create`)
+### Phase 19: Finding emission (dual-path: maintainer-aware default, explicit overrides)
 
-For each **actionable** finding in the audit report (anything that lands in section 13 *MCP server issues* or in section 14 *Improvement suggestions* with a concrete fix sketch), render one finding envelope and emit it to **one of two destinations** depending on the `--auto-file` flag passed to the skill:
+For each **actionable** finding in the audit report (anything that lands in section 13 *MCP server issues* or in section 14 *Improvement suggestions* with a concrete fix sketch), render one finding envelope and emit it to **one of two destinations**.
+
+**Routing decision (compute once, before iterating findings):**
+
+1. If the skill received `--no-auto-file`, route = **stdout-print**.
+2. Else if the skill received `--auto-file`, route = **auto-file** (subject to `gh` available + authenticated; otherwise fall back to stdout-print with one warning line).
+3. Else probe the operator's identity by dot-sourcing the renderer and calling `Test-IsMaintainer` (which wraps `gh api user --jq .login` and compares against the upstream repo owner derived from the single `$script:UpstreamRepo` constant in `lib/render-finding.ps1`). `$true` → route = **auto-file**. `$false` (gh missing, unauthenticated, network failure, login mismatch) → route = **stdout-print**.
+
+Record the routing decision and the maintainer-probe outcome in the audit report's *Finding emission* section before emitting.
 
 **Envelope (shared across both destinations):**
 
@@ -627,7 +678,7 @@ pwsh -NoProfile -Command ". '${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-tes
 
 Returns `{title, labels, body, refusedPublic}`. Use `body` for stdout-print and `gh issue create --body-file`; respect `refusedPublic` for the P0/security refusal contract below.
 
-**Default (no `--auto-file`):** print each finding envelope to stdout as a ready-to-paste GitHub Issue body. Format (rendered by `Render-FindingIssue`):
+**Stdout-print path** (non-maintainer default, or `--no-auto-file` explicit): print each finding envelope to stdout as a ready-to-paste GitHub Issue body. Format (rendered by `Render-FindingIssue`):
 
 ```
 ## TITLE: <id>
@@ -646,7 +697,7 @@ Body:
 - proposed-fix: <proposed-fix>
 ```
 
-**With `--auto-file`** (and only when `gh` is on `PATH` and `gh auth status` is authenticated): for each non-refused finding, write the body block to a temp file and call:
+**Auto-file path** (maintainer default — `gh api user --jq .login` == `darylmcd` — or `--auto-file` explicit; in both cases `gh` must be on `PATH` and `gh auth status` must be authenticated): for each non-refused finding, write the body block to a temp file and call:
 
 ```
 gh issue create --repo darylmcd/Roslyn-Backed-MCP \
@@ -659,14 +710,14 @@ Capture the returned Issue URL and append it to the audit report's *Finding emis
 
 **Refusal contract — load-bearing pre-disclosure safeguard:**
 
-The skill **must not** call `gh issue create` for any finding whose `severity == P0` OR `area == security`. Such findings always print to stdout, regardless of the `--auto-file` flag, prefixed with:
+The skill **must not** call `gh issue create` for any finding whose `severity == P0` OR `area == security`. Such findings always print to stdout, regardless of detected maintainer identity, `--auto-file`, or `--no-auto-file`, prefixed with:
 
 ```
 **SECURITY / P0 finding — DO NOT FILE PUBLICLY.**
 Escalate via GitHub security advisories: https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new
 ```
 
-The refusal is non-negotiable and applies even when `--auto-file` is explicitly passed.
+The refusal is non-negotiable and applies even when the maintainer is detected or `--auto-file` is explicitly passed.
 
 `**N/A — no actionable findings**` is a valid Phase 19 outcome when sections 13 + 14 are both empty.
 
@@ -716,7 +767,7 @@ This prompt writes **raw per-run evidence only**. The audit report belongs in th
 **Canonical path:** `<audited-repo-root>/audit-reports/<timestamp>_<repo-id>_mcp-server-surface-test.md`
 
 - `<timestamp>` = current UTC `yyyyMMddTHHmmssZ`.
-- The prose `.md` report stays in the audited repo's own `audit-reports/` directory. Cross-repo handoff to upstream happens via the Phase 19 finding emission (stdout-print or `gh issue create`), not by relocating the prose report.
+- The prose `.md` report stays in the audited repo's own `audit-reports/` directory. Cross-repo handoff to upstream happens via two channels: (a) Phase 19 finding emission (stdout-print or `gh issue create`) for actionable items, and (b) the maintainer's `eng/stage-review-inbox.ps1` + `eng/aggregate-promotion-scorecards.ps1` pipeline, which discovers reports under either `audit-reports/` or `ai_docs/audit-reports/` across sibling repos and consolidates findings into `review-inbox/` + a quorum-aware scorecard verdict. Consumers do not need to relocate the prose report manually.
 
 ### Promotion scorecard JSON (sibling artifact — MANDATORY)
 

--- a/skills/mcp-server-surface-test/prompts/quick.md
+++ b/skills/mcp-server-surface-test/prompts/quick.md
@@ -202,9 +202,14 @@ Identical to the `--full` tier's Phase 19 contract — see `prompts/full.md` *Ph
 
 - **Use the shared renderer.** Dot-source `${CLAUDE_PLUGIN_ROOT}/skills/mcp-server-surface-test/lib/render-finding.ps1` and call `Render-FindingIssue -Finding $f`. Same renderer the maintainer's `/backlog-intake --publish` uses, so the body bytes are identical across both paths.
 - **Required envelope fields:** `id`, `source-repo`, `severity`, `area`, `server-version` (from `server_info.version` at Phase -1), `anchors`, `finding`, `repro`, `proposed-fix`. The `area` enum includes `security` — pick it for any pre-disclosure-relevant finding so the refusal contract triggers regardless of severity.
-- **Default:** print each actionable finding's envelope to stdout as a ready-to-paste GitHub Issue body.
-- **`--auto-file`:** call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <id> --label "area:<area>" --label "severity:<severity>" --body-file <tempfile>` per non-refused finding. Fall back to stdout-print if `gh` is missing or unauthenticated.
-- **Refusal contract:** P0 or `area: security` findings are **never** auto-filed, regardless of the `--auto-file` flag. Use `Test-FindingShouldRefusePublicFile -Finding $f` to short-circuit before invoking `gh`. Print to stdout with the security-advisory escalation banner pointing at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new (the renderer prepends it automatically when `refusedPublic` is `$true`).
+- **Routing:** compute once before iterating findings.
+  1. `--no-auto-file` → stdout-print.
+  2. Else `--auto-file` → auto-file (subject to gh available + authenticated).
+  3. Else dot-source the renderer and call `Test-IsMaintainer` (wraps `gh api user --jq .login` and compares against the `$script:UpstreamRepo` constant). `$true` → auto-file; `$false` → stdout-print.
+  Record the routing decision and probe outcome in the report's *Finding emission* section.
+- **Stdout-print path** (non-maintainer default, or `--no-auto-file`): print each actionable finding's envelope to stdout as a ready-to-paste GitHub Issue body.
+- **Auto-file path** (maintainer default, or `--auto-file`): call `gh issue create --repo darylmcd/Roslyn-Backed-MCP --title <id> --label "area:<area>" --label "severity:<severity>" --body-file <tempfile>` per non-refused finding. Fall back to stdout-print with one warning line if `gh` is missing or unauthenticated.
+- **Refusal contract:** P0 or `area: security` findings are **never** auto-filed, regardless of detected maintainer identity, `--auto-file`, or `--no-auto-file`. Use `Test-FindingShouldRefusePublicFile -Finding $f` to short-circuit before invoking `gh`. Print to stdout with the security-advisory escalation banner pointing at https://github.com/darylmcd/Roslyn-Backed-MCP/security/advisories/new (the renderer prepends it automatically when `refusedPublic` is `$true`).
 
 `**N/A — no actionable findings**` is a valid Phase 19 outcome.
 


### PR DESCRIPTION
## Summary

- **Surface-test skill auto-file**: maintainer-aware default. `gh api user --jq .login` matching the upstream owner enables auto-file; everyone else gets stdout-print. New `--no-auto-file` flag for maintainer dry-runs. Single-source `$script:UpstreamRepo` constant in `lib/render-finding.ps1` with derived login/URL and a `Test-IsMaintainer` helper.
- **Subagent dispatch plan for `--full` tier**: new Phase 0.5 mandates orchestrator dispatch of phase groups (G1–G8) to `audit-phase-runner` subagents, eliminating silent representative-probe truncation. New `--single-agent` escape hatch. `skipped-budget` is now a P1 audit defect, not a soft fallback.
- **eng/ pipeline plumbing**: `stage-review-inbox.ps1` recognizes `*_mcp-server-surface-test.md` and defaults to MOVE-from-siblings + COPY-from-self. `aggregate-promotion-scorecards.ps1` probes both `ai_docs/audit-reports/` and top-level `audit-reports/`. New `eng/process-audit-reports.ps1` is the one-command wrapper (stage → aggregate → next-step pointer).
- **`.gitignore`**: `audit-reports/` and flat `review-inbox/*.md` are per-run / transient and should not land in repo history; `review-inbox/archive/` stays tracked because backlog rows cite into it.

## Test plan

- [x] `pwsh eng/stage-review-inbox.ps1 -DryRun` — discovers reports across siblings + this repo with the new pattern.
- [x] `pwsh eng/aggregate-promotion-scorecards.ps1` — picks up DotNet-Firewall-Analyzer's scorecard at top-level `audit-reports/`.
- [x] `pwsh eng/process-audit-reports.ps1` — end-to-end smoke (stage + aggregate + next-step pointer).
- [x] `Render-FindingIssue` test (`RenderFindingScriptTests.cs:170`) preserved — security-advisories URL still asserts byte-identical via the new constant.
- [ ] `/mcp-server-surface-test` re-run with the new dispatch plan (deferred — needs re-cut release + plugin update to take effect locally).
- [ ] `/backlog-intake` against staged `review-inbox/` (deferred — operator step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)