### PR TITLE
docs(sweep): add gh pr collision check to Step 2 (sweep-executor-pr-collision-check)

### DIFF
--- a/ai_docs/prompts/backlog-sweep-execute.md
+++ b/ai_docs/prompts/backlog-sweep-execute.md
@@ -162,6 +162,25 @@ skip it, and pick the next pending one. The planner skips these at plan time,
 but this catches the race where a maintainer reserves a row between plan
 generation and execution.
 
+**Defense-in-depth — open contributor PRs touching anchor files.** After the
+Reserved-marker re-check, query GitHub for open PRs whose diffs overlap the
+initiative's anchor files (the production files listed in its Scope field):
+
+```
+gh pr list --state open --json number,headRefName,title,updatedAt,files \
+  --jq '.[] | select(.files[].path | IN(<anchor-file-1>, <anchor-file-2>, ...))'
+```
+
+For each matching PR, check its `updatedAt` timestamp. If any open PR was updated
+within the past 14 days AND its diff touches at least one of the initiative's anchor
+files, treat this as a live contributor collision: mark the initiative `obsolete` in
+state.json with reason `"open PR #<n> (<headRefName>) touches anchor file(s) and was
+updated within 14 days — contributor work in flight"`, skip it, and pick the next
+pending one. PRs updated more than 14 days ago are considered abandoned and do not
+block the claim. This check catches the race where a contributor opens a PR for the
+same file set between plan generation and execution without using the Reserved-row
+marker.
+
 If the first-in-queue has `scheduleHint == "heroic-last"`: verify all other
 non-heroic initiatives are `merged` or `obsolete` before proceeding. If not,
 skip this one and pick the next pending non-heroic.

--- a/changelog.d/sweep-executor-pr-collision-check.md
+++ b/changelog.d/sweep-executor-pr-collision-check.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** `/backlog-sweep:execute` Step 2 defense-in-depth now also queries `gh pr list` for open contributor PRs touching the initiative's anchor files — initiatives with file collisions updated within the past 14 days are marked `obsolete` before claim, closing the race where a contributor opens a PR for the same file set between plan generation and execution without using the Reserved-row marker.


### PR DESCRIPTION
## Summary

- Adds a second defense-in-depth check to `/backlog-sweep:execute` Step 2 that queries `gh pr list` for open contributor PRs whose diffs touch the initiative's anchor files
- Open PRs updated within 14 days that overlap anchor files cause the initiative to be marked `obsolete` before claim, closing the race between plan generation and execution
- Abandoned PRs (updated >14 days ago) do not block the claim

## Validation

- `./eng/verify-ai-docs.ps1` passed
- Doc-only change; no C# code modified

## Closes

Closes: sweep-executor-pr-collision-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)