### PR TITLE
fix(release): enforce changelog fragment YAML frontmatter and abort plugin update on pull failure

### DIFF
--- a/.claude/agents/initiative-executor.md
+++ b/.claude/agents/initiative-executor.md
@@ -39,8 +39,23 @@ If any field is missing, emit a failure `<<<RESULT>>>` immediately — do not gu
    - Before PR (CI-parity): `./eng/verify-release.ps1 -Configuration Release` AND `./eng/verify-ai-docs.ps1`. Both must pass.
 
 4. **Commit + push + open PR** with explicit staged paths (never `git add -A`):
+
+   Before staging, write `changelog.d/{initiative.id}.md` using the CHANGELOG draft from the inlined plan section. The file **must** use YAML frontmatter — the `/bump` skill's fragment consumer hard-refuses any fragment without it:
+
    ```
-   git add -- src/... tests/...
+   ---
+   category: <Fixed|Changed|Added|Maintenance|Changed — BREAKING>
+   ---
+
+   - **<Category>:** <one-sentence description from the CHANGELOG draft in the plan>
+   ```
+
+   Valid categories (case-sensitive, em-dash `—` for `Changed — BREAKING`): `Fixed`, `Changed`, `Changed — BREAKING`, `Added`, `Maintenance`.
+
+   Include the fragment in the explicit staged paths:
+
+   ```
+   git add -- src/... tests/... changelog.d/{initiative.id}.md
    git commit -m "{type}({scope}): {description} ({initiative.id})"
    git push -u origin remediation/{initiative.id}
    gh pr create --title "..." --body "..."

--- a/eng/update-claude-plugin.ps1
+++ b/eng/update-claude-plugin.ps1
@@ -70,9 +70,18 @@ if (-not (Test-Path $installedPluginsPath)) {
 Write-Step "Pulling marketplace clone in $marketplaceDir"
 Push-Location $marketplaceDir
 try {
-    git fetch origin | Out-Null
-    git checkout main | Out-Null
-    git pull --ff-only origin main | Out-Null
+    git fetch origin 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git fetch failed (exit $LASTEXITCODE) — network or auth issue. Aborting to avoid syncing a stale cache."
+    }
+    git checkout main 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git checkout main failed (exit $LASTEXITCODE)."
+    }
+    git pull --ff-only origin main 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git pull --ff-only failed (exit $LASTEXITCODE) — network issue or diverged branch. Aborting to avoid syncing a stale cache."
+    }
     $headSha = (git rev-parse HEAD).Trim()
     Write-Host "    HEAD is now $headSha"
 }

--- a/eng/verify-changelog-fragments.ps1
+++ b/eng/verify-changelog-fragments.ps1
@@ -1,0 +1,85 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Validates changelog.d/*.md fragments have proper YAML frontmatter before a release bump.
+
+.DESCRIPTION
+    Scans changelog.d/*.md (excluding README.md). For each fragment, verifies:
+      - File starts with a --- frontmatter block
+      - Frontmatter has a 'category' key
+      - Category is one of the five canonical values
+      - File has non-empty body after the closing ---
+
+    A malformed fragment discovered here is a PR-time catch rather than a release-cut
+    surprise. Called from verify-release.ps1.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$fragmentDir = Join-Path $repoRoot 'changelog.d'
+
+$validCategories = @('Fixed', 'Changed', 'Changed — BREAKING', 'Added', 'Maintenance')
+
+$fragments = Get-ChildItem -Path $fragmentDir -Filter '*.md' |
+    Where-Object { $_.Name -ne 'README.md' }
+
+if ($fragments.Count -eq 0) {
+    Write-Host "changelog.d/ — no fragments (ok)"
+    exit 0
+}
+
+$errors = @()
+
+foreach ($file in $fragments) {
+    $content = Get-Content $file.FullName -Raw
+
+    # Must start with ---
+    if (-not $content.TrimStart().StartsWith('---')) {
+        $errors += "$($file.Name): missing YAML frontmatter (file must start with ---)"
+        continue
+    }
+
+    # Find the closing ---
+    $lines = $content -split "`n"
+    $frontmatterEnd = -1
+    for ($i = 1; $i -lt $lines.Count; $i++) {
+        if ($lines[$i].Trim() -eq '---') {
+            $frontmatterEnd = $i
+            break
+        }
+    }
+
+    if ($frontmatterEnd -eq -1) {
+        $errors += "$($file.Name): YAML frontmatter not closed (no second ---)"
+        continue
+    }
+
+    # Extract category value
+    $frontmatter = $lines[1..($frontmatterEnd - 1)] -join "`n"
+    if ($frontmatter -notmatch 'category\s*:\s*(.+)') {
+        $errors += "$($file.Name): missing 'category' key in frontmatter"
+        continue
+    }
+    $category = $Matches[1].Trim()
+
+    if ($validCategories -notcontains $category) {
+        $errors += "$($file.Name): invalid category '$category' — expected one of: $($validCategories -join ' / ')"
+        continue
+    }
+
+    # Must have non-empty body
+    $body = ($lines[($frontmatterEnd + 1)..($lines.Count - 1)] -join "`n").Trim()
+    if ([string]::IsNullOrWhiteSpace($body)) {
+        $errors += "$($file.Name): no body content after frontmatter"
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $msg = "changelog.d/ fragment validation failed ($($errors.Count) error(s)):`n" +
+           ($errors -join "`n")
+    Write-Error $msg
+    exit 1
+}
+
+Write-Host "changelog.d/ — $($fragments.Count) fragment(s) valid"

--- a/eng/verify-release.ps1
+++ b/eng/verify-release.ps1
@@ -38,6 +38,10 @@ if (-not $NoCoverage) {
 # references in ./skills/ (repo-only skills belong in .claude/skills/).
 & (Join-Path $PSScriptRoot 'verify-skills-are-generic.ps1')
 
+# Changelog fragment format check — catches malformed changelog.d/*.md files
+# at PR time rather than at release-cut time (where they block /bump).
+& (Join-Path $PSScriptRoot 'verify-changelog-fragments.ps1')
+
 dotnet restore $solutionPath --nologo
 Invoke-DotnetStep "dotnet restore (main solution)"
 


### PR DESCRIPTION
## Summary

- **`eng/verify-changelog-fragments.ps1`** (new) — validates all `changelog.d/*.md` fragments have YAML frontmatter with a valid `category` key and non-empty body; called from `verify-release.ps1` so malformed fragments fail CI at PR time instead of blocking `/bump` at release-cut time
- **`eng/verify-release.ps1`** — wires in `verify-changelog-fragments.ps1` after the existing `verify-skills-are-generic.ps1` step
- **`.claude/agents/initiative-executor.md`** — Step 4 now instructs subagents to create `changelog.d/{initiative.id}.md` with YAML frontmatter before staging, and adds the fragment to the explicit `git add` path list
- **`eng/update-claude-plugin.ps1`** — adds `$LASTEXITCODE` checks after `git fetch`, `git checkout`, and `git pull`; throws with a clear abort message on failure so the script never silently syncs a stale marketplace clone (root cause of the Layer-2 version mismatch in the v1.36.0 release-cut)

## Test plan

- [x] `eng/verify-changelog-fragments.ps1` passes on an empty `changelog.d/` (no fragments — ok)
- [ ] Verify script fails correctly when a fragment without frontmatter is present
- [ ] Confirm `verify-release.ps1` calls the new script (inspect the added line)
- [ ] Confirm `update-claude-plugin.ps1` exits non-zero when `git fetch` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)