### PR TITLE
release: v1.38.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.38.0",
+      "version": "1.38.1",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "1.38.0",
+  "version": "1.38.1",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "1.38.0",
+      "version": "1.38.1",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.38.1] - 2026-05-13
+
+### Fixed
+
+- **Fixed:** `WorkspaceCloseDrainTests` used hardcoded Windows paths (`C:\repo\...`) that caused `Path.GetDirectoryName` to return an empty string on Linux, silently skipping the drain call and failing the assertion; paths replaced with `Path.Combine(Path.GetTempPath(), ...)` so the test is cross-platform. This was blocking NuGet publish for v1.37.0 and v1.38.0.
+
+### Maintenance
+
+- **Maintenance:** `PersistentCompositeStorage` and `WorkspaceCacheStore` now accept an optional `ILogger<T>` (injected via DI in both `ServiceCollectionExtensions`); corrupt-entry drops and best-effort delete failures are logged at `Debug` level instead of silently swallowed.
+
 ## [1.38.0] - 2026-05-13
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.38.0</Version>
+    <Version>1.38.1</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/disk-store-observability.md
+++ b/changelog.d/disk-store-observability.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** `PersistentCompositeStorage` and `WorkspaceCacheStore` now accept an optional `ILogger<T>` (injected via DI in both `ServiceCollectionExtensions`); corrupt-entry drops and best-effort delete failures are logged at `Debug` level instead of silently swallowed.

--- a/changelog.d/fix-drain-test-linux-path.md
+++ b/changelog.d/fix-drain-test-linux-path.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `WorkspaceCloseDrainTests` used hardcoded Windows paths (`C:\repo\...`) that caused `Path.GetDirectoryName` to return an empty string on Linux, silently skipping the drain call and failing the assertion; paths replaced with `Path.Combine(Path.GetTempPath(), ...)` so the test is cross-platform. This was blocking NuGet publish for v1.37.0 and v1.38.0.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

- Version bump to 1.38.1 across all 6 version files
- Consumes 2 changelog fragments: `Fixed` (cross-platform drain test) + `Maintenance` (ILogger for disk stores)

## Test plan

- [x] `verify-release.ps1` green locally (1268 tests, 0 failures)
- [x] `WorkspaceCloseDrainTests` verified passing on Linux via Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)