### PR TITLE
fix(cross-project-refactoring): emit usings for source-project types (extract-interface-cross-project-uncompilable)

### DIFF
--- a/changelog.d/extract-interface-cross-project-uncompilable.md
+++ b/changelog.d/extract-interface-cross-project-uncompilable.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_interface_cross_project_preview` no longer generates an uncompilable interface file when the source type's method signatures reference types from a sibling namespace inside the source project. The generated interface now emits the required `using` directives via the same semantic-walker approach (`CollectReferencedNamespaces` + `BuildUsingDirectives`) already used by `extract_interface_preview` for same-project extraction. Replaces the legacy text-grep `FilterUsingsForMember` filter that compared each using's last namespace segment against `MinimallyQualifiedFormat` short names and silently dropped source-project usings whose last segment didn't match. Also fixes the same regression on the DI-inversion path (`dependency_inversion_preview`), which routes through the same code path. Closes `extract-interface-cross-project-uncompilable` (gh #765).

--- a/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
@@ -153,7 +153,13 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         await DetectExistingTypeConflictAsync(solution, namespaceName, resolvedInterfaceName, ct).ConfigureAwait(false);
 
-        var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, resolvedInterfaceName, namespaceName, isCrossProject);
+        // gh #765 — walk the source type's public-instance member symbols semantically and
+        // collect every referenced type's containing namespace. The generated interface file's
+        // using block is built from that set (plus aliases/static/global from the source file)
+        // instead of the legacy text-grep that dropped source-project usings whose last segment
+        // didn't match the synthesized short name. Mirrors InterfaceExtractionService:301-338.
+        var requiredNamespaces = CollectReferencedNamespaces(typeSymbol, namespaceName);
+        var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, resolvedInterfaceName, namespaceName, isCrossProject, requiredNamespaces);
         var interfaceFilePath = Path.Combine(interfaceDirectory, resolvedInterfaceName + ".cs");
         if (File.Exists(interfaceFilePath))
         {
@@ -404,11 +410,17 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         MemberDeclarationSyntax member,
         string namespaceName,
         bool filterUsings = false,
-        bool normalizeWhitespace = false)
+        bool normalizeWhitespace = false,
+        SyntaxList<UsingDirectiveSyntax>? overrideUsings = null)
     {
-        var usings = filterUsings
-            ? FilterUsingsForMember(sourceRoot.Usings, member, crossProjectExtraction: filterUsings)
-            : sourceRoot.Usings;
+        // `overrideUsings` (gh #765) lets the interface-extraction path supply a semantically-
+        // derived using list and bypass both the text-grep FilterUsingsForMember and the
+        // raw-copy fallback. The move-type path leaves it null and continues to use either
+        // FilterUsingsForMember (filterUsings: true) or the raw source usings.
+        var usings = overrideUsings
+            ?? (filterUsings
+                ? FilterUsingsForMember(sourceRoot.Usings, member, crossProjectExtraction: filterUsings)
+                : sourceRoot.Usings);
 
         if (normalizeWhitespace)
         {
@@ -497,7 +509,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         INamedTypeSymbol typeSymbol,
         string interfaceName,
         string namespaceName,
-        bool filterUsings = false)
+        bool isCrossProject,
+        IReadOnlyCollection<string> requiredNamespaces)
     {
         var interfaceMembers = typeSymbol.GetMembers()
             .Where(member => member.DeclaredAccessibility == Accessibility.Public && !member.IsStatic && !member.IsImplicitlyDeclared)
@@ -514,9 +527,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         // BUG-003: Match the source type's accessibility. A cross-project extraction MUST stay
         // public because the interface is moved into a different assembly and an internal
         // interface would not be visible to consumers; for in-project extraction we honor
-        // internal/private types so we don't accidentally widen visibility. `filterUsings` is
-        // true exactly when this is a cross-project extraction.
-        var matchSourceAccessibility = !filterUsings;
+        // internal/private types so we don't accidentally widen visibility.
+        var matchSourceAccessibility = !isCrossProject;
         var accessibilityToken = matchSourceAccessibility
             ? GetAccessibilityToken(typeSymbol.DeclaredAccessibility)
             : SyntaxFactory.Token(SyntaxKind.PublicKeyword);
@@ -524,6 +536,12 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         var interfaceDeclaration = SyntaxFactory.InterfaceDeclaration(interfaceName)
             .AddModifiers(accessibilityToken)
             .WithMembers(SyntaxFactory.List(interfaceMembers));
+
+        // gh #765 — build the using list semantically. Drop the legacy text-grep filter
+        // (`FilterUsingsForMember`) which silently dropped source-project usings whose last
+        // segment didn't match a `MinimallyQualifiedFormat` short name. Mirrors
+        // `InterfaceExtractionService.BuildUsingDirectives`.
+        var overrideUsings = BuildUsingDirectives(sourceRoot.Usings, requiredNamespaces);
 
         // FORMAT-BUG-001 (dr-9-2-format-bug-001-cross-project-interface-extractio): the
         // interface declaration and its members are built from raw SyntaxFactory nodes that
@@ -534,8 +552,9 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
             sourceRoot,
             interfaceDeclaration,
             namespaceName,
-            filterUsings,
-            normalizeWhitespace: true);
+            filterUsings: false,
+            normalizeWhitespace: true,
+            overrideUsings: overrideUsings);
     }
 
     /// <summary>
@@ -752,7 +771,11 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         await DetectExistingTypeConflictAsync(solution, namespaceName, interfaceName, ct).ConfigureAwait(false);
 
-        var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, interfaceName, namespaceName, isCrossProject);
+        // gh #765 — collect required namespaces semantically (see PreviewExtractInterfaceAsync
+        // for the same call). The DI-inversion path routes through here too, so missing this
+        // produces silent regressions for cross-project extract+invert scenarios.
+        var requiredNamespaces = CollectReferencedNamespaces(typeSymbol, namespaceName);
+        var interfaceRoot = CreateInterfaceCompilationUnit(sourceRoot, typeSymbol, interfaceName, namespaceName, isCrossProject, requiredNamespaces);
         var interfaceFileDirectory = isCrossProject
             ? ResolvePreferredInterfaceSubdirectory(solution, targetProject, targetProjectDirectory)
             : targetProjectDirectory;
@@ -795,5 +818,190 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
         return typeSymbol.ContainingNamespace.IsGlobalNamespace
             ? typeSymbol.MetadataName
             : typeSymbol.ContainingNamespace.ToDisplayString() + "." + typeSymbol.MetadataName;
+    }
+
+    /// <summary>
+    /// gh #765 — semantic using-collection. Walks the source type's public-instance method,
+    /// property, and event symbols and collects the containing namespaces of every referenced
+    /// type (return type, parameter types, property type, event type, type-parameter
+    /// constraints, recursive generic arguments, array element types). The result is the
+    /// authoritative list of namespaces the generated interface file needs, independent of
+    /// what the source file happened to declare. Excludes the target interface's own
+    /// namespace (a self-referential using would be invalid). Mirrors
+    /// <c>InterfaceExtractionService.CollectReferencedNamespaces</c>.
+    /// </summary>
+    private static IReadOnlyCollection<string> CollectReferencedNamespaces(
+        INamedTypeSymbol typeSymbol,
+        string targetNamespaceName)
+    {
+        var namespaces = new HashSet<string>(StringComparer.Ordinal);
+        var ownNamespace = string.IsNullOrWhiteSpace(targetNamespaceName) ? null : targetNamespaceName;
+
+        var members = typeSymbol.GetMembers()
+            .Where(member => member.DeclaredAccessibility == Accessibility.Public && !member.IsStatic && !member.IsImplicitlyDeclared);
+
+        foreach (var member in members)
+        {
+            switch (member)
+            {
+                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                    AddType(namespaces, method.ReturnType, ownNamespace);
+                    foreach (var parameter in method.Parameters)
+                    {
+                        AddType(namespaces, parameter.Type, ownNamespace);
+                    }
+                    foreach (var typeParameter in method.TypeParameters)
+                    {
+                        foreach (var constraint in typeParameter.ConstraintTypes)
+                        {
+                            AddType(namespaces, constraint, ownNamespace);
+                        }
+                    }
+                    break;
+                case IPropertySymbol property:
+                    AddType(namespaces, property.Type, ownNamespace);
+                    break;
+                case IEventSymbol evt:
+                    AddType(namespaces, evt.Type, ownNamespace);
+                    break;
+            }
+        }
+
+        return namespaces;
+    }
+
+    private static void AddType(HashSet<string> namespaces, ITypeSymbol type, string? ownNamespace)
+    {
+        if (type is null)
+        {
+            return;
+        }
+
+        // Type-parameter symbols have no containing namespace — skip them outright.
+        if (type is ITypeParameterSymbol)
+        {
+            return;
+        }
+
+        var typeNamespace = type.ContainingNamespace;
+        if (typeNamespace is { IsGlobalNamespace: false })
+        {
+            var nsName = typeNamespace.ToDisplayString();
+            if (!string.Equals(nsName, ownNamespace, StringComparison.Ordinal))
+            {
+                namespaces.Add(nsName);
+            }
+        }
+
+        // Walk generic type arguments recursively so Task<SourceProjectType>, List<Foo>,
+        // Dictionary<Foo, Bar>, IEnumerable<Item>, etc. all contribute their inner-type
+        // namespaces. Without this the Task is captured but the inner is missed.
+        if (type is INamedTypeSymbol named && named.IsGenericType)
+        {
+            foreach (var argument in named.TypeArguments)
+            {
+                AddType(namespaces, argument, ownNamespace);
+            }
+        }
+
+        // Array element types and pointer element types also contribute. Rare for
+        // interfaces but handled for completeness.
+        if (type is IArrayTypeSymbol array)
+        {
+            AddType(namespaces, array.ElementType, ownNamespace);
+        }
+    }
+
+    /// <summary>
+    /// gh #765 — merge the semantically-required namespaces with the source file's using
+    /// block. Keeps source-file aliases, static usings, and global usings (they cannot be
+    /// re-synthesized from symbols), and adds plain-<c>using</c> directives for every
+    /// required namespace. Drops plain source-file usings that the semantic walk determined
+    /// are unnecessary. Mirrors <c>InterfaceExtractionService.BuildUsingDirectives</c>.
+    /// </summary>
+    private static SyntaxList<UsingDirectiveSyntax> BuildUsingDirectives(
+        SyntaxList<UsingDirectiveSyntax> sourceUsings,
+        IReadOnlyCollection<string> requiredNamespaces)
+    {
+        var result = new List<UsingDirectiveSyntax>();
+        var alreadyAddedPlainNamespaces = new HashSet<string>(StringComparer.Ordinal);
+
+        PreserveSpecialAndRequiredSourceUsings(
+            sourceUsings,
+            requiredNamespaces,
+            result,
+            alreadyAddedPlainNamespaces);
+        AddMissingRequiredUsingDirectives(requiredNamespaces, alreadyAddedPlainNamespaces, result);
+        return SortUsingDirectives(result);
+    }
+
+    private static void PreserveSpecialAndRequiredSourceUsings(
+        SyntaxList<UsingDirectiveSyntax> sourceUsings,
+        IReadOnlyCollection<string> requiredNamespaces,
+        List<UsingDirectiveSyntax> result,
+        ISet<string> alreadyAddedPlainNamespaces)
+    {
+        foreach (var source in sourceUsings)
+        {
+            if (IsSpecialUsingDirective(source))
+            {
+                result.Add(source);
+                continue;
+            }
+
+            var name = GetUsingNamespace(source);
+            if (name is null || !requiredNamespaces.Contains(name))
+            {
+                continue;
+            }
+
+            result.Add(source);
+            alreadyAddedPlainNamespaces.Add(name);
+        }
+    }
+
+    private static void AddMissingRequiredUsingDirectives(
+        IReadOnlyCollection<string> requiredNamespaces,
+        ISet<string> alreadyAddedPlainNamespaces,
+        List<UsingDirectiveSyntax> result)
+    {
+        foreach (var ns in requiredNamespaces)
+        {
+            if (!alreadyAddedPlainNamespaces.Contains(ns))
+            {
+                result.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ns)));
+            }
+        }
+    }
+
+    private static SyntaxList<UsingDirectiveSyntax> SortUsingDirectives(List<UsingDirectiveSyntax> usings)
+    {
+        var systemUsings = usings
+            .Where(IsSystemUsingDirective)
+            .OrderBy(u => u.Name!.ToString(), StringComparer.Ordinal);
+        var otherPlain = usings
+            .Where(u => !IsSpecialUsingDirective(u) && !IsSystemUsingDirective(u))
+            .OrderBy(u => u.Name!.ToString(), StringComparer.Ordinal);
+        var specials = usings.Where(IsSpecialUsingDirective);
+        return SyntaxFactory.List(systemUsings.Concat(otherPlain).Concat(specials));
+    }
+
+    private static string? GetUsingNamespace(UsingDirectiveSyntax source)
+    {
+        var name = source.Name?.ToString();
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    private static bool IsSystemUsingDirective(UsingDirectiveSyntax usingDirective)
+    {
+        return !IsSpecialUsingDirective(usingDirective)
+            && (usingDirective.Name?.ToString().StartsWith("System", StringComparison.Ordinal) ?? false);
+    }
+
+    private static bool IsSpecialUsingDirective(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.Alias is not null
+            || usingDirective.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
+            || usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
     }
 }

--- a/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
@@ -308,6 +308,171 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
         Assert.IsFalse(
             consumerContents.Contains("IAnimalServiceservice", StringComparison.Ordinal),
             $"Consumer parameter has glued-together type and name (FORMAT-BUG-002 regression).\nFile contents:\n{consumerContents}");
+
+        // (6) gh #765 — the DI-inversion path routes through CreateInterfaceExtractionSolutionAsync
+        // which calls CreateInterfaceCompilationUnit just like PreviewExtractInterfaceAsync. The
+        // generated interface in Contracts references IAnimal (lives in SampleLib) via the
+        // MakeThemSpeak / CountAnimals signatures; the using MUST be emitted or the apply round-trip
+        // produces a CS0246 in the Contracts project. Guards against silent regression of the
+        // semantic-walker pair on this path.
+        var interfaceFilePath = workspace.GetPath("Contracts", "IAnimalService.cs");
+        Assert.IsTrue(File.Exists(interfaceFilePath), "DI-inversion path must emit interface file.");
+        var interfaceContents = await File.ReadAllTextAsync(interfaceFilePath, CancellationToken.None);
+        StringAssert.Contains(
+            interfaceContents,
+            "using SampleLib;",
+            $"DI-inversion interface MUST emit `using SampleLib;` — IAnimal is referenced by " +
+            $"the synthesized interface signatures and lives in the source project's namespace (gh #765).\nFile contents:\n{interfaceContents}");
+    }
+
+    [TestMethod]
+    public async Task Extract_Interface_Cross_Project_Emits_Using_For_Source_Project_Types()
+    {
+        // Regression for gh #765 (extract-interface-cross-project-uncompilable). Before the fix:
+        // CrossProjectRefactoringService.CreateInterfaceCompilationUnit routed usings through
+        // FilterUsingsForMember — a text-grep over the synthesized interface body that compared
+        // each source-file using's last namespace segment against MinimallyQualifiedFormat short
+        // names emitted into the interface text. When the source method's signature referenced a
+        // type from a sibling namespace inside the SAME source project (e.g. `Shape` from
+        // `SampleLib.Hierarchy`), the using's last segment (`Hierarchy`) never matched the
+        // short name (`Shape`), so the using was dropped. The cross-project fallback at the
+        // end of FilterUsingsForMember refused the full-source fallback, leaving an EMPTY
+        // using list — producing a generated interface file whose method signature referenced
+        // `Shape` without a `using SampleLib.Hierarchy;`, yielding CS0246 at compile time.
+        //
+        // After the fix: CollectReferencedNamespaces walks the type's public-instance member
+        // symbols and collects every referenced type's containing namespace. The generated
+        // interface emits a `using` for every collected namespace (excluding the interface's
+        // own target namespace, which would be self-referential).
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        AddProjectToCopiedSolution(workspace.RootPath, "Contracts", "net10.0");
+
+        // Replace SampleLib/AnimalService.cs with a fixture whose method signature pulls in a
+        // type from a sibling namespace (SampleLib.Hierarchy.Shape). The interface file must
+        // emit `using SampleLib.Hierarchy;` or the apply round-trip produces uncompilable code.
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+        const string sourceWithSiblingNamespaceDependency = """
+            using SampleLib.Hierarchy;
+
+            namespace SampleLib;
+
+            public class AnimalService
+            {
+                public Shape GetShape()
+                {
+                    throw new System.NotImplementedException();
+                }
+
+                public List<Shape> GetShapes()
+                {
+                    return new List<Shape>();
+                }
+            }
+            """;
+        File.WriteAllText(sourceFilePath, sourceWithSiblingNamespaceDependency);
+
+        var interfaceFilePath = workspace.GetPath("Contracts", "IAnimalService.cs");
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var preview = await CrossProjectRefactoringService.PreviewExtractInterfaceAsync(
+            workspace.WorkspaceId,
+            sourceFilePath,
+            "AnimalService",
+            "IAnimalService",
+            "Contracts",
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.IsTrue(File.Exists(interfaceFilePath));
+
+        var interfaceText = await File.ReadAllTextAsync(interfaceFilePath, CancellationToken.None);
+
+        // (1) The required using for the source-project sibling namespace MUST be emitted.
+        // Without this the generated interface references `Shape` with no `using`, producing
+        // CS0246 in the consumer project at compile time.
+        StringAssert.Contains(
+            interfaceText,
+            "using SampleLib.Hierarchy;",
+            $"Generated interface MUST emit `using SampleLib.Hierarchy;` — the source type's " +
+            $"method signature references Shape from that namespace (gh #765).\nFile contents:\n{interfaceText}");
+
+        // (2) The synthesized interface signature itself must reference the short name
+        // `Shape` (MinimallyQualifiedFormat) — proving the using actually disambiguates it.
+        StringAssert.Contains(interfaceText, "Shape GetShape");
+
+        // (3) The generated file must parse as valid C# (sanity that the structural shape is intact).
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(interfaceText);
+        var parseDiagnostics = tree.GetDiagnostics()
+            .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .ToList();
+        Assert.AreEqual(
+            0,
+            parseDiagnostics.Count,
+            $"Generated interface must parse as valid C#. Diagnostics: {string.Join("; ", parseDiagnostics.Select(d => d.ToString()))}\nFile contents:\n{interfaceText}");
+
+        // (4) The interface's target namespace must NOT also appear as a self-referential using
+        // (e.g. if the target namespace happens to match a referenced symbol's namespace by
+        // coincidence, the walker is supposed to exclude it). The target namespace here is
+        // derived from the Contracts project root, so it should be just "Contracts" — and there
+        // should not be a `using Contracts;` line because no symbol lives in that namespace yet.
+        Assert.IsFalse(
+            interfaceText.Contains("using Contracts;", StringComparison.Ordinal),
+            $"Generated interface must not emit a using for its own target namespace.\nFile contents:\n{interfaceText}");
+    }
+
+    [TestMethod]
+    public async Task Extract_Interface_Cross_Project_Recurses_Into_Generic_Arguments_For_Source_Project_Types()
+    {
+        // Companion to Extract_Interface_Cross_Project_Emits_Using_For_Source_Project_Types.
+        // Covers the recursive case: `Task<SourceProjectType>` must contribute both
+        // `System.Threading.Tasks` AND the source-project namespace (the inner generic
+        // argument). Mirrors `ExtractInterface_Recurses_Into_Generic_Arguments` in the
+        // same-project semantic-using tests.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        AddProjectToCopiedSolution(workspace.RootPath, "Contracts", "net10.0");
+
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+        const string sourceWithGenericArg = """
+            using System.Threading.Tasks;
+            using SampleLib.Hierarchy;
+
+            namespace SampleLib;
+
+            public class AnimalService
+            {
+                public Task<Shape> FetchAsync()
+                {
+                    throw new System.NotImplementedException();
+                }
+            }
+            """;
+        File.WriteAllText(sourceFilePath, sourceWithGenericArg);
+
+        var interfaceFilePath = workspace.GetPath("Contracts", "IAnimalService.cs");
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var preview = await CrossProjectRefactoringService.PreviewExtractInterfaceAsync(
+            workspace.WorkspaceId,
+            sourceFilePath,
+            "AnimalService",
+            "IAnimalService",
+            "Contracts",
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+        var interfaceText = await File.ReadAllTextAsync(interfaceFilePath, CancellationToken.None);
+        StringAssert.Contains(
+            interfaceText,
+            "using System.Threading.Tasks;",
+            $"Generated interface MUST emit `using System.Threading.Tasks;` — the outer generic Task lives there.\nFile contents:\n{interfaceText}");
+        StringAssert.Contains(
+            interfaceText,
+            "using SampleLib.Hierarchy;",
+            $"Generated interface MUST emit `using SampleLib.Hierarchy;` — the inner generic " +
+            $"argument Shape lives there. Recursion through TypeArguments is the gh #765 fix.\nFile contents:\n{interfaceText}");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- Fix `extract_interface_cross_project_preview` generating an uncompilable interface file when method signatures reference types from a sibling namespace inside the source project (gh #765). The legacy text-grep `FilterUsingsForMember` dropped any source-project using whose last namespace segment didn't match a `MinimallyQualifiedFormat` short name in the synthesized interface body; the cross-project fallback then refused to fall back to source usings, leaving an empty using list and CS0246 at compile time.
- Port the `CollectReferencedNamespaces` + `BuildUsingDirectives` semantic-walker pair from `InterfaceExtractionService` (already in use for same-project extraction) into `CrossProjectRefactoringService`. The walker inspects the type's public-instance member symbols (return types, parameter types, type-parameter constraints, recursive generic arguments, array element types) and collects their containing namespaces, excluding the target interface's own namespace. `BuildUsingDirectives` then merges the required namespaces with the source file's special usings (aliases / static / global), drops unused plain usings, and sorts.
- Both call sites updated: `PreviewExtractInterfaceAsync` and `CreateInterfaceExtractionSolutionAsync` (which backs `PreviewDependencyInversionAsync`).
- The move-type path (`PreviewMoveTypeToProjectAsync`) is unchanged — `FilterUsingsForMember` remains for that route.

## Test plan

- [x] New test `Extract_Interface_Cross_Project_Emits_Using_For_Source_Project_Types` reproduces gh #765 with a method whose signature references `SampleLib.Hierarchy.Shape` and asserts `using SampleLib.Hierarchy;` appears in the generated interface (Contracts project)
- [x] New test `Extract_Interface_Cross_Project_Recurses_Into_Generic_Arguments_For_Source_Project_Types` covers the recursive `Task<Shape>` case (both outer and inner namespaces emitted)
- [x] Added using-assertion to `Dependency_Inversion_Preview_Preserves_Source_File_Formatting` to guard the DI-inversion path against silent regression
- [x] All 9 tests in `CrossProjectRefactoringIntegrationTests` pass (7 pre-existing + 2 new)
- [x] All 4 tests in `ExtractInterfaceSemanticUsingsTests` (same-project path) still pass — confirms the ported walker mirrors the original behavior
- [x] `compile_check` clean on both edited files
- [x] `verify-ai-docs.ps1` passes
- [x] `verify-changelog-fragments.ps1` validates the new fragment
- [ ] CI (self-hosted runner) for `verify-release.ps1`

Closes: extract-interface-cross-project-uncompilable
Fixes #765