### PR TITLE
fix(type-move): single-type file error message now points at move_file_preview

### DIFF
--- a/changelog.d/move-type-to-file-rejects-single-type.md
+++ b/changelog.d/move-type-to-file-rejects-single-type.md
@@ -1,0 +1,1 @@
+**Fixed:** `move_type_to_file_preview` error message on single-type source files now points callers at `move_file_preview` (the correct tool for rename-style operations) instead of the misleading "nested types cannot be extracted" message. Closes gh #626.

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -21,7 +21,7 @@ public static class TypeMoveTools
     [McpServerTool(Name = "move_type_to_file_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "stable", true, false,
         "Preview moving a type declaration into its own file."),
-     Description("Preview moving a type declaration from a multi-type file into its own dedicated file within the same project")]
+     Description("Preview moving a type declaration from a multi-type file into its own dedicated file within the same project. Requires the source file to contain at least two top-level types; for single-type rename/move operations use move_file_preview instead.")]
     public static Task<string> PreviewMoveTypeToFile(
         IWorkspaceExecutionGate gate,
         ITypeMoveService typeMoveService,

--- a/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeMoveService.cs
@@ -76,8 +76,9 @@ public sealed class TypeMoveService : ITypeMoveService
         if (typeCount < 2)
         {
             throw new InvalidOperationException(
-                "Source file only contains one top-level type. " +
-                "Nested types cannot be extracted with this tool — only top-level type declarations are considered.");
+                "Source file contains only one top-level type. " +
+                "To move or rename the file, use move_file_preview instead. " +
+                "move_type_to_file_preview is for extracting one type out of a file that contains multiple top-level types.");
         }
 
         // Determine target file path

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -47,6 +47,29 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task MoveType_SingleTypeFile_ErrorMessagePointsAtMoveFilePreview()
+    {
+        // Regression guard: when a caller tries to "rename" a single-type file via
+        // move_type_to_file_preview, the error must point them at move_file_preview
+        // instead of surfacing the misleading "nested types cannot be extracted" wording.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Dog.cs") == true);
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            TypeMoveService.PreviewMoveTypeToFileAsync(
+                wsId, doc.FilePath!, "Dog", null, CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "move_file_preview",
+            $"Error message must point callers at move_file_preview; got: {ex.Message}");
+        Assert.IsFalse(ex.Message.Contains("Nested types cannot be extracted", StringComparison.Ordinal),
+            $"Misleading 'Nested types cannot be extracted' wording must not appear; got: {ex.Message}");
+    }
+
+    [TestMethod]
     public async Task MoveType_NonExistentType_ThrowsInvalidOperation()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

- `move_type_to_file_preview` on a single-type source file previously emitted the misleading message *"Nested types cannot be extracted with this tool — only top-level type declarations are considered"*, which is factually wrong when the file has exactly one top-level type (no nested types).
- Updated the error message to: *"Source file contains only one top-level type. To move or rename the file, use move_file_preview instead. move_type_to_file_preview is for extracting one type out of a file that contains multiple top-level types."*
- Updated the `move_type_to_file_preview` tool `Description` attribute to document the multi-type prerequisite and the `move_file_preview` alternative.
- Added regression test `MoveType_SingleTypeFile_ErrorMessagePointsAtMoveFilePreview` to `TypeMoveTests.cs` asserting the new message text and the absence of the old misleading wording.

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~TypeMoveTests"` — all 8 tests pass (7 existing + 1 new)
- [ ] Existing `MoveType_SingleTypeFile_ThrowsInvalidOperation` still passes (error is still thrown)
- [ ] New fixture asserts message contains `move_file_preview` and does NOT contain `Nested types cannot be extracted`

Closes: `move-type-to-file-rejects-single-type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)