### PR TITLE
fix(symbols): cap symbol_search payload + summary=true projection

### DIFF
--- a/changelog.d/symbol-search-broad-query-response-cap-overflow.md
+++ b/changelog.d/symbol-search-broad-query-response-cap-overflow.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `symbol_search` regression (gh #617): broad queries with `limit > ~30` exceeded the MCP inline transport cap (171 KB observed at `limit=100`). Added `summary=true` parameter that drops expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType). Lowered server-side hard cap from 200 to 50; callers relying on `limit > 50` were already receiving tool-results-file fallbacks.

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -16,7 +16,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class SymbolTools
 {
 
-    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace. Matching is substring (case-insensitive) — pass a bare fragment like 'Animal' to find 'AnimalService', 'IAnimal', 'CatAnimal', etc. Wildcards (*, ?) and regex metacharacters are NOT interpreted; they are matched literally. Response shape: { count, totalCount, hasMore, offset, limit, symbols }.")]
+    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace. Matching is substring (case-insensitive) — pass a bare fragment like 'Animal' to find 'AnimalService', 'IAnimal', 'CatAnimal', etc. Wildcards (*, ?) and regex metacharacters are NOT interpreted; they are matched literally. Pass `summary=true` to drop expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType) for broad queries — useful when the default payload exceeds the MCP cap (~171 KB observed at limit=100 without summary). Response shape: { count, totalCount, hasMore, offset, limit, summary, symbols }.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Search symbols by name across the workspace.")]
     public static Task<string> SearchSymbols(
@@ -28,15 +28,16 @@ public static class SymbolTools
         [Description("Optional: filter by project name")] string? projectName = null,
         [Description("Optional: filter by symbol kind (Class, Method, Property, Field, Interface, etc.)")] string? kind = null,
         [Description("Optional: filter by namespace")] string? @namespace = null,
-        [Description("Maximum number of results to return (default: 50, max: 200)")] int limit = 50,
+        [Description("Maximum number of results to return (default: 50, max: 50)")] int limit = 50,
         [Description("Number of results to skip before returning (default: 0)")] int offset = 0,
+        [Description("When true, drops expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType) to keep the response small for broad queries. Locator-essential fields (name, fullyQualifiedName, symbolHandle, kind, filePath, startLine, startColumn) remain populated. Default false preserves the full SymbolDto shape.")] bool summary = false,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             ParameterValidation.ValidatePagination(offset, limit);
-            if (limit > 200)
-                throw new ArgumentException($"Invalid limit '{limit}'. Limit must be 200 or less.");
+            if (limit > 50)
+                throw new ArgumentException($"Invalid limit '{limit}'. Limit must be 50 or less.");
 
             // Guard: empty/whitespace queries would otherwise dump the full workspace symbol index
             // (observed 70-80 KB payloads on mid-sized solutions). Return a structured empty-query
@@ -50,6 +51,7 @@ public static class SymbolTools
                     hasMore = false,
                     offset,
                     limit,
+                    summary,
                     symbols = Array.Empty<object>(),
                     note = "query must be non-empty — pass a bare substring like 'Animal' to find 'AnimalService', 'IAnimal', etc."
                 }, JsonDefaults.Indented);
@@ -61,6 +63,24 @@ public static class SymbolTools
             var allResults = await symbolSearchService.SearchSymbolsAsync(workspaceId, query, projectName, kind, @namespace, maxResults, c);
             var paged = allResults.Skip(offset).Take(limit).ToList();
             var hasMore = offset + paged.Count < allResults.Count;
+
+            // symbol-search-broad-query-response-cap-overflow: project paged results to a
+            // summary shape (drops Documentation, Parameters, BaseTypes, Interfaces, Modifiers,
+            // ReturnType) BEFORE serialization so the aggregate JSON stays under the MCP
+            // inline transport cap. Mirrors the pattern in find_references but at the tool
+            // wrapper (SymbolDto / ISymbolSearchService stay untouched).
+            object ProjectSymbol(Core.Models.SymbolDto s) => summary
+                ? (object)new
+                {
+                    name = s.Name,
+                    fullyQualifiedName = s.FullyQualifiedName,
+                    symbolHandle = s.SymbolHandle,
+                    kind = s.Kind,
+                    filePath = s.FilePath,
+                    startLine = s.StartLine,
+                    startColumn = s.StartColumn,
+                }
+                : s;
 
             // elicit-disambiguation-on-multi-symbol-resolve: when the search returns >1 candidate
             // and the client supports MCP elicitation, ask the agent which candidate to focus on
@@ -97,7 +117,8 @@ public static class SymbolTools
                         hasMore,
                         offset,
                         limit,
-                        symbols = new[] { paged[idx] },
+                        summary,
+                        symbols = new[] { ProjectSymbol(paged[idx]) },
                         chosenViaElicitation = true,
                     }, JsonDefaults.Indented);
                 }
@@ -110,7 +131,8 @@ public static class SymbolTools
                 hasMore,
                 offset,
                 limit,
-                symbols = paged,
+                summary,
+                symbols = paged.Select(ProjectSymbol).ToList(),
             }, JsonDefaults.Indented);
         }, ct);
     }

--- a/tests/RoslynMcp.Tests/SymbolSearchPaginationTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolSearchPaginationTests.cs
@@ -7,8 +7,11 @@ namespace RoslynMcp.Tests;
 
 /// <summary>
 /// Regression coverage for <c>symbol-search-pagination</c>: <c>symbol_search</c> now supports
-/// <c>offset</c> / <c>limit</c> pagination (max 200) with <c>totalCount</c> and <c>hasMore</c>
-/// in the response envelope.
+/// <c>offset</c> / <c>limit</c> pagination (max 50, lowered from 200 in
+/// <c>symbol-search-broad-query-response-cap-overflow</c>) with <c>totalCount</c> and
+/// <c>hasMore</c> in the response envelope. Also covers the <c>summary=true</c> projection
+/// that drops expensive per-symbol fields (documentation, parameters, baseTypes, interfaces,
+/// modifiers, returnType) to keep broad-query payloads under the MCP inline transport cap.
 /// </summary>
 [DoNotParallelize]
 [TestClass]
@@ -111,21 +114,23 @@ public sealed class SymbolSearchPaginationTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task SymbolSearch_HasMore_FalseOnLastPage()
     {
-        // First page: find out how many Animal symbols are present.
+        // First page: find out how many Animal symbols are present. The hard cap is 50
+        // (lowered from 200 in symbol-search-broad-query-response-cap-overflow); SampleSolution
+        // currently surfaces well under 50 'Animal' matches so a single page covers the full set.
         var probeJson = await ToolExecutionTestHarness.RunAsync(
             "symbol_search",
             () => SymbolTools.SearchSymbols(
                 server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
                 query: "Animal",
                 projectName: null, kind: null, @namespace: null,
-                limit: 200, offset: 0,
+                limit: 50, offset: 0,
                 ct: CancellationToken.None));
 
         using var probeDoc = JsonDocument.Parse(probeJson);
         var total = probeDoc.RootElement.GetProperty("totalCount").GetInt32();
         var hasMoreProbe = probeDoc.RootElement.GetProperty("hasMore").GetBoolean();
         Assert.IsFalse(hasMoreProbe,
-            "When limit=200 covers all results, hasMore must be false");
+            "When limit=50 covers all results, hasMore must be false");
         Assert.IsTrue(total >= 1, "SampleSolution must contain at least one 'Animal' symbol");
     }
 
@@ -160,10 +165,10 @@ public sealed class SymbolSearchPaginationTests : SharedWorkspaceTestBase
         }
     }
 
-    // ── limit = 200 max ─────────────────────────────────────────────────────
+    // ── limit = 50 max (lowered from 200 in symbol-search-broad-query-response-cap-overflow) ─
 
     [TestMethod]
-    public async Task SymbolSearch_LimitExceeds200_ThrowsArgumentException()
+    public async Task SymbolSearch_LimitExceeds50_ThrowsArgumentException()
     {
         await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
         {
@@ -171,7 +176,7 @@ public sealed class SymbolSearchPaginationTests : SharedWorkspaceTestBase
                 server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
                 query: "Animal",
                 projectName: null, kind: null, @namespace: null,
-                limit: 201, offset: 0,
+                limit: 51, offset: 0,
                 ct: CancellationToken.None);
         });
     }
@@ -214,5 +219,114 @@ public sealed class SymbolSearchPaginationTests : SharedWorkspaceTestBase
         Assert.IsFalse(root.GetProperty("hasMore").GetBoolean());
         Assert.AreEqual(0, root.GetProperty("offset").GetInt32());
         Assert.AreEqual(50, root.GetProperty("limit").GetInt32());
+    }
+
+    // ── summary=true projection (symbol-search-broad-query-response-cap-overflow) ───────────
+
+    [TestMethod]
+    public async Task SymbolSearch_Summary_DropsExpensiveFields()
+    {
+        // summary=true must strip Documentation, Parameters, BaseTypes, Interfaces, Modifiers,
+        // and ReturnType while retaining the locator-essential fields (Name, FullyQualifiedName,
+        // SymbolHandle, Kind, FilePath, StartLine, StartColumn).
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 10, offset: 0,
+                summary: true,
+                ct: CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        var symbols = doc.RootElement.GetProperty("symbols");
+        Assert.AreEqual(JsonValueKind.Array, symbols.ValueKind);
+        Assert.IsTrue(symbols.GetArrayLength() > 0,
+            "SampleSolution must surface at least one 'Animal' symbol for the projection to be observable");
+
+        var first = symbols[0];
+
+        // Locator-essential fields must remain.
+        Assert.IsTrue(first.TryGetProperty("name", out _), "name must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("fullyQualifiedName", out _), "fullyQualifiedName must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("symbolHandle", out _), "symbolHandle must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("kind", out _), "kind must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("filePath", out _), "filePath must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("startLine", out _), "startLine must remain in summary mode");
+        Assert.IsTrue(first.TryGetProperty("startColumn", out _), "startColumn must remain in summary mode");
+
+        // Expensive fields must be dropped.
+        Assert.IsFalse(first.TryGetProperty("documentation", out _), "documentation must be dropped in summary mode");
+        Assert.IsFalse(first.TryGetProperty("parameters", out _), "parameters must be dropped in summary mode");
+        Assert.IsFalse(first.TryGetProperty("baseTypes", out _), "baseTypes must be dropped in summary mode");
+        Assert.IsFalse(first.TryGetProperty("interfaces", out _), "interfaces must be dropped in summary mode");
+        Assert.IsFalse(first.TryGetProperty("modifiers", out _), "modifiers must be dropped in summary mode");
+        Assert.IsFalse(first.TryGetProperty("returnType", out _), "returnType must be dropped in summary mode");
+    }
+
+    [TestMethod]
+    public async Task SymbolSearch_Summary_EchoedInEnvelope()
+    {
+        // The summary flag must surface in the envelope so callers can confirm whether
+        // their request resulted in a stripped projection.
+        var jsonTrue = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 5, offset: 0,
+                summary: true,
+                ct: CancellationToken.None));
+
+        using (var doc = JsonDocument.Parse(jsonTrue))
+        {
+            Assert.IsTrue(doc.RootElement.TryGetProperty("summary", out var s),
+                "envelope must echo the summary flag");
+            Assert.IsTrue(s.GetBoolean(), "summary=true must echo as true");
+        }
+
+        var jsonFalse = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Animal",
+                projectName: null, kind: null, @namespace: null,
+                limit: 5, offset: 0,
+                summary: false,
+                ct: CancellationToken.None));
+
+        using (var doc = JsonDocument.Parse(jsonFalse))
+        {
+            Assert.IsTrue(doc.RootElement.TryGetProperty("summary", out var s),
+                "envelope must echo the summary flag even when false");
+            Assert.IsFalse(s.GetBoolean(), "summary=false must echo as false");
+        }
+    }
+
+    [TestMethod]
+    public async Task SymbolSearch_Summary_BroadQuery_PayloadBounded()
+    {
+        // Broad-query regression guard: at limit=50 with summary=true the projected payload
+        // must stay well under the MCP inline transport cap (~64 KB). Asserting < 50 KB gives
+        // headroom and remains robust as SampleSolution grows.
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "symbol_search",
+            () => SymbolTools.SearchSymbols(
+                server: null!, WorkspaceExecutionGate, SymbolSearchService, WorkspaceId,
+                query: "Service",
+                projectName: null, kind: null, @namespace: null,
+                limit: 50, offset: 0,
+                summary: true,
+                ct: CancellationToken.None));
+
+        Assert.IsTrue(json.Length < 50_000,
+            $"summary=true broad-query payload must stay under 50 KB; got {json.Length} bytes");
+
+        // Still a well-formed envelope.
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("symbols", out var symbols));
+        Assert.AreEqual(JsonValueKind.Array, symbols.ValueKind);
     }
 }


### PR DESCRIPTION
## Summary

Fixes `symbol-search-broad-query-response-cap-overflow` from the 20260516T200033Z backlog sweep — `symbol_search` broad queries with `limit > ~30` exceeded the MCP inline transport cap (171 KB observed at `limit=100`) because `SymbolDto`'s 21-field shape produced ~1.7 KB per result indented. PR #659 fixed *count* via pagination but not per-item payload size.

Two-pronged fix at the tool wrapper only (`SymbolDto` and `ISymbolSearchService` untouched):

1. **`summary=true` parameter** (mirroring the `find_references` precedent) projects each `SymbolDto` to a locator-essential anonymous object (`name`, `fullyQualifiedName`, `symbolHandle`, `kind`, `filePath`, `startLine`, `startColumn`). Applied at **both** response sites — the elicitation single-pick envelope AND the default list envelope — so neither path reopens the overflow.
2. **Hard cap lowered 200 → 50.** Per the regression evidence, `limit > 50` callers were already receiving tool-results-file fallbacks, so the breaking-change surface is effectively empty.

The envelope now echoes `summary` (mirroring `find_references`) and the description text on the tool advertises the new parameter.

## Test plan

- [x] `mcp__roslyn__compile_check` green on `SymbolTools.cs` and `SymbolSearchPaginationTests.cs`
- [x] `mcp__roslyn__test_run --filter SymbolSearchPaginationTests` — 10/10 pass (3 new + 7 existing with renames/updates)
- [x] `mcp__roslyn__test_run --filter Top10V3RegressionTests` — 9/9 pass (regression guard for `symbol_search` envelope shape)
- [x] `mcp__roslyn__test_run --filter ServerSurfaceCatalog` — 6/6 pass (no surface-catalog drift)
- [x] `project_diagnostics RoslynMcp.Host.Stdio severityFilter=Error` — 0 errors, 0 warnings introduced
- [ ] CI green on self-hosted runner (`./eng/verify-release.ps1 -Configuration Release`)

New test coverage:
- `SymbolSearch_Summary_DropsExpensiveFields` — asserts the 6 expensive fields are stripped and the 7 locator-essential fields remain
- `SymbolSearch_Summary_EchoedInEnvelope` — confirms the `summary` echo for both `true` and `false`
- `SymbolSearch_Summary_BroadQuery_PayloadBounded` — `query="Service"`, `limit=50`, `summary=true` payload under 50 KB
- `SymbolSearch_LimitExceeds50_ThrowsArgumentException` — renamed from `Exceeds200`, passes `limit: 51`

Closes: symbol-search-broad-query-response-cap-overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)