### PR TITLE
fix(extract_method): single-statement if-block selection ending at closing brace (extract-method-preview-same-block-scope-false-negative)

### DIFF
--- a/changelog.d/extract-method-preview-same-block-scope-false-negative.md
+++ b/changelog.d/extract-method-preview-same-block-scope-false-negative.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_method_preview` rejecting valid single-statement if-block selections with "All selected statements must be in the same block scope" when `endColumn` landed on or adjacent to the closing brace. The statement collector now anchors on statement start position and restricts to direct children of the innermost enclosing block, rather than requiring the full statement span to fall within selection bounds (gh #744).

--- a/samples/SampleSolution/SampleLib/RefactoringProbe.cs
+++ b/samples/SampleSolution/SampleLib/RefactoringProbe.cs
@@ -40,4 +40,23 @@ public class RefactoringProbe
         result = result + 5;
         return result;
     }
+
+    // Lines 56-60: single-statement if-block scenario for
+    // extract-method-preview-same-block-scope-false-negative (gh #744). The if
+    // statement spans lines 56-60 and ends with a closing brace on line 60.
+    // Selecting the entire if-block with `endColumn` pointing at or adjacent to
+    // that closing brace used to trip the same-block-scope false-negative
+    // because the if-statement's exclusive `Span.End` exceeded the computed
+    // selection end. The statement collector now anchors on `SpanStart` so the
+    // outer if-statement is captured even though its `}` falls outside the
+    // selection. The body only reads `input` and writes via `Console.WriteLine`
+    // (no out-flowing variables) so the extract is unambiguously legal.
+    public void IfBlockScenario(int input)
+    {
+        if (input > 0)
+        {
+            Console.WriteLine($"positive: {input}");
+            Console.WriteLine($"doubled:  {input * 2}");
+        }
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
@@ -415,13 +415,55 @@ public sealed class ExtractMethodService : IExtractMethodService
     private static List<StatementSyntax> FindStatementsInSelection(
         SyntaxNode enclosingMember, Microsoft.CodeAnalysis.Text.TextSpan selectionSpan)
     {
-        return enclosingMember
-            .DescendantNodes()
-            .OfType<StatementSyntax>()
-            .Where(s => s.Parent is BlockSyntax
-                     && selectionSpan.Contains(s.Span))
+        // extract-method-preview-same-block-scope-false-negative (gh #744):
+        // the previous implementation walked every descendant `StatementSyntax`
+        // and filtered with `selectionSpan.Contains(s.Span)`. That predicate
+        // rejected the outer statement when `BuildSelectionSpan` produced an
+        // end position one short of the statement's exclusive `Span.End` — the
+        // classic "endColumn points at the closing brace" case — while still
+        // accepting the statement's nested-block children. The collected set
+        // then mixed children of the enclosing block with children of a nested
+        // block, and the caller's same-parent guard fired the false-negative
+        // "All selected statements must be in the same block scope" error.
+        //
+        // The fix is two changes in one:
+        //
+        //   (a) anchor the selection on statement start (`SpanStart`) rather
+        //       than full-span containment, so a multi-line statement whose
+        //       closing brace lands exactly at `selectionSpan.End` is captured;
+        //
+        //   (b) restrict the collected set to DIRECT statement children of
+        //       the innermost block enclosing the selection start, so we do
+        //       not also collect descendants from compound statements (e.g.
+        //       the `if`-body children when the user selected the `if` as a
+        //       whole). The caller's same-parent guard then naturally holds.
+        var targetBlock = FindEnclosingBlock(enclosingMember, selectionSpan.Start);
+        if (targetBlock is null)
+            return new List<StatementSyntax>();
+
+        return targetBlock.Statements
+            .Where(s => s.SpanStart >= selectionSpan.Start
+                     && s.SpanStart < selectionSpan.End)
             .OrderBy(s => s.SpanStart)
             .ToList();
+    }
+
+    private static BlockSyntax? FindEnclosingBlock(SyntaxNode enclosingMember, int position)
+    {
+        // Walk from the token at `position` up to the enclosing member,
+        // returning the first `BlockSyntax` ancestor. `FindToken` skips
+        // leading trivia and returns the next real token, so selections
+        // starting on indentation whitespace still resolve to the correct
+        // statement's containing block.
+        var token = enclosingMember.FindToken(position);
+        var current = token.Parent;
+        while (current is not null && current != enclosingMember.Parent)
+        {
+            if (current is BlockSyntax block)
+                return block;
+            current = current.Parent;
+        }
+        return null;
     }
 
     private static ITypeSymbol? GetSymbolType(ISymbol symbol) => symbol switch

--- a/tests/RoslynMcp.Tests/ExtractMethodTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodTests.cs
@@ -207,4 +207,43 @@ public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(diff.Contains("var doubled=ComputeDoubled") || diff.Contains("var doubled = ComputeDoubled"),
             $"Expected `var doubled = ComputeDoubled(...)` since the local is introduced by the region. Diff:\n{diff}");
     }
+
+    /// <summary>
+    /// extract-method-preview-same-block-scope-false-negative (gh #744): selecting a single
+    /// multi-line if-block where `endColumn` lands on the closing `}` used to throw the
+    /// "All selected statements must be in the same block scope" guard, because the old
+    /// `selectionSpan.Contains(s.Span)` filter rejected the outer if-statement (its
+    /// exclusive `Span.End` exceeded `selectionSpan.End`), leaving only the nested-block
+    /// body children whose parent differed from any outer statements that might have been
+    /// captured. The start-anchor filter restores correct collection of the outer if.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethod_SingleIfBlockEndingAtClosingBrace_Succeeds()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
+
+        // IfBlockScenario lines 56-60: select the entire if-statement.
+        //   Line 56: "        if (result > 0)"            (if keyword starts at col 9, 1-based)
+        //   Line 60: "        }"                           (closing brace at col 9, 1-based)
+        // `endColumn: 9` puts the selection end exactly on the `}` character —
+        // the exclusive `Span.End` of the if-statement is one past `}`, so the
+        // pre-fix `Contains` predicate dropped the if-statement entirely and
+        // the same-block-scope guard fired the false-negative.
+        var preview = await ExtractMethodService.PreviewExtractMethodAsync(
+            workspace.WorkspaceId,
+            filePath,
+            startLine: 56, startColumn: 9,
+            endLine: 60, endColumn: 9,
+            "AmplifyResult",
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview.PreviewToken,
+            "Preview must produce a token — the if-block is a valid extraction target.");
+        Assert.IsTrue(preview.Changes.Count > 0, "Expected at least one file change.");
+
+        var diff = preview.Changes[0].UnifiedDiff;
+        Assert.IsTrue(diff.Contains("AmplifyResult"),
+            $"Diff should contain the extracted method name. Diff:\n{diff}");
+    }
 }


### PR DESCRIPTION
## Summary

`extract_method_preview` rejected valid single-statement if-block selections with `All selected statements must be in the same block scope` when the caller's `endColumn` landed at or just past the closing `}`. `FindStatementsInSelection` used `selectionSpan.Contains(s.Span)` — a full-span containment predicate — which dropped the outer statement (its exclusive `Span.End` exceeded the selection end) while still picking up its nested-block children. The collected set then mixed children of the enclosing block with children of a nested block, and the caller's same-parent guard fired the false-negative.

## Approach

`FindStatementsInSelection` now performs two coordinated changes:

- **(a) Start-anchor filter.** Statements are matched on `SpanStart` falling within the selection (`SpanStart >= selectionSpan.Start && SpanStart < selectionSpan.End`) rather than full-span containment. A multi-line statement whose closing brace lands at `selectionSpan.End` is captured.
- **(b) Direct-child enumeration.** Collection is restricted to the direct `Statements` of the innermost `BlockSyntax` enclosing `selectionSpan.Start` (resolved by a small `FindEnclosingBlock` helper that walks ancestors of `FindToken(position).Parent`). Compound-statement descendants are no longer double-collected.

The caller's same-parent guard in `FindEnclosingMethodAndStatements` now holds naturally because every element of the collected set is a direct child of the same `BlockSyntax`.

## Test plan

- [x] Added `RefactoringProbe.IfBlockScenario` fixture (single multi-line if-block with no out-flowing variables).
- [x] New test `ExtractMethod_SingleIfBlockEndingAtClosingBrace_Succeeds` selects the entire if-block with `endColumn: 9` (exactly at the `}` character) and asserts the preview succeeds and the diff contains the extracted method name.
- [x] All 12 unrelated `~ExtractMethod` tests pass. Pre-existing `ExtractMethod_PreviewAndApply_CompilationSucceeds` and `ExtractMethod_ReassignsExistingLocal_EmitsAssignmentNotVarDecl` failures (caused by MSTest reference resolution friction in the isolated test workspace) reproduce on the baseline before this PR and are unrelated to this change.
- [x] `SelectionRangeCodeActionTests` (3/3 pass) — sibling selection-range code paths unaffected.
- [x] `compile_check` on `RoslynMcp.Roslyn` and `RoslynMcp.Tests` reports 0 errors / 0 warnings.
- [x] `verify-changelog-fragments.ps1` validates the new fragment.
- [x] `verify-ai-docs.ps1` passes.
- [ ] CI on self-hosted runner will run `verify-release.ps1` post-push (local run skipped per maintainer policy `feedback_self_hosted_runner_no_duplicate_local_run`).

Closes: extract-method-preview-same-block-scope-false-negative
Fixes #744

Generated with [Claude Code](https://claude.com/claude-code)