### PR TITLE
fix(audit): autonomous symbol selection for surface-test G2 subagents

### DIFF
--- a/agents/audit-phase-runner.md
+++ b/agents/audit-phase-runner.md
@@ -1,6 +1,6 @@
 ---
 name: audit-phase-runner
-description: Run one context-heavy /mcp-server-stress phase and return a compact structured summary to the orchestrator. Use for Phase 1 diagnostics, Phase 2 metrics, Phase 8 build/test validation, and Phase 8b concurrency stress. Never run Phase 6 refactoring or any preview/apply chain.
+description: Run one context-heavy /mcp-server-stress phase and return a compact structured summary to the orchestrator. Use for Phase 1 diagnostics, Phase 2 metrics, Phase 3 deep symbol analysis, Phase 4 flow analysis, Phase 8 build/test validation, and Phase 8b concurrency stress. Never run Phase 6 refactoring or any preview/apply chain.
 ---
 
 You are the phase runner for `/mcp-server-stress`. You execute exactly one delegated audit phase, then return a compact structured summary. You do not edit source files, do not open PRs, and do not merge.
@@ -9,7 +9,7 @@ You are the phase runner for `/mcp-server-stress`. You execute exactly one deleg
 
 The orchestrator supplies:
 
-- `phase` — one of `1`, `2`, `8`, or `8b`.
+- `phase` — one of `1`, `2`, `3`, `4`, `8`, or `8b`.
 - `repoRoot` — absolute path to the repository being audited.
 - `workspaceId` — loaded Roslyn workspace id, when the phase needs workspace-scoped tools.
 - `solutionPath` — loaded solution / project path.
@@ -26,6 +26,8 @@ Only these phases may be delegated:
 |---|---|---|
 | Phase 1 | Broad diagnostics scan | `compile_check`, `project_diagnostics`, targeted diagnostic explainers |
 | Phase 2 | Code quality metrics | complexity, cohesion, dead-code, dependency metrics |
+| Phase 3 | Deep symbol analysis | `symbol_search`, `symbol_info`, `type_hierarchy`, `find_implementations`, `find_references` |
+| Phase 4 | Flow analysis | `analyze_data_flow`, `analyze_control_flow`, `get_operations`, `trace_exception_flow` |
 | Phase 8 | Build and test validation | `build_workspace`, `test_related_files`, `test_run`, validation bundle |
 | Phase 8b | Concurrency stress | read fan-out, sequential baselines, bounded read/write probes |
 
@@ -38,6 +40,7 @@ All other phases stay inline with the orchestrator. Phase 6 refactoring and any 
 - If a tool fails, capture the tool name, error category, and shortest useful message. Do not paste full logs.
 - If a phase needs a long shell validation, summarize only the final exit code, elapsed time, test counts, and failure names.
 - Do not call any `*_apply`, `apply_*`, file-write, git-mutation, PR, or merge command.
+- Do not call `AskUserQuestion` under any circumstances. If input is insufficient (missing `workspaceId`, ambiguous phase scope, Phase 2 data absent with no fallback rule, or any other gap), return `blocked` per the Input Contract — never ask the operator. The selection rules in Phase 3 and Phase 4 prompt excerpts are deterministic; apply them and proceed, or return `blocked` if even the alphabetical fallback cannot be computed.
 - Return one final structured summary and stop.
 
 ## Budget and truncation contract (load-bearing)

--- a/changelog.d/surface-test-subagent-symbol-selection-must-be-autonomous.md
+++ b/changelog.d/surface-test-subagent-symbol-selection-must-be-autonomous.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `audit-phase-runner` subagents dispatched for Phases 3 and 4 of `/mcp-server-surface-test --full` now use a deterministic type/method selection rule (top-N by cyclomatic score; alphabetical fallback) and are explicitly prohibited from calling `AskUserQuestion`.

--- a/skills/mcp-server-surface-test/prompts/full.md
+++ b/skills/mcp-server-surface-test/prompts/full.md
@@ -88,7 +88,8 @@ Execute phases in the order stated in the *Phase order* line above: **-1 → 0 �
 This orchestrator delegates log-heavy read-side phases to the `audit-phase-runner` agent via the **Subagent dispatch groups** defined in `prompts/phases/setup-and-analysis.md`. The dispatch groups are:
 
 - **Group A** (read-side diagnostics and metrics): phases 1, 2
-- **Group B** (build, test, concurrency): phases 7, 8, 8b
+- **Group B** (symbol and flow analysis on selected types/methods): phases 3, 4
+- **Group C** (build, test, concurrency): phases 7, 8, 8b
 
 **Orchestrator-owned phases** (never delegated): Phase 6 **setup** and teardown of the disposable worktree remain in this orchestrator. The try/finally discipline for the worktree must live in this single surviving caller — a crashed runner subagent must not leak an open worktree. All preview/apply chains in Phase 6 stay inline.
 

--- a/skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md
+++ b/skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md
@@ -86,6 +86,8 @@ Group all dispatches in a single message with multiple `Agent` tool-use blocks w
 
 Each subagent prompt must include: (a) the workspace `workspaceId` (already loaded — subagents reuse the orchestrator's MCP session, no `workspace_load` needed), (b) the audit report path (read-only — for context only, do not write), (c) the disposable worktree path when relevant (G4 only), (d) the explicit phase numbers + the relevant prompt section excerpt, (e) "return a compact structured summary in <RESULT> envelope" instruction. The orchestrator pastes each returned summary into the report under the matching phase heading.
 
+**G2 data passthrough (Phase 2 → Phase 3/4):** When dispatching G2, the orchestrator MUST also paste Phase 2's `get_complexity_metrics` result (or a compact projection of it: list of `{ symbol, kind, cyclomatic }` entries sorted descending by cyclomatic score) into the subagent brief. Phase 3 and Phase 4 selection rules ("top-N by cyclomatic score") require this data — without it, the subagent falls back to alphabetical selection (functionally correct, less targeted). If G1 was skipped or its Phase 2 result was empty, paste an explicit `complexity: none` marker so the subagent knows to use the alphabetical fallback rather than ask.
+
 **Completion gate (load-bearing — replaces the soft `skipped-budget` fallback):**
 
 Any subagent that returns `skipped-budget`, `skipped-context`, `truncated`, or any equivalent self-imposed-limit marker for a phase is a **hard FAIL** of the `--full` contract. The orchestrator must either (a) re-dispatch that phase to a fresh subagent with a smaller scope, or (b) record `phase-failed-budget` in the coverage ledger and surface it in the report's *Coverage summary* as a P1 audit defect. Silent truncation labeled as "representative probe" is no longer an acceptable outcome — `--full` means full or it means honest failure with a named cause.
@@ -136,6 +138,8 @@ When the SKILL receives `--single-agent`, skip this dispatch plan and run all ph
 
 ### Phase 3: Deep symbol analysis (pick 3–5 key types)
 
+**Selection rule (deterministic, do not ask the operator):** Select types by descending cyclomatic score from Phase 2's `get_complexity_metrics` result — take the top 3–5. If Phase 2 did not run or returned no results, fall back to the first 3–5 type names in alphabetical order from `document_symbols` on the primary project's root namespace. Subagents dispatched for this phase must never call `AskUserQuestion` to disambiguate — apply the rule, record the resulting type list in the summary, and proceed.
+
 For each key type:
 
 1. `symbol_search` to locate by name.
@@ -162,6 +166,8 @@ For each key type:
 ---
 
 ### Phase 4: Flow analysis (pick 3–5 complex methods)
+
+**Selection rule (deterministic, do not ask the operator):** Select methods by descending cyclomatic score from Phase 2's `get_complexity_metrics` result with score > 5 — take the top 3–5. If Phase 2 did not run, returned no scores above the threshold, or returned no results at all, fall back to the first 3–5 method names in alphabetical order from `document_symbols` on the primary project's root namespace. Subagents dispatched for this phase must never call `AskUserQuestion` to disambiguate — apply the rule, record the resulting method list in the summary, and proceed.
 
 For each:
 

--- a/tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs
@@ -68,13 +68,15 @@ public sealed class AuditPhaseRunnerHandoffTests
     [TestMethod]
     public void PromptAndRunner_AgreeOnDelegatedPhaseSet()
     {
-        // The runner agent declares the contract: phase parameter is one of `1`, `2`, `8`, or `8b`.
+        // The runner agent declares the contract: phase parameter is one of `1`, `2`, `3`, `4`, `8`, or `8b`.
         // The canonical prompt's Phase 0.5 dispatch plan must include those phase numbers somewhere
-        // in its group tables so the two files stay in sync.
+        // in its group tables so the two files stay in sync. Phase 3 (deep symbol analysis) and
+        // Phase 4 (flow analysis) were added in the surface-test-subagent-symbol-selection-must-be-autonomous
+        // initiative so G2 subagents have a codified phase listing and selection rule.
         var prompt = File.ReadAllText(ResolveFullPromptPath());
         var runner = File.ReadAllText(ResolveRunnerPath());
 
-        StringAssert.Contains(runner, "one of `1`, `2`, `8`, or `8b`");
+        StringAssert.Contains(runner, "one of `1`, `2`, `3`, `4`, `8`, or `8b`");
 
         // Each of these phase numbers must appear in the prompt's dispatch plan section. We don't
         // pin exact group placement because Phase 0.5 may legitimately re-group phases across
@@ -86,7 +88,7 @@ public sealed class AuditPhaseRunnerHandoffTests
         Assert.IsTrue(dispatchPlanEnd > dispatchPlanStart, "Phase 1 section not found after Phase 0.5 in full.md");
         var dispatchPlan = prompt[dispatchPlanStart..dispatchPlanEnd];
 
-        foreach (var phase in new[] { "1, 2", "7, 8, 8b" })
+        foreach (var phase in new[] { "1, 2", "3, 4", "7, 8, 8b" })
         {
             StringAssert.Contains(dispatchPlan, phase);
         }


### PR DESCRIPTION
## Summary

Two-gap fix in the `/mcp-server-surface-test --full` Phase 3/4 → `audit-phase-runner` subagent handoff: previously Phase 3 ("pick 3–5 key types") and Phase 4 ("pick 3–5 complex methods") gave no deterministic selection rule, and `audit-phase-runner.md` neither listed those phases in its Allowed Phases table nor prohibited `AskUserQuestion`. A 2026-05-16 SysLog-Server retro showed a G2 subagent could stall waiting on the operator.

**Edits (5 files):**

- `skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md` — added explicit selection rules to Phase 3 (top-N by cyclomatic, alphabetical fallback) and Phase 4 (top-N by cyclomatic > 5, alphabetical fallback). Added a G2 data-passthrough clause to the Phase 0.5 dispatch contract so the subagent brief carries Phase 2's complexity metrics.
- `agents/audit-phase-runner.md` — added Phase 3 and Phase 4 rows to the Allowed Phases table (preserving numeric order), updated the description and phase-param contract, and added an explicit `AskUserQuestion` prohibition bullet to Execution Rules (ordering: tool-preference → output-discipline → mutation-prohibition → ask-prohibition → terminator).
- `skills/mcp-server-surface-test/prompts/full.md` — added a "Group B (symbol and flow analysis): phases 3, 4" line to the dispatch summary so the orchestrator surface matches the detail file.
- `tests/RoslynMcp.Tests/Skills/AuditPhaseRunnerHandoffTests.cs` — updated `PromptAndRunner_AgreeOnDelegatedPhaseSet` to track the expanded `1`, `2`, `3`, `4`, `8`, `8b` phase set and assert `"3, 4"` appears in the prompt's dispatch plan.
- `changelog.d/surface-test-subagent-symbol-selection-must-be-autonomous.md` — Fixed-category fragment for `/bump` consumption.

**Why not just edit the prompt files only:** the runner contract test (`AuditPhaseRunnerHandoffTests.PromptAndRunner_AgreeOnDelegatedPhaseSet`) hard-asserts the exact phase-param phrase from `audit-phase-runner.md`. Expanding the allowed set without updating the test would have broken CI. Per session policy ("correctness over cheap"), the test was updated to track the contract rather than work around it. Total edit count is 4 production files + 1 fragment, within the 4-file Rule 3 budget (the fragment doesn't count against production scope).

## Test plan

- [x] `mcp__roslyn__compile_check` on `AuditPhaseRunnerHandoffTests.cs` — 0 errors after `dotnet restore`.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~AuditPhaseRunnerHandoffTests` — 5/5 pass.
- [x] `./eng/verify-ai-docs.ps1` — passes (no broken markdown links).
- [x] `./eng/verify-changelog-fragments.ps1` — 5 fragments valid.
- [ ] Manual `/mcp-server-surface-test --full` re-run against a loaded workspace to confirm no `AskUserQuestion` calls in Phases 3/4 subagent transcripts (deferred — covered by the next stress audit cycle).
- [ ] CI (self-hosted runner) verify-release.ps1 — pending PR check run.

Closes: `surface-test-subagent-symbol-selection-must-be-autonomous`

🤖 Generated with [Claude Code](https://claude.com/claude-code)