### PR TITLE
docs(tools): clarify string[] params require native JSON array (#19)

### DIFF
--- a/changelog.d/filepaths-array-vs-stringified-tool-description-clarification.md
+++ b/changelog.d/filepaths-array-vs-stringified-tool-description-clarification.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `[Description]` text on `string[]`-typed tool parameters (`usings`, `imports`, `projects`, `changedFilePaths`) now explicitly states "Pass as a native JSON array, not a JSON-encoded string" with a concrete example, preventing LLM clients from mis-encoding array values as stringified JSON.

--- a/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
@@ -18,7 +18,7 @@ public static class ScriptingTools
     public static async Task<string> EvaluateCSharp(
         IScriptingService scriptingService,
         [Description("The C# code to evaluate (expression, statement, or multi-line script)")] string code,
-        [Description("Optional: additional namespace imports, e.g. [\"System.IO\", \"System.Net.Http\"]")] string[]? imports = null,
+        [Description("Optional: additional namespace imports. Pass as a native JSON array, not a JSON-encoded string. Example: [\"System.IO\", \"System.Net.Http\"].")] string[]? imports = null,
         [Description("Optional: per-call timeout in seconds (UX-002). Overrides ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS for this single invocation. Must be > 0; null falls back to the configured default.")] int? timeoutSeconds = null,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)

--- a/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
@@ -16,7 +16,7 @@ public static class SnippetAnalysisTools
     public static async Task<string> AnalyzeSnippet(
         ISnippetAnalysisService snippetAnalysisService,
         [Description("The C# code to analyze")] string code,
-        [Description("Optional: additional using directives as an array, e.g. [\"System.IO\", \"System.Net.Http\"]")] string[]? usings = null,
+        [Description("Optional: additional using directives. Pass as a native JSON array, not a JSON-encoded string. Example: [\"System.IO\", \"System.Net.Http\"].")] string[]? usings = null,
         [Description("The snippet kind: 'expression', 'statements', 'returnExpression', 'members', or 'program' (default)")] string kind = "program",
         CancellationToken ct = default)
     {

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -26,7 +26,7 @@ public static class ValidationBundleTools
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: explicit list of changed file paths. When omitted, the change tracker's session-wide change set is used. Empty list means no test discovery.")] string[]? changedFilePaths = null,
+        [Description("Optional: explicit list of changed file paths. Pass as a native JSON array of absolute file paths, not a JSON-encoded string. Example: [\"/abs/path/a.cs\", \"/abs/path/b.cs\"]. When omitted, the change tracker's session-wide change set is used. Empty list means no test discovery.")] string[]? changedFilePaths = null,
         [Description("When true, runs the discovered related tests via dotnet test --filter. Default: false (discovery only).")] bool runTests = false,
         [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default false preserves the v1.18 shape.")] bool summary = false,
         [Description("Response shape: \"json\" (default) returns the indented JSON envelope; \"markdown\" returns a compact summary table built from the same DTO so the verdict is identical across shapes. Case-insensitive.")] string? responseFormat = null,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
@@ -31,7 +31,7 @@ public static class WorkspaceWarmTools
         IWorkspaceExecutionGate gate,
         IWorkspaceWarmService warmService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: project names to warm. Case-insensitive; unknown names are silently skipped. Omit or pass an empty array to warm every project in the solution.")] string[]? projects = null,
+        [Description("Optional: project names to warm. Pass as a native JSON array, not a JSON-encoded string. Example: [\"MyProject.Core\", \"MyProject.Tests\"]. Case-insensitive; unknown names are silently skipped. Omit or pass an empty array to warm every project in the solution.")] string[]? projects = null,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)
     {

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -260,6 +260,49 @@ public sealed class SurfaceCatalogTests
         Assert.IsNull(endLine.DefaultValue);
     }
 
+    [TestMethod]
+    public void AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase()
+    {
+        // filepaths-array-vs-stringified-tool-description-clarification: the 4 in-scope
+        // string[]-typed parameters must each carry "native JSON array" in their [Description]
+        // so LLM clients do not mis-encode array values as stringified JSON.
+        var assembly = typeof(ServerTools).Assembly;
+
+        var inScopePairs = new HashSet<(string toolName, string paramName)>(
+        [
+            ("analyze_snippet", "usings"),
+            ("evaluate_csharp", "imports"),
+            ("workspace_warm", "projects"),
+            ("validate_workspace", "changedFilePaths"),
+        ]);
+
+        var failures = new List<string>();
+        var foundCount = 0;
+
+        foreach (var method in assembly.GetTypes()
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)))
+        {
+            var serverTool = method.GetCustomAttribute<McpServerToolAttribute>();
+            if (serverTool is null) continue;
+
+            var toolName = serverTool.Name ?? string.Empty;
+            foreach (var param in method.GetParameters())
+            {
+                if (!inScopePairs.Contains((toolName, param.Name ?? string.Empty))) continue;
+
+                foundCount++;
+                var description = param.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description ?? string.Empty;
+                if (!description.Contains("native JSON array", StringComparison.Ordinal))
+                    failures.Add($"({toolName}, {param.Name}): [Description] does not contain 'native JSON array'. Got: \"{description}\"");
+            }
+        }
+
+        Assert.IsTrue(foundCount > 0,
+            "No in-scope (toolName, paramName) pairs found — assembly may have failed to load or tool names changed.");
+        Assert.AreEqual(0, failures.Count,
+            "Array-typed parameters missing 'native JSON array' in [Description]:\n  " + string.Join("\n  ", failures));
+    }
+
     private static string[] GetRegisteredNames<TAttribute>(Assembly assembly)
         where TAttribute : Attribute
     {


### PR DESCRIPTION
## Summary

- Updated `[Description]` attributes on 4 `string[]`-typed tool parameters (`usings`, `imports`, `projects`, `changedFilePaths`) to explicitly state "Pass as a native JSON array, not a JSON-encoded string" with a concrete example in each.
- Added regression test `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` to `SurfaceCatalogTests.cs` that asserts the phrase `native JSON array` appears in each of the 4 in-scope parameter descriptions.
- Changelog fragment added at `changelog.d/filepaths-array-vs-stringified-tool-description-clarification.md`.

**Follow-on row needed** (orchestrator to add to `ai_docs/backlog.md`):
Row id: `filepaths-array-vs-stringified-tool-description-clarification-batch-2`
P4 — update `[Description]` on the remaining 5 `string[]`/`IReadOnlyList<string>?` params: `AdvancedAnalysisTools.cs:filePaths`, `MSBuildTools.cs:includedNames`, `InterfaceExtractionTools.cs:memberNames`, `ScaffoldingTools.cs:interfaces`, `ParameterObjectTools.cs:dtoFolders`. Add `native JSON array` phrase + example to each. Extend the `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` test allowlist with these 5 pairs.

## Test plan

- [x] `dotnet build` Release with `TreatWarningsAsErrors=true` — passes (0 warnings, 0 errors)
- [x] `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` — passes (1/1)
- [x] Full `SurfaceCatalogTests` class — passes (12/12)

Closes: filepaths-array-vs-stringified-tool-description-clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)