### PR TITLE
test(categorize): tag remaining heavy integration & perf tests with TestCategory lanes

### DIFF
--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -20,6 +20,20 @@ This document is the single canonical source for validation requirements and mer
 - For release-impacting or code changes, run `./eng/verify-release.ps1`.
 - `eng/verify-release.ps1` performs restore, build, test (with Cobertura coverage under `artifacts/coverage`), publish, and hash-manifest generation. Pass `-NoCoverage` to skip the `--collect:"XPlat Code Coverage"` IL-rewrite step for faster iteration when you don't need the coverage artifact (matches the CI pull-request path).
 
+### Test Category Lanes
+
+Tests are tagged with `[TestCategory(...)]` to enable selective execution. Only `Benchmark` is excluded from the default CI run (`eng/verify-release.ps1` applies `--filter "TestCategory!=Benchmark"`); all other lanes execute in the default pipeline and are available for local opt-in filtering when you want to isolate or skip heavy lanes during iteration.
+
+| Lane | Meaning | Sample opt-in / opt-out filter |
+|---|---|---|
+| `Benchmark` | Wall-clock micro-benchmarks (e.g. `WorkspaceReadConcurrencyBenchmark`). Excluded from default CI. | Opt-in: `dotnet test --filter "TestCategory=Benchmark"` |
+| `Network` | Live calls to external services (e.g. `api.nuget.org` from `NuGetVulnerabilityScanIntegrationTests`). | Opt-out: `dotnet test --filter "TestCategory!=Network"` |
+| `RepoSolution` | Loads the repository's own `RoslynMcp.slnx` (or a second large workspace) rather than the small sample fixture; high memory + warm-up cost. | Opt-out: `dotnet test --filter "TestCategory!=RepoSolution"` |
+| `Process` | Shells out to an external process (e.g. `dotnet test` via `IDotnetCommandRunner.RunAsync`); requires the .NET SDK and is sensitive to process-startup variance. | Opt-out: `dotnet test --filter "TestCategory!=Process"` |
+| `Performance` | Wall-clock budget assertions (the `PerformanceBaselineTests` class); pass/fail depends on CPU contention and is flaky under heavy parallel load. | Opt-out: `dotnet test --filter "TestCategory!=Performance"` |
+
+Combine filters with `&` (AND) or `\|` (OR) per `dotnet test --filter` syntax — e.g. `dotnet test --filter "TestCategory!=Network&TestCategory!=Performance"` to skip both lanes while iterating on a normal change.
+
 ## Merge Gating Expectations
 
 - Treat the documented CI workflow as the required merge gate.

--- a/changelog.d/test-suite-heavy-lane-categorization.md
+++ b/changelog.d/test-suite-heavy-lane-categorization.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Add `[TestCategory("RepoSolution")]`, `[TestCategory("Process")]`, and `[TestCategory("Performance")]` to remaining heavy integration and performance tests; document new lane categories and local filter syntax in `CI_POLICY.md`.

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -390,6 +390,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    [TestCategory("RepoSolution")]
     public async Task Reflection_And_Di_Analysis_Run_On_Repo_Solution()
     {
         var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
@@ -553,6 +554,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    [TestCategory("Process")]
     public async Task TestCoverageTool_Returns_Structured_Response()
     {
         var json = await TestCoverageTools.RunTestCoverage(

--- a/tests/RoslynMcp.Tests/PerformanceBaselineTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBaselineTests.cs
@@ -11,6 +11,7 @@ namespace RoslynMcp.Tests;
 /// </summary>
 [DoNotParallelize]
 [TestClass]
+[TestCategory("Performance")]
 public sealed class PerformanceBaselineTests : SharedWorkspaceTestBase
 {
     private static string WorkspaceId { get; set; } = null!;

--- a/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/SecurityDiagnosticIntegrationTests.cs
@@ -7,6 +7,7 @@ namespace RoslynMcp.Tests;
 
 [DoNotParallelize]
 [TestClass]
+[TestCategory("RepoSolution")]
 public class SecurityDiagnosticIntegrationTests : SharedWorkspaceTestBase
 {
     private static string WorkspaceId { get; set; } = null!;


### PR DESCRIPTION
## Summary

Tags the four remaining uncategorized heavy lanes with `[TestCategory(...)]` so local iteration can opt out of slow workspace/process/wall-clock tests without losing them from default CI:

- `ExpandedSurfaceIntegrationTests.Reflection_And_Di_Analysis_Run_On_Repo_Solution` -> `[TestCategory("RepoSolution")]` (method-level; loads the repo's own `RoslynMcp.slnx`)
- `ExpandedSurfaceIntegrationTests.TestCoverageTool_Returns_Structured_Response` -> `[TestCategory("Process")]` (method-level; shells `dotnet test`)
- `SecurityDiagnosticIntegrationTests` -> class-level `[TestCategory("RepoSolution")]` (loads a second large workspace in `ClassInitialize`; class already `[DoNotParallelize]`)
- `PerformanceBaselineTests` -> class-level `[TestCategory("Performance")]` (7 wall-clock budget methods)

Extends `CI_POLICY.md` "Local Validation" with a Test Category Lanes subsection documenting all five lanes (`Benchmark`, `Network`, `RepoSolution`, `Process`, `Performance`) and the opt-in/opt-out `dotnet test --filter` syntax. `eng/verify-release.ps1` unchanged: only `Benchmark` is excluded from the default CI run; the new lanes still execute in CI and are only filtered locally on demand.

## Test plan

- [x] `mcp__roslyn__compile_check` on `RoslynMcp.Tests` project — 0 errors, 0 warnings.
- [x] `dotnet test --list-tests --filter "TestCategory=Performance"` enumerates all 7 `PerformanceBaselineTests` methods.
- [x] `dotnet test --list-tests --filter "TestCategory=RepoSolution"` enumerates `Reflection_And_Di_Analysis_Run_On_Repo_Solution` plus every method on `SecurityDiagnosticIntegrationTests` (class-level fan-out as designed).
- [x] `dotnet test --list-tests --filter "TestCategory=Process"` enumerates `TestCoverageTool_Returns_Structured_Response`.
- [x] `./eng/verify-ai-docs.ps1` passes.
- [ ] Self-hosted CI (`verify-release.ps1`) runs the named tests in the default lane (not excluded; verified by lack of `--filter` exclusion for the new categories in `eng/verify-release.ps1:70`).

Closes: `test-suite-heavy-lane-categorization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)