### PR TITLE
chore(skills): add installed_as frontmatter to wave-7 SKILL.md files (skill-namespace-installed-as-wave-7)

### DIFF
--- a/changelog.d/skill-namespace-installed-as-wave-7.md
+++ b/changelog.d/skill-namespace-installed-as-wave-7.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `installed_as: roslyn-mcp:<bare-name>` frontmatter to `skills/format-sweep`, `skills/generate-tests`, `skills/impact-assessment`, and `skills/inheritance-explorer` SKILL.md files (wave 7 of 12 in the bulk `installed_as` migration).

--- a/skills/format-sweep/SKILL.md
+++ b/skills/format-sweep/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: format-sweep
+installed_as: roslyn-mcp:format-sweep
 description: "Whole-solution formatting compliance pass. Use when: enforcing whole-solution formatting, running `dotnet format` equivalents, bulk-organizing usings, or performing an editorconfig compliance sweep. Optionally takes a project name or file glob to narrow scope."
 user-invocable: true
 argument-hint: "(optional) project name or file glob"

--- a/skills/generate-tests/SKILL.md
+++ b/skills/generate-tests/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: generate-tests
+installed_as: roslyn-mcp:generate-tests
 description: "Batch-scaffold test stubs for untested public APIs. Use when: batch-scaffolding tests for untested public APIs, generating test stubs, or bootstrapping a test project. Takes a top-N count, a project name, or a type name."
 user-invocable: true
 argument-hint: "[top-N | project name | type name]"

--- a/skills/impact-assessment/SKILL.md
+++ b/skills/impact-assessment/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: impact-assessment
+installed_as: roslyn-mcp:impact-assessment
 description: "Pre-change blast-radius report for a C# symbol. Use when: planning a rename, signature change, or deletion and you need to know how far the change reaches before touching code. Takes a symbol name (and optional change type) as input. Produces a ranked safe-to-change verdict with direct references, semantic consumers, polymorphic impact, and mutation sites."
 user-invocable: true
 argument-hint: "<symbol-name> [change-type: rename|signature|delete]"

--- a/skills/inheritance-explorer/SKILL.md
+++ b/skills/inheritance-explorer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: inheritance-explorer
+installed_as: roslyn-mcp:inheritance-explorer
 description: "Walk the inheritance and member-override graph for a type or member. Use when: exploring type hierarchies, finding overrides, finding implementations, understanding polymorphic dispatch, auditing interfaces. Takes a type or member name as input."
 user-invocable: true
 argument-hint: "<type-or-member-name>"


### PR DESCRIPTION
## Summary

- Inserts `installed_as: roslyn-mcp:<bare-name>` as the second line of YAML frontmatter (immediately after `name:`) in four SKILL.md files: `skills/format-sweep`, `skills/generate-tests`, `skills/impact-assessment`, and `skills/inheritance-explorer`.
- This is wave 7 of 12 in the bulk `installed_as` frontmatter migration tracked by `skill-namespace-installed-as-bulk-frontmatter-migration`.

## Validation

- `eng/list-skills.ps1`: missing count dropped from **22 → 18** (delta -4, as expected)
- `eng/verify-ai-docs.ps1`: passed — "AI docs validation passed."

## Closes

Closes: skill-namespace-installed-as-wave-7