### PR TITLE
chore(plan): start initiative 7 (prompts-full-md-phase0-worktree-path-sandbox)

### DIFF
--- a/ai_docs/plans/20260511T184004Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260511T184004Z_backlog-sweep/plan.md
@@ -126,7 +126,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | in-progress (branch: remediation/prompts-full-md-phase0-worktree-path-sandbox, worktree: .worktrees/prompts-full-md-phase0-worktree-path-sandbox) |
 | Backlog rows closed | `prompts-full-md-phase0-worktree-path-sandbox` |
 | Diagnosis | Prompt-side patch for `workspace-load-sibling-worktree-sanctioned-root`. The `prompts/full.md` Phase 0 step 2 instructs `git worktree add ../<repo>-surface-test-<ts>` (sibling path, outside sanctioned root). Doc-only fix. |
 | Approach | Update `skills/mcp-server-surface-test/prompts/full.md` Phase 0 step 2 to use an inside-repo worktree path (`git worktree add .worktrees/surface-test-<ts>`). No corresponding maintainer-overlay update needed — it's deleted. |

--- a/ai_docs/plans/20260511T184004Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260511T184004Z_backlog-sweep/state.json
@@ -237,7 +237,7 @@
     {
       "id": "prompts-full-md-phase0-worktree-path-sandbox",
       "order": 7,
-      "status": "pending",
+      "status": "in-progress",
       "backlogRowsClosed": [
         "prompts-full-md-phase0-worktree-path-sandbox"
       ],
@@ -249,8 +249,8 @@
       "scheduleHint": null,
       "fanoutEstimate": null,
       "fanoutOversize": false,
-      "branch": null,
-      "worktreePath": null,
+      "branch": "remediation/prompts-full-md-phase0-worktree-path-sandbox",
+      "worktreePath": ".worktrees/prompts-full-md-phase0-worktree-path-sandbox",
       "prUrl": null,
       "mergedAt": null,
       "notes": "Doc-only \u2014 prompt-side fix for sanctioned-root issue."


### PR DESCRIPTION
## Summary

Plan-state flip recording the start of initiative 7 (`prompts-full-md-phase0-worktree-path-sandbox`) in the active backlog-sweep plan at `ai_docs/plans/20260511T184004Z_backlog-sweep/`.

- `state.json`: `status: pending` → `in-progress`; populated `branch` + `worktreePath`.
- `plan.md`: Status row updated with branch + worktree paths.

Per `~/.claude/prompts/backlog-sweep-execute.md` § Step 5c, plan-state-only flips go to `main` first; this chore branch + PR exists because direct push to `main` is hook-blocked.

The implementation PR (under branch `remediation/prompts-full-md-phase0-worktree-path-sandbox`) follows separately and is the substantive change.

## Test plan

- [x] state.json edit isolated to single initiative entry.
- [x] plan.md edit isolated to Status row of initiative 7.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)