### PR TITLE
docs(skills): add per-file occurrence preflight to /bump skill (bump-skill-double-version-string-detect)

### DIFF
--- a/.claude/skills/bump/SKILL.md
+++ b/.claude/skills/bump/SKILL.md
@@ -52,6 +52,25 @@ Parse the current version as `major.minor.patch`. Apply the bump type:
 
 Display the new version and confirm with the user before proceeding.
 
+### Step 2.5 — Preflight: occurrence count
+
+Before making any edits, grep each target file for the OLD version string and emit a preflight table:
+
+| File | Occurrences | Edit Strategy |
+|------|-------------|---------------|
+| `Directory.Build.props` | N | single / replace_all / ABORT |
+| `.claude-plugin/plugin.json` | N | single / replace_all / ABORT |
+| `.claude-plugin/marketplace.json` | N | single / replace_all / ABORT |
+| `manifest.json` | N | single / replace_all / ABORT |
+| `.claude-plugin/server.json` | N | replace_all (expected: 2) |
+
+**Rules:**
+- **0 occurrences** → ABORT with: "Preflight failed: OLD version `X.Y.Z` not found in `FILE` — file may have already been bumped or is tracking a different version. Verify before proceeding."
+- **1 occurrence** → standard single-replacement Edit.
+- **2+ occurrences** → use `replace_all: true` in the Edit call.
+
+Note: `server.json` is expected to have 2 occurrences (top-level `"version"` and `packages[0].version`); Step 3 already documents `replace_all: true` for it. The zero-occurrence guard is the critical new protection against partial-application re-runs.
+
 ### Step 3: Edit Version Files 1-5
 
 First, create the release-managed-edit override sentinel so the PreToolUse guard (`eng/guard-release-managed-files.ps1`) allows the version-file edits:

--- a/changelog.d/bump-skill-double-version-string-detect.md
+++ b/changelog.d/bump-skill-double-version-string-detect.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** `/bump` skill now runs a per-file occurrence preflight before editing version files; files with >1 occurrence of the old version string use `replace_all: true` automatically, and files where the version string is absent abort with an explicit error rather than silently failing. Prevents the "Found 2 matches of the string to replace" Edit error against `.claude-plugin/server.json`.


### PR DESCRIPTION
## Summary

- Inserts a new **Step 2.5 — Preflight: occurrence count** section between Step 2 and Step 3 of `.claude/skills/bump/SKILL.md`
- Before any Edit calls, the skill now greps each of the 5 target version files for the OLD version string and emits a preflight table
- Files with 0 occurrences abort with an explicit error; files with 2+ occurrences use `replace_all: true`; files with exactly 1 use standard single-replacement Edit
- `.claude-plugin/server.json` is annotated as expected to have 2 occurrences (top-level `"version"` and `packages[0].version`)

## Motivation

PR #597 fixed a drift where `server.json` had accumulated a second `"version"` field and wasn't listed as a bump target. Without a proactive preflight check, any future file that gains a second version occurrence will produce the same "Found 2 matches" Edit error. This step makes that scenario impossible to hit silently.

## Test plan

- [x] `eng/verify-ai-docs.ps1` passes (AI docs validation passed, 32 SKILL.md checked)
- [x] Step 2.5 is present between Step 2 and Step 3 in the modified SKILL.md
- [x] Changelog fragment created with `Maintenance` category

Closes: bump-skill-double-version-string-detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)