### PR TITLE
fix(symbols): document_symbols and get_symbol_outline accept symbolHandle/metadataName

### DIFF
--- a/changelog.d/document-symbols-accepts-symbol-handle.md
+++ b/changelog.d/document-symbols-accepts-symbol-handle.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `document_symbols` and its alias `get_symbol_outline` now accept either `filePath` OR `symbolHandle` (or `metadataName`), mirroring the locator flexibility of `symbol_info`. Callers can now pivot directly from a `symbol_info` handle to a document outline without an intermediate file-path roundtrip.

--- a/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolSearchService.cs
@@ -27,4 +27,11 @@ public interface ISymbolSearchService
     /// </param>
     Task<SymbolDto?> GetSymbolInfoAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool allowAdjacent = false);
     Task<IReadOnlyList<DocumentSymbolDto>> GetDocumentSymbolsAsync(string workspaceId, string filePath, CancellationToken ct);
+    /// <summary>
+    /// document-symbols-accepts-symbol-handle: overload that resolves a <see cref="SymbolLocator"/>
+    /// (handle, metadata name, or file+position) to its source file path, then delegates to the
+    /// <c>filePath</c>-based overload. Throws <see cref="KeyNotFoundException"/> when the locator
+    /// cannot be resolved or the resolved symbol has no source location.
+    /// </summary>
+    Task<IReadOnlyList<DocumentSymbolDto>> GetDocumentSymbolsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -265,7 +265,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree. Response shape: { count, symbols, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. get_symbol_outline).")]
+    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree. Accepts either filePath OR a symbol locator (symbolHandle / metadataName) — mirroring the flexibility of symbol_info. Response shape: { count, symbols, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. get_symbol_outline).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "List declared symbols in a document.")]
     public static Task<string> GetDocumentSymbols(
@@ -273,29 +273,51 @@ public static class SymbolTools
         IWorkspaceExecutionGate gate,
         ISymbolSearchService symbolSearchService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file")] string filePath,
+        [Description("Optional: absolute path to the source file")] string? filePath = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
-        return GetDocumentSymbolsCore(server, gate, symbolSearchService, workspaceId, filePath, deprecation: null, ct);
+        return GetDocumentSymbolsCore(server, gate, symbolSearchService, workspaceId, filePath, symbolHandle, metadataName, deprecation: null, ct);
     }
 
     // roslyn-mcp-sister-tool-name-aliases: shared core invoked by both the canonical
     // `document_symbols` tool and the `get_symbol_outline` alias. The alias passes a populated
     // `deprecation` envelope so callers can see the canonical name inline; the canonical method
     // passes `null` so the response schema always carries the field.
+    // document-symbols-accepts-symbol-handle: when symbolHandle or metadataName is provided,
+    // delegates to the locator-based service overload which resolves the handle to a source path.
+    // When only filePath is provided, delegates to the original filePath-based overload.
     internal static Task<string> GetDocumentSymbolsCore(
         McpServer server,
         IWorkspaceExecutionGate gate,
         ISymbolSearchService symbolSearchService,
         string workspaceId,
-        string filePath,
+        string? filePath,
+        string? symbolHandle,
+        string? metadataName,
         ToolAliasDeprecation? deprecation,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
-            var results = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, c);
+            IReadOnlyList<Core.Models.DocumentSymbolDto> results;
+
+            if (!string.IsNullOrWhiteSpace(symbolHandle) || !string.IsNullOrWhiteSpace(metadataName))
+            {
+                // Locator-driven path: resolve handle/metadataName to a source file, then collect.
+                var locator = SymbolLocatorFactory.Create(filePath, null, null, symbolHandle, metadataName);
+                results = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, locator, c).ConfigureAwait(false);
+            }
+            else
+            {
+                // Classic filePath path — validate against workspace roots before the service call.
+                if (string.IsNullOrWhiteSpace(filePath))
+                    throw new ArgumentException("Provide either a filePath, a symbolHandle, or a metadataName.");
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+                results = await symbolSearchService.GetDocumentSymbolsAsync(workspaceId, filePath, c).ConfigureAwait(false);
+            }
+
             return JsonSerializer.Serialize(new { count = results.Count, symbols = results, deprecation }, JsonDefaults.Indented);
         }, ct);
     }
@@ -311,7 +333,9 @@ public static class SymbolTools
         IWorkspaceExecutionGate gate,
         ISymbolSearchService symbolSearchService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file")] string filePath,
+        [Description("Optional: absolute path to the source file")] string? filePath = null,
+        [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
+        [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
         return GetDocumentSymbolsCore(
@@ -320,6 +344,8 @@ public static class SymbolTools
             symbolSearchService,
             workspaceId,
             filePath,
+            symbolHandle,
+            metadataName,
             ToolAliasDeprecation.ForSisterAlias("document_symbols"),
             ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -247,6 +247,30 @@ public sealed class SymbolSearchService : ISymbolSearchService
         return CollectSymbols(root, ct);
     }
 
+    // document-symbols-accepts-symbol-handle: locator-based overload — resolves the locator to
+    // an ISymbol, extracts its first source location path, then delegates to the filePath overload.
+    // Throws KeyNotFoundException when the locator cannot be resolved or has no source location
+    // (e.g. BCL types defined only in metadata).
+    public async Task<IReadOnlyList<DocumentSymbolDto>> GetDocumentSymbolsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    {
+        _logger.LogDebug("SymbolSearchService.GetDocumentSymbolsAsync(locator): workspaceId={WorkspaceId} locator={Locator}", workspaceId, locator);
+        locator.Validate();
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
+        if (symbol is null)
+            throw new KeyNotFoundException($"No symbol could be resolved for the given locator.");
+
+        var sourcePath = symbol.Locations
+            .FirstOrDefault(l => l.IsInSource)
+            ?.GetLineSpan().Path;
+
+        if (sourcePath is null)
+            throw new KeyNotFoundException(
+                $"Symbol '{symbol.ToDisplayString()}' has no source location. Symbols defined only in metadata (e.g. BCL types) cannot be used with document_symbols.");
+
+        return await GetDocumentSymbolsAsync(workspaceId, sourcePath, ct).ConfigureAwait(false);
+    }
+
     private static bool MatchesKind(ISymbol symbol, string kindFilter)
     {
         var kinds = new[]

--- a/tests/RoslynMcp.Tests/DocumentSymbolsSymbolHandleTests.cs
+++ b/tests/RoslynMcp.Tests/DocumentSymbolsSymbolHandleTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// document-symbols-accepts-symbol-handle: verifies that <c>document_symbols</c> and its alias
+/// <c>get_symbol_outline</c> accept a <c>symbolHandle</c> (or <c>metadataName</c>) in place of a
+/// <c>filePath</c>, returning the same outline as the equivalent filePath-driven invocation.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class DocumentSymbolsSymbolHandleTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    private static string FindDocumentPath(string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        return solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == name).FilePath!;
+    }
+
+    [TestMethod]
+    public async Task DocumentSymbols_AcceptsSymbolHandle_ReturnsMatchingOutline()
+    {
+        // Obtain a symbolHandle for AnimalService using symbol_info.
+        var symbolInfoJson = await SymbolTools.GetSymbolInfo(
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            metadataName: "SampleLib.AnimalService",
+            ct: CancellationToken.None);
+
+        using var symbolInfoDoc = JsonDocument.Parse(symbolInfoJson);
+        var symbolHandle = symbolInfoDoc.RootElement.GetProperty("symbolHandle").GetString();
+        Assert.IsNotNull(symbolHandle, "symbol_info must return a non-null symbolHandle for AnimalService.");
+
+        // Call document_symbols with the symbolHandle (no filePath).
+        var handleJson = await SymbolTools.GetDocumentSymbols(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            symbolHandle: symbolHandle,
+            ct: CancellationToken.None);
+
+        using var handleDoc = JsonDocument.Parse(handleJson);
+        Assert.IsTrue(handleDoc.RootElement.TryGetProperty("count", out var countProp),
+            "document_symbols response must include a 'count' field.");
+        var count = countProp.GetInt32();
+        Assert.IsTrue(count > 0,
+            $"document_symbols(symbolHandle) must return at least one symbol; got count={count}.");
+
+        // Call document_symbols with the filePath for the same type and assert same count.
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+        var filePathJson = await SymbolTools.GetDocumentSymbols(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            filePath: animalServicePath,
+            ct: CancellationToken.None);
+
+        using var filePathDoc = JsonDocument.Parse(filePathJson);
+        var filePathCount = filePathDoc.RootElement.GetProperty("count").GetInt32();
+        Assert.AreEqual(filePathCount, count,
+            $"document_symbols(symbolHandle) and document_symbols(filePath) must return the same symbol count for AnimalService.");
+    }
+
+    [TestMethod]
+    public async Task DocumentSymbols_AcceptsMetadataName_ReturnsNonEmptyOutline()
+    {
+        var json = await SymbolTools.GetDocumentSymbols(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            metadataName: "SampleLib.AnimalService",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("count", out var countProp),
+            "document_symbols response must include a 'count' field.");
+        Assert.IsTrue(countProp.GetInt32() > 0,
+            "document_symbols(metadataName) must return at least one symbol for AnimalService.");
+    }
+
+    [TestMethod]
+    public async Task GetSymbolOutline_AcceptsSymbolHandle_ReturnsMatchingOutline()
+    {
+        // get_symbol_outline is the alias for document_symbols — must accept symbolHandle too.
+        var symbolInfoJson = await SymbolTools.GetSymbolInfo(
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            metadataName: "SampleLib.AnimalService",
+            ct: CancellationToken.None);
+
+        using var symbolInfoDoc = JsonDocument.Parse(symbolInfoJson);
+        var symbolHandle = symbolInfoDoc.RootElement.GetProperty("symbolHandle").GetString();
+        Assert.IsNotNull(symbolHandle);
+
+        var aliasJson = await SymbolTools.GetSymbolOutline(
+            server: null!,
+            gate: WorkspaceExecutionGate,
+            symbolSearchService: SymbolSearchService,
+            workspaceId: WorkspaceId,
+            symbolHandle: symbolHandle,
+            ct: CancellationToken.None);
+
+        using var aliasDoc = JsonDocument.Parse(aliasJson);
+        Assert.IsTrue(aliasDoc.RootElement.TryGetProperty("count", out var countProp),
+            "get_symbol_outline response must include a 'count' field.");
+        Assert.IsTrue(countProp.GetInt32() > 0,
+            "get_symbol_outline(symbolHandle) must return at least one symbol for AnimalService.");
+
+        // The alias must populate the deprecation envelope.
+        Assert.IsTrue(aliasDoc.RootElement.TryGetProperty("deprecation", out var deprecation),
+            "get_symbol_outline must return a 'deprecation' field.");
+        Assert.AreNotEqual(JsonValueKind.Null, deprecation.ValueKind,
+            "get_symbol_outline 'deprecation' must not be null.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `symbolHandle` and `metadataName` optional parameters to `document_symbols` and its alias `get_symbol_outline`, mirroring the locator flexibility already present in `symbol_info`, `find_overrides`, and other symbol tools.
- Adds a `GetDocumentSymbolsAsync(workspaceId, SymbolLocator, ct)` overload to `ISymbolSearchService` and `SymbolSearchService`. The overload resolves the locator to its source file path, then delegates to the existing `filePath`-based implementation. Throws `KeyNotFoundException` for metadata-only symbols (e.g. BCL types with no source location).
- `GetDocumentSymbolsCore` now routes handle/metadataName calls through the locator overload and filePath-only calls through the original overload with root-path validation.
- Adds 3 integration tests in `DocumentSymbolsSymbolHandleTests` covering `symbolHandle`, `metadataName`, and the alias.

## Test plan

- [ ] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — passes (0 warnings, 0 errors)
- [ ] `dotnet test --filter DocumentSymbolsSymbolHandle` — 3/3 pass
- [ ] `./eng/verify-ai-docs.ps1` — passes
- [ ] Existing `AliasToolsTests` (named-argument callers of `GetDocumentSymbols`/`GetSymbolOutline`) compile and pass unchanged

Closes: `document-symbols-accepts-symbol-handle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)