### PR TITLE
fix(editorconfig): override stale Roslyn-cached values with disk on GetOptionsAsync

### DIFF
--- a/changelog.d/editorconfig-write-no-auto-invalidation.md
+++ b/changelog.d/editorconfig-write-no-auto-invalidation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `get_editorconfig_options` returning stale cached values for known keys (e.g. `indent_size`, `csharp_style_var_for_built_in_types`) immediately after `set_editorconfig_option` writes a new value. The disk-parsed value is now authoritative when the `.editorconfig` file is present, overriding the Roslyn workspace snapshot for any key the snapshot had cached before the write.

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -57,6 +57,10 @@ public sealed class EditorConfigService : IEditorConfigService
         // dr-get-editorconfig-options-incomplete-after-set: Supplement Roslyn-enumerated
         // keys with any keys present on disk that Roslyn's cached snapshot hasn't picked
         // up yet (e.g., after set_editorconfig_option writes a new key).
+        // editorconfig-write-no-auto-invalidation: Also override Roslyn-cached values for
+        // known keys with the disk-parsed value — the disk is authoritative because
+        // SetOptionAsync writes directly to it, and the Roslyn workspace snapshot may be
+        // stale until the next workspace_reload.
         if (editorconfigPath is not null && File.Exists(editorconfigPath))
         {
             var existingKeys = new HashSet<string>(options.Select(o => o.Key), StringComparer.OrdinalIgnoreCase);
@@ -66,6 +70,18 @@ public sealed class EditorConfigService : IEditorConfigService
                 {
                     options.Add(new EditorConfigEntryDto(key, value, "disk"));
                     existingKeys.Add(key);
+                }
+            }
+
+            // Second pass: override cached values for keys that the disk file has also
+            // enumerated. Roslyn's snapshot may lag behind a recent set_editorconfig_option
+            // write, so the on-disk value wins whenever the file exists.
+            foreach (var (key, diskValue) in ParseEditorconfigCsKeys(editorconfigPath))
+            {
+                var idx = options.FindIndex(o => string.Equals(o.Key, key, StringComparison.OrdinalIgnoreCase));
+                if (idx >= 0 && options[idx].Source != "disk")
+                {
+                    options[idx] = new EditorConfigEntryDto(key, diskValue, "disk");
                 }
             }
         }

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -47,6 +47,46 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
         Assert.AreEqual(value, entry!.Value);
     }
 
+    /// <summary>
+    /// Regression test for <c>editorconfig-write-no-auto-invalidation</c>:
+    /// <see cref="IEditorConfigService.GetOptionsAsync"/> must return the value that
+    /// <see cref="IEditorConfigService.SetOptionAsync"/> just wrote for a <em>known</em>
+    /// key (one that Roslyn's <c>AnalyzerConfigOptionsProvider</c> already has in its
+    /// cached workspace snapshot) — without requiring a <c>workspace_reload</c> call
+    /// in between.
+    /// </summary>
+    [TestMethod]
+    public async Task SetThenGet_KnownKey_ReturnsNewValueWithoutReload()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // indent_size is a well-known key that Roslyn's AnalyzerConfigOptionsProvider
+        // enumerates. Writing a new value via SetOptionAsync must be visible on the
+        // immediately-following GetOptionsAsync call without an intervening workspace_reload.
+        const string knownKey = "indent_size";
+        const string newValue = "4";
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, knownKey, newValue, "set_editorconfig_option", CancellationToken.None);
+        Assert.IsTrue(File.Exists(setResult.EditorConfigPath));
+
+        // Intentionally NOT calling workspace_reload — that is the bug surface.
+        var options = await EditorConfigService.GetOptionsAsync(
+            workspaceId, dogFilePath, CancellationToken.None);
+
+        var entry = options.Options.FirstOrDefault(o =>
+            string.Equals(o.Key, knownKey, StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(entry,
+            $"Get must surface '{knownKey}' after Set writes it. " +
+            $"Returned keys: {string.Join(", ", options.Options.Select(o => o.Key))}");
+        Assert.AreEqual(newValue, entry!.Value,
+            $"Get must return the newly-written value '{newValue}' without a workspace_reload. " +
+            $"Actual value returned: '{entry.Value}'. This indicates the Roslyn-cached snapshot " +
+            $"was returned instead of the on-disk value.");
+    }
+
     [TestMethod]
     public void SectionMatchesCSharp_RecognizesCommonGlobs()
     {


### PR DESCRIPTION
## Summary

- `GetOptionsAsync` was returning the Roslyn workspace-snapshot value for **known keys** (e.g. `indent_size`, `csharp_style_var_for_built_in_types`) immediately after `set_editorconfig_option` wrote a new value to disk — because the supplement guard only added **missing** keys, not overriding **stale** ones.
- Added a second pass in the `if (editorconfigPath is not null && File.Exists(editorconfigPath))` block that iterates `ParseEditorconfigCsKeys` again and replaces any existing entry whose source is not already `"disk"` with the disk-parsed value.
- The disk is authoritative: `SetOptionAsync` writes directly to `.editorconfig` without reloading the workspace, so the on-disk value wins until the next `workspace_reload`.

## Files changed

- `src/RoslynMcp.Roslyn/Services/EditorConfigService.cs` — second-pass disk override in `GetOptionsAsync`
- `tests/RoslynMcp.Tests/EditorConfigServiceTests.cs` — new test `SetThenGet_KnownKey_ReturnsNewValueWithoutReload`

## Test plan

- [x] `mcp__roslyn__compile_check` — 0 errors, 0 warnings
- [x] `mcp__roslyn__test_run --filter EditorConfigServiceTests` — 3/3 passed (2 pre-existing + 1 new)
- [x] `./eng/verify-ai-docs.ps1` — passed

Closes: editorconfig-write-no-auto-invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)