### PR TITLE
fix(analysis): classify static-class consumers as StaticMemberAccess/invocation not Other

### DIFF
--- a/changelog.d/find-consumers-static-class-classification.md
+++ b/changelog.d/find-consumers-static-class-classification.md
@@ -1,0 +1,3 @@
+# find-consumers-static-class-classification
+
+**Fixed:** `find_consumers` and `find_type_consumers` now classify static-class consumers as `StaticMemberAccess` / `invocation` instead of the uninformative `Other` / `local` buckets. Calls like `AnimalFormatter.Format(...)` are now correctly identified rather than falling through to the catch-all bucket.

--- a/samples/SampleSolution/SampleApp/Program.cs
+++ b/samples/SampleSolution/SampleApp/Program.cs
@@ -27,3 +27,9 @@ foreach (var shape in shapes)
 {
     Console.WriteLine(shape.Describe());
 }
+
+// Explicit static-class invocation — tests assert this produces StaticMemberAccess, not Other.
+var formatted = AnimalFormatter.Format(animals.First());
+Console.WriteLine(formatted);
+var allFormatted = AnimalFormatter.FormatAll(animals);
+Console.WriteLine(allFormatted);

--- a/samples/SampleSolution/SampleLib.Tests/AnimalFormatterTests.cs
+++ b/samples/SampleSolution/SampleLib.Tests/AnimalFormatterTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SampleLib;
+
+namespace SampleLib.Tests;
+
+// Consumer of AnimalFormatter via explicit static-class invocation syntax.
+// Used by RoslynMcp.Tests to assert that static-class consumers are classified as
+// StaticMemberAccess / invocation rather than Other.
+[TestClass]
+public class AnimalFormatterTests
+{
+    [TestMethod]
+    public void Format_ReturnsDogLabel()
+    {
+        var service = new AnimalService();
+        var animals = service.GetAllAnimals();
+        var dog = animals.First(a => a.Name == "Dog");
+
+        // Explicit static-class invocation — this is what the classification fix targets.
+        var result = AnimalFormatter.Format(dog);
+
+        StringAssert.Contains(result, "Dog");
+    }
+
+    [TestMethod]
+    public void FormatAll_ContainsAllAnimals()
+    {
+        var service = new AnimalService();
+        var animals = service.GetAllAnimals();
+
+        // Second explicit static-class invocation on the same class.
+        var result = AnimalFormatter.FormatAll(animals);
+
+        StringAssert.Contains(result, "Dog");
+        StringAssert.Contains(result, "Cat");
+    }
+}

--- a/samples/SampleSolution/SampleLib/AnimalFormatter.cs
+++ b/samples/SampleSolution/SampleLib/AnimalFormatter.cs
@@ -1,0 +1,15 @@
+namespace SampleLib;
+
+/// <summary>
+/// Static helper for formatting animal descriptions.
+/// Used by tests that assert static-class consumers are classified as
+/// StaticMemberAccess / invocation rather than Other.
+/// </summary>
+public static class AnimalFormatter
+{
+    public static string Format(IAnimal animal) =>
+        $"[{animal.Name}] says: {animal.Speak()}";
+
+    public static string FormatAll(IEnumerable<IAnimal> animals) =>
+        string.Join(", ", animals.Select(Format));
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -13,7 +13,7 @@ public static class ConsumerAnalysisTools
     [McpServerTool(Name = "find_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
         "Find all types that depend on a given type or interface, classified by dependency kind. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated)."),
-     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the consumer walk to the listed project(s) — matches semantic_grep's filter semantics.")]
+     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument, StaticMemberAccess). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the consumer walk to the listed project(s) — matches semantic_grep's filter semantics.")]
     public static Task<string> FindConsumers(
         IWorkspaceExecutionGate gate,
         IConsumerAnalysisService consumerAnalysisService,

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -130,6 +130,12 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
                 or "AddKeyedSingleton" or "AddKeyedScoped" or "AddKeyedTransient")
             return nameof(TypeUsageClassification.DIRegistration);
 
+        // StaticClass.Method(...) — the type name appears as the left-hand side of a member access.
+        // This is the primary pattern for static-class consumers (e.g. MathHelper.Compute(...),
+        // AnimalExtensions.Describe(...)) and produces "StaticMemberAccess" instead of "Other".
+        if (parent is MemberAccessExpressionSyntax)
+            return nameof(TypeUsageClassification.StaticMemberAccess);
+
         // Constructor parameter
         if (parent is ParameterSyntax param)
         {

--- a/src/RoslynMcp.Roslyn/Services/TypeConsumersService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeConsumersService.cs
@@ -199,6 +199,11 @@ public sealed class TypeConsumersService : ITypeConsumersService
                     return "field";
                 case LocalDeclarationStatementSyntax:
                     return "local";
+                // StaticClass.Method(...) — type name appears as the receiver of a member access
+                // (e.g. AnimalExtensions.Describe(...)). Classify as "invocation" so static-class
+                // consumers are no longer bucketed into the uninformative "other" bucket.
+                case MemberAccessExpressionSyntax:
+                    return "invocation";
                 // Stop walking once we leave a member declaration boundary so a nested type
                 // reference inside a method body does not bubble up to its containing field
                 // initializer or class declaration accidentally.

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -59,4 +59,27 @@ public sealed class ConsumerAnalysisTests : SharedWorkspaceTestBase
         Assert.IsNotNull(rectangle, "Rectangle should consume Shape");
         CollectionAssert.Contains(rectangle.DependencyKinds.ToList(), "BaseType");
     }
+
+    [TestMethod]
+    public async Task FindConsumers_StaticClass_ClassifiesAsStaticMemberAccess()
+    {
+        // find-consumers-static-class-classification: consumers that call static methods on a
+        // public static class must be classified as "StaticMemberAccess", not "Other".
+        // SampleApp/Program.cs calls AnimalFormatter.Format(...) and AnimalFormatter.FormatAll(...)
+        // using explicit static-class syntax — this is the canonical static-consumer pattern.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalFormatter");
+        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Consumers.Count >= 1,
+            $"Expected at least 1 consumer of AnimalFormatter, got {result.Consumers.Count}");
+
+        // All dependency kinds reported for AnimalFormatter consumers must NOT include "Other".
+        // The presence of "StaticMemberAccess" is the positive assertion.
+        var allKinds = result.Consumers.SelectMany(c => c.DependencyKinds).Distinct().ToList();
+        CollectionAssert.Contains(allKinds, "StaticMemberAccess",
+            $"Expected 'StaticMemberAccess' kind for static-class consumers. Actual kinds: [{string.Join(", ", allKinds)}]");
+        CollectionAssert.DoesNotContain(allKinds, "Other",
+            $"'Other' kind must not appear for static-class consumers. Actual kinds: [{string.Join(", ", allKinds)}]");
+    }
 }

--- a/tests/RoslynMcp.Tests/TypeConsumersServiceTests.cs
+++ b/tests/RoslynMcp.Tests/TypeConsumersServiceTests.cs
@@ -31,10 +31,12 @@ public sealed class TypeConsumersServiceTests : SharedWorkspaceTestBase
             Assert.IsTrue(entry.Count >= 1, $"Rollup for '{entry.FilePath}' has zero sites.");
             Assert.IsTrue(entry.Kinds.Count >= 1, $"Rollup for '{entry.FilePath}' has empty kinds.");
             // Every kind string must be one of the documented values.
+            // "invocation" was added by find-consumers-static-class-classification to cover
+            // static-class consumers (StaticClass.Method(...) syntax).
             foreach (var kind in entry.Kinds)
             {
                 CollectionAssert.Contains(
-                    new[] { "using", "ctor", "inherit", "field", "local", "other" },
+                    new[] { "using", "ctor", "inherit", "field", "local", "invocation", "other" },
                     kind,
                     $"Unexpected kind '{kind}' in rollup for '{entry.FilePath}'.");
             }
@@ -100,5 +102,24 @@ public sealed class TypeConsumersServiceTests : SharedWorkspaceTestBase
         Assert.IsNotNull(rectangle, "Rectangle.cs should appear in the Shape rollup.");
         CollectionAssert.Contains(rectangle.Kinds.ToList(), "inherit",
             $"Rectangle.cs should classify its Shape usage as 'inherit'; got [{string.Join(", ", rectangle.Kinds)}].");
+    }
+
+    [TestMethod]
+    public async Task FindTypeConsumers_StaticClass_ClassifiesAsInvocation()
+    {
+        // find-consumers-static-class-classification: SampleApp/Program.cs calls
+        // AnimalFormatter.Format(...) and AnimalFormatter.FormatAll(...) using explicit
+        // static-class syntax. The rollup for Program.cs must include "invocation", not "other".
+        var results = await TypeConsumersService.FindTypeConsumersAsync(
+            WorkspaceId, "SampleLib.AnimalFormatter", limit: 100, CancellationToken.None);
+
+        Assert.IsTrue(results.Count >= 1,
+            $"Expected at least 1 file consuming AnimalFormatter, got {results.Count}.");
+
+        var allKinds = results.SelectMany(r => r.Kinds).Distinct().ToList();
+        CollectionAssert.Contains(allKinds, "invocation",
+            $"Expected 'invocation' kind for static-class consumers. Actual kinds: [{string.Join(", ", allKinds)}]");
+        CollectionAssert.DoesNotContain(allKinds, "other",
+            $"'other' kind must not appear for static-class consumers. Actual kinds: [{string.Join(", ", allKinds)}]");
     }
 }

--- a/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
@@ -140,8 +140,10 @@ public class ValidationIntegrationTests : SharedWorkspaceTestBase
             CancellationToken.None);
 
         Assert.IsTrue(result.Execution.Succeeded, result.Execution.StdErr);
-        Assert.AreEqual(2, result.Total);
-        Assert.AreEqual(2, result.Passed);
+        // Total includes AnimalServiceTests (2) + AnimalFormatterTests (2, added by
+        // find-consumers-static-class-classification to exercise static-class invocation).
+        Assert.AreEqual(4, result.Total);
+        Assert.AreEqual(4, result.Passed);
         Assert.AreEqual(0, result.Failed);
     }
 


### PR DESCRIPTION
## Summary

- `find_consumers` classified all static-class consumers (e.g. `AnimalFormatter.Format(...)`) as `Other` because `MemberAccessExpressionSyntax` was not handled in `ClassifyDependencyKind`. Fix: detect `MemberAccessExpressionSyntax` parent and return `StaticMemberAccess` (already in the `TypeUsageClassification` enum).
- `find_type_consumers` classified the same pattern as `other` (via the `MemberDeclarationSyntax` catch-all). Fix: detect `MemberAccessExpressionSyntax` in the ancestor-walk and return `"invocation"` before the catch-all fires.
- Added `AnimalFormatter` static class + `AnimalFormatterTests` consumer to `SampleSolution` as fixture, with tests asserting the new classifications.

## Files changed

- `src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs` — `MemberAccessExpressionSyntax` → `StaticMemberAccess`
- `src/RoslynMcp.Roslyn/Services/TypeConsumersService.cs` — `MemberAccessExpressionSyntax` → `"invocation"`
- `src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs` — updated description to mention `StaticMemberAccess`
- `tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs` — new `FindConsumers_StaticClass_ClassifiesAsStaticMemberAccess` test
- `tests/RoslynMcp.Tests/TypeConsumersServiceTests.cs` — new `FindTypeConsumers_StaticClass_ClassifiesAsInvocation` test + updated allowed-kinds list
- `tests/RoslynMcp.Tests/ValidationIntegrationTests.cs` — updated hardcoded test count (2 → 4) after adding `AnimalFormatterTests`
- `samples/SampleSolution/SampleLib/AnimalFormatter.cs` — new static class fixture
- `samples/SampleSolution/SampleLib.Tests/AnimalFormatterTests.cs` — consumer fixture
- `samples/SampleSolution/SampleApp/Program.cs` — additional explicit static-class call
- `changelog.d/find-consumers-static-class-classification.md` — changelog fragment

## Test plan

- [x] `ConsumerAnalysis` tests: 4/4 pass
- [x] `TypeConsumers` tests: 6/6 pass
- [x] `Test_Run_Returns_Structured_Success` pass (updated count 2→4)
- [x] Build succeeded: 0 warnings, 0 errors (Release)
- [x] `verify-ai-docs.ps1` passed

Closes: `find-consumers-static-class-classification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)