### PR TITLE
fix(cross-project-refactoring): guard EnsureProjectReference against circular dependencies with human-readable names

### DIFF
--- a/changelog.d/move-type-to-project-preview-leaks-projectid-tokens.md
+++ b/changelog.d/move-type-to-project-preview-leaks-projectid-tokens.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `move_type_to_project_preview` (and the related `extract_interface_cross_project_preview` / `dependency_inversion_preview`) emitting raw Roslyn `ProjectId` tuple strings in circular-dependency error messages. The error message now reads "Adding project reference from 'ProjectA' to 'ProjectB' would create a circular dependency." using the human-readable project names the caller supplied.

--- a/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
@@ -688,7 +688,48 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
             return solution;
         }
 
+        var targetProject = solution.GetProject(targetProjectId)
+            ?? throw new InvalidOperationException("Target project was not found in the updated solution.");
+
+        if (WouldCreateCrossProjectCycle(sourceProject, targetProject))
+        {
+            throw new InvalidOperationException(
+                $"Adding project reference from '{sourceProject.Name}' to '{targetProject.Name}' would create a circular dependency.");
+        }
+
         return solution.AddProjectReference(sourceProjectId, new ProjectReference(targetProjectId));
+    }
+
+    private static bool WouldCreateCrossProjectCycle(Project source, Project target)
+    {
+        var visited = new HashSet<ProjectId>();
+        var stack = new Stack<Project>();
+        stack.Push(target);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!visited.Add(current.Id))
+            {
+                continue;
+            }
+
+            if (current.Id == source.Id)
+            {
+                return true;
+            }
+
+            foreach (var reference in current.ProjectReferences)
+            {
+                var next = current.Solution.GetProject(reference.ProjectId);
+                if (next is not null)
+                {
+                    stack.Push(next);
+                }
+            }
+        }
+
+        return false;
     }
 
     private static async Task<Solution> CreateInterfaceExtractionSolutionAsync(

--- a/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
@@ -310,6 +310,49 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
             $"Consumer parameter has glued-together type and name (FORMAT-BUG-002 regression).\nFile contents:\n{consumerContents}");
     }
 
+    [TestMethod]
+    public async Task Move_Type_To_Project_Preview_Rejects_Circular_Dependency_With_Human_Readable_Names()
+    {
+        // Regression for move-type-to-project-preview-leaks-projectid-tokens.
+        // Before the fix: EnsureProjectReference called solution.AddProjectReference with no
+        // cycle pre-check, causing Roslyn internals to throw an InvalidOperationException whose
+        // message contained raw "(ProjectId, #<guid> - <abs-path>)" tuple strings.
+        // After the fix: the error message uses human-readable project names.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        // Set up CircularTarget with a pre-existing reference back to SampleLib.
+        // CircularTarget -> SampleLib already exists, so adding SampleLib -> CircularTarget
+        // would create a cycle.
+        AddProjectToCopiedSolution(workspace.RootPath, "CircularTarget", "net10.0");
+        var circularTargetCsproj = workspace.GetPath("CircularTarget", "CircularTarget.csproj");
+        var sampleLibRelativePath = Path.Combine("..", "SampleLib", "SampleLib.csproj");
+        File.WriteAllText(
+            circularTargetCsproj,
+            $"<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n    <Nullable>enable</Nullable>\n    <ImplicitUsings>enable</ImplicitUsings>\n  </PropertyGroup>\n  <ItemGroup>\n    <ProjectReference Include=\"{sampleLibRelativePath}\" />\n  </ItemGroup>\n</Project>\n");
+
+        var sourceFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+            await CrossProjectRefactoringService.PreviewMoveTypeToProjectAsync(
+                workspace.WorkspaceId,
+                sourceFilePath,
+                "Dog",
+                "CircularTarget",
+                null,
+                CancellationToken.None,
+                preserveNamespace: false));
+
+        // Message must contain the human-readable project names.
+        StringAssert.Contains(exception.Message, "SampleLib");
+        StringAssert.Contains(exception.Message, "CircularTarget");
+
+        // Message must NOT contain raw ProjectId tuple tokens leaked from Roslyn internals.
+        Assert.IsFalse(
+            exception.Message.Contains("ProjectId", StringComparison.Ordinal),
+            $"Error message leaks raw ProjectId token (regression).\nActual message: {exception.Message}");
+    }
+
     private static void AddProjectToCopiedSolution(string copiedRoot, string projectName, string targetFramework)
     {
         var projectDirectory = Path.Combine(copiedRoot, projectName);


### PR DESCRIPTION
## Summary

- Added a BFS cycle check in `EnsureProjectReference` before calling `solution.AddProjectReference`, preventing Roslyn internals from throwing raw `(ProjectId, #<guid>)` tuple strings in error messages.
- Added a `WouldCreateCrossProjectCycle` private helper in `CrossProjectRefactoringService` mirroring the existing pattern in `ProjectMutationService.WouldCreateProjectReferenceCycle`.
- Added a new integration test `Move_Type_To_Project_Preview_Rejects_Circular_Dependency_With_Human_Readable_Names` that sets up a circular dependency scenario and asserts the error message contains project names, not `ProjectId` tokens.

## Test plan

- [x] New test `Move_Type_To_Project_Preview_Rejects_Circular_Dependency_With_Human_Readable_Names` passes in isolation
- [x] All 6 other `CrossProjectRefactoringIntegrationTests` pass (1 pre-existing flaky test `Extract_Interface_Preview_And_Apply_Creates_Interface_File_And_Project_Reference` fails on main branch too — state isolation issue unrelated to this change)
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` passes
- [x] `./eng/verify-ai-docs.ps1` passes

Closes: `move-type-to-project-preview-leaks-projectid-tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)