### PR TITLE
fix(validate-workspace): surface "test-zero-run" when runTests=true returns total=0

### DIFF
--- a/changelog.d/validate-workspace-runtests-total-zero.md
+++ b/changelog.d/validate-workspace-runtests-total-zero.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** Fixed `validate_workspace(runTests=true)` falsely reporting `overallStatus=clean` when `testRunResult.total=0` despite a non-empty discovered test filter. Status now returns `test-zero-run` and the response includes a diagnostic warning identifying the likely filter-resolution failure (working-directory or `IChangeTracker` timing). Breaking: callers exact-matching `overallStatus="clean"` need to handle `"test-zero-run"` as a non-passing verdict. (Fixes gh #764)

--- a/src/RoslynMcp.Core/Services/IWorkspaceValidationService.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceValidationService.cs
@@ -50,7 +50,7 @@ public interface IWorkspaceValidationService
 /// <summary>
 /// Aggregated output of <see cref="IWorkspaceValidationService.ValidateAsync"/>.
 /// </summary>
-/// <param name="OverallStatus">One of <c>clean</c>, <c>compile-error</c>, <c>analyzer-error</c>, <c>test-failure</c>, <c>skipped</c>.</param>
+/// <param name="OverallStatus">One of <c>clean</c>, <c>compile-error</c>, <c>analyzer-error</c>, <c>test-failure</c>, <c>test-zero-run</c>, <c>skipped</c>. <c>test-zero-run</c> (added in validate-workspace-runtests-total-zero) indicates <c>runTests=true</c> produced <c>testRunResult.Total=0</c> with a non-empty discovered filter — almost always a filter-resolution failure (working-directory or IChangeTracker timing), not a real pass. Callers exact-matching <c>"clean"</c> as the only passing verdict need to treat <c>"test-zero-run"</c> as a non-passing verdict.</param>
 /// <param name="ChangedFilePaths">Caller-supplied paths that actually resolved to a document in the workspace. Drives compile-check scoping + test discovery.</param>
 /// <param name="UnknownFilePaths">
 /// dr-9-8-bug-validate-fabricated-accepts-fabricated-silen — caller-supplied paths that did NOT

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -217,6 +217,24 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
 
         var status = ComputeOverallStatus(compile, allErrors, testRunResult, runTests);
 
+        // validate-workspace-runtests-total-zero: when the new "test-zero-run" verdict fires,
+        // append a diagnostic warning that names the discovered filter and points at the most
+        // likely cause. Helps the caller decide whether to re-run test_run standalone (which
+        // tends to succeed because it does not race with the workspace's IChangeTracker
+        // refresh / dotnet test working-directory resolution).
+        var emittedWarnings = warnings;
+        if (runTests && testRunResult is not null && testRunResult.Total == 0 && !string.IsNullOrWhiteSpace(related.DotnetTestFilter))
+        {
+            emittedWarnings = warnings
+                .Concat(new[]
+                {
+                    $"validate_workspace: runTests=true produced testRunResult.total=0 with filter '{related.DotnetTestFilter}'; "
+                    + "this likely indicates filter resolution failure (working-directory or IChangeTracker timing). "
+                    + "Run test_run with the same filter to confirm."
+                })
+                .ToArray();
+        }
+
         // validate-workspace-output-cap-summary-mode: drop per-diagnostic + per-test detail
         // when caller asked for a summary. Counts + status still surface the verdict; the
         // CompileResult and TestRunResult are kept because they already carry their own
@@ -235,7 +253,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             DiscoveredTests: emittedTests,
             DotnetTestFilter: string.IsNullOrWhiteSpace(related.DotnetTestFilter) ? null : related.DotnetTestFilter,
             TestRunResult: testRunResult,
-            Warnings: warnings);
+            Warnings: emittedWarnings);
     }
 
     /// <summary>
@@ -317,6 +335,15 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     // "no work" signal, not a compiler failure. Gating on !Success alone would emit
     // overallStatus: compile-error with zero error diagnostics. Use ErrorCount and the
     // merged error-severity rows instead.
+    //
+    // validate-workspace-runtests-total-zero: when runTests=true and the test-run reports
+    // Total=0, dotnet test matched no tests for the discovered filter — almost always a
+    // filter-resolution failure (working-directory mismatch or IChangeTracker timing race),
+    // not a real pass. Pre-fix this branch returned "clean" because Failed==0 fired the
+    // final fall-through. The new "test-zero-run" verdict surfaces the symptom explicitly
+    // so a caller exact-matching "clean" doesn't treat a zero-run as success. This is a
+    // BREAKING change for callers that exact-match "clean" as the only passing value; the
+    // CHANGELOG flags it as such.
     internal static string ComputeOverallStatus(
         CompileCheckDto compile,
         IReadOnlyList<DiagnosticDto> errors,
@@ -330,6 +357,8 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             return "analyzer-error";
         if (runTests && testRunResult is not null && testRunResult.Failed > 0)
             return "test-failure";
+        if (runTests && testRunResult is not null && testRunResult.Total == 0)
+            return "test-zero-run";
         return "clean";
     }
 

--- a/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
@@ -153,4 +153,92 @@ public sealed class WorkspaceValidationOverallStatusTests
 
         Assert.AreEqual("analyzer-error", status);
     }
+
+    /// <summary>
+    /// validate-workspace-runtests-total-zero: when runTests=true and the discovered filter
+    /// produced a non-empty expression, but dotnet test reported Total=0, the symptom is almost
+    /// always a filter-resolution failure (working-directory or IChangeTracker timing). Pre-fix
+    /// this branch hit the final fall-through and returned "clean" — making the bundle silently
+    /// claim success on a non-pass. The new "test-zero-run" verdict surfaces the symptom.
+    /// </summary>
+    [TestMethod]
+    public void ComputeOverallStatus_RunTestsTrue_TotalZero_NonEmptyFilter_YieldsTestZeroRun()
+    {
+        var compileClean = new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            Cancelled: false,
+            CompletedProjects: 1,
+            TotalProjects: 1);
+
+        // Simulates the gh #764 repro: dotnet test exited 0 (Succeeded=true), but matched no
+        // tests for the auto-derived filter, so Total/Passed/Failed/Skipped all settle at 0.
+        var testRunZero = new TestRunResultDto(
+            new CommandExecutionDto(
+                Command: "dotnet",
+                Arguments: ["test", "--filter", "FullyQualifiedName~Foo"],
+                WorkingDirectory: "/repo",
+                TargetPath: string.Empty,
+                ExitCode: 0,
+                Succeeded: true,
+                DurationMs: 0,
+                StdOut: string.Empty,
+                StdErr: string.Empty),
+            Total: 0,
+            Passed: 0,
+            Failed: 0,
+            Skipped: 0,
+            Failures: []);
+
+        var status = WorkspaceValidationService.ComputeOverallStatus(
+            compileClean,
+            Array.Empty<DiagnosticDto>(),
+            testRunZero,
+            runTests: true);
+
+        Assert.AreEqual(
+            "test-zero-run",
+            status,
+            "runTests=true with Total=0 must surface 'test-zero-run' — not 'clean' — so callers don't silently treat a filter-resolution failure as a pass.");
+    }
+
+    /// <summary>
+    /// Negative-control for the test-zero-run guard: runTests=false (the default) must keep
+    /// the legacy "clean" verdict even when no test_run was attempted. The guard only fires
+    /// when the caller asked for tests AND a test_run actually executed AND returned Total=0.
+    /// </summary>
+    [TestMethod]
+    public void ComputeOverallStatus_RunTestsFalse_NullTestResult_StillYieldsClean()
+    {
+        var compileClean = new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            Cancelled: false,
+            CompletedProjects: 1,
+            TotalProjects: 1);
+
+        var status = WorkspaceValidationService.ComputeOverallStatus(
+            compileClean,
+            Array.Empty<DiagnosticDto>(),
+            testRunResult: null,
+            runTests: false);
+
+        Assert.AreEqual("clean", status, "runTests=false must remain a 'clean' verdict on a clean compile — the new test-zero-run guard must not regress that path.");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes `validate_workspace(runTests=true)` falsely reporting `overallStatus=clean` when `dotnet test` returns `total=0` despite a non-empty discovered filter. Pre-fix the `Failed==0` branch caused the final fall-through to `"clean"` — a filter-resolution failure (working-directory mismatch or `IChangeTracker` timing race) was silently treated as a pass.

The new `"test-zero-run"` verdict fires when `runTests=true && testRunResult.Total == 0`, and `ValidateInternalAsync` now appends a diagnostic warning naming the discovered filter and the likely cause.

## Changes

- `src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs`: new `total==0` guard in `ComputeOverallStatus`; warning append in `ValidateInternalAsync`.
- `src/RoslynMcp.Core/Services/IWorkspaceValidationService.cs`: doc-comment now lists `test-zero-run` alongside the other status values.
- `tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs`: two new cases (positive + `runTests=false` negative-control).
- `changelog.d/validate-workspace-runtests-total-zero.md`: BREAKING changelog fragment.

## Breaking change

Callers that exact-match `overallStatus == "clean"` as the only passing verdict must now treat `"test-zero-run"` as a non-passing verdict. The CHANGELOG flags this explicitly.

## Test plan

- [x] `WorkspaceValidationOverallStatusTests`: 7 tests pass (5 existing + 2 new).
- [x] `ValidationBundleToolsTests` + `ValidateWorkspaceMarkdownFormatterTests`: 10 tests pass — no regressions on `Total > 0` paths.
- [x] `ValidateRecentGitChangesTests` + `ValidateWorkspaceSummaryTests`: 10 tests (7 pass + 3 pre-existing skips) — these only use `runTests=false`.
- [x] `compile_check` (RoslynMcp.Roslyn + RoslynMcp.Core + RoslynMcp.Tests): zero errors.
- [x] `project_diagnostics` on all three changed files: zero warnings.
- [x] `eng/verify-ai-docs.ps1`: passes.
- [ ] Self-hosted CI runner will execute `eng/verify-release.ps1 -Configuration Release` on PR.

Closes: validate-workspace-runtests-total-zero
Fixes #764