### PR TITLE
fix(namespace-deps): surface AnalyzedProjectCount in response

### DIFF
--- a/src/RoslynMcp.Core/Models/NamespaceDependencyDto.cs
+++ b/src/RoslynMcp.Core/Models/NamespaceDependencyDto.cs
@@ -3,10 +3,25 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents a namespace dependency graph for one or more projects.
 /// </summary>
+/// <param name="Nodes">Namespace nodes (declared or referenced) in the analyzed scope.</param>
+/// <param name="Edges">Namespace-to-namespace dependency edges with reference counts.</param>
+/// <param name="CircularDependencies">Cycles detected via DFS over the edge set.</param>
+/// <param name="AnalyzedProjectCount">
+/// Number of projects whose compilations were successfully walked. Lets callers distinguish
+/// "no cycles found across N projects" from "analysis did not run" when <paramref name="CircularDependencies"/>
+/// is empty — a gap that previously surfaced on large multi-project solutions (gh #615).
+/// </param>
+/// <param name="TotalNamespacesScanned">
+/// Total count of distinct namespace declarations encountered during the walk. Equals
+/// <paramref name="Nodes"/>.Count when no filtering has been applied at the tool-wrapper layer
+/// (the <c>circularOnly</c> filter can reduce <paramref name="Nodes"/> below this value).
+/// </param>
 public sealed record NamespaceDependencyGraphDto(
     IReadOnlyList<NamespaceNodeDto> Nodes,
     IReadOnlyList<NamespaceEdgeDto> Edges,
-    IReadOnlyList<CircularDependencyDto> CircularDependencies);
+    IReadOnlyList<CircularDependencyDto> CircularDependencies,
+    int AnalyzedProjectCount,
+    int TotalNamespacesScanned);
 
 /// <summary>
 /// Represents a namespace node in a dependency graph.

--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.cs
@@ -255,10 +255,11 @@ public static partial class RoslynPrompts
             var graphJson = PromptMessageBuilder.SerializeTruncatedList(graph.Projects, 50, JsonDefaults.Indented);
 
             var namespaceDeps = await namespaceDependencyService.GetNamespaceDependenciesAsync(workspaceId, null, ct).ConfigureAwait(false);
-            var truncatedNamespaceDeps = new Core.Models.NamespaceDependencyGraphDto(
-                namespaceDeps.Nodes.Take(100).ToList(),
-                namespaceDeps.Edges.Take(100).ToList(),
-                namespaceDeps.CircularDependencies);
+            var truncatedNamespaceDeps = namespaceDeps with
+            {
+                Nodes = namespaceDeps.Nodes.Take(100).ToList(),
+                Edges = namespaceDeps.Edges.Take(100).ToList(),
+            };
             var namespaceDepsJson = JsonSerializer.Serialize(truncatedNamespaceDeps, JsonDefaults.Indented);
             if (namespaceDeps.Edges.Count > 100)
                 namespaceDepsJson += $"\n[Showing 100 of {namespaceDeps.Edges.Count} edges]";

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -202,15 +202,21 @@ public static class AdvancedAnalysisTools
                     result.CircularDependencies.SelectMany(cd => cd.Cycle),
                     StringComparer.Ordinal);
 
-                result = new RoslynMcp.Core.Models.NamespaceDependencyGraphDto(
-                    result.Nodes.Where(n => cyclicNamespaces.Contains(n.Namespace)).ToList(),
-                    result.Edges.Where(e => cyclicNamespaces.Contains(e.FromNamespace) &&
-                                            cyclicNamespaces.Contains(e.ToNamespace)).ToList(),
-                    result.CircularDependencies);
+                // `with` preserves AnalyzedProjectCount + TotalNamespacesScanned so callers can
+                // still see "we analyzed N projects" even when the filtered Nodes/Edges shrink
+                // to the cycle subset.
+                result = result with
+                {
+                    Nodes = result.Nodes.Where(n => cyclicNamespaces.Contains(n.Namespace)).ToList(),
+                    Edges = result.Edges.Where(e => cyclicNamespaces.Contains(e.FromNamespace) &&
+                                                    cyclicNamespaces.Contains(e.ToNamespace)).ToList(),
+                };
             }
             else if (circularOnly)
             {
-                result = new RoslynMcp.Core.Models.NamespaceDependencyGraphDto([], [], []);
+                // No cycles found — drop Nodes/Edges but retain the analysis-coverage counts so
+                // the caller can distinguish "no cycles across N projects" from "not analyzed".
+                result = result with { Nodes = [], Edges = [] };
             }
 
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);

--- a/src/RoslynMcp.Roslyn/Services/NamespaceDependencyService.cs
+++ b/src/RoslynMcp.Roslyn/Services/NamespaceDependencyService.cs
@@ -34,6 +34,7 @@ public sealed class NamespaceDependencyService : INamespaceDependencyService
 
         var namespaceCounts = new Dictionary<string, (int Count, string? Project)>();
         var edges = new Dictionary<(string From, string To), int>();
+        var analyzedProjectCount = 0;
 
         foreach (var project in projects)
         {
@@ -41,6 +42,7 @@ public sealed class NamespaceDependencyService : INamespaceDependencyService
 
             var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
+            analyzedProjectCount++;
 
             foreach (var tree in compilation.SyntaxTrees)
             {
@@ -100,7 +102,20 @@ public sealed class NamespaceDependencyService : INamespaceDependencyService
         // Detect circular dependencies using DFS
         var cycles = DetectCycles(edgeList);
 
-        return new NamespaceDependencyGraphDto(nodes, edgeList, cycles);
+        // TotalNamespacesScanned counts only namespaces that were actually declared in the walk
+        // (where namespaceCounts[ns].Count > 0 OR the namespace key existed before the edge-fill
+        // step). Edge-only nodes (Count == 0 with null project) are referenced-but-not-declared
+        // and should not inflate the scanned figure. Using the post-edge-fill keys minus the
+        // edge-only additions is equivalent to "namespaces that produced at least one type
+        // declaration during the walk", which is the metric callers want.
+        var declaredNamespaceCount = namespaceCounts.Count(kvp => kvp.Value.Project is not null);
+
+        return new NamespaceDependencyGraphDto(
+            nodes,
+            edgeList,
+            cycles,
+            AnalyzedProjectCount: analyzedProjectCount,
+            TotalNamespacesScanned: declaredNamespaceCount);
     }
 
     private static IReadOnlyList<CircularDependencyDto> DetectCycles(IReadOnlyList<NamespaceEdgeDto> edges)

--- a/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
@@ -106,6 +106,30 @@ public sealed class HighValueCoverageIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task DependencyAnalysis_GetNamespaceDependencies_MultiProject_Reports_AnalyzedProjectCount()
+    {
+        // gh #615 regression guard: on a multi-project solution the response MUST surface
+        // how many projects were actually analyzed so callers can distinguish
+        // "no cycles found" from "analysis did not run" when CircularDependencies is empty.
+        var graph = await NamespaceDependencyService.GetNamespaceDependenciesAsync(
+            SampleWorkspaceId, projectFilter: null, CancellationToken.None);
+
+        var sampleSolution = WorkspaceManager.GetCurrentSolution(SampleWorkspaceId);
+        var expectedProjectCount = sampleSolution.Projects.Count();
+
+        Assert.IsTrue(
+            expectedProjectCount > 1,
+            $"Test fixture precondition: SampleSolution should be multi-project (was {expectedProjectCount}).");
+        Assert.AreEqual(
+            expectedProjectCount,
+            graph.AnalyzedProjectCount,
+            "AnalyzedProjectCount should match the number of projects whose compilations were walked.");
+        Assert.IsTrue(
+            graph.TotalNamespacesScanned > 0,
+            "TotalNamespacesScanned should be non-zero on a multi-project solution that declares namespaces.");
+    }
+
+    [TestMethod]
     public async Task DependencyAnalysis_GetNuGetDependencies_Returns_Packages_For_SampleSolution()
     {
         var result = await NuGetDependencyService.GetNuGetDependenciesAsync(


### PR DESCRIPTION
## Summary

On multi-project solutions, `get_namespace_dependencies(circularOnly=true)` returned empty arrays without any signal of how much analysis ran — callers couldn't distinguish "no cycles found across N projects" from "analysis did not run".

- Adds `AnalyzedProjectCount` and `TotalNamespacesScanned` to `NamespaceDependencyGraphDto`
- Populates both in `NamespaceDependencyService` from the analysis loop
- Preserves the counts through the `circularOnly` filter in the tool wrapper via record `with`-expressions
- Adds a regression test on the multi-project SampleSolution fixture asserting `AnalyzedProjectCount` matches the project count and `TotalNamespacesScanned > 0`

## Test plan

- [x] `mcp__roslyn__compile_check` clean across all 5 projects
- [x] `NamespaceDependency` filter — 2/2 pass (existing + new regression test)
- [x] `ExpandedSurface` filter — 17/17 pass (no regression on tool wrapper)
- [ ] CI verify-release.ps1 (self-hosted runner)
- [ ] CI verify-ai-docs.ps1

Closes: gh #615 — `get-namespace-dependencies-empty-multiproject`