### PR TITLE
fix(workspace): evaluate OutputType via MSBuild for SDK-Web/Worker projects

### DIFF
--- a/changelog.d/project-graph-output-type-misreports-sdk-defaulted-exe.md
+++ b/changelog.d/project-graph-output-type-misreports-sdk-defaulted-exe.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `project_graph` silently misreporting `outputType: "Library"` for ASP.NET Core Web (`Microsoft.NET.Sdk.Web`) and Worker (`Microsoft.NET.Sdk.Worker`) projects that omit an explicit `<OutputType>` element. Now populated via MSBuild property evaluation (fixes gh #773).

--- a/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ProjectMetadataParser.cs
@@ -119,9 +119,51 @@ internal static class ProjectMetadataParser
         return IsTestProject(doc);
     }
 
+    /// <summary>
+    /// project-graph-output-type-misreports-sdk-defaulted-exe: SDK-defaulted OutputType
+    /// resolution. The raw-XML overload below sees no <c>&lt;OutputType&gt;</c> element for
+    /// <c>Microsoft.NET.Sdk.Web</c> and <c>Microsoft.NET.Sdk.Worker</c> projects that omit
+    /// the property explicitly, and incorrectly returns <c>"Library"</c>. The SDK targets
+    /// inject <c>OutputType=Exe</c> at evaluation time; this overload runs the same
+    /// <see cref="ProjectCollection"/> evaluation as <see cref="GetEvaluatedTargetFrameworks"/>
+    /// and falls back to the XML-only path when MSBuild evaluation is unavailable.
+    /// </summary>
+    public static string GetOutputType(RoslynProject project, XDocument? document, ILogger? logger = null)
+    {
+        var evaluated = GetEvaluatedOutputType(project.FilePath, logger);
+        return !string.IsNullOrWhiteSpace(evaluated) ? evaluated : GetOutputType(document);
+    }
+
     public static string GetOutputType(XDocument? document)
     {
         return document?.Descendants("OutputType").FirstOrDefault()?.Value.Trim() ?? "Library";
+    }
+
+    internal static string? GetEvaluatedOutputType(string? projectFilePath, ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilePath) || !File.Exists(projectFilePath))
+        {
+            return null;
+        }
+
+        MsBuildInitializer.EnsureInitialized();
+        var projectCollection = new ProjectCollection();
+
+        try
+        {
+            var evaluatedProject = projectCollection.LoadProject(projectFilePath);
+            var outputType = evaluatedProject.GetPropertyValue("OutputType");
+            return string.IsNullOrWhiteSpace(outputType) ? null : outputType.Trim();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed to evaluate output type for project {Path}", projectFilePath);
+            return null;
+        }
+        finally
+        {
+            projectCollection.UnloadAllProjects();
+        }
     }
 
     public static string GetAssemblyName(RoslynProject project)

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -2131,7 +2131,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 TargetFrameworks: Helpers.ProjectMetadataParser.GetTargetFrameworks(project, projectDoc, _logger),
                 IsTestProject: Helpers.ProjectMetadataParser.IsTestProject(projectDoc),
                 AssemblyName: Helpers.ProjectMetadataParser.GetAssemblyName(project),
-                OutputType: Helpers.ProjectMetadataParser.GetOutputType(projectDoc));
+                OutputType: Helpers.ProjectMetadataParser.GetOutputType(project, projectDoc, _logger));
         }).ToImmutableArray();
     }
 

--- a/tests/RoslynMcp.Tests/ProjectOutputTypeTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectOutputTypeTests.cs
@@ -1,0 +1,164 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// project-graph-output-type-misreports-sdk-defaulted-exe regression guard. SDK-style
+/// projects that rely on <c>Microsoft.NET.Sdk.Web</c> or <c>Microsoft.NET.Sdk.Worker</c>
+/// inherit <c>OutputType=Exe</c> from the SDK's targets and typically omit the
+/// <c>&lt;OutputType&gt;</c> element from the .csproj XML. The pre-fix XML-only path read
+/// the absent element and defaulted to <c>"Library"</c>; the post-fix path runs MSBuild
+/// property evaluation via <see cref="Microsoft.Build.Evaluation.ProjectCollection"/> so the
+/// SDK-injected value surfaces correctly.
+/// </summary>
+[TestClass]
+public sealed class ProjectOutputTypeTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        // Ensures MSBuild is registered for the ProjectCollection evaluations below.
+        InitializeServices();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public void GetEvaluatedOutputType_SdkWebProject_WithoutExplicitOutputType_ReturnsExe()
+    {
+        // Pre-fix: GetOutputType(XDocument?) saw no <OutputType> element and returned "Library".
+        // Post-fix: GetEvaluatedOutputType opens the project under MSBuild and reads the
+        // SDK-defaulted property, returning "Exe".
+        using var fixture = CreateProjectFixture(
+            "WebApp.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var result = ProjectMetadataParser.GetEvaluatedOutputType(fixture.ProjectPath, NullLogger.Instance);
+
+        Assert.AreEqual("Exe", result,
+            "Microsoft.NET.Sdk.Web projects inherit OutputType=Exe from the SDK targets; the evaluator must surface it even when the XML omits the element.");
+    }
+
+    [TestMethod]
+    public void GetEvaluatedOutputType_SdkWorkerProject_WithoutExplicitOutputType_ReturnsExe()
+    {
+        // Worker SDK is the other commonly-affected case — generic-host background services
+        // (ASP.NET Core hosted services, IHostedService apps) use Microsoft.NET.Sdk.Worker
+        // and rely on the same SDK-defaulted OutputType=Exe.
+        using var fixture = CreateProjectFixture(
+            "WorkerApp.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Worker">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var result = ProjectMetadataParser.GetEvaluatedOutputType(fixture.ProjectPath, NullLogger.Instance);
+
+        Assert.AreEqual("Exe", result,
+            "Microsoft.NET.Sdk.Worker projects inherit OutputType=Exe from the SDK targets; the evaluator must surface it.");
+    }
+
+    [TestMethod]
+    public void GetEvaluatedOutputType_PlainSdkLibrary_WithoutExplicitOutputType_ReturnsLibrary()
+    {
+        // Regression guard: a plain Microsoft.NET.Sdk library project (no <OutputType>) must
+        // still return "Library" via MSBuild evaluation — the SDK defaults the property to
+        // "Library" for this case. This proves the evaluator did not just hard-code "Exe".
+        using var fixture = CreateProjectFixture(
+            "PlainLib.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var result = ProjectMetadataParser.GetEvaluatedOutputType(fixture.ProjectPath, NullLogger.Instance);
+
+        Assert.AreEqual("Library", result,
+            "Microsoft.NET.Sdk library projects default OutputType=Library; the evaluator must report that value, not silently misreport.");
+    }
+
+    [TestMethod]
+    public void GetEvaluatedOutputType_ExplicitExe_PreservesValue()
+    {
+        // An explicit <OutputType>Exe</OutputType> on a plain Microsoft.NET.Sdk console
+        // project must still produce "Exe" — the evaluator and the XML-only path agree
+        // on this case.
+        using var fixture = CreateProjectFixture(
+            "ConsoleApp.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var result = ProjectMetadataParser.GetEvaluatedOutputType(fixture.ProjectPath, NullLogger.Instance);
+
+        Assert.AreEqual("Exe", result,
+            "Explicit <OutputType>Exe</OutputType> must round-trip through the evaluator unchanged.");
+    }
+
+    [TestMethod]
+    public void GetEvaluatedOutputType_MissingFile_ReturnsNull()
+    {
+        // The evaluator must not throw when handed a non-existent path; the caller falls
+        // back to the XML-only path which itself returns "Library".
+        var missingPath = Path.Combine(Path.GetTempPath(), $"does_not_exist_{Guid.NewGuid():N}.csproj");
+        var result = ProjectMetadataParser.GetEvaluatedOutputType(missingPath, NullLogger.Instance);
+
+        Assert.IsNull(result, "A non-existent project path must return null, not throw or return a default value.");
+    }
+
+    private static ProjectFixture CreateProjectFixture(string fileName, string content)
+    {
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "RoslynMcpTests",
+            "ProjectOutputTypeTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        var projectPath = Path.Combine(tempRoot, fileName);
+        File.WriteAllText(projectPath, content);
+        return new ProjectFixture(tempRoot, projectPath);
+    }
+
+    private sealed class ProjectFixture(string rootPath, string projectPath) : IDisposable
+    {
+        public string ProjectPath { get; } = projectPath;
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup. Locked files just leak a temp directory that the
+                // OS will reclaim on the next sweep.
+            }
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationIntegrationTests.cs
@@ -31,7 +31,11 @@ public class ValidationIntegrationTests : SharedWorkspaceTestBase
 
         Assert.IsNotNull(testProject, "SampleLib.Tests project not found.");
         Assert.IsTrue(testProject.IsTestProject, "SampleLib.Tests should be recognized as a test project.");
-        Assert.AreEqual("Library", testProject.OutputType);
+        // Microsoft.NET.Test.Sdk injects <OutputType>Exe</OutputType> for the test-host runner
+        // (`dotnet test` invokes testhost.exe). The post-fix MSBuild evaluator surfaces this value;
+        // the pre-fix XML-only path saw no element and defaulted to "Library". Test-vs-library
+        // discrimination lives on IsTestProject (asserted above), not OutputType.
+        Assert.AreEqual("Exe", testProject.OutputType);
         Assert.AreEqual("SampleLib.Tests", testProject.AssemblyName);
     }
 


### PR DESCRIPTION
## Summary

- `project_graph` previously read `<OutputType>` from the raw `.csproj` XML and defaulted to `"Library"` when the element was absent. `Microsoft.NET.Sdk.Web` and `Microsoft.NET.Sdk.Worker` projects inherit `OutputType=Exe` from the SDK targets and routinely omit the explicit element, so the project graph misreported those projects as libraries.
- Adds `ProjectMetadataParser.GetOutputType(RoslynProject, XDocument?, ILogger?)` that runs MSBuild property evaluation (same `ProjectCollection` pattern as `GetEvaluatedTargetFrameworks`) and falls back to the raw-XML path when evaluation is unavailable. The single call site in `WorkspaceManager.BuildProjectStatuses` is updated; the legacy one-arg XML-only overload stays intact for any future callers.
- Compared with `get_msbuild_properties`, which already calls `projectCollection.LoadProject(...).GetPropertyValue(...)` for full SDK evaluation, the project graph now uses the same evaluator path.

## Test plan

- [x] `ProjectOutputTypeTests` — 5 new tests covering Web SDK, Worker SDK, plain SDK library, explicit `<OutputType>Exe</OutputType>`, and missing-file fallback.
- [x] `WorkspaceToolsIntegrationTests.WorkspaceTools_GetProjectGraph_*` — regression: 2 existing tests still pass.
- [x] `BacklogFixTests.WorkspaceManager_*`, `WorkspaceManagerEvictionTests`, `HardeningBehaviorTests.WorkspaceManager_*` — 11 related WorkspaceManager tests pass.
- [x] `mcp__roslyn__compile_check` (all 5 projects) — 0 errors, 0 warnings.
- [x] `SdkStyleCsprojInjectionTests` — 19 unrelated `ProjectMetadataParser` tests still pass.

Closes: `project-graph-output-type-misreports-sdk-defaulted-exe`
Closes #773

Plan: ai_docs/plans/20260516T200033Z_backlog-sweep/plan.md initiative 7