### PR TITLE
fix(symbols): suppress symbol_relationships unbounded enumeration on builtin-type tokens (symbol-relationships-builtin-type-unbounded-enumeration)

### DIFF
--- a/changelog.d/symbol-relationships-builtin-type-unbounded-enumeration.md
+++ b/changelog.d/symbol-relationships-builtin-type-unbounded-enumeration.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `symbol_relationships` returning a 57+ KB payload overflow when `preferDeclaringMember=false` and the cursor lands on a builtin-type token (e.g. `void`, `int`). The tool now detects builtin-type resolution (`SpecialType != None`) and returns an empty relationship envelope with a `hint` field explaining the suppression, rather than enumerating all solution-wide references to the builtin. The `preferDeclaringMember=true` auto-promotion path is unaffected. Closes gh #757.

--- a/src/RoslynMcp.Core/Models/SymbolRelationshipsDto.cs
+++ b/src/RoslynMcp.Core/Models/SymbolRelationshipsDto.cs
@@ -3,10 +3,17 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Represents definitions, references, and hierarchy relationships for a symbol.
 /// </summary>
+/// <param name="Hint">
+/// Optional human-readable hint explaining why the response is short-circuited (e.g. the cursor
+/// landed on a builtin-type token like <c>void</c> or <c>int</c> with <c>preferDeclaringMember=false</c>,
+/// which would otherwise enumerate every reference to the special type solution-wide). Null when the
+/// envelope is a normal, populated result.
+/// </param>
 public sealed record SymbolRelationshipsDto(
     SymbolDto Symbol,
     IReadOnlyList<LocationDto> Definitions,
     IReadOnlyList<LocationDto> References,
     IReadOnlyList<LocationDto> Implementations,
     IReadOnlyList<SymbolDto> BaseMembers,
-    IReadOnlyList<SymbolDto> Overrides);
+    IReadOnlyList<SymbolDto> Overrides,
+    string? Hint = null);

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -502,6 +502,7 @@ public static class SymbolTools
                 overrides,
                 limit,
                 hasMore,
+                hint = result.Hint,
                 totals = new
                 {
                     references = result.References.Count,

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -141,6 +141,27 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
 
         var originalSymbol = symbol;
         symbol = await PromoteToDeclaringMemberIfRequestedAsync(solution, locator, symbol, preferDeclaringMember, ct).ConfigureAwait(false);
+
+        // `symbol-relationships-builtin-type-unbounded-enumeration` (gh #757): when the caret lands
+        // on a builtin-type token (e.g. `void`, `int`) and `preferDeclaringMember=false`, the
+        // promotion above intentionally short-circuits and we fall through to FindReferencesAsync
+        // on `System.Void`/`System.Int32`, which enumerates every reference to the special type
+        // solution-wide (measured 57+ KB on an 11-project / 759-document solution). Detect the
+        // post-promotion builtin and return an empty envelope with a Hint explaining the
+        // suppression. The `preferDeclaringMember=true` auto-promotion path is unaffected because
+        // by then the symbol has been swapped to the enclosing member.
+        if (!preferDeclaringMember && symbol is INamedTypeSymbol namedSym && namedSym.SpecialType != SpecialType.None)
+        {
+            return new SymbolRelationshipsDto(
+                Symbol: SymbolMapper.ToDto(symbol, solution),
+                Definitions: [],
+                References: [],
+                Implementations: [],
+                BaseMembers: [],
+                Overrides: [],
+                Hint: "Resolved to builtin type — references list suppressed. Set preferDeclaringMember=true or relocate cursor to a non-builtin token.");
+        }
+
         var relationshipLocator = SymbolEqualityComparer.Default.Equals(originalSymbol, symbol)
             ? locator
             : CreateLocatorForPromotedSymbol(symbol, locator);

--- a/tests/RoslynMcp.Tests/SymbolRelationshipsBuiltinTypeSuppressionTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolRelationshipsBuiltinTypeSuppressionTests.cs
@@ -1,0 +1,94 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression tests for <c>symbol-relationships-builtin-type-unbounded-enumeration</c> (gh #757):
+/// when the caret lands on a builtin-type token like <c>void</c> and the caller passes
+/// <c>preferDeclaringMember=false</c>, the legacy code path resolved the token to
+/// <c>System.Void</c> and then called <c>FindReferencesAsync</c> on the special type — which
+/// enumerated every reference to the type solution-wide (measured 57+ KB on an 11-project /
+/// 759-document solution). The fix detects post-promotion builtin types and returns an empty
+/// envelope with a <c>Hint</c> field instead of enumerating the unbounded reference set.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class SymbolRelationshipsBuiltinTypeSuppressionTests : SharedWorkspaceTestBase
+{
+    private static string _workspaceId = string.Empty;
+    private static string _animalServicePath = string.Empty;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        _workspaceId = await LoadSharedSampleWorkspaceAsync();
+        var sampleSolutionRoot = Path.GetDirectoryName(SampleSolutionPath)!;
+        _animalServicePath = Path.Combine(sampleSolutionRoot, "SampleLib", "AnimalService.cs");
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    /// <summary>
+    /// Cursor on <c>void</c> token in <c>AnimalService.MakeThemSpeak</c> (line 16, col 12) with
+    /// <c>preferDeclaringMember=false</c>: the resolved symbol is <c>System.Void</c>
+    /// (<c>SpecialType.System_Void</c>). Pre-fix: <c>FindReferencesAsync(System.Void)</c> enumerates
+    /// every void-returning method reference solution-wide. Post-fix: short-circuit returns an
+    /// empty envelope with a non-null <c>Hint</c> explaining the suppression.
+    /// </summary>
+    [TestMethod]
+    public async Task BuiltinVoidToken_PreferDeclaringMemberFalse_SuppressesReferencesAndReturnsHint()
+    {
+        var locator = SymbolLocator.BySource(_animalServicePath, line: 16, column: 12);
+
+        var result = await SymbolRelationshipService.GetSymbolRelationshipsAsync(
+            _workspaceId,
+            locator,
+            preferDeclaringMember: false,
+            CancellationToken.None);
+
+        Assert.IsNotNull(result, "Resolver should still produce an envelope, not return null.");
+        Assert.AreEqual(0, result.References.Count,
+            "References list MUST be suppressed when the cursor resolves to a builtin type with preferDeclaringMember=false — the pre-fix code returned 57+ KB of unbounded references.");
+        Assert.AreEqual(0, result.Implementations.Count, "Implementations should also be empty in the suppression envelope.");
+        Assert.AreEqual(0, result.BaseMembers.Count, "BaseMembers should also be empty in the suppression envelope.");
+        Assert.AreEqual(0, result.Overrides.Count, "Overrides should also be empty in the suppression envelope.");
+        Assert.AreEqual(0, result.Definitions.Count, "Definitions should also be empty — System.Void has no in-source location.");
+        Assert.IsNotNull(result.Hint, "Hint MUST be populated so the caller can recover by setting preferDeclaringMember=true.");
+        Assert.IsTrue(result.Hint!.Contains("builtin", StringComparison.OrdinalIgnoreCase),
+            $"Hint should explain the builtin-type suppression. Got: {result.Hint}");
+        Assert.IsTrue(result.Hint.Contains("preferDeclaringMember", StringComparison.Ordinal),
+            $"Hint should point the caller at preferDeclaringMember=true as the recovery path. Got: {result.Hint}");
+    }
+
+    /// <summary>
+    /// Regression guard: when <c>preferDeclaringMember=true</c> (the default), the cursor on the
+    /// <c>void</c> token auto-promotes to the enclosing <c>MakeThemSpeak</c> method and the
+    /// normal relationship enumeration runs. The suppression hint MUST NOT fire on the
+    /// promoted path — the promoted symbol is a method (not a builtin type), so this verifies the
+    /// guard's <c>!preferDeclaringMember</c> condition.
+    /// </summary>
+    [TestMethod]
+    public async Task BuiltinVoidToken_PreferDeclaringMemberTrue_PromotesToMethodWithoutHint()
+    {
+        var locator = SymbolLocator.BySource(_animalServicePath, line: 16, column: 12);
+
+        var result = await SymbolRelationshipService.GetSymbolRelationshipsAsync(
+            _workspaceId,
+            locator,
+            preferDeclaringMember: true,
+            CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("MakeThemSpeak", result.Symbol.Name,
+            "preferDeclaringMember=true should promote the void token to the enclosing method.");
+        Assert.IsNull(result.Hint,
+            "The suppression hint MUST NOT fire on the promoted-method path — the guard checks !preferDeclaringMember first.");
+        Assert.IsTrue(result.Definitions.Count > 0,
+            "The promoted method should have its declaration as a definition location.");
+    }
+}


### PR DESCRIPTION
## Summary

When the caret resolves to a builtin type (e.g. `void`, `int`) and the caller passes `preferDeclaringMember=false`, the legacy `symbol_relationships` path called `FindReferencesAsync` on `System.Void` / `System.Int32`, enumerating every reference to the special type solution-wide. Measured 57+ KB payload on TradeWise's 11-project / 759-document solution.

The fix adds a post-promotion guard in `SymbolRelationshipService.GetSymbolRelationshipsAsync` that detects `INamedTypeSymbol` with `SpecialType != None` and returns an empty envelope with a `Hint` field pointing the caller at `preferDeclaringMember=true` as the recovery path. The auto-promotion path (`preferDeclaringMember=true`) is unaffected — by then the symbol has been swapped to the enclosing member.

- `SymbolRelationshipsDto`: nullable trailing `Hint` property (named-argument construction at the existing call site, no breaking change to consumers).
- `SymbolRelationshipService.GetSymbolRelationshipsAsync`: post-promotion `!preferDeclaringMember && SpecialType != None` short-circuit.
- `SymbolTools.GetSymbolRelationships`: threads `hint = result.Hint` through the JSON envelope.

## Test plan

- [x] `SymbolRelationshipsBuiltinTypeSuppressionTests.BuiltinVoidToken_PreferDeclaringMemberFalse_SuppressesReferencesAndReturnsHint` — caret on `void` token in `AnimalService.MakeThemSpeak` (line 16, col 12) with `preferDeclaringMember=false` returns empty buckets + non-null `Hint`.
- [x] `SymbolRelationshipsBuiltinTypeSuppressionTests.BuiltinVoidToken_PreferDeclaringMemberTrue_PromotesToMethodWithoutHint` — same caret position with `preferDeclaringMember=true` promotes to `MakeThemSpeak` method, `Hint` is null, definitions populated.
- [x] `SemanticExpansionTests` (10 tests, including `Symbol_Relationships_ReturnTypeToken_UsesPromotedMemberForBuckets` which already exercises `preferDeclaringMember=false`) — all pass.
- [x] `IntegrationTests_SymbolNavigation` (14 tests) — all pass.
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- [x] `./eng/verify-ai-docs.ps1` — AI docs validation passed; 32 shipped skills checked as generic.

## Performance

N/A — correctness fix. The guard adds one `SpecialType` property read before async work; negligible cost (constant-time enum comparison).

## Spin-offs

None.

Closes: `symbol-relationships-builtin-type-unbounded-enumeration`
Fixes #757

Generated with Claude Code