### PR TITLE
feat(eng): add audit-experimental-age.ps1 advisory script (eternal-experimental-age-audit)

### DIFF
--- a/.claude/skills/publish-preflight/SKILL.md
+++ b/.claude/skills/publish-preflight/SKILL.md
@@ -147,6 +147,23 @@ The script emits a single JSON object on stdout. Parse it and branch on the resu
 
 **Pass** when the aggregator ran cleanly (regardless of whether any entries were `promote: ready`). **Fail** is reserved for: aggregator exit code non-zero, or output that prevents parsing. Stale-but-readable scorecards are WARN, not FAIL.
 
+### Step 8.5: Experimental Age Audit (advisory, non-blocking)
+
+This step surfaces experimental-tier surface entries that have been experimental for more than 180 days without promotion or deprecation. It does not auto-promote or auto-deprecate any entry; it is informational only.
+
+Run the auditor via Bash:
+```
+pwsh -NoProfile -File eng/audit-experimental-age.ps1
+```
+
+(Optional: pass `-ThresholdDays <N>` to lower or raise the age threshold; see `pwsh -NoProfile -File eng/audit-experimental-age.ps1 -?` for all parameters.)
+
+The script emits a Markdown table of experimental entries whose `git blame` age exceeds `$ThresholdDays` days (default 180). If no entries exceed the threshold, the script prints a one-line "no entries found" message and exits 0.
+
+**Action:** Review the table. For each entry that has aged significantly with no promotion path in sight, consider opening a backlog row to either promote it (if real-world usage supports stable tier) or deprecate it (if it has not seen adoption). No action is required before publishing; the gate's purpose is visibility, not enforcement.
+
+**Pass** always — the script always exits 0. Include the output (or a "no stale entries" note) in the summary report as an informational line.
+
 ## Summary Report
 
 After all steps, display a table:

--- a/changelog.d/eternal-experimental-age-audit.md
+++ b/changelog.d/eternal-experimental-age-audit.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `eng/audit-experimental-age.ps1` — advisory script that walks `ServerSurfaceCatalog.*` for experimental-tier entries, runs `git blame` on each catalog line, computes age, emits a table of entries older than 180 days. Does not auto-promote or auto-deprecate. Optional advisory hook added to `/publish-preflight` Step 8.5.

--- a/eng/audit-experimental-age.ps1
+++ b/eng/audit-experimental-age.ps1
@@ -1,0 +1,166 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Audit experimental-tier entries in ServerSurfaceCatalog.*.cs for age using git blame.
+
+.DESCRIPTION
+    Walks every `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.*.cs` partial file,
+    extracts lines that register experimental-tier surface entries via the `Tool(...)`,
+    `Resource(...)`, or `Prompt(...)` factory call pattern (anchored on the string literal
+    `"experimental"` in the third argument position), then runs `git blame` on each matching
+    line to determine the commit timestamp. Entries older than `$ThresholdDays` days (UTC) are
+    collected and emitted as a Markdown table.
+
+    The script is ADVISORY ONLY. It does not auto-promote or auto-deprecate any entry. A non-zero
+    exit code is never emitted due to aging — the script exits 0 always.
+
+    NOTE: `git blame` returns the committer-date of the commit that last touched the line. Branch
+    imports may inflate the apparent age when large changes land together. This is acceptable for an
+    advisory audit script; treat the result as a lower bound on staleness.
+
+    Age is computed in UTC days from the blame commit timestamp to the current UTC date.
+
+.PARAMETER ThresholdDays
+    Minimum age in days for an entry to appear in the output table. Default: 180.
+    Pass 0 to emit ALL experimental entries regardless of age.
+
+.PARAMETER RepoRoot
+    Root of the git repository to inspect. Defaults to the parent directory of the `eng/` folder
+    that contains this script (i.e., the Roslyn-Backed-MCP repo root).
+
+.EXAMPLE
+    ./eng/audit-experimental-age.ps1
+
+    Emit entries that have been experimental for more than 180 days.
+
+.EXAMPLE
+    ./eng/audit-experimental-age.ps1 -ThresholdDays 0
+
+    Emit ALL experimental entries regardless of age.
+
+.EXAMPLE
+    ./eng/audit-experimental-age.ps1 -ThresholdDays 90 -RepoRoot C:\Other\Repo
+
+    Run against a different repo root with a 90-day threshold.
+#>
+[CmdletBinding()]
+param(
+    [int]$ThresholdDays = 180,
+    [string]$RepoRoot = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+
+# Normalize to absolute path.
+$RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).ProviderPath
+
+$catalogGlob = Join-Path $RepoRoot 'src' 'RoslynMcp.Host.Stdio' 'Catalog' 'ServerSurfaceCatalog.*.cs'
+$catalogFiles = @(Get-ChildItem -Path $catalogGlob -ErrorAction SilentlyContinue)
+
+if ($catalogFiles.Count -eq 0) {
+    Write-Warning "No catalog partial files found at: $catalogGlob"
+    exit 0
+}
+
+# Regex: captures method kind (Tool/Resource/Prompt), name (first arg), category (second arg).
+# Anchors on the third string argument being "experimental". Handles both single-line and the
+# common case where the closing paren is on the same line.
+#
+# Pattern: Tool|Resource|Prompt followed by optional whitespace, open paren, then:
+#   "name"   , "category"  , "experimental"
+# Single-quoted strings are NOT used in the catalog, so we only match double-quoted literals.
+$entryRegex = [System.Text.RegularExpressions.Regex]::new(
+    '(?<kind>Tool|Resource|Prompt)\s*\(\s*"(?<name>[^"]+)"\s*,\s*"(?<category>[^"]+)"\s*,\s*"experimental"',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+)
+
+$nowUtc = [System.DateTime]::UtcNow.Date
+
+$results = New-Object System.Collections.Generic.List[pscustomobject]
+
+foreach ($file in $catalogFiles) {
+    $lines = [System.IO.File]::ReadAllLines($file.FullName)
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        $line = $lines[$i]
+        $m = $entryRegex.Match($line)
+        if (-not $m.Success) { continue }
+
+        $kind     = $m.Groups['kind'].Value
+        $name     = $m.Groups['name'].Value
+        $category = $m.Groups['category'].Value
+        $lineNo   = $i + 1  # git blame uses 1-based line numbers
+
+        # Relative path from repo root for git blame.
+        $relPath = $file.FullName.Substring($RepoRoot.Length).TrimStart('\', '/')
+        # Normalize to forward slashes for git.
+        $relPath = $relPath -replace '\\', '/'
+
+        # Run git blame with --porcelain to get the commit timestamp.
+        # We capture author-time (Unix epoch) for accurate commit date.
+        $blameArgs = @('blame', '-L', "$lineNo,$lineNo", '--porcelain', $relPath)
+        $blameOutput = & git -C $RepoRoot @blameArgs 2>&1
+
+        $commitHash = ''
+        $commitDate = [System.DateTime]::MinValue
+
+        if ($LASTEXITCODE -eq 0) {
+            foreach ($blameLine in $blameOutput) {
+                if ($blameLine -match '^([0-9a-f]{40})\s') {
+                    $commitHash = $Matches[1].Substring(0, 8)
+                }
+                if ($blameLine -match '^author-time\s+(\d+)$') {
+                    $epoch = [long]$Matches[1]
+                    $commitDate = [System.DateTimeOffset]::FromUnixTimeSeconds($epoch).UtcDateTime.Date
+                }
+            }
+        }
+
+        $ageDays = if ($commitDate -ne [System.DateTime]::MinValue) {
+            ($nowUtc - $commitDate).Days
+        } else {
+            -1
+        }
+
+        if ($ageDays -ge $ThresholdDays -or ($ThresholdDays -eq 0 -and $ageDays -ge 0)) {
+            $results.Add([pscustomobject]@{
+                Kind        = $kind
+                Name        = $name
+                Category    = $category
+                File        = $relPath
+                Line        = $lineNo
+                AgeDays     = $ageDays
+                BlameCommit = $commitHash
+                BlameDate   = if ($commitDate -ne [System.DateTime]::MinValue) { $commitDate.ToString('yyyy-MM-dd') } else { 'unknown' }
+            }) | Out-Null
+        }
+    }
+}
+
+if ($results.Count -eq 0) {
+    Write-Output "No experimental entries found older than $ThresholdDays days."
+    exit 0
+}
+
+# Sort by age descending.
+$sorted = $results | Sort-Object -Property AgeDays -Descending
+
+# Emit Markdown table.
+Write-Output ''
+Write-Output "## Experimental-Tier Age Audit (threshold: $ThresholdDays days)"
+Write-Output ''
+Write-Output "Generated: $($nowUtc.ToString('yyyy-MM-dd')) UTC | Entries: $($sorted.Count)"
+Write-Output ''
+Write-Output '| Kind | Name | Category | File | Line | Age (days) | Blame Commit | Blame Date |'
+Write-Output '|------|------|----------|------|------|-----------|--------------|------------|'
+foreach ($r in $sorted) {
+    $shortFile = Split-Path -Leaf $r.File
+    Write-Output "| $($r.Kind) | $($r.Name) | $($r.Category) | $shortFile | $($r.Line) | $($r.AgeDays) | $($r.BlameCommit) | $($r.BlameDate) |"
+}
+Write-Output ''
+
+exit 0

--- a/tests/RoslynMcp.Tests/Skills/ExperimentalAgeAuditScriptTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/ExperimentalAgeAuditScriptTests.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// eternal-experimental-age-audit: behavior tests for `eng/audit-experimental-age.ps1`.
+///
+/// The script walks `ServerSurfaceCatalog.*.cs` partials, extracts experimental-tier
+/// factory call lines, runs `git blame` on each to compute age, and emits a Markdown
+/// table for entries older than `$ThresholdDays` days (default 180).
+///
+/// Strategy: all tests run the script against an ISOLATED temp directory — never the
+/// real Code-Repo tree. To avoid a live git-blame dependency (which requires committed
+/// history), tests use `-ThresholdDays 0` so the age check passes for any entry whose
+/// blame timestamp is readable. Tests that specifically probe the table format seed a
+/// real git repo in the temp directory so blame returns valid output.
+/// </summary>
+[TestClass]
+public sealed class ExperimentalAgeAuditScriptTests
+{
+    private string _tempDir = string.Empty;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "RoslynMcpTests", "ExperimentalAgeAudit", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        if (!Directory.Exists(_tempDir)) return;
+        // .git directories may contain readonly files on Windows; clear attributes before delete.
+        foreach (var file in Directory.EnumerateFiles(_tempDir, "*", SearchOption.AllDirectories))
+        {
+            try { File.SetAttributes(file, FileAttributes.Normal); } catch { /* best effort */ }
+        }
+        TestFixtureFileSystem.DeleteDirectoryIfExists(_tempDir);
+    }
+
+    [TestMethod]
+    public void Script_FileExistsAtDocumentedPath()
+    {
+        var scriptPath = ResolveScriptPath();
+        Assert.IsTrue(
+            File.Exists(scriptPath),
+            $"audit-experimental-age.ps1 was not found at '{scriptPath}'. " +
+            "publish-preflight Step 8.5 references this exact path; without the file the docs ship dead links.");
+    }
+
+    [TestMethod]
+    public void Script_NoEntriesFound_EmitsNoEntriesMessage()
+    {
+        // Catalog dir with a file that has NO experimental entries.
+        var catalogDir = CreateCatalogDir();
+        File.WriteAllText(
+            Path.Combine(catalogDir, "ServerSurfaceCatalog.Empty.cs"),
+            "// No experimental entries here.\n");
+
+        var result = RunScript(repoRoot: _tempDir, thresholdDays: 0);
+
+        Assert.AreEqual(0, result.ExitCode, $"Script exited non-zero: stderr={result.StdErr}");
+        Assert.IsTrue(
+            result.StdOut.Contains("No experimental entries found", StringComparison.OrdinalIgnoreCase),
+            $"Expected 'no entries' message when catalog has no experimental entries. stdout: {result.StdOut}");
+    }
+
+    [TestMethod]
+    public void Script_ExperimentalEntryPresent_WithThresholdZeroAndRealGit_EmitsEntryInTable()
+    {
+        // Seed a minimal git repo in _tempDir so git blame can return real output.
+        InitGitRepo(_tempDir);
+
+        var catalogDir = CreateCatalogDir();
+        var catalogFile = Path.Combine(catalogDir, "ServerSurfaceCatalog.Test.cs");
+
+        // Write a catalog partial with one experimental Tool entry.
+        var content = "namespace X; public static partial class ServerSurfaceCatalog {\n" +
+                      "    static object[] Tools = { Tool(\"test_audit_tool\", \"tools\", \"experimental\", true, false, \"desc\") };\n" +
+                      "}\n";
+        File.WriteAllText(catalogFile, content);
+        CommitFile(_tempDir, catalogFile, "add test catalog entry");
+
+        // ThresholdDays=0 means emit ALL entries regardless of age.
+        var result = RunScript(repoRoot: _tempDir, thresholdDays: 0);
+
+        Assert.AreEqual(0, result.ExitCode, $"Script exited non-zero: stderr={result.StdErr}");
+        Assert.IsTrue(
+            result.StdOut.Contains("test_audit_tool", StringComparison.Ordinal),
+            $"Expected 'test_audit_tool' in output table. stdout:\n{result.StdOut}");
+        Assert.IsTrue(
+            result.StdOut.Contains("Experimental-Tier Age Audit", StringComparison.OrdinalIgnoreCase),
+            $"Expected table header in output. stdout:\n{result.StdOut}");
+    }
+
+    [TestMethod]
+    public void Script_MultipleKinds_AllAppearInTableWithThresholdZero()
+    {
+        InitGitRepo(_tempDir);
+        var catalogDir = CreateCatalogDir();
+
+        // Seed one Tool, one Resource, one Prompt — all experimental.
+        var content =
+            "namespace X; public static partial class ServerSurfaceCatalog {\n" +
+            "    static object a = Tool(\"my_tool\", \"tools\", \"experimental\", true, false, \"t\");\n" +
+            "    static object b = Resource(\"my_resource\", \"resources\", \"experimental\", true, false, \"r\");\n" +
+            "    static object c = Prompt(\"my_prompt\", \"prompts\", \"experimental\", true, false, \"p\");\n" +
+            "}\n";
+        var catalogFile = Path.Combine(catalogDir, "ServerSurfaceCatalog.Multi.cs");
+        File.WriteAllText(catalogFile, content);
+        CommitFile(_tempDir, catalogFile, "add multi-kind catalog entries");
+
+        var result = RunScript(repoRoot: _tempDir, thresholdDays: 0);
+
+        Assert.AreEqual(0, result.ExitCode, $"Script exited non-zero: stderr={result.StdErr}");
+        Assert.IsTrue(result.StdOut.Contains("my_tool", StringComparison.Ordinal),
+            $"Expected 'my_tool' in output. stdout:\n{result.StdOut}");
+        Assert.IsTrue(result.StdOut.Contains("my_resource", StringComparison.Ordinal),
+            $"Expected 'my_resource' in output. stdout:\n{result.StdOut}");
+        Assert.IsTrue(result.StdOut.Contains("my_prompt", StringComparison.Ordinal),
+            $"Expected 'my_prompt' in output. stdout:\n{result.StdOut}");
+    }
+
+    [TestMethod]
+    public void Script_HighThreshold_SkipsRecentEntries()
+    {
+        InitGitRepo(_tempDir);
+        var catalogDir = CreateCatalogDir();
+
+        var catalogFile = Path.Combine(catalogDir, "ServerSurfaceCatalog.Recent.cs");
+        File.WriteAllText(
+            catalogFile,
+            "namespace X; public static partial class S {\n" +
+            "    static object x = Tool(\"recent_tool\", \"tools\", \"experimental\", true, false, \"d\");\n" +
+            "}\n");
+        CommitFile(_tempDir, catalogFile, "add recent tool");
+
+        // ThresholdDays=9999 — a brand-new commit will NEVER be this old.
+        var result = RunScript(repoRoot: _tempDir, thresholdDays: 9999);
+
+        Assert.AreEqual(0, result.ExitCode, $"Script exited non-zero: stderr={result.StdErr}");
+        Assert.IsFalse(
+            result.StdOut.Contains("recent_tool", StringComparison.Ordinal),
+            $"Expected 'recent_tool' NOT to appear when threshold is 9999 days. stdout:\n{result.StdOut}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static string ResolveScriptPath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, "eng", "audit-experimental-age.ps1");
+    }
+
+    private string CreateCatalogDir()
+    {
+        var dir = Path.Combine(_tempDir, "src", "RoslynMcp.Host.Stdio", "Catalog");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void InitGitRepo(string dir)
+    {
+        RunGit(dir, "init", "-b", "main");
+        RunGit(dir, "config", "user.email", "test@test.local");
+        RunGit(dir, "config", "user.name", "Test");
+        // Create an initial commit so HEAD exists.
+        var readme = Path.Combine(dir, "README.md");
+        File.WriteAllText(readme, "test");
+        RunGit(dir, "add", "README.md");
+        RunGit(dir, "commit", "-m", "init");
+    }
+
+    private static void CommitFile(string repoDir, string absoluteFilePath, string message)
+    {
+        // Stage using relative path from repo root.
+        var relPath = Path.GetRelativePath(repoDir, absoluteFilePath).Replace('\\', '/');
+        RunGit(repoDir, "add", relPath);
+        RunGit(repoDir, "commit", "-m", message);
+    }
+
+    private static void RunGit(string workDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start git.");
+        proc.WaitForExit(10_000);
+    }
+
+    private PwshResult RunScript(string repoRoot, int thresholdDays)
+    {
+        var scriptPath = ResolveScriptPath();
+        var pwsh = OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = pwsh,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-NonInteractive");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(scriptPath);
+        psi.ArgumentList.Add("-RepoRoot");
+        psi.ArgumentList.Add(repoRoot);
+        psi.ArgumentList.Add("-ThresholdDays");
+        psi.ArgumentList.Add(thresholdDays.ToString());
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{pwsh}'.");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        if (!proc.WaitForExit(milliseconds: 60_000))
+        {
+            proc.Kill(entireProcessTree: true);
+            throw new TimeoutException("audit-experimental-age.ps1 timed out after 60s.");
+        }
+
+        return new PwshResult(proc.ExitCode, stdout, stderr);
+    }
+
+    private sealed record PwshResult(int ExitCode, string StdOut, string StdErr);
+}


### PR DESCRIPTION
## Summary

- Added `eng/audit-experimental-age.ps1` — advisory script that walks `ServerSurfaceCatalog.*.cs` partials, runs `git blame` on each experimental-tier entry line, computes age in UTC days, and emits a Markdown table for entries older than the threshold (default 180 days).
- Added Step 8.5 advisory note to `.claude/skills/publish-preflight/SKILL.md` directing maintainers to run the script before each release.
- Added `tests/RoslynMcp.Tests/Skills/ExperimentalAgeAuditScriptTests.cs` with 5 xUnit tests covering: file existence, no-entries path, multi-kind entries, table output with `-ThresholdDays 0`, and high-threshold skip.

## Test plan

- [ ] `pwsh -NoProfile -File eng/audit-experimental-age.ps1` — emits "no entries older than 180 days" (all current entries are recent)
- [ ] `pwsh -NoProfile -File eng/audit-experimental-age.ps1 -ThresholdDays 0` — emits all 82 experimental entries
- [ ] `dotnet test --filter ExperimentalAgeAuditScriptTests` — 5/5 pass
- [ ] `pwsh -NoProfile -File eng/verify-ai-docs.ps1` — passes

Closes: eternal-experimental-age-audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)