### PR TITLE
refactor(tests): adopt IsolatedWorkspaceTestBase in cohesion + validate-git suites

### DIFF
--- a/changelog.d/test-suite-fixture-reuse-cohesion-and-validate-git.md
+++ b/changelog.d/test-suite-fixture-reuse-cohesion-and-validate-git.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Converted `CohesionAnalysisTests`, `ValidateRecentGitChangesTests`, and `ChangeSignaturePreviewMetadataNameShapeTests` to `IsolatedWorkspaceTestBase`, replacing manual `CreateSampleSolutionCopy()` + `try/finally` cleanup with the `IsolatedWorkspaceScope` RAII pattern introduced in PR #795. Also hardened `TestFixtureFileSystem.DeleteDirectoryIfExists` to clear the read-only attribute (equivalent to PowerShell `Remove-Item -Recurse -Force`) so `IsolatedWorkspaceScope.Dispose()` reliably removes git-init'd temp roots on Windows.

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
@@ -17,7 +17,7 @@ namespace RoslynMcp.Tests;
 /// `symbol_search`).
 /// </summary>
 [TestClass]
-public sealed class ChangeSignaturePreviewMetadataNameShapeTests : TestBase
+public sealed class ChangeSignaturePreviewMetadataNameShapeTests : IsolatedWorkspaceTestBase
 {
     private static ChangeSignatureService _changeSignatureService = null!;
 
@@ -46,52 +46,44 @@ public sealed class ChangeSignaturePreviewMetadataNameShapeTests : TestBase
     [TestMethod]
     public async Task ChangeSignaturePreview_MetadataNameWithParens_RejectsWithActionableError()
     {
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-        var workspaceId = loadResult.WorkspaceId;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await workspace.LoadAsync(CancellationToken.None);
 
-        try
-        {
-            // Parenthesized metadata name — exactly the shape an agent that pastes a
-            // Roslyn `ToDisplayString()` output naturally produces. Pre-fix this throws
-            // `InvalidOperationException("requires a method symbol; resolved null")` —
-            // misleading. Post-fix it throws `ArgumentException` whose message names the
-            // shape mismatch and the supported alternatives.
-            var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals(string)");
-            var request = new ChangeSignatureRequest(
-                Op: "remove",
-                Name: null,
-                ParameterType: null,
-                Position: 0,
-                NewName: null,
-                DefaultValue: null);
+        // Parenthesized metadata name — exactly the shape an agent that pastes a
+        // Roslyn `ToDisplayString()` output naturally produces. Pre-fix this throws
+        // `InvalidOperationException("requires a method symbol; resolved null")` —
+        // misleading. Post-fix it throws `ArgumentException` whose message names the
+        // shape mismatch and the supported alternatives.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals(string)");
+        var request = new ChangeSignatureRequest(
+            Op: "remove",
+            Name: null,
+            ParameterType: null,
+            Position: 0,
+            NewName: null,
+            DefaultValue: null);
 
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                await _changeSignatureService.PreviewChangeSignatureAsync(
-                    workspaceId, locator, request, CancellationToken.None));
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspace.WorkspaceId, locator, request, CancellationToken.None));
 
-            // Error must name the shape mismatch (the actual cause) so the agent knows what
-            // to fix.
-            StringAssert.Contains(ex.Message, "parenthesized",
-                $"error must call out the parenthesized signature as the cause; got: {ex.Message}");
+        // Error must name the shape mismatch (the actual cause) so the agent knows what
+        // to fix.
+        StringAssert.Contains(ex.Message, "parenthesized",
+            $"error must call out the parenthesized signature as the cause; got: {ex.Message}");
 
-            // Error must point at the supported alternative.
-            StringAssert.Contains(ex.Message, "symbolHandle",
-                $"error must name `symbolHandle` as the alternative; got: {ex.Message}");
+        // Error must point at the supported alternative.
+        StringAssert.Contains(ex.Message, "symbolHandle",
+            $"error must name `symbolHandle` as the alternative; got: {ex.Message}");
 
-            // Error must echo back the offending input so the agent can correlate with
-            // its own request payload.
-            StringAssert.Contains(ex.Message, "SampleLib.AnimalService.GetAllAnimals(string)",
-                $"error must echo the offending metadata name input; got: {ex.Message}");
+        // Error must echo back the offending input so the agent can correlate with
+        // its own request payload.
+        StringAssert.Contains(ex.Message, "SampleLib.AnimalService.GetAllAnimals(string)",
+            $"error must echo the offending metadata name input; got: {ex.Message}");
 
-            // Error must NOT use the misleading pre-fix wording.
-            Assert.IsFalse(ex.Message.Contains("requires a method symbol", StringComparison.Ordinal),
-                $"error must NOT use the pre-fix 'requires a method symbol' wording; got: {ex.Message}");
-        }
-        finally
-        {
-            WorkspaceManager.Close(workspaceId);
-        }
+        // Error must NOT use the misleading pre-fix wording.
+        Assert.IsFalse(ex.Message.Contains("requires a method symbol", StringComparison.Ordinal),
+            $"error must NOT use the pre-fix 'requires a method symbol' wording; got: {ex.Message}");
     }
 
     /// <summary>
@@ -106,44 +98,36 @@ public sealed class ChangeSignaturePreviewMetadataNameShapeTests : TestBase
     [TestMethod]
     public async Task ChangeSignaturePreview_BareMetadataName_DoesNotHitShapeMismatchPath()
     {
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-        var workspaceId = loadResult.WorkspaceId;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await workspace.LoadAsync(CancellationToken.None);
 
+        // Bare fully-qualified method name — the supported shape. The resolver must
+        // accept this and proceed past the new shape-rejection branch. The downstream
+        // service may still surface a different error (e.g. method has no parameters,
+        // or position out of range), but that error must NOT contain the new
+        // shape-mismatch wording.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals");
+        var request = new ChangeSignatureRequest(
+            Op: "remove",
+            Name: null,
+            ParameterType: null,
+            Position: 99, // genuinely out of range — exercises the post-resolution path
+            NewName: null,
+            DefaultValue: null);
+
+        // The bare name resolves and the pipeline proceeds past the parenthesis check.
+        // The downstream behavior may succeed or fail, but it must NOT raise the new
+        // shape-mismatch error.
         try
         {
-            // Bare fully-qualified method name — the supported shape. The resolver must
-            // accept this and proceed past the new shape-rejection branch. The downstream
-            // service may still surface a different error (e.g. method has no parameters,
-            // or position out of range), but that error must NOT contain the new
-            // shape-mismatch wording.
-            var locator = SymbolLocator.ByMetadataName("SampleLib.AnimalService.GetAllAnimals");
-            var request = new ChangeSignatureRequest(
-                Op: "remove",
-                Name: null,
-                ParameterType: null,
-                Position: 99, // genuinely out of range — exercises the post-resolution path
-                NewName: null,
-                DefaultValue: null);
-
-            // The bare name resolves and the pipeline proceeds past the parenthesis check.
-            // The downstream behavior may succeed or fail, but it must NOT raise the new
-            // shape-mismatch error.
-            try
-            {
-                await _changeSignatureService.PreviewChangeSignatureAsync(
-                    workspaceId, locator, request, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                // Whatever the downstream raises, it must NOT be the shape-mismatch error.
-                Assert.IsFalse(ex.Message.Contains("parenthesized", StringComparison.Ordinal),
-                    $"bare name must not be flagged as parenthesized; got: {ex.Message}");
-            }
+            await _changeSignatureService.PreviewChangeSignatureAsync(
+                workspace.WorkspaceId, locator, request, CancellationToken.None);
         }
-        finally
+        catch (Exception ex)
         {
-            WorkspaceManager.Close(workspaceId);
+            // Whatever the downstream raises, it must NOT be the shape-mismatch error.
+            Assert.IsFalse(ex.Message.Contains("parenthesized", StringComparison.Ordinal),
+                $"bare name must not be flagged as parenthesized; got: {ex.Message}");
         }
     }
 }

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -4,7 +4,7 @@ namespace RoslynMcp.Tests;
 
 [DoNotParallelize]
 [TestClass]
-public sealed class CohesionAnalysisTests : SharedWorkspaceTestBase
+public sealed class CohesionAnalysisTests : IsolatedWorkspaceTestBase
 {
     private static string WorkspaceId { get; set; } = null!;
 
@@ -12,7 +12,7 @@ public sealed class CohesionAnalysisTests : SharedWorkspaceTestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+        WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]
@@ -92,14 +92,10 @@ public sealed class CohesionAnalysisTests : SharedWorkspaceTestBase
         // several [LoggerMessage] partials previously got Lcom4Score = N+1 because each
         // partial was counted as its own LCOM4 cluster. After the fix, partials are excluded
         // from the method enumeration entirely, so the score reflects only the real method.
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var filePath = Path.Combine(copiedRoot, "SampleLib", "QuestionClassifier.cs");
-            await File.WriteAllTextAsync(filePath, """
+        var filePath = workspace.GetPath("SampleLib", "QuestionClassifier.cs");
+        await File.WriteAllTextAsync(filePath, """
 namespace SampleLib;
 
 using Microsoft.Extensions.Logging;
@@ -124,11 +120,11 @@ public partial class QuestionClassifier
 }
 """, CancellationToken.None);
 
-            // Add a stub LoggerMessageAttribute so the file compiles without referencing the
-            // Microsoft.Extensions.Logging.Abstractions package — IsSourceGenPartial matches
-            // by fully-qualified attribute name regardless of where the type is declared.
-            var stubPath = Path.Combine(copiedRoot, "SampleLib", "LoggerMessageStub.cs");
-            await File.WriteAllTextAsync(stubPath, """
+        // Add a stub LoggerMessageAttribute so the file compiles without referencing the
+        // Microsoft.Extensions.Logging.Abstractions package — IsSourceGenPartial matches
+        // by fully-qualified attribute name regardless of where the type is declared.
+        var stubPath = workspace.GetPath("SampleLib", "LoggerMessageStub.cs");
+        await File.WriteAllTextAsync(stubPath, """
 namespace Microsoft.Extensions.Logging;
 
 [System.AttributeUsage(System.AttributeTargets.Method)]
@@ -142,33 +138,22 @@ internal interface ILogger { }
 internal enum LogLevel { Information }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
-                workspaceId, filePath, projectFilter: null, minMethods: 1, limit: 50,
-                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 1, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
 
-            var classifier = metrics.FirstOrDefault(m => m.TypeName == "QuestionClassifier");
-            // With minMethods=1 and only Classify counted, the score should be 1 (or 0 if the
-            // class is filtered out for having < 2 instance methods after exclusions). The
-            // bug case was Lcom4Score = 2+ because LogStarting was a separate cluster.
-            if (classifier is not null)
-            {
-                Assert.AreEqual(1, classifier.Lcom4Score,
-                    "QuestionClassifier should have Lcom4Score=1 — only the real method counts, not [LoggerMessage] partials.");
-                Assert.AreEqual(1, classifier.MethodCount,
-                    "MethodCount should exclude source-gen partials.");
-            }
-        }
-        finally
+        var classifier = metrics.FirstOrDefault(m => m.TypeName == "QuestionClassifier");
+        // With minMethods=1 and only Classify counted, the score should be 1 (or 0 if the
+        // class is filtered out for having < 2 instance methods after exclusions). The
+        // bug case was Lcom4Score = 2+ because LogStarting was a separate cluster.
+        if (classifier is not null)
         {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
+            Assert.AreEqual(1, classifier.Lcom4Score,
+                "QuestionClassifier should have Lcom4Score=1 — only the real method counts, not [LoggerMessage] partials.");
+            Assert.AreEqual(1, classifier.MethodCount,
+                "MethodCount should exclude source-gen partials.");
         }
     }
 
@@ -179,14 +164,10 @@ internal enum LogLevel { Information }
         // method that two public methods both call previously appeared in the cluster's
         // SharedFields list alongside real fields. After the split into methodFieldMap +
         // methodCallMap, only fields/properties show up in SharedFields.
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var filePath = Path.Combine(copiedRoot, "SampleLib", "AdapterUnderTest.cs");
-            await File.WriteAllTextAsync(filePath, """
+        var filePath = workspace.GetPath("SampleLib", "AdapterUnderTest.cs");
+        await File.WriteAllTextAsync(filePath, """
 namespace SampleLib;
 
 public class AdapterUnderTest
@@ -215,45 +196,30 @@ public class AdapterUnderTest
 }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
-                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
-                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
 
-            var adapter = metrics.FirstOrDefault(m => m.TypeName == "AdapterUnderTest");
-            Assert.IsNotNull(adapter, "AdapterUnderTest should appear in cohesion metrics.");
-            Assert.IsTrue(adapter.Clusters.Count >= 1, "AdapterUnderTest should have at least one cluster.");
+        var adapter = metrics.FirstOrDefault(m => m.TypeName == "AdapterUnderTest");
+        Assert.IsNotNull(adapter, "AdapterUnderTest should appear in cohesion metrics.");
+        Assert.IsTrue(adapter.Clusters.Count >= 1, "AdapterUnderTest should have at least one cluster.");
 
-            foreach (var cluster in adapter.Clusters)
-            {
-                Assert.IsFalse(cluster.SharedFields.Contains("CreateFailure"),
-                    "BUG-N9: SharedFields must not contain private helper method names.");
-            }
-        }
-        finally
+        foreach (var cluster in adapter.Clusters)
         {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
+            Assert.IsFalse(cluster.SharedFields.Contains("CreateFailure"),
+                "BUG-N9: SharedFields must not contain private helper method names.");
         }
     }
 
     [TestMethod]
     public async Task GetCohesionMetrics_SharedFields_IncludePrivateProperties_ButNotHelperNames()
     {
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var filePath = Path.Combine(copiedRoot, "SampleLib", "PropertyBackedAdapter.cs");
-            await File.WriteAllTextAsync(filePath, """
+        var filePath = workspace.GetPath("SampleLib", "PropertyBackedAdapter.cs");
+        await File.WriteAllTextAsync(filePath, """
 namespace SampleLib;
 
 public class PropertyBackedAdapter
@@ -277,32 +243,21 @@ public class PropertyBackedAdapter
 }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
-                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
-                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
 
-            var adapter = metrics.FirstOrDefault(m => m.TypeName == "PropertyBackedAdapter");
-            Assert.IsNotNull(adapter, "PropertyBackedAdapter should appear in cohesion metrics.");
-            Assert.IsTrue(adapter.Clusters.Count >= 1, "PropertyBackedAdapter should have at least one cluster.");
+        var adapter = metrics.FirstOrDefault(m => m.TypeName == "PropertyBackedAdapter");
+        Assert.IsNotNull(adapter, "PropertyBackedAdapter should appear in cohesion metrics.");
+        Assert.IsTrue(adapter.Clusters.Count >= 1, "PropertyBackedAdapter should have at least one cluster.");
 
-            var sharedFields = adapter.Clusters.SelectMany(cluster => cluster.SharedFields).ToList();
-            CollectionAssert.Contains(sharedFields, "ConnectionString",
-                "Private properties accessed by multiple public methods should still appear in SharedFields.");
-            CollectionAssert.DoesNotContain(sharedFields, "Format",
-                "Private helper method names must stay out of SharedFields.");
-        }
-        finally
-        {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
-        }
+        var sharedFields = adapter.Clusters.SelectMany(cluster => cluster.SharedFields).ToList();
+        CollectionAssert.Contains(sharedFields, "ConnectionString",
+            "Private properties accessed by multiple public methods should still appear in SharedFields.");
+        CollectionAssert.DoesNotContain(sharedFields, "Format",
+            "Private helper method names must stay out of SharedFields.");
     }
 
     [TestMethod]
@@ -313,14 +268,10 @@ public class PropertyBackedAdapter
         // public methods are orthogonal on fields by design. LCOM4 should still report the
         // real cluster count, but the DTO carries LifecyclePattern="action-triad" and a
         // softened Recommendation so callers can suppress the "split" suggestion.
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var filePath = Path.Combine(copiedRoot, "SampleLib", "FooAction.cs");
-            await File.WriteAllTextAsync(filePath, """
+        var filePath = workspace.GetPath("SampleLib", "FooAction.cs");
+        await File.WriteAllTextAsync(filePath, """
 namespace SampleLib;
 
 public class FooAction
@@ -344,36 +295,25 @@ public class FooAction
 }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
-                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
-                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
 
-            var action = metrics.FirstOrDefault(m => m.TypeName == "FooAction");
-            Assert.IsNotNull(action, "FooAction should appear in cohesion metrics.");
-            Assert.AreEqual("action-triad", action.LifecyclePattern,
-                "FooAction with Describe/Validate/Execute triad should be classified as action-triad.");
-            Assert.IsNotNull(action.Recommendation,
-                "Recommendation should be populated for a detected lifecycle pattern.");
-            StringAssert.Contains(action.Recommendation, "action-triad",
-                "Recommendation should mention the action-triad pattern so callers can downgrade the split suggestion.");
-            // Triad methods are orthogonal on fields — each uses a different private field and
-            // forms its own LCOM4 cluster. Lcom4Score = 3 confirms this is exactly the shape the
-            // detector is designed to de-emphasize (without suppressing the raw score itself).
-            Assert.AreEqual(3, action.Lcom4Score,
-                "Describe/_name, Validate/_limit, Execute/_strict are orthogonal → expect Lcom4Score=3.");
-        }
-        finally
-        {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
-        }
+        var action = metrics.FirstOrDefault(m => m.TypeName == "FooAction");
+        Assert.IsNotNull(action, "FooAction should appear in cohesion metrics.");
+        Assert.AreEqual("action-triad", action.LifecyclePattern,
+            "FooAction with Describe/Validate/Execute triad should be classified as action-triad.");
+        Assert.IsNotNull(action.Recommendation,
+            "Recommendation should be populated for a detected lifecycle pattern.");
+        StringAssert.Contains(action.Recommendation, "action-triad",
+            "Recommendation should mention the action-triad pattern so callers can downgrade the split suggestion.");
+        // Triad methods are orthogonal on fields — each uses a different private field and
+        // forms its own LCOM4 cluster. Lcom4Score = 3 confirms this is exactly the shape the
+        // detector is designed to de-emphasize (without suppressing the raw score itself).
+        Assert.AreEqual(3, action.Lcom4Score,
+            "Describe/_name, Validate/_limit, Execute/_strict are orthogonal → expect Lcom4Score=3.");
     }
 
     [TestMethod]
@@ -383,14 +323,10 @@ public class FooAction
         // methods are NOT the Describe/Validate*/Execute* triad should still report a regular
         // LCOM4 score with no LifecyclePattern and no softened Recommendation — ensuring the
         // detector is conservative and does not suppress real low-cohesion signals.
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var filePath = Path.Combine(copiedRoot, "SampleLib", "NotATriadAction.cs");
-            await File.WriteAllTextAsync(filePath, """
+        var filePath = workspace.GetPath("SampleLib", "NotATriadAction.cs");
+        await File.WriteAllTextAsync(filePath, """
 namespace SampleLib;
 
 public class NotATriadAction
@@ -414,44 +350,29 @@ public class NotATriadAction
 }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
-                workspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
-                includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
 
-            var notTriad = metrics.FirstOrDefault(m => m.TypeName == "NotATriadAction");
-            Assert.IsNotNull(notTriad, "NotATriadAction should appear in cohesion metrics.");
-            Assert.IsNull(notTriad.LifecyclePattern,
-                "LifecyclePattern must be null when the Describe/Validate/Execute triad is incomplete (only Describe + Foo + Bar).");
-            Assert.IsNull(notTriad.Recommendation,
-                "Recommendation must be null when no lifecycle pattern applies, so callers fall back to the default split suggestion.");
-            Assert.AreEqual(3, notTriad.Lcom4Score,
-                "Three orthogonal methods with no shared fields should yield Lcom4Score=3 (default message applies).");
-        }
-        finally
-        {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
-        }
+        var notTriad = metrics.FirstOrDefault(m => m.TypeName == "NotATriadAction");
+        Assert.IsNotNull(notTriad, "NotATriadAction should appear in cohesion metrics.");
+        Assert.IsNull(notTriad.LifecyclePattern,
+            "LifecyclePattern must be null when the Describe/Validate/Execute triad is incomplete (only Describe + Foo + Bar).");
+        Assert.IsNull(notTriad.Recommendation,
+            "Recommendation must be null when no lifecycle pattern applies, so callers fall back to the default split suggestion.");
+        Assert.AreEqual(3, notTriad.Lcom4Score,
+            "Three orthogonal methods with no shared fields should yield Lcom4Score=3 (default message applies).");
     }
 
     [TestMethod]
     public async Task FindSharedMembers_Supports_StaticClasses()
     {
-        var copiedSolutionPath = CreateSampleSolutionCopy();
-        var copiedRoot = Path.GetDirectoryName(copiedSolutionPath)!;
-        string? workspaceId = null;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
-        try
-        {
-            var staticFilePath = Path.Combine(copiedRoot, "SampleLib", "StaticUtility.cs");
-            await File.WriteAllTextAsync(staticFilePath, """
+        var staticFilePath = workspace.GetPath("SampleLib", "StaticUtility.cs");
+        await File.WriteAllTextAsync(staticFilePath, """
 namespace SampleLib;
 
 public static class StaticUtility
@@ -470,25 +391,14 @@ public static class StaticUtility
 }
 """, CancellationToken.None);
 
-            var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
 
-            var shared = await CohesionAnalysisService.FindSharedMembersAsync(
-                workspaceId,
-                SymbolLocator.ByMetadataName("SampleLib.StaticUtility"),
-                CancellationToken.None);
+        var shared = await CohesionAnalysisService.FindSharedMembersAsync(
+            workspace.WorkspaceId,
+            SymbolLocator.ByMetadataName("SampleLib.StaticUtility"),
+            CancellationToken.None);
 
-            Assert.IsTrue(shared.Any(m => m.MemberName == "_counter"),
-                "Expected static private field '_counter' to be reported as shared by multiple public static methods.");
-        }
-        finally
-        {
-            if (workspaceId is not null)
-            {
-                WorkspaceManager.Close(workspaceId);
-            }
-
-            DeleteDirectoryIfExists(copiedRoot);
-        }
+        Assert.IsTrue(shared.Any(m => m.MemberName == "_counter"),
+            "Expected static private field '_counter' to be reported as shared by multiple public static methods.");
     }
 }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestFixtureFileSystem.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestFixtureFileSystem.cs
@@ -30,9 +30,30 @@ internal static class TestFixtureFileSystem
 
     public static void DeleteDirectoryIfExists(string path)
     {
-        if (Directory.Exists(path))
+        if (!Directory.Exists(path))
         {
-            Directory.Delete(path, recursive: true);
+            return;
+        }
+
+        // `Directory.Delete(..., recursive: true)` fails on Windows when the tree contains
+        // read-only files (e.g. `.git/objects/**` loose objects after `git init`, which the
+        // git tooling marks read-only by convention). Clear the read-only attribute on every
+        // file first so the recursive delete succeeds. Equivalent to PowerShell's
+        // `Remove-Item -Recurse -Force`. Tests that run `git init` inside an
+        // `IsolatedWorkspaceScope` rely on this behavior at scope-dispose time.
+        ClearReadOnlyAttributes(path);
+        Directory.Delete(path, recursive: true);
+    }
+
+    private static void ClearReadOnlyAttributes(string path)
+    {
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            var attributes = File.GetAttributes(file);
+            if ((attributes & FileAttributes.ReadOnly) != 0)
+            {
+                File.SetAttributes(file, attributes & ~FileAttributes.ReadOnly);
+            }
         }
     }
 

--- a/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
@@ -13,7 +13,7 @@ namespace RoslynMcp.Tests;
 /// </summary>
 [TestClass]
 [DoNotParallelize]
-public sealed class ValidateRecentGitChangesTests : TestBase
+public sealed class ValidateRecentGitChangesTests : IsolatedWorkspaceTestBase
 {
     private static WorkspaceValidationService _validationService = null!;
 
@@ -47,59 +47,51 @@ public sealed class ValidateRecentGitChangesTests : TestBase
             return;
         }
 
-        var solutionPath = CreateSampleSolutionCopy();
-        var solutionDir = Path.GetDirectoryName(solutionPath)!;
-        InitializeGitRepo(solutionDir);
-        StageAndCommitAll(solutionDir); // seed HEAD so only our edits appear as Modified
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath); // seed HEAD so only our edits appear as Modified
 
         // Edit three existing `.cs` files so porcelain reports them as Modified — the
         // initial `git add -A && commit` above ensures nothing else is pending.
-        var file1 = Path.Combine(solutionDir, "SampleLib", "AnimalService.cs");
-        var file2 = Path.Combine(solutionDir, "SampleLib", "AnimalExtensions.cs");
-        var file3 = Path.Combine(solutionDir, "SampleLib", "Cat.cs");
+        var file1 = workspace.GetPath("SampleLib", "AnimalService.cs");
+        var file2 = workspace.GetPath("SampleLib", "AnimalExtensions.cs");
+        var file3 = workspace.GetPath("SampleLib", "Cat.cs");
         foreach (var path in new[] { file1, file2, file3 })
         {
             // Append-only mutation keeps the file compilable (just adds a trailing comment).
             await File.AppendAllTextAsync(path, $"{Environment.NewLine}// touched {Guid.NewGuid():N}{Environment.NewLine}");
         }
 
-        var status = await WorkspaceManager.LoadAsync(solutionPath, CancellationToken.None);
-        var workspaceId = status.WorkspaceId;
-        try
-        {
-            var result = await _validationService.ValidateRecentGitChangesAsync(
-                workspaceId, runTests: false, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
 
-            // Warnings must be empty — git was present, so the scoped path ran.
-            Assert.AreEqual(0, result.Warnings.Count,
-                $"Expected no warnings on happy path; got [{string.Join("; ", result.Warnings)}].");
+        var result = await _validationService.ValidateRecentGitChangesAsync(
+            workspace.WorkspaceId, runTests: false, CancellationToken.None);
 
-            // Because we committed the seed state first, only our three edits are pending.
-            // The scoped set must be exactly those three (set-comparison — order / casing
-            // may vary across platforms).
-            var changedLower = result.ChangedFilePaths
-                .Select(p => Path.GetFullPath(p).ToLowerInvariant())
-                .ToHashSet();
-            Assert.AreEqual(3, changedLower.Count,
-                $"Expected exactly 3 touched files; got: {string.Join("; ", result.ChangedFilePaths)}");
-            Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file1).ToLowerInvariant()),
-                $"Missing {file1} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
-            Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file2).ToLowerInvariant()),
-                $"Missing {file2} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
-            Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file3).ToLowerInvariant()),
-                $"Missing {file3} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
+        // Warnings must be empty — git was present, so the scoped path ran.
+        Assert.AreEqual(0, result.Warnings.Count,
+            $"Expected no warnings on happy path; got [{string.Join("; ", result.Warnings)}].");
 
-            // UnknownFilePaths must be empty — every touched file lives in the workspace.
-            Assert.AreEqual(0, result.UnknownFilePaths.Count,
-                $"Unexpected unknown paths: [{string.Join("; ", result.UnknownFilePaths)}].");
+        // Because we committed the seed state first, only our three edits are pending.
+        // The scoped set must be exactly those three (set-comparison — order / casing
+        // may vary across platforms).
+        var changedLower = result.ChangedFilePaths
+            .Select(p => Path.GetFullPath(p).ToLowerInvariant())
+            .ToHashSet();
+        Assert.AreEqual(3, changedLower.Count,
+            $"Expected exactly 3 touched files; got: {string.Join("; ", result.ChangedFilePaths)}");
+        Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file1).ToLowerInvariant()),
+            $"Missing {file1} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
+        Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file2).ToLowerInvariant()),
+            $"Missing {file2} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
+        Assert.IsTrue(changedLower.Contains(Path.GetFullPath(file3).ToLowerInvariant()),
+            $"Missing {file3} in ChangedFilePaths: {string.Join("; ", result.ChangedFilePaths)}");
 
-            // OverallStatus must surface — the bundle ran end-to-end.
-            Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
-        }
-        finally
-        {
-            WorkspaceManager.Close(workspaceId);
-        }
+        // UnknownFilePaths must be empty — every touched file lives in the workspace.
+        Assert.AreEqual(0, result.UnknownFilePaths.Count,
+            $"Unexpected unknown paths: [{string.Join("; ", result.UnknownFilePaths)}].");
+
+        // OverallStatus must surface — the bundle ran end-to-end.
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
     }
 
     [TestMethod]
@@ -111,16 +103,14 @@ public sealed class ValidateRecentGitChangesTests : TestBase
             return;
         }
 
-        var solutionPath = CreateSampleSolutionCopy();
-        var solutionDir = Path.GetDirectoryName(solutionPath)!;
-        InitializeGitRepo(solutionDir);
-        StageAndCommitAll(solutionDir);
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath);
 
-        var touchedFile = Path.Combine(solutionDir, "SampleLib", "AnimalService.cs");
+        var touchedFile = workspace.GetPath("SampleLib", "AnimalService.cs");
         await File.AppendAllTextAsync(touchedFile, $"{Environment.NewLine}// timeout scope {Guid.NewGuid():N}{Environment.NewLine}");
 
-        var status = await WorkspaceManager.LoadAsync(solutionPath, CancellationToken.None);
-        var workspaceId = status.WorkspaceId;
+        await workspace.LoadAsync(CancellationToken.None);
         var timeoutService = new WorkspaceValidationService(
             new SlowCompileCheckService(),
             DiagnosticService,
@@ -131,28 +121,21 @@ public sealed class ValidateRecentGitChangesTests : TestBase
             gitStatusTimeout: TimeSpan.FromSeconds(5),
             validationPhaseTimeout: TimeSpan.FromMilliseconds(25));
 
-        try
-        {
-            var result = await timeoutService.ValidateRecentGitChangesAsync(
-                workspaceId, runTests: false, CancellationToken.None);
+        var result = await timeoutService.ValidateRecentGitChangesAsync(
+            workspace.WorkspaceId, runTests: false, CancellationToken.None);
 
-            Assert.AreEqual("timeout", result.OverallStatus);
-            Assert.AreEqual(1, result.ChangedFilePaths.Count,
-                $"Timeout envelope should keep the git-derived changed-file set; got [{string.Join("; ", result.ChangedFilePaths)}].");
-            Assert.AreEqual(Path.GetFullPath(touchedFile), Path.GetFullPath(result.ChangedFilePaths[0]));
-            Assert.IsTrue(result.Warnings.Any(w => w.Contains("compile_check", StringComparison.Ordinal)
-                && w.Contains("retryable=true", StringComparison.Ordinal)),
-                $"Expected retryable compile_check timeout warning; got [{string.Join("; ", result.Warnings)}].");
-            Assert.IsNotNull(result.TestRunResult?.FailureEnvelope,
-                "Timeout result should include a structured retry envelope.");
-            Assert.AreEqual("Timeout", result.TestRunResult.FailureEnvelope.ErrorKind);
-            Assert.IsTrue(result.TestRunResult.FailureEnvelope.IsRetryable);
-            StringAssert.Contains(result.TestRunResult.FailureEnvelope.Summary, "compile_check");
-        }
-        finally
-        {
-            WorkspaceManager.Close(workspaceId);
-        }
+        Assert.AreEqual("timeout", result.OverallStatus);
+        Assert.AreEqual(1, result.ChangedFilePaths.Count,
+            $"Timeout envelope should keep the git-derived changed-file set; got [{string.Join("; ", result.ChangedFilePaths)}].");
+        Assert.AreEqual(Path.GetFullPath(touchedFile), Path.GetFullPath(result.ChangedFilePaths[0]));
+        Assert.IsTrue(result.Warnings.Any(w => w.Contains("compile_check", StringComparison.Ordinal)
+            && w.Contains("retryable=true", StringComparison.Ordinal)),
+            $"Expected retryable compile_check timeout warning; got [{string.Join("; ", result.Warnings)}].");
+        Assert.IsNotNull(result.TestRunResult?.FailureEnvelope,
+            "Timeout result should include a structured retry envelope.");
+        Assert.AreEqual("Timeout", result.TestRunResult.FailureEnvelope.ErrorKind);
+        Assert.IsTrue(result.TestRunResult.FailureEnvelope.IsRetryable);
+        StringAssert.Contains(result.TestRunResult.FailureEnvelope.Summary, "compile_check");
     }
 
     // ------------------------------------------------------------------
@@ -163,36 +146,28 @@ public sealed class ValidateRecentGitChangesTests : TestBase
     [TestMethod]
     public async Task ValidateRecentGitChangesAsync_NoGitRepo_FallsBackWithWarning()
     {
-        var solutionPath = CreateSampleSolutionCopy();
-        var solutionDir = Path.GetDirectoryName(solutionPath)!;
+        await using var workspace = CreateIsolatedWorkspaceCopy();
 
         // Ensure no `.git` entry is anywhere at or above the solution dir. The helper
         // returns a path under `%TEMP%` which should never be inside a repo, but we
         // guard explicitly so the test is robust against future changes.
-        RemoveAnyAncestorGitDir(solutionDir);
+        RemoveAnyAncestorGitDir(workspace.RootPath);
 
-        var status = await WorkspaceManager.LoadAsync(solutionPath, CancellationToken.None);
-        var workspaceId = status.WorkspaceId;
-        try
-        {
-            var result = await _validationService.ValidateRecentGitChangesAsync(
-                workspaceId, runTests: false, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
 
-            Assert.AreEqual(1, result.Warnings.Count,
-                $"Expected exactly one warning on git-unavailable fallback; got [{string.Join("; ", result.Warnings)}].");
-            StringAssert.Contains(result.Warnings[0], "git",
-                "Warning must explain why git scoping was skipped.");
-            StringAssert.Contains(result.Warnings[0], "full workspace",
-                "Warning must indicate the fallback scope.");
+        var result = await _validationService.ValidateRecentGitChangesAsync(
+            workspace.WorkspaceId, runTests: false, CancellationToken.None);
 
-            // OverallStatus must still surface — the bundle ran end-to-end against the
-            // full workspace instead of the (now-empty) scoped set.
-            Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
-        }
-        finally
-        {
-            WorkspaceManager.Close(workspaceId);
-        }
+        Assert.AreEqual(1, result.Warnings.Count,
+            $"Expected exactly one warning on git-unavailable fallback; got [{string.Join("; ", result.Warnings)}].");
+        StringAssert.Contains(result.Warnings[0], "git",
+            "Warning must explain why git scoping was skipped.");
+        StringAssert.Contains(result.Warnings[0], "full workspace",
+            "Warning must indicate the fallback scope.");
+
+        // OverallStatus must still surface — the bundle ran end-to-end against the
+        // full workspace instead of the (now-empty) scoped set.
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
     }
 
     // ------------------------------------------------------------------
@@ -210,28 +185,20 @@ public sealed class ValidateRecentGitChangesTests : TestBase
             return;
         }
 
-        var solutionPath = CreateSampleSolutionCopy();
-        var solutionDir = Path.GetDirectoryName(solutionPath)!;
-        InitializeGitRepo(solutionDir);
-        StageAndCommitAll(solutionDir);
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath);
 
-        var status = await WorkspaceManager.LoadAsync(solutionPath, CancellationToken.None);
-        var workspaceId = status.WorkspaceId;
-        try
-        {
-            var result = await _validationService.ValidateRecentGitChangesAsync(
-                workspaceId, runTests: false, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
 
-            Assert.AreEqual(0, result.Warnings.Count,
-                $"Expected no warnings on clean tree; got [{string.Join("; ", result.Warnings)}].");
-            Assert.AreEqual(0, result.ChangedFilePaths.Count,
-                $"Expected empty scope on clean tree; got [{string.Join("; ", result.ChangedFilePaths)}].");
-            Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
-        }
-        finally
-        {
-            WorkspaceManager.Close(workspaceId);
-        }
+        var result = await _validationService.ValidateRecentGitChangesAsync(
+            workspace.WorkspaceId, runTests: false, CancellationToken.None);
+
+        Assert.AreEqual(0, result.Warnings.Count,
+            $"Expected no warnings on clean tree; got [{string.Join("; ", result.Warnings)}].");
+        Assert.AreEqual(0, result.ChangedFilePaths.Count,
+            $"Expected empty scope on clean tree; got [{string.Join("; ", result.ChangedFilePaths)}].");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(result.OverallStatus));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Continuation of PR #795. Converts three more test classes to `IsolatedWorkspaceTestBase`, eliminating manual `CreateSampleSolutionCopy()` + `try/finally` + `WorkspaceManager.Close()` + `DeleteDirectoryIfExists()` boilerplate in favor of the `IsolatedWorkspaceScope` RAII pattern.

- `CohesionAnalysisTests` (11 tests): base class flipped `SharedWorkspaceTestBase` -> `IsolatedWorkspaceTestBase`. ClassInit replaced `LoadSharedSampleWorkspaceAsync` with `GetOrLoadWorkspaceIdAsync(SampleSolutionPath, ...)`; the 6 isolated tests now use `await using var workspace = CreateIsolatedWorkspaceCopy()`.
- `ValidateRecentGitChangesTests` (5 tests, 4 effective on Windows + git): base class flipped `TestBase` -> `IsolatedWorkspaceTestBase`. Git-mutation tests still call `InitializeGitRepo()` + `StageAndCommitAll()` BEFORE `workspace.LoadAsync()` to preserve the existing ordering. `[DoNotParallelize]` preserved. `RemoveAnyAncestorGitDir` / `IsGitAvailable` / `RunGit` / `SlowCompileCheckService` helpers untouched.
- `ChangeSignaturePreviewMetadataNameShapeTests` (2 tests): base class flipped, two tests converted to the RAII pattern. Mirrors `ChangeSignaturePreviewTests.cs:39-67` exactly.

### Test-infra hardening (scope expansion)

While running the converted `ValidateRecentGitChangesTests`, three of the four git-init'd tests failed at `IsolatedWorkspaceScope.Dispose()` with `UnauthorizedAccessException: Access to the path '...' is denied.` Root cause: `git init` writes loose objects under `.git/objects/**` with the read-only attribute set, and `Directory.Delete(path, recursive: true)` on .NET/Windows refuses to traverse read-only files.

Plan risk #4 asserted scope disposal would handle this; empirically it did not. Per session policy (correctness over band-aid), `TestFixtureFileSystem.DeleteDirectoryIfExists` was hardened to clear read-only attributes via `File.SetAttributes(..., attributes & ~FileAttributes.ReadOnly)` before recursive delete — equivalent to PowerShell's `Remove-Item -Recurse -Force`. This is a strict superset of prior behavior (only changes outcomes for read-only files, which were previously failing). All 50 existing callers benefit. Adding this fourth modified file took the change from 3 -> 4 files; without it the `ValidateRecentGitChangesTests` conversion is dead in the water.

## Test plan

- [x] `mcp__roslyn__compile_check` clean on all four modified files.
- [x] `dotnet test --filter "FullyQualifiedName~ChangeSignaturePreviewMetadataNameShapeTests"` -> 2/2 pass.
- [x] `dotnet test --filter "FullyQualifiedName~ValidateRecentGitChangesTests"` -> 4/4 pass.
- [x] `dotnet test --filter "FullyQualifiedName~CohesionAnalysisTests"` -> 11/11 pass.
- [x] Reference pattern `ChangeSignaturePreviewTests.ChangeSignaturePreview_AddOp_PreservesBodyBraceLineBreak` still passes (touched-infra regression check).
- [x] Grep confirms no `CreateSampleSolutionCopy()` direct calls remain in any of the three converted files (only one docstring mention in the `RemoveAnyAncestorGitDir` comment, which is documentation, not a call).
- [ ] CI runs the full `verify-release.ps1` gate on push via the self-hosted runner.

Closes: test-suite-fixture-reuse-cohesion-and-validate-git