### PR TITLE
fix(scaffolding): emit using directives for ctor-param namespaces in scaffold_test_preview

### DIFF
--- a/SampleLib/MultiNamespaceService.cs
+++ b/SampleLib/MultiNamespaceService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SampleLib;
+
+/// <summary>
+/// Sample service whose constructor takes parameters from three distinct BCL namespaces
+/// (System.IO, System.Text, System.Collections.Generic). Used by the
+/// scaffold-test-preview-missing-usings fixture to verify that scaffold_test_preview and
+/// scaffold_first_test_file_preview emit using directives for all constructor-parameter
+/// namespaces, not just the service type's own namespace.
+/// </summary>
+public class MultiNamespaceService
+{
+    private readonly TextWriter _writer;
+    private readonly StringBuilder _buffer;
+    private readonly IList<string> _items;
+
+    public MultiNamespaceService(TextWriter writer, StringBuilder buffer, IList<string> items)
+    {
+        _writer = writer;
+        _buffer = buffer;
+        _items = items;
+    }
+
+    public void Flush()
+    {
+        _writer.Write(_buffer.ToString());
+        _buffer.Clear();
+    }
+
+    public int Count() => _items.Count;
+}

--- a/changelog.d/scaffold-test-preview-missing-usings.md
+++ b/changelog.d/scaffold-test-preview-missing-usings.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `scaffold_test_preview` and `scaffold_first_test_file_preview` now emit `using` directives for all constructor-parameter namespaces — generated test files compile out of the box. Closes [gh #624](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/624).

--- a/samples/SampleSolution/SampleLib/MultiNamespaceService.cs
+++ b/samples/SampleSolution/SampleLib/MultiNamespaceService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SampleLib;
+
+/// <summary>
+/// Sample service whose constructor takes parameters from three distinct BCL namespaces
+/// (System.IO, System.Text, System.Collections.Generic). Used by the
+/// scaffold-test-preview-missing-usings fixture to verify that scaffold_test_preview and
+/// scaffold_first_test_file_preview emit using directives for all constructor-parameter
+/// namespaces, not just the service type's own namespace.
+/// </summary>
+public class MultiNamespaceService
+{
+    private readonly TextWriter _writer;
+    private readonly StringBuilder _buffer;
+    private readonly IList<string> _items;
+
+    public MultiNamespaceService(TextWriter writer, StringBuilder buffer, IList<string> items)
+    {
+        _writer = writer;
+        _buffer = buffer;
+        _items = items;
+    }
+
+    public void Flush()
+    {
+        _writer.Write(_buffer.ToString());
+        _buffer.Clear();
+    }
+
+    public int Count() => _items.Count;
+}

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -511,7 +511,8 @@ public sealed class ScaffoldingService : IScaffoldingService
             constructorArgs,
             publicMethods,
             framework,
-            siblingInference.Pattern);
+            siblingInference.Pattern,
+            serviceSymbol);
 
         var warnings = new List<string>();
         warnings.AddRange(siblingInference.Warnings);
@@ -742,11 +743,17 @@ public sealed class ScaffoldingService : IScaffoldingService
         string constructorArgs,
         IReadOnlyList<IMethodSymbol> publicMethods,
         string framework,
-        SiblingTestPattern? siblingPattern)
+        SiblingTestPattern? siblingPattern,
+        INamedTypeSymbol? serviceSymbol = null)
     {
         var usingDirective = string.IsNullOrWhiteSpace(serviceNamespace)
             ? string.Empty
             : $"using {serviceNamespace};\n";
+
+        // Collect namespaces from constructor parameter types that differ from the service's own
+        // namespace — these are not captured by the single usingDirective above and would cause
+        // CS0246 when the generated file is compiled as-is (scaffold-test-preview-missing-usings).
+        var ctorParamUsings = BuildCtorParamUsings(serviceSymbol, serviceNamespace, testNamespace);
 
         var ctorCall = string.IsNullOrWhiteSpace(constructorArgs)
             ? $"new {serviceTypeName}()"
@@ -754,15 +761,16 @@ public sealed class ScaffoldingService : IScaffoldingService
 
         return framework switch
         {
-            "xunit" => BuildFirstTestFileXunit(testNamespace, usingDirective, serviceTypeName, ctorCall, publicMethods, siblingPattern),
-            "nunit" => BuildFirstTestFileNUnit(testNamespace, usingDirective, serviceTypeName, ctorCall, publicMethods, siblingPattern),
-            _ => BuildFirstTestFileMSTest(testNamespace, usingDirective, serviceTypeName, ctorCall, publicMethods, siblingPattern),
+            "xunit" => BuildFirstTestFileXunit(testNamespace, usingDirective, ctorParamUsings, serviceTypeName, ctorCall, publicMethods, siblingPattern),
+            "nunit" => BuildFirstTestFileNUnit(testNamespace, usingDirective, ctorParamUsings, serviceTypeName, ctorCall, publicMethods, siblingPattern),
+            _ => BuildFirstTestFileMSTest(testNamespace, usingDirective, ctorParamUsings, serviceTypeName, ctorCall, publicMethods, siblingPattern),
         };
     }
 
     private static string BuildFirstTestFileMSTest(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string serviceTypeName,
         string ctorCall,
         IReadOnlyList<IMethodSymbol> publicMethods,
@@ -779,6 +787,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var sb = new System.Text.StringBuilder();
         sb.Append("using Microsoft.VisualStudio.TestTools.UnitTesting;\n");
         sb.Append(usingDirective);
+        sb.Append(ctorParamUsings);
         sb.Append(extraUsings);
         sb.Append('\n');
         sb.Append("namespace ").Append(testNamespace).Append(";\n\n");
@@ -823,6 +832,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildFirstTestFileXunit(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string serviceTypeName,
         string ctorCall,
         IReadOnlyList<IMethodSymbol> publicMethods,
@@ -835,6 +845,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var sb = new System.Text.StringBuilder();
         sb.Append("using Xunit;\n");
         sb.Append(usingDirective);
+        sb.Append(ctorParamUsings);
         sb.Append(extraUsings);
         sb.Append('\n');
         sb.Append("namespace ").Append(testNamespace).Append(";\n\n");
@@ -877,6 +888,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildFirstTestFileNUnit(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string serviceTypeName,
         string ctorCall,
         IReadOnlyList<IMethodSymbol> publicMethods,
@@ -889,6 +901,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         var sb = new System.Text.StringBuilder();
         sb.Append("using NUnit.Framework;\n");
         sb.Append(usingDirective);
+        sb.Append(ctorParamUsings);
         sb.Append(extraUsings);
         sb.Append('\n');
         sb.Append("namespace ").Append(testNamespace).Append(";\n\n");
@@ -1751,6 +1764,51 @@ public sealed class ScaffoldingService : IScaffoldingService
             CollectNamespaces(array.ElementType, requiredUsings);
     }
 
+    /// <summary>
+    /// Builds a block of <c>using</c> directives for namespaces introduced by constructor
+    /// parameter types of <paramref name="typeSymbol"/> — namespaces that are NOT already
+    /// covered by <paramref name="typeNamespace"/> or <paramref name="testNamespace"/>.
+    /// Returns an empty string when no additional namespaces are needed.
+    /// This fixes scaffold-test-preview-missing-usings: previously only the service type's own
+    /// namespace was emitted, leaving any ctor-parameter namespaces as unresolved CS0246 errors.
+    /// </summary>
+    private static string BuildCtorParamUsings(
+        INamedTypeSymbol? typeSymbol,
+        string? typeNamespace,
+        string? testNamespace)
+    {
+        if (typeSymbol is null)
+            return string.Empty;
+
+        var bestCtor = typeSymbol.Constructors
+            .Where(c => !c.IsImplicitlyDeclared || c.Parameters.Length == 0)
+            .Where(c => c.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal)
+            .OrderByDescending(c => c.Parameters.Length)
+            .FirstOrDefault();
+
+        if (bestCtor is null || bestCtor.Parameters.Length == 0)
+            return string.Empty;
+
+        var excluded = new HashSet<string>(StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(typeNamespace)) excluded.Add(typeNamespace);
+        if (!string.IsNullOrWhiteSpace(testNamespace)) excluded.Add(testNamespace);
+        // Always exclude well-known root namespaces that don't need using directives.
+        excluded.Add("System");
+
+        var paramNamespaces = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var p in bestCtor.Parameters)
+            CollectNamespaces(p.Type, paramNamespaces);
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var ns in paramNamespaces
+            .Where(n => !excluded.Contains(n))
+            .OrderBy(n => n, StringComparer.Ordinal))
+        {
+            sb.Append("using ").Append(ns).Append(";\n");
+        }
+        return sb.ToString();
+    }
+
     private static string BuildTypeContent(string typeNamespace, ScaffoldTypeDto request, InterfaceResolutionResult interfaceResolution)
     {
         var inheritance = new List<string>();
@@ -2107,6 +2165,11 @@ public sealed class ScaffoldingService : IScaffoldingService
             ? string.Empty
             : $"using {targetNamespace};\n";
 
+        // Collect namespaces from constructor parameter types that differ from the target's own
+        // namespace — these are not captured by the single usingDirective above and would cause
+        // CS0246 when the generated file is compiled as-is (scaffold-test-preview-missing-usings).
+        var ctorParamUsings = BuildCtorParamUsings(matchedType, targetNamespace, testNamespace);
+
         var useStaticScaffold = ShouldUseStaticTestScaffold(matchedType);
 
         // scaffold-test-internal-target-accessibility: when the target is internal-not-visible
@@ -2132,9 +2195,9 @@ public sealed class ScaffoldingService : IScaffoldingService
 
         return framework switch
         {
-            "xunit" => BuildXUnitTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
-            "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
-            _ => BuildMSTestTestContent(testNamespace, usingDirective, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
+            "xunit" => BuildXUnitTestContent(testNamespace, usingDirective, ctorParamUsings, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
+            "nunit" => BuildNUnitTestContent(testNamespace, usingDirective, ctorParamUsings, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
+            _ => BuildMSTestTestContent(testNamespace, usingDirective, ctorParamUsings, simpleTypeName, methodName, ctorCall, methodTargetBlock, suppressInstanceSubject, siblingPattern),
         };
     }
 
@@ -2595,6 +2658,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildMSTestTestContent(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string targetTypeName,
         string methodName,
         string ctorCall,
@@ -2613,6 +2677,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         return
             "using Microsoft.VisualStudio.TestTools.UnitTesting;\n" +
             usingDirective +
+            ctorParamUsings +
             extraUsings +
             "\nnamespace " + testNamespace + ";\n\n" +
             extraAttributes +
@@ -2633,6 +2698,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildXUnitTestContent(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string targetTypeName,
         string methodName,
         string ctorCall,
@@ -2651,6 +2717,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         return
             "using Xunit;\n" +
             usingDirective +
+            ctorParamUsings +
             extraUsings +
             "\nnamespace " + testNamespace + ";\n\n" +
             extraAttributes +
@@ -2670,6 +2737,7 @@ public sealed class ScaffoldingService : IScaffoldingService
     private static string BuildNUnitTestContent(
         string testNamespace,
         string usingDirective,
+        string ctorParamUsings,
         string targetTypeName,
         string methodName,
         string ctorCall,
@@ -2688,6 +2756,7 @@ public sealed class ScaffoldingService : IScaffoldingService
         return
             "using NUnit.Framework;\n" +
             usingDirective +
+            ctorParamUsings +
             extraUsings +
             "\nnamespace " + testNamespace + ";\n\n" +
             extraAttributes +

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -149,4 +149,42 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
         StringAssert.Contains(ex.Message, "fully-qualified",
             "Error should remind callers that the input is a metadata name (FQN).");
     }
+
+    [TestMethod]
+    public async Task FirstTestFile_EmitsUsings_ForCtorParamNamespaces()
+    {
+        // scaffold-test-preview-missing-usings: scaffold_first_test_file_preview previously
+        // only emitted a using directive for the service's own namespace. Constructor
+        // parameter types from other namespaces were silently omitted, producing 7+ CS0246
+        // errors in the generated file. This test verifies that all three constructor-
+        // parameter namespaces of SampleLib.MultiNamespaceService are emitted.
+        //
+        // MultiNamespaceService(TextWriter writer, StringBuilder buffer, IList<string> items)
+        //   → using System.IO;               (TextWriter)
+        //   → using System.Text;             (StringBuilder)
+        //   → using System.Collections.Generic; (IList<T>)
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var destinationPath = workspace.GetPath("SampleLib.Tests", "MultiNamespaceServiceTests.cs");
+        Assert.IsFalse(File.Exists(destinationPath),
+            $"Test precondition violated: '{destinationPath}' must NOT exist before scaffolding.");
+
+        var preview = await ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
+            workspace.WorkspaceId,
+            new ScaffoldFirstTestFileDto("SampleLib.MultiNamespaceService", "SampleLib.Tests"),
+            CancellationToken.None);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        var contents = await File.ReadAllTextAsync(destinationPath, CancellationToken.None);
+
+        // Each constructor-parameter namespace must appear as a using directive so the
+        // generated file compiles without CS0246 errors.
+        StringAssert.Contains(contents, "using System.IO;",
+            "System.IO must be emitted for the TextWriter ctor parameter.");
+        StringAssert.Contains(contents, "using System.Text;",
+            "System.Text must be emitted for the StringBuilder ctor parameter.");
+        StringAssert.Contains(contents, "using System.Collections.Generic;",
+            "System.Collections.Generic must be emitted for the IList<string> ctor parameter.");
+    }
 }

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -1064,6 +1064,40 @@ public class SnapshotContentHasher
             "Static-members-only class scaffold must NOT emit a `subject` instance.");
     }
 
+    [TestMethod]
+    public async Task Scaffold_Test_EmitsUsings_ForCtorParamNamespaces()
+    {
+        // scaffold-test-preview-missing-usings: scaffold_test_preview previously only emitted
+        // a using directive for the target type's own namespace. Constructor parameter types
+        // from other namespaces were silently omitted, producing CS0246 errors in the generated
+        // file. This test verifies all three ctor-parameter namespaces of
+        // SampleLib.MultiNamespaceService appear as using directives.
+        //
+        // MultiNamespaceService(TextWriter, StringBuilder, IList<string>)
+        //   → using System.IO;               (TextWriter)
+        //   → using System.Text;             (StringBuilder)
+        //   → using System.Collections.Generic; (IList<T>)
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto("SampleLib.Tests", "MultiNamespaceService", "Flush"),
+            CancellationToken.None);
+        await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        var generatedPath = workspace.GetPath("SampleLib.Tests", "MultiNamespaceServiceGeneratedTests.cs");
+        var contents = await File.ReadAllTextAsync(generatedPath, CancellationToken.None);
+
+        // Each constructor-parameter namespace must appear as a using directive so the
+        // generated file compiles without CS0246 errors.
+        StringAssert.Contains(contents, "using System.IO;",
+            "System.IO must be emitted for the TextWriter ctor parameter.");
+        StringAssert.Contains(contents, "using System.Text;",
+            "System.Text must be emitted for the StringBuilder ctor parameter.");
+        StringAssert.Contains(contents, "using System.Collections.Generic;",
+            "System.Collections.Generic must be emitted for the IList<string> ctor parameter.");
+    }
+
     private sealed class RecordingTestNameSuggestionProvider(string methodName) : ITestNameSuggestionProvider
     {
         public int CallCount { get; private set; }


### PR DESCRIPTION
## Summary

- `scaffold_test_preview` and `scaffold_first_test_file_preview` previously emitted only the service type's own namespace as a `using` directive — constructor parameter types from other namespaces (e.g. `System.IO`, `System.Text`, `System.Collections.Generic`) were silently omitted, producing 7+ CS0246 errors in every generated test file where the target class took multi-namespace ctor dependencies.
- Added `BuildCtorParamUsings` helper that collects all namespaces from the widest accessible constructor's parameter types (via the existing `CollectNamespaces` helper) and emits them as sorted `using` directives in all 6 per-framework emitters (MSTest / xUnit / NUnit, first-file and per-method paths).
- Added `SampleLib.MultiNamespaceService` (TextWriter + StringBuilder + IList<string> ctor) to both SampleLib trees and two new regression tests.

## Test plan

- [x] `FirstTestFile_EmitsUsings_ForCtorParamNamespaces` — asserts System.IO, System.Text, System.Collections.Generic appear in `scaffold_first_test_file_preview` output
- [x] `Scaffold_Test_EmitsUsings_ForCtorParamNamespaces` — asserts same for `scaffold_test_preview` output
- [x] All 29 existing scaffolding tests still pass
- [x] Full suite: 1215 passed, 0 failed (`verify-release.ps1 -Configuration Release`)
- [x] `verify-ai-docs.ps1` passes

Closes: scaffold-test-preview-missing-usings

🤖 Generated with [Claude Code](https://claude.com/claude-code)