### PR TITLE
fix(test_reference_map): cap MockDriftWarnings via maxMockDriftWarnings (#774)

### DIFF
--- a/changelog.d/test-reference-map-pagination-only-covers-covered-symbols.md
+++ b/changelog.d/test-reference-map-pagination-only-covers-covered-symbols.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `test_reference_map` ignoring `limit` for mock-drift warnings: `mockDriftWarnings` is now bounded by a new `maxMockDriftWarnings` parameter (default 50) with `totalMockDriftCount`/`hasMoreMockDrift` metadata (fixes gh #774).

--- a/src/RoslynMcp.Core/Services/ITestReferenceMapService.cs
+++ b/src/RoslynMcp.Core/Services/ITestReferenceMapService.cs
@@ -29,11 +29,18 @@ public interface ITestReferenceMapService
     /// Maximum symbols returned per page. Clamps to [1, 500]. Default 200 matches the other
     /// paginated tools.
     /// </param>
+    /// <param name="maxMockDriftWarnings">
+    /// Maximum NSubstitute mock-drift warnings returned. Clamps to [0, 500]. Default 50 keeps
+    /// typical small-workspace responses near pre-fix sizing while bounding pathological cases
+    /// where production code accumulates dozens of unstubbed interface methods. Pre-fix the
+    /// collection was uncapped and dominated payload size in repos with many mocked interfaces.
+    /// </param>
     Task<TestReferenceMapDto> BuildAsync(
         string workspaceId,
         string? projectName,
         int offset,
         int limit,
+        int maxMockDriftWarnings,
         CancellationToken ct);
 }
 
@@ -45,12 +52,14 @@ public interface ITestReferenceMapService
 /// <param name="CoveragePercent">Ratio <c>covered/(covered+uncovered)</c> × 100, rounded to one decimal. Always computed against the full (pre-pagination) counts so the verdict doesn't change with page size.</param>
 /// <param name="InspectedTestProjects">Test projects actually scanned during the sweep.</param>
 /// <param name="Notes">Structural caveats the caller should surface (e.g., reflection-heavy code, DI-driven tests).</param>
-/// <param name="MockDriftWarnings">Item 9 (v1.18) — NSubstitute mock drift findings. Not paginated (typically small).</param>
+/// <param name="MockDriftWarnings">Item 9 (v1.18) — NSubstitute mock drift findings. Bounded to <c>maxMockDriftWarnings</c>; see <see cref="HasMoreMockDrift"/> and <see cref="TotalMockDriftCount"/> for the full count.</param>
 /// <param name="Offset">Echoes the effective (clamped) offset so callers can paginate without re-computing.</param>
 /// <param name="Limit">Echoes the effective (clamped) limit.</param>
 /// <param name="TotalCoveredCount">Full covered-symbol count before pagination.</param>
 /// <param name="TotalUncoveredCount">Full uncovered-symbol count before pagination.</param>
+/// <param name="TotalMockDriftCount">Full mock-drift warning count before the per-collection cap.</param>
 /// <param name="HasMore">True when <c>Offset + CoveredSymbols.Count + UncoveredSymbols.Count</c> is less than the combined total.</param>
+/// <param name="HasMoreMockDrift">True when <c>TotalMockDriftCount</c> exceeds <c>MockDriftWarnings.Count</c> — the per-collection cap truncated the warning list.</param>
 public sealed record TestReferenceMapDto(
     IReadOnlyList<CoveredSymbolDto> CoveredSymbols,
     IReadOnlyList<string> UncoveredSymbols,
@@ -62,7 +71,9 @@ public sealed record TestReferenceMapDto(
     int Limit,
     int TotalCoveredCount,
     int TotalUncoveredCount,
-    bool HasMore);
+    int TotalMockDriftCount,
+    bool HasMore,
+    bool HasMoreMockDrift);
 
 /// <summary>One covered-symbol row with referencing test method names.</summary>
 public sealed record CoveredSymbolDto(

--- a/src/RoslynMcp.Host.Stdio/Tools/TestReferenceMapTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestReferenceMapTools.cs
@@ -25,10 +25,11 @@ public static class TestReferenceMapTools
         [Description("Optional: restrict to a single project (name or path). Matching a productive project filters the covered/uncovered sets to that project's symbols; matching a test project scopes the test scan. Unknown name → structured error.")] string? projectName = null,
         [Description("0-based start index. Clamped to [0, total]. Default 0.")] int offset = 0,
         [Description("Max entries returned per page. Clamped to [1, 500]. Default 200.")] int limit = 200,
+        [Description("Max mock-drift warnings returned. Clamped to [0, 500]. Default 50. Use totalMockDriftCount and hasMoreMockDrift on the response to detect truncation.")] int maxMockDriftWarnings = 50,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => testReferenceMapService.BuildAsync(workspaceId, projectName, offset, limit, c),
+            c => testReferenceMapService.BuildAsync(workspaceId, projectName, offset, limit, maxMockDriftWarnings, c),
             ct);
 }

--- a/src/RoslynMcp.Roslyn/Services/TestReferenceMapService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestReferenceMapService.cs
@@ -25,6 +25,7 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
         string? projectName,
         int offset,
         int limit,
+        int maxMockDriftWarnings,
         CancellationToken ct)
     {
         var status = _workspace.GetStatus(workspaceId);
@@ -71,7 +72,7 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
             .ToArray();
 
         return BuildPaginatedResult(
-            coveredAll, uncoveredAll, offset, limit, scannedTestProjects, notes, mockDrift);
+            coveredAll, uncoveredAll, offset, limit, maxMockDriftWarnings, scannedTestProjects, notes, mockDrift);
     }
 
     /// <summary>
@@ -248,12 +249,29 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
     /// The combined ordering is stable between calls so callers can resume at
     /// <c>offset + returnedCount</c>. <see cref="TestReferenceMapDto.CoveragePercent"/> stays pegged
     /// to the full counts so the verdict doesn't wobble based on page window.
+    ///
+    /// <para>
+    /// gh #774 follow-up (test-reference-map-pagination-only-covers-covered-symbols): the
+    /// <see cref="TestReferenceMapDto.MockDriftWarnings"/> collection is also bounded by
+    /// <paramref name="maxMockDriftWarnings"/> (clamped to [0, 500]) — pre-fix the collection
+    /// passed through uncapped and dominated payload size in repos with many mocked interfaces.
+    /// <see cref="TestReferenceMapDto.TotalMockDriftCount"/> always carries the full count and
+    /// <see cref="TestReferenceMapDto.HasMoreMockDrift"/> flags truncation.
+    /// </para>
+    ///
+    /// <para>
+    /// Internal (not private) so <c>TestReferenceMapServiceTests</c> can exercise the cap with
+    /// synthetic mock-drift inputs that cannot be produced through the public <see cref="BuildAsync"/>
+    /// surface — <see cref="DetectMockDriftAsync"/> walks live Roslyn data and the sample
+    /// solution does not produce 109-entry edge cases organically.
+    /// </para>
     /// </summary>
-    private static TestReferenceMapDto BuildPaginatedResult(
+    internal static TestReferenceMapDto BuildPaginatedResult(
         CoveredSymbolDto[] coveredAll,
         string[] uncoveredAll,
         int offset,
         int limit,
+        int maxMockDriftWarnings,
         IReadOnlyList<string> scannedTestProjects,
         IReadOnlyList<string> notes,
         IReadOnlyList<MockDriftWarningDto> mockDrift)
@@ -280,18 +298,29 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
         var returned = coveredPage.Length + uncoveredPage.Length;
         var hasMore = clampedOffset + returned < denominator;
 
+        // gh #774: per-collection cap for MockDriftWarnings. Clamp to [0, 500]; a 0 max returns
+        // an empty list while keeping TotalMockDriftCount/HasMoreMockDrift truthful so callers
+        // can still detect drift exists without paying the payload tax.
+        var clampedMaxMockDrift = Math.Clamp(maxMockDriftWarnings, 0, 500);
+        var mockDriftPage = clampedMaxMockDrift > 0 && mockDrift.Count > 0
+            ? (IReadOnlyList<MockDriftWarningDto>)mockDrift.Take(clampedMaxMockDrift).ToArray()
+            : Array.Empty<MockDriftWarningDto>();
+        var hasMoreMockDrift = mockDrift.Count > mockDriftPage.Count;
+
         return new TestReferenceMapDto(
             coveredPage,
             uncoveredPage,
             percent,
             scannedTestProjects,
             notes,
-            mockDrift,
+            mockDriftPage,
             Offset: clampedOffset,
             Limit: clampedLimit,
             TotalCoveredCount: coveredAll.Length,
             TotalUncoveredCount: uncoveredAll.Length,
-            HasMore: hasMore);
+            TotalMockDriftCount: mockDrift.Count,
+            HasMore: hasMore,
+            HasMoreMockDrift: hasMoreMockDrift);
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
+++ b/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
@@ -1,3 +1,4 @@
+using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -6,6 +7,16 @@ namespace RoslynMcp.Tests;
 /// dr-9-5-bug-pagination-001-has-no-pagination-filter-igno: regression coverage for
 /// <see cref="TestReferenceMapService.BuildAsync"/> pagination + projectName scoping.
 /// Service shipped without tests — these are the first, scoped to the I-23 defects.
+///
+/// <para>
+/// gh #774 / test-reference-map-pagination-only-covers-covered-symbols: extended with mock-drift
+/// cap coverage. Because <see cref="TestReferenceMapService.BuildPaginatedResult"/> is the only
+/// seam that exercises the per-collection cap and <c>DetectMockDriftAsync</c> builds drift
+/// findings from live Roslyn data (the sample solution does not produce pathological cases
+/// organically), the cap tests exercise the <c>internal static</c> seam directly with synthetic
+/// inputs. <c>InternalsVisibleTo("RoslynMcp.Tests")</c> is already declared in
+/// <c>RoslynMcp.Roslyn.csproj</c>.
+/// </para>
 /// </summary>
 [DoNotParallelize]
 [TestClass]
@@ -13,6 +24,8 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
 {
     private static string WorkspaceId { get; set; } = null!;
     private static TestReferenceMapService Service { get; set; } = null!;
+
+    private const int DefaultMaxMockDriftWarnings = 50;
 
     [ClassInitialize]
     public static async Task ClassInit(TestContext _)
@@ -26,7 +39,8 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     public async Task BuildAsync_DefaultPagination_ReturnsFullSetOnSmallSolution()
     {
         var result = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 500, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 500,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
 
         Assert.AreEqual(0, result.Offset);
         Assert.AreEqual(500, result.Limit);
@@ -42,7 +56,8 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     public async Task BuildAsync_Limit1_TruncatesAndSurfacesHasMore()
     {
         var result = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 1, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 1,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
 
         Assert.AreEqual(1, result.Limit);
         Assert.AreEqual(1, result.CoveredSymbols.Count + result.UncoveredSymbols.Count,
@@ -59,11 +74,13 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     public async Task BuildAsync_OffsetClampsToTotal_ReturnsEmptyPageNoHasMore()
     {
         var first = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 500, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 500,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
         var totals = first.TotalCoveredCount + first.TotalUncoveredCount;
 
         var tail = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: totals + 50, limit: 10, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: totals + 50, limit: 10,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
 
         Assert.AreEqual(totals, tail.Offset, "Offset must clamp to the combined total.");
         Assert.AreEqual(0, tail.CoveredSymbols.Count + tail.UncoveredSymbols.Count);
@@ -74,9 +91,11 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     public async Task BuildAsync_CoveragePercentStable_AcrossPageSizes()
     {
         var full = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 500, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 500,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
         var paged = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 1, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 1,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
 
         Assert.AreEqual(full.CoveragePercent, paged.CoveragePercent,
             "CoveragePercent is pegged to the full totals; page size must not change the verdict.");
@@ -88,9 +107,11 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
         // SampleLib is the productive project; filtering to it should shrink the productive
         // symbol set vs the unscoped sweep while still scanning the solution's test projects.
         var unscoped = await Service.BuildAsync(
-            WorkspaceId, projectName: null, offset: 0, limit: 500, CancellationToken.None);
+            WorkspaceId, projectName: null, offset: 0, limit: 500,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
         var scoped = await Service.BuildAsync(
-            WorkspaceId, projectName: "SampleLib", offset: 0, limit: 500, CancellationToken.None);
+            WorkspaceId, projectName: "SampleLib", offset: 0, limit: 500,
+            maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None);
 
         var unscopedTotal = unscoped.TotalCoveredCount + unscoped.TotalUncoveredCount;
         var scopedTotal = scoped.TotalCoveredCount + scoped.TotalUncoveredCount;
@@ -110,6 +131,123 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     {
         await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
             Service.BuildAsync(
-                WorkspaceId, projectName: "DefinitelyNotARealProject", offset: 0, limit: 10, CancellationToken.None));
+                WorkspaceId, projectName: "DefinitelyNotARealProject", offset: 0, limit: 10,
+                maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None));
+    }
+
+    // gh #774 / test-reference-map-pagination-only-covers-covered-symbols: cap MockDriftWarnings.
+    // Tests exercise the internal static seam directly because DetectMockDriftAsync builds drift
+    // from live Roslyn data — the sample solution does not produce a 50+ warning case organically.
+    // InternalsVisibleTo("RoslynMcp.Tests") is already wired in RoslynMcp.Roslyn.csproj.
+
+    [TestMethod]
+    public void BuildPaginatedResult_MockDriftCap_DefaultCapOf50_WhenMoreExist()
+    {
+        var mockDrift = SyntheticMockDrift(count: 109);
+
+        var result = TestReferenceMapService.BuildPaginatedResult(
+            coveredAll: Array.Empty<CoveredSymbolDto>(),
+            uncoveredAll: Array.Empty<string>(),
+            offset: 0,
+            limit: 200,
+            maxMockDriftWarnings: 50,
+            scannedTestProjects: Array.Empty<string>(),
+            notes: Array.Empty<string>(),
+            mockDrift: mockDrift);
+
+        Assert.AreEqual(50, result.MockDriftWarnings.Count,
+            "Cap of 50 must truncate the 109-entry collection to 50 entries.");
+        Assert.AreEqual(109, result.TotalMockDriftCount,
+            "TotalMockDriftCount must always reflect the full pre-cap count.");
+        Assert.IsTrue(result.HasMoreMockDrift,
+            "HasMoreMockDrift must be true when the cap truncated the collection.");
+    }
+
+    [TestMethod]
+    public void BuildPaginatedResult_MockDriftCap_Zero_ReturnsNoneWithMetadata()
+    {
+        var mockDrift = SyntheticMockDrift(count: 7);
+
+        var result = TestReferenceMapService.BuildPaginatedResult(
+            coveredAll: Array.Empty<CoveredSymbolDto>(),
+            uncoveredAll: Array.Empty<string>(),
+            offset: 0,
+            limit: 200,
+            maxMockDriftWarnings: 0,
+            scannedTestProjects: Array.Empty<string>(),
+            notes: Array.Empty<string>(),
+            mockDrift: mockDrift);
+
+        Assert.AreEqual(0, result.MockDriftWarnings.Count,
+            "maxMockDriftWarnings=0 must return an empty drift list.");
+        Assert.AreEqual(7, result.TotalMockDriftCount,
+            "TotalMockDriftCount must always reflect the full count even when the cap is 0.");
+        Assert.IsTrue(result.HasMoreMockDrift,
+            "HasMoreMockDrift must be true when warnings exist but the cap returned none — callers still need to know drift was detected.");
+    }
+
+    [TestMethod]
+    public void BuildPaginatedResult_MockDriftCap_NoTruncation_HasMoreMockDriftFalse()
+    {
+        var mockDrift = SyntheticMockDrift(count: 3);
+
+        var result = TestReferenceMapService.BuildPaginatedResult(
+            coveredAll: Array.Empty<CoveredSymbolDto>(),
+            uncoveredAll: Array.Empty<string>(),
+            offset: 0,
+            limit: 200,
+            maxMockDriftWarnings: 50,
+            scannedTestProjects: Array.Empty<string>(),
+            notes: Array.Empty<string>(),
+            mockDrift: mockDrift);
+
+        Assert.AreEqual(3, result.MockDriftWarnings.Count,
+            "Cap above the actual count must pass all entries through.");
+        Assert.AreEqual(3, result.TotalMockDriftCount);
+        Assert.IsFalse(result.HasMoreMockDrift,
+            "HasMoreMockDrift must be false when no truncation occurred.");
+    }
+
+    [TestMethod]
+    public void BuildPaginatedResult_MockDriftCap_AboveUpperBound_Clamps()
+    {
+        // The cap is clamped to [0, 500]; an out-of-range request should not over-allocate.
+        var mockDrift = SyntheticMockDrift(count: 600);
+
+        var result = TestReferenceMapService.BuildPaginatedResult(
+            coveredAll: Array.Empty<CoveredSymbolDto>(),
+            uncoveredAll: Array.Empty<string>(),
+            offset: 0,
+            limit: 200,
+            maxMockDriftWarnings: 5000,
+            scannedTestProjects: Array.Empty<string>(),
+            notes: Array.Empty<string>(),
+            mockDrift: mockDrift);
+
+        Assert.AreEqual(500, result.MockDriftWarnings.Count,
+            "maxMockDriftWarnings must clamp to 500 even when callers request more.");
+        Assert.AreEqual(600, result.TotalMockDriftCount);
+        Assert.IsTrue(result.HasMoreMockDrift,
+            "HasMoreMockDrift must be true after a clamp-induced truncation.");
+    }
+
+    /// <summary>
+    /// Produce a deterministic synthetic <see cref="MockDriftWarningDto"/> list. The exact
+    /// contents are irrelevant to the cap-logic tests — only <see cref="IReadOnlyList{T}.Count"/>
+    /// matters — but distinct strings per row keep failure messages readable when an assertion
+    /// trips and dumps the collection.
+    /// </summary>
+    private static IReadOnlyList<MockDriftWarningDto> SyntheticMockDrift(int count)
+    {
+        var warnings = new MockDriftWarningDto[count];
+        for (var i = 0; i < count; i++)
+        {
+            warnings[i] = new MockDriftWarningDto(
+                TestClassDisplay: $"Test.Class{i}",
+                MockedInterfaceDisplay: $"IService{i}",
+                MissingStubMethod: $"IService{i}.Method{i}",
+                ProductionCallerDisplay: $"file{i}.cs:{i + 1}");
+        }
+        return warnings;
     }
 }


### PR DESCRIPTION
## Summary
- Bounds `test_reference_map`'s `MockDriftWarnings` collection by a new `maxMockDriftWarnings` parameter (default 50, clamped to [0, 500]). Pre-fix the list was uncapped and dominated payload regardless of `limit` in repos with many NSubstitute mocked interfaces (gh #774 saw 109 findings overflow the MCP response budget).
- Extends `TestReferenceMapDto` with `TotalMockDriftCount` + `HasMoreMockDrift` (mirrors the existing `TotalCovered/UncoveredCount` + `HasMore` shape) so callers can detect truncation without re-calling.
- Bumps `BuildPaginatedResult` from `private static` to `internal static` so tests can exercise the cap with synthetic 50+ drift entries — the sample solution does not produce a pathological case organically and `DetectMockDriftAsync` walks live Roslyn data. `InternalsVisibleTo("RoslynMcp.Tests")` was already wired.

**Breaking change:** callers who unintentionally received all detected drift findings now see the first 50 plus `HasMoreMockDrift=true`. Pass an explicit `maxMockDriftWarnings` (up to 500) to opt into a wider cap. This is the desired corrective behavior — the pre-fix path silently exceeded the MCP cap on real-world workspaces.

## Test plan
- [x] `mcp__roslyn__compile_check` clean on RoslynMcp.Core / RoslynMcp.Roslyn / RoslynMcp.Host.Stdio / RoslynMcp.Tests (0 errors, 0 warnings).
- [x] `mcp__roslyn__test_run --filter TestReferenceMapServiceTests`: 10/10 pass — 6 pre-existing pagination tests updated to thread the new parameter, plus 4 new mock-drift cap tests (`DefaultCapOf50_WhenMoreExist`, `Zero_ReturnsNoneWithMetadata`, `NoTruncation_HasMoreMockDriftFalse`, `AboveUpperBound_Clamps`).
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true`: succeeds with 0 warnings.
- [x] `eng/verify-ai-docs.ps1`: passes.
- [ ] CI (`eng/verify-release.ps1 -Configuration Release`) — runs on the self-hosted runner attached to this PR (parallel-mode discipline: not run locally).

Closes: `test-reference-map-pagination-only-covers-covered-symbols`
Closes #774