### PR TITLE
fix(project-mutation): set_conditional_property_preview error includes MSBuild-quoting example

### DIFF
--- a/changelog.d/set-conditional-property-error-msg-quoting.md
+++ b/changelog.d/set-conditional-property-error-msg-quoting.md
@@ -1,0 +1,1 @@
+**Fixed:** `set_conditional_property_preview` error message now includes the MSBuild-quoting example (`'$(Configuration)' == 'Release'`) so first-time callers see the expected syntax. Closes gh #622.

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -629,7 +629,8 @@ public sealed class ProjectMutationService : IProjectMutationService
         if (!SupportedConditionPattern.IsMatch(condition))
         {
             throw new InvalidOperationException(
-                "Conditional property updates only support equality conditions on $(Configuration), $(TargetFramework), or $(Platform).");
+                "Conditional property updates only support equality conditions on $(Configuration), $(TargetFramework), or $(Platform). " +
+                "Use MSBuild-style single-quoting: '$(Configuration)' == 'Release'");
         }
     }
 

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -509,4 +509,22 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
         var revertedBytes = await File.ReadAllTextAsync(projectFilePath, CancellationToken.None);
         Assert.AreEqual(preApplyBytes, revertedBytes, "Revert must restore the .csproj byte-exact.");
     }
+
+    [TestMethod]
+    public async Task Set_Conditional_Property_Preview_Invalid_Condition_Error_Message_Includes_MSBuild_Quoting_Example()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        // Pass a condition that omits MSBuild-style single-quoting (the common first-time caller mistake).
+        const string invalidCondition = "$(Configuration) == Release";
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            ProjectMutationService.PreviewSetConditionalPropertyAsync(
+                workspace.WorkspaceId,
+                new SetConditionalPropertyDto("SampleLib", "LangVersion", "preview", invalidCondition),
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "'$(Configuration)' == 'Release'",
+            "Error message must include the MSBuild-quoting example so first-time callers see the expected syntax.");
+    }
 }


### PR DESCRIPTION
## Summary

- `set_conditional_property_preview` validates the `condition` parameter against a regex requiring MSBuild-style single-quoting (`'$(Configuration)' == 'Release'`), but the previous error message only said which variables were allowed — it gave no hint about the quoting syntax.
- Updated the `ValidateSupportedCondition` error message to append the canonical example: `'$(Configuration)' == 'Release'`.
- Added a regression test (`Set_Conditional_Property_Preview_Invalid_Condition_Error_Message_Includes_MSBuild_Quoting_Example`) asserting the example string appears in the exception message when an unquoted condition is passed.

## Test plan

- [x] New test passes: `Set_Conditional_Property_Preview_Invalid_Condition_Error_Message_Includes_MSBuild_Quoting_Example`
- [x] Existing tests pass: both `Set_Conditional_Property_Preview_*` tests green (2/2)
- [x] `compile_check` on `RoslynMcp.Roslyn` and `RoslynMcp.Tests` — 0 errors

Closes: set-conditional-property-error-msg-quoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)