### PR TITLE
fix(set-project-property): warn when property already inherited from Directory.Build.props

### DIFF
--- a/changelog.d/set-project-property-preview-directory-build-props-blindness.md
+++ b/changelog.d/set-project-property-preview-directory-build-props-blindness.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `set_project_property_preview` silently generating redundant property entries when the target property is already inherited from `Directory.Build.props`. The tool now inspects the evaluated MSBuild property graph and includes a `warnings` annotation when the requested value is already globally effective.

--- a/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
@@ -106,7 +106,7 @@ public static class ProjectMutationTools
     [McpServerTool(Name = "set_project_property_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("project-mutation", "stable", true, false,
         "Preview setting an allowlisted property in a project file."),
-     Description("Preview setting an allowlisted property in a project file in the loaded workspace.")]
+     Description("Preview setting an allowlisted property in a project file in the loaded workspace. When the property value is already inherited from Directory.Build.props, the response includes a warning annotation.")]
     public static Task<string> PreviewSetProjectProperty(
         IWorkspaceExecutionGate gate,
         IProjectMutationService projectMutationService,

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -169,12 +169,20 @@ public sealed class ProjectMutationService : IProjectMutationService
         }, $"Remove project reference '{request.ReferencedProjectName}'", ct);
     }
 
-    public Task<RefactoringPreviewDto> PreviewSetProjectPropertyAsync(string workspaceId, SetProjectPropertyDto request, CancellationToken ct)
+    public async Task<RefactoringPreviewDto> PreviewSetProjectPropertyAsync(string workspaceId, SetProjectPropertyDto request, CancellationToken ct)
     {
-        return PreviewProjectMutationAsync(workspaceId, request.ProjectName, document =>
-        {
-            ValidateAllowedProperty(request.PropertyName);
+        ValidateAllowedProperty(request.PropertyName);
 
+        // Inspect the evaluated MSBuild property graph to detect values inherited from Directory.Build.props
+        // or other imported targets — the XDocument-only check below cannot see those.
+        var evaluated = await _msbuildEvaluation.EvaluatePropertyAsync(workspaceId, request.ProjectName, request.PropertyName, ct).ConfigureAwait(false);
+
+        // Use a captured list so the mutator lambda can populate warnings; the list is passed to
+        // PreviewProjectMutationAsync after the lambda executes (the overload reads it post-mutation).
+        var warnings = new List<string>();
+
+        var preview = await PreviewProjectMutationAsync(workspaceId, request.ProjectName, document =>
+        {
             var propertyGroup = document.Root?.Elements("PropertyGroup").FirstOrDefault();
             if (propertyGroup is null)
             {
@@ -184,12 +192,23 @@ public sealed class ProjectMutationService : IProjectMutationService
                 OrchestrationMsBuildXml.InsertFirstElementChildWithFormatting(document, propertyGroup);
             }
 
-            // Detect no-op: check if property already has the target value
+            // Detect no-op: check if property already has the target value in the .csproj itself
             var existingElement = propertyGroup.Element(request.PropertyName);
             if (string.Equals(existingElement?.Value, request.Value, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     $"No changes needed — property '{request.PropertyName}' is already set to '{request.Value}'.");
+            }
+
+            // Warn (but do not block) when the evaluated effective value already matches the requested
+            // value and the property is NOT declared in this .csproj — i.e. it is inherited from
+            // Directory.Build.props or another imported file. Applying the preview would create a
+            // redundant entry, so surface a warning annotation for the caller to inspect.
+            if (existingElement is null
+                && !string.IsNullOrEmpty(evaluated.EvaluatedValue)
+                && string.Equals(evaluated.EvaluatedValue, request.Value, StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Add($"Property '{request.PropertyName}' is already set to '{request.Value}' via the inherited MSBuild property graph (e.g. Directory.Build.props). Applying this preview will create a redundant entry in the .csproj.");
             }
 
             // project-mutation-preview-xml-formatting: SetElementValue inserts a new XElement with
@@ -207,7 +226,10 @@ public sealed class ProjectMutationService : IProjectMutationService
                     propertyGroup,
                     new XElement(request.PropertyName, request.Value));
             }
-        }, $"Set project property '{request.PropertyName}'", ct);
+        }, $"Set project property '{request.PropertyName}'", ct).ConfigureAwait(false);
+
+        // Attach warnings collected by the mutator lambda (warnings.Count == 0 means no annotation).
+        return warnings.Count > 0 ? preview with { Warnings = warnings } : preview;
     }
 
     public async Task<RefactoringPreviewDto> PreviewAddTargetFrameworkAsync(string workspaceId, AddTargetFrameworkDto request, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -527,4 +527,61 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
         StringAssert.Contains(ex.Message, "'$(Configuration)' == 'Release'",
             "Error message must include the MSBuild-quoting example so first-time callers see the expected syntax.");
     }
+
+    [TestMethod]
+    public async Task Set_Project_Property_Preview_Warns_When_Property_Already_Inherited_From_Directory_Build_Props()
+    {
+        // set-project-property-preview-directory-build-props-blindness: when a property value is
+        // already set via the inherited MSBuild property graph (e.g. Directory.Build.props) but NOT
+        // declared in the .csproj itself, the tool must warn — not throw — and still emit a diff
+        // so the caller can inspect the redundancy and decide whether to proceed.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        // Write a Directory.Build.props that sets Nullable=enable globally.
+        await File.WriteAllTextAsync(
+            Path.Combine(workspace.RootPath, "Directory.Build.props"),
+            """
+            <Project>
+              <PropertyGroup>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """,
+            CancellationToken.None).ConfigureAwait(false);
+
+        // Rewrite SampleLib.csproj to not declare Nullable, so the value comes exclusively from
+        // Directory.Build.props.
+        var projectFilePath = workspace.GetPath("SampleLib", "SampleLib.csproj");
+        await File.WriteAllTextAsync(
+            projectFilePath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+            </Project>
+            """,
+            CancellationToken.None).ConfigureAwait(false);
+
+        await workspace.LoadAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // Requesting Nullable=enable should NOT throw because the value matches — but should warn.
+        var preview = await ProjectMutationService.PreviewSetProjectPropertyAsync(
+            workspace.WorkspaceId,
+            new SetProjectPropertyDto("SampleLib", "Nullable", "enable"),
+            CancellationToken.None).ConfigureAwait(false);
+
+        // Warn-not-reject: the preview must include a warning.
+        Assert.IsNotNull(preview.Warnings, "Warnings must be non-null when the property is inherited.");
+        Assert.IsTrue(preview.Warnings.Count > 0, "Warnings collection must be non-empty.");
+        StringAssert.Contains(preview.Warnings[0], "already",
+            $"Warning message must contain 'already'. Actual: {preview.Warnings[0]}");
+
+        // Warn-not-reject: a diff must still be present so the caller can see what would be added.
+        Assert.IsTrue(preview.Changes.Any(), "Preview must still emit a file diff (warn-not-reject).");
+        var diff = preview.Changes.First().UnifiedDiff;
+        Assert.IsTrue(diff.Contains("Nullable", StringComparison.OrdinalIgnoreCase),
+            "Diff must reference the Nullable property.");
+    }
 }


### PR DESCRIPTION
## Summary

- `PreviewSetProjectPropertyAsync` now calls `EvaluatePropertyAsync` to inspect the evaluated MSBuild property graph before the XDocument mutation
- When the effective value already matches the requested value and the property is NOT declared in the `.csproj` itself (inherited from `Directory.Build.props` or similar), a warning is added to `RefactoringPreviewDto.Warnings` — the preview diff is still produced (warn-not-reject)
- `[Description]` on `set_project_property_preview` updated to document the warning annotation
- New integration test: `Set_Project_Property_Preview_Warns_When_Property_Already_Inherited_From_Directory_Build_Props`

## Test plan

- [x] 20/20 `ProjectMutationIntegrationTests` pass (including new test and existing `Set_Project_Property_Preview_And_Apply_Updates_Isolated_Project_File`)
- [x] `compile_check` clean on `RoslynMcp.Roslyn` and `RoslynMcp.Tests`

Closes: set-project-property-preview-directory-build-props-blindness

🤖 Generated with [Claude Code](https://claude.com/claude-code)