### PR TITLE
fix(validation): document conditional-required-as-a-group locator params in test_related schema

### DIFF
--- a/changelog.d/test-related-column-required-schema-mismatch.md
+++ b/changelog.d/test-related-column-required-schema-mismatch.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `test_related` schema now documents the conditional-required-as-a-group relationship between `filePath`, `line`, and `column`. Callers using source-location mode must supply all three together; callers using `symbolHandle` or `metadataName` mode omit all three. Fixes gh #618.

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -171,16 +171,16 @@ public static class ValidationTools
         }, ct);
     }
 
-    [McpServerTool(Name = "test_related", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find likely related tests for a symbol by source location or symbol handle. Two-pass match: (1) heuristic name overlap (substring of the symbol name in test methods/classes — fast, catches the common case), plus (2) reference sweep via SymbolFinder.FindReferencesAsync over the symbol + its overrides/implementations (covers interface-dispatch tests that don't mention the interface name). An empty result set usually means: (a) the symbol's simple name doesn't appear in any test method/class name AND no test file references the symbol (or any implementation) by position, (b) the target symbol is a local/anonymous construct that isn't reachable by name. For file-based impact, use `test_related_files` instead.")]
+    [McpServerTool(Name = "test_related", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find likely related tests for a symbol by source location or symbol handle. Three mutually-exclusive locator modes: (1) symbolHandle alone — pass the stable handle returned by other semantic tools; (2) metadataName alone — pass a fully-qualified metadata name such as Namespace.TypeName; (3) source-location — pass filePath, line, AND column all together (all three are required when using this mode). Two-pass match: (1) heuristic name overlap (substring of the symbol name in test methods/classes — fast, catches the common case), plus (2) reference sweep via SymbolFinder.FindReferencesAsync over the symbol + its overrides/implementations (covers interface-dispatch tests that don't mention the interface name). An empty result set usually means: (a) the symbol's simple name doesn't appear in any test method/class name AND no test file references the symbol (or any implementation) by position, (b) the target symbol is a local/anonymous construct that isn't reachable by name. For file-based impact, use `test_related_files` instead.")]
     [McpToolMetadata("validation", "stable", true, false,
         "Find tests related to a symbol.")]
     public static Task<string> FindRelatedTests(
         IWorkspaceExecutionGate gate,
         ITestDiscoveryService testDiscoveryService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: absolute path to the source file")] string? filePath = null,
-        [Description("Optional: 1-based line number")] int? line = null,
-        [Description("Optional: 1-based column number")] int? column = null,
+        [Description("Source-location mode: absolute path to the source file. Must be provided together with line and column (all three are required as a group). Omit all three source-location parameters when using symbolHandle or metadataName instead.")] string? filePath = null,
+        [Description("Source-location mode: 1-based line number. Must be provided together with filePath and column (all three are required as a group). Omit all three source-location parameters when using symbolHandle or metadataName instead.")] int? line = null,
+        [Description("Source-location mode: 1-based column number pointing at the symbol identifier token (not the start of the line). Must be provided together with filePath and line (all three are required as a group). Note: this server uses 'column' (1-based), not the LSP-style 'character'. Omit all three source-location parameters when using symbolHandle or metadataName instead.")] int? column = null,
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         [Description("Maximum number of test cases to return (default: 100)")] int maxResults = 100,

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -149,6 +149,51 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
         Assert.AreEqual(string.Empty, result.DotnetTestFilter);
     }
 
+    // test-related-column-required-schema-mismatch: a caller who supplies filePath+line but
+    // omits column is using a partial source-location (mode-3 incomplete). The runtime MUST
+    // throw ArgumentException with a message that names the missing field — not a generic
+    // "provide one of…" fallthrough. This regression test pins that diagnostic path.
+    [TestMethod]
+    public async Task TestRelated_PartialSourceLocation_MissingColumn_ThrowsArgumentExceptionWithDiagnostic()
+    {
+        var programPath = FindDocumentPath("Program.cs");
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await ValidationTools.FindRelatedTests(
+                WorkspaceExecutionGate,
+                TestDiscoveryService,
+                WorkspaceId,
+                filePath: programPath,
+                line: 1,
+                column: null,
+                symbolHandle: null,
+                metadataName: null,
+                maxResults: 100,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "column",
+            $"Expected exception message to mention 'column' as the missing field. Actual: {ex.Message}");
+        StringAssert.Contains(ex.Message, "incomplete",
+            $"Expected exception message to contain 'incomplete'. Actual: {ex.Message}");
+    }
+
+    // test-related-column-required-schema-mismatch: a caller using metadataName mode (mode-2)
+    // must succeed without providing any source-location parameters. This is the normal happy
+    // path for callers who read the corrected schema and understand the three locator modes.
+    [TestMethod]
+    public async Task TestRelated_MetadataNameMode_Succeeds_WithoutSourceLocation()
+    {
+        var result = await TestDiscoveryService.FindRelatedTestsAsync(
+            WorkspaceId,
+            RoslynMcp.Core.Models.SymbolLocator.ByMetadataName("SampleLib.AnimalService"),
+            maxResults: 100,
+            CancellationToken.None);
+
+        // The call must succeed (not throw) and return a valid result envelope.
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Tests);
+        Assert.IsNotNull(result.Pagination);
+    }
+
     // test-related-response-envelope-parity: test_related and test_related_files MUST emit
     // identically-shaped envelopes — Tests / DotnetTestFilter / Pagination — so callers can
     // route either response through the same downstream test_run --filter pipeline. This


### PR DESCRIPTION
## Summary

- Rewrites the `[Description]` attributes on `filePath`, `line`, and `column` parameters of `FindRelatedTests` (`test_related` tool) to explicitly document the three mutually-exclusive locator modes: (1) `symbolHandle` alone, (2) `metadataName` alone, (3) `filePath` + `line` + `column` all together as a required group.
- Adds top-level tool description sentence listing the three modes so MCP clients can derive the correct schema without reading individual parameter docs.
- Adds two regression tests: one asserting that a partial source-location call (filePath+line, no column) throws `ArgumentException` naming the missing field; one asserting that `metadataName` mode succeeds without any source-location parameters.

## Test plan

- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 errors, 0 warnings
- [x] `mcp__roslyn__test_run --filter ValidationToolsIntegrationTests` — 14 passed, 1 pre-existing failure (`CompileCheck_Service_GetDiagnostics_Succeeds_For_SampleSolution`) that reproduces on main in the same parallel test run (transient MSBuildWorkspace state)
- [x] `./eng/verify-ai-docs.ps1` — AI docs validation passed
- [x] New test `TestRelated_PartialSourceLocation_MissingColumn_ThrowsArgumentExceptionWithDiagnostic` verifies mode-3 partial call throws with diagnostic naming `column`
- [x] New test `TestRelated_MetadataNameMode_Succeeds_WithoutSourceLocation` verifies mode-2 metadataName round-trip succeeds

Closes: test-related-column-required-schema-mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)