### PR TITLE
feat(workspace): expandSanctionedRoots operator-opt-in for workspace_load

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
@@ -29,9 +29,23 @@ internal static class ClientRootPathValidator
     /// <param name="ct">Cancellation token.</param>
     /// <param name="logger">Optional logger for diagnostics.</param>
     /// <param name="securityOptions">Security options controlling fail-open/fail-closed behavior.</param>
+    /// <param name="expandSanctionedRoots">
+    /// Operator-opt-in flag (default <c>false</c>). When <c>true</c>, the validator additionally
+    /// accepts paths under the immediate parent directory of any client-sanctioned root. This
+    /// widens the allowlist by exactly one level — enough to permit a disposable sibling worktree
+    /// at <c>../&lt;sibling&gt;</c> (e.g. mcp-server-surface-test's audit worktree) without
+    /// exposing arbitrary filesystem locations. Higher ancestors (grandparent etc.) remain
+    /// disallowed. This flag must only be plumbed through tools whose own parameter is operator-
+    /// supplied — never auto-enable on every request.
+    /// </param>
     /// <exception cref="System.ArgumentException">Thrown when the path falls outside all client-sanctioned roots.</exception>
     public static async Task ValidatePathAgainstRootsAsync(
-        McpServer server, string path, CancellationToken ct, ILogger? logger = null, SecurityOptions? securityOptions = null)
+        McpServer server,
+        string path,
+        CancellationToken ct,
+        ILogger? logger = null,
+        SecurityOptions? securityOptions = null,
+        bool expandSanctionedRoots = false)
     {
         var failOpen = securityOptions?.PathValidationFailOpen ?? true;
 
@@ -49,29 +63,22 @@ internal static class ClientRootPathValidator
             }
 
             var fullPath = ResolvePath(path);
-            foreach (var root in rootsResult.Roots)
-            {
-                if (root.Uri.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
-                {
-                    var rootPath = new Uri(root.Uri).LocalPath;
-                    if (string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return;
-                    }
+            var rootPaths = rootsResult.Roots
+                .Where(r => r.Uri.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+                .Select(r => new Uri(r.Uri).LocalPath)
+                .ToList();
 
-                    var normalizedRoot = rootPath.EndsWith(Path.DirectorySeparatorChar)
-                        ? rootPath
-                        : rootPath + Path.DirectorySeparatorChar;
-                    if (fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return;
-                    }
-                }
+            if (IsPathUnderAnyRoot(fullPath, rootPaths, expandSanctionedRoots))
+            {
+                return;
             }
 
+            var widenedNote = expandSanctionedRoots
+                ? " (expandSanctionedRoots=true was applied — parent directories of each root were also checked)"
+                : string.Empty;
             throw new ArgumentException(
                 $"Path '{path}' is not under any client-sanctioned root. " +
-                $"Allowed roots: {string.Join(", ", rootsResult.Roots.Select(r => r.Uri))}");
+                $"Allowed roots: {string.Join(", ", rootsResult.Roots.Select(r => r.Uri))}{widenedNote}");
         }
         catch (ArgumentException)
         {
@@ -93,6 +100,65 @@ internal static class ClientRootPathValidator
                     $"Set ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN=true to allow access when roots lookup fails.");
             }
         }
+    }
+
+    /// <summary>
+    /// Pure path-match helper extracted for unit-testability of the sanctioned-root
+    /// allowlist + <c>expandSanctionedRoots</c> widening logic. <paramref name="fullPath"/>
+    /// must already be canonicalized via <see cref="ResolvePath"/>; <paramref name="rootPaths"/>
+    /// must be the <c>file://</c>-decoded LocalPath strings reported by the client.
+    /// </summary>
+    /// <param name="fullPath">Canonicalized candidate path.</param>
+    /// <param name="rootPaths">Decoded client-sanctioned roots (local paths, not URIs).</param>
+    /// <param name="expandSanctionedRoots">When <c>true</c>, also accept paths under the
+    /// immediate parent directory of each root (one level of widening only). Drive-root
+    /// parents are excluded so a root at <c>C:\Foo</c> does NOT widen to the entire drive.</param>
+    /// <returns><c>true</c> when <paramref name="fullPath"/> falls under any root (or, with
+    /// widening, any root's parent directory).</returns>
+    internal static bool IsPathUnderAnyRoot(string fullPath, IReadOnlyList<string> rootPaths, bool expandSanctionedRoots)
+    {
+        if (rootPaths.Count == 0)
+        {
+            return false;
+        }
+
+        var allowedRoots = new List<string>(rootPaths.Count * (expandSanctionedRoots ? 2 : 1));
+        foreach (var rootPath in rootPaths)
+        {
+            allowedRoots.Add(rootPath);
+
+            if (expandSanctionedRoots)
+            {
+                // Widen by exactly one level — the parent directory of each sanctioned
+                // root. This permits sibling worktrees (e.g. parent/main is sanctioned and
+                // the worktree is at parent/.worktrees/foo) without exposing arbitrary
+                // grandparent or unrelated filesystem locations. Drive-root parents are
+                // skipped to avoid widening to the entire drive.
+                var parent = Path.GetDirectoryName(rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (!string.IsNullOrEmpty(parent) && Path.GetPathRoot(parent) != parent)
+                {
+                    allowedRoots.Add(parent);
+                }
+            }
+        }
+
+        foreach (var rootPath in allowedRoots)
+        {
+            if (string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var normalizedRoot = rootPath.EndsWith(Path.DirectorySeparatorChar)
+                ? rootPath
+                : rootPath + Path.DirectorySeparatorChar;
+            if (fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -28,6 +28,7 @@ public static class WorkspaceTools
         [Description("When true, return the full per-project tree and workspace diagnostics. Default false returns only counts and load state.")] bool verbose = false,
         [Description("When true and the loaded status reports restoreRequired=true, run `dotnet restore` on the target and reload once before returning.")] bool autoRestore = false,
         [Description("When true, run `workspace_warm` immediately after the load (and any auto-restore reload) succeeds, then include the warm result in the response. When omitted, large solutions with more than 50 projects are prewarmed automatically. Pass false to opt out and preserve the cold-load profile.")] bool? prewarm = null,
+        [Description("Operator-opt-in security flag (default false). When true, the client-sanctioned-root path validator additionally accepts paths under the immediate PARENT directory of each sanctioned root — enough to permit a sibling worktree at `../<name>` (e.g. mcp-server-surface-test's disposable audit worktree). Higher ancestors (grandparent etc.) are NOT widened. Pass true only from operator-controlled call sites; do not auto-enable on every request.")] bool expandSanctionedRoots = false,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
@@ -46,7 +47,8 @@ public static class WorkspaceTools
             // audit-coverage initiative. See ProgressHelper remarks for the label-naming contract.
             var totalStages = prewarm == true ? 5 : 4;
             ProgressHelper.ReportStage(progress, 0, totalStages, "validating-path");
-            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, path, c).ConfigureAwait(false);
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(
+                server, path, c, expandSanctionedRoots: expandSanctionedRoots).ConfigureAwait(false);
             ProgressHelper.ReportStage(progress, 1, totalStages, "opening-workspace");
             var status = await workspace.LoadAsync(path, c).ConfigureAwait(false);
             ProgressHelper.ReportStage(progress, 2, totalStages, "checking-restore");

--- a/tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs
+++ b/tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs
@@ -86,4 +86,108 @@ public class ClientRootPathValidatorTests
             null!, "C:\\any\\path", CancellationToken.None);
         // No exception = pass
     }
+
+    // ───────── IsPathUnderAnyRoot tests (sanctioned-root + expandSanctionedRoots widening) ─────────
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Path_Inside_Root_Allowed()
+    {
+        var roots = new[] { @"C:\repo\main" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\main\src\file.cs", roots, expandSanctionedRoots: false));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Path_Equal_To_Root_Allowed()
+    {
+        var roots = new[] { @"C:\repo\main" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\main", roots, expandSanctionedRoots: false));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Sibling_Worktree_Rejected_Without_Flag()
+    {
+        // The whole reason this initiative exists: a sibling worktree at parent/.worktrees/foo
+        // is structurally OUTSIDE parent/main — without the opt-in flag it must be rejected.
+        var roots = new[] { @"C:\repo\main" };
+        Assert.IsFalse(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\sibling\src\file.cs", roots, expandSanctionedRoots: false));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Sibling_Worktree_Allowed_With_Flag()
+    {
+        // With expandSanctionedRoots=true, the parent directory (C:\repo) is also accepted,
+        // so a sibling at C:\repo\sibling falls under the widened allowlist.
+        var roots = new[] { @"C:\repo\main" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\sibling\src\file.cs", roots, expandSanctionedRoots: true));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Worktree_Subdir_Allowed_With_Flag()
+    {
+        // The mcp-server-surface-test skill's disposable worktree at ../<sibling> —
+        // verifies the canonical Phase 6/9/10/12/13 disposable-worktree audit path.
+        var roots = new[] { @"C:\Code-Repo\TradeWise" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\Code-Repo\TradeWise-surface-audit-20260511\src\App.csproj",
+            roots,
+            expandSanctionedRoots: true));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Grandparent_Path_Rejected_Even_With_Flag()
+    {
+        // Widening is exactly ONE level — a grandparent path must still be rejected.
+        // Root: C:\Code-Repo\TradeWise -> parent C:\Code-Repo is widened, but C:\Other is NOT.
+        var roots = new[] { @"C:\Code-Repo\TradeWise" };
+        Assert.IsFalse(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\Other\anything.cs", roots, expandSanctionedRoots: true));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Drive_Root_Never_Widens()
+    {
+        // Defensive: if a client sanctions C:\repo, widening to C:\ is dangerous (entire drive).
+        // The implementation skips drive-root parents, so any path on C: not under \repo is rejected.
+        var roots = new[] { @"C:\repo" };
+        Assert.IsFalse(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\Windows\System32\cmd.exe", roots, expandSanctionedRoots: true));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_TrailingSlash_Root_Normalized()
+    {
+        var roots = new[] { @"C:\repo\main\" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\main\src\file.cs", roots, expandSanctionedRoots: false));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Prefix_Trap_Rejected()
+    {
+        // Naive prefix match would allow C:\repo\main2 against root C:\repo\main —
+        // normalized comparison must reject this.
+        var roots = new[] { @"C:\repo\main" };
+        Assert.IsFalse(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\main2\file.cs", roots, expandSanctionedRoots: false));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Empty_Roots_Rejects()
+    {
+        Assert.IsFalse(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\any\path", Array.Empty<string>(), expandSanctionedRoots: true));
+    }
+
+    [TestMethod]
+    public void IsPathUnderAnyRoot_Case_Insensitive_On_Windows()
+    {
+        // Windows filesystem semantics — root casing should not matter.
+        var roots = new[] { @"C:\Repo\Main" };
+        Assert.IsTrue(ClientRootPathValidator.IsPathUnderAnyRoot(
+            @"C:\repo\main\src\file.cs", roots, expandSanctionedRoots: false));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new operator-opt-in `expandSanctionedRoots` parameter on `workspace_load` that widens the `ClientRootPathValidator` allowlist by exactly one level — the immediate parent directory of each client-sanctioned root. This unblocks the mcp-server-surface-test skill's disposable sibling worktree (at `../<sibling>`), which was forcing Phases 6/9/10/12/13 of the consumer-repo audit to `skipped-safety` on every run.

## Security boundary

- **Default off.** The flag is `false` unless the operator explicitly passes `true`. No auto-widening on every request.
- **Exactly one level.** Only the immediate parent of each root is added — grandparents and unrelated locations remain rejected (`IsPathUnderAnyRoot_Grandparent_Path_Rejected_Even_With_Flag`).
- **Drive-root excluded.** A root at `C:\Foo` does NOT widen to `C:\` (`IsPathUnderAnyRoot_Drive_Root_Never_Widens`). Without this guard, sanctioning a top-level repo would expose the entire drive.
- **Operator-supplied only.** The parameter is plumbed solely through `workspace_load`; downstream read/write tools continue to use the strict (un-widened) validator.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs` — new optional `expandSanctionedRoots` arg on `ValidatePathAgainstRootsAsync`; extracted pure `IsPathUnderAnyRoot` helper for unit-testability.
- `src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs` — new `expandSanctionedRoots` parameter on `LoadWorkspace`, threaded to the validator. Description documents the security semantics.
- `tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs` — 10 new unit tests covering rejection without flag, sibling-worktree acceptance with flag, prefix-trap rejection (`C:\repo\main` vs `C:\repo\main2`), drive-root protection, grandparent rejection, trailing-slash normalization, case-insensitive matching, and empty-roots rejection.

## Test plan

- [x] `mcp__roslyn__compile_check` clean on all three production files (0 errors / 0 warnings).
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~ClientRootPathValidatorTests` → 19/19 passed.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~WorkspaceTool|FullyQualifiedName~SurfaceCatalog|FullyQualifiedName~ToolParameterIndex` → 31/31 passed (catalog parity + reflection-driven parameter index pick up the new arg automatically).
- [ ] PR-CI `verify-release.ps1` (self-hosted runner handles full sweep).

Closes: workspace-load-sibling-worktree-sanctioned-root