### PR TITLE
release: v1.39.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "1.38.1",
+      "version": "1.39.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "1.38.1",
+  "version": "1.39.0",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "1.38.1",
+      "version": "1.39.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [1.39.0] - 2026-05-17
+
+### Fixed
+
+- **Fixed:** `find_reflection_usages` now returns bounded, paginated results (`offset` / `limit` / `summary` / `hasMore` / `totalCount`) — previously returned all hits with no cap, producing 100+ KB responses on reflection-heavy solutions (gh #760).
+- **Fixed:** `find_unused_symbols` false positives for test-bridge accessor methods: names ending in `ForTest`, `ForTesting`, `_ForTest`, or `Internal` are now excluded when `excludeConventionInvoked=true` (default), matching the standard test-bridge accessor pattern (fixes gh #775).
+- **Fixed:** `get_di_registrations` default response now returns a bounded first page (`offset` / `limit`, default 100 registrations) with `totalCount` / `hasMore` metadata, preventing MCP inline transport cap overflow on large DI graphs (fixes gh #771).
+- **Fixed:** `get_prompt_text` side effects — `debug_test_failure` and `security_review` prompts now return pure instruction templates instead of eagerly invoking `dotnet test` and NuGet vulnerability scans during rendering. The previous implementations called `ITestRunnerService.RunTestsAsync` and `INuGetDependencyService.ScanNuGetVulnerabilitiesAsync` (which spawns `dotnet list package --vulnerable`) on every prompt fetch, violating the `get_prompt_text` contract of pure template substitution. Callers now invoke `test_run` / `security_analyzer_status` / `security_diagnostics` / `nuget_vulnerability_scan` explicitly and pass the structured results back into the analysis step (fixes gh #772).
+- **Fixed:** `guided_extract_interface` prompt overflow — `get_prompt_text` for this prompt now returns a bounded response by capping the embedded document-symbol list (50 entries) and project graph (20 projects), preventing MCP inline payload cap overflow on 9+ project solutions. The previous implementation embedded full `JsonSerializer.Serialize` output for both the `IReadOnlyList<DocumentSymbolDto>` and the entire `ProjectGraphDto`, scaling linearly with workspace size and exceeding the inline payload cap (~30+ KB observed) on larger solutions. Mirrors the truncation pattern already used by `analyze_dependencies` (fixes gh #776).
+- **Fixed:** `project_graph` silently misreporting `outputType: "Library"` for ASP.NET Core Web (`Microsoft.NET.Sdk.Web`) and Worker (`Microsoft.NET.Sdk.Worker`) projects that omit an explicit `<OutputType>` element. Now populated via MSBuild property evaluation (fixes gh #773).
+- **Fixed:** `audit-phase-runner` subagents dispatched for Phases 3 and 4 of `/mcp-server-surface-test --full` now use a deterministic type/method selection rule (top-N by cyclomatic score; alphabetical fallback) and are explicitly prohibited from calling `AskUserQuestion`.
+- **Fixed:** `symbol_refactor_preview` incorrectly applying each chained sub-operation to the workspace during preview, writing files to disk and recording ledger entries before the agent called any `*_apply` tool. Preview now chains operations purely in-memory and stores the accumulated mutations under one `apply_composite_preview` token (fixes gh #770).
+- **Fixed:** `symbol_search` regression (gh #617): broad queries with `limit > ~30` exceeded the MCP inline transport cap (171 KB observed at `limit=100`). Added `summary=true` parameter that drops expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType). Lowered server-side hard cap from 200 to 50; callers relying on `limit > 50` were already receiving tool-results-file fallbacks.
+- **Fixed:** `test_coverage` now returns a structured `failureEnvelope` (`errorKind=Timeout` or `errorKind=Unknown`) when the dotnet test run is cancelled or encounters an unexpected runner error, instead of surfacing a bare invocation exception to the MCP host.
+- **Fixed:** `test_reference_map` ignoring `limit` for mock-drift warnings: `mockDriftWarnings` is now bounded by a new `maxMockDriftWarnings` parameter (default 50) with `totalMockDriftCount`/`hasMoreMockDrift` metadata (fixes gh #774).
+- **Fixed:** `workspace_load` partial-load UX for legacy .NET Framework and COM-reference projects — `ResolveComReference` and `.NET Core MSBuild` diagnostics are now downgraded from `WORKSPACE_FAILURE` Error to Warning, the summary DTO reports `isReady: false`, and `restoreHint` carries the concrete remediation ("requires Visual Studio MSBuild — remove COM references or load from an environment where msbuild.exe is on PATH") instead of misleading callers toward `dotnet restore`.
+
+### Maintenance
+
+- **Maintenance:** Refactored `ChangeSignaturePreviewTests` to inherit `IsolatedWorkspaceTestBase`, replacing 14 repeated copy/load/close boilerplate blocks with `CreateIsolatedWorkspaceCopy()` — no behaviour change.
+- **Maintenance:** Add `[TestCategory("RepoSolution")]`, `[TestCategory("Process")]`, and `[TestCategory("Performance")]` to remaining heavy integration and performance tests; document new lane categories and local filter syntax in `CI_POLICY.md`.
+- **Maintenance:** split `IntegrationTests` kitchen-sink class into three focused classes (`IntegrationTests_WorkspaceCore`, `IntegrationTests_SymbolNavigation`, `IntegrationTests_EditApply`) — no assertions changed.
+
 ## [1.38.1] - 2026-05-13
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>1.38.1</Version>
+    <Version>1.39.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/compact-paged-high-volume-analysis-results.md
+++ b/changelog.d/compact-paged-high-volume-analysis-results.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_reflection_usages` now returns bounded, paginated results (`offset` / `limit` / `summary` / `hasMore` / `totalCount`) — previously returned all hits with no cap, producing 100+ KB responses on reflection-heavy solutions (gh #760).

--- a/changelog.d/find-unused-symbols-test-bridge-suffix-exclusion-gap.md
+++ b/changelog.d/find-unused-symbols-test-bridge-suffix-exclusion-gap.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_unused_symbols` false positives for test-bridge accessor methods: names ending in `ForTest`, `ForTesting`, `_ForTest`, or `Internal` are now excluded when `excludeConventionInvoked=true` (default), matching the standard test-bridge accessor pattern (fixes gh #775).

--- a/changelog.d/get-di-registrations-default-response-exceeds-mcp-cap.md
+++ b/changelog.d/get-di-registrations-default-response-exceeds-mcp-cap.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `get_di_registrations` default response now returns a bounded first page (`offset` / `limit`, default 100 registrations) with `totalCount` / `hasMore` metadata, preventing MCP inline transport cap overflow on large DI graphs (fixes gh #771).

--- a/changelog.d/get-prompt-text-side-effects-in-rendering.md
+++ b/changelog.d/get-prompt-text-side-effects-in-rendering.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `get_prompt_text` side effects — `debug_test_failure` and `security_review` prompts now return pure instruction templates instead of eagerly invoking `dotnet test` and NuGet vulnerability scans during rendering. The previous implementations called `ITestRunnerService.RunTestsAsync` and `INuGetDependencyService.ScanNuGetVulnerabilitiesAsync` (which spawns `dotnet list package --vulnerable`) on every prompt fetch, violating the `get_prompt_text` contract of pure template substitution. Callers now invoke `test_run` / `security_analyzer_status` / `security_diagnostics` / `nuget_vulnerability_scan` explicitly and pass the structured results back into the analysis step (fixes gh #772).

--- a/changelog.d/guided-extract-interface-prompt-payload-cap.md
+++ b/changelog.d/guided-extract-interface-prompt-payload-cap.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `guided_extract_interface` prompt overflow — `get_prompt_text` for this prompt now returns a bounded response by capping the embedded document-symbol list (50 entries) and project graph (20 projects), preventing MCP inline payload cap overflow on 9+ project solutions. The previous implementation embedded full `JsonSerializer.Serialize` output for both the `IReadOnlyList<DocumentSymbolDto>` and the entire `ProjectGraphDto`, scaling linearly with workspace size and exceeding the inline payload cap (~30+ KB observed) on larger solutions. Mirrors the truncation pattern already used by `analyze_dependencies` (fixes gh #776).

--- a/changelog.d/project-graph-output-type-misreports-sdk-defaulted-exe.md
+++ b/changelog.d/project-graph-output-type-misreports-sdk-defaulted-exe.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `project_graph` silently misreporting `outputType: "Library"` for ASP.NET Core Web (`Microsoft.NET.Sdk.Web`) and Worker (`Microsoft.NET.Sdk.Worker`) projects that omit an explicit `<OutputType>` element. Now populated via MSBuild property evaluation (fixes gh #773).

--- a/changelog.d/surface-test-subagent-symbol-selection-must-be-autonomous.md
+++ b/changelog.d/surface-test-subagent-symbol-selection-must-be-autonomous.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `audit-phase-runner` subagents dispatched for Phases 3 and 4 of `/mcp-server-surface-test --full` now use a deterministic type/method selection rule (top-N by cyclomatic score; alphabetical fallback) and are explicitly prohibited from calling `AskUserQuestion`.

--- a/changelog.d/symbol-refactor-preview-auto-applies-without-explicit-apply-call.md
+++ b/changelog.d/symbol-refactor-preview-auto-applies-without-explicit-apply-call.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `symbol_refactor_preview` incorrectly applying each chained sub-operation to the workspace during preview, writing files to disk and recording ledger entries before the agent called any `*_apply` tool. Preview now chains operations purely in-memory and stores the accumulated mutations under one `apply_composite_preview` token (fixes gh #770).

--- a/changelog.d/symbol-search-broad-query-response-cap-overflow.md
+++ b/changelog.d/symbol-search-broad-query-response-cap-overflow.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `symbol_search` regression (gh #617): broad queries with `limit > ~30` exceeded the MCP inline transport cap (171 KB observed at `limit=100`). Added `summary=true` parameter that drops expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType). Lowered server-side hard cap from 200 to 50; callers relying on `limit > 50` were already receiving tool-results-file fallbacks.

--- a/changelog.d/test-coverage-timeout-failure-envelope.md
+++ b/changelog.d/test-coverage-timeout-failure-envelope.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `test_coverage` now returns a structured `failureEnvelope` (`errorKind=Timeout` or `errorKind=Unknown`) when the dotnet test run is cancelled or encounters an unexpected runner error, instead of surfacing a bare invocation exception to the MCP host.

--- a/changelog.d/test-reference-map-pagination-only-covers-covered-symbols.md
+++ b/changelog.d/test-reference-map-pagination-only-covers-covered-symbols.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `test_reference_map` ignoring `limit` for mock-drift warnings: `mockDriftWarnings` is now bounded by a new `maxMockDriftWarnings` parameter (default 50) with `totalMockDriftCount`/`hasMoreMockDrift` metadata (fixes gh #774).

--- a/changelog.d/test-suite-heavy-fixture-reuse.md
+++ b/changelog.d/test-suite-heavy-fixture-reuse.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Refactored `ChangeSignaturePreviewTests` to inherit `IsolatedWorkspaceTestBase`, replacing 14 repeated copy/load/close boilerplate blocks with `CreateIsolatedWorkspaceCopy()` — no behaviour change.

--- a/changelog.d/test-suite-heavy-lane-categorization.md
+++ b/changelog.d/test-suite-heavy-lane-categorization.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Add `[TestCategory("RepoSolution")]`, `[TestCategory("Process")]`, and `[TestCategory("Performance")]` to remaining heavy integration and performance tests; document new lane categories and local filter syntax in `CI_POLICY.md`.

--- a/changelog.d/test-suite-integration-class-split.md
+++ b/changelog.d/test-suite-integration-class-split.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** split `IntegrationTests` kitchen-sink class into three focused classes (`IntegrationTests_WorkspaceCore`, `IntegrationTests_SymbolNavigation`, `IntegrationTests_EditApply`) — no assertions changed.

--- a/changelog.d/workspace-toolchain-status-preflight.md
+++ b/changelog.d/workspace-toolchain-status-preflight.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `workspace_load` partial-load UX for legacy .NET Framework and COM-reference projects — `ResolveComReference` and `.NET Core MSBuild` diagnostics are now downgraded from `WORKSPACE_FAILURE` Error to Warning, the summary DTO reports `isReady: false`, and `restoreHint` carries the concrete remediation ("requires Visual Studio MSBuild — remove COM references or load from an environment where msbuild.exe is on PATH") instead of misleading callers toward `dotnet restore`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Minor release v1.38.1 → v1.39.0. Bundles the 15-initiative 20260516T200033Z backlog sweep that landed via PRs #779–#782, #785–#786, #788–#790, #792–#795, #797–#798 plus precursor #783.

## Highlights

### Fixed (12)
- `find_reflection_usages` paginated (gh #760)
- `find_unused_symbols` test-bridge suffix exclusion (gh #775)
- `get_di_registrations` default pagination (gh #771)
- `get_prompt_text` pure-template prompts — `debug_test_failure`, `security_review` no longer eagerly invoke services (gh #772)
- `guided_extract_interface` payload cap (gh #776)
- `project_graph.outputType` via MSBuild eval for Web/Worker SDKs (gh #773)
- `audit-phase-runner` deterministic symbol selection + AskUserQuestion ban
- `symbol_refactor_preview` in-memory Solution-chaining (gh #770)
- `symbol_search` `summary=true` + cap 200→50 (gh #617)
- `test_coverage` structured `failureEnvelope`
- `test_reference_map` `maxMockDriftWarnings` cap (gh #774)
- `workspace_load` VS-MSBuild-required remediation hint for COM-ref/.NET-Framework projects

### Maintenance (3)
- `ChangeSignaturePreviewTests` adopts `IsolatedWorkspaceTestBase` (−135 LOC)
- TestCategory lanes (`RepoSolution` / `Process` / `Performance`) + `CI_POLICY.md`
- `IntegrationTests` split into 3 focused classes

## Files touched

- All 6 version files bumped to 1.39.0
- `CHANGELOG.md`: new `## [1.39.0] - 2026-05-17` section
- 15 `changelog.d/*.md` fragments consumed and deleted

## Test plan

- [x] `verify-version-drift.ps1` passes (all 6 files agree on 1.39.0)
- [x] `verify-ai-docs.ps1` passes
- [ ] Self-hosted CI runs full `verify-release.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)