### PR TITLE
fix(test_coverage): emit structured failureEnvelope on cancel/unknown errors

### DIFF
--- a/changelog.d/test-coverage-timeout-failure-envelope.md
+++ b/changelog.d/test-coverage-timeout-failure-envelope.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `test_coverage` now returns a structured `failureEnvelope` (`errorKind=Timeout` or `errorKind=Unknown`) when the dotnet test run is cancelled or encounters an unexpected runner error, instead of surfacing a bare invocation exception to the MCP host.

--- a/src/RoslynMcp.Core/Models/TestCoverageDto.cs
+++ b/src/RoslynMcp.Core/Models/TestCoverageDto.cs
@@ -15,7 +15,7 @@ public sealed record TestCoverageResultDto(
 /// Structured failure envelope for test coverage operations, enabling programmatic
 /// detection of failure conditions (e.g., missing coverlet package).
 /// </summary>
-/// <param name="ErrorKind">Machine-readable bucket: <c>CoverletMissing</c>, <c>TestFailure</c>, <c>Unknown</c>.</param>
+/// <param name="ErrorKind">Machine-readable bucket: <c>CoverletMissing</c>, <c>TestFailure</c>, <c>Timeout</c>, <c>Unknown</c>.</param>
 /// <param name="IsRetryable">True when the caller can retry after fixing a transient condition.</param>
 /// <param name="Summary">Human-readable summary.</param>
 /// <param name="MissingPackages">

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -90,21 +90,69 @@ public static class TestCoverageTools
                 coverageDir
             };
 
-            var execution = await commandRunner.RunAsync(Path.GetDirectoryName(loadedPath)!, targetPath, arguments, c).ConfigureAwait(false);
-            ProgressHelper.Report(progress, 0.8f, 1);
+            // test-coverage-timeout-failure-envelope: wrap the runner invocation and the
+            // downstream coverage-file scan so that cancellation (MCP timeout, caller cancel)
+            // or an unexpected runner exception is reported as a structured failureEnvelope
+            // rather than escaping the gate lambda as a bare invocation error. Mirrors the
+            // WorkspaceValidationService pattern at lines 185-208 (OCE-then-Exception order)
+            // and the TestRunnerService timeout-envelope shape at lines 98-127.
+            try
+            {
+                var execution = await commandRunner.RunAsync(Path.GetDirectoryName(loadedPath)!, targetPath, arguments, c).ConfigureAwait(false);
+                ProgressHelper.Report(progress, 0.8f, 1);
 
-            // Find the coverage XML file
-            var coverageFiles = Directory.Exists(coverageDir)
-                ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
-                : [];
+                // Find the coverage XML file
+                var coverageFiles = Directory.Exists(coverageDir)
+                    ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
+                    : [];
 
-            if (coverageFiles.Length == 0)
+                if (coverageFiles.Length == 0)
+                {
+                    ProgressHelper.Report(progress, 1, 1);
+                    var errorKind = !execution.Succeeded ? "TestFailure" : "CoverletMissing";
+                    var summary = !execution.Succeeded
+                        ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found."
+                        : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.";
+                    return SerializeWithDeprecation(new TestCoverageResultDto(
+                        Success: false,
+                        Error: summary,
+                        LineCoveragePercent: null,
+                        BranchCoveragePercent: null,
+                        Modules: [],
+                        FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                            ErrorKind: errorKind,
+                            IsRetryable: errorKind == "TestFailure",
+                            Summary: summary)), deprecation);
+                }
+
+                var latestCoverage = coverageFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
+                var result = ParseCoberturaXml(latestCoverage);
+                ProgressHelper.Report(progress, 1, 1);
+                return SerializeWithDeprecation(result, deprecation);
+            }
+            catch (OperationCanceledException)
+            {
+                // OCE-first ordering: if the generic Exception catch is ordered first the
+                // cancellation path would be misclassified as Unknown. Do NOT re-throw —
+                // the gate lambda's return type is string and the caller expects a structured
+                // envelope identical to the other failure paths above.
+                ProgressHelper.Report(progress, 1, 1);
+                const string cancelSummary = "test_coverage was cancelled (timeout or caller cancellation).";
+                return SerializeWithDeprecation(new TestCoverageResultDto(
+                    Success: false,
+                    Error: cancelSummary,
+                    LineCoveragePercent: null,
+                    BranchCoveragePercent: null,
+                    Modules: [],
+                    FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                        ErrorKind: "Timeout",
+                        IsRetryable: false,
+                        Summary: cancelSummary)), deprecation);
+            }
+            catch (Exception ex)
             {
                 ProgressHelper.Report(progress, 1, 1);
-                var errorKind = !execution.Succeeded ? "TestFailure" : "CoverletMissing";
-                var summary = !execution.Succeeded
-                    ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found."
-                    : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.";
+                var summary = $"test_coverage failed with an unexpected error: {ex.Message}";
                 return SerializeWithDeprecation(new TestCoverageResultDto(
                     Success: false,
                     Error: summary,
@@ -112,15 +160,10 @@ public static class TestCoverageTools
                     BranchCoveragePercent: null,
                     Modules: [],
                     FailureEnvelope: new TestCoverageFailureEnvelopeDto(
-                        ErrorKind: errorKind,
-                        IsRetryable: errorKind == "TestFailure",
+                        ErrorKind: "Unknown",
+                        IsRetryable: false,
                         Summary: summary)), deprecation);
             }
-
-            var latestCoverage = coverageFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
-            var result = ParseCoberturaXml(latestCoverage);
-            ProgressHelper.Report(progress, 1, 1);
-            return SerializeWithDeprecation(result, deprecation);
         }, ct);
     }
 

--- a/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
@@ -1,0 +1,259 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the structured failure envelope for <c>test_coverage</c> — backlog row
+/// <c>test-coverage-timeout-failure-envelope</c> (P2). When the <c>dotnet test</c>
+/// runner is cancelled (MCP timeout, caller cancellation) or throws an unexpected
+/// exception, the tool must emit a typed <see cref="TestCoverageFailureEnvelopeDto"/>
+/// (<c>errorKind=Timeout</c> or <c>errorKind=Unknown</c>) instead of letting the
+/// bare exception escape <see cref="TestCoverageTools.RunTestCoverageCore"/> and
+/// surface to the MCP host as a raw invocation error.
+/// </summary>
+[TestClass]
+public sealed class TestCoverageFailureEnvelopeTests
+{
+    /// <summary>
+    /// (1) OCE thrown from <c>RunAsync</c> must be classified as <c>Timeout</c> with
+    /// <c>isRetryable=false</c>. The handler must not re-throw — the gate lambda
+    /// contract returns a JSON string and the caller expects a structured envelope.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_RunnerThrowsOperationCanceled_EmitsTimeoutEnvelope()
+    {
+        var gate = new PassthroughGate();
+        var workspace = new FakeWorkspaceManager();
+        var runner = new ThrowingDotnetCommandRunner(new OperationCanceledException("simulated cancel"));
+
+        var json = await TestCoverageTools.RunTestCoverageCore(
+            gate,
+            workspace,
+            runner,
+            workspaceId: "ws-coverage-timeout",
+            projectName: null,
+            deprecation: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.GetProperty("success").GetBoolean(),
+            "Cancelled coverage runs must report success=false.");
+
+        var envelope = root.GetProperty("failureEnvelope");
+        Assert.AreEqual(JsonValueKind.Object, envelope.ValueKind,
+            "Cancelled runs must populate failureEnvelope, not leave it null.");
+        Assert.AreEqual("Timeout", envelope.GetProperty("errorKind").GetString());
+        Assert.IsFalse(envelope.GetProperty("isRetryable").GetBoolean(),
+            "Timeout/cancellation is not transient — retry without a config change is wasted.");
+        StringAssert.Contains(envelope.GetProperty("summary").GetString() ?? string.Empty,
+            "cancelled");
+    }
+
+    /// <summary>
+    /// (2) An arbitrary <see cref="Exception"/> from <c>RunAsync</c> must be classified as
+    /// <c>Unknown</c> with the underlying message embedded in the summary so the caller
+    /// has a debuggable handle on what failed.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_RunnerThrowsUnknown_EmitsUnknownEnvelopeWithMessage()
+    {
+        var gate = new PassthroughGate();
+        var workspace = new FakeWorkspaceManager();
+        var runner = new ThrowingDotnetCommandRunner(new InvalidOperationException("disk full"));
+
+        var json = await TestCoverageTools.RunTestCoverageCore(
+            gate,
+            workspace,
+            runner,
+            workspaceId: "ws-coverage-unknown",
+            projectName: null,
+            deprecation: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.GetProperty("success").GetBoolean());
+
+        var envelope = root.GetProperty("failureEnvelope");
+        Assert.AreEqual(JsonValueKind.Object, envelope.ValueKind);
+        Assert.AreEqual("Unknown", envelope.GetProperty("errorKind").GetString());
+        Assert.IsFalse(envelope.GetProperty("isRetryable").GetBoolean(),
+            "Unknown failures default to non-retryable until a caller can classify them.");
+        StringAssert.Contains(envelope.GetProperty("summary").GetString() ?? string.Empty,
+            "disk full",
+            "Underlying exception message must surface in the summary for debuggability.");
+    }
+
+    /// <summary>
+    /// (3) Regression guard — a normal <c>RunAsync</c> return with <c>Succeeded=false</c>
+    /// and <c>ExitCode=1</c> must still emit the pre-existing <c>TestFailure</c> envelope
+    /// at <c>TestCoverageTools.cs:104-117</c>. Adding the new exception-path catches must
+    /// not shadow the no-coverage-file fallback for a successfully-invoked runner.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_RunnerReturnsExit1NoCoverageFile_EmitsTestFailureEnvelope()
+    {
+        var gate = new PassthroughGate();
+        var workspace = new FakeWorkspaceManager();
+        var failingExecution = new CommandExecutionDto(
+            Command: "dotnet",
+            Arguments: ["test", "sample.csproj"],
+            WorkingDirectory: "C:/fake/workdir",
+            TargetPath: "C:/fake/workdir/sample.csproj",
+            ExitCode: 1,
+            Succeeded: false,
+            DurationMs: 1234,
+            StdOut: "Failing test detected",
+            StdErr: string.Empty);
+        var runner = new StaticDotnetCommandRunner(failingExecution);
+
+        var json = await TestCoverageTools.RunTestCoverageCore(
+            gate,
+            workspace,
+            runner,
+            workspaceId: "ws-coverage-testfailure",
+            projectName: null,
+            deprecation: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.GetProperty("success").GetBoolean());
+
+        var envelope = root.GetProperty("failureEnvelope");
+        Assert.AreEqual(JsonValueKind.Object, envelope.ValueKind);
+        Assert.AreEqual("TestFailure", envelope.GetProperty("errorKind").GetString(),
+            "Pre-existing TestFailure path must remain reachable — the new catch blocks " +
+            "guard only the exception path, not the no-coverage-file fallback.");
+        Assert.IsTrue(envelope.GetProperty("isRetryable").GetBoolean(),
+            "TestFailure is retryable once the test is fixed.");
+    }
+
+    // ── Test doubles ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Minimal stand-in for <see cref="IWorkspaceExecutionGate"/> that invokes the lambda
+    /// directly with the caller-supplied cancellation token. Mirrors the
+    /// <c>PassthroughWorkspaceExecutionGate</c> shape from <c>WorkspaceCachePrewarmTests</c>.
+    /// </summary>
+    private sealed class PassthroughGate : IWorkspaceExecutionGate
+    {
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct) =>
+            action(ct);
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true) =>
+            action(ct);
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct) =>
+            action(ct);
+
+        public void RemoveGate(string workspaceId) { }
+    }
+
+    /// <summary>
+    /// Workspace stub that returns a status with an empty project list so
+    /// <c>FindTestProjectsWithoutCoverlet</c> short-circuits without touching disk
+    /// and execution proceeds into the <c>commandRunner.RunAsync</c> call we want
+    /// to exercise.
+    /// </summary>
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+        public event Action<string>? WorkspaceReloaded { add { } remove { } }
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) =>
+            throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) =>
+            throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => true;
+        public bool IsStale(string workspaceId) => false;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+        public WorkspaceStatusDto GetStatus(string workspaceId) => BuildStatus(workspaceId);
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(BuildStatus(workspaceId));
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) =>
+            throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) =>
+            throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => 1;
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+
+        private static WorkspaceStatusDto BuildStatus(string workspaceId) =>
+            new(
+                WorkspaceId: workspaceId,
+                LoadedPath: "C:\\fake\\workspace\\Sample.slnx",
+                WorkspaceVersion: 1,
+                SnapshotToken: "snapshot",
+                LoadedAtUtc: DateTimeOffset.UtcNow,
+                ProjectCount: 0,
+                DocumentCount: 0,
+                Projects: [],
+                IsLoaded: true,
+                IsStale: false,
+                WorkspaceDiagnostics: []);
+    }
+
+    /// <summary>
+    /// Runner stub that always throws the configured exception when <c>RunAsync</c> is
+    /// invoked. Mirrors the <c>HangingDotnetCommandRunner</c> hand-rolled-stub style from
+    /// <c>HardeningBehaviorTests</c> rather than reaching for NSubstitute.
+    /// </summary>
+    private sealed class ThrowingDotnetCommandRunner : IDotnetCommandRunner
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowingDotnetCommandRunner(Exception toThrow)
+        {
+            _toThrow = toThrow;
+        }
+
+        public Task<CommandExecutionDto> RunAsync(
+            string workingDirectory,
+            string targetPath,
+            IReadOnlyList<string> arguments,
+            CancellationToken ct) =>
+            throw _toThrow;
+    }
+
+    /// <summary>
+    /// Runner stub that returns a pre-built <see cref="CommandExecutionDto"/>. Used by
+    /// the regression-guard test to exercise the existing exit-code-1 no-coverage-file
+    /// fallback without triggering the new exception-path catches.
+    /// </summary>
+    private sealed class StaticDotnetCommandRunner : IDotnetCommandRunner
+    {
+        private readonly CommandExecutionDto _result;
+
+        public StaticDotnetCommandRunner(CommandExecutionDto result)
+        {
+            _result = result;
+        }
+
+        public Task<CommandExecutionDto> RunAsync(
+            string workingDirectory,
+            string targetPath,
+            IReadOnlyList<string> arguments,
+            CancellationToken ct) =>
+            Task.FromResult(_result);
+    }
+}


### PR DESCRIPTION
## Summary

Closes backlog row `test-coverage-timeout-failure-envelope` (initiative 9 from plan `20260516T200033Z_backlog-sweep`).

`TestCoverageTools.RunTestCoverageCore` called `commandRunner.RunAsync(...)` with no exception handling. If the `CancellationToken` fired (MCP timeout, caller cancellation) or the runner threw an unexpected exception, the exception escaped the `gate.RunReadAsync` lambda and the caller received a bare invocation error with no machine-readable hint — by contrast, `test_run` and `validate_recent_git_changes` already produce structured envelopes for the same conditions.

Wraps the runner invocation plus the downstream coverage-file scan in try/catch:
- **`OperationCanceledException`** (ordered first) → `errorKind=Timeout`, `isRetryable=false`. Not re-thrown — the gate lambda's return type is `string`, and the caller expects a structured envelope identical to the other failure paths.
- **`Exception`** → `errorKind=Unknown`, `isRetryable=false`, with `ex.Message` embedded in `summary`.

XML doc on `TestCoverageFailureEnvelopeDto.ErrorKind` extended to list `Timeout`. No DTO signature change.

Mirrors the precedent at `WorkspaceValidationService.cs:185-208` (catch OCE first, then Exception) and `TestRunnerService.cs:98-127` (timeout-envelope shape).

## Files changed

- `src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs` — wrap body in try/catch with OCE-first ordering
- `src/RoslynMcp.Core/Models/TestCoverageDto.cs` — XML doc on `ErrorKind` lists `Timeout`
- `tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs` — new test class, 3 tests (OCE → Timeout; arbitrary Exception → Unknown w/ message; regression guard for the existing TestFailure path)
- `changelog.d/test-coverage-timeout-failure-envelope.md` — Fixed-category fragment

## Test plan

- [x] `mcp__roslyn__compile_check` → 0 errors
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~TestCoverageFailureEnvelopeTests` → 3 passed
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~ServiceCoverageTests|FullyQualifiedName~HighValueCoverageIntegrationTests` → 22 passed (regression)
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~AliasToolsTests` → 6 passed (alias path regression)
- [x] `./eng/verify-ai-docs.ps1` → AI docs validation passed
- [x] `./eng/verify-changelog-fragments.ps1` → 7 fragments valid
- [ ] CI-parity `./eng/verify-release.ps1 -Configuration Release` — deferred to self-hosted runner per session policy

Closes: test-coverage-timeout-failure-envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)