### PR TITLE
chore(skills): add installed_as frontmatter to wave-6 SKILL.md files (skill-namespace-installed-as-wave-6)

### DIFF
--- a/changelog.d/skill-namespace-installed-as-wave-6.md
+++ b/changelog.d/skill-namespace-installed-as-wave-6.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `installed_as` frontmatter to `skills/document`, `skills/exception-audit`, `skills/explain-error`, and `skills/extract-method` SKILL.md files (wave 6/12 of bulk frontmatter migration).

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: document
+installed_as: roslyn-mcp:document
 description: "C# XML documentation generator. Use when: adding XML doc comments, documenting public APIs, fixing CS1591 warnings, or improving documentation quality in *.cs files. Takes a file path or type name as input."
 user-invocable: true
 argument-hint: "file path or type name"

--- a/skills/exception-audit/SKILL.md
+++ b/skills/exception-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: exception-audit
+installed_as: roslyn-mcp:exception-audit
 description: "Repo-wide classification of exception handling patterns. Use when: auditing exception handling, finding swallowed exceptions, classifying catch patterns, finding overly-broad catches, or mapping unhandled-at-boundary throw sites in a C# solution. Optionally takes an exception type name to filter the audit."
 user-invocable: true
 argument-hint: "(optional) exception type filter; default: all"

--- a/skills/explain-error/SKILL.md
+++ b/skills/explain-error/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: explain-error
+installed_as: roslyn-mcp:explain-error
 description: "Diagnostic explainer and fixer. Use when: understanding a C# compiler error or warning, finding fixes for diagnostics, batch-fixing all instances of a diagnostic, or troubleshooting build failures. Takes a diagnostic ID (e.g., CS0246) or file:line as input."
 user-invocable: true
 argument-hint: "CSxxxx | file:line | description"

--- a/skills/extract-method/SKILL.md
+++ b/skills/extract-method/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: extract-method
+installed_as: roslyn-mcp:extract-method
 description: "Extract method refactoring. Use when: extracting a block of statements into a new method, reducing method complexity, or breaking up long methods. Describe the code region and target method name as input."
 user-invocable: true
 argument-hint: "<method name> from <file or type>"


### PR DESCRIPTION
## Summary

- Add `installed_as: roslyn-mcp:document` to `skills/document/SKILL.md`
- Add `installed_as: roslyn-mcp:exception-audit` to `skills/exception-audit/SKILL.md`
- Add `installed_as: roslyn-mcp:explain-error` to `skills/explain-error/SKILL.md`
- Add `installed_as: roslyn-mcp:extract-method` to `skills/extract-method/SKILL.md`
- Add changelog fragment `changelog.d/skill-namespace-installed-as-wave-6.md`

Wave 6 of 12 in the bulk `installed_as` frontmatter migration. Missing count drops from 26 to 22 (delta −4).

## Closes

Closes: skill-namespace-installed-as-wave-6

## Validation

- `eng/list-skills.ps1`: missing count 26 → 22 (delta −4 confirmed)
- `eng/verify-ai-docs.ps1`: passed

## Files touched

4 SKILL.md files + 1 changelog fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)