### PR TITLE
fix(refactor): symbol_refactor_preview no longer auto-applies sub-ops to disk (symbol-refactor-preview-auto-applies-without-explicit-apply-call)

### DIFF
--- a/changelog.d/symbol-refactor-preview-auto-applies-without-explicit-apply-call.md
+++ b/changelog.d/symbol-refactor-preview-auto-applies-without-explicit-apply-call.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `symbol_refactor_preview` incorrectly applying each chained sub-operation to the workspace during preview, writing files to disk and recording ledger entries before the agent called any `*_apply` tool. Preview now chains operations purely in-memory and stores the accumulated mutations under one `apply_composite_preview` token (fixes gh #770).

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -275,6 +275,77 @@ public sealed class EditService : IEditService
     }
 
     /// <summary>
+    /// symbol-refactor-preview-auto-applies-without-explicit-apply-call: pure-functional
+    /// multi-file-edit simulation that operates on an explicit input
+    /// <paramref name="inputSolution"/> and returns the post-edit <see cref="Solution"/>
+    /// snapshot. Mirrors <see cref="PreviewMultiFileTextEditsAsync"/>'s validation +
+    /// accumulator semantics but never touches the workspace, the disk, or
+    /// <see cref="Contracts.IPreviewStore"/>. Used by <see cref="SymbolRefactorService.PreviewAsync"/>
+    /// to chain ops in-memory so each op sees its predecessor's rewrites without the previous
+    /// auto-apply-each-step disk write that fired before the agent ever called
+    /// <c>apply_composite_preview</c>.
+    /// </summary>
+    internal async Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description, IReadOnlyList<string>? Warnings)>
+        PreviewMultiFileTextEditsOnSolutionAsync(
+            Solution inputSolution,
+            IReadOnlyList<FileEditsDto> fileEdits,
+            CancellationToken ct,
+            bool skipSyntaxCheck = false)
+    {
+        if (fileEdits is null || fileEdits.Count == 0)
+        {
+            throw new InvalidOperationException("preview_multi_file_edit requires at least one file edit.");
+        }
+
+        var perFile = new List<(Document Document, SourceText SourceText, string FilePath, IReadOnlyList<TextEditDto> Edits)>();
+        foreach (var fileEdit in fileEdits)
+        {
+            var (document, sourceText) = await ResolveDocumentAndTextAsync(inputSolution, fileEdit.FilePath, ct).ConfigureAwait(false);
+            ValidateEdits(fileEdit.FilePath, fileEdit.Edits, sourceText);
+            perFile.Add((document, sourceText, fileEdit.FilePath, fileEdit.Edits));
+        }
+
+        var accumulator = inputSolution;
+        var changes = new List<FileChangeDto>();
+        var warnings = new List<string>();
+
+        foreach (var (document, sourceText, filePath, edits) in perFile)
+        {
+            var merged = BuildPatchedSourceText(sourceText, edits);
+            if (!skipSyntaxCheck
+                && string.Equals(Path.GetExtension(filePath), ".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                var syntaxErrors = GetCSharpSyntaxErrors(merged, filePath);
+                if (syntaxErrors.Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        $"preview_multi_file_edit: simulated edits for '{filePath}' produce {syntaxErrors.Count} syntax error(s). " +
+                        "Pass skipSyntaxCheck=true if the intermediate state is intentional.");
+                }
+            }
+
+            var docInAccum = accumulator.GetDocument(document.Id);
+            if (docInAccum is null)
+            {
+                warnings.Add($"Skipped '{filePath}': document no longer present in the working solution.");
+                continue;
+            }
+            accumulator = accumulator.WithDocumentText(docInAccum.Id, merged);
+
+            var unified = DiffGenerator.GenerateUnifiedDiff(sourceText.ToString(), merged.ToString(), filePath);
+            changes.Add(new FileChangeDto(filePath, unified));
+        }
+
+        if (changes.Count == 0)
+        {
+            throw new InvalidOperationException("preview_multi_file_edit produced no diffs. See Warnings for per-file reasons.");
+        }
+
+        var description = $"Preview multi-file edit across {changes.Count} file(s)";
+        return (accumulator, changes, description, warnings.Count > 0 ? warnings : null);
+    }
+
+    /// <summary>
     /// Resolves <paramref name="filePath"/> against the supplied <paramref name="solution"/> and
     /// reads the current <see cref="SourceText"/>. Uses the shared
     /// <see cref="DocumentResolution"/> helper so every preview / apply path raises a single

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -119,6 +119,47 @@ public sealed class RefactoringService : IRefactoringService
         return new RefactoringPreviewDto(token, description, changes, warnings);
     }
 
+    /// <summary>
+    /// symbol-refactor-preview-auto-applies-without-explicit-apply-call: pure-functional
+    /// rename simulation that operates on an explicit input <paramref name="inputSolution"/>
+    /// and returns the post-rename <see cref="Solution"/> snapshot without touching the
+    /// workspace, the disk, the preview store, the change tracker, or any post-apply
+    /// resolver. Used by <see cref="SymbolRefactorService.PreviewAsync"/> to chain ops
+    /// in-memory so each op sees its predecessor's rewrites without the previous
+    /// auto-apply-each-step disk write that fired before the agent ever called
+    /// <c>apply_composite_preview</c>.
+    /// </summary>
+    /// <remarks>
+    /// Returned tuple carries the modified solution plus a per-file <see cref="FileChangeDto"/>
+    /// list (full-diff form — summary mode is not relevant here because the composite caller
+    /// aggregates diffs across ops before applying its own truncation) and a human-readable
+    /// step description suitable for the composite preview's combined description string.
+    /// </remarks>
+    internal async Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        PreviewRenameOnSolutionAsync(
+            Solution inputSolution, SymbolLocator locator, string newName, CancellationToken ct)
+    {
+        var symbol = await SymbolResolver.ResolveAsync(inputSolution, locator, ct).ConfigureAwait(false);
+        if (symbol is null)
+            throw new InvalidOperationException(BuildRenameTargetNotFoundMessage(locator));
+
+        if (!symbol.Locations.Any(static l => l.IsInSource))
+        {
+            throw new InvalidOperationException(
+                $"Cannot rename metadata or built-in symbol '{symbol.ToDisplayString()}' — renames require a source declaration.");
+        }
+
+        IdentifierValidation.ThrowIfInvalidIdentifier(newName);
+
+        var newSolution = await Renamer.RenameSymbolAsync(
+            inputSolution, symbol, new SymbolRenameOptions(), newName, ct).ConfigureAwait(false);
+
+        var changes = await SolutionDiffHelper.ComputeChangesAsync(inputSolution, newSolution, ct).ConfigureAwait(false);
+        var description = $"Rename '{symbol.Name}' to '{newName}'";
+
+        return (newSolution, changes, description);
+    }
+
     private static string BuildRenameTargetNotFoundMessage(SymbolLocator locator)
     {
         if (locator.HasMetadataName)

--- a/src/RoslynMcp.Roslyn/Services/RestructureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RestructureService.cs
@@ -114,6 +114,85 @@ public sealed class RestructureService : IRestructureService
         return new RefactoringPreviewDto(token, description, changes, null);
     }
 
+    /// <summary>
+    /// symbol-refactor-preview-auto-applies-without-explicit-apply-call: pure-functional
+    /// structural-rewrite simulation that operates on an explicit input
+    /// <paramref name="inputSolution"/> and returns the post-rewrite <see cref="Solution"/>
+    /// snapshot. Mirrors <see cref="PreviewRestructureAsync"/>'s parse-and-walk logic but
+    /// never touches the workspace, the disk, or <see cref="IPreviewStore"/>. Used by
+    /// <see cref="SymbolRefactorService.PreviewAsync"/> to chain ops in-memory so each op
+    /// sees its predecessor's rewrites without the previous auto-apply-each-step disk write
+    /// that fired before the agent ever called <c>apply_composite_preview</c>.
+    /// </summary>
+    internal async Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        PreviewRestructureOnSolutionAsync(
+            Solution inputSolution, string pattern, string goal, RestructureScope scope, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+            throw new ArgumentException("pattern must be non-empty.", nameof(pattern));
+        if (goal is null)
+            throw new ArgumentException("goal must be non-null (use empty string to delete matches).", nameof(goal));
+
+        var (patternNode, patternKind) = ParsePatternOrGoal(pattern, "pattern");
+        var (goalNode, goalKind) = ParsePatternOrGoal(goal, "goal");
+        if (patternKind != goalKind)
+        {
+            throw new ArgumentException(
+                $"pattern and goal must be the same syntactic kind (both expressions or both statements). " +
+                $"pattern={patternKind}, goal={goalKind}.");
+        }
+
+        var patternPlaceholderNames = ExtractPlaceholderNames(patternNode);
+        var goalPlaceholderNames = ExtractPlaceholderNames(goalNode);
+        var orphaned = goalPlaceholderNames.Except(patternPlaceholderNames, StringComparer.Ordinal).ToList();
+        if (orphaned.Count > 0)
+        {
+            throw new ArgumentException(
+                $"goal references placeholder(s) not captured by the pattern: {string.Join(", ", orphaned.Select(n => $"__{n}__"))}. " +
+                $"Every `__name__` in the goal must appear in the pattern so it has a captured value to substitute.",
+                nameof(goal));
+        }
+
+        var accumulator = inputSolution;
+        var changes = new List<FileChangeDto>();
+        var totalMatches = 0;
+
+        foreach (var project in EnumerateProjects(inputSolution, scope))
+        {
+            foreach (var document in EnumerateDocuments(project, scope))
+            {
+                ct.ThrowIfCancellationRequested();
+                var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                if (root is null) continue;
+
+                var rewriter = new StructuralRewriter(patternNode, goalNode, goalPlaceholderNames);
+                var newRoot = rewriter.Visit(root);
+
+                if (rewriter.MatchCount == 0 || newRoot is null) continue;
+                totalMatches += rewriter.MatchCount;
+
+                var newText = newRoot.ToFullString();
+                var oldText = root.ToFullString();
+
+                accumulator = accumulator.WithDocumentText(document.Id, Microsoft.CodeAnalysis.Text.SourceText.From(newText));
+                var docPath = document.FilePath ?? document.Name;
+                changes.Add(new FileChangeDto(
+                    FilePath: docPath,
+                    UnifiedDiff: DiffGenerator.GenerateUnifiedDiff(oldText, newText, docPath)));
+            }
+        }
+
+        if (changes.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"restructure_preview: no matches found for pattern in scope. " +
+                $"Verify pattern kind ({patternKind}), placeholder names, and scope filters.");
+        }
+
+        var description = $"Restructure {totalMatches} match(es) across {changes.Count} file(s)";
+        return (accumulator, changes, description);
+    }
+
     private static (SyntaxNode Node, string Kind) ParsePatternOrGoal(string text, string argName)
     {
         // Try expression first (most common case per the backlog examples); fall back to statement.

--- a/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
@@ -36,6 +36,19 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
     private readonly ICompositePreviewStore _compositePreviewStore;
     private readonly IDiRegistrationService _diRegistrationService;
 
+    // symbol-refactor-preview-auto-applies-without-explicit-apply-call: concrete-typed
+    // accessors for in-memory composite chaining. The interface fields above remain the
+    // canonical references for everything except PreviewAsync's per-step Solution
+    // threading; the DI registration only ever resolves to these concrete types
+    // (RoslynMcp.Roslyn/ServiceCollectionExtensions.cs:67-69 + 71-73 + 78-80), so the
+    // downcast cannot fail under production wiring. Tests wiring a mock would
+    // surface as InvalidCastException at construction — the right outcome, since the
+    // composite path relies on the in-process Solution-threading semantics that mocks
+    // cannot reproduce.
+    private readonly RefactoringService _refactoringServiceConcrete;
+    private readonly EditService _editServiceConcrete;
+    private readonly RestructureService _restructureServiceConcrete;
+
     public SymbolRefactorService(
         IWorkspaceManager workspace,
         IPreviewStore previewStore,
@@ -52,8 +65,24 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
         _restructureService = restructureService;
         _compositePreviewStore = compositePreviewStore;
         _diRegistrationService = diRegistrationService;
+        _refactoringServiceConcrete = (RefactoringService)refactoringService;
+        _editServiceConcrete = (EditService)editService;
+        _restructureServiceConcrete = (RestructureService)restructureService;
     }
 
+    /// <summary>
+    /// Chains rename / edit / restructure operations in-memory and stores the accumulated
+    /// per-file mutations under one composite-preview token. The pre-fix implementation
+    /// auto-applied each sub-operation's preview to disk between steps so the next step's
+    /// service call could read the rewritten state from the live workspace — a side-effect
+    /// that wrote files and recorded ledger entries before the agent ever called
+    /// <c>apply_composite_preview</c> (gh #770). The current implementation threads a single
+    /// <see cref="Solution"/> snapshot through the loop via the concrete services'
+    /// <c>Preview*OnSolutionAsync</c> internal overloads, so no disk write or change-tracker
+    /// entry occurs at preview time. The composite token is stored in
+    /// <see cref="ICompositePreviewStore"/> (NOT <see cref="IPreviewStore"/>) so that
+    /// <c>apply_composite_preview</c>'s file-mutation replay path can redeem it.
+    /// </summary>
     public async Task<RefactoringPreviewDto> PreviewAsync(
         string workspaceId, IReadOnlyList<SymbolRefactorOperation> operations, CancellationToken ct)
     {
@@ -65,6 +94,8 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
 
         var aggregatedDiffs = new Dictionary<string, FileChangeDto>(StringComparer.OrdinalIgnoreCase);
         var descriptions = new List<string>();
+        var initialSolution = _workspace.GetCurrentSolution(workspaceId);
+        var accumulator = initialSolution;
 
         for (var i = 0; i < operations.Count; i++)
         {
@@ -72,18 +103,16 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
             var op = operations[i];
             try
             {
-                var stepPreview = await ExecuteOperationAsync(workspaceId, op, ct).ConfigureAwait(false);
-                descriptions.Add($"[{i + 1}/{operations.Count}] {op.Kind}: {stepPreview.Description}");
+                var (nextSolution, stepChanges, stepDescription) =
+                    await ExecuteOperationOnSolutionAsync(accumulator, op, ct).ConfigureAwait(false);
 
-                foreach (var change in stepPreview.Changes)
+                descriptions.Add($"[{i + 1}/{operations.Count}] {op.Kind}: {stepDescription}");
+                accumulator = nextSolution;
+
+                foreach (var change in stepChanges)
                 {
                     aggregatedDiffs[change.FilePath] = change;
                 }
-
-                // The previous step persisted its own preview token; we don't need it after the
-                // text changes have flowed into the workspace. Apply the step so the next op
-                // sees the rewritten state.
-                await _refactoringService.ApplyRefactoringAsync(stepPreview.PreviewToken, "symbol_refactor_preview", ct).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -98,13 +127,15 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
             }
         }
 
-        // After applying every step the workspace now reflects the final state. Snapshot the
-        // current solution and store it as the composite preview token. (Note: each sub-op
-        // already wrote to disk via apply — symbol_refactor_apply will be a no-op; this hands
-        // the user a unified diff while leaving the workspace in the post-refactor state.)
-        var finalSolution = _workspace.GetCurrentSolution(workspaceId);
+        // Build a CompositeFileMutation list from the accumulated Solution diff. The redeem
+        // path (apply_composite_preview / CompositeApplyOrchestrator) iterates this list and
+        // performs a plain File.WriteAllText per entry, so we materialize per-file text snapshots
+        // here from the post-final-op Solution.
+        var mutations = await BuildCompositeMutationsAsync(initialSolution, accumulator, ct).ConfigureAwait(false);
+
         var description = "Composite refactor:\n  " + string.Join("\n  ", descriptions);
-        var token = _previewStore.Store(workspaceId, finalSolution, _workspace.GetCurrentVersion(workspaceId), description);
+        var token = _compositePreviewStore.Store(
+            workspaceId, _workspace.GetCurrentVersion(workspaceId), description, mutations);
 
         return new RefactoringPreviewDto(
             PreviewToken: token,
@@ -113,42 +144,98 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
             Warnings: null);
     }
 
-    private async Task<RefactoringPreviewDto> ExecuteOperationAsync(
-        string workspaceId, SymbolRefactorOperation op, CancellationToken ct)
+    private async Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        ExecuteOperationOnSolutionAsync(Solution inputSolution, SymbolRefactorOperation op, CancellationToken ct)
     {
         return op.Kind?.ToLowerInvariant() switch
         {
-            "rename" => await ExecuteRenameAsync(workspaceId, op, ct).ConfigureAwait(false),
-            "edit" => await ExecuteEditAsync(workspaceId, op, ct).ConfigureAwait(false),
-            "restructure" => await ExecuteRestructureAsync(workspaceId, op, ct).ConfigureAwait(false),
+            "rename" => await ExecuteRenameOnSolutionAsync(inputSolution, op, ct).ConfigureAwait(false),
+            "edit" => await ExecuteEditOnSolutionAsync(inputSolution, op, ct).ConfigureAwait(false),
+            "restructure" => await ExecuteRestructureOnSolutionAsync(inputSolution, op, ct).ConfigureAwait(false),
             _ => throw new ArgumentException(
                 $"Unsupported operation kind '{op.Kind}'. Valid: rename, edit, restructure."),
         };
     }
 
-    private Task<RefactoringPreviewDto> ExecuteRenameAsync(string workspaceId, SymbolRefactorOperation op, CancellationToken ct)
+    private Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        ExecuteRenameOnSolutionAsync(Solution inputSolution, SymbolRefactorOperation op, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(op.NewName))
             throw new ArgumentException("kind='rename' requires NewName.");
         var locator = new SymbolLocator(op.FilePath, op.Line, op.Column, op.SymbolHandle, op.MetadataName);
         locator.Validate();
-        return _refactoringService.PreviewRenameAsync(workspaceId, locator, op.NewName, ct);
+        return _refactoringServiceConcrete.PreviewRenameOnSolutionAsync(inputSolution, locator, op.NewName, ct);
     }
 
-    private Task<RefactoringPreviewDto> ExecuteEditAsync(string workspaceId, SymbolRefactorOperation op, CancellationToken ct)
+    private async Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        ExecuteEditOnSolutionAsync(Solution inputSolution, SymbolRefactorOperation op, CancellationToken ct)
     {
         if (op.FileEdits is null || op.FileEdits.Count == 0)
             throw new ArgumentException("kind='edit' requires FileEdits.");
-        return _editService.PreviewMultiFileTextEditsAsync(workspaceId, op.FileEdits, ct, skipSyntaxCheck: false);
+        var (newSolution, changes, description, _) = await _editServiceConcrete
+            .PreviewMultiFileTextEditsOnSolutionAsync(inputSolution, op.FileEdits, ct, skipSyntaxCheck: false)
+            .ConfigureAwait(false);
+        return (newSolution, changes, description);
     }
 
-    private Task<RefactoringPreviewDto> ExecuteRestructureAsync(string workspaceId, SymbolRefactorOperation op, CancellationToken ct)
+    private Task<(Solution NewSolution, IReadOnlyList<FileChangeDto> Changes, string Description)>
+        ExecuteRestructureOnSolutionAsync(Solution inputSolution, SymbolRefactorOperation op, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(op.Pattern) || op.Goal is null)
             throw new ArgumentException("kind='restructure' requires Pattern and Goal.");
-        return _restructureService.PreviewRestructureAsync(
-            workspaceId, op.Pattern, op.Goal,
+        return _restructureServiceConcrete.PreviewRestructureOnSolutionAsync(
+            inputSolution, op.Pattern, op.Goal,
             new RestructureScope(op.ScopeFilePath, op.ScopeProjectName), ct);
+    }
+
+    /// <summary>
+    /// Walks the Solution diff between <paramref name="initialSolution"/> and
+    /// <paramref name="finalSolution"/> and materializes a
+    /// <see cref="CompositeFileMutation"/> per changed / added / removed document. The
+    /// composite-apply redeem path (<c>CompositeApplyOrchestrator.ApplyCompositeAsync</c>)
+    /// iterates the list and writes per-entry via <see cref="File.WriteAllTextAsync(string, string?, CancellationToken)"/>
+    /// — no Solution snapshot is consulted at apply time, so the snapshot's lineage to the
+    /// post-apply workspace is irrelevant here.
+    /// </summary>
+    private static async Task<IReadOnlyList<CompositeFileMutation>> BuildCompositeMutationsAsync(
+        Solution initialSolution, Solution finalSolution, CancellationToken ct)
+    {
+        var mutations = new List<CompositeFileMutation>();
+        var solutionChanges = finalSolution.GetChanges(initialSolution);
+
+        foreach (var projectChange in solutionChanges.GetProjectChanges())
+        {
+            foreach (var docId in projectChange.GetChangedDocuments())
+            {
+                ct.ThrowIfCancellationRequested();
+                var newDoc = finalSolution.GetDocument(docId);
+                if (newDoc is null) continue;
+                var newText = (await newDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+                var filePath = newDoc.FilePath ?? newDoc.Name;
+                mutations.Add(new CompositeFileMutation(filePath, newText));
+            }
+
+            foreach (var docId in projectChange.GetAddedDocuments())
+            {
+                ct.ThrowIfCancellationRequested();
+                var newDoc = finalSolution.GetDocument(docId);
+                if (newDoc is null) continue;
+                var newText = (await newDoc.GetTextAsync(ct).ConfigureAwait(false)).ToString();
+                var filePath = newDoc.FilePath ?? newDoc.Name;
+                mutations.Add(new CompositeFileMutation(filePath, newText));
+            }
+
+            foreach (var docId in projectChange.GetRemovedDocuments())
+            {
+                ct.ThrowIfCancellationRequested();
+                var oldDoc = initialSolution.GetDocument(docId);
+                if (oldDoc is null) continue;
+                var filePath = oldDoc.FilePath ?? oldDoc.Name;
+                mutations.Add(new CompositeFileMutation(filePath, UpdatedContent: null, DeleteFile: true));
+            }
+        }
+
+        return mutations;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/SymbolRefactorPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolRefactorPreviewTests.cs
@@ -1,0 +1,253 @@
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression tests for <c>symbol-refactor-preview-auto-applies-without-explicit-apply-call</c>
+/// (gh #770). Pre-fix, <see cref="SymbolRefactorService.PreviewAsync"/> chained each
+/// sub-operation by calling <c>RefactoringService.ApplyRefactoringAsync</c> between steps so
+/// the next step could read the rewritten state from the live workspace — a side-effect that
+/// wrote files to disk and recorded change-tracker entries before the agent ever called
+/// <c>apply_composite_preview</c>. The fix threads a single <see cref="Microsoft.CodeAnalysis.Solution"/>
+/// snapshot through the loop and stores the accumulated mutations under one composite-preview
+/// token, deferring all disk writes until the apply call.
+///
+/// <para>
+/// The three scenarios pinned here cover the validation requirements in the plan:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     Single rename op: preview alone leaves the on-disk file unchanged and the
+///     <see cref="IChangeTracker"/> ledger empty for the workspace.
+///   </description></item>
+///   <item><description>
+///     Two chained ops (rename then edit): same no-side-effect assertions after preview.
+///   </description></item>
+///   <item><description>
+///     Redeem the composite token via <see cref="CompositeApplyOrchestrator.ApplyCompositeAsync"/>:
+///     both edits land on disk AND <see cref="IChangeTracker.GetChanges"/> shows exactly ONE
+///     entry whose <c>ToolName</c> is <c>apply_composite_preview</c> (the inner-apply
+///     entries that polluted the ledger pre-fix are gone).
+///   </description></item>
+/// </list>
+/// </summary>
+[TestClass]
+public sealed class SymbolRefactorPreviewTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task SingleRenameOp_Preview_DoesNotWriteToDisk_AndChangeTrackerStaysEmpty()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        var dogFile = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+        var dogFilePath = dogFile.FilePath!;
+        var originalContent = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        ChangeTracker.Clear(wsId);
+
+        var compositeStore = new CompositePreviewStore();
+        var service = CreateSymbolRefactorService(compositeStore);
+
+        var preview = await service.PreviewAsync(
+            wsId,
+            new[]
+            {
+                new SymbolRefactorOperation(
+                    Kind: "rename",
+                    MetadataName: "SampleLib.Dog",
+                    NewName: "Puppy"),
+            },
+            CancellationToken.None);
+
+        // Preview MUST be inert: file content on disk unchanged.
+        var afterPreview = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalContent, afterPreview,
+            "symbol_refactor_preview must NOT write to disk; the pre-fix auto-apply-each-step behavior is the regression.");
+
+        // Change tracker MUST be empty (no inner apply fired).
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(0, changes.Count,
+            $"symbol_refactor_preview must NOT record any change-tracker entries pre-apply. Got: [{string.Join(", ", changes.Select(c => c.ToolName))}]");
+
+        // Preview must still return a usable composite token.
+        Assert.IsFalse(string.IsNullOrEmpty(preview.PreviewToken),
+            "A successful preview must return a non-empty composite token.");
+        var retrieved = compositeStore.Retrieve(preview.PreviewToken);
+        Assert.IsNotNull(retrieved,
+            "The returned token must be retrievable from the composite-preview store, not the legacy IPreviewStore.");
+        Assert.IsTrue(retrieved.Value.Mutations.Count > 0,
+            "The composite mutation list must contain at least one entry for the renamed file(s).");
+        Assert.IsTrue(retrieved.Value.Mutations.Any(m =>
+                string.Equals(m.FilePath, dogFilePath, StringComparison.OrdinalIgnoreCase)
+                && m.UpdatedContent is not null
+                && m.UpdatedContent.Contains("class Puppy", StringComparison.Ordinal)),
+            "The rename must surface in the stored mutation set as updated text containing the new identifier.");
+    }
+
+    [TestMethod]
+    public async Task ChainedRenameAndEditOps_Preview_DoesNotWriteToDisk_AndChangeTrackerStaysEmpty()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        var dogFile = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+        var dogFilePath = dogFile.FilePath!;
+        var originalContent = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        ChangeTracker.Clear(wsId);
+
+        var compositeStore = new CompositePreviewStore();
+        var service = CreateSymbolRefactorService(compositeStore);
+
+        // Chain: (1) rename `Dog` → `Puppy`, (2) edit a line in the renamed-but-not-yet-applied
+        // file. The edit's text-targeting still uses original-file coordinates because the
+        // rename only renames identifiers; line/column geometry is unchanged.
+        var preview = await service.PreviewAsync(
+            wsId,
+            new[]
+            {
+                new SymbolRefactorOperation(
+                    Kind: "rename",
+                    MetadataName: "SampleLib.Dog",
+                    NewName: "Puppy"),
+                new SymbolRefactorOperation(
+                    Kind: "edit",
+                    FileEdits: new[]
+                    {
+                        // Replace `"Woof"` on line 7 with `"Yip"` — covers the literal at column 24-30.
+                        new FileEditsDto(
+                            FilePath: dogFilePath,
+                            Edits: new[]
+                            {
+                                new TextEditDto(
+                                    StartLine: 7,
+                                    StartColumn: 30,
+                                    EndLine: 7,
+                                    EndColumn: 36,
+                                    NewText: "\"Yip\""),
+                            }),
+                    }),
+            },
+            CancellationToken.None);
+
+        // Preview MUST be inert on disk and ledger.
+        var afterPreview = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalContent, afterPreview,
+            "Chained symbol_refactor_preview must NOT write to disk after either sub-operation.");
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(0, changes.Count,
+            $"Chained symbol_refactor_preview must NOT record any change-tracker entries pre-apply. Got: [{string.Join(", ", changes.Select(c => c.ToolName))}]");
+
+        Assert.IsFalse(string.IsNullOrEmpty(preview.PreviewToken),
+            "Chained preview must return a non-empty composite token.");
+        var retrieved = compositeStore.Retrieve(preview.PreviewToken);
+        Assert.IsNotNull(retrieved, "Chained composite token must be retrievable.");
+
+        // Stored mutation for Dog.cs must include BOTH the rename and the literal edit.
+        var dogMutation = retrieved.Value.Mutations
+            .FirstOrDefault(m => string.Equals(m.FilePath, dogFilePath, StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(dogMutation,
+            "The stored mutation set must include an entry for the chained-edit target file.");
+        Assert.IsTrue(dogMutation.UpdatedContent!.Contains("class Puppy", StringComparison.Ordinal),
+            "The rename from op#1 must appear in the chained mutation's text.");
+        Assert.IsTrue(dogMutation.UpdatedContent.Contains("\"Yip\"", StringComparison.Ordinal),
+            "The literal edit from op#2 must appear in the chained mutation's text.");
+    }
+
+    [TestMethod]
+    public async Task RedeemCompositeToken_AppliesAllChainedEdits_AndChangeTrackerHasSingleEntry()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        var dogFile = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.Name == "Dog.cs");
+        var dogFilePath = dogFile.FilePath!;
+
+        ChangeTracker.Clear(wsId);
+
+        var compositeStore = new CompositePreviewStore();
+        var service = CreateSymbolRefactorService(compositeStore);
+
+        var preview = await service.PreviewAsync(
+            wsId,
+            new[]
+            {
+                new SymbolRefactorOperation(
+                    Kind: "rename",
+                    MetadataName: "SampleLib.Dog",
+                    NewName: "Puppy"),
+                new SymbolRefactorOperation(
+                    Kind: "edit",
+                    FileEdits: new[]
+                    {
+                        new FileEditsDto(
+                            FilePath: dogFilePath,
+                            Edits: new[]
+                            {
+                                new TextEditDto(
+                                    StartLine: 7,
+                                    StartColumn: 30,
+                                    EndLine: 7,
+                                    EndColumn: 36,
+                                    NewText: "\"Yip\""),
+                            }),
+                    }),
+            },
+            CancellationToken.None);
+
+        // Redeem through CompositeApplyOrchestrator (the production path for apply_composite_preview).
+        var orchestrator = new CompositeApplyOrchestrator(WorkspaceManager, compositeStore, ChangeTracker);
+        var applyResult = await orchestrator.ApplyCompositeAsync(preview.PreviewToken, CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, $"Composite apply must succeed; error={applyResult.Error}");
+
+        // Both edits must be on disk now.
+        var finalContent = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.IsTrue(finalContent.Contains("class Puppy", StringComparison.Ordinal),
+            $"Rename from op#1 must land on disk after redeem. Content: {finalContent}");
+        Assert.IsTrue(finalContent.Contains("\"Yip\"", StringComparison.Ordinal),
+            $"Literal edit from op#2 must land on disk after redeem. Content: {finalContent}");
+
+        // Change tracker must show exactly ONE entry attributed to apply_composite_preview.
+        // Pre-fix, this assertion would have failed: each chained sub-op recorded its own
+        // entry under the bogus "symbol_refactor_preview" tool name, polluting the ledger
+        // with N inner-apply records before the outer redeem fired.
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count,
+            $"Exactly one ledger entry expected after composite redeem; got [{string.Join(", ", changes.Select(c => c.ToolName))}].");
+        Assert.AreEqual("apply_composite_preview", changes[0].ToolName,
+            "The single ledger entry must be attributed to apply_composite_preview, not the inner sub-op tool name.");
+    }
+
+    private static SymbolRefactorService CreateSymbolRefactorService(CompositePreviewStore compositeStore)
+    {
+        // Mirrors CompositeSplitServiceDiPreviewTests.CreateSymbolRefactorService — we construct
+        // a fresh RestructureService per test (the shared one in TestBase is not exposed) and
+        // reuse the shared singletons for everything else.
+        var restructureService = new RestructureService(WorkspaceManager, PreviewStore);
+        return new SymbolRefactorService(
+            WorkspaceManager,
+            PreviewStore,
+            RefactoringService,
+            EditService,
+            restructureService,
+            compositeStore,
+            DiRegistrationService);
+    }
+}


### PR DESCRIPTION
## Summary

`symbol_refactor_preview` was applying each chained sub-operation to the workspace mid-preview, writing files to disk and recording change-tracker entries before the agent called any `*_apply` tool. Threads a single `Solution` snapshot through the sub-op loop instead and stores the accumulated mutations under one `apply_composite_preview`-redeemable token.

## Root cause

`SymbolRefactorService.PreviewAsync` chained ops by calling `RefactoringService.ApplyRefactoringAsync(stepPreview.PreviewToken, "symbol_refactor_preview", ct)` between steps so the next op's underlying preview service could read the rewritten state from the live workspace. Each apply persisted text changes via `PersistChangedDocumentsFromSolutionAsync` and recorded a ledger entry attributed to the bogus `symbol_refactor_preview` tool name (gh #770).

## Fix

- Added internal `Preview*OnSolutionAsync` overloads on `RefactoringService`, `EditService`, and `RestructureService` that mirror the public preview methods but operate on an explicit input `Solution` and return the post-op `Solution` snapshot. None of the new helpers touch the workspace manager, the preview store, the change tracker, or disk.
- Rewrote `SymbolRefactorService.PreviewAsync` to thread a single `Solution` accumulator through the loop via the new helpers.
- After the final op, the accumulated `Solution` diff is converted into a `List<CompositeFileMutation>` and stored in `ICompositePreviewStore` (the right store for the `apply_composite_preview` redeem path — `CompositeApplyOrchestrator` reads from it).

## Files changed

| File | Change |
|---|---|
| `src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs` | Rewrote `PreviewAsync` + 3 per-kind helpers; added `BuildCompositeMutationsAsync`. Constructor now also holds concrete-typed accessors for the internal overloads. |
| `src/RoslynMcp.Roslyn/Services/RefactoringService.cs` | Added internal `PreviewRenameOnSolutionAsync` overload. |
| `src/RoslynMcp.Roslyn/Services/EditService.cs` | Added internal `PreviewMultiFileTextEditsOnSolutionAsync` overload. |
| `src/RoslynMcp.Roslyn/Services/RestructureService.cs` | Added internal `PreviewRestructureOnSolutionAsync` overload. |
| `tests/RoslynMcp.Tests/SymbolRefactorPreviewTests.cs` | 3 regression tests covering no-side-effect preview semantics. |
| `changelog.d/symbol-refactor-preview-auto-applies-without-explicit-apply-call.md` | Changelog fragment. |

Production files touched: 4 (Rule 3 cap = 4).

## Validation

- `mcp__roslyn__compile_check` — zero errors, zero warnings across all 5 projects.
- New `SymbolRefactorPreviewTests` — 3/3 pass.
- Pre-existing `Preview` / `Refactor` / `Edit` / `Restructure` / `Composite` / `ChangeTracker` test surface — 282 tests pass.
- `eng/verify-ai-docs.ps1` — passed (32 skill files validated).
- `eng/verify-changelog-fragments.ps1` — fragment is valid.
- Full `eng/verify-release.ps1` runs on the self-hosted CI runner per repo policy.

## Test plan

- [x] Preview a single rename — file unchanged on disk, ledger empty.
- [x] Preview chained rename+edit — file unchanged on disk, ledger empty, both edits visible in the stored mutation set.
- [x] Redeem via `apply_composite_preview` — both edits land on disk, single ledger entry attributed to `apply_composite_preview`.
- [x] Compile-clean across the solution.
- [x] All adjacent preview/refactor/edit test surface remains green.

Closes: symbol-refactor-preview-auto-applies-without-explicit-apply-call