### PR TITLE
docs(skills): add session-end Roslyn self-check to refactor/architecture-review skills (audit-and-refactor-skills-roslyn-self-check)

### DIFF
--- a/.claude/skills/mcp-server-stress/SKILL.md
+++ b/.claude/skills/mcp-server-stress/SKILL.md
@@ -47,3 +47,7 @@ Functionally equivalent to typing `/mcp-server-surface-test --output-mode=fragme
 - **Mutation isolation contract.** Phase 7 / 8b / 13 writes target the disposable worktree only. Run-end primary-checkout `git status` MUST be empty (Phase 0 baseline + Final surface closure step 3a hard gate).
 - **No silent truncation.** Subagent phases that return `skipped-budget` / `skipped-context` / `truncated` markers are hard FAILs; orchestrator re-dispatches or records `phase-failed-budget` as P1.
 - **P0 / security findings never go to GitHub Issues** under findings mode. Under fragments mode, `area: security` triggers `/backlog-intake --publish`'s refusal contract when the fragment is later published.
+
+## Exit annotation
+
+This skill is a thin alias and does not track its own semantic-call count. To verify that the underlying surface-test run made meaningful Roslyn tool calls, check the audit report's **tool-invocation section** (Phase 17 in `full.md`): it records the complete list of MCP tools called and their call counts for the session. If the tool-invocation section is absent or shows zero semantic calls (only infrastructure calls such as `workspace_load` / `server_info`), treat the run as potentially incomplete and re-invoke with an explicit `--single-agent` flag to reduce context-budget pressure.

--- a/changelog.d/audit-and-refactor-skills-roslyn-self-check.md
+++ b/changelog.d/audit-and-refactor-skills-roslyn-self-check.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** The `refactor`, `refactor-loop`, and `architecture-review` skills now append a session-end self-check block on exit: when the CWD is classified as a C# repo but zero Roslyn semantic tool calls were made, the skill emits `summary: { semanticCalls: 0, classificationApplied: "csharp" }` and a warning recommending a Roslyn-first rerun. Companion to `routine-flows-wrap-csharp-work-with-roslyn-bookends`.

--- a/skills/architecture-review/SKILL.md
+++ b/skills/architecture-review/SKILL.md
@@ -141,3 +141,27 @@ Stop the skill and tell the user which condition tripped if any of the following
 
 1. **Workspace load failed** — `workspace_load` returned an error, or `workspace_status` reports an unrecoverable load failure. Ask the user to fix the solution path or underlying build error and re-run.
 2. **Zero projects in the solution** — `project_graph` returned an empty project list (nothing to audit). Confirm the path points at a real `.sln` / `.slnx` / `.csproj` that contains at least one project.
+
+## Step 8: Session Self-Check
+
+After producing the final report, emit a summary:
+
+```
+summary: { semanticCalls: N, classificationApplied: <repo-stack> }
+```
+
+Determine `classificationApplied`:
+- Glob CWD (depth=1) for `*.slnx`, `*.sln`, `*.csproj` → if any found: `"csharp"`
+- Otherwise: `"unknown"`
+
+Determine `semanticCalls`: count of Roslyn semantic tool calls made during this session (e.g. `project_graph`, `get_namespace_dependencies`, `symbol_relationships`, `find_references`, `get_di_registrations`, `type_hierarchy`, `find_reflection_usages`, etc.). Do NOT count `workspace_load`, `workspace_list`, `workspace_status`, or `server_info` — those are infrastructure calls, not semantic calls.
+
+If `classificationApplied == "csharp"` AND `semanticCalls == 0`:
+> **Warning:** This session operated on a C# repository but made zero Roslyn semantic tool calls. The architecture review may be incomplete. The following Steps were each expected to use specific Roslyn tools that were not called:
+> - **Step 2** (`project_graph`) — project dependency topology and cycle detection
+> - **Step 3** (`get_namespace_dependencies`) — namespace-level cycle detection per project
+> - **Step 4** (`symbol_relationships`, `find_references`) — improper downward references and DIP violations
+> - **Step 5** (`get_di_registrations`, `type_hierarchy`) — DI composition-root audit
+> - **Step 6** (`find_reflection_usages`) — reflection escape points
+>
+> Consider re-running with `mcp__roslyn__workspace_load` to enable semantic analysis for all steps.

--- a/skills/refactor-loop/SKILL.md
+++ b/skills/refactor-loop/SKILL.md
@@ -117,3 +117,20 @@ After each successful loop iteration:
 3. **Next suggestion** — if the user's intent implies more work (e.g. "rename + propagate"), suggest the next stage with the corresponding primitive.
 
 Keep responses tight. The user wants the change made and verified, not a tutorial.
+
+## Stage 6: Session Self-Check
+
+After completing all refactoring work, emit a final summary:
+
+```
+summary: { semanticCalls: N, classificationApplied: <repo-stack> }
+```
+
+Determine `classificationApplied`:
+- Glob CWD (depth=1) for `*.slnx`, `*.sln`, `*.csproj` → if any found: `"csharp"`
+- Otherwise: `"unknown"`
+
+Determine `semanticCalls`: count of Roslyn semantic tool calls made during this session (e.g. `find_references`, `symbol_search`, `document_symbols`, `rename_preview`, `extract_method_preview`, `compile_check`, etc.). Do NOT count `workspace_load`, `workspace_list`, `workspace_status`, or `server_info` — those are infrastructure calls, not semantic calls.
+
+If `classificationApplied == "csharp"` AND `semanticCalls == 0`:
+> **Warning:** This session operated on a C# repository but made zero Roslyn semantic tool calls. The refactoring may have relied on text-based editing rather than semantic analysis. Consider re-running with `mcp__roslyn__workspace_load` + semantic tools for correctness guarantees.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -128,3 +128,20 @@ Summarize:
   2. Fix the errors manually
   3. Try a different approach
 - If a preview token is rejected (stale workspace), reload and re-preview.
+
+## Step 7: Session Self-Check
+
+After completing all refactoring work, emit a final summary:
+
+```
+summary: { semanticCalls: N, classificationApplied: <repo-stack> }
+```
+
+Determine `classificationApplied`:
+- Glob CWD (depth=1) for `*.slnx`, `*.sln`, `*.csproj` → if any found: `"csharp"`
+- Otherwise: `"unknown"`
+
+Determine `semanticCalls`: count of Roslyn semantic tool calls made during this session (e.g. `find_references`, `symbol_search`, `document_symbols`, `rename_preview`, `extract_method_preview`, `compile_check`, etc.). Do NOT count `workspace_load`, `workspace_list`, `workspace_status`, or `server_info` — those are infrastructure calls, not semantic calls.
+
+If `classificationApplied == "csharp"` AND `semanticCalls == 0`:
+> **Warning:** This session operated on a C# repository but made zero Roslyn semantic tool calls. The refactoring may have relied on text-based editing rather than semantic analysis. Consider re-running with `mcp__roslyn__workspace_load` + semantic tools for correctness guarantees.


### PR DESCRIPTION
## Summary

- Adds **Step 7: Session Self-Check** to `skills/refactor/SKILL.md` (EOF-append after Error Recovery)
- Adds **Stage 6: Session Self-Check** to `skills/refactor-loop/SKILL.md` (EOF-append after Output)
- Adds **Step 8: Session Self-Check** to `skills/architecture-review/SKILL.md` (EOF-append after Refusal conditions), with per-step Roslyn tool citations (Steps 2–6)
- Adds **Exit annotation** to `.claude/skills/mcp-server-stress/SKILL.md` (thin alias; directs operator to the audit report's tool-invocation section instead of a full self-check block)

Each self-check emits `summary: { semanticCalls: N, classificationApplied: <repo-stack> }`. When `classificationApplied == "csharp"` and `semanticCalls == 0`, a warning is emitted recommending a Roslyn-first rerun.

Entry-time prelude regions (workspace auto-probe blocks added by `routine-flows-wrap-csharp-work-with-roslyn-bookends`) are untouched — all edits are strictly EOF-append.

## Test plan

- [x] `eng/verify-ai-docs.ps1` passes (32 SKILL.md checked, AI docs validation passed)
- [x] Entry-time prelude lines ~17-25 of `refactor/SKILL.md` and `refactor-loop/SKILL.md` confirmed unchanged
- [x] Self-check sections present at EOF in all 4 files with correct markdown structure
- [x] `architecture-review` Step 8 cites Steps 2–6 with expected Roslyn tools

Closes: [`audit-and-refactor-skills-roslyn-self-check`]

🤖 Generated with [Claude Code](https://claude.com/claude-code)