### PR TITLE
fix(orchestration): detect duplicate interface on extract_and_wire_interface_preview

### DIFF
--- a/changelog.d/extract-and-wire-interface-duplicate-cross-project.md
+++ b/changelog.d/extract-and-wire-interface-duplicate-cross-project.md
@@ -1,0 +1,1 @@
+**Fixed:** `extract_and_wire_interface_preview` now detects when the target type already implements an interface with the same name (cross-project or in-project) and declines with a pointer at `extract_interface_cross_project_preview`. Closes gh #625.

--- a/src/RoslynMcp.Roslyn/Services/ExtractAndWireOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/ExtractAndWireOrchestrator.cs
@@ -1,5 +1,6 @@
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
@@ -40,6 +41,8 @@ public sealed class ExtractAndWireOrchestrator : IExtractAndWireOrchestrator
         var workspaceVersion = _workspace.GetCurrentVersion(workspaceId);
         var resolvedInterfaceName = string.IsNullOrWhiteSpace(interfaceName) ? $"I{typeName}" : interfaceName;
         var currentSolution = _workspace.GetCurrentSolution(workspaceId);
+
+        await DetectDuplicateInterfaceAsync(currentSolution, filePath, typeName, resolvedInterfaceName, ct).ConfigureAwait(false);
 
         var extractionPreview = await _crossProjectRefactoringService.PreviewExtractInterfaceAsync(
             workspaceId,
@@ -106,6 +109,68 @@ public sealed class ExtractAndWireOrchestrator : IExtractAndWireOrchestrator
         var description = $"Extract interface '{resolvedInterfaceName}' from '{typeName}' and wire consumers";
         var token = _compositePreviewStore.Store(workspaceId, workspaceVersion, description, mutations);
         return new RefactoringPreviewDto(token, description, changes, warnings.Count == 0 ? null : warnings);
+    }
+
+    /// <summary>
+    /// Detects whether the target type already implements an interface with the same simple name
+    /// as <paramref name="resolvedInterfaceName"/> (across any project). When found, throws with
+    /// a structured message that directs the caller to use
+    /// <c>extract_interface_cross_project_preview</c> instead.
+    /// </summary>
+    private static async Task DetectDuplicateInterfaceAsync(
+        Solution solution,
+        string filePath,
+        string typeName,
+        string resolvedInterfaceName,
+        CancellationToken ct)
+    {
+        var sourceDocument = SymbolResolver.FindDocument(solution, filePath);
+        if (sourceDocument is null)
+        {
+            return;
+        }
+
+        var sourceRoot = await sourceDocument.GetSyntaxRootAsync(ct).ConfigureAwait(false) as CompilationUnitSyntax;
+        if (sourceRoot is null)
+        {
+            return;
+        }
+
+        var typeDeclaration = sourceRoot.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(candidate => string.Equals(candidate.Identifier.ValueText, typeName, StringComparison.Ordinal));
+        if (typeDeclaration is null)
+        {
+            return;
+        }
+
+        var semanticModel = await sourceDocument.GetSemanticModelAsync(ct).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var typeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, ct) as INamedTypeSymbol;
+        if (typeSymbol is null)
+        {
+            return;
+        }
+
+        var existingInterface = typeSymbol.Interfaces.FirstOrDefault(iface =>
+            string.Equals(iface.Name, resolvedInterfaceName, StringComparison.Ordinal));
+
+        if (existingInterface is not null)
+        {
+            var existingProject = solution.Projects.FirstOrDefault(project =>
+                project.Id == existingInterface.ContainingAssembly?.Locations
+                    .Select(loc => solution.GetDocument(loc.SourceTree)?.Project.Id)
+                    .FirstOrDefault(id => id is not null));
+
+            var projectHint = existingProject is not null ? $" (project '{existingProject.Name}')" : string.Empty;
+            throw new InvalidOperationException(
+                $"Type '{typeName}' already implements interface '{resolvedInterfaceName}'{projectHint}. " +
+                $"extract_and_wire_interface_preview cannot create a duplicate. " +
+                $"If you intended to extract a cross-project interface contract, use extract_interface_cross_project_preview instead.");
+        }
     }
 
     private static void UpsertMutation(List<CompositeFileMutation> mutations, string filePath, string updatedContent)

--- a/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
@@ -364,6 +364,52 @@ public sealed class OrchestrationIntegrationTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(registrationsContents.Contains("AddSingleton<IAnimalService, AnimalService>()", StringComparison.Ordinal));
     }
 
+    [TestMethod]
+    public async Task Extract_And_Wire_Interface_Preview_Declines_When_Type_Already_Implements_Same_Named_Interface()
+    {
+        // extract-and-wire-interface-duplicate-cross-project regression:
+        // When the target type already implements an interface with the same simple name — even
+        // from a different project — extract_and_wire_interface_preview must decline immediately
+        // with a structured message pointing the caller at extract_interface_cross_project_preview.
+        // Pre-fix, the orchestrator delegated to CrossProjectRefactoringService which either
+        // produced a duplicate base-type declaration or hit an unrelated file-exists conflict.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        // Create a Contracts project that already declares IAnimalService.
+        AddProjectToCopiedSolution(workspace.RootPath, "Contracts", "net10.0");
+        var contractsProjectFile = workspace.GetPath("Contracts", "Contracts.csproj");
+        var existingInterfaceFile = workspace.GetPath("Contracts", "IAnimalService.cs");
+        File.WriteAllText(
+            existingInterfaceFile,
+            "namespace Contracts;\n\npublic interface IAnimalService\n{\n    System.Collections.Generic.List<SampleLib.IAnimal> GetAllAnimals();\n}\n");
+
+        // Wire SampleLib to already implement IAnimalService from Contracts.
+        var sampleLibProjectFile = workspace.GetPath("SampleLib", "SampleLib.csproj");
+        InjectProjectReference(sampleLibProjectFile, "..\\Contracts\\Contracts.csproj");
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+        File.WriteAllText(
+            sourceFilePath,
+            "using System.Collections.Generic;\nusing Contracts;\n\nnamespace SampleLib;\n\npublic class AnimalService : IAnimalService\n{\n    public List<IAnimal> GetAllAnimals()\n    {\n        return [new Dog(), new Cat()];\n    }\n    public void MakeThemSpeak(System.Collections.Generic.IEnumerable<IAnimal> animals) { }\n    public int CountAnimals(List<IAnimal> animals) => animals.Count;\n    public int CountAnimals(System.Collections.Generic.IEnumerable<IAnimal> animals) => 0;\n}\n");
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        // Attempting to extract IAnimalService again must produce a structured rejection.
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            ExtractAndWireOrchestrator.PreviewExtractAndWireInterfaceAsync(
+                workspace.WorkspaceId,
+                sourceFilePath,
+                "AnimalService",
+                "IAnimalService",
+                "Contracts",
+                updateDiRegistrations: false,
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "already implements interface 'IAnimalService'",
+            $"extract_and_wire_interface_preview must report the duplicate interface. Actual message: {ex.Message}");
+        StringAssert.Contains(ex.Message, "extract_interface_cross_project_preview",
+            $"rejection message must point at extract_interface_cross_project_preview. Actual message: {ex.Message}");
+    }
+
     private static void InjectPackageReference(string projectFilePath, string packageId)
     {
         var projectXml = XDocument.Load(projectFilePath, LoadOptions.PreserveWhitespace);


### PR DESCRIPTION
## Summary

- `ExtractAndWireOrchestrator.PreviewExtractAndWireInterfaceAsync` now checks the target type's `Interfaces` collection (name-only, cross-project aware) before delegating to `CrossProjectRefactoringService`
- When the type already implements an interface with the same simple name, declines with a structured `InvalidOperationException` pointing the caller at `extract_interface_cross_project_preview`
- New test in `OrchestrationIntegrationTests` covers the cross-project duplicate scenario end-to-end

## Test plan

- [x] New test `Extract_And_Wire_Interface_Preview_Declines_When_Type_Already_Implements_Same_Named_Interface` passes
- [x] All existing `OrchestrationIntegrationTests` (8 total) pass
- [x] Production and test projects build with 0 errors

Closes: extract-and-wire-interface-duplicate-cross-project