### PR TITLE
fix(tools): add native JSON array guard phrase to get_complexity_metrics.filePaths and get_msbuild_properties.includedNames (filepaths-batch-2a-advanced-msbuild)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -147,7 +147,7 @@ public static class AdvancedAnalysisTools
         ICodeMetricsService codeMetricsService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by source file path")] string? filePath = null,
-        [Description("Optional: list of source file paths to include (union with filePath). Empty list means no filter. Useful for re-running complexity on a changed-file set after a refactor.")] IReadOnlyList<string>? filePaths = null,
+        [Description("Optional: list of source file paths to include (union with filePath). Pass as a native JSON array of absolute file paths, not a JSON-encoded string. Example: [\"/abs/path/a.cs\", \"/abs/path/b.cs\"]. Empty list means no filter. Useful for re-running complexity on a changed-file set after a refactor.")] IReadOnlyList<string>? filePaths = null,
         [Description("Optional: filter by project name")] string? projectName = null,
         [Description("Optional: minimum cyclomatic complexity threshold (default: return all)")] int? minComplexity = null,
         [Description("Maximum number of results to return (default: 50)")] int limit = 50,

--- a/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
@@ -57,7 +57,7 @@ public static class MSBuildTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Project name as loaded in the workspace")] string projectName,
         [Description("Optional: case-insensitive substring filter applied to property names (e.g., 'Nullable', 'Target')")] string? propertyNameFilter = null,
-        [Description("Optional: explicit allowlist of property names to return. Takes precedence over propertyNameFilter when supplied.")] string[]? includedNames = null,
+        [Description("Optional: explicit allowlist of property names to return. Pass as a native JSON array, not a JSON-encoded string. Example: [\"Nullable\", \"TargetFramework\"]. Takes precedence over propertyNameFilter when supplied.")] string[]? includedNames = null,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -263,7 +263,7 @@ public sealed class SurfaceCatalogTests
     [TestMethod]
     public void AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase()
     {
-        // filepaths-array-vs-stringified-tool-description-clarification: the 4 in-scope
+        // filepaths-array-vs-stringified-tool-description-clarification: the 6 in-scope
         // string[]-typed parameters must each carry "native JSON array" in their [Description]
         // so LLM clients do not mis-encode array values as stringified JSON.
         var assembly = typeof(ServerTools).Assembly;
@@ -274,6 +274,8 @@ public sealed class SurfaceCatalogTests
             ("evaluate_csharp", "imports"),
             ("workspace_warm", "projects"),
             ("validate_workspace", "changedFilePaths"),
+            ("get_complexity_metrics", "filePaths"),
+            ("get_msbuild_properties", "includedNames"),
         ]);
 
         var failures = new List<string>();


### PR DESCRIPTION
## Summary

- Fixed `get_complexity_metrics` (`filePaths`) `[Description]` to include the \"native JSON array\" guard phrase and example, matching the pattern from PR #697.
- Fixed `get_msbuild_properties` (`includedNames`) `[Description]` similarly, preventing LLM clients from mis-encoding the array argument as a stringified JSON string.
- Extended `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` lockstep test: added `("get_complexity_metrics", "filePaths")` and `("get_msbuild_properties", "includedNames")` to `inScopePairs` (4 → 6 pairs). Test passes with `foundCount == 6`.

**Closes:** `filepaths-batch-2a-advanced-msbuild`

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → Build succeeded, 0 warnings, 0 errors.
- `dotnet test --filter AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` → Passed (1/1).
- Both edited `[Description]` strings contain literal `native JSON array` (case-sensitive, `StringComparison.Ordinal` match confirmed).

## Spin-offs

None.