### PR TITLE
chore(skills): add installed_as frontmatter to wave-11 SKILL.md files (skill-namespace-installed-as-wave-11)

### DIFF
--- a/changelog.d/skill-namespace-installed-as-wave-11.md
+++ b/changelog.d/skill-namespace-installed-as-wave-11.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/test-coverage`, `skills/test-triage`, `skills/trace-flow`, and `skills/update` SKILL.md files (wave 11/12 of bulk `installed_as` migration), reducing the missing-field count from 6 to 2.

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: test-coverage
+installed_as: roslyn-mcp:test-coverage
 description: "Test coverage analysis. Use when: checking test coverage, finding untested code, identifying gaps in test suites, scaffolding new tests, or auditing which public APIs have tests. Optionally takes a project name."
 user-invocable: true
 argument-hint: "[optional project or test project name]"

--- a/skills/test-triage/SKILL.md
+++ b/skills/test-triage/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: test-triage
+installed_as: roslyn-mcp:test-triage
 description: "Test discovery and failure triage. Use when: CI is red, tests fail locally, or you need to find and run the right tests after a change. Optionally takes project name or filter."
 user-invocable: true
 argument-hint: "[optional project name or test filter]"

--- a/skills/trace-flow/SKILL.md
+++ b/skills/trace-flow/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: trace-flow
+installed_as: roslyn-mcp:trace-flow
 description: "Walk a value, parameter, or symbol through control flow, data flow, and exception flow paths. Use when: tracing a value through control/data/exception flow, understanding how a parameter propagates, finding where an exception is caught, or answering 'where can this value go?' / 'what paths does control take?' / 'if this throws, who catches it?'."
 user-invocable: true
 argument-hint: "<symbol-or-file:line> [mode: control|data|exception|all]"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: update
+installed_as: roslyn-mcp:update
 description: "Update the Roslyn MCP plugin. Use when: server_info shows an update is available, the user wants to update to the latest version, or the plugin reports an older version than NuGet. Handles both the global tool binary (Layer 1) and the Claude Code plugin metadata (Layer 2)."
 user-invocable: true
 argument-hint: ""


### PR DESCRIPTION
## Summary

- Add `installed_as: roslyn-mcp:<name>` frontmatter to 4 SKILL.md files in `skills/` tree
- Wave 11/12 of the bulk `installed_as` migration
- Missing count: 6 → 2 (delta -4)

## Files changed

- `skills/test-coverage/SKILL.md` — added `installed_as: roslyn-mcp:test-coverage`
- `skills/test-triage/SKILL.md` — added `installed_as: roslyn-mcp:test-triage`
- `skills/trace-flow/SKILL.md` — added `installed_as: roslyn-mcp:trace-flow`
- `skills/update/SKILL.md` — added `installed_as: roslyn-mcp:update`

## Validation

```
46 skill(s) found.  2 missing installed_as: (shown in yellow).
```

- `pwsh -NoProfile -File eng/list-skills.ps1`: 46 skills, 2 missing (was 6 before this wave)
- `pwsh -NoProfile -File eng/verify-ai-docs.ps1`: AI docs validation passed

## Notes

`.claude/skills/update/SKILL.md` was NOT touched — it was patched in wave 4 and already has `installed_as: update`.

Closes: skill-namespace-installed-as-wave-11