### PR TITLE
fix(tools): add native JSON array guard phrase to parameter_object_preview.dtoFolders (filepaths-batch-2c-parameter-object)

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
@@ -34,7 +34,7 @@ public static class ParameterObjectTools
         [Description("Optional: bare fully-qualified method name without parentheses (e.g. 'Foo.Bar.Baz').")] string? metadataName = null,
         [Description("Optional override project for the new record. Defaults to the method's project. When different, every caller project must already reference it (no auto-add of <ProjectReference> in v1).")] string? dtoProjectName = null,
         [Description("Optional namespace for the new record. Defaults to the method's containing namespace.")] string? dtoNamespace = null,
-        [Description("Optional folder segments under the project root for the new record file. Defaults to folders derived from the namespace.")] string[]? dtoFolders = null,
+        [Description("Optional folder segments under the project root for the new record file. Pass as a native JSON array, not a JSON-encoded string. Example: [\"Models\", \"Requests\"]. Defaults to folders derived from the namespace.")] string[]? dtoFolders = null,
         [Description("Optional name for the new single record-typed parameter on the rewritten method. Defaults to the camelCased newTypeName.")] string? parameterName = null,
         CancellationToken ct = default)
     {

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -263,7 +263,7 @@ public sealed class SurfaceCatalogTests
     [TestMethod]
     public void AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase()
     {
-        // filepaths-array-vs-stringified-tool-description-clarification: the 8 in-scope
+        // filepaths-array-vs-stringified-tool-description-clarification: the 9 in-scope
         // string[]-typed parameters must each carry "native JSON array" in their [Description]
         // so LLM clients do not mis-encode array values as stringified JSON.
         var assembly = typeof(ServerTools).Assembly;
@@ -278,6 +278,7 @@ public sealed class SurfaceCatalogTests
             ("get_msbuild_properties", "includedNames"),
             ("extract_interface_preview", "memberNames"),
             ("scaffold_type_preview", "interfaces"),
+            ("parameter_object_preview", "dtoFolders"),
         ]);
 
         var failures = new List<string>();


### PR DESCRIPTION
## Summary

- Fixed `parameter_object_preview` (`dtoFolders`) `[Description]` to include the \"native JSON array\" guard phrase and example (`[\"Models\", \"Requests\"]`), matching the clarification pattern applied to other array-typed parameters in PR #697 (batch-1), #702 (batch-2a), and #703 (batch-2b).
- Extended `AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` lockstep test `inScopePairs` from 8 to 9 pairs. Test passes with `foundCount == 9`.

**Closes:** `filepaths-batch-2c-parameter-object`

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → Build succeeded, 0 warnings, 0 errors.
- `dotnet test --filter AllArrayTypedToolParameters_DescriptionContainsNativeJsonArrayPhrase` → Passed (1/1, foundCount == 9).
- Edited `[Description]` string contains literal `native JSON array`.

## Spin-offs

None.