### PR TITLE
fix(workflow): auto-inject Fixes #NNN into initiative-executor PR bodies

### DIFF
--- a/.claude/agents/initiative-executor.md
+++ b/.claude/agents/initiative-executor.md
@@ -60,7 +60,15 @@ If any field is missing, emit a failure `<<<RESULT>>>` immediately — do not gu
    git push -u origin remediation/{initiative.id}
    gh pr create --title "..." --body "..."
    ```
-   PR body MUST include `Closes: <backlog row ids>` for orchestrator correlation.
+   PR body MUST include both:
+   - `Closes: <backlog row ids>` — orchestrator correlation (machine-greppable).
+   - `Fixes #NNN` — one line per non-Reserved `[gh #NNN]` reference found in the row's `do` cell in `ai_docs/backlog.md`. GitHub then auto-closes the linked Issue when the PR merges. Reserved rows (text starts `**Reserved — [gh #NNN] (good first issue); skip in sweeps...**`) are pre-skipped by `/backlog-sweep:plan`, so this typically yields 0 or 1 reference; defensive parsing handles the rare follow-on row that references a parent tracked-only Issue (e.g. row text `[gh #760] follow-on (split from ..., shipped in PR #780)` — shipping this PR closes #760).
+
+   **Resolution algorithm** (run before `gh pr create`):
+   1. For each `rowId` in `Closes:`, `Grep` `^\| \`<rowId>\`` in `ai_docs/backlog.md` to locate the row.
+   2. Extract the `do` cell (text after the 4th `|`, before the trailing `|`).
+   3. Find every `\[gh #(\d+)\]` match in the cell that is NOT inside a `**Reserved — ... **` span.
+   4. Emit one `Fixes #N` line per surviving match. Zero matches = no `Fixes` lines (common case for rows without a GitHub mirror — the PR ships without auto-closing any Issue).
 
 5. **Emit `<<<RESULT>>>`** — see output contract below.
 

--- a/ai_docs/prompts/backlog-sweep-execute.md
+++ b/ai_docs/prompts/backlog-sweep-execute.md
@@ -492,10 +492,30 @@ PR title: `{type}({scope}): {short description} ({initiative.id})`. Examples:
 PR body must include:
 
 - **Closes:** explicit list of backlog row ids closed (machine-greppable).
+- **Fixes #NNN** (one line per linked Issue): for every non-Reserved
+  `[gh #NNN]` reference in the row's `do` cell in `ai_docs/backlog.md`, emit a
+  `Fixes #NNN` line. GitHub auto-closes the linked Issue on merge. **Reserved**
+  rows (`**Reserved — [gh #NNN] (good first issue); skip in sweeps...**`) are
+  pre-skipped by `/backlog-sweep:plan`; the parser still skips them defensively.
+  Follow-on rows that reference a parent tracked-only Issue (e.g. row text
+  `[gh #760] follow-on (split from ...)`) DO inject `Fixes #760` — the parent
+  Issue closes when the follow-on ships.
 - **Validation:** verify-release.ps1 outcome, test counts (before → after), any
   notable manual checks.
 - **Performance:** before/after numbers if Step 4 of plan declared a perf review.
 - **Spin-offs:** any new backlog rows added during verification (Step 3 of the plan).
+
+**Resolving Fixes references** (algorithm for the subagent / orchestrator at
+PR-create time):
+
+1. For each `rowId` in `Closes:`, `Grep` `^\| \`<rowId>\`` in
+   `ai_docs/backlog.md` to locate the row.
+2. Extract the `do` cell — everything after the 4th `|` and before the trailing `|`.
+3. Find every `\[gh #(\d+)\]` match in the cell.
+4. Skip any match whose position is inside a `\*\*Reserved — .*?\*\*` span
+   (non-greedy, no space before the closing `**`).
+5. Emit one `Fixes #N` line per surviving match. Zero matches → no `Fixes` lines
+   (common: rows without a GitHub mirror ship without auto-closing any Issue).
 
 ## Step 9 — Update state
 


### PR DESCRIPTION
## Summary

Closes the drift gap surfaced today by `/reconcile-backlog-vs-issues` — the executor's PR-body contract did not inject `Fixes #NNN` for non-Reserved `[gh #NNN]` references in the backlog row's `do` cell, so auto-filed audit Issues stayed open after the implementing PR merged. Example: PR #780 shipped #760 in full but used `Refs gh #760` instead of `Fixes #760`; #760 was manually closed today.

## Changes

- `.claude/agents/initiative-executor.md` — agent's PR-body contract now requires both `Closes: <row-ids>` AND `Fixes #NNN` lines, with a 4-step resolution algorithm.
- `ai_docs/prompts/backlog-sweep-execute.md` — repo-local mirror updated (Step 8 PR body section) for doc consistency.
- (Also `~/.claude/prompts/backlog-sweep-execute.md` outside this repo — canonical global prompt updated to match.)

## Resolution algorithm (executor runs this before `gh pr create`)

1. For each `rowId` in `Closes:`, grep `^| \`<rowId>\`` in `ai_docs/backlog.md`.
2. Extract the `do` cell (after the 4th `|`, before the trailing `|`).
3. Regex-find `\[gh #(\d+)\]` matches.
4. Skip matches inside a `\*\*Reserved — .*?\*\*` span (Reserved rows are pre-skipped by `/backlog-sweep:plan`; defensive only).
5. Emit one `Fixes #N` line per surviving match.

## Trace against current sweep (20260517T025647Z)

| Initiative | `do` cell refs | Result |
|---|---|---|
| `compact-semantic-grep-pagination` | `[gh #760]` (non-Reserved, follow-on) | `Fixes #760` |
| `test-suite-fixture-reuse-cohesion-and-validate-git` | none | no Fixes lines |
| `test-suite-expanded-surface-class-split` | none | no Fixes lines |

## Test plan

- [ ] CI passes (verify-release.ps1 + verify-ai-docs.ps1).
- [ ] Next `/backlog-sweep:execute` run on Init 1 produces a PR body containing `Fixes #760` (Issue #760 is already closed, but the keyword still verifies the algorithm fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)