### PR TITLE
release: v1.35.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.35.2",
+      "version": "1.35.3",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.35.2",
+  "version": "1.35.3",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "1.35.2",
+  "version": "1.35.3",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "1.35.2",
+      "version": "1.35.3",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Maintenance
 
 - **Maintenance:** `/mcp-server-stress` audit completion gate — no-silent-truncation contract on the `audit-phase-runner` subagent. Partial runs surface as P1 audit defects rather than quiet ledger entries; orchestrator re-dispatches with smaller scope or records `phase-failed-budget` in the coverage summary. Runner agent definition documents the `skipped-budget` / `skipped-context` / `truncated` marker contract.
-- **Maintenance:** Backlog ↔ GitHub Issue cross-link convention added with two flavors — reserved-for-contributor-pickup (`good first issue` / `help wanted`) rows get a `**Reserved — [gh #NNN](url)...**` marker that `/backlog-sweep:plan` Step 1 hard-skips; tracked-only rows get a plain `[gh #NNN](url) — ` prefix and remain sweep-eligible. `/backlog-sweep:execute` Step 2 has defense-in-depth re-check at initiative-claim time so a row reserved between plan emission and execution is marked `obsolete` rather than raced.
+- **Maintenance:** Backlog ↔ GitHub Issue cross-link convention added with two flavors — reserved-for-contributor-pickup (`good first issue` / `help wanted`) rows get a `**Reserved — gh #NNN ...**` marker that `/backlog-sweep:plan` Step 1 hard-skips; tracked-only rows get a plain `gh #NNN — ` prefix and remain sweep-eligible. `/backlog-sweep:execute` Step 2 has defense-in-depth re-check at initiative-claim time so a row reserved between plan emission and execution is marked `obsolete` rather than raced.
 
 ## [1.35.2] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.35.3] - 2026-05-11
+
+### Fixed
+
+- **Fixed:** `/mcp-server-surface-test --auto-file` now dedup-checks against existing GitHub Issues before each `gh issue create`. Open near-matches (by tool name + symptom keywords in title) are skipped with an audit-trail entry; closed near-matches are also skipped and do NOT refile prior fixes. Closes a real workflow gap where the 2026-05-11 IT-Chat-Bot audit auto-filed a duplicate of a pre-existing maintainer-promoted issue. P0/security refusal contract still applies first.
+- **Fixed:** `/backlog-intake --publish` adds a dedup pre-check at Phase 6.5 before each `gh issue create`. Primary fingerprint is a body grep for `Closes <row-id> in ai_docs/backlog.md`; falls back to a title-keyword match for cross-skill collisions. Prevents the maintainer-publish path from re-filing findings already filed by `/mcp-server-surface-test --auto-file` in a sibling session.
+
+### Changed
+
+- **Changed:** Plugin contributor-readiness package — added `.github/PULL_REQUEST_TEMPLATE.md` (summary, linked-issue, test plan, optional backlog-row closure); expanded `.gitignore` with `.env.*` variants (allowlist `.env.example`/`.sample`/`.template`), Linux OS junk (`*~`/`.directory`/`.Trash-*`/`.fuse_hidden*`/`.nfs*`), JetBrains user files (`*.iml`/`*.iws`), and an explicit `.cursor/*` allowlist mirroring the existing `.claude/*` pattern.
+
+### Maintenance
+
+- **Maintenance:** `/mcp-server-stress` audit completion gate — no-silent-truncation contract on the `audit-phase-runner` subagent. Partial runs surface as P1 audit defects rather than quiet ledger entries; orchestrator re-dispatches with smaller scope or records `phase-failed-budget` in the coverage summary. Runner agent definition documents the `skipped-budget` / `skipped-context` / `truncated` marker contract.
+- **Maintenance:** Backlog ↔ GitHub Issue cross-link convention added with two flavors — reserved-for-contributor-pickup (`good first issue` / `help wanted`) rows get a `**Reserved — [gh #NNN](url)...**` marker that `/backlog-sweep:plan` Step 1 hard-skips; tracked-only rows get a plain `[gh #NNN](url) — ` prefix and remain sweep-eligible. `/backlog-sweep:execute` Step 2 has defense-in-depth re-check at initiative-claim time so a row reserved between plan emission and execution is marked `obsolete` rather than raced.
+
 ## [1.35.2] - 2026-05-10
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.35.2</Version>
+    <Version>1.35.3</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.35.2",
+  "version": "1.35.3",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
Version bump to 1.35.3. See CHANGELOG.md for details.

## Highlights

**Fixed (dedup gap closure)** — both `/mcp-server-surface-test --auto-file` and `/backlog-intake --publish` now query existing GitHub Issues before each `gh issue create`. Open near-matches are skipped with an audit-trail entry; closed near-matches are skipped without re-filing prior fixes. Triggered by the 2026-05-11 IT-Chat-Bot audit which produced a duplicate of an existing maintainer-promoted issue.

**Changed** — plugin contributor-readiness package: PR template + expanded `.gitignore`.

**Maintenance** — `/mcp-server-stress` audit completion gate (no silent truncation); backlog ↔ GitHub Issue cross-link convention with sweep-skip rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)