### PR TITLE
fix(editorconfig): upsert recognizes no-space key=value variant (set-editorconfig-option-duplicate-key-append)

### DIFF
--- a/changelog.d/set-editorconfig-option-duplicate-key-append.md
+++ b/changelog.d/set-editorconfig-option-duplicate-key-append.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `set_editorconfig_option` (and `set_diagnostic_severity`) appending a duplicate key line when the target `.editorconfig` already contains the same key. Key-matching now normalizes whitespace around `=` so both `key = value` and `key=value` variants are recognized and replaced in place. Repeated calls with the same key+value are now a no-op leaving the file hash unchanged. Closes gh #735.

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -386,7 +386,6 @@ public sealed class EditorConfigService : IEditorConfigService
             return;
         }
 
-        var keyPrefix = key + " =";
         var end = lines.Count;
         for (var i = sectionIndex + 1; i < lines.Count; i++)
         {
@@ -398,6 +397,15 @@ public sealed class EditorConfigService : IEditorConfigService
             }
         }
 
+        // set-editorconfig-option-duplicate-key-append: parse each non-comment, non-blank
+        // line by splitting on the FIRST '=' and case-insensitively comparing the trimmed
+        // key portion. This recognizes `key=value`, `key = value`, and `key=  value`
+        // variants (hand-edited or IDE-generated .editorconfig files often omit the space
+        // around `=`). Previously the matcher used `trimmed.StartsWith(key + " =", ...)`,
+        // which silently missed the no-space variant and fell through to `Insert`,
+        // appending a duplicate key line. Split-on-first '=' mirrors the existing
+        // ParseEditorconfigCsKeys idiom (line 129) and is safe even when the value
+        // happens to contain '=' (e.g. quoted strings).
         for (var i = sectionIndex + 1; i < end; i++)
         {
             var trimmed = lines[i].Trim();
@@ -406,7 +414,14 @@ public sealed class EditorConfigService : IEditorConfigService
                 continue;
             }
 
-            if (trimmed.StartsWith(keyPrefix, StringComparison.OrdinalIgnoreCase))
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex <= 0)
+            {
+                continue;
+            }
+
+            var existingKey = trimmed[..eqIndex].Trim();
+            if (string.Equals(existingKey, key, StringComparison.OrdinalIgnoreCase))
             {
                 lines[i] = assignment;
                 return;

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -87,6 +87,123 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
             $"was returned instead of the on-disk value.");
     }
 
+    /// <summary>
+    /// Regression test for <c>set-editorconfig-option-duplicate-key-append</c> (gh #735):
+    /// <see cref="IEditorConfigService.SetOptionAsync"/> previously matched existing keys
+    /// with <c>StartsWith(key + " =", ...)</c>, which silently missed the no-space variant
+    /// <c>key=value</c> common in hand-edited or IDE-generated <c>.editorconfig</c> files.
+    /// When the predicate missed, the writer fell through to <c>Insert</c> and appended
+    /// a duplicate key line on every subsequent call. The fix splits each line on the
+    /// first <c>=</c> and compares the trimmed key portion case-insensitively, so the
+    /// writer always upserts in place regardless of whitespace around <c>=</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task SetOptionAsync_SecondCallSameKeyValue_NoOp()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        const string key = "dotnet_diagnostic.CA1234.severity";
+        const string firstValue = "warning";
+        const string secondValue = "error";
+
+        var firstResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, firstValue, "set_editorconfig_option", CancellationToken.None);
+        Assert.IsTrue(File.Exists(firstResult.EditorConfigPath));
+
+        // Second call: identical key + value must be an in-place upsert (no duplicate line).
+        await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, firstValue, "set_editorconfig_option", CancellationToken.None);
+
+        var linesAfterIdempotent = await File.ReadAllLinesAsync(firstResult.EditorConfigPath, CancellationToken.None);
+        var firstOccurrences = linesAfterIdempotent.Count(l =>
+        {
+            var trimmed = l.Trim();
+            if (trimmed.Length == 0 || trimmed[0] == '#' || trimmed[0] == ';' || trimmed[0] == '[')
+                return false;
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex <= 0) return false;
+            return string.Equals(trimmed[..eqIndex].Trim(), key, StringComparison.OrdinalIgnoreCase);
+        });
+        Assert.AreEqual(1, firstOccurrences,
+            $"After two identical SetOptionAsync calls, key '{key}' must appear exactly once. " +
+            $"File content:\n{string.Join("\n", linesAfterIdempotent)}");
+
+        // Third call: same key, different value. Still exactly one occurrence; value updated.
+        await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, secondValue, "set_editorconfig_option", CancellationToken.None);
+
+        var linesAfterUpdate = await File.ReadAllLinesAsync(firstResult.EditorConfigPath, CancellationToken.None);
+        var matchingLines = linesAfterUpdate.Where(l =>
+        {
+            var trimmed = l.Trim();
+            if (trimmed.Length == 0 || trimmed[0] == '#' || trimmed[0] == ';' || trimmed[0] == '[')
+                return false;
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex <= 0) return false;
+            return string.Equals(trimmed[..eqIndex].Trim(), key, StringComparison.OrdinalIgnoreCase);
+        }).ToList();
+        Assert.AreEqual(1, matchingLines.Count,
+            $"After three SetOptionAsync calls (same key), key '{key}' must still appear exactly once. " +
+            $"File content:\n{string.Join("\n", linesAfterUpdate)}");
+
+        // Verify the value was updated to secondValue.
+        var updatedLine = matchingLines[0].Trim();
+        var updatedEqIdx = updatedLine.IndexOf('=');
+        var updatedValue = updatedLine[(updatedEqIdx + 1)..].Trim();
+        Assert.AreEqual(secondValue, updatedValue,
+            $"Third call must have updated the value to '{secondValue}'. Actual: '{updatedValue}'.");
+    }
+
+    /// <summary>
+    /// Regression test for <c>set-editorconfig-option-duplicate-key-append</c> (gh #735):
+    /// hand-edited or IDE-generated <c>.editorconfig</c> files commonly write keys as
+    /// <c>key=value</c> with no surrounding whitespace. The pre-fix matcher used
+    /// <c>StartsWith(key + " =", ...)</c> and missed this variant, so a subsequent
+    /// <c>SetOptionAsync</c> call would append a duplicate. After the fix, the writer
+    /// splits each line on the first <c>=</c> and recognizes the existing key,
+    /// replacing it in place with the canonical <c>key = value</c> format.
+    /// </summary>
+    [TestMethod]
+    public async Task SetOptionAsync_NoSpaceVariantOnDisk_ReplacedInPlace()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Pre-seed an .editorconfig with the [*.{cs,csx,cake}] section and a no-space
+        // entry that mirrors what a hand-edit or IDE generator typically produces.
+        var editorconfigPath = Path.Combine(workspace.RootPath, ".editorconfig");
+        const string key = "dotnet_diagnostic.CA9876.severity";
+        await File.WriteAllLinesAsync(editorconfigPath,
+            ["[*.{cs,csx,cake}]", $"{key}=warning"], CancellationToken.None);
+
+        // SetOptionAsync must recognize the existing no-space entry and replace it in place.
+        await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, "error", "set_editorconfig_option", CancellationToken.None);
+
+        var lines = await File.ReadAllLinesAsync(editorconfigPath, CancellationToken.None);
+        var matchingLines = lines.Where(l =>
+        {
+            var trimmed = l.Trim();
+            if (trimmed.Length == 0 || trimmed[0] == '#' || trimmed[0] == ';' || trimmed[0] == '[')
+                return false;
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex <= 0) return false;
+            return string.Equals(trimmed[..eqIndex].Trim(), key, StringComparison.OrdinalIgnoreCase);
+        }).ToList();
+        Assert.AreEqual(1, matchingLines.Count,
+            $"After SetOptionAsync against a no-space pre-existing entry, key '{key}' must appear exactly once. " +
+            $"File content:\n{string.Join("\n", lines)}");
+
+        var updatedLine = matchingLines[0].Trim();
+        var updatedEqIdx = updatedLine.IndexOf('=');
+        var updatedValue = updatedLine[(updatedEqIdx + 1)..].Trim();
+        Assert.AreEqual("error", updatedValue,
+            $"No-space pre-existing entry must have been replaced with the new value. Actual: '{updatedValue}'.");
+    }
+
     [TestMethod]
     public void SectionMatchesCSharp_RecognizesCommonGlobs()
     {


### PR DESCRIPTION
## Summary

`UpsertKeyInSection` in `EditorConfigService` used `StartsWith(key + " =", ...)` as its key-matching predicate, which silently missed the no-space `key=value` variant commonly produced by hand-edits and IDE generators. When the predicate missed, the writer fell through to `lines.Insert(end, assignment)` and appended a duplicate key line — so repeated `set_editorconfig_option` / `set_diagnostic_severity` calls progressively grew the file with duplicate keys, even when the value was identical.

The fix replaces the `StartsWith` predicate with a split-on-first-`=` key extraction (mirroring the existing `ParseEditorconfigCsKeys` idiom at line 129). The matcher now recognizes `key=value`, `key = value`, and `key=  value` variants and upserts in place. Repeated calls with the same key+value become true no-ops; the value-update path also works against both whitespace forms.

## Changes

- `src/RoslynMcp.Roslyn/Services/EditorConfigService.cs` — rewrite `UpsertKeyInSection` key-matching from `StartsWith(key + " =", ...)` to `IndexOf('=')` + `Equals` on the trimmed key portion. Inline comment documents the failure mode and the parser-idiom alignment.
- `tests/RoslynMcp.Tests/EditorConfigServiceTests.cs` — two new regression tests:
  - `SetOptionAsync_SecondCallSameKeyValue_NoOp` — three calls (same key, two identical + one new value) leave exactly one occurrence per pass.
  - `SetOptionAsync_NoSpaceVariantOnDisk_ReplacedInPlace` — pre-seeded `key=value` (no-space) entry is recognized and replaced in place; not duplicated.
- `changelog.d/set-editorconfig-option-duplicate-key-append.md` — Fixed fragment.

## Out of scope

- The `[*]`-section / different-glob edge case (writer's constant `[*.{cs,csx,cake}]` does not match a key already under a different section glob) remains a known limitation documented in the plan's Risks. Fix is confined to the same-section write path; a separate row can address cross-section coalescing if it becomes a real-world hit.

## Test plan

- [x] `mcp__roslyn__compile_check` — zero errors on full solution.
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~EditorConfigServiceTests"` — 5/5 passed (3 pre-existing + 2 new).
- [x] `eng/verify-ai-docs.ps1` — passed.
- [ ] `eng/verify-release.ps1 -Configuration Release` — deferred to the self-hosted CI runner per `~/.claude/CLAUDE.md` policy (avoid double-running while the runner is active).
- [ ] Pre-merge CI green on this PR.

Closes: set-editorconfig-option-duplicate-key-append

Fixes #735