### PR TITLE
chore(skills): add installed_as frontmatter to wave-10 SKILL.md files (skill-namespace-installed-as-wave-10)

### DIFF
--- a/changelog.d/skill-namespace-installed-as-wave-10.md
+++ b/changelog.d/skill-namespace-installed-as-wave-10.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/security`, `skills/semantic-find`, `skills/session-undo`, and `skills/snippet-eval` SKILL.md files (wave 10/12 of bulk frontmatter migration).

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security
+installed_as: roslyn-mcp:security
 description: "Security audit for C# solutions. Use when: auditing for vulnerabilities, checking NuGet packages for CVEs, reviewing security diagnostics, finding reflection usage, auditing DI registrations, or doing an OWASP-style security review. Optionally takes a project name."
 user-invocable: true
 argument-hint: "[optional project name]"

--- a/skills/semantic-find/SKILL.md
+++ b/skills/semantic-find/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: semantic-find
+installed_as: roslyn-mcp:semantic-find
 description: "Natural-language code search across a C# codebase. Use when: looking for a class, method, or pattern described in plain English (e.g. 'the class that handles payment refunds', 'methods that retry on failure'), locating code by behavior rather than exact name, or orienting in an unfamiliar solution. Takes a natural-language description as input."
 user-invocable: true
 argument-hint: "natural-language description of the code you want to find"

--- a/skills/session-undo/SKILL.md
+++ b/skills/session-undo/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: session-undo
+installed_as: roslyn-mcp:session-undo
 description: "Session history and undo. Use when: the user wants to see what Roslyn MCP changed, undo the last apply, reload the workspace from disk, or recover from a bad refactoring."
 user-invocable: true
 argument-hint: "[workspaceId if multiple sessions]"

--- a/skills/snippet-eval/SKILL.md
+++ b/skills/snippet-eval/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: snippet-eval
+installed_as: roslyn-mcp:snippet-eval
 description: "Quick C# feedback without loading a solution. Use when: validating syntax, semantics, or running a small script; prototyping an expression; or explaining an isolated code fragment."
 user-invocable: true
 argument-hint: "snippet path | inline code | script"


### PR DESCRIPTION
## Summary

- Inserts `installed_as: roslyn-mcp:<name>` frontmatter into 4 SKILL.md files: `skills/security`, `skills/semantic-find`, `skills/session-undo`, `skills/snippet-eval`
- Wave 10/12 of the bulk `installed_as` frontmatter migration
- Missing count in worktree: 22 → 18 (delta -4, confirmed by `eng/list-skills.ps1`)

## Validation

- `eng/list-skills.ps1`: missing count dropped 22 → 18
- `eng/verify-ai-docs.ps1`: passed — "AI docs validation passed."

## Test plan

- [ ] Confirm `eng/list-skills.ps1` shows 18 missing after merge (parallel waves 7–9 will reduce further)
- [ ] Confirm `eng/verify-ai-docs.ps1` passes in CI

Closes: skill-namespace-installed-as-wave-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)