### PR TITLE
fix(tools): paginate get_di_registrations default response (get-di-registrations-default-response-exceeds-mcp-cap)

### DIFF
--- a/changelog.d/get-di-registrations-default-response-exceeds-mcp-cap.md
+++ b/changelog.d/get-di-registrations-default-response-exceeds-mcp-cap.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `get_di_registrations` default response now returns a bounded first page (`offset` / `limit`, default 100 registrations) with `totalCount` / `hasMore` metadata, preventing MCP inline transport cap overflow on large DI graphs (fixes gh #771).

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -52,18 +52,25 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_di_registrations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Inspect DI registration patterns in source."),
-     Description("Scan the solution for dependency injection registrations (AddSingleton, AddScoped, AddTransient) and return the service-to-implementation mappings. Pass showLifetimeOverrides=true to additionally emit per-service-type override chains (winning lifetime, lifetime-mismatch flag, dead-registration count) — opt-in to keep the default payload shape stable. Pass summary=true for large graphs to return aggregate counts plus a bounded page of override-chain summaries instead of full registrations/overrideChains.")]
+     Description("Scan the solution for dependency injection registrations (AddSingleton, AddScoped, AddTransient) and return the service-to-implementation mappings. " +
+        "Paginated via offset/limit (default limit=100) to bound response size on large DI graphs — callers on solutions with > limit registrations " +
+        "should iterate by increasing offset until hasMore=false. totalCount counts ALL registrations in the queried scope; the paged registrations slice " +
+        "contains only the [offset, offset+limit) window. Pass showLifetimeOverrides=true to additionally emit per-service-type override chains (winning lifetime, " +
+        "lifetime-mismatch flag, dead-registration count) — opt-in to keep the default payload shape stable; pagination applies identically to the registrations list " +
+        "in this mode while overrideChains remains unpaged (use summary=true if the override-chain list also needs paging). " +
+        "Pass summary=true for large graphs to return aggregate counts plus a bounded page of override-chain summaries instead of full registrations/overrideChains.")]
     public static Task<string> GetDiRegistrations(
         IWorkspaceExecutionGate gate,
         IDiRegistrationService diRegistrationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: filter by project name")] string? projectName = null,
-        [Description("When true, also emit overrideChains[] grouping registrations by service type with the winning lifetime, lifetime-mismatch flag (Singleton vs Scoped vs Transient), and dead-registration count. Default: false (legacy shape: count + registrations[]).")] bool showLifetimeOverrides = false,
-        [Description("When true, return a compact aggregate shape for large DI graphs. The detailed legacy/default response is unchanged when false.")] bool summary = false,
-        [Description("0-based offset into the compact override-chain summary page when summary=true. Ignored for detailed responses.")] int offset = 0,
-        [Description("Maximum override-chain summaries returned when summary=true. Clamped to [1, 500]. Ignored for detailed responses.")] int limit = 50,
+        [Description("When true, also emit overrideChains[] grouping registrations by service type with the winning lifetime, lifetime-mismatch flag (Singleton vs Scoped vs Transient), and dead-registration count. Default: false (legacy shape: count + registrations[] — now augmented with totalCount/hasMore/offset/limit for paging).")] bool showLifetimeOverrides = false,
+        [Description("When true, return a compact aggregate shape for large DI graphs. The detailed/default response is paginated via offset/limit when false.")] bool summary = false,
+        [Description("0-based offset into the paginated response. Applies to the registrations list in detailed mode and to the override-chain summary page when summary=true.")] int offset = 0,
+        [Description("Maximum items returned per call. Applies to the registrations list in detailed mode (default 100) and to the override-chain summary page when summary=true (clamped to [1, 500]).")] int limit = 100,
         CancellationToken ct = default)
     {
+        ParameterValidation.ValidatePagination(offset, limit);
         return gate.RunReadAsync(workspaceId, async c =>
         {
             if (!showLifetimeOverrides)
@@ -76,11 +83,25 @@ public static class AdvancedAnalysisTools
                         JsonDefaults.Indented);
                 }
 
-                return JsonSerializer.Serialize(new { count = results.Count, registrations = results }, JsonDefaults.Indented);
+                // gh #771: bound the detailed response to a paged window. Mirrors find_type_usages /
+                // find_reflection_usages envelope — collect-all + Skip/Take; totalCount = full count;
+                // hasMore = (offset + count) < totalCount.
+                var pagedResults = results.Skip(offset).Take(limit).ToList();
+                var resultsHasMore = offset + pagedResults.Count < results.Count;
+                return JsonSerializer.Serialize(new
+                {
+                    count = pagedResults.Count,
+                    totalCount = results.Count,
+                    offset,
+                    limit,
+                    hasMore = resultsHasMore,
+                    registrations = pagedResults,
+                }, JsonDefaults.Indented);
             }
 
-            // di-lifetime-mismatch-detection: opt-in path returns the legacy registrations
-            // list (unchanged shape) plus the per-service-type override chains.
+            // di-lifetime-mismatch-detection: opt-in path returns the (paged) registrations
+            // list plus the per-service-type override chains. Override-chain output remains
+            // unpaged in this mode — callers needing chain-level paging use summary=true.
             var scan = await diRegistrationService.GetDiRegistrationsWithOverridesAsync(workspaceId, projectName, c);
             if (summary)
             {
@@ -89,10 +110,19 @@ public static class AdvancedAnalysisTools
                     JsonDefaults.Indented);
             }
 
+            // gh #771: same paging contract for the registrations list when override chains
+            // are also emitted. overrideChainCount/overrideChains continue to reflect the
+            // full chain set unchanged.
+            var pagedRegistrations = scan.Registrations.Skip(offset).Take(limit).ToList();
+            var registrationsHasMore = offset + pagedRegistrations.Count < scan.Registrations.Count;
             return JsonSerializer.Serialize(new
             {
-                count = scan.Registrations.Count,
-                registrations = scan.Registrations,
+                count = pagedRegistrations.Count,
+                totalCount = scan.Registrations.Count,
+                offset,
+                limit,
+                hasMore = registrationsHasMore,
+                registrations = pagedRegistrations,
                 overrideChainCount = scan.OverrideChains.Count,
                 overrideChains = scan.OverrideChains,
             }, JsonDefaults.Indented);

--- a/tests/RoslynMcp.Tests/DiLifetimeOverrideTests.cs
+++ b/tests/RoslynMcp.Tests/DiLifetimeOverrideTests.cs
@@ -179,6 +179,113 @@ public sealed class DiLifetimeOverrideTests : IsolatedWorkspaceTestBase
     }
 
     /// <summary>
+    /// gh #771: the detailed default response previously serialized the entire registrations
+    /// list with no cap, producing an 86 KB body on a 141-registration DI graph that exceeded
+    /// the MCP inline transport cap. The fix paginates the detailed response via offset/limit
+    /// (default limit=100) and emits totalCount/hasMore/offset/limit alongside the paged
+    /// registrations slice. This test writes 101 distinct service-type registrations and
+    /// verifies the default call returns a bounded first page with hasMore=true.
+    /// </summary>
+    [TestMethod]
+    public async Task Default_Detailed_Response_Pages_Registrations_With_Hundred_Item_Default_Limit()
+    {
+        const int TotalRegistrations = 101;
+
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await WriteServiceCollectionShimAsync(workspace, CancellationToken.None);
+        await WriteManyRegistrationsAsync(workspace, TotalRegistrations, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        // showLifetimeOverrides=false, summary=false → exercises the detailed default path
+        // at AdvancedAnalysisTools.cs:79 with default offset=0, limit=100.
+        var jsonDefault = await AdvancedAnalysisTools.GetDiRegistrations(
+            WorkspaceExecutionGate,
+            DiRegistrationService,
+            workspace.WorkspaceId,
+            projectName: "SampleLib",
+            showLifetimeOverrides: false,
+            summary: false,
+            ct: CancellationToken.None);
+
+        using var documentDefault = JsonDocument.Parse(jsonDefault);
+        var rootDefault = documentDefault.RootElement;
+        Assert.AreEqual(100, rootDefault.GetProperty("count").GetInt32(),
+            "Default limit=100 must bound the registrations slice.");
+        Assert.AreEqual(TotalRegistrations, rootDefault.GetProperty("totalCount").GetInt32(),
+            "totalCount must reflect the full registration count across the queried scope.");
+        Assert.AreEqual(0, rootDefault.GetProperty("offset").GetInt32());
+        Assert.AreEqual(100, rootDefault.GetProperty("limit").GetInt32());
+        Assert.IsTrue(rootDefault.GetProperty("hasMore").GetBoolean(),
+            "With 101 registrations and default limit=100, hasMore must be true.");
+        Assert.IsTrue(rootDefault.TryGetProperty("registrations", out var registrationsDefault));
+        Assert.AreEqual(100, registrationsDefault.GetArrayLength(),
+            "The paged registrations array must contain exactly limit entries.");
+
+        // Also verify the showLifetimeOverrides=true detailed path applies the same pagination
+        // to the registrations list (separate serialize site at AdvancedAnalysisTools.cs:92-98).
+        // Note: the override-chains output remains unpaged in this mode; pagination only applies
+        // to the registrations list. With 101 single-registration service types we expect zero
+        // override chains (services need >= 2 registrations to qualify).
+        var jsonOverrides = await AdvancedAnalysisTools.GetDiRegistrations(
+            WorkspaceExecutionGate,
+            DiRegistrationService,
+            workspace.WorkspaceId,
+            projectName: "SampleLib",
+            showLifetimeOverrides: true,
+            summary: false,
+            ct: CancellationToken.None);
+
+        using var documentOverrides = JsonDocument.Parse(jsonOverrides);
+        var rootOverrides = documentOverrides.RootElement;
+        Assert.AreEqual(100, rootOverrides.GetProperty("count").GetInt32(),
+            "Default limit=100 must bound the registrations slice on the overrides path too.");
+        Assert.AreEqual(TotalRegistrations, rootOverrides.GetProperty("totalCount").GetInt32());
+        Assert.IsTrue(rootOverrides.GetProperty("hasMore").GetBoolean(),
+            "hasMore must also be true on the overrides path with > limit registrations.");
+        Assert.IsTrue(rootOverrides.TryGetProperty("registrations", out var registrationsOverrides));
+        Assert.AreEqual(100, registrationsOverrides.GetArrayLength());
+        Assert.IsTrue(rootOverrides.TryGetProperty("overrideChainCount", out _),
+            "overrideChainCount must still be emitted on the overrides path.");
+        Assert.IsTrue(rootOverrides.TryGetProperty("overrideChains", out _),
+            "overrideChains must still be emitted on the overrides path.");
+    }
+
+    /// <summary>
+    /// Materialises <paramref name="count"/> distinct service-type registrations into the
+    /// workspace by emitting one file with <paramref name="count"/> interfaces, implementations,
+    /// and AddSingleton&lt;,&gt; calls — sufficient for exercising paging on the detailed
+    /// response shape without interacting with the shared shim used by the other tests.
+    /// </summary>
+    private static async Task WriteManyRegistrationsAsync(IsolatedWorkspaceScope workspace, int count, CancellationToken ct)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("namespace SampleLib;");
+        sb.AppendLine();
+        for (var i = 0; i < count; i++)
+        {
+            sb.Append("public interface IService").Append(i).AppendLine(" { }");
+            sb.Append("public sealed class Service").Append(i).Append("Impl : IService").Append(i).AppendLine(" { }");
+        }
+        sb.AppendLine();
+        sb.AppendLine("public static class ManyRegistrations");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static void Configure(IServiceCollection services)");
+        sb.AppendLine("    {");
+        for (var i = 0; i < count; i++)
+        {
+            sb.Append("        services.AddSingleton<IService").Append(i)
+              .Append(", Service").Append(i).AppendLine("Impl>();");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        await File.WriteAllTextAsync(
+            workspace.GetPath("SampleLib", "ManyRegistrations.cs"),
+            sb.ToString(),
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Writes a self-contained shim of <c>IServiceCollection</c> + extension methods to
     /// SampleLib. The DI registration walker matches by containing-type name shape
     /// ("ServiceCollection") and method-name lifetime mapping, so this gives full semantic


### PR DESCRIPTION
## Summary
- Bound `get_di_registrations` detailed response via `offset` / `limit` (default `limit=100`) and emit `totalCount` / `hasMore` / `offset` / `limit` alongside the paged registrations slice — previously serialized the entire registrations list with no cap, producing 86 KB+ bodies on 141-registration DI graphs that exceeded the MCP inline transport cap.
- Both non-summary paths (`showLifetimeOverrides=false` and `showLifetimeOverrides=true`) page the registrations list identically. Override-chains output remains unpaged in the overrides mode — callers needing chain-level paging continue to use `summary=true`.
- Envelope mirrors the existing `find_type_usages` (`AnalysisTools.cs:403-417`) and `find_reflection_usages` (`AdvancedAnalysisTools.cs:216-230`) paged shape; uses the shared `ParameterValidation.ValidatePagination(offset, limit)` helper.
- One new test method covers the 101-registration default-page contract for both detailed paths.

Closes: `get-di-registrations-default-response-exceeds-mcp-cap`
Fixes: gh #771

## Test plan
- [x] `mcp__roslyn__compile_check` on both edited files — zero errors / warnings.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~DiLifetimeOverrideTests` — 6/6 passed (5 existing + 1 new).
- [x] Adjacent regression check: `ExpandedSurfaceIntegrationTests.AdvancedAnalysisTools_Return_Expected_Results` + `Top10V2RegressionTests.GetDiRegistrations_RepeatCallSameVersion_ReturnsCachedReference` — 2/2 passed.
- [ ] CI (self-hosted runner): `./eng/verify-release.ps1 -Configuration Release` + `./eng/verify-ai-docs.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)