### PR TITLE
fix(workspace): VS-MSBuild-required diagnostic classification + concrete remediation

### DIFF
--- a/changelog.d/workspace-toolchain-status-preflight.md
+++ b/changelog.d/workspace-toolchain-status-preflight.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_load` partial-load UX for legacy .NET Framework and COM-reference projects — `ResolveComReference` and `.NET Core MSBuild` diagnostics are now downgraded from `WORKSPACE_FAILURE` Error to Warning, the summary DTO reports `isReady: false`, and `restoreHint` carries the concrete remediation ("requires Visual Studio MSBuild — remove COM references or load from an environment where msbuild.exe is on PATH") instead of misleading callers toward `dotnet restore`.

--- a/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
@@ -58,6 +58,7 @@ public sealed record WorkspaceStatusSummaryDto(
         var errors = 0;
         var warnings = 0;
         var unresolvedAnalyzerWarnings = 0;
+        var vsMsbuildRequired = false;
         foreach (var diagnostic in status.WorkspaceDiagnostics)
         {
             if (string.Equals(diagnostic.Severity, "Error", StringComparison.OrdinalIgnoreCase))
@@ -72,9 +73,20 @@ public sealed record WorkspaceStatusSummaryDto(
                     unresolvedAnalyzerWarnings++;
                 }
             }
+
+            // VS-MSBuild-only diagnostics arrive with Id="WORKSPACE_FAILURE" and are downgraded
+            // to Warning by WorkspaceDiagnosticSeverityClassifier. Detect them by message content
+            // here (Core can't reference Roslyn for the helper) — mirrors the substring scan in
+            // BuildRestoreHint below. Treated as an analyzers-not-ready condition so callers see
+            // isReady=false and surface the VS-MSBuild remediation hint instead of proceeding
+            // with degraded results.
+            if (IsVsMsbuildRequiredMessage(diagnostic.Message))
+            {
+                vsMsbuildRequired = true;
+            }
         }
 
-        var analyzersReady = unresolvedAnalyzerWarnings == 0;
+        var analyzersReady = unresolvedAnalyzerWarnings == 0 && !vsMsbuildRequired;
         var solutionFileName = GetSolutionOrProjectFileName(status.LoadedPath);
         var restoreRequired = status.RestoreRequired;
         var isReady = status.IsLoaded && !status.IsStale && analyzersReady && errors == 0 && !restoreRequired;
@@ -83,7 +95,8 @@ public sealed record WorkspaceStatusSummaryDto(
             isStale: status.IsStale,
             errors: errors,
             unresolvedAnalyzerWarnings: unresolvedAnalyzerWarnings,
-            restoreRequired: restoreRequired);
+            restoreRequired: restoreRequired,
+            vsMsbuildRequired: vsMsbuildRequired);
 
         return new WorkspaceStatusSummaryDto(
             WorkspaceId: status.WorkspaceId,
@@ -107,8 +120,9 @@ public sealed record WorkspaceStatusSummaryDto(
 
     /// <summary>
     /// Builds an actionable hint string explaining why the workspace is not ready.
-    /// Three cases, in priority order:
+    /// Four cases, in priority order:
     /// <list type="number">
+    ///   <item><description>VS-MSBuild required (COM references, .NET Core MSBuild limitation) → tell caller this project needs Visual Studio MSBuild on PATH.</description></item>
     ///   <item><description>Unresolved analyzer warnings → tell caller analyzer-driven tools will under-report.</description></item>
     ///   <item><description>Many "could not be found" / CS0234 style errors → suggest <c>dotnet restore</c>.</description></item>
     ///   <item><description>Workspace is stale with no errors → likely transient post-apply; suggest a brief retry before reload.</description></item>
@@ -120,8 +134,17 @@ public sealed record WorkspaceStatusSummaryDto(
         bool isStale,
         int errors,
         int unresolvedAnalyzerWarnings,
-        bool restoreRequired)
+        bool restoreRequired,
+        bool vsMsbuildRequired)
     {
+        // Highest priority: COM references / .NET Core MSBuild limitations cannot be fixed by
+        // `dotnet restore` and must surface a concrete remediation BEFORE any restore-style hint.
+        // See `workspace-toolchain-status-preflight` (BioRemote 2026-05).
+        if (vsMsbuildRequired)
+        {
+            return "This project requires Visual Studio MSBuild (e.g. COM references or .NET Framework-only tasks). The .NET Core MSBuild bundled with this server cannot resolve these. Remediation: (a) remove or interop-wrap COM references, or (b) load this project from an environment where msbuild.exe (Visual Studio) is on PATH.";
+        }
+
         if (restoreRequired)
         {
             return "Package-restore inputs changed since the last restore. Run `dotnet restore` on the solution or project, then `workspace_reload`.";
@@ -178,5 +201,23 @@ public sealed record WorkspaceStatusSummaryDto(
             file.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
             return file;
         return file;
+    }
+
+    /// <summary>
+    /// VS-MSBuild-only diagnostic detector. Kept local to Core (DTO layer cannot depend on
+    /// the Roslyn layer for the canonical helper) — mirrors
+    /// <c>RoslynMcp.Roslyn.Helpers.WorkspaceDiagnosticSeverityClassifier.IsVsMsbuildRequiredMessage</c>.
+    /// Keep the two substring lists in sync.
+    /// </summary>
+    private static bool IsVsMsbuildRequiredMessage(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        return message.Contains("ResolveComReference", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("type library", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("The .NET Core version of MSBuild", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/RoslynMcp.Roslyn/Helpers/WorkspaceDiagnosticSeverityClassifier.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/WorkspaceDiagnosticSeverityClassifier.cs
@@ -45,6 +45,36 @@ public static class WorkspaceDiagnosticSeverityClassifier
             return true;
         }
 
+        // VS-MSBuild-only failure indicators: COM references and .NET Framework-only MSBuild
+        // tasks that the .NET Core MSBuild bundled with this server cannot resolve. Downgrade
+        // to Warning so partial-load UX surfaces a concrete remediation hint instead of
+        // gating callers with raw WORKSPACE_FAILURE errors that suggest `dotnet restore`.
+        // See `workspace-toolchain-status-preflight` (BioRemote 2026-05).
+        if (IsVsMsbuildRequiredMessage(message))
+        {
+            return true;
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// Returns true if the message indicates a VS-MSBuild-only feature that the .NET Core
+    /// MSBuild cannot resolve. Currently matches COM-reference resolution failures
+    /// (<c>ResolveComReference</c>, <c>type library</c>) and explicit .NET Core MSBuild
+    /// limitation messages (<c>"The .NET Core version of MSBuild..."</c>). Public so the
+    /// hint builder in <see cref="Core.Models.WorkspaceStatusSummaryDto"/> can re-use the
+    /// detection without duplicating the substring list.
+    /// </summary>
+    public static bool IsVsMsbuildRequiredMessage(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        return message.Contains("ResolveComReference", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("type library", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("The .NET Core version of MSBuild", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/RoslynMcp.Tests/WorkspaceToolchainClassifierTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolchainClassifierTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the VS-MSBuild-required diagnostic detection added by
+/// `workspace-toolchain-status-preflight` (BioRemote 2026-05): COM-reference and
+/// .NET-Core-MSBuild-limitation messages should be downgraded from raw
+/// <c>WORKSPACE_FAILURE</c> Errors to Warnings, and the
+/// <see cref="WorkspaceStatusSummaryDto"/> should expose <c>isReady=false</c> with a
+/// concrete remediation hint instead of the misleading "run dotnet restore" path.
+/// </summary>
+[TestClass]
+public sealed class WorkspaceToolchainClassifierTests
+{
+    private static readonly string SampleLoadedPath = Path.Combine("work", "SampleSolution.slnx");
+
+    private static WorkspaceStatusDto BaselineStatus(IReadOnlyList<DiagnosticDto> diagnostics, bool isStale = false) =>
+        new(
+            WorkspaceId: "abc",
+            LoadedPath: SampleLoadedPath,
+            WorkspaceVersion: 1,
+            SnapshotToken: "snap",
+            LoadedAtUtc: DateTimeOffset.UtcNow,
+            ProjectCount: 2,
+            DocumentCount: 10,
+            Projects: [],
+            IsLoaded: true,
+            IsStale: isStale,
+            WorkspaceDiagnostics: diagnostics);
+
+    [TestMethod]
+    public void Classify_ComReferenceMessage_ReturnsWarning()
+    {
+        // Realistic COM-reference failure messages from MSBuildWorkspace include the
+        // ResolveComReference task name and a "type library" mention.
+        var severity = WorkspaceDiagnosticSeverityClassifier.Classify(
+            WorkspaceDiagnosticKind.Failure,
+            "ResolveComReference: Cannot register type library 'TLB1234' for COM interop.");
+        Assert.AreEqual("Warning", severity,
+            "COM-reference failures must downgrade to Warning so partial-load UX surfaces a remediation hint.");
+    }
+
+    [TestMethod]
+    public void Classify_DotNetCoreMSBuildMessage_ReturnsWarning()
+    {
+        var severity = WorkspaceDiagnosticSeverityClassifier.Classify(
+            WorkspaceDiagnosticKind.Failure,
+            "The .NET Core version of MSBuild does not support this task.");
+        Assert.AreEqual("Warning", severity,
+            ".NET Core MSBuild limitation messages must downgrade to Warning.");
+    }
+
+    [TestMethod]
+    public void Classify_UnrelatedFailure_ReturnsError()
+    {
+        // Regression guard: arbitrary failure messages must remain Error so we don't
+        // accidentally silence real workspace problems.
+        var severity = WorkspaceDiagnosticSeverityClassifier.Classify(
+            WorkspaceDiagnosticKind.Failure,
+            "Project file is invalid: missing closing tag at line 42.");
+        Assert.AreEqual("Error", severity,
+            "Arbitrary failure messages must stay at Error severity.");
+    }
+
+    [TestMethod]
+    public void IsVsMsbuildRequiredMessage_TypeLibrary_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceDiagnosticSeverityClassifier.IsVsMsbuildRequiredMessage(
+            "Could not find type library."));
+    }
+
+    [TestMethod]
+    public void IsVsMsbuildRequiredMessage_EmptyOrNull_ReturnsFalse()
+    {
+        Assert.IsFalse(WorkspaceDiagnosticSeverityClassifier.IsVsMsbuildRequiredMessage(string.Empty));
+        Assert.IsFalse(WorkspaceDiagnosticSeverityClassifier.IsVsMsbuildRequiredMessage(null!));
+    }
+
+    /// <summary>
+    /// End-to-end check that VS-MSBuild-required diagnostics flip <c>isReady</c> to false
+    /// in the summary DTO and emit the concrete VS-MSBuild remediation hint instead of the
+    /// misleading "run dotnet restore" path. Mirrors
+    /// <c>From_UnresolvedAnalyzerWarning_AnalyzersReadyFalse_AndIsReadyFalse</c>.
+    /// </summary>
+    [TestMethod]
+    public void From_VsMsbuildRequired_IsReadyFalse_HintContainsRemediation()
+    {
+        // After the classifier downgrades the failure, the diagnostic arrives at the DTO
+        // with Id="WORKSPACE_FAILURE" (the ingress stamper does not know about VS-MSBuild)
+        // and Severity="Warning". The DTO detects the condition by message content.
+        var diagnostics = new DiagnosticDto[]
+        {
+            new(
+                "WORKSPACE_FAILURE",
+                "ResolveComReference: Cannot resolve COM reference 'MSXML2'.",
+                "Warning",
+                "Workspace",
+                null, null, null, null, null),
+        };
+
+        var summary = WorkspaceStatusSummaryDto.From(BaselineStatus(diagnostics));
+
+        Assert.IsFalse(summary.AnalyzersReady,
+            "AnalyzersReady must be false when a VS-MSBuild-required diagnostic is present.");
+        Assert.IsFalse(summary.IsReady,
+            "IsReady must require AnalyzersReady.");
+        Assert.IsNotNull(summary.RestoreHint,
+            "VS-MSBuild-required workspace must produce a remediation hint.");
+        StringAssert.Contains(summary.RestoreHint, "Visual Studio MSBuild",
+            "Hint must name the VS-MSBuild requirement explicitly.");
+        StringAssert.Contains(summary.RestoreHint, "COM references",
+            "Hint must mention COM references as the canonical remediation target.");
+    }
+
+    /// <summary>
+    /// The VS-MSBuild branch must take priority over the legacy "suggest dotnet restore"
+    /// path even when the diagnostic list also looks restore-shaped. Without this priority
+    /// ordering, BioRemote-style sessions would still see the misleading restore hint.
+    /// </summary>
+    [TestMethod]
+    public void From_VsMsbuildRequired_TakesPriorityOverRestoreSuggestion()
+    {
+        var diagnostics = new DiagnosticDto[]
+        {
+            new("WORKSPACE_FAILURE", "ResolveComReference failed for tlbimp output.", "Warning", "Workspace", null, null, null, null, null),
+            new("CS0234", "Type 'A' could not be found", "Error", "Workspace", null, null, null, null, null),
+            new("CS0234", "Type 'B' could not be found", "Error", "Workspace", null, null, null, null, null),
+            new("CS0234", "Type 'C' could not be found", "Error", "Workspace", null, null, null, null, null),
+        };
+
+        var summary = WorkspaceStatusSummaryDto.From(BaselineStatus(diagnostics));
+
+        Assert.IsNotNull(summary.RestoreHint);
+        StringAssert.Contains(summary.RestoreHint, "Visual Studio MSBuild",
+            "VS-MSBuild hint must win over the generic dotnet-restore suggestion.");
+    }
+}


### PR DESCRIPTION
## Summary

Two-site fix for `workspace_load` partial-load UX on legacy .NET Framework and COM-reference projects — the BioRemote 2026-05 sessions were misled to run `dotnet restore` for `ResolveComReference` failures that `dotnet restore` cannot fix.

### What changed

- **`src/RoslynMcp.Roslyn/Helpers/WorkspaceDiagnosticSeverityClassifier.cs`** — `IsInformationalWorkspaceFailureMessage` now also matches `ResolveComReference`, `type library`, and "The .NET Core version of MSBuild" so VS-MSBuild-required failures arrive at the DTO as Warning instead of raw `WORKSPACE_FAILURE` Error. New public helper `IsVsMsbuildRequiredMessage` exposes the substring detection for downstream re-use.
- **`src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs`** — `From()` scans the diagnostic list for the VS-MSBuild-required message pattern (Core can't reference Roslyn for the canonical helper; the substring list is mirrored locally with a sync comment) and treats it as an analyzers-not-ready condition. `BuildRestoreHint` gains a fourth, highest-priority branch that returns "requires Visual Studio MSBuild — remove COM references or load from an environment where msbuild.exe is on PATH." instead of the misleading `dotnet restore` suggestion.

### Why message-content detection (vs. a new diagnostic Id)

The plan/handoff explicitly steers away from editing the `WorkspaceManager.cs` ingress (it auto-stamps `WORKSPACE_FAILURE` and is the wave-conflict hotspot for init 7). Mirroring the existing `WORKSPACE_UNRESOLVED_ANALYZER`-id flow plus the substring scan already in `BuildRestoreHint` keeps this change out of the hotspot and out of the Core→Roslyn dependency direction problem.

### Tests added

`tests/RoslynMcp.Tests/WorkspaceToolchainClassifierTests.cs` (new):

- `Classify_ComReferenceMessage_ReturnsWarning`
- `Classify_DotNetCoreMSBuildMessage_ReturnsWarning`
- `Classify_UnrelatedFailure_ReturnsError` (regression guard)
- `IsVsMsbuildRequiredMessage_TypeLibrary_ReturnsTrue`
- `IsVsMsbuildRequiredMessage_EmptyOrNull_ReturnsFalse`
- `From_VsMsbuildRequired_IsReadyFalse_HintContainsRemediation` (end-to-end through the DTO)
- `From_VsMsbuildRequired_TakesPriorityOverRestoreSuggestion` (priority guard)

## Test plan

- [x] `mcp__roslyn__compile_check` on all three touched files: 0 errors, 0 warnings, 5/5 projects clean
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~WorkspaceToolchainClassifier`: 7/7 passed
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~WorkspaceStatusSummaryDto`: 7/7 passed (existing regression suite intact)
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~DiagnosticServiceFilterTotals`: 5/5 passed (classifier consumer intact)
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors
- [x] `./eng/verify-ai-docs.ps1`: passes (AI docs validation + 32 SKILL.md generic check)
- [ ] CI self-hosted runner: `verify-release.ps1 -Configuration Release` (deferred — runner active, do not duplicate locally)

Closes: `workspace-toolchain-status-preflight`