### PR TITLE
feat(search): add offset/totalCount/hasMore pagination to symbol_search

### DIFF
--- a/changelog.d/symbol-search-pagination.md
+++ b/changelog.d/symbol-search-pagination.md
@@ -1,0 +1,3 @@
+# symbol-search-pagination
+
+**Added:** `symbol_search` now supports `offset` / `limit` pagination (max 200) with `totalCount` and `hasMore` in the response envelope. Closes gh #617.

--- a/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
@@ -8,8 +8,15 @@ namespace RoslynMcp.Core.Services;
 /// </summary>
 public interface ISymbolSearchService
 {
+    /// <param name="maxResults">
+    /// symbol-search-pagination: hard internal cap on the number of matching symbols collected
+    /// before offset/limit slicing is applied by the caller. Defaults to 1000. Callers that
+    /// need accurate <c>totalCount</c> must pass a value large enough to accommodate all
+    /// matching symbols; the tool layer uses <c>offset + limit</c> floored at 1000 to avoid
+    /// over-fetching on targeted queries.
+    /// </param>
     Task<IReadOnlyList<SymbolDto>> SearchSymbolsAsync(
-        string workspaceId, string query, string? projectFilter, string? kindFilter, string? namespaceFilter, int limit, CancellationToken ct);
+        string workspaceId, string query, string? projectFilter, string? kindFilter, string? namespaceFilter, int maxResults, CancellationToken ct);
     /// <param name="allowAdjacent">
     /// symbol-info-lenient-whitespace-resolution: when <see langword="false"/> (the default),
     /// a caret that falls on whitespace adjacent to an identifier does NOT resolve to that

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -16,7 +16,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class SymbolTools
 {
 
-    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace. Matching is substring (case-insensitive) — pass a bare fragment like 'Animal' to find 'AnimalService', 'IAnimal', 'CatAnimal', etc. Wildcards (*, ?) and regex metacharacters are NOT interpreted; they are matched literally.")]
+    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace. Matching is substring (case-insensitive) — pass a bare fragment like 'Animal' to find 'AnimalService', 'IAnimal', 'CatAnimal', etc. Wildcards (*, ?) and regex metacharacters are NOT interpreted; they are matched literally. Response shape: { count, totalCount, hasMore, offset, limit, symbols }.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Search symbols by name across the workspace.")]
     public static Task<string> SearchSymbols(
@@ -28,11 +28,16 @@ public static class SymbolTools
         [Description("Optional: filter by project name")] string? projectName = null,
         [Description("Optional: filter by symbol kind (Class, Method, Property, Field, Interface, etc.)")] string? kind = null,
         [Description("Optional: filter by namespace")] string? @namespace = null,
-        [Description("Maximum number of results to return (default: 50)")] int limit = 50,
+        [Description("Maximum number of results to return (default: 50, max: 200)")] int limit = 50,
+        [Description("Number of results to skip before returning (default: 0)")] int offset = 0,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            ParameterValidation.ValidatePagination(offset, limit);
+            if (limit > 200)
+                throw new ArgumentException($"Invalid limit '{limit}'. Limit must be 200 or less.");
+
             // Guard: empty/whitespace queries would otherwise dump the full workspace symbol index
             // (observed 70-80 KB payloads on mid-sized solutions). Return a structured empty-query
             // envelope so the caller gets an actionable note instead of a giant unfiltered dump.
@@ -41,22 +46,32 @@ public static class SymbolTools
                 return JsonSerializer.Serialize(new
                 {
                     count = 0,
+                    totalCount = 0,
+                    hasMore = false,
+                    offset,
+                    limit,
                     symbols = Array.Empty<object>(),
                     note = "query must be non-empty — pass a bare substring like 'Animal' to find 'AnimalService', 'IAnimal', etc."
                 }, JsonDefaults.Indented);
             }
-            var results = await symbolSearchService.SearchSymbolsAsync(workspaceId, query, projectName, kind, @namespace, limit, c);
+
+            // symbol-search-pagination: collect up to max(1000, offset+limit) results so that
+            // totalCount accurately reflects the available pool within the internal cap.
+            var maxResults = Math.Max(1000, offset + limit);
+            var allResults = await symbolSearchService.SearchSymbolsAsync(workspaceId, query, projectName, kind, @namespace, maxResults, c);
+            var paged = allResults.Skip(offset).Take(limit).ToList();
+            var hasMore = offset + paged.Count < allResults.Count;
 
             // elicit-disambiguation-on-multi-symbol-resolve: when the search returns >1 candidate
             // and the client supports MCP elicitation, ask the agent which candidate to focus on
             // and return ONLY that one with a chosenViaElicitation marker. Purely additive: if the
             // client lacks elicitation OR the user declines, fall through to the existing list shape.
-            if (results.Count > 1 && StructuredCallToolFilter.HasElicitation(server?.ClientCapabilities))
+            if (paged.Count > 1 && StructuredCallToolFilter.HasElicitation(server?.ClientCapabilities))
             {
-                var options = new List<(string Key, string Label)>(results.Count);
-                for (var i = 0; i < results.Count; i++)
+                var options = new List<(string Key, string Label)>(paged.Count);
+                for (var i = 0; i < paged.Count; i++)
                 {
-                    var r = results[i];
+                    var r = paged[i];
                     var label = string.IsNullOrEmpty(r.FilePath)
                         ? $"{r.Kind} {r.FullyQualifiedName}"
                         : $"{r.Kind} {r.FullyQualifiedName} — {Path.GetFileName(r.FilePath)}:{r.StartLine}";
@@ -67,24 +82,36 @@ public static class SymbolTools
                     server,
                     paramName: "choice",
                     title: "Pick a symbol",
-                    description: $"symbol_search returned {results.Count} candidates for '{query}'. Pick one to focus on.",
+                    description: $"symbol_search returned {allResults.Count} candidates for '{query}'. Pick one to focus on.",
                     options,
                     c).ConfigureAwait(false);
 
                 if (chosenKey is not null
                     && int.TryParse(chosenKey, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var idx)
-                    && idx >= 0 && idx < results.Count)
+                    && idx >= 0 && idx < paged.Count)
                 {
                     return JsonSerializer.Serialize(new
                     {
                         count = 1,
-                        symbols = new[] { results[idx] },
+                        totalCount = allResults.Count,
+                        hasMore,
+                        offset,
+                        limit,
+                        symbols = new[] { paged[idx] },
                         chosenViaElicitation = true,
                     }, JsonDefaults.Indented);
                 }
             }
 
-            return JsonSerializer.Serialize(new { count = results.Count, symbols = results }, JsonDefaults.Indented);
+            return JsonSerializer.Serialize(new
+            {
+                count = paged.Count,
+                totalCount = allResults.Count,
+                hasMore,
+                offset,
+                limit,
+                symbols = paged,
+            }, JsonDefaults.Indented);
         }, ct);
     }
 

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -35,9 +35,9 @@ public sealed class SymbolSearchService : ISymbolSearchService
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.None);
 
     public async Task<IReadOnlyList<SymbolDto>> SearchSymbolsAsync(
-        string workspaceId, string query, string? projectFilter, string? kindFilter, string? namespaceFilter, int limit, CancellationToken ct)
+        string workspaceId, string query, string? projectFilter, string? kindFilter, string? namespaceFilter, int maxResults, CancellationToken ct)
     {
-        _logger.LogDebug("SymbolSearchService.SearchSymbolsAsync: workspaceId={WorkspaceId} query={Query} projectFilter={ProjectFilter} kindFilter={KindFilter} namespaceFilter={NamespaceFilter} limit={Limit}", workspaceId, query, projectFilter, kindFilter, namespaceFilter, limit);
+        _logger.LogDebug("SymbolSearchService.SearchSymbolsAsync: workspaceId={WorkspaceId} query={Query} projectFilter={ProjectFilter} kindFilter={KindFilter} namespaceFilter={NamespaceFilter} maxResults={MaxResults}", workspaceId, query, projectFilter, kindFilter, namespaceFilter, maxResults);
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var results = new List<SymbolDto>();
         var seenKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -47,15 +47,15 @@ public sealed class SymbolSearchService : ISymbolSearchService
             return [];
 
         await RunPrimaryPatternSearchAsync(
-            solution, query, limit, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
+            solution, query, maxResults, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
 
         // symbol-search-partial-match-gap: FQN-substring pass. Only runs when we still have
-        // budget under `limit` — most queries are single-word simple-name lookups and the
+        // budget under `maxResults` — most queries are single-word simple-name lookups and the
         // primary pattern search already nails those.
-        if (results.Count < limit && !ct.IsCancellationRequested)
+        if (results.Count < maxResults && !ct.IsCancellationRequested)
         {
             await RunFqnSubstringFallbackAsync(
-                solution, query, limit, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
+                solution, query, maxResults, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
         }
 
         return results;

--- a/tests/RoslynMcp.Tests/SymbolSearchPaginationTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolSearchPaginationTests.cs
@@ -1,0 +1,218 @@
+using System.Text.Json;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <c>symbol-search-pagination</c>: <c>symbol_search</c> now supports
+/// <c>offset</c> / <c>limit</c> pagination (max 200) with <c>totalCount</c> and <c>hasMore</c>
+/// in the response envelope.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class SymbolSearchPaginationTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    // ── pagination envelope fields ──────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_ResponseContainsPaginationFields()
+    {
+        // Any non-empty query into SampleSolution should return the pagination envelope.
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 5, offset: 0,
+                ct: CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("count", out var count), "count field must be present");
+        Assert.IsTrue(root.TryGetProperty("totalCount", out var totalCount), "totalCount field must be present");
+        Assert.IsTrue(root.TryGetProperty("hasMore", out _), "hasMore field must be present");
+        Assert.IsTrue(root.TryGetProperty("offset", out var offsetProp), "offset field must be present");
+        Assert.IsTrue(root.TryGetProperty("limit", out var limitProp), "limit field must be present");
+        Assert.IsTrue(root.TryGetProperty("symbols", out var symbols), "symbols field must be present");
+        Assert.AreEqual(JsonValueKind.Array, symbols.ValueKind);
+
+        Assert.AreEqual(0, offsetProp.GetInt32(), "offset must echo the requested value");
+        Assert.AreEqual(5, limitProp.GetInt32(), "limit must echo the requested value");
+        Assert.IsTrue(totalCount.GetInt32() >= count.GetInt32(),
+            "totalCount must be >= count (paged slice size)");
+        Assert.IsTrue(count.GetInt32() <= 5, "count must not exceed the requested limit");
+    }
+
+    // ── offset slicing ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_OffsetSlicesResults()
+    {
+        // Fetch first two pages and verify they are disjoint and together cover page 0.
+        var page0Json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 3, offset: 0,
+                ct: CancellationToken.None));
+
+        var page1Json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 3, offset: 3,
+                ct: CancellationToken.None));
+
+        using var doc0 = JsonDocument.Parse(page0Json);
+        using var doc1 = JsonDocument.Parse(page1Json);
+
+        var symbols0 = doc0.RootElement.GetProperty("symbols").EnumerateArray()
+            .Select(s => s.GetProperty("fullyQualifiedName").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        var symbols1 = doc1.RootElement.GetProperty("symbols").EnumerateArray()
+            .Select(s => s.GetProperty("fullyQualifiedName").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Consecutive pages must be disjoint (no repeated FQNs across offset=0 and offset=3).
+        var overlap = symbols0.Intersect(symbols1).ToList();
+        Assert.AreEqual(0, overlap.Count,
+            $"Pages must be disjoint. Overlapping FQNs: {string.Join(", ", overlap)}");
+
+        // totalCount must be the same on both pages (same query, same underlying result set).
+        var total0 = doc0.RootElement.GetProperty("totalCount").GetInt32();
+        var total1 = doc1.RootElement.GetProperty("totalCount").GetInt32();
+        Assert.AreEqual(total0, total1,
+            "totalCount must be identical across pages of the same query");
+    }
+
+    // ── hasMore flag ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_HasMore_FalseOnLastPage()
+    {
+        // First page: find out how many Animal symbols are present.
+        var probeJson = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 200, offset: 0,
+                ct: CancellationToken.None));
+
+        using var probeDoc = JsonDocument.Parse(probeJson);
+        var total = probeDoc.RootElement.GetProperty("totalCount").GetInt32();
+        var hasMoreProbe = probeDoc.RootElement.GetProperty("hasMore").GetBoolean();
+        Assert.IsFalse(hasMoreProbe,
+            "When limit=200 covers all results, hasMore must be false");
+        Assert.IsTrue(total >= 1, "SampleSolution must contain at least one 'Animal' symbol");
+    }
+
+    [TestMethod]
+    public async Task SymbolSearch_HasMore_TrueWhenResultsExceedLimit()
+    {
+        // Use a very small limit to force hasMore=true when the solution has multiple Animal symbols.
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 1, offset: 0,
+                ct: CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        var total = doc.RootElement.GetProperty("totalCount").GetInt32();
+        var hasMore = doc.RootElement.GetProperty("hasMore").GetBoolean();
+
+        if (total > 1)
+        {
+            // SampleSolution has multiple Animal symbols — hasMore must be true.
+            Assert.IsTrue(hasMore,
+                $"With limit=1 and totalCount={total}, hasMore must be true");
+        }
+        else
+        {
+            // Edge case: only 1 match — hasMore must be false.
+            Assert.IsFalse(hasMore,
+                "When exactly 1 result and limit=1 there is nothing more, hasMore must be false");
+        }
+    }
+
+    // ── limit = 200 max ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_LimitExceeds200_ThrowsArgumentException()
+    {
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+        {
+            await SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 201, offset: 0,
+                ct: CancellationToken.None);
+        });
+    }
+
+    // ── negative offset ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_NegativeOffset_ThrowsArgumentException()
+    {
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+        {
+            await SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 10, offset: -1,
+                ct: CancellationToken.None);
+        });
+    }
+
+    // ── empty-query envelope carries pagination fields ───────────────────────
+
+    [TestMethod]
+    public async Task SymbolSearch_EmptyQuery_EnvelopeHasPaginationFields()
+    {
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "",
+                projectName: null, kind: null, @namespace: null,
+                limit: 50, offset: 0,
+                ct: CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(0, root.GetProperty("count").GetInt32());
+        Assert.AreEqual(0, root.GetProperty("totalCount").GetInt32());
+        Assert.IsFalse(root.GetProperty("hasMore").GetBoolean());
+        Assert.AreEqual(0, root.GetProperty("offset").GetInt32());
+        Assert.AreEqual(50, root.GetProperty("limit").GetInt32());
+    }
+}

--- a/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
@@ -33,8 +33,8 @@ public sealed class Top10V3RegressionTests : IsolatedWorkspaceTestBase
             () => SymbolTools.SearchSymbols(
                 server: null!, WorkspaceExecutionGate, SymbolSearchService, _workspaceId,
                 query: "AnimalService",
-                projectName: null, kind: null, @namespace: null, limit: 10,
-                CancellationToken.None));
+                projectName: null, kind: null, @namespace: null, limit: 10, offset: 0,
+                ct: CancellationToken.None));
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("count", out var count),
@@ -60,8 +60,8 @@ public sealed class Top10V3RegressionTests : IsolatedWorkspaceTestBase
             () => SymbolTools.SearchSymbols(
                 server: null!, WorkspaceExecutionGate, SymbolSearchService, _workspaceId,
                 query: query,
-                projectName: null, kind: null, @namespace: null, limit: 50,
-                CancellationToken.None));
+                projectName: null, kind: null, @namespace: null, limit: 50, offset: 0,
+                ct: CancellationToken.None));
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.TryGetProperty("count", out var count),
@@ -88,8 +88,8 @@ public sealed class Top10V3RegressionTests : IsolatedWorkspaceTestBase
             () => SymbolTools.SearchSymbols(
                 server: null!, WorkspaceExecutionGate, SymbolSearchService, _workspaceId,
                 query: "AnimalService",
-                projectName: null, kind: null, @namespace: null, limit: 10,
-                CancellationToken.None));
+                projectName: null, kind: null, @namespace: null, limit: 10, offset: 0,
+                ct: CancellationToken.None));
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsFalse(doc.RootElement.TryGetProperty("note", out _),

--- a/tests/RoslynMcp.Tests/UnresolvedAnalyzerReferenceTests.cs
+++ b/tests/RoslynMcp.Tests/UnresolvedAnalyzerReferenceTests.cs
@@ -80,7 +80,7 @@ public sealed class UnresolvedAnalyzerReferenceTests : IsolatedWorkspaceTestBase
         var workspaceId = await workspace.LoadAsync();
 
         var animalSearch = await SymbolSearchService.SearchSymbolsAsync(
-            workspaceId, "IAnimal", projectFilter: null, kindFilter: "Interface", namespaceFilter: null, limit: 5, CancellationToken.None);
+            workspaceId, "IAnimal", projectFilter: null, kindFilter: "Interface", namespaceFilter: null, maxResults: 5, CancellationToken.None);
         var iAnimal = animalSearch.FirstOrDefault();
         Assert.IsNotNull(iAnimal, "Sample fixture must contain IAnimal symbol.");
 


### PR DESCRIPTION
## Summary

- `symbol_search` now supports `offset` / `limit` pagination (max 200) with `totalCount` and `hasMore` in the response envelope, mirroring the `find_references` contract
- Service layer (`ISymbolSearchService.SearchSymbolsAsync`, `SymbolSearchService`) renames `limit` to `maxResults` — the tool passes `max(1000, offset+limit)` so `totalCount` accurately reflects the available pool within the internal cap
- Tool layer adds `offset` (default 0) parameter, validates via `ParameterValidation.ValidatePagination`, enforces `limit <= 200`, and emits `{ count, totalCount, hasMore, offset, limit, symbols }` response shape
- Two existing test call sites (`Top10V3RegressionTests`, `UnresolvedAnalyzerReferenceTests`) updated to use the new signature
- New `SymbolSearchPaginationTests` adds 7 fixtures covering: envelope fields, offset slicing, hasMore flag, max-limit enforcement, and negative-offset rejection

## Test plan

- [x] `SymbolSearchPaginationTests` — 7/7 pass
- [x] `Top10V3RegressionTests` — 9/9 pass (existing symbol_search regressions)
- [x] `UnresolvedAnalyzerReferenceTests` — 3/3 pass
- [x] Full solution build: 0 errors, 0 warnings
- [x] `verify-ai-docs.ps1` passed

Closes: symbol-search-pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)