### PR TITLE
chore(skills): add installed_as frontmatter to wave-9 SKILL.md files (skill-namespace-installed-as-wave-9)

### DIFF
--- a/changelog.d/skill-namespace-installed-as-wave-9.md
+++ b/changelog.d/skill-namespace-installed-as-wave-9.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `installed_as: roslyn-mcp:*` frontmatter to `skills/project-inspection`, `skills/refactor-loop`, `skills/refactor`, and `skills/review` SKILL.md files (wave 9 of 12 in the bulk `installed_as` migration), reducing the missing-field count from 22 to 18.

--- a/skills/project-inspection/SKILL.md
+++ b/skills/project-inspection/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: project-inspection
+installed_as: roslyn-mcp:project-inspection
 description: "MSBuild and project-file inspection. Use when: debugging TargetFramework, OutputPath, package references, item includes, or evaluated MSBuild properties for a .csproj."
 user-invocable: true
 argument-hint: "path to .csproj [property or item type]"

--- a/skills/refactor-loop/SKILL.md
+++ b/skills/refactor-loop/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: refactor-loop
+installed_as: roslyn-mcp:refactor-loop
 description: "Guided refactor → preview → apply → validate loop using v1.17/v1.18 primitives. Use when: implementing a non-trivial refactor that benefits from explicit staging through preview, apply-with-verify, and the validate_workspace bundle. Pairs well with the refactor skill for upstream symbol-level work."
 user-invocable: true
 argument-hint: "natural-language refactor intent"

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: refactor
+installed_as: roslyn-mcp:refactor
 description: "Guided semantic refactoring. Use when: renaming symbols, extracting interfaces, extracting types, moving types between files or projects, splitting classes, or performing bulk type replacements in C# code. Describe the desired refactoring as input."
 user-invocable: true
 argument-hint: "natural-language refactoring goal"

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: review
+installed_as: roslyn-mcp:review
 description: "Semantic code review. Use when: reviewing C# code quality, finding issues before a PR, auditing a file or project for problems, or doing a comprehensive quality check. Optionally takes a file path or project name as input."
 user-invocable: true
 argument-hint: "[optional file path or project name]"


### PR DESCRIPTION
## Summary

- Adds `installed_as: roslyn-mcp:<bare-name>` frontmatter to 4 SKILL.md files: `project-inspection`, `refactor-loop`, `refactor`, and `review`
- Wave 9 of 12 in the bulk `installed_as` migration
- Missing-field count: 22 → 18 in this worktree

## Validation

- `eng/list-skills.ps1`: 18 missing (down from 22) — delta -4, correct
- `eng/verify-ai-docs.ps1`: AI docs validation passed

## Files changed

- `skills/project-inspection/SKILL.md`
- `skills/refactor-loop/SKILL.md`
- `skills/refactor/SKILL.md`
- `skills/review/SKILL.md`
- `changelog.d/skill-namespace-installed-as-wave-9.md`

Closes: skill-namespace-installed-as-wave-9