### PR TITLE
fix(tools): add native JSON array guard phrase to extract_interface_preview.memberNames and scaffold_type_preview.interfaces (filepaths-batch-2b-interface-scaffolding)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -27,7 +27,7 @@ public static class InterfaceExtractionTools
         [Description("Absolute path to the source file containing the type")] string filePath,
         [Description("Name of the concrete type to extract from")] string typeName,
         [Description("Name for the new interface (e.g., IMyService)")] string interfaceName,
-        [Description("Optional: specific member names to include. If omitted, all public instance members are included.")] string[]? memberNames = null,
+        [Description("Optional: specific member names to include. Pass as a native JSON array, not a JSON-encoded string. Example: [\"GetValue\", \"SetValue\"]. If omitted, all public instance members are included.")] string[]? memberNames = null,
         [Description("If true, replace parameter and field references to the concrete type with the interface (default: false)")] bool replaceUsages = false,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -32,7 +32,7 @@ public static class ScaffoldingTools
         [Description("Type kind: class, interface, record, or enum")] string typeKind = "class",
         [Description("Optional: namespace override")] string? @namespace = null,
         [Description("Optional: base type name")] string? baseType = null,
-        [Description("Optional: additional interface names to declare on the scaffolded type")] string[]? interfaces = null,
+        [Description("Optional: additional interface names to declare on the scaffolded type. Pass as a native JSON array, not a JSON-encoded string. Example: [\"IDisposable\", \"IMyService\"].")] string[]? interfaces = null,
         [Description("When true (default), auto-implement interface members of baseType/interfaces as NotImplementedException stubs; set false to emit an empty class body")] bool implementInterface = true,
         CancellationToken ct = default)
     {

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -263,7 +263,7 @@ public sealed class SurfaceCatalogTests
     [TestMethod]
     public void AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase()
     {
-        // filepaths-array-vs-stringified-tool-description-clarification: the 6 in-scope
+        // filepaths-array-vs-stringified-tool-description-clarification: the 8 in-scope
         // string[]-typed parameters must each carry "native JSON array" in their [Description]
         // so LLM clients do not mis-encode array values as stringified JSON.
         var assembly = typeof(ServerTools).Assembly;
@@ -276,6 +276,8 @@ public sealed class SurfaceCatalogTests
             ("validate_workspace", "changedFilePaths"),
             ("get_complexity_metrics", "filePaths"),
             ("get_msbuild_properties", "includedNames"),
+            ("extract_interface_preview", "memberNames"),
+            ("scaffold_type_preview", "interfaces"),
         ]);
 
         var failures = new List<string>();


### PR DESCRIPTION
## Summary

- Fixed `extract_interface_preview` (`memberNames`) `[Description]` to include the \"native JSON array\" guard phrase and example.
- Fixed `scaffold_type_preview` (`interfaces`) `[Description]` similarly.
- Extended `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` lockstep test `inScopePairs` from 6 to 8 pairs. Test passes with `foundCount == 8`.

Follows the pattern established in PR #697 (batch-1) and PR #702 (batch-2a).

**Closes:** `filepaths-batch-2b-interface-scaffolding`

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → Build succeeded, 0 warnings, 0 errors.
- `dotnet test --filter AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` → Passed (1/1).
- Both edited `[Description]` strings contain literal `native JSON array`.

## Spin-offs

None.