### PR TITLE
fix(split_service_with_di): migrate fields into partitions and strip async from forwarding stubs (split-service-with-di-broken-output)

### DIFF
--- a/changelog.d/split-service-with-di-broken-output.md
+++ b/changelog.d/split-service-with-di-broken-output.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `split_service_with_di_preview` emitting non-functional partition/facade code: instance fields are now migrated into the correct partition types (with a synthesized constructor when needed), and `async` modifiers are stripped from facade forwarding stubs so `ValueTask`/`Task` return types compile correctly (gh #766).

--- a/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
@@ -304,12 +304,15 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
     }
 
     /// <summary>
-    /// Resolved context for a split-service preview: the target type declaration, its methods,
-    /// the per-member partition mapping, and formatting scaffolding (namespace, directory, usings).
+    /// Resolved context for a split-service preview: the target type declaration, its methods
+    /// and fields, the per-member partition mapping, and formatting scaffolding (namespace,
+    /// directory, usings). Field declarations are needed so that partition files include any
+    /// instance fields referenced by their migrated methods (split-service-with-di-broken-output).
     /// </summary>
     private sealed record SplitServiceContext(
         TypeDeclarationSyntax TypeDeclaration,
         IReadOnlyList<MethodDeclarationSyntax> MethodDeclarations,
+        IReadOnlyList<FieldDeclarationSyntax> FieldDeclarations,
         IReadOnlyDictionary<string, SplitServicePartition> MemberToPartition,
         string NamespaceName,
         string SourceDirectory,
@@ -335,6 +338,15 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
         // methods cleanly; we keep the first version intentionally method-only to avoid writing
         // a richer generator for properties / fields in scope).
         var methodDeclarations = typeDeclaration.Members.OfType<MethodDeclarationSyntax>().ToArray();
+
+        // split-service-with-di-broken-output: also collect instance field declarations so each
+        // partition file can migrate the fields its methods reference. Without this, partition
+        // classes emit field-less and any `_field.Member(...)` reference in the migrated method
+        // body fails to compile (gh #766).
+        var fieldDeclarations = typeDeclaration.Members.OfType<FieldDeclarationSyntax>()
+            .Where(field => !field.Modifiers.Any(token => token.IsKind(SyntaxKind.StaticKeyword)))
+            .ToArray();
+
         var memberToPartition = new Dictionary<string, SplitServicePartition>(StringComparer.Ordinal);
         foreach (var partition in partitions)
         {
@@ -359,13 +371,17 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
         return new SplitServiceContext(
             typeDeclaration,
             methodDeclarations,
+            fieldDeclarations,
             memberToPartition,
             GetNamespaceName(typeDeclaration),
             sourceDirectory,
             StripLeadingTriviaFromFirstUsing(root.Usings));
     }
 
-    // 1) Create partition files.
+    // 1) Create partition files. Each partition file emits the requested methods PLUS any
+    //    instance fields those methods reference (split-service-with-di-broken-output). When
+    //    a partition migrates one or more uninitialized fields, BuildPartitionFile also
+    //    synthesizes a constructor that accepts and assigns them so the partition compiles.
     private static void EmitPartitionFiles(
         SplitServiceContext context,
         IReadOnlyList<SplitServicePartition> partitions,
@@ -374,16 +390,64 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
     {
         foreach (var partition in partitions)
         {
-            var partitionMethods = context.MethodDeclarations
+            var rawPartitionMethods = context.MethodDeclarations
                 .Where(method => partition.MemberNames.Contains(method.Identifier.ValueText, StringComparer.Ordinal))
+                .ToArray();
+
+            var partitionMethods = rawPartitionMethods
                 .Select(method => NormalizeMemberForPartition(method))
                 .ToArray();
 
+            var referencedFields = ResolveFieldsReferencedByMethods(context.FieldDeclarations, rawPartitionMethods);
+
             var partitionFilePath = Path.Combine(context.SourceDirectory, $"{partition.TypeName}.cs");
-            var partitionContent = BuildPartitionFile(context.NamespaceName, partition.TypeName, partitionMethods, context.Usings);
+            var partitionContent = BuildPartitionFile(
+                context.NamespaceName, partition.TypeName, referencedFields, partitionMethods, context.Usings);
             mutations.Add(new CompositeFileMutation(partitionFilePath, partitionContent));
             changes.Add(new FileChangeDto(partitionFilePath, DiffGenerator.GenerateUnifiedDiff(string.Empty, partitionContent, partitionFilePath)));
         }
+    }
+
+    /// <summary>
+    /// Walks every method body and scans descendant <see cref="IdentifierNameSyntax"/> nodes
+    /// against the supplied field-name set. Any field whose declarator-name appears anywhere
+    /// in a method body is included in the returned set so the partition can carry it.
+    /// </summary>
+    private static IReadOnlyList<FieldDeclarationSyntax> ResolveFieldsReferencedByMethods(
+        IReadOnlyList<FieldDeclarationSyntax> candidateFields,
+        IReadOnlyList<MethodDeclarationSyntax> methods)
+    {
+        if (candidateFields.Count == 0 || methods.Count == 0)
+        {
+            return Array.Empty<FieldDeclarationSyntax>();
+        }
+
+        // Index every field by each declarator name so a multi-declarator field (`int x, y;`)
+        // is matched when either name appears in a method body.
+        var nameToField = new Dictionary<string, FieldDeclarationSyntax>(StringComparer.Ordinal);
+        foreach (var field in candidateFields)
+        {
+            foreach (var declarator in field.Declaration.Variables)
+            {
+                nameToField[declarator.Identifier.ValueText] = field;
+            }
+        }
+
+        var referenced = new HashSet<FieldDeclarationSyntax>();
+        foreach (var method in methods)
+        {
+            foreach (var identifier in method.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (nameToField.TryGetValue(identifier.Identifier.ValueText, out var field))
+                {
+                    referenced.Add(field);
+                }
+            }
+        }
+
+        // Preserve the original declaration order so the migrated file reads top-to-bottom
+        // in source order rather than a hash-randomized layout.
+        return candidateFields.Where(referenced.Contains).ToArray();
     }
 
     // 2) Rewrite the original file: the source type becomes a forwarding facade whose
@@ -638,16 +702,107 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
     private static string BuildPartitionFile(
         string namespaceName,
         string partitionTypeName,
+        IReadOnlyList<FieldDeclarationSyntax> referencedFields,
         IReadOnlyList<MethodDeclarationSyntax> methods,
         SyntaxList<UsingDirectiveSyntax> usings)
     {
+        // split-service-with-di-broken-output: assemble fields + (optional) ctor + methods so the
+        // partition file compiles when its migrated methods reference instance fields. Fields
+        // with their own initializer (`= new()`) keep the initializer and are NOT plumbed
+        // through the constructor; uninitialized fields become constructor parameters and are
+        // assigned in the synthesized ctor body. When no uninitialized fields remain the ctor
+        // is omitted entirely so we don't conflict with the implicit default constructor.
+        var partitionMembers = new List<MemberDeclarationSyntax>();
+        partitionMembers.AddRange(referencedFields.Select(NormalizeFieldForPartition));
+
+        var ctorEligibleFields = referencedFields
+            .Where(field => !FieldHasInitializer(field))
+            .ToArray();
+        if (ctorEligibleFields.Length > 0)
+        {
+            partitionMembers.Add(BuildPartitionConstructor(partitionTypeName, ctorEligibleFields));
+        }
+
+        partitionMembers.AddRange(methods);
+
         var classDecl = SyntaxFactory.ClassDeclaration(partitionTypeName)
             .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
-            .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(methods));
+            .WithMembers(SyntaxFactory.List(partitionMembers));
 
         var compilationUnit = SyntaxFactory.CompilationUnit().WithUsings(usings);
         compilationUnit = WrapInNamespace(compilationUnit, namespaceName, classDecl);
         return compilationUnit.NormalizeWhitespace().ToFullString() + Environment.NewLine;
+    }
+
+    private static FieldDeclarationSyntax NormalizeFieldForPartition(FieldDeclarationSyntax field)
+    {
+        // Strip attributes and reset trivia so the migrated field sits cleanly at the top of the
+        // partition. Field initializers are preserved verbatim — they may carry trailing trivia
+        // we don't want to disturb (e.g. `= new(); // configured at construction`).
+        return field
+            .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
+            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed))
+            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
+    }
+
+    private static bool FieldHasInitializer(FieldDeclarationSyntax field)
+    {
+        return field.Declaration.Variables.Any(declarator => declarator.Initializer is not null);
+    }
+
+    private static ConstructorDeclarationSyntax BuildPartitionConstructor(
+        string partitionTypeName, IReadOnlyList<FieldDeclarationSyntax> ctorFields)
+    {
+        // Synthesize one parameter per migrated field-without-initializer, matching the facade's
+        // `LowerFirst` naming convention. A field named `_channel` becomes parameter `channel`
+        // with body `_channel = channel;`. Multi-declarator fields produce one parameter per
+        // declarator (rare but supported).
+        var parameters = new List<ParameterSyntax>();
+        var assignments = new List<StatementSyntax>();
+        foreach (var field in ctorFields)
+        {
+            foreach (var declarator in field.Declaration.Variables)
+            {
+                if (declarator.Initializer is not null)
+                {
+                    // Mixed-initializer field (`int _a, _b = 1;`) — only the uninitialized
+                    // declarator should be plumbed through the ctor.
+                    continue;
+                }
+
+                var fieldName = declarator.Identifier.ValueText;
+                var paramName = ParameterNameFromFieldName(fieldName);
+                parameters.Add(SyntaxFactory.Parameter(SyntaxFactory.Identifier(paramName))
+                    .WithType(field.Declaration.Type));
+                assignments.Add(SyntaxFactory.ExpressionStatement(
+                    SyntaxFactory.AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        SyntaxFactory.IdentifierName(fieldName),
+                        SyntaxFactory.IdentifierName(paramName))));
+            }
+        }
+
+        return SyntaxFactory.ConstructorDeclaration(partitionTypeName)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters)))
+            .WithBody(SyntaxFactory.Block(assignments));
+    }
+
+    private static string ParameterNameFromFieldName(string fieldName)
+    {
+        // Strip leading underscore(s) and lowercase the first remaining char so `_channel`
+        // becomes `channel` and `_FooBar` becomes `fooBar`. Identifiers that are pure
+        // underscores or empty fall back to `value` so we never emit an invalid parameter name.
+        if (string.IsNullOrEmpty(fieldName))
+        {
+            return "value";
+        }
+        var stripped = fieldName.TrimStart('_');
+        if (stripped.Length == 0)
+        {
+            return "value";
+        }
+        return LowerFirst(stripped);
     }
 
     private static string BuildFacadeFile(
@@ -732,8 +887,17 @@ public sealed class SymbolRefactorService : ISymbolRefactorService
             ? SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(invocation))
             : SyntaxFactory.Block(SyntaxFactory.ReturnStatement(invocation));
 
+        // split-service-with-di-broken-output: strip `async` from the forwarding stub. The stub
+        // body is a sync `return _field.Method(args)` (no `await`); copying `async` verbatim
+        // from the source method triggers CS4016 on `Task` / `ValueTask` return types because
+        // the compiler expects an awaited expression in an async method. Returning the Task
+        // synchronously is the correct delegation pattern here — the partition method retains
+        // its `async` modifier and does the awaiting; the facade simply forwards the Task.
+        var modifiers = SyntaxFactory.TokenList(
+            original.Modifiers.Where(token => !token.IsKind(SyntaxKind.AsyncKeyword)));
+
         return SyntaxFactory.MethodDeclaration(original.ReturnType, original.Identifier)
-            .WithModifiers(original.Modifiers)
+            .WithModifiers(modifiers)
             .WithTypeParameterList(original.TypeParameterList)
             .WithParameterList(original.ParameterList)
             .WithBody(body);

--- a/tests/RoslynMcp.Tests/CompositeSplitServiceDiPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/CompositeSplitServiceDiPreviewTests.cs
@@ -94,6 +94,112 @@ public sealed class CompositeSplitServiceDiPreviewTests : IsolatedWorkspaceTestB
     }
 
     [TestMethod]
+    public async Task Split_Service_With_Di_Preview_Migrates_Fields_And_Strips_Async_From_Forwarding_Stubs()
+    {
+        // Regression for split-service-with-di-broken-output (gh #766): a service with private
+        // instance fields plus async ValueTask methods was emitting non-compiling code.
+        //   - Bug 1: partition class lacked the `_channel` field referenced by its migrated
+        //     method body → CS0103 'name does not exist in the current context'.
+        //   - Bug 2: facade's forwarding stub copied `async` verbatim, producing
+        //     `async ValueTask Foo() { return _field.Foo(...); }` → CS4016.
+        // This test reproduces the JobQueue shape (Channel<int> field + async ValueTask method
+        // + sync TryDequeue) and pins both fixes.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var serviceFilePath = workspace.GetPath("SampleLib", "JobQueue.cs");
+        await File.WriteAllTextAsync(
+            serviceFilePath,
+            "using System.Threading.Channels;\n" +
+            "using System.Threading.Tasks;\n" +
+            "\n" +
+            "namespace SampleLib;\n" +
+            "\n" +
+            "public class JobQueue\n" +
+            "{\n" +
+            "    private readonly Channel<int> _channel;\n" +
+            "\n" +
+            "    public JobQueue(Channel<int> channel)\n" +
+            "    {\n" +
+            "        _channel = channel;\n" +
+            "    }\n" +
+            "\n" +
+            "    public async ValueTask EnqueueAsync(int item)\n" +
+            "    {\n" +
+            "        await _channel.Writer.WriteAsync(item);\n" +
+            "    }\n" +
+            "\n" +
+            "    public bool TryDequeue(out int item)\n" +
+            "    {\n" +
+            "        return _channel.Reader.TryRead(out item);\n" +
+            "    }\n" +
+            "}\n",
+            CancellationToken.None);
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var compositeStore = new CompositePreviewStore();
+        var service = CreateSymbolRefactorService(compositeStore);
+        var preview = await service.PreviewSplitServiceWithDiAsync(
+            workspace.WorkspaceId,
+            serviceFilePath,
+            "JobQueue",
+            new[]
+            {
+                new SplitServicePartition("JobQueueWriter", new[] { "EnqueueAsync" }),
+                new SplitServicePartition("JobQueueReader", new[] { "TryDequeue" }),
+            },
+            hostRegistrationFile: null,
+            CancellationToken.None);
+
+        await ApplyMutationsAsync(compositeStore, preview.PreviewToken, CancellationToken.None);
+
+        var writerPartition = await File.ReadAllTextAsync(workspace.GetPath("SampleLib", "JobQueueWriter.cs"), CancellationToken.None);
+        var readerPartition = await File.ReadAllTextAsync(workspace.GetPath("SampleLib", "JobQueueReader.cs"), CancellationToken.None);
+        var facadeContents = await File.ReadAllTextAsync(serviceFilePath, CancellationToken.None);
+
+        // Bug 1 — field migration: both partitions touch `_channel`, so both must declare it.
+        // The shared field is duplicated (not split exclusively into one partition) — see the
+        // Sonnet handoff "shared field referenced by methods in two different partitions" note.
+        StringAssert.Contains(writerPartition, "private readonly Channel<int> _channel",
+            "Writer partition must migrate the _channel field referenced by EnqueueAsync.");
+        StringAssert.Contains(readerPartition, "private readonly Channel<int> _channel",
+            "Reader partition must also migrate the shared _channel field referenced by TryDequeue.");
+
+        // Each partition gets a synthesized ctor that accepts and assigns its migrated fields.
+        StringAssert.Contains(writerPartition, "public JobQueueWriter(Channel<int> channel)",
+            "Writer partition needs a constructor taking the migrated field as a parameter.");
+        StringAssert.Contains(writerPartition, "_channel = channel",
+            "Writer partition ctor body must assign the constructor parameter to the field.");
+        StringAssert.Contains(readerPartition, "public JobQueueReader(Channel<int> channel)",
+            "Reader partition needs a constructor taking the migrated field as a parameter.");
+
+        // The partition keeps the original `async` modifier on its method (it does the awaiting).
+        StringAssert.Contains(writerPartition, "async ValueTask EnqueueAsync",
+            "Writer partition method must retain its async modifier — the partition does the awaiting.");
+
+        // Bug 2 — async fix: facade forwarding stub for EnqueueAsync must NOT carry `async`,
+        // because its body is sync `return _field.EnqueueAsync(item);` with no `await`.
+        // Constructing the assertion against the EnqueueAsync stub specifically (not the whole
+        // file) lets us catch a regression even if some other async method appears nearby.
+        var enqueueIndex = facadeContents.IndexOf("EnqueueAsync", StringComparison.Ordinal);
+        Assert.IsTrue(enqueueIndex > 0, "Facade should contain an EnqueueAsync forwarding stub.");
+        var enqueueStubWindow = facadeContents.Substring(
+            Math.Max(0, enqueueIndex - 60), Math.Min(120, facadeContents.Length - Math.Max(0, enqueueIndex - 60)));
+        Assert.IsFalse(enqueueStubWindow.Contains("async ", StringComparison.Ordinal),
+            $"Facade's EnqueueAsync forwarding stub must NOT carry the async modifier (would trigger CS4016). Window: {enqueueStubWindow}");
+
+        // Facade must still forward correctly.
+        StringAssert.Contains(facadeContents, "_jobQueueWriter.EnqueueAsync(item)",
+            "Facade must forward EnqueueAsync to the writer partition.");
+        StringAssert.Contains(facadeContents, "_jobQueueReader.TryDequeue(item)",
+            "Facade must forward TryDequeue to the reader partition.");
+
+        // Facade should NOT re-emit the migrated _channel field — state lives on the partitions.
+        Assert.IsFalse(facadeContents.Contains("Channel<int> _channel", StringComparison.Ordinal),
+            "Facade must not re-emit the migrated _channel field; state belongs to the partitions.");
+    }
+
+    [TestMethod]
     public async Task Split_Service_With_Di_Preview_Returns_Warning_When_Registration_Not_Found()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();


### PR DESCRIPTION
## Summary

Fixes two co-located bugs in `SymbolRefactorService.PreviewSplitServiceWithDiAsync` that caused the `split_service_with_di_preview` composite to emit non-compiling partition/facade code (gh #766):

1. **Field migration:** `SplitServiceContext` collected only methods. Instance fields referenced by migrated method bodies (e.g. `_channel`) were never carried into the partition class, so any partition method that touched a field failed with CS0103 "name does not exist in the current context".

2. **Async modifier propagation:** `BuildForwardingMethod` copied `original.Modifiers` verbatim, including `async`. The forwarding stub body is sync `return _field.Method(args)` with no `await`, so `async ValueTask Foo() { return _channel.Foo(...); }` triggered CS4016 on every async `ValueTask` / `Task<T>` method touched by the split.

### Implementation

- `SplitServiceContext` record gains `FieldDeclarations`, populated in `ResolveSplitServiceContextAsync` from the source type's non-static field declarations.
- New helper `ResolveFieldsReferencedByMethods` walks each partition method's `DescendantNodes().OfType<IdentifierNameSyntax>()` and matches identifiers against the field-name set. Shared fields are duplicated into every referencing partition (per Sonnet handoff guidance — the safe minimal path that avoids redesigning partition contracts).
- `BuildPartitionFile` now emits the matched fields followed by a synthesized constructor that accepts and assigns every uninitialized field. Fields with their own initializer are kept verbatim and skip the ctor plumbing. Parameter naming strips the leading underscore (`_channel` → `channel`), matching the facade's `LowerFirst` convention.
- `BuildForwardingMethod` filters `SyntaxKind.AsyncKeyword` out of `original.Modifiers` before applying them to the facade stub.

### Test

New regression test `Split_Service_With_Di_Preview_Migrates_Fields_And_Strips_Async_From_Forwarding_Stubs` in `CompositeSplitServiceDiPreviewTests` exercises the JobQueue shape (`Channel<int>` field + `async ValueTask EnqueueAsync` + sync `TryDequeue`). Asserts:

- Both partitions migrate the shared `_channel` field (since both methods reference it).
- Each partition declares a synthesized public constructor that takes the field as a parameter.
- The writer partition retains `async ValueTask EnqueueAsync` (the partition does the awaiting).
- The facade's `EnqueueAsync` forwarding stub has NO `async` modifier in a ±60-char window.
- Facade forwards correctly to both partitions and does NOT re-emit the `_channel` field.

## Test plan

- [x] `mcp__roslyn__compile_check` — all 5 projects, zero errors
- [x] `CompositeSplitServiceDiPreviewTests` — 3/3 pass (including new test)
- [x] `SymbolRefactorPreviewTests` + `RecordFieldAddSatelliteTests` — 9/9 related-test pass
- [x] `eng/verify-ai-docs.ps1` — passed
- [x] `eng/verify-changelog-fragments.ps1` — 5/5 fragments valid (including new fragment)
- [ ] Full `eng/verify-release.ps1` — running on self-hosted runner via CI

Closes: split-service-with-di-broken-output
Fixes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)