### PR TITLE
fix(tests): update audit-phase-runner.md path after PR #734 relocation

### DIFF
--- a/tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs
@@ -95,7 +95,7 @@ public sealed class AuditPhaseRunnerHandoffTests
     private static string ResolveRunnerPath()
     {
         var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
-        return Path.Combine(repoRoot, ".claude", "agents", "audit-phase-runner.md");
+        return Path.Combine(repoRoot, "agents", "audit-phase-runner.md");
     }
 
     private static string ResolveFullPromptPath()


### PR DESCRIPTION
## Summary

PR #734 (`chore: relocate audit-phase-runner and prune consumed reports`) moved `.claude/agents/audit-phase-runner.md` → `agents/audit-phase-runner.md` but did not update `AuditPhaseRunnerHandoffTests.ResolveRunnerPath()` at `tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs:98`.

Three tests have thrown `FileNotFoundException` on every PR's validate run since #734 merged:
- `Runner_FileExists_WithStructuredSummaryContract`
- `Runner_ForbidsMutationApplyAndGitActions`
- `PromptAndRunner_AgreeOnDelegatedPhaseSet`

One-line fix: drop the stale `.claude` segment from the path resolver.

## Why a precursor PR

This is a precursor for the 20260516T200033Z_backlog-sweep wave-1 PRs (#779, #780, #781, #782) whose CI is gated by the same validate step. Folding this into one of those PRs would mix an unrelated test fix into a feature PR; landing it as its own PR keeps the wave-1 PRs reviewable on their own merits.

## Test plan

- [x] Confirmed `agents/audit-phase-runner.md` exists on main (file is at the new location)
- [ ] CI validate run passes the three previously-failing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)