### PR TITLE
chore(plan): close initiative 7 (prompts-full-md-phase0-worktree-path-sandbox merged via #647)

### DIFF
--- a/ai_docs/plans/20260511T184004Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260511T184004Z_backlog-sweep/plan.md
@@ -126,7 +126,7 @@
 
 | Field | Content |
 |---|---|
-| Status | pending |
+| Status | merged (PR #647, 2026-05-11) |
 | Backlog rows closed | `prompts-full-md-phase0-worktree-path-sandbox` |
 | Diagnosis | Prompt-side patch for `workspace-load-sibling-worktree-sanctioned-root`. The `prompts/full.md` Phase 0 step 2 instructs `git worktree add ../<repo>-surface-test-<ts>` (sibling path, outside sanctioned root). Doc-only fix. |
 | Approach | Update `skills/mcp-server-surface-test/prompts/full.md` Phase 0 step 2 to use an inside-repo worktree path (`git worktree add .worktrees/surface-test-<ts>`). No corresponding maintainer-overlay update needed — it's deleted. |

--- a/ai_docs/plans/20260511T184004Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260511T184004Z_backlog-sweep/state.json
@@ -237,7 +237,7 @@
     {
       "id": "prompts-full-md-phase0-worktree-path-sandbox",
       "order": 7,
-      "status": "pending",
+      "status": "merged",
       "backlogRowsClosed": [
         "prompts-full-md-phase0-worktree-path-sandbox"
       ],
@@ -251,9 +251,9 @@
       "fanoutOversize": false,
       "branch": null,
       "worktreePath": null,
-      "prUrl": null,
-      "mergedAt": null,
-      "notes": "Doc-only \u2014 prompt-side fix for sanctioned-root issue."
+      "prUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP/pull/647",
+      "mergedAt": "2026-05-11T21:59:46Z",
+      "notes": "Doc-only \u2014 prompt-side fix for sanctioned-root issue. Shipped as PR #647 (squash ddbc1ad2a7). Single-initiative smoke test of /backlog-sweep:execute under the new global flow (post-A1+A2+B1+B2+B3+D1+D4+P1.4 remediation)."
     },
     {
       "id": "file-lock-aware-prompt-validation-guidance",


### PR DESCRIPTION
## Summary

Plan-state closeout for initiative 7 (`prompts-full-md-phase0-worktree-path-sandbox`) in the active backlog-sweep plan at `ai_docs/plans/20260511T184004Z_backlog-sweep/`.

- `state.json`: `status: pending` → `merged`; populated `prUrl` + `mergedAt`.
- `plan.md`: Status row updated to `merged (PR #647, 2026-05-11)`.

This is the **terminal** state flip for initiative 7. Per `~/.claude/prompts/backlog-sweep-execute.md` § Step 5c, terminal closeout state flips MUST land before the execute run reports complete.

Companion records:
- Implementation PR: #647 (merged 2026-05-11T21:59:46Z, squash `ddbc1ad2a7`)
- Pre-work state flip: #646 (superseded by this PR — leave open for the next `/backlog-sweep:execute` Step 2a sweep to land or close)

## Test plan

- [x] state.json edit scoped to initiative-7 entry only.
- [x] plan.md edit scoped to Status row of initiative 7.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)