### PR TITLE
fix(eng): stage-review-inbox Strict Mode .Count crash

### DIFF
--- a/eng/stage-review-inbox.ps1
+++ b/eng/stage-review-inbox.ps1
@@ -221,8 +221,8 @@ if ($staged.Count -gt 0 -and -not (Test-Path $inbox)) {
 }
 
 if ($staged.Count -gt 0) {
-    $copyCount = ($staged | Where-Object { $_.Action -eq 'Copy' }).Count
-    $moveCount = ($staged | Where-Object { $_.Action -eq 'Move' }).Count
+    $copyCount = @($staged | Where-Object { $_.Action -eq 'Copy' }).Count
+    $moveCount = @($staged | Where-Object { $_.Action -eq 'Move' }).Count
     Write-Host "Staging $($staged.Count) artifact(s) -> $inbox (Copy: $copyCount, Move: $moveCount)" -ForegroundColor Cyan
 
     foreach ($item in $staged) {


### PR DESCRIPTION
## Summary

`Where-Object` returns scalar / `\$null` for 0 or 1 matches. PowerShell Strict Mode then refuses `.Count` on those. Wrap both filters in `@(...)` to force array context.

## Repro

\`\`\`
pwsh -File eng/stage-review-inbox.ps1
\`\`\`

with a single sibling report queued for move emitted:

\`\`\`
The property 'Count' cannot be found on this object.
\`\`\`

## Test plan

- [x] Re-ran \`pwsh eng/process-audit-reports.ps1\` after fix; staged 1 + skipped 2 cleanly.
- [x] Two-line change inside the \`if (\$staged.Count -gt 0)\` branch — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)