### PR TITLE
fix(workspace): raise MaxConcurrentWorkspaces to 16 and add evictPolicy=lru to workspace_load

### DIFF
--- a/changelog.d/parallel-mode-workspace-cap-lru-or-raise.md
+++ b/changelog.d/parallel-mode-workspace-cap-lru-or-raise.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Fixed parallel-mode workspace saturation: raised the default `MaxConcurrentWorkspaces` from 8 to 16 and added `evictPolicy="lru"` to `workspace_load` so callers can opt into silent LRU eviction of idle workspaces instead of receiving a hard error. Strict-mode errors now include `activeWorkspaces` and `lruCandidate` fields for one-round-trip self-recovery.

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -15,7 +16,7 @@ public static class WorkspaceTools
 {
     private const int AutoPrewarmProjectThreshold = 50;
 
-    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj file into the workspace for semantic analysis. Returns a lean summary by default — pass verbose=true for the full per-project tree (large solutions can produce ~30 KB or more). Idempotent by path: if the same solution/project file is already loaded in this host process, workspace_load returns the EXISTING WorkspaceId instead of creating a new one — no extra workspace slot is consumed. Set autoRestore=true to run dotnet restore and one follow-up reload when the loaded status reports restoreRequired=true. Set prewarm=true to immediately run the workspace_warm compilation/semantic-model prewarm after a successful load or auto-restore reload; set prewarm=false to opt out. When prewarm is omitted, workspace_load automatically prewarms solutions with more than 50 projects. The response includes a prewarm result block only when warming ran. DocumentCount note: the per-project DocumentCount often exceeds the <Compile> item count (from evaluate_msbuild_items) by about 3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit <Compile> items. Sessions persist for the lifetime of the stdio host process — there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 8) forced an eviction. When a previously valid workspaceId returns 'Workspace was not found', call workspace_load again rather than treating it as an error.")]
+    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj file into the workspace for semantic analysis. Returns a lean summary by default — pass verbose=true for the full per-project tree (large solutions can produce ~30 KB or more). Idempotent by path: if the same solution/project file is already loaded in this host process, workspace_load returns the EXISTING WorkspaceId instead of creating a new one — no extra workspace slot is consumed. Set autoRestore=true to run dotnet restore and one follow-up reload when the loaded status reports restoreRequired=true. Set prewarm=true to immediately run the workspace_warm compilation/semantic-model prewarm after a successful load or auto-restore reload; set prewarm=false to opt out. When prewarm is omitted, workspace_load automatically prewarms solutions with more than 50 projects. The response includes a prewarm result block only when warming ran. DocumentCount note: the per-project DocumentCount often exceeds the <Compile> item count (from evaluate_msbuild_items) by about 3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit <Compile> items. Sessions persist for the lifetime of the stdio host process — there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 16) forced an eviction. When a previously valid workspaceId returns 'Workspace was not found', call workspace_load again rather than treating it as an error. Pass evictPolicy=lru to silently evict the least-recently-used idle workspace when the cap is reached instead of receiving a hard error.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Load a .sln, .slnx, or .csproj into a named Roslyn workspace session.")]
     public static Task<string> LoadWorkspace(
@@ -29,6 +30,7 @@ public static class WorkspaceTools
         [Description("When true and the loaded status reports restoreRequired=true, run `dotnet restore` on the target and reload once before returning.")] bool autoRestore = false,
         [Description("When true, run `workspace_warm` immediately after the load (and any auto-restore reload) succeeds, then include the warm result in the response. When omitted, large solutions with more than 50 projects are prewarmed automatically. Pass false to opt out and preserve the cold-load profile.")] bool? prewarm = null,
         [Description("Operator-opt-in security flag (default false). When true, the client-sanctioned-root path validator additionally accepts paths under the immediate PARENT directory of each sanctioned root — enough to permit a sibling worktree at `../<name>` (e.g. mcp-server-surface-test's disposable audit worktree). Higher ancestors (grandparent etc.) are NOT widened. Pass true only from operator-controlled call sites; do not auto-enable on every request.")] bool expandSanctionedRoots = false,
+        [Description("Controls cap-reached behaviour. 'Strict' (default) throws with activeWorkspaces and lruCandidate context for one-round-trip self-recovery. 'Lru' silently evicts the least-recently-used idle workspace to make room for the new load.")] EvictPolicy evictPolicy = EvictPolicy.Strict,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {
@@ -50,7 +52,7 @@ public static class WorkspaceTools
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(
                 server, path, c, expandSanctionedRoots: expandSanctionedRoots).ConfigureAwait(false);
             ProgressHelper.ReportStage(progress, 1, totalStages, "opening-workspace");
-            var status = await workspace.LoadAsync(path, c).ConfigureAwait(false);
+            var status = await workspace.LoadAsync(path, evictPolicy, c).ConfigureAwait(false);
             ProgressHelper.ReportStage(progress, 2, totalStages, "checking-restore");
             status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, c).ConfigureAwait(false);
             var shouldPrewarm = ShouldPrewarmAfterLoad(prewarm, status);

--- a/src/RoslynMcp.Roslyn/Contracts/EvictPolicy.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/EvictPolicy.cs
@@ -1,0 +1,23 @@
+namespace RoslynMcp.Roslyn.Contracts;
+
+/// <summary>
+/// Controls how <see cref="RoslynMcp.Roslyn.Contracts.IWorkspaceManager.LoadAsync"/> behaves when
+/// the concurrent-workspace cap (<c>ROSLYNMCP_MAX_WORKSPACES</c>) is reached.
+/// </summary>
+public enum EvictPolicy
+{
+    /// <summary>
+    /// Throw <see cref="System.InvalidOperationException"/> when the cap is reached.
+    /// The error message includes the list of active workspaces and the least-recently-used
+    /// candidate so callers can perform one-round-trip self-recovery. This is the default.
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Silently evict the least-recently-used workspace (the one with the smallest
+    /// <c>LastAccessedUtc</c>) and proceed with the new load. Locked sessions that are
+    /// currently executing a read or write operation are skipped during the LRU scan; if
+    /// all sessions are locked the behaviour falls back to <see cref="Strict"/>.
+    /// </summary>
+    Lru,
+}

--- a/src/RoslynMcp.Roslyn/Contracts/IWorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IWorkspaceManager.cs
@@ -39,8 +39,13 @@ public interface IWorkspaceManager
     /// Loads a solution or project file from disk into a new named workspace session.
     /// </summary>
     /// <param name="path">The absolute path to the <c>.sln</c>, <c>.slnx</c>, or <c>.csproj</c> file to load.</param>
+    /// <param name="evictPolicy">
+    /// Controls cap-reached behaviour. <see cref="EvictPolicy.Strict"/> (default) throws with
+    /// diagnostic context; <see cref="EvictPolicy.Lru"/> silently evicts the idle workspace with
+    /// the smallest <c>LastAccessedUtc</c> before retrying.
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
-    Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct);
+    Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct);
 
     /// <summary>
     /// Reloads an existing workspace session from disk, discarding any pending previews.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -155,10 +156,20 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     }
 
     public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct)
-        => LoadAsync(path, globalProperties: null, ct);
+        => LoadAsync(path, EvictPolicy.Strict, globalProperties: null, ct);
+
+    public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct)
+        => LoadAsync(path, evictPolicy, globalProperties: null, ct);
+
+    public Task<WorkspaceStatusDto> LoadAsync(
+        string path,
+        IDictionary<string, string>? globalProperties,
+        CancellationToken ct)
+        => LoadAsync(path, EvictPolicy.Strict, globalProperties, ct);
 
     public async Task<WorkspaceStatusDto> LoadAsync(
         string path,
+        EvictPolicy evictPolicy,
         IDictionary<string, string>? globalProperties,
         CancellationToken ct)
     {
@@ -191,9 +202,57 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
 
         if (!await _workspaceSlots.WaitAsync(0, ct).ConfigureAwait(false))
         {
+            if (evictPolicy == EvictPolicy.Lru)
+            {
+                // parallel-mode-workspace-cap-lru-or-raise: LRU eviction path.
+                // Pick the session with the smallest LastAccessedUtc, skipping any that
+                // currently hold their LoadLock (i.e. are actively being loaded or read).
+                // If all sessions are locked, fall through to the Strict error path.
+                var lruCandidate = _sessions.Values
+                    .Where(s => s.LoadLock.CurrentCount > 0)
+                    .OrderBy(s => s.LastAccessedUtc)
+                    .FirstOrDefault();
+
+                if (lruCandidate is not null)
+                {
+                    _logger.LogInformation(
+                        "workspace_load: LRU eviction of workspace '{WorkspaceId}' (lastAccessed={LastAccessedUtc:O}) to make room for '{Path}'",
+                        lruCandidate.WorkspaceId,
+                        lruCandidate.LastAccessedUtc,
+                        fullPath);
+                    Close(lruCandidate.WorkspaceId);
+
+                    // After Close() the semaphore slot has been released — retry immediately.
+                    if (!await _workspaceSlots.WaitAsync(0, ct).ConfigureAwait(false))
+                    {
+                        // The slot was consumed by a concurrent caller between the Close() and
+                        // our retry. Fall through to the Strict error path.
+                        goto strictError;
+                    }
+                    goto slotAcquired;
+                }
+            }
+
+            strictError:
+            var activeWorkspaces = _sessions.Values
+                .Select(s => new
+                {
+                    id = s.WorkspaceId,
+                    loadedAtUtc = s.LoadedAtUtc,
+                    lastAccessedUtc = s.LastAccessedUtc,
+                    path = s.LoadedPath ?? string.Empty,
+                })
+                .OrderBy(s => s.lastAccessedUtc)
+                .ToList();
+            var lruCandidateId = activeWorkspaces.FirstOrDefault()?.id;
             throw new InvalidOperationException(
-                $"The server is already tracking {_options.MaxConcurrentWorkspaces} workspaces. Close an existing workspace before loading another.");
+                $"The server is already tracking {_options.MaxConcurrentWorkspaces} workspaces. " +
+                $"Close an existing workspace before loading another (or pass evictPolicy=lru to auto-evict the idle workspace). " +
+                $"activeWorkspaces={JsonSerializer.Serialize(activeWorkspaces)}" +
+                (lruCandidateId is not null ? $" lruCandidate={lruCandidateId}" : string.Empty));
         }
+
+        slotAcquired:
         var workspaceId = Guid.NewGuid().ToString("N");
         var session = new WorkspaceSession(workspaceId);
         var sessionAdded = false;

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManagerOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManagerOptions.cs
@@ -7,9 +7,9 @@ public sealed record WorkspaceManagerOptions
 {
     /// <summary>
     /// Gets the maximum number of workspace sessions that may be open concurrently.
-    /// Defaults to 8.
+    /// Defaults to 16.
     /// </summary>
-    public int MaxConcurrentWorkspaces { get; init; } = 8;
+    public int MaxConcurrentWorkspaces { get; init; } = 16;
 
     /// <summary>
     /// Gets the maximum number of source-generated documents to return per workspace query.

--- a/tests/RoslynMcp.Tests/Benchmarks/WorkspaceReadConcurrencyBenchmark.cs
+++ b/tests/RoslynMcp.Tests/Benchmarks/WorkspaceReadConcurrencyBenchmark.cs
@@ -72,7 +72,7 @@ public sealed class WorkspaceReadConcurrencyBenchmark
         public bool ContainsWorkspace(string workspaceId) => true;
         public bool IsStale(string workspaceId) => false;
 
-        public Task<Core.Models.WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<Core.Models.WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<Core.Models.WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => true;
         public IReadOnlyList<Core.Models.WorkspaceStatusDto> ListWorkspaces() => [];

--- a/tests/RoslynMcp.Tests/CodeMetricsNestingTests.cs
+++ b/tests/RoslynMcp.Tests/CodeMetricsNestingTests.cs
@@ -331,7 +331,7 @@ public sealed class CodeMetricsNestingTests
         public bool IsStale(string workspaceId) => false;
         public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/CompilationCacheTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheTests.cs
@@ -131,7 +131,7 @@ public sealed class CompilationCacheTests
         public void RestoreVersion(string workspaceId, int version) => Version = version;
 
         // ----- Unused by CompilationCache; throw to surface unexpected coupling -----
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => workspaceId == WorkspaceId;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
@@ -484,7 +484,7 @@ public sealed class DeadFieldDetectorTests
         public bool IsStale(string workspaceId) => false;
         public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/DeadLocalDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DeadLocalDetectorTests.cs
@@ -546,7 +546,7 @@ public sealed class DeadLocalDetectorTests
         public bool IsStale(string workspaceId) => false;
         public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateHelperDetectionTests.cs
@@ -425,7 +425,7 @@ public sealed class DuplicateHelperDetectionTests
         public bool IsStale(string workspaceId) => false;
         public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
@@ -509,7 +509,7 @@ public sealed class DuplicateMethodDetectorTests
         public bool IsStale(string workspaceId) => false;
         public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool Close(string workspaceId) => throw new NotSupportedException();
         public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();

--- a/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -107,7 +107,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => !string.IsNullOrWhiteSpace(workspaceId);
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/HostProcessMetadataTests.cs
+++ b/tests/RoslynMcp.Tests/HostProcessMetadataTests.cs
@@ -391,7 +391,7 @@ public sealed class HostProcessMetadataTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -143,7 +143,7 @@ public class PerformanceBehaviorTests : SharedWorkspaceTestBase
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
 
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
 

--- a/tests/RoslynMcp.Tests/ServerHeartbeatTests.cs
+++ b/tests/RoslynMcp.Tests/ServerHeartbeatTests.cs
@@ -31,7 +31,7 @@ public sealed class ServerHeartbeatTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/ServerInfoUpdateLatestTests.cs
+++ b/tests/RoslynMcp.Tests/ServerInfoUpdateLatestTests.cs
@@ -32,7 +32,7 @@ public sealed class ServerInfoUpdateLatestTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
+++ b/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
@@ -242,7 +242,7 @@ public sealed class StartupDiagnosticsTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -289,7 +289,7 @@ public sealed class SurfaceCatalogTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
         public bool ContainsWorkspace(string workspaceId) => false;
         public bool IsStale(string workspaceId) => false;

--- a/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
@@ -22,7 +22,7 @@ internal sealed class WorkspaceIdCache
                 return cachedId;
             }
 
-            var status = await workspaceManager.LoadAsync(solutionPath, ct).ConfigureAwait(false);
+            var status = await workspaceManager.LoadAsync(solutionPath, EvictPolicy.Strict, ct).ConfigureAwait(false);
             _workspaceIds[solutionPath] = status.WorkspaceId;
             return status.WorkspaceId;
         }

--- a/tests/RoslynMcp.Tests/Workspace/WorkspaceCachePrewarmTests.cs
+++ b/tests/RoslynMcp.Tests/Workspace/WorkspaceCachePrewarmTests.cs
@@ -278,7 +278,7 @@ public sealed class WorkspaceCachePrewarmTests : IsolatedWorkspaceTestBase
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => Task.FromResult(status);
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => Task.FromResult(status);
 
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) =>
             throw new NotSupportedException("These tests disable autoRestore; reload should not be invoked.");

--- a/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+using RoslynMcp.Tests;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for <c>parallel-mode-workspace-cap-lru-or-raise</c>:
+/// <list type="bullet">
+///   <item><description>The default <see cref="WorkspaceManagerOptions.MaxConcurrentWorkspaces"/> is raised to 16.</description></item>
+///   <item><description><see cref="EvictPolicy.Lru"/> silently evicts the least-recently-used unlocked session when the cap is reached.</description></item>
+///   <item><description><see cref="EvictPolicy.Strict"/> throws with <c>activeWorkspaces</c> and <c>lruCandidate</c> context.</description></item>
+/// </list>
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class WorkspaceCapLruEvictionTests
+{
+    private static string s_repositoryRootPath = null!;
+    private static string s_sampleSolutionPath = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        s_repositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
+        s_sampleSolutionPath = TestFixtureFileSystem.FindFixturePath(
+            s_repositoryRootPath,
+            "SampleSolution",
+            "SampleSolution.slnx",
+            "SampleSolution.sln");
+    }
+
+    /// <summary>
+    /// Validates that <see cref="WorkspaceManagerOptions.MaxConcurrentWorkspaces"/> defaults to 16
+    /// and that the semaphore is initialised with that value so 16 independent loads can succeed
+    /// without hitting the cap (verified via property, not by loading 16 real workspaces to keep
+    /// the test fast).
+    /// </summary>
+    [TestMethod]
+    public void DefaultMaxConcurrentWorkspaces_Is_16()
+    {
+        var opts = new WorkspaceManagerOptions();
+        Assert.AreEqual(16, opts.MaxConcurrentWorkspaces,
+            "Default cap must be 16 after parallel-mode-workspace-cap-lru-or-raise.");
+    }
+
+    /// <summary>
+    /// When the cap is reached and <see cref="EvictPolicy.Lru"/> is requested, the workspace with
+    /// the smallest <c>LastAccessedUtc</c> is evicted and the new load succeeds. The evicted
+    /// workspace is no longer tracked.
+    /// </summary>
+    [TestMethod]
+    public async Task LruEviction_WhenCapReached_EvictsLeastRecentlyUsed_AndSucceeds()
+    {
+        // Use a cap of 1 so a single loaded workspace saturates the semaphore.
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            // Load the first workspace — it now holds the single slot.
+            var status1 = await manager.LoadAsync(path1, CancellationToken.None);
+            Assert.IsTrue(manager.ContainsWorkspace(status1.WorkspaceId),
+                "First workspace must be tracked after load.");
+
+            // LRU load: should evict the first workspace and load the second.
+            var status2 = await manager.LoadAsync(path2, EvictPolicy.Lru, CancellationToken.None);
+            Assert.IsTrue(manager.ContainsWorkspace(status2.WorkspaceId),
+                "Second workspace must be tracked after LRU load.");
+            Assert.IsFalse(manager.ContainsWorkspace(status1.WorkspaceId),
+                "First workspace must have been evicted by the LRU policy.");
+            Assert.AreNotEqual(status1.WorkspaceId, status2.WorkspaceId,
+                "Evicted and new workspaces must have distinct IDs.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    /// <summary>
+    /// When the cap is reached and <see cref="EvictPolicy.Strict"/> is requested (the default),
+    /// an <see cref="InvalidOperationException"/> is thrown whose message includes
+    /// <c>activeWorkspaces</c> and <c>lruCandidate</c> fields for one-round-trip self-recovery.
+    /// </summary>
+    [TestMethod]
+    public async Task StrictEviction_WhenCapReached_Throws_WithDiagnosticContext()
+    {
+        // Use a cap of 1 so a single loaded workspace saturates the semaphore.
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var status1 = await manager.LoadAsync(path1, CancellationToken.None);
+            Assert.IsTrue(manager.ContainsWorkspace(status1.WorkspaceId),
+                "First workspace must be tracked (sanity).");
+
+            // Strict load: must throw because the cap is full.
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => manager.LoadAsync(path2, EvictPolicy.Strict, CancellationToken.None));
+
+            // Message must carry activeWorkspaces JSON and lruCandidate for self-recovery.
+            StringAssert.Contains(ex.Message, "activeWorkspaces",
+                "Strict-mode error must include 'activeWorkspaces' field for agent self-recovery.");
+            StringAssert.Contains(ex.Message, "lruCandidate",
+                "Strict-mode error must include 'lruCandidate' field for agent self-recovery.");
+            StringAssert.Contains(ex.Message, status1.WorkspaceId,
+                "The active workspace ID must appear in the error to identify the eviction candidate.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    private static WorkspaceManager CreateManager(int maxConcurrentWorkspaces = 4)
+    {
+        return new WorkspaceManager(
+            NullLogger<WorkspaceManager>.Instance,
+            new PreviewStore(),
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = maxConcurrentWorkspaces });
+    }
+}

--- a/tests/RoslynMcp.Tests/WorkspaceCloseDrainTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceCloseDrainTests.cs
@@ -211,7 +211,7 @@ public sealed class WorkspaceCloseDrainTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) =>
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) =>
             Task.FromResult(status ?? throw new KeyNotFoundException("No status configured."));
 
         public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) =>

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -829,7 +829,7 @@ public class WorkspaceExecutionGateTests
         public event Action<string>? WorkspaceClosed { add { } remove { } }
         public event Action<string>? WorkspaceReloaded { add { } remove { } }
 
-        public Task<WorkspaceStatusDto> LoadAsync(string path, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
 
         public async Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct)
         {


### PR DESCRIPTION
## Summary

- Raised default `MaxConcurrentWorkspaces` from 8 to 16 in `WorkspaceManagerOptions` so parallel-mode sweeps no longer saturate the cap on typical codebases
- Added `EvictPolicy` enum (`Strict` / `Lru`) in `src/RoslynMcp.Roslyn/Contracts/EvictPolicy.cs` and threaded it through `IWorkspaceManager.LoadAsync` and the `workspace_load` tool parameter
- LRU eviction selects the session with the smallest `LastAccessedUtc`, skipping any sessions that currently hold their `LoadLock` (actively loading/reading); falls back to `Strict` if all sessions are locked
- Strict-mode cap errors now include `activeWorkspaces` (JSON array with id/loadedAtUtc/lastAccessedUtc/path) and `lruCandidate` field for one-round-trip self-recovery
- Updated 16 test-only fake/stub `IWorkspaceManager` implementations to implement the new required interface member

## Test plan

- [x] `WorkspaceCapLruEvictionTests.DefaultMaxConcurrentWorkspaces_Is_16` — asserts the new default
- [x] `WorkspaceCapLruEvictionTests.LruEviction_WhenCapReached_EvictsLeastRecentlyUsed_AndSucceeds` — end-to-end LRU eviction with a cap-1 manager
- [x] `WorkspaceCapLruEvictionTests.StrictEviction_WhenCapReached_Throws_WithDiagnosticContext` — asserts `activeWorkspaces` and `lruCandidate` in error message
- [x] `verify-release.ps1 -Configuration Release` — 1245 tests, all passed
- [x] `verify-ai-docs.ps1` — passed

Closes: parallel-mode-workspace-cap-lru-or-raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)