### PR TITLE
fix(analysis): add offset/totalCount/hasMore to semantic_grep envelope (compact-semantic-grep-pagination)

### DIFF
--- a/changelog.d/compact-semantic-grep-pagination.md
+++ b/changelog.d/compact-semantic-grep-pagination.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `semantic_grep` response envelope now includes `offset`, `totalCount`, and `hasMore` fields and accepts an `offset` parameter, enabling callers to page past the first 500-hit window on broad queries. Decouples the 500-hit collection ceiling from the user-facing page `limit` so pagination actually advances. Mirrors the pagination contract established by `find_reflection_usages` and `find_type_usages`. Closes `compact-semantic-grep-pagination` (split from gh #760, companion to PR #780).

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -418,7 +418,16 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "semantic_grep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Token-aware regex search over the loaded C# workspace. Walks every document's syntax tokens (and comment trivia) and applies the supplied .NET regex to the text of tokens whose syntactic kind matches `scope`. Lets callers exclude false-positive matches that plain text grep would return inside string literals or comments. Scopes: `identifiers` (identifier tokens only), `strings` (string-literal tokens — verbatim, interpolated text, raw, char, utf8), `comments` (single-line, multi-line, and doc-comment trivia), or `all` (the union). Pattern syntax: uses .NET regex (System.Text.RegularExpressions), NOT ripgrep/PCRE syntax — backreferences, lookaheads, and .NET-specific constructs are supported; use anchors (^/$) carefully as each token is matched independently. Per-document regex evaluation is hard-capped at 2 seconds; tokens that trigger a timeout are silently skipped rather than failing the call — use simpler patterns if results seem incomplete on large files. Optional `projectFilter` restricts the walk by Project.Name. Hard-capped at 500 hits per call to bound response size — narrow `pattern` or `projectFilter` if hits are truncated. Response shape: { count, items: [{ filePath, line, column, tokenKind, snippet }] } sorted by ascending file/line/column.")]
+    /// <summary>
+    /// Hard cap on the per-call hit collection inside <see cref="SemanticGrep"/>.
+    /// Mirrors the legacy default-500 ceiling that callers and docs already expect, but
+    /// decouples the collection cap from the user-facing page <c>limit</c> so pagination
+    /// can actually advance: the service collects up to <see cref="SemanticGrepHardCap"/>
+    /// hits, then the wrapper slices a <c>[offset, offset+limit)</c> window client-side.
+    /// </summary>
+    private const int SemanticGrepHardCap = 500;
+
+    [McpServerTool(Name = "semantic_grep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Token-aware regex search over the loaded C# workspace. Walks every document's syntax tokens (and comment trivia) and applies the supplied .NET regex to the text of tokens whose syntactic kind matches `scope`. Lets callers exclude false-positive matches that plain text grep would return inside string literals or comments. Scopes: `identifiers` (identifier tokens only), `strings` (string-literal tokens — verbatim, interpolated text, raw, char, utf8), `comments` (single-line, multi-line, and doc-comment trivia), or `all` (the union). Pattern syntax: uses .NET regex (System.Text.RegularExpressions), NOT ripgrep/PCRE syntax — backreferences, lookaheads, and .NET-specific constructs are supported; use anchors (^/$) carefully as each token is matched independently. Per-document regex evaluation is hard-capped at 2 seconds; tokens that trigger a timeout are silently skipped rather than failing the call — use simpler patterns if results seem incomplete on large files. Optional `projectFilter` restricts the walk by Project.Name. Hard-capped at 500 hits per call to bound response size — narrow `pattern` or `projectFilter` if hits are truncated. Paginated via offset/limit — callers should iterate until hasMore=false. totalCount counts all hits up to the 500-hit hard cap (collection ceiling, decoupled from the user-facing page limit); the paged items slice contains only the [offset, offset+limit) window. Response shape: { count, totalCount, hasMore, offset, limit, items: [{ filePath, line, column, tokenKind, snippet }] } sorted by ascending file/line/column.")]
     [McpToolMetadata("analysis", "experimental", true, false,
         "Token-aware regex search over C# code (identifier / string / comment scopes).")]
     public static Task<string> SemanticGrep(
@@ -428,13 +437,29 @@ public static class AnalysisTools
         [Description(".NET regex pattern to match against token text.")] string pattern,
         [Description("Token-kind scope: 'identifiers' | 'strings' | 'comments' | 'all'.")] string scope = "identifiers",
         [Description("Optional: case-sensitive Project.Name filter to scope the walk.")] string? projectFilter = null,
-        [Description("Maximum hits to return (default 500; hard cap to bound response size).")] int limit = 500,
+        [Description("Page size — maximum hits to return per call (default 500). Hits beyond the 500-hit collection ceiling are dropped; narrow pattern or projectFilter if hasMore stays true at offset=500.")] int limit = 500,
+        [Description("Number of hits to skip before returning results (default: 0).")] int offset = 0,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            var results = await semanticGrepService.SearchAsync(workspaceId, pattern, scope, projectFilter, limit, c);
-            return JsonSerializer.Serialize(new { count = results.Count, items = results }, JsonDefaults.Indented);
+            ParameterValidation.ValidatePagination(offset, limit);
+            // Always collect up to the 500-hit hard cap so pagination can actually advance.
+            // The user-facing `limit` is the page size, not the collection ceiling — see
+            // SemanticGrepHardCap comment. Mirrors find_type_usages / find_reflection_usages
+            // which collect-all then Skip/Take client-side.
+            var results = await semanticGrepService.SearchAsync(workspaceId, pattern, scope, projectFilter, SemanticGrepHardCap, c);
+            var paged = results.Skip(offset).Take(limit).ToList();
+            var hasMore = offset + paged.Count < results.Count;
+            return JsonSerializer.Serialize(new
+            {
+                count = paged.Count,
+                totalCount = results.Count,
+                hasMore,
+                offset,
+                limit,
+                items = paged,
+            }, JsonDefaults.Indented);
         }, ct);
     }
 }

--- a/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Tools;
+
 namespace RoslynMcp.Tests;
 
 [DoNotParallelize]
@@ -118,5 +121,117 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
         await Assert.ThrowsExceptionAsync<ArgumentException>(
             () => SemanticGrepService.SearchAsync(
                 WorkspaceId, "(unclosed", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
+    }
+
+    // ----- Pagination envelope tests (PR for compact-semantic-grep-pagination, gh #760 split) -----
+    //
+    // These tests exercise the wrapper layer in AnalysisTools.SemanticGrep, not the service.
+    // The service still hard-caps collection at `limit`; the wrapper slices the returned list
+    // via Skip(offset).Take(limit) and emits the { count, totalCount, hasMore, offset, limit,
+    // items } envelope. Mirrors the contract established by FindReflectionUsages and FindTypeUsages.
+
+    /// <summary>
+    /// Bounded-collection contract: when offset=0 and limit &lt; the actual hit count the
+    /// response must report hasMore=true, count==limit, and a totalCount strictly greater
+    /// than count. Uses the "." all-identifier pattern, which on the shared sample workspace
+    /// always produces a totalCount well above 5 (most identifier tokens are single-character-
+    /// or-longer, so they match ".").
+    /// </summary>
+    [TestMethod]
+    public async Task SemanticGrep_WrapperLimitSmallerThanTotal_ReportsHasMoreAndPagedCount()
+    {
+        const int Limit = 5;
+
+        var json = await AnalysisTools.SemanticGrep(
+            gate: WorkspaceExecutionGate,
+            semanticGrepService: SemanticGrepService,
+            workspaceId: WorkspaceId,
+            pattern: ".",
+            scope: "identifiers",
+            projectFilter: null,
+            limit: Limit,
+            offset: 0,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var count = root.GetProperty("count").GetInt32();
+        var totalCount = root.GetProperty("totalCount").GetInt32();
+        var hasMore = root.GetProperty("hasMore").GetBoolean();
+
+        Assert.AreEqual(Limit, count, "count must equal the requested limit when totalCount > limit.");
+        Assert.IsTrue(totalCount > Limit,
+            $"Sample workspace totalCount ({totalCount}) must exceed Limit ({Limit}) for this test to be meaningful.");
+        Assert.IsTrue(hasMore, "hasMore must be true when totalCount > offset + count.");
+
+        // Echoed paging knobs let callers route follow-up requests off the same envelope shape.
+        Assert.AreEqual(0, root.GetProperty("offset").GetInt32());
+        Assert.AreEqual(Limit, root.GetProperty("limit").GetInt32());
+
+        // items array must contain exactly `count` entries.
+        var items = root.GetProperty("items");
+        Assert.AreEqual(count, items.GetArrayLength(),
+            "items.Length must equal count (the paged slice size).");
+    }
+
+    /// <summary>
+    /// Pagination is deterministic: the first window (offset=0, limit=N) and a second
+    /// window (offset=N, limit=N) must return different first items. Service results are
+    /// sorted by ascending file/line/column, so the items[0] of the two windows must differ
+    /// whenever totalCount &gt; N. Both windows must report the same totalCount.
+    /// </summary>
+    [TestMethod]
+    public async Task SemanticGrep_WrapperDifferentOffsets_ReturnDifferentSlicesSameTotal()
+    {
+        const int Limit = 5;
+
+        var firstJson = await AnalysisTools.SemanticGrep(
+            gate: WorkspaceExecutionGate,
+            semanticGrepService: SemanticGrepService,
+            workspaceId: WorkspaceId,
+            pattern: ".",
+            scope: "identifiers",
+            projectFilter: null,
+            limit: Limit,
+            offset: 0,
+            ct: CancellationToken.None);
+
+        var secondJson = await AnalysisTools.SemanticGrep(
+            gate: WorkspaceExecutionGate,
+            semanticGrepService: SemanticGrepService,
+            workspaceId: WorkspaceId,
+            pattern: ".",
+            scope: "identifiers",
+            projectFilter: null,
+            limit: Limit,
+            offset: Limit,
+            ct: CancellationToken.None);
+
+        using var first = JsonDocument.Parse(firstJson);
+        using var second = JsonDocument.Parse(secondJson);
+
+        var firstTotal = first.RootElement.GetProperty("totalCount").GetInt32();
+        var secondTotal = second.RootElement.GetProperty("totalCount").GetInt32();
+        Assert.AreEqual(firstTotal, secondTotal,
+            "totalCount must be stable across paging requests against the same workspace.");
+
+        Assert.AreEqual(0, first.RootElement.GetProperty("offset").GetInt32());
+        Assert.AreEqual(Limit, second.RootElement.GetProperty("offset").GetInt32());
+
+        // items[0] of the two windows must differ since the service returns results sorted
+        // deterministically and totalCount > 2*Limit.
+        Assert.IsTrue(firstTotal > 2 * Limit,
+            $"Sample workspace totalCount ({firstTotal}) must exceed 2*Limit ({2 * Limit}) for the disjoint-window assertion.");
+
+        var firstItems = first.RootElement.GetProperty("items");
+        var secondItems = second.RootElement.GetProperty("items");
+        Assert.IsTrue(firstItems.GetArrayLength() > 0);
+        Assert.IsTrue(secondItems.GetArrayLength() > 0);
+
+        var firstItem0 = firstItems[0].GetRawText();
+        var secondItem0 = secondItems[0].GetRawText();
+        Assert.AreNotEqual(firstItem0, secondItem0,
+            "offset=0 and offset=Limit windows must surface different first items (deterministic file/line/column sort).");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `offset` parameter and `{ count, totalCount, hasMore, offset, limit, items }` envelope fields to the `semantic_grep` tool wrapper.
- Decouples the 500-hit collection ceiling from the user-facing page `limit` so `Skip(offset).Take(limit)` slicing actually advances — previously the wrapper passed the user's `limit` to the service as both the collection cap AND the return cap, so `hasMore` was permanently `false` once a caller set `limit < totalCount`.
- Mirrors the pagination contract used by `find_reflection_usages` and `find_type_usages`: collect up to the hard cap, slice client-side, emit the standard envelope.

## Implementation notes
- Single production file changed: `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs`.
- Added `private const int SemanticGrepHardCap = 500` for the collection ceiling.
- Added `ParameterValidation.ValidatePagination(offset, limit)` at the top of the lambda, matching `FindTypeUsages` / `FindReflectionUsages`.
- Updated the `[Description(...)]` attribute text to document the new envelope fields and the cap/page-limit decoupling.
- Extended `tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs` with two new tests that exercise the wrapper (not the service): `SemanticGrep_WrapperLimitSmallerThanTotal_ReportsHasMoreAndPagedCount` and `SemanticGrep_WrapperDifferentOffsets_ReturnDifferentSlicesSameTotal`.
- `ISemanticGrepService` / `SemanticGrepService` signatures are unchanged; the existing `SemanticGrep_Limit_CapsResultCount` service-level test still passes.

## Plan-author bug fix (caught during validation)
The plan-as-written said "pass user's `limit` to the service then `Skip(offset).Take(limit)` client-side." That approach is functionally broken: the service hard-caps collection at the passed `limit`, so `results.Count <= limit` always and `hasMore` is permanently `false`. Confirmed with a failing test run before the fix.
The correct fix — and what the plan-author clearly intended per the description text "totalCount counts all hits up to the hard cap" — is to pass the 500-hit cap to the service and use the user's `limit` only as the slice page size. Both new tests now pass against this implementation.

## Test plan
- [x] `mcp__roslyn__compile_check` on `AnalysisTools.cs` — zero errors.
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~SemanticGrepServiceTests"` — 10/10 pass (8 existing + 2 new).
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~AnalysisToolsTests|ExpandedSurfaceIntegrationTests|ToolDispatchTests"` — 31/31 pass.
- [x] `mcp__roslyn__find_references` on `AnalysisTools.SemanticGrep` — only the three new test call sites, no production consumers broken by the signature change.

Closes: compact-semantic-grep-pagination
Fixes #760