### PR TITLE
refactor(tests): split ExpandedSurfaceIntegrationTests into 4 focused classes (test-suite-expanded-surface-class-split)

### DIFF
--- a/changelog.d/test-suite-expanded-surface-class-split.md
+++ b/changelog.d/test-suite-expanded-surface-class-split.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Split `ExpandedSurfaceIntegrationTests` (683 lines, 17 methods) into three focused test classes (`ExpandedSurfaceIntegrationTests_ToolContract`, `ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis`, `ExpandedSurfaceIntegrationTests_CoverageProcess`) mirroring the `IntegrationTests_*` pattern from PR #793. Class-level `[TestCategory("RepoSolution")]` and `[TestCategory("Process")]` attributes now scope the CI lane filters without per-method decoration. No product behavior changes. Closes `test-suite-expanded-surface-class-split`.

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.CoverageProcess.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.CoverageProcess.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+[DoNotParallelize]
+[TestClass]
+[TestCategory("Process")]
+public sealed class ExpandedSurfaceIntegrationTests_CoverageProcess : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task TestCoverageTool_Returns_Structured_Response()
+    {
+        var json = await TestCoverageTools.RunTestCoverage(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            DotnetCommandRunner,
+            WorkspaceId,
+            projectName: "SampleLib.Tests",
+            progress: null,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.TryGetProperty("success", out _));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
+    }
+
+    // test-coverage-vague-error-when-coverlet-missing: if the sample solution's test project
+    // doesn't reference coverlet.collector, the tool must return success=false with
+    // errorKind=CoverletMissing and a populated missingPackages list. If it DOES reference
+    // coverlet, the tool should attempt to run tests (the test doesn't assert success of
+    // that run, only that the short-circuit didn't fire when coverlet is present).
+    [TestMethod]
+    public async Task TestCoverageTool_WhenCoverletMissing_ReturnsStructuredErrorBeforeRunning()
+    {
+        var json = await TestCoverageTools.RunTestCoverage(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            DotnetCommandRunner,
+            WorkspaceId,
+            projectName: "SampleLib.Tests",
+            progress: null,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var hasEnvelope = doc.RootElement.TryGetProperty("failureEnvelope", out var envelope)
+            && envelope.ValueKind == JsonValueKind.Object;
+
+        // Find whether the sample test csproj references coverlet. The regression test tracks
+        // the branch that matches this fixture's state.
+        var testProjectPath = Path.Combine(Path.GetDirectoryName(SampleSolutionPath)!, "SampleLib.Tests", "SampleLib.Tests.csproj");
+        var hasCoverlet = File.Exists(testProjectPath) &&
+            File.ReadAllText(testProjectPath).Contains("coverlet.collector", StringComparison.OrdinalIgnoreCase);
+
+        if (!hasCoverlet)
+        {
+            Assert.IsTrue(hasEnvelope,
+                $"Sample test project lacks coverlet.collector — tool must emit a structured envelope. JSON: {json}");
+            Assert.AreEqual("CoverletMissing", envelope.GetProperty("errorKind").GetString());
+            Assert.IsTrue(envelope.TryGetProperty("missingPackages", out var missing)
+                && missing.ValueKind == JsonValueKind.Array
+                && missing.GetArrayLength() >= 1,
+                "missingPackages must list the test projects that need coverlet.");
+            var names = missing.EnumerateArray().Select(e => e.GetString()).ToList();
+            CollectionAssert.Contains(names, "SampleLib.Tests",
+                "The sample test project name must appear in missingPackages.");
+        }
+        else
+        {
+            // Sample has coverlet — the short-circuit must NOT have fired, so either success
+            // is true (coverage ran) or the envelope is something other than CoverletMissing.
+            if (hasEnvelope && envelope.TryGetProperty("errorKind", out var kind))
+            {
+                Assert.AreNotEqual("CoverletMissing", kind.GetString(),
+                    "Sample has coverlet but tool short-circuited as CoverletMissing.");
+            }
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs
@@ -1,0 +1,50 @@
+namespace RoslynMcp.Tests;
+
+[DoNotParallelize]
+[TestClass]
+[TestCategory("RepoSolution")]
+public sealed class ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public async Task Reflection_And_Di_Analysis_Run_On_Repo_Solution()
+    {
+        var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
+        var status = await WorkspaceManager.LoadAsync(repositorySolutionPath, CancellationToken.None);
+
+        try
+        {
+            var reflectionUsages = await CodePatternAnalyzer.FindReflectionUsagesAsync(
+                status.WorkspaceId,
+                "RoslynMcp.Roslyn",
+                CancellationToken.None);
+            var diRegistrations = await DiRegistrationService.GetDiRegistrationsAsync(
+                status.WorkspaceId,
+                "RoslynMcp.Roslyn",
+                CancellationToken.None);
+
+            Assert.IsTrue(reflectionUsages.Count > 0, "Expected reflection analysis to complete with results on the repo solution.");
+            Assert.IsTrue(diRegistrations.Any(registration =>
+                registration.FilePath.EndsWith("ServiceCollectionExtensions.cs", StringComparison.OrdinalIgnoreCase)),
+                "Expected DI registrations from ServiceCollectionExtensions.cs.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(status.WorkspaceId);
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.ToolContract.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.ToolContract.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Host.Stdio.Prompts;
+using RoslynMcp.Host.Stdio.Resources;
+using RoslynMcp.Host.Stdio.Tools;
+using ModelContextProtocol.Protocol;
+
+namespace RoslynMcp.Tests;
+
+[DoNotParallelize]
+[TestClass]
+public sealed class ExpandedSurfaceIntegrationTests_ToolContract : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    [TestMethod]
+    public void Resources_Return_Machine_Readable_Contracts()
+    {
+        using var catalogDoc = JsonDocument.Parse(ServerResources.GetServerCatalog());
+        Assert.AreEqual("local-first", catalogDoc.RootElement.GetProperty("productShape").GetString());
+        // dr-9-11-payload-exceeds-mcp-tool-result-cap (PR #188): default catalog now returns
+        // a summary with toolCount + toolsResourceTemplate instead of an inline tools array.
+        Assert.IsTrue(catalogDoc.RootElement.GetProperty("toolCount").GetInt32() > 0);
+
+        using var templatesDoc = JsonDocument.Parse(ServerResources.GetResourceTemplates());
+        Assert.IsTrue(templatesDoc.RootElement.GetProperty("count").GetInt32() >= 1);
+        Assert.IsTrue(templatesDoc.RootElement.GetProperty("resources")
+            .EnumerateArray()
+            .Any(resource => string.Equals(
+                resource.GetProperty("uriTemplate").GetString(),
+                "roslyn://workspace/{workspaceId}/status",
+                StringComparison.Ordinal)));
+
+        using var workspacesDoc = JsonDocument.Parse(WorkspaceResources.GetWorkspaces(WorkspaceManager));
+        Assert.IsTrue(workspacesDoc.RootElement.GetProperty("count").GetInt32() >= 1);
+    }
+
+    [TestMethod]
+    public async Task Prompts_Return_Actionable_Context()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var reviewMessages = (await RoslynPrompts.ReviewFile(
+            WorkspaceManager,
+            SymbolSearchService,
+            DiagnosticService,
+            WorkspaceId,
+            filePath,
+            CancellationToken.None)).ToList();
+
+        Assert.AreEqual(1, reviewMessages.Count);
+        var reviewText = GetPromptText(reviewMessages[0]);
+        StringAssert.Contains(reviewText, "AnimalService.cs");
+        StringAssert.Contains(reviewText, "Perform a thorough code review");
+
+        var dependencyMessages = (await RoslynPrompts.AnalyzeDependencies(
+            WorkspaceManager,
+            NamespaceDependencyService,
+            NuGetDependencyService,
+            WorkspaceId,
+            CancellationToken.None)).ToList();
+        Assert.AreEqual(1, dependencyMessages.Count);
+        StringAssert.Contains(GetPromptText(dependencyMessages[0]), "Project Dependency Graph");
+    }
+
+    [TestMethod]
+    public async Task PreviewCodeAction_Serializes_Service_Response()
+    {
+        var previewJson = await CodeActionTools.PreviewCodeAction(
+            WorkspaceExecutionGate,
+            new FakeCodeActionService(),
+            WorkspaceId,
+            filePath: "C:\\temp\\Example.cs",
+            startLine: 1,
+            startColumn: 1,
+            actionIndex: 0,
+            endLine: null,
+            endColumn: null,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(previewJson);
+        Assert.AreEqual("preview-token", doc.RootElement.GetProperty("previewToken").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("changes").GetArrayLength() == 1);
+    }
+
+    private static string FindDocumentPath(string name)
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var path = solution.Projects
+            .SelectMany(project => project.Documents)
+            .FirstOrDefault(document => string.Equals(document.Name, name, StringComparison.Ordinal))?.FilePath;
+
+        return path ?? throw new AssertFailedException($"Document '{name}' was not found.");
+    }
+
+    private static string GetPromptText(PromptMessage message)
+    {
+        return (message.Content as TextContentBlock)?.Text
+            ?? throw new AssertFailedException("Prompt content was not a text block.");
+    }
+
+    private sealed class FakeCodeActionService : RoslynMcp.Core.Services.ICodeActionService
+    {
+        public Task<CodeActionListDto> GetCodeActionsAsync(
+            string workspaceId,
+            string filePath,
+            int startLine,
+            int startColumn,
+            int? endLine,
+            int? endColumn,
+            CancellationToken ct)
+        {
+            IReadOnlyList<CodeActionDto> actions = [new CodeActionDto(0, "Demo action", "Refactor", "demo")];
+            return Task.FromResult(new CodeActionListDto(actions.Count, Hint: null, actions));
+        }
+
+        public Task<RefactoringPreviewDto> PreviewCodeActionAsync(
+            string workspaceId,
+            string filePath,
+            int startLine,
+            int startColumn,
+            int? endLine,
+            int? endColumn,
+            int actionIndex,
+            CancellationToken ct)
+        {
+            return Task.FromResult(new RefactoringPreviewDto(
+                "preview-token",
+                "Demo preview",
+                [new FileChangeDto(filePath, "--- before\n+++ after")],
+                null));
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -1,9 +1,6 @@
 using System.Text.Json;
 using RoslynMcp.Core.Models;
-using RoslynMcp.Host.Stdio.Prompts;
-using RoslynMcp.Host.Stdio.Resources;
 using RoslynMcp.Host.Stdio.Tools;
-using ModelContextProtocol.Protocol;
 
 namespace RoslynMcp.Tests;
 
@@ -390,84 +387,6 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    [TestCategory("RepoSolution")]
-    public async Task Reflection_And_Di_Analysis_Run_On_Repo_Solution()
-    {
-        var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
-        var status = await WorkspaceManager.LoadAsync(repositorySolutionPath, CancellationToken.None);
-
-        try
-        {
-            var reflectionUsages = await CodePatternAnalyzer.FindReflectionUsagesAsync(
-                status.WorkspaceId,
-                "RoslynMcp.Roslyn",
-                CancellationToken.None);
-            var diRegistrations = await DiRegistrationService.GetDiRegistrationsAsync(
-                status.WorkspaceId,
-                "RoslynMcp.Roslyn",
-                CancellationToken.None);
-
-            Assert.IsTrue(reflectionUsages.Count > 0, "Expected reflection analysis to complete with results on the repo solution.");
-            Assert.IsTrue(diRegistrations.Any(registration =>
-                registration.FilePath.EndsWith("ServiceCollectionExtensions.cs", StringComparison.OrdinalIgnoreCase)),
-                "Expected DI registrations from ServiceCollectionExtensions.cs.");
-        }
-        finally
-        {
-            WorkspaceManager.Close(status.WorkspaceId);
-        }
-    }
-
-    [TestMethod]
-    public void Resources_Return_Machine_Readable_Contracts()
-    {
-        using var catalogDoc = JsonDocument.Parse(ServerResources.GetServerCatalog());
-        Assert.AreEqual("local-first", catalogDoc.RootElement.GetProperty("productShape").GetString());
-        // dr-9-11-payload-exceeds-mcp-tool-result-cap (PR #188): default catalog now returns
-        // a summary with toolCount + toolsResourceTemplate instead of an inline tools array.
-        Assert.IsTrue(catalogDoc.RootElement.GetProperty("toolCount").GetInt32() > 0);
-
-        using var templatesDoc = JsonDocument.Parse(ServerResources.GetResourceTemplates());
-        Assert.IsTrue(templatesDoc.RootElement.GetProperty("count").GetInt32() >= 1);
-        Assert.IsTrue(templatesDoc.RootElement.GetProperty("resources")
-            .EnumerateArray()
-            .Any(resource => string.Equals(
-                resource.GetProperty("uriTemplate").GetString(),
-                "roslyn://workspace/{workspaceId}/status",
-                StringComparison.Ordinal)));
-
-        using var workspacesDoc = JsonDocument.Parse(WorkspaceResources.GetWorkspaces(WorkspaceManager));
-        Assert.IsTrue(workspacesDoc.RootElement.GetProperty("count").GetInt32() >= 1);
-    }
-
-    [TestMethod]
-    public async Task Prompts_Return_Actionable_Context()
-    {
-        var filePath = FindDocumentPath("AnimalService.cs");
-        var reviewMessages = (await RoslynPrompts.ReviewFile(
-            WorkspaceManager,
-            SymbolSearchService,
-            DiagnosticService,
-            WorkspaceId,
-            filePath,
-            CancellationToken.None)).ToList();
-
-        Assert.AreEqual(1, reviewMessages.Count);
-        var reviewText = GetPromptText(reviewMessages[0]);
-        StringAssert.Contains(reviewText, "AnimalService.cs");
-        StringAssert.Contains(reviewText, "Perform a thorough code review");
-
-        var dependencyMessages = (await RoslynPrompts.AnalyzeDependencies(
-            WorkspaceManager,
-            NamespaceDependencyService,
-            NuGetDependencyService,
-            WorkspaceId,
-            CancellationToken.None)).ToList();
-        Assert.AreEqual(1, dependencyMessages.Count);
-        StringAssert.Contains(GetPromptText(dependencyMessages[0]), "Project Dependency Graph");
-    }
-
-    [TestMethod]
     public async Task CodeActionTools_Return_Structured_Results()
     {
         var filePath = FindDocumentPath("AnimalService.cs");
@@ -485,26 +404,6 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         using var actionsDoc = JsonDocument.Parse(actionsJson);
         Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("count", out _));
         Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("actions", out _));
-    }
-
-    [TestMethod]
-    public async Task PreviewCodeAction_Serializes_Service_Response()
-    {
-        var previewJson = await CodeActionTools.PreviewCodeAction(
-            WorkspaceExecutionGate,
-            new FakeCodeActionService(),
-            WorkspaceId,
-            filePath: "C:\\temp\\Example.cs",
-            startLine: 1,
-            startColumn: 1,
-            actionIndex: 0,
-            endLine: null,
-            endColumn: null,
-            CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(previewJson);
-        Assert.AreEqual("preview-token", doc.RootElement.GetProperty("previewToken").GetString());
-        Assert.IsTrue(doc.RootElement.GetProperty("changes").GetArrayLength() == 1);
     }
 
     [TestMethod]
@@ -553,76 +452,6 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         }
     }
 
-    [TestMethod]
-    [TestCategory("Process")]
-    public async Task TestCoverageTool_Returns_Structured_Response()
-    {
-        var json = await TestCoverageTools.RunTestCoverage(
-            WorkspaceExecutionGate,
-            WorkspaceManager,
-            DotnetCommandRunner,
-            WorkspaceId,
-            projectName: "SampleLib.Tests",
-            progress: null,
-            CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("success", out _));
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
-    }
-
-    // test-coverage-vague-error-when-coverlet-missing: if the sample solution's test project
-    // doesn't reference coverlet.collector, the tool must return success=false with
-    // errorKind=CoverletMissing and a populated missingPackages list. If it DOES reference
-    // coverlet, the tool should attempt to run tests (the test doesn't assert success of
-    // that run, only that the short-circuit didn't fire when coverlet is present).
-    [TestMethod]
-    public async Task TestCoverageTool_WhenCoverletMissing_ReturnsStructuredErrorBeforeRunning()
-    {
-        var json = await TestCoverageTools.RunTestCoverage(
-            WorkspaceExecutionGate,
-            WorkspaceManager,
-            DotnetCommandRunner,
-            WorkspaceId,
-            projectName: "SampleLib.Tests",
-            progress: null,
-            CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(json);
-        var hasEnvelope = doc.RootElement.TryGetProperty("failureEnvelope", out var envelope)
-            && envelope.ValueKind == JsonValueKind.Object;
-
-        // Find whether the sample test csproj references coverlet. The regression test tracks
-        // the branch that matches this fixture's state.
-        var testProjectPath = Path.Combine(Path.GetDirectoryName(SampleSolutionPath)!, "SampleLib.Tests", "SampleLib.Tests.csproj");
-        var hasCoverlet = File.Exists(testProjectPath) &&
-            File.ReadAllText(testProjectPath).Contains("coverlet.collector", StringComparison.OrdinalIgnoreCase);
-
-        if (!hasCoverlet)
-        {
-            Assert.IsTrue(hasEnvelope,
-                $"Sample test project lacks coverlet.collector — tool must emit a structured envelope. JSON: {json}");
-            Assert.AreEqual("CoverletMissing", envelope.GetProperty("errorKind").GetString());
-            Assert.IsTrue(envelope.TryGetProperty("missingPackages", out var missing)
-                && missing.ValueKind == JsonValueKind.Array
-                && missing.GetArrayLength() >= 1,
-                "missingPackages must list the test projects that need coverlet.");
-            var names = missing.EnumerateArray().Select(e => e.GetString()).ToList();
-            CollectionAssert.Contains(names, "SampleLib.Tests",
-                "The sample test project name must appear in missingPackages.");
-        }
-        else
-        {
-            // Sample has coverlet — the short-circuit must NOT have fired, so either success
-            // is true (coverage ran) or the envelope is something other than CoverletMissing.
-            if (hasEnvelope && envelope.TryGetProperty("errorKind", out var kind))
-            {
-                Assert.AreNotEqual("CoverletMissing", kind.GetString(),
-                    "Sample has coverlet but tool short-circuited as CoverletMissing.");
-            }
-        }
-    }
-
     private static string FindDocumentPath(string name) => FindDocumentPath(WorkspaceId, name);
 
     private static string FindDocumentPath(string workspaceId, string name)
@@ -635,48 +464,9 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         return path ?? throw new AssertFailedException($"Document '{name}' was not found.");
     }
 
-    private static string GetPromptText(PromptMessage message)
-    {
-        return (message.Content as TextContentBlock)?.Text
-            ?? throw new AssertFailedException("Prompt content was not a text block.");
-    }
-
     private static async Task<string> LoadWorkspaceCopyAsync(string workspacePath)
     {
         var status = await WorkspaceManager.LoadAsync(workspacePath, CancellationToken.None);
         return status.WorkspaceId;
-    }
-
-    private sealed class FakeCodeActionService : RoslynMcp.Core.Services.ICodeActionService
-    {
-        public Task<CodeActionListDto> GetCodeActionsAsync(
-            string workspaceId,
-            string filePath,
-            int startLine,
-            int startColumn,
-            int? endLine,
-            int? endColumn,
-            CancellationToken ct)
-        {
-            IReadOnlyList<CodeActionDto> actions = [new CodeActionDto(0, "Demo action", "Refactor", "demo")];
-            return Task.FromResult(new CodeActionListDto(actions.Count, Hint: null, actions));
-        }
-
-        public Task<RefactoringPreviewDto> PreviewCodeActionAsync(
-            string workspaceId,
-            string filePath,
-            int startLine,
-            int startColumn,
-            int? endLine,
-            int? endColumn,
-            int actionIndex,
-            CancellationToken ct)
-        {
-            return Task.FromResult(new RefactoringPreviewDto(
-                "preview-token",
-                "Demo preview",
-                [new FileChangeDto(filePath, "--- before\n+++ after")],
-                null));
-        }
     }
 }


### PR DESCRIPTION
## Summary

Mirror the `IntegrationTests_*` pattern shipped in PR #793 and break the 683-line, 17-method `ExpandedSurfaceIntegrationTests` (`tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs`) into three new sibling files plus a trimmed original. Each new class is `[DoNotParallelize]` + `[TestClass]`, duplicates the `[ClassInitialize]`/`[ClassCleanup]` shape, and shares the cached MSBuild workspace via `SharedWorkspaceTestBase`'s path-keyed cache. Pure move; no product behavior or assertion changes.

- **`ExpandedSurfaceIntegrationTests.ToolContract.cs`** — `ExpandedSurfaceIntegrationTests_ToolContract` (3 tests + `FakeCodeActionService` + `GetPromptText` helper + local single-arg `FindDocumentPath` overload): `Resources_Return_Machine_Readable_Contracts`, `Prompts_Return_Actionable_Context`, `PreviewCodeAction_Serializes_Service_Response`.
- **`ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs`** — `ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis` with class-level `[TestCategory("RepoSolution")]` (1 test): `Reflection_And_Di_Analysis_Run_On_Repo_Solution`. Per-method `[TestCategory("RepoSolution")]` removed (now redundant under class-level).
- **`ExpandedSurfaceIntegrationTests.CoverageProcess.cs`** — `ExpandedSurfaceIntegrationTests_CoverageProcess` with class-level `[TestCategory("Process")]` (2 tests): `TestCoverageTool_Returns_Structured_Response`, `TestCoverageTool_WhenCoverletMissing_ReturnsStructuredErrorBeforeRunning`. Class-level attribute correctly scopes both (the second test was previously not decorated — corrected here).
- **Trimmed `ExpandedSurfaceIntegrationTests.cs`** keeps the 11 general shared-workspace tool-contract tests + `FindDocumentPath` (both overloads) + `LoadWorkspaceCopyAsync` helpers.

Closes: test-suite-expanded-surface-class-split

## Test plan

- [x] `mcp__roslyn__project_diagnostics` on `RoslynMcp.Tests` — 0 errors / 0 warnings.
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~ExpandedSurfaceIntegrationTests"` — 17/17 pass across the 4 resulting classes.
- [x] `mcp__roslyn__test_run --filter "TestCategory=RepoSolution&FullyQualifiedName~ExpandedSurface"` — 1/1 pass (`Reflection_And_Di_Analysis_Run_On_Repo_Solution`).
- [x] `mcp__roslyn__test_run --filter "TestCategory=Process&FullyQualifiedName~ExpandedSurface"` — 2/2 pass (both coverage tests).
- [ ] Self-hosted CI runner gates the full release-verify on push.