### PR TITLE
release: v1.38.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "1.37.0",
+  "version": "1.38.0",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.38.0] - 2026-05-13
+
+### Fixed
+
+- **Fixed:** `compile_check` transport-disconnect errors now emit a structured `category: "Disconnected"` envelope with a `workspace_reload` recovery hint instead of a raw `"Not connected"` string.
+- **Fixed:** `list_analyzers` returning non-deterministic `totalRules` counts across sessions against the same workspace. The service-layer deduplication guard was exiting early on the first project to reference an analyzer assembly, discarding rules visible only from other projects' language contexts. The fix accumulates rules from all projects before deduplicating by rule ID, making the result session-stable.
+- **Fixed:** Cross-workspace staleness contamination where writes to a worktree workspace (`.worktrees/`) under the same solution root triggered spurious stale-reload delays on the primary workspace.
+
+### Maintenance
+
+- **Maintenance:** Split `ScaffoldingService.cs` (2776 lines) into three focused partial-class files by scaffold type: `ScaffoldingService.TypePreview.cs` (type scaffolding + interface resolution), `ScaffoldingService.TestPreview.cs` (single-test scaffolding + sibling-pattern inference), and `ScaffoldingService.TestBatchAndFirstTestPreview.cs` (batch-test and first-test-file scaffolding). Pure code organization — no behavior changes; all 24 ScaffoldingIntegration tests pass unchanged.
+- **Maintenance:** Add `installed_as` frontmatter field to backlog-intake, backlog-split, bump, and close-backlog-rows SKILL.md files so the skill namespace resolver can match each skill to its installed name without ambiguity.
+- **Maintenance:** Added `installed_as:` frontmatter field to 4 maintainer-only `.claude/skills/` SKILL.md files (`draft-changelog-entry`, `mcp-server-stress`, `promote-tier`, `publish-preflight`), reducing the missing-field count from 42 to 38.
+- **Maintenance:** Add `installed_as` frontmatter to `.claude/skills/reconcile-backlog-sweep-plan`, `reconcile-backlog-vs-issues`, `recover-stalled-subagent`, and `release-cut` SKILL.md files (wave 3 of bulk migration).
+- **Maintenance:** Add `installed_as:` frontmatter to `.claude/skills/surface-audit`, `.claude/skills/update`, `skills/analyze`, and `skills/architecture-review` SKILL.md files (wave 4 of 12 in the bulk `installed_as` migration).
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/code-actions`, `skills/complexity`, `skills/dead-code`, and `skills/di-audit` SKILL.md files (wave 5 of 12 bulk migration).
+- **Maintenance:** Add `installed_as` frontmatter to `skills/document`, `skills/exception-audit`, `skills/explain-error`, and `skills/extract-method` SKILL.md files (wave 6/12 of bulk frontmatter migration).
+- **Maintenance:** Add `installed_as: roslyn-mcp:<bare-name>` frontmatter to `skills/format-sweep`, `skills/generate-tests`, `skills/impact-assessment`, and `skills/inheritance-explorer` SKILL.md files (wave 7 of 12 in the bulk `installed_as` migration).
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/mcp-server-surface-test`, `skills/migrate-package`, `skills/modernize`, and `skills/nuget-preflight` SKILL.md files (wave 8 of 12 bulk frontmatter migration, reducing missing count from 18 to 14).
+- **Maintenance:** Add `installed_as: roslyn-mcp:*` frontmatter to `skills/project-inspection`, `skills/refactor-loop`, `skills/refactor`, and `skills/review` SKILL.md files (wave 9 of 12 in the bulk `installed_as` migration), reducing the missing-field count from 22 to 18.
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/security`, `skills/semantic-find`, `skills/session-undo`, and `skills/snippet-eval` SKILL.md files (wave 10/12 of bulk frontmatter migration).
+- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/test-coverage`, `skills/test-triage`, `skills/trace-flow`, and `skills/update` SKILL.md files (wave 11/12 of bulk `installed_as` migration), reducing the missing-field count from 6 to 2.
+- **Maintenance:** Completed `installed_as:` frontmatter migration (wave 12/12): added `installed_as: roslyn-mcp:version-bump` to `skills/version-bump/SKILL.md` and `installed_as: roslyn-mcp:workspace-health` to `skills/workspace-health/SKILL.md`; removed `[Ignore]` from `SkillFrontmatterInstalledAsTests` to activate full CI enforcement of the 46-file `installed_as:` contract (`skill-namespace-installed-as-wave-12`, `skill-namespace-installed-as-bulk-frontmatter-migration`).
+
 ## [1.37.0] - 2026-05-12
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.37.0</Version>
+    <Version>1.38.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/compile-check-not-connected-raw-transport-error-envelope.md
+++ b/changelog.d/compile-check-not-connected-raw-transport-error-envelope.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `compile_check` transport-disconnect errors now emit a structured `category: "Disconnected"` envelope with a `workspace_reload` recovery hint instead of a raw `"Not connected"` string.

--- a/changelog.d/list-analyzers-totalrules-variance.md
+++ b/changelog.d/list-analyzers-totalrules-variance.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `list_analyzers` returning non-deterministic `totalRules` counts across sessions against the same workspace. The service-layer deduplication guard was exiting early on the first project to reference an analyzer assembly, discarding rules visible only from other projects' language contexts. The fix accumulates rules from all projects before deduplicating by rule ID, making the result session-stable.

--- a/changelog.d/scaffolding-service-split-by-scaffold-type.md
+++ b/changelog.d/scaffolding-service-split-by-scaffold-type.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Split `ScaffoldingService.cs` (2776 lines) into three focused partial-class files by scaffold type: `ScaffoldingService.TypePreview.cs` (type scaffolding + interface resolution), `ScaffoldingService.TestPreview.cs` (single-test scaffolding + sibling-pattern inference), and `ScaffoldingService.TestBatchAndFirstTestPreview.cs` (batch-test and first-test-file scaffolding). Pure code organization — no behavior changes; all 24 ScaffoldingIntegration tests pass unchanged.

--- a/changelog.d/skill-namespace-installed-as-bulk-frontmatter-migration.md
+++ b/changelog.d/skill-namespace-installed-as-bulk-frontmatter-migration.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as` frontmatter field to backlog-intake, backlog-split, bump, and close-backlog-rows SKILL.md files so the skill namespace resolver can match each skill to its installed name without ambiguity.

--- a/changelog.d/skill-namespace-installed-as-wave-10.md
+++ b/changelog.d/skill-namespace-installed-as-wave-10.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/security`, `skills/semantic-find`, `skills/session-undo`, and `skills/snippet-eval` SKILL.md files (wave 10/12 of bulk frontmatter migration).

--- a/changelog.d/skill-namespace-installed-as-wave-11.md
+++ b/changelog.d/skill-namespace-installed-as-wave-11.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/test-coverage`, `skills/test-triage`, `skills/trace-flow`, and `skills/update` SKILL.md files (wave 11/12 of bulk `installed_as` migration), reducing the missing-field count from 6 to 2.

--- a/changelog.d/skill-namespace-installed-as-wave-12.md
+++ b/changelog.d/skill-namespace-installed-as-wave-12.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Completed `installed_as:` frontmatter migration (wave 12/12): added `installed_as: roslyn-mcp:version-bump` to `skills/version-bump/SKILL.md` and `installed_as: roslyn-mcp:workspace-health` to `skills/workspace-health/SKILL.md`; removed `[Ignore]` from `SkillFrontmatterInstalledAsTests` to activate full CI enforcement of the 46-file `installed_as:` contract (`skill-namespace-installed-as-wave-12`, `skill-namespace-installed-as-bulk-frontmatter-migration`).

--- a/changelog.d/skill-namespace-installed-as-wave-2.md
+++ b/changelog.d/skill-namespace-installed-as-wave-2.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Added `installed_as:` frontmatter field to 4 maintainer-only `.claude/skills/` SKILL.md files (`draft-changelog-entry`, `mcp-server-stress`, `promote-tier`, `publish-preflight`), reducing the missing-field count from 42 to 38.

--- a/changelog.d/skill-namespace-installed-as-wave-3.md
+++ b/changelog.d/skill-namespace-installed-as-wave-3.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as` frontmatter to `.claude/skills/reconcile-backlog-sweep-plan`, `reconcile-backlog-vs-issues`, `recover-stalled-subagent`, and `release-cut` SKILL.md files (wave 3 of bulk migration).

--- a/changelog.d/skill-namespace-installed-as-wave-4.md
+++ b/changelog.d/skill-namespace-installed-as-wave-4.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as:` frontmatter to `.claude/skills/surface-audit`, `.claude/skills/update`, `skills/analyze`, and `skills/architecture-review` SKILL.md files (wave 4 of 12 in the bulk `installed_as` migration).

--- a/changelog.d/skill-namespace-installed-as-wave-5.md
+++ b/changelog.d/skill-namespace-installed-as-wave-5.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/code-actions`, `skills/complexity`, `skills/dead-code`, and `skills/di-audit` SKILL.md files (wave 5 of 12 bulk migration).

--- a/changelog.d/skill-namespace-installed-as-wave-6.md
+++ b/changelog.d/skill-namespace-installed-as-wave-6.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as` frontmatter to `skills/document`, `skills/exception-audit`, `skills/explain-error`, and `skills/extract-method` SKILL.md files (wave 6/12 of bulk frontmatter migration).

--- a/changelog.d/skill-namespace-installed-as-wave-7.md
+++ b/changelog.d/skill-namespace-installed-as-wave-7.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:<bare-name>` frontmatter to `skills/format-sweep`, `skills/generate-tests`, `skills/impact-assessment`, and `skills/inheritance-explorer` SKILL.md files (wave 7 of 12 in the bulk `installed_as` migration).

--- a/changelog.d/skill-namespace-installed-as-wave-8.md
+++ b/changelog.d/skill-namespace-installed-as-wave-8.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:<name>` frontmatter to `skills/mcp-server-surface-test`, `skills/migrate-package`, `skills/modernize`, and `skills/nuget-preflight` SKILL.md files (wave 8 of 12 bulk frontmatter migration, reducing missing count from 18 to 14).

--- a/changelog.d/skill-namespace-installed-as-wave-9.md
+++ b/changelog.d/skill-namespace-installed-as-wave-9.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `installed_as: roslyn-mcp:*` frontmatter to `skills/project-inspection`, `skills/refactor-loop`, `skills/refactor`, and `skills/review` SKILL.md files (wave 9 of 12 in the bulk `installed_as` migration), reducing the missing-field count from 22 to 18.

--- a/changelog.d/workspace-staleness-cross-workspace-contamination.md
+++ b/changelog.d/workspace-staleness-cross-workspace-contamination.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Cross-workspace staleness contamination where writes to a worktree workspace (`.worktrees/`) under the same solution root triggered spurious stale-reload delays on the primary workspace.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

- Bump version 1.37.0 → 1.38.0 across all 6 version files
- Consume 16 `changelog.d/` fragments (3 Fixed + 13 Maintenance)
- Populate `## [1.38.0] - 2026-05-13` section in CHANGELOG.md

## Changes

**Fixed:** compile_check Disconnected envelope, list_analyzers totalRules determinism, cross-workspace staleness contamination.

**Maintenance:** ScaffoldingService.cs split into 3 partial files; complete `installed_as:` frontmatter migration across all 46 shipped SKILL.md files (waves 2–12).

## Test plan
- [x] `eng/verify-release.ps1` — 1266 tests passed, 0 failures
- [x] `eng/verify-ai-docs.ps1` — all 32 shipped skills generic
- [x] `eng/verify-version-drift.ps1` — all 6 files agree on 1.38.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)