### PR TITLE
fix(host): PreviewTokenStale category replaces NotFound on stale-token apply

### DIFF
--- a/changelog.d/preview-token-stale-across-auto-reload.md
+++ b/changelog.d/preview-token-stale-across-auto-reload.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Preview token rejection after workspace auto-reload now returns a structured `PreviewTokenStale` error category instead of a generic `NotFound`, giving callers a machine-readable signal to re-issue the paired `*_preview` call (gh #767).

--- a/src/RoslynMcp.Core/Services/PreviewTokenStaleException.cs
+++ b/src/RoslynMcp.Core/Services/PreviewTokenStaleException.cs
@@ -1,0 +1,101 @@
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Signals that an <c>*_apply</c> tool call attempted to redeem a preview token that
+/// has been invalidated — most commonly because the workspace was auto-reloaded
+/// (version bump) after the preview was created, dropping the stored snapshot via
+/// <c>IPreviewStore.InvalidateOnVersionBump</c>. The structural distinction from
+/// <see cref="System.Collections.Generic.KeyNotFoundException"/> is the
+/// <c>PreviewTokenStale</c> error category surfaced by
+/// <c>RoslynMcp.Host.Stdio.Tools.ToolErrorHandler</c>: callers can branch on the
+/// envelope category to recover (re-issue the paired <c>*_preview</c> call against
+/// the post-reload workspace) instead of guessing whether they mis-spelled the
+/// <c>workspaceId</c> or the symbol itself is gone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> the <c>preview-token-stale-across-auto-reload</c> row
+/// (gh #767, P1 firewallanalyzer audit) observed that a typical
+/// preview → apply → preview → apply sequence — where the first apply triggers an
+/// auto-reload that bumps the workspace version past the second preview's pinned
+/// span — surfaced as a bare <see cref="System.Collections.Generic.KeyNotFoundException"/>
+/// with <c>category=NotFound</c>. The shape was indistinguishable from "workspace not
+/// found" or "symbol not found": agents had no machine-readable signal that the
+/// correct recovery was "re-issue the paired <c>*_preview</c> call" rather than
+/// "check the workspace id" or "re-resolve the symbol."
+/// </para>
+///
+/// <para>
+/// <b>Inheritance choice:</b> derives from <see cref="System.InvalidOperationException"/>
+/// rather than <see cref="System.Collections.Generic.KeyNotFoundException"/>. This is a
+/// deliberate departure from <c>WorkspaceEvictedException</c> (which derives from
+/// <c>KeyNotFoundException</c> for catch-site compatibility with preexisting
+/// <c>catch (KeyNotFoundException)</c> sites): no production code paths catch the
+/// stale-token throw — both throw sites in
+/// <c>ToolDispatch.ApplyByTokenAsync</c> and <c>ApplyWithVerifyTool.ApplyWithVerify</c>
+/// surface directly to <c>ToolErrorHandler</c> via the tool-call boundary, so changing
+/// the base type breaks no internal contracts. Using <c>InvalidOperationException</c>
+/// keeps the "the preview entry is structurally absent" lookup-miss signal scoped to
+/// <c>KeyNotFoundException</c> (workspace evictions, symbol miss) and gives the
+/// stale-token state its own "the operation cannot proceed because the prerequisite
+/// is no longer valid" semantic — closer to .NET conventions for "object was disposed"
+/// or "the underlying state changed."
+/// </para>
+///
+/// <para>
+/// <b>Registration order:</b> because the type derives from
+/// <see cref="System.InvalidOperationException"/>, <c>ToolErrorHandler</c>'s handler
+/// dictionary MUST register this type BEFORE the generic
+/// <see cref="System.InvalidOperationException"/> entry so the more-specific
+/// <c>PreviewTokenStale</c> category wins on the dispatch walk
+/// (<c>Type.IsAssignableFrom</c> matches in insertion order). The classifier's
+/// <c>IsInvocationWrapper</c> short-circuit operates earlier in the pipeline, so
+/// stale-token throws (which are NOT invocation wrappers — no inner exception, no
+/// "invocation" in the type name) fall through to the dictionary walk normally.
+/// </para>
+///
+/// <para>
+/// <b>Two staleness lifecycles covered:</b>
+/// </para>
+/// <list type="bullet">
+///   <item><description><b>Version-bump invalidation</b> — the dominant path: an
+///     auto-reload via <c>WorkspaceManager.LoadIntoSessionAsync</c> calls
+///     <c>IPreviewStore.InvalidateOnVersionBump</c>, which drops entries whose pinned
+///     <c>[StoreVersion, StoreVersion + MaxVersionSpan]</c> range no longer covers
+///     the new workspace version. The default <c>MaxVersionSpan = 1</c> means a single
+///     bump is tolerated; a second concurrent reload pushes the ceiling past and the
+///     token is dropped.</description></item>
+///   <item><description><b>TTL expiration</b> — the secondary path: entries expire
+///     after a fixed TTL regardless of version-bump activity. Composite preview stores
+///     (<c>ICompositePreviewStore</c>, <c>IProjectMutationPreviewStore</c>) are NOT
+///     wired to <c>InvalidateOnVersionBump</c>, so their tokens can only stale via TTL.
+///     The envelope message uses "expired or invalidated" to cover both reasons
+///     without forcing a per-store distinction at the throw site.</description></item>
+/// </list>
+///
+/// <para>
+/// This is a <b>retry-able</b> error in the same sense as
+/// <see cref="StaleWorkspaceTransitionException"/>: callers re-issue the paired
+/// <c>*_preview</c> against the current workspace state and immediately redeem the
+/// fresh token. Distinct from <c>NotFound</c> (which implies the underlying entity is
+/// permanently absent) and <c>WorkspaceEvicted</c> (which requires
+/// <c>workspace_load</c> to rehydrate the session itself before any preview can be
+/// issued).
+/// </para>
+/// </remarks>
+public sealed class PreviewTokenStaleException : System.InvalidOperationException
+{
+    /// <summary>
+    /// The opaque preview token that was rejected. Carried separately from
+    /// <see cref="System.Exception.Message"/> so consumers can branch without
+    /// parsing the message string — and so <c>ToolErrorHandler</c> can include it
+    /// as a structured field in the error envelope.
+    /// </summary>
+    public string PreviewToken { get; }
+
+    public PreviewTokenStaleException(string previewToken, string message, System.Exception? inner = null)
+        : base(message, inner)
+    {
+        PreviewToken = previewToken;
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -31,7 +31,9 @@ public static class ApplyWithVerifyTool
         CancellationToken ct = default)
     {
         var workspaceId = previewStore.PeekWorkspaceId(previewToken)
-            ?? throw new KeyNotFoundException($"Preview token '{previewToken}' not found or expired.");
+            ?? throw new PreviewTokenStaleException(
+                previewToken,
+                $"Preview token '{previewToken}' has expired or was invalidated: the workspace was reloaded after the preview was created, dropping the stored solution snapshot. Re-issue the paired *_preview call against the current workspace.");
 
         return gate.RunWriteAsync(workspaceId, async c =>
         {

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -76,12 +76,14 @@ internal static class ToolDispatch
     /// <returns>
     /// The DTO serialized with <see cref="JsonDefaults.Indented"/>.
     /// </returns>
-    /// <exception cref="KeyNotFoundException">
+    /// <exception cref="PreviewTokenStaleException">
     /// Thrown when <paramref name="previewToken"/> is not present in
-    /// <paramref name="previewStore"/> (expired, invalidated, or never stored). The
-    /// exception message matches the format used by the existing hand-written
-    /// shims so existing error-envelope tests remain valid when shims migrate to
-    /// this helper.
+    /// <paramref name="previewStore"/> (expired, invalidated by an auto-reload version
+    /// bump via <c>InvalidateOnVersionBump</c>, or never stored). Distinct from a bare
+    /// <see cref="KeyNotFoundException"/> so <c>ToolErrorHandler</c> can surface the
+    /// dedicated <c>PreviewTokenStale</c> category — callers re-issue the paired
+    /// <c>*_preview</c> against the post-reload workspace rather than mistaking the
+    /// failure for "workspace not found" or "symbol not found."
     /// </exception>
     public static Task<string> ApplyByTokenAsync<TDto>(
         IWorkspaceExecutionGate gate,
@@ -118,10 +120,12 @@ internal static class ToolDispatch
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>
     /// <returns>The DTO serialized with <see cref="JsonDefaults.Indented"/>.</returns>
-    /// <exception cref="KeyNotFoundException">
-    /// Thrown when <paramref name="peekWorkspaceId"/> returns <see langword="null"/>. The
-    /// exception message matches the format used by the existing hand-written shims so
-    /// existing error-envelope tests remain valid when shims migrate to this helper.
+    /// <exception cref="PreviewTokenStaleException">
+    /// Thrown when <paramref name="peekWorkspaceId"/> returns <see langword="null"/>
+    /// (token expired, invalidated by an auto-reload version bump, or never stored).
+    /// Distinct from a bare <see cref="KeyNotFoundException"/> so <c>ToolErrorHandler</c>
+    /// can surface the dedicated <c>PreviewTokenStale</c> category and direct callers to
+    /// re-issue the paired <c>*_preview</c>.
     /// </exception>
     public static Task<string> ApplyByTokenAsync<TDto>(
         IWorkspaceExecutionGate gate,
@@ -131,7 +135,9 @@ internal static class ToolDispatch
         CancellationToken ct)
     {
         var wsId = peekWorkspaceId(previewToken)
-            ?? throw new KeyNotFoundException($"Preview token '{previewToken}' not found or expired.");
+            ?? throw new PreviewTokenStaleException(
+                previewToken,
+                $"Preview token '{previewToken}' has expired or was invalidated: the workspace was reloaded after the preview was created, dropping the stored solution snapshot. Re-issue the paired *_preview call against the current workspace.");
         return gate.RunWriteAsync(wsId, async c =>
         {
             var result = await serviceCall(c).ConfigureAwait(false);

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -60,6 +60,22 @@ internal static class ToolErrorHandler
         [typeof(TimeoutException)] = (ex, _) => new("Timeout",
             $"Timed out: {ex.Message}. For build/test operations, increase ROSLYNMCP_BUILD_TIMEOUT_SECONDS or " +
             "ROSLYNMCP_TEST_TIMEOUT_SECONDS. For other operations, increase ROSLYNMCP_REQUEST_TIMEOUT_SECONDS."),
+        // preview-token-stale-across-auto-reload: a *_apply call whose paired preview was
+        // invalidated by an auto-reload version bump (InvalidateOnVersionBump) or TTL
+        // expiry surfaces as PreviewTokenStaleException instead of the legacy bare
+        // KeyNotFoundException. PreviewTokenStaleException derives from
+        // InvalidOperationException so this entry MUST register BEFORE the generic
+        // InvalidOperationException handler below — the dictionary walk's
+        // Type.IsAssignableFrom check uses insertion order, so a later InvalidOperation
+        // entry would otherwise win and surface the less-specific category. Recovery hint
+        // mirrors WorkspaceEvicted: structured, copy-pasteable signal that the workspace
+        // is intact and the client just needs to re-issue the paired *_preview call.
+        [typeof(PreviewTokenStaleException)] = (ex, _) =>
+        {
+            var stale = (PreviewTokenStaleException)ex;
+            return new("PreviewTokenStale",
+                $"Preview token '{stale.PreviewToken}' has expired: the workspace was reloaded after the preview was created, invalidating the stored solution snapshot. Re-issue the paired *_preview call.");
+        },
         // compile-check-not-connected-raw-transport-error-envelope: a disconnected stdio
         // pipe surfaces as InvalidOperationException("Not connected") from PipeStream when
         // the SDK attempts a write on an already-closed transport. Registered BEFORE the

--- a/tests/RoslynMcp.Tests/PreviewTokenStaleAcrossAutoReloadTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewTokenStaleAcrossAutoReloadTests.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for <c>preview-token-stale-across-auto-reload</c> (gh #767, P1
+/// firewallanalyzer audit): an <c>*_apply</c> tool call whose paired preview was
+/// invalidated by an auto-reload version bump used to surface as a bare
+/// <see cref="KeyNotFoundException"/> with <c>category="NotFound"</c>, indistinguishable
+/// from "workspace not found" or "symbol not found." The remediation introduces
+/// <see cref="PreviewTokenStaleException"/> at the two <c>?? throw</c> sites
+/// (<c>ToolDispatch.ApplyByTokenAsync</c>, <c>ApplyWithVerifyTool.ApplyWithVerify</c>)
+/// and a dedicated <c>PreviewTokenStale</c> classifier entry in
+/// <see cref="ToolErrorHandler"/> registered BEFORE the generic
+/// <see cref="InvalidOperationException"/> handler so the more-specific category wins
+/// on the dictionary walk.
+/// </summary>
+/// <remarks>
+/// The test surface covers three orthogonal axes:
+/// <list type="bullet">
+///   <item><description><b>End-to-end repro</b> — store a token in a real
+///     <see cref="PreviewStore"/>, evict via the production
+///     <see cref="IPreviewStore.InvalidateOnVersionBump"/> call (the same path
+///     <c>WorkspaceManager.LoadIntoSessionAsync</c> invokes after every reload), then
+///     dispatch through <see cref="ToolDispatch.ApplyByTokenAsync{TDto}"/> and assert
+///     the envelope category and message shape.</description></item>
+///   <item><description><b>Classifier-direct</b> — feed the new exception directly to
+///     <see cref="ToolExecutionTestHarness"/> so the classifier wiring is asserted
+///     independently of the dispatch wrapper.</description></item>
+///   <item><description><b>Registration-order safety net</b> — a bare
+///     <see cref="InvalidOperationException"/> must still surface as <c>InvalidOperation</c>,
+///     proving the dedicated <c>PreviewTokenStale</c> entry does not capture sibling
+///     subclasses by accident.</description></item>
+/// </list>
+/// </remarks>
+[TestClass]
+public sealed class PreviewTokenStaleAcrossAutoReloadTests
+{
+    [TestMethod]
+    public async Task DispatchPath_WhenTokenInvalidatedByVersionBump_ReturnsPreviewTokenStaleCategory()
+    {
+        // Real PreviewStore — exercises the production InvalidateOnVersionBump path that
+        // WorkspaceManager.LoadIntoSessionAsync calls after every reload. DefaultMaxVersionSpan
+        // is 1, so storing at V=1 and bumping to V=3 pushes the token past its pinned ceiling
+        // (V=2) and triggers the same drop as a real preview → apply → reload → apply sequence
+        // where two consecutive auto-reloads happen between preview and apply.
+        var store = new PreviewStore();
+        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+        const string workspaceId = "ws-repro";
+        var token = store.Store(workspaceId, solution, workspaceVersion: 1, "scaffold_test_preview");
+
+        // Confirm the token is initially valid (guards against test setup drift).
+        Assert.IsNotNull(store.PeekWorkspaceId(token),
+            "test setup precondition: token must be redeemable before the version bump");
+
+        // Simulate two consecutive auto-reloads: V=1 → V=2 (kept) → V=3 (drops because
+        // pinned ceiling = StoreVersion + DefaultMaxVersionSpan = 1 + 1 = 2).
+        store.InvalidateOnVersionBump(workspaceId, newWorkspaceVersion: 3);
+        Assert.IsNull(store.PeekWorkspaceId(token),
+            "test setup precondition: token must be invalidated by the version bump before the dispatch call");
+
+        // Route through the same harness production code uses for tool error formatting.
+        // The dispatch helper throws PreviewTokenStaleException; the harness classifies and
+        // serializes the envelope exactly as StructuredCallToolFilter does on the real path.
+        var envelope = await ToolExecutionTestHarness.RunAsync(
+            "scaffold_test_apply",
+            () => ToolDispatch.ApplyByTokenAsync<UnusedDto>(
+                new ThrowingGate(),
+                store,
+                previewToken: token,
+                serviceCall: _ => Task.FromResult(new UnusedDto()),
+                ct: CancellationToken.None));
+
+        var doc = JsonDocument.Parse(envelope);
+        Assert.AreEqual("PreviewTokenStale",
+            doc.RootElement.GetProperty("category").GetString(),
+            $"expected PreviewTokenStale category, full payload: {envelope}");
+        Assert.IsTrue(doc.RootElement.GetProperty("error").GetBoolean(),
+            "error envelope must set error=true");
+        Assert.AreEqual("scaffold_test_apply",
+            doc.RootElement.GetProperty("tool").GetString(),
+            "envelope must carry the originating tool name through the harness");
+
+        var message = doc.RootElement.GetProperty("message").GetString()!;
+        StringAssert.Contains(message, token,
+            "envelope must name the rejected token so log scrapers can correlate");
+        StringAssert.Contains(message, "workspace was reloaded",
+            "envelope must explain the version-bump invalidation lifecycle");
+        StringAssert.Contains(message, "Re-issue the paired *_preview call",
+            "envelope must direct the caller to the recovery action");
+    }
+
+    [TestMethod]
+    public async Task Classifier_PreviewTokenStaleException_MapsToDedicatedCategory()
+    {
+        // Asserts the classifier wiring independently of the dispatch helper: feed the
+        // exception directly and verify the dedicated entry in ToolErrorHandler.ErrorHandlers
+        // is reached (rather than the base InvalidOperationException entry registered later
+        // in the dictionary).
+        var envelope = await ToolExecutionTestHarness.RunAsync(
+            "apply_with_verify",
+            () => throw new PreviewTokenStaleException(
+                "tok-abc123",
+                "Preview token 'tok-abc123' has expired or was invalidated."));
+
+        var doc = JsonDocument.Parse(envelope);
+        Assert.AreEqual("PreviewTokenStale",
+            doc.RootElement.GetProperty("category").GetString(),
+            "registration order must make PreviewTokenStaleException win over InvalidOperationException");
+
+        var message = doc.RootElement.GetProperty("message").GetString()!;
+        StringAssert.Contains(message, "tok-abc123",
+            "classifier must populate the envelope message from the PreviewToken property");
+        StringAssert.Contains(message, "Re-issue the paired *_preview call");
+    }
+
+    [TestMethod]
+    public async Task Classifier_BareInvalidOperationException_StillMapsToInvalidOperationCategory()
+    {
+        // Registration-order safety net: introducing PreviewTokenStaleException (which derives
+        // from InvalidOperationException) must NOT capture sibling InvalidOperationException
+        // throws. If the dictionary walked the entries in the wrong order (or used the base
+        // type for matching), a bare InvalidOperationException would incorrectly surface as
+        // PreviewTokenStale. This guards against that regression.
+        var envelope = await ToolExecutionTestHarness.RunAsync(
+            "test_tool",
+            () => throw new InvalidOperationException("workspace stale"));
+
+        var doc = JsonDocument.Parse(envelope);
+        Assert.AreEqual("InvalidOperation",
+            doc.RootElement.GetProperty("category").GetString(),
+            "a bare InvalidOperationException must still classify as InvalidOperation; otherwise " +
+            "the new PreviewTokenStale entry is over-matching");
+    }
+
+    [TestMethod]
+    public async Task Classifier_KeyNotFoundException_UnaffectedByNewEntry()
+    {
+        // Negative test: the new PreviewTokenStaleException derives from
+        // InvalidOperationException (not KeyNotFoundException), so a bare
+        // KeyNotFoundException must continue to surface as the standard NotFound envelope.
+        // Guards against an accidental re-base of the exception hierarchy.
+        var envelope = await ToolExecutionTestHarness.RunAsync(
+            "find_references",
+            () => throw new KeyNotFoundException("symbol not found"));
+
+        var doc = JsonDocument.Parse(envelope);
+        Assert.AreEqual("NotFound",
+            doc.RootElement.GetProperty("category").GetString(),
+            "KeyNotFoundException classification must be unaffected by the new PreviewTokenStale entry");
+    }
+
+    /// <summary>
+    /// Trivial DTO placeholder — the dispatch path fails before <c>serviceCall</c> runs, so
+    /// the payload type only needs to satisfy the generic constraint.
+    /// </summary>
+    private sealed record UnusedDto;
+
+    /// <summary>
+    /// Stand-in for <see cref="IWorkspaceExecutionGate"/> that throws on any call. The dispatch
+    /// path must fail with <see cref="PreviewTokenStaleException"/> at the
+    /// <c>PeekWorkspaceId(...) ?? throw</c> site BEFORE entering the gate; if the gate is
+    /// reached, this throw makes the test fail loudly with the actual misroute.
+    /// </summary>
+    private sealed class ThrowingGate : IWorkspaceExecutionGate
+    {
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new InvalidOperationException(
+                $"ThrowingGate.RunReadAsync invoked with workspaceId='{workspaceId}' — dispatch path must fail before reaching the gate");
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true)
+            => throw new InvalidOperationException(
+                $"ThrowingGate.RunWriteAsync invoked with workspaceId='{workspaceId}' — dispatch path must fail before reaching the gate");
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new InvalidOperationException("ThrowingGate.RunLoadGateAsync must not be reached on the stale-token path");
+
+        public void RemoveGate(string workspaceId)
+            => throw new InvalidOperationException("ThrowingGate.RemoveGate must not be reached on the stale-token path");
+    }
+}

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -56,12 +56,17 @@ public sealed class ToolDispatchTests
     }
 
     [TestMethod]
-    public async Task ApplyByTokenAsync_UnknownToken_ThrowsKeyNotFoundException_WithExpectedMessage()
+    public async Task ApplyByTokenAsync_UnknownToken_ThrowsPreviewTokenStaleException_WithTokenAndRecoveryHint()
     {
+        // preview-token-stale-across-auto-reload: when PeekWorkspaceId returns null (token
+        // never stored, TTL-expired, or invalidated by InvalidateOnVersionBump after an
+        // auto-reload), ApplyByTokenAsync must throw PreviewTokenStaleException rather than
+        // a bare KeyNotFoundException so ToolErrorHandler can emit category=PreviewTokenStale
+        // with a re-issue-preview recovery hint instead of the generic NotFound envelope.
         var gate = new FakeGate();
         var store = new FakePreviewStore(token: "real-token", workspaceId: "ws-x");
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(() =>
+        var ex = await Assert.ThrowsExceptionAsync<PreviewTokenStaleException>(() =>
             ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
                 gate,
                 store,
@@ -69,8 +74,12 @@ public sealed class ToolDispatchTests
                 serviceCall: _ => Task.FromResult(new FakeResultDto("unused", 0)),
                 ct: CancellationToken.None));
 
-        // Matches the hand-written shim format — migration must not change error envelope shape.
-        Assert.AreEqual("Preview token 'bogus-token' not found or expired.", ex.Message);
+        Assert.AreEqual("bogus-token", ex.PreviewToken,
+            "PreviewToken property must carry the rejected token for structured envelope use");
+        StringAssert.Contains(ex.Message, "bogus-token",
+            "exception message must name the failing token so log scrapers can correlate");
+        StringAssert.Contains(ex.Message, "*_preview",
+            "exception message must direct the caller to the recovery action (re-issue paired *_preview)");
         Assert.AreEqual(0, gate.WriteCallCount, "Must fail before entering the write gate");
     }
 


### PR DESCRIPTION
## Summary

Stale-token `*_apply` calls — where a paired `*_preview` was invalidated by a workspace auto-reload version bump via `InvalidateOnVersionBump` — now surface a dedicated `PreviewTokenStale` error category instead of being conflated with `NotFound`, giving callers a machine-readable signal that the correct recovery is to re-issue the paired `*_preview` (not to check the workspace id or re-resolve a symbol).

- New `PreviewTokenStaleException` in `RoslynMcp.Core/Services/` derives from `InvalidOperationException` (deliberate departure from `WorkspaceEvictedException`'s `KeyNotFoundException` base — no production code catches the stale-token throw, and this keeps the "lookup miss" signal scoped to `KeyNotFoundException`).
- Throw sites updated: `ToolDispatch.ApplyByTokenAsync` (covers all `*_apply` shims that route through the shared helper) and `ApplyWithVerifyTool.ApplyWithVerify`. Recovery-hint message includes the rejected token and the explicit re-issue instruction.
- `ToolErrorHandler` registers the new entry BEFORE the generic `InvalidOperationException` entry so `Type.IsAssignableFrom` produces the more-specific category on the dictionary walk.

Closes gh #767 (P1 firewallanalyzer audit).

## Behavior change

`category="NotFound"` -> `category="PreviewTokenStale"` for the stale-token throw shape. External callers that exact-match `category="NotFound"` for this case will need to handle `PreviewTokenStale` (which is strictly more actionable).

## Test plan

- [x] `mcp__roslyn__compile_check` on each touched file (0 errors)
- [x] New regression: `PreviewTokenStaleAcrossAutoReloadTests` (4 tests, all pass) — covers end-to-end repro via real `PreviewStore` + `InvalidateOnVersionBump`, classifier-direct mapping, bare `InvalidOperationException` safety net, and `KeyNotFoundException` non-interference.
- [x] Existing `ToolDispatchTests.ApplyByTokenAsync_UnknownToken_*` updated to assert the new exception type + recovery-hint message shape.
- [x] `PreviewStoreTests` + `PreviewTokenCrossCouplingTests` + `ToolErrorHandlerWorkspaceReloadRaceTests` + `BacklogFixTests` + `ToolErrorHandlerParameterValidationTests` + `StructuredCallToolFilterTests` + `Top10V2RegressionTests.ApplyWithVerify_*` — all green.
- [x] CI-parity `verify-release.ps1 -Configuration Release`: 1314/1314 tests pass, 0 warnings, 0 errors.
- [x] `verify-ai-docs.ps1` passes.

Closes: `preview-token-stale-across-auto-reload`
Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)