### PR TITLE
feat(eng): add list-skills.ps1 enumerator and installed_as contract test

### DIFF
--- a/changelog.d/skill-namespace-and-semantic-search-discoverability.md
+++ b/changelog.d/skill-namespace-and-semantic-search-discoverability.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Added `eng/list-skills.ps1` skill enumerator and `SkillFrontmatterInstalledAsTests` lockstep test establishing the `installed_as:` frontmatter contract for SKILL.md files. Test ships `[Ignore]`-marked; bulk frontmatter migration (46 files) tracked in follow-on row `skill-namespace-installed-as-bulk-frontmatter-migration`.

--- a/eng/list-skills.ps1
+++ b/eng/list-skills.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Lists all SKILL.md files with their frontmatter fields, including the `installed_as:` contract field.
+
+.DESCRIPTION
+    Walks `.claude/skills/*/SKILL.md` (maintainer-only, not shipped) and `skills/*/SKILL.md`
+    (shipped plugin skills) from the repository root.  For each file, parses the YAML frontmatter
+    and emits a formatted table with columns:
+
+        name | installed_as | path
+
+    When `installed_as:` is absent from the frontmatter, the column shows `[missing]`.
+    This is the discovery tool for the `installed_as:` contract established by the
+    `skill-namespace-and-semantic-search-discoverability` initiative.  Bulk migration of the
+    `installed_as:` field across all SKILL.md files is tracked in the follow-on backlog row
+    `skill-namespace-installed-as-bulk-frontmatter-migration`.
+
+.PARAMETER RepoRoot
+    Path to the repository root.  Defaults to the parent of the directory containing this script.
+
+.EXAMPLE
+    pwsh -NoProfile -File eng/list-skills.ps1
+    # Emits one row per skill.  All `installed_as:` entries will show [missing] until the
+    # bulk migration is complete.
+
+.EXAMPLE
+    pwsh -NoProfile -File eng/list-skills.ps1 -RepoRoot C:/Code-Repo/Roslyn-Backed-MCP
+#>
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+
+# Collect SKILL.md files from both skill directories.
+$skillDirs = @(
+    (Join-Path $RepoRoot '.claude' 'skills'),
+    (Join-Path $RepoRoot 'skills')
+)
+
+$skillFiles = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+
+foreach ($dir in $skillDirs) {
+    if (Test-Path $dir) {
+        $found = Get-ChildItem -Path $dir -Recurse -File -Filter 'SKILL.md'
+        foreach ($f in $found) {
+            $skillFiles.Add($f)
+        }
+    }
+}
+
+if ($skillFiles.Count -eq 0) {
+    Write-Host "No SKILL.md files found under .claude/skills/ or skills/."
+    exit 0
+}
+
+# Parse frontmatter and collect rows.
+$rows = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($file in $skillFiles) {
+    $contents = Get-Content -LiteralPath $file.FullName -Raw
+
+    # Extract the leading `---\n ... \n---\n` frontmatter block (non-greedy, Singleline).
+    $frontmatterMatch = [regex]::Match($contents, '(?s)^---\s*\r?\n(?<body>.*?)\r?\n---\s*\r?\n')
+
+    $name = '[no frontmatter]'
+    $installedAs = '[missing]'
+
+    if ($frontmatterMatch.Success) {
+        $body = $frontmatterMatch.Groups['body'].Value
+        foreach ($raw in ($body -split '\r?\n')) {
+            $line = $raw.TrimEnd()
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $colon = $line.IndexOf(':')
+            if ($colon -lt 0) { continue }
+            $key   = $line.Substring(0, $colon).Trim()
+            $value = $line.Substring($colon + 1).Trim()
+            # Strip surrounding double quotes.
+            if ($value.Length -ge 2 -and $value[0] -eq '"' -and $value[-1] -eq '"') {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+            if ($key -eq 'name')         { $name         = $value }
+            if ($key -eq 'installed_as') { $installedAs   = $value }
+        }
+    }
+
+    # Compute a relative path for display (prefer forward slashes).
+    $rel = $file.FullName
+    if ($rel.StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rel = $rel.Substring($RepoRoot.Length).TrimStart('\', '/') -replace '\\', '/'
+    }
+
+    $rows.Add([PSCustomObject]@{
+        name         = $name
+        installed_as = $installedAs
+        path         = $rel
+    })
+}
+
+# Sort by path for stable output.
+$sorted = $rows | Sort-Object path
+
+# Determine column widths for aligned table output.
+$nameWidth  = [Math]::Max('name'.Length,         ($sorted | ForEach-Object { $_.name.Length }         | Measure-Object -Maximum).Maximum)
+$asWidth    = [Math]::Max('installed_as'.Length,  ($sorted | ForEach-Object { $_.installed_as.Length } | Measure-Object -Maximum).Maximum)
+
+$separator = ('-' * $nameWidth) + '-+-' + ('-' * $asWidth) + '-+-' + '-' * 10
+$header    = ('{0,-' + $nameWidth + '} | {1,-' + $asWidth + '} | {2}') -f 'name', 'installed_as', 'path'
+
+Write-Host ""
+Write-Host $header
+Write-Host $separator
+foreach ($row in $sorted) {
+    $line = ('{0,-' + $nameWidth + '} | {1,-' + $asWidth + '} | {2}') -f $row.name, $row.installed_as, $row.path
+    if ($row.installed_as -eq '[missing]') {
+        Write-Host $line -ForegroundColor Yellow
+    } else {
+        Write-Host $line
+    }
+}
+Write-Host ""
+
+$missingCount = ($sorted | Where-Object { $_.installed_as -eq '[missing]' }).Count
+$totalCount   = $sorted.Count
+
+Write-Host "$totalCount skill(s) found.  $missingCount missing `installed_as:` (shown in yellow)."
+Write-Host "To fix: add `installed_as: <bare-name>` or `installed_as: roslyn-mcp:<bare-name>` to each SKILL.md frontmatter."
+Write-Host "Bulk migration tracked in: skill-namespace-installed-as-bulk-frontmatter-migration"
+Write-Host ""

--- a/tests/RoslynMcp.Tests/Skills/SkillFrontmatterInstalledAsTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/SkillFrontmatterInstalledAsTests.cs
@@ -1,0 +1,152 @@
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// Lockstep contract test that asserts every SKILL.md in both the maintainer-only
+/// `.claude/skills/*/SKILL.md` tree and the shipped `skills/*/SKILL.md` tree has an
+/// <c>installed_as:</c> frontmatter field with a valid value.
+///
+/// The <c>installed_as:</c> field is the machine-readable contract that lets the slash-command
+/// picker, backlog-sweep planner, and semantic-search routing unambiguously identify which
+/// skill handles a given invocation token.  Without it, Claude must guess from freeform
+/// <c>description:</c> text, which causes mis-routing (e.g. session a26fdd10 — "stress test"
+/// routed to the wrong skill because no canonical identifier was present).
+///
+/// Valid values:
+///   <c>installed_as: &lt;bare-name&gt;</c>          — bare kebab-case identifier (no namespace)
+///   <c>installed_as: roslyn-mcp:&lt;bare-name&gt;</c> — plugin-namespaced identifier
+///
+/// This test is shipped <c>[Ignore]</c>-marked to avoid blocking CI until the bulk frontmatter
+/// migration (backlog row <c>skill-namespace-installed-as-bulk-frontmatter-migration</c>) is
+/// complete.  Once that row ships, remove the <c>[Ignore]</c> attribute.
+/// </summary>
+[TestClass]
+public sealed class SkillFrontmatterInstalledAsTests
+{
+    // Valid installed_as values.
+    //   bare:       foo-bar, my-skill-name
+    //   namespaced: roslyn-mcp:foo-bar
+    private static readonly Regex ValidInstalledAsPattern =
+        new(@"^(?:roslyn-mcp:)?[a-z][a-z0-9-]+$", RegexOptions.Compiled);
+
+    // Frontmatter block: leading `---\n` ... `\n---\n` (non-greedy, dotall).
+    private static readonly Regex FrontmatterPattern =
+        new(@"^---\s*\r?\n(?<body>.*?)\r?\n---\s*\r?\n", RegexOptions.Compiled | RegexOptions.Singleline);
+
+    [TestMethod]
+    [Ignore("Pending bulk frontmatter migration — see backlog row skill-namespace-installed-as-bulk-frontmatter-migration")]
+    public void AllSkillFiles_ShouldHave_InstalledAs_Frontmatter()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+
+        // Collect SKILL.md files from both trees.
+        var skillFiles = CollectSkillFiles(repoRoot);
+
+        Assert.IsTrue(
+            skillFiles.Count > 0,
+            $"No SKILL.md files found under '.claude/skills/' or 'skills/' relative to repo root '{repoRoot}'. " +
+            "If the skill directories were reorganised, update the paths in this test.");
+
+        var failures = new List<string>();
+
+        foreach (var path in skillFiles)
+        {
+            var contents = File.ReadAllText(path);
+            var frontmatter = ExtractFrontmatter(contents, path);
+
+            if (frontmatter is null)
+            {
+                failures.Add($"{RelPath(repoRoot, path)}: missing `---`-delimited frontmatter block");
+                continue;
+            }
+
+            if (!frontmatter.TryGetValue("installed_as", out var installedAs) ||
+                string.IsNullOrWhiteSpace(installedAs))
+            {
+                failures.Add($"{RelPath(repoRoot, path)}: missing `installed_as:` frontmatter field");
+                continue;
+            }
+
+            if (!ValidInstalledAsPattern.IsMatch(installedAs))
+            {
+                failures.Add(
+                    $"{RelPath(repoRoot, path)}: `installed_as: {installedAs}` does not match " +
+                    @"required pattern `^(?:roslyn-mcp:)?[a-z][a-z0-9-]+$`");
+            }
+        }
+
+        Assert.AreEqual(
+            0, failures.Count,
+            $"{failures.Count} of {skillFiles.Count} SKILL.md file(s) are missing a valid `installed_as:` field:\n" +
+            string.Join("\n", failures) + "\n\n" +
+            "Add `installed_as: <bare-name>` or `installed_as: roslyn-mcp:<bare-name>` to each frontmatter block. " +
+            "See backlog row `skill-namespace-installed-as-bulk-frontmatter-migration` for the migration plan.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static List<string> CollectSkillFiles(string repoRoot)
+    {
+        var result = new List<string>();
+        var skillDirs = new[]
+        {
+            Path.Combine(repoRoot, ".claude", "skills"),
+            Path.Combine(repoRoot, "skills"),
+        };
+
+        foreach (var dir in skillDirs)
+        {
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(dir, "SKILL.md", SearchOption.AllDirectories))
+            {
+                result.Add(file);
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, string>? ExtractFrontmatter(string contents, string path)
+    {
+        var match = FrontmatterPattern.Match(contents);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in match.Groups["body"].Value.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line)) { continue; }
+            var colon = line.IndexOf(':');
+            if (colon < 0) { continue; }
+            var key   = line[..colon].Trim();
+            var value = line[(colon + 1)..].Trim();
+            // Strip surrounding double quotes.
+            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            {
+                value = value[1..^1];
+            }
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    private static string RelPath(string repoRoot, string fullPath)
+    {
+        if (fullPath.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return fullPath[repoRoot.Length..].TrimStart(Path.DirectorySeparatorChar, '/').Replace('\\', '/');
+        }
+        return fullPath;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `eng/list-skills.ps1`: walks `.claude/skills/*/SKILL.md` and `skills/*/SKILL.md`, parses YAML frontmatter, emits an aligned table with columns `name | installed_as | path`. Missing `installed_as:` renders as `[missing]` (highlighted yellow). Mirrors the style of `eng/verify-skills-are-generic.ps1`.
- Adds `tests/RoslynMcp.Tests/Skills/SkillFrontmatterInstalledAsTests.cs`: lockstep contract test asserting every SKILL.md has a valid `installed_as:` frontmatter field. Ships with `[Ignore("Pending bulk frontmatter migration — see backlog row skill-namespace-installed-as-bulk-frontmatter-migration")]` to avoid blocking CI until migration completes.
- All 46 current SKILL.md files show `[missing]` — expected pre-migration state.

## Motivation

Session a26fdd10 observed Claude routing to the wrong skill when asked about a "stress test" skill because no machine-readable `installed_as:` field existed. This PR establishes the infrastructure and the contract; the bulk migration is tracked separately.

## Validation

- `pwsh -NoProfile -File eng/list-skills.ps1` — 46 rows, all `[missing]` as expected
- `dotnet build` — 0 errors, 0 warnings
- `dotnet test --filter SkillFrontmatterInstalledAsTests` — 1 Skipped (Ignored), 0 Failed
- `pwsh -NoProfile -File eng/verify-skills-are-generic.ps1` — 32 SKILL.md checked, clean

## Spin-offs

The orchestrator should add a new backlog row:

- **Row id:** `skill-namespace-installed-as-bulk-frontmatter-migration`
- **Description:** Add `installed_as:` frontmatter to all 46 SKILL.md files (`.claude/skills/*/SKILL.md` and `skills/*/SKILL.md`) with the appropriate bare (`<name>`) or plugin-namespaced (`roslyn-mcp:<name>`) value. Once all 46 are migrated, remove the `[Ignore]` attribute from `SkillFrontmatterInstalledAsTests`.

Closes: skill-namespace-and-semantic-search-discoverability