### PR TITLE
fix(symbols): separate true overrides from sibling interface impls (member-hierarchy-overrides-mislabels-sibling-interface-impls)

### DIFF
--- a/changelog.d/member-hierarchy-overrides-mislabels-sibling-interface-impls.md
+++ b/changelog.d/member-hierarchy-overrides-mislabels-sibling-interface-impls.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** Fixed cross-tool semantic inconsistency between `find_overrides` and `member_hierarchy.overrides` — both tools now use the canonical definition of "override" (symbols actually marked `override` of a virtual/abstract declaration). Sibling interface implementations (e.g., independent `IDisposable.Dispose` implementations across a solution) are no longer misclassified as overrides; they now appear in the new `member_hierarchy.siblingInterfaceImplementations` bucket. `find_overrides` and `member_hierarchy.overrides` now agree on the same target. Breaking: `symbol_relationships.overrides` also loses sibling interface impls (shared `FindOverridesAsync` fix). Closes [gh #736], [gh #737].

--- a/src/RoslynMcp.Core/Models/MemberHierarchyDto.cs
+++ b/src/RoslynMcp.Core/Models/MemberHierarchyDto.cs
@@ -1,9 +1,22 @@
 namespace RoslynMcp.Core.Models;
 
 /// <summary>
-/// Represents the base and override relationships for a member symbol.
+/// Represents the base, override, and sibling-implementation relationships for a member symbol.
 /// </summary>
+/// <param name="Symbol">The resolved member.</param>
+/// <param name="BaseMembers">Members the resolved symbol overrides or implements (its base chain).</param>
+/// <param name="Overrides">
+/// True virtual/abstract overrides — members actually marked <c>override</c> of a virtual or
+/// abstract declaration. Sibling interface implementations live in
+/// <paramref name="SiblingInterfaceImplementations"/>, not here.
+/// </param>
+/// <param name="SiblingInterfaceImplementations">
+/// Concrete implementations of an interface member across the solution (e.g., every
+/// <c>IDisposable.Dispose</c> implementation). Empty when the resolved symbol is not an
+/// interface member or has no concrete implementations.
+/// </param>
 public sealed record MemberHierarchyDto(
     SymbolDto Symbol,
     IReadOnlyList<SymbolDto> BaseMembers,
-    IReadOnlyList<SymbolDto> Overrides);
+    IReadOnlyList<SymbolDto> Overrides,
+    IReadOnlyList<SymbolDto> SiblingInterfaceImplementations);

--- a/src/RoslynMcp.Core/Services/IReferenceService.cs
+++ b/src/RoslynMcp.Core/Services/IReferenceService.cs
@@ -43,13 +43,26 @@ public interface IReferenceService
         CancellationToken ct,
         bool includeGeneratedPartials = false);
     /// <summary>
-    /// Finds overriding/implementing members for a virtual, abstract, or interface member resolved at
-    /// <paramref name="locator"/>. Returns <see cref="SymbolDto"/> rather than <see cref="LocationDto"/> so
-    /// that members whose definition lives in metadata (e.g. <c>IEquatable&lt;T&gt;.Equals</c>) are not
-    /// silently dropped — a metadata-only result still carries <see cref="SymbolDto.FullyQualifiedName"/>
-    /// with <see cref="SymbolDto.FilePath"/>=<c>null</c>. Aligns with <c>member_hierarchy</c>.
+    /// Finds true virtual/abstract overrides for the member resolved at <paramref name="locator"/> —
+    /// only members actually marked <c>override</c> of a virtual or abstract declaration. Sibling
+    /// interface implementations (e.g., independent <c>IDisposable.Dispose</c> implementations across
+    /// a solution) are NOT included; use
+    /// <see cref="FindSiblingInterfaceImplementationsAsync"/> for that bucket. Returns
+    /// <see cref="SymbolDto"/> rather than <see cref="LocationDto"/> so that members whose definition
+    /// lives in metadata (e.g. <c>IEquatable&lt;T&gt;.Equals</c>) are not silently dropped — a
+    /// metadata-only result still carries <see cref="SymbolDto.FullyQualifiedName"/> with
+    /// <see cref="SymbolDto.FilePath"/>=<c>null</c>. Aligns with <c>member_hierarchy.overrides</c>.
     /// </summary>
     Task<IReadOnlyList<SymbolDto>> FindOverridesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    /// <summary>
+    /// Finds sibling interface implementations for the member resolved at <paramref name="locator"/> —
+    /// every concrete type in the solution whose member fulfills the interface contract
+    /// (<c>type.FindImplementationForInterfaceMember(symbol)</c>). When the locator resolves to a
+    /// non-interface member (e.g. a virtual method on a class) the result is empty. Aligns with
+    /// <c>member_hierarchy.siblingInterfaceImplementations</c>.
+    /// </summary>
+    Task<IReadOnlyList<SymbolDto>> FindSiblingInterfaceImplementationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
 
     /// <summary>
     /// Finds base or implemented members for an override or implementation resolved at

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
@@ -12,7 +12,7 @@ public static partial class ServerSurfaceCatalog
         Tool("document_symbols", "symbols", "stable", true, false, "List declared symbols in a document."),
         Tool("find_overrides", "symbols", "stable", true, false, "Find overrides of a virtual or abstract member."),
         Tool("find_base_members", "symbols", "stable", true, false, "Find base or implemented members."),
-        Tool("member_hierarchy", "symbols", "stable", true, false, "Summarize base and override relationships for a member."),
+        Tool("member_hierarchy", "symbols", "stable", true, false, "Summarize base, override, and sibling interface implementation relationships for a member."),
         Tool("symbol_signature_help", "symbols", "stable", true, false, "Return symbol signature and documentation."),
         Tool("symbol_relationships", "symbols", "stable", true, false, "Combine definition, reference, base, and implementation relationships."),
         Tool("find_references_bulk", "symbols", "stable", true, false, "Resolve references for multiple symbols in one request."),

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -372,7 +372,7 @@ public static class SymbolTools
             ct);
     }
 
-    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find overriding members for a virtual, abstract, or interface member. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) now surface with FilePath=null so count matches member_hierarchy.")]
+    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find true virtual/abstract overrides for a member — only symbols actually marked `override` of a virtual or abstract declaration. Sibling interface implementations (e.g. independent IDisposable.Dispose impls across a solution) are NOT included here; query member_hierarchy and read the siblingInterfaceImplementations bucket for that. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) surface with FilePath=null so the count matches member_hierarchy.overrides.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find overrides of a virtual or abstract member.")]
     public static Task<string> FindOverrides(
@@ -416,9 +416,9 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "member_hierarchy", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get a summary of base members and overrides for a symbol")]
+    [McpServerTool(Name = "member_hierarchy", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get a summary of base members, true virtual/abstract overrides, and sibling interface implementations for a symbol. Response buckets: `baseMembers` (the base chain), `overrides` (members actually marked `override` of a virtual/abstract declaration — matches find_overrides), `siblingInterfaceImplementations` (every concrete type whose member fulfills the same interface contract — e.g. independent IDisposable.Dispose impls across a solution).")]
     [McpToolMetadata("symbols", "stable", true, false,
-        "Summarize base and override relationships for a member.")]
+        "Summarize base, override, and sibling interface implementation relationships for a member.")]
     public static Task<string> GetMemberHierarchy(
         IWorkspaceExecutionGate gate,
         ISymbolRelationshipService symbolRelationshipService,

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -155,9 +155,13 @@ public sealed class ReferenceService : IReferenceService
         // yield the same (complete) result set.
         var promoted = PromoteToVirtualRoot(symbol);
 
-        var overrides = (await SymbolFinder.FindOverridesAsync(promoted, solution, cancellationToken: ct).ConfigureAwait(false))
-            .ToList();
-        overrides.AddRange(await FindInterfaceMemberImplementationsAsync(promoted, solution, ct).ConfigureAwait(false));
+        // member-hierarchy-overrides-mislabels-sibling-interface-impls (gh #736, gh #737):
+        // FindOverridesAsync now returns ONLY true virtual/abstract overrides — symbols
+        // actually marked `override` of a virtual/abstract declaration. Sibling interface
+        // implementations (e.g., independent IDisposable.Dispose impls across a solution)
+        // moved to FindSiblingInterfaceImplementationsAsync; consumers that want both
+        // buckets must call both methods (see member_hierarchy).
+        var overrides = await SymbolFinder.FindOverridesAsync(promoted, solution, cancellationToken: ct).ConfigureAwait(false);
 
         // find-base-members-vs-member-hierarchy-metadata-drift: return SymbolDto instead of
         // LocationDto so metadata-boundary members (e.g. IEquatable<T>.Equals implementations
@@ -166,6 +170,29 @@ public sealed class ReferenceService : IReferenceService
         return overrides
             .Distinct(SymbolEqualityComparer.Default)
             .Select(overrideSymbol => SymbolMapper.ToDto(overrideSymbol, solution))
+            .OrderBy(d => d.FilePath ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(d => d.StartLine ?? int.MaxValue)
+            .ThenBy(d => d.StartColumn ?? int.MaxValue)
+            .ThenBy(d => d.FullyQualifiedName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<SymbolDto>> FindSiblingInterfaceImplementationsAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
+    {
+        _logger.LogDebug("ReferenceService.FindSiblingInterfaceImplementationsAsync: workspaceId={WorkspaceId} locator={Locator}", workspaceId, locator);
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(solution, locator, ct).ConfigureAwait(false);
+
+        // Mirror the override-site promotion so a caret on an implementing method
+        // (e.g., `Dog.Speak`) resolves to the same interface root as a caret on the
+        // interface declaration (`IAnimal.Speak`) and produces the same sibling set.
+        var promoted = PromoteToVirtualRoot(symbol);
+
+        var siblings = await FindInterfaceMemberImplementationsAsync(promoted, solution, ct).ConfigureAwait(false);
+
+        return siblings
+            .Distinct(SymbolEqualityComparer.Default)
+            .Select(sibling => SymbolMapper.ToDto(sibling, solution))
             .OrderBy(d => d.FilePath ?? string.Empty, StringComparer.Ordinal)
             .ThenBy(d => d.StartLine ?? int.MaxValue)
             .ThenBy(d => d.StartColumn ?? int.MaxValue)

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -123,10 +123,22 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
             return null;
         }
 
+        // member-hierarchy-overrides-mislabels-sibling-interface-impls (gh #736, gh #737):
+        // member_hierarchy now exposes true overrides and sibling interface implementations
+        // as two distinct buckets so callers can tell the difference between "this is the
+        // override chain" and "these are the unrelated types that happen to satisfy the
+        // same interface contract". Run both lookups in parallel — they hit disjoint
+        // Roslyn APIs.
         var baseMembers = SymbolServiceHelpers.GetBaseMembers(symbol).Select(baseMember => SymbolMapper.ToDto(baseMember, solution)).ToList();
-        var overrides = await _referenceService.FindOverridesAsync(workspaceId, locator, ct).ConfigureAwait(false);
+        var overridesTask = _referenceService.FindOverridesAsync(workspaceId, locator, ct);
+        var siblingImplsTask = _referenceService.FindSiblingInterfaceImplementationsAsync(workspaceId, locator, ct);
+        await Task.WhenAll(overridesTask, siblingImplsTask).ConfigureAwait(false);
 
-        return new MemberHierarchyDto(SymbolMapper.ToDto(symbol, solution), baseMembers, overrides);
+        return new MemberHierarchyDto(
+            Symbol: SymbolMapper.ToDto(symbol, solution),
+            BaseMembers: baseMembers,
+            Overrides: await overridesTask.ConfigureAwait(false),
+            SiblingInterfaceImplementations: await siblingImplsTask.ConfigureAwait(false));
     }
 
     public async Task<SymbolRelationshipsDto?> GetSymbolRelationshipsAsync(string workspaceId, SymbolLocator locator, bool preferDeclaringMember, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/MemberHierarchyCrossToolConsistencyTests.cs
+++ b/tests/RoslynMcp.Tests/MemberHierarchyCrossToolConsistencyTests.cs
@@ -1,0 +1,120 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Closes gh #736 (member_hierarchy.overrides mislabels sibling interface impls) and gh
+/// #737 (find_overrides vs member_hierarchy cross-tool inconsistency). Both symptoms had a
+/// shared root cause in <c>ReferenceService.FindOverridesAsync</c>, which conflated true
+/// virtual/abstract overrides with sibling interface implementations into a single bucket.
+/// </summary>
+/// <remarks>
+/// Post-fix invariants enforced here:
+/// <list type="number">
+///   <item><description><c>find_overrides</c> and <c>member_hierarchy.overrides</c> always agree
+///   on the same definition of "override" — symbols actually marked <c>override</c> of a
+///   virtual or abstract declaration.</description></item>
+///   <item><description>Sibling interface implementations live in the new
+///   <c>member_hierarchy.SiblingInterfaceImplementations</c> bucket.</description></item>
+///   <item><description>The agreement holds across all locator strategies (source position
+///   on the implementing method, source position on the interface declaration, and metadata
+///   name on the interface member).</description></item>
+/// </list>
+/// </remarks>
+[DoNotParallelize]
+[TestClass]
+public sealed class MemberHierarchyCrossToolConsistencyTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task IDisposableDispose_OverridesEmpty_SiblingImplsPopulated_AcrossTools()
+    {
+        // BacklogDisposableSample.Dispose (line 12, col 17) is an implementation of the
+        // IDisposable.Dispose interface contract, NOT a true `override` of any virtual
+        // method. Pre-fix: find_overrides returned the impls (mislabelled), and
+        // member_hierarchy.overrides matched. Post-fix: both surfaces return 0 for
+        // overrides; the impls move to member_hierarchy.SiblingInterfaceImplementations.
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var backlogFile = solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == "BacklogSamples.cs");
+
+        var locatorAtImpl = SymbolLocator.BySource(backlogFile.FilePath!, 12, 17);
+
+        var findOverridesAtImpl = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locatorAtImpl, CancellationToken.None);
+        var hierarchyAtImpl = await SymbolRelationshipService.GetMemberHierarchyAsync(
+            WorkspaceId, locatorAtImpl, CancellationToken.None);
+
+        Assert.IsNotNull(hierarchyAtImpl);
+        Assert.AreEqual(0, findOverridesAtImpl.Count,
+            "find_overrides on BacklogDisposableSample.Dispose must be 0 — Dispose is a sibling impl, not a true override.");
+        Assert.AreEqual(
+            hierarchyAtImpl.Overrides.Count,
+            findOverridesAtImpl.Count,
+            "find_overrides and member_hierarchy.overrides must agree (both = 0 for sibling impls).");
+        Assert.IsTrue(hierarchyAtImpl.SiblingInterfaceImplementations.Count > 0,
+            "member_hierarchy.SiblingInterfaceImplementations should surface the IDisposable.Dispose impls (was previously bucketed under overrides).");
+        Assert.IsTrue(
+            hierarchyAtImpl.SiblingInterfaceImplementations.Any(symbol =>
+                symbol.Name == "Dispose" &&
+                symbol.FilePath?.EndsWith("BacklogSamples.cs", StringComparison.OrdinalIgnoreCase) == true),
+            "BacklogDisposableSample.Dispose should appear in the SiblingInterfaceImplementations bucket.");
+
+        // Cross-tool symmetry: querying by metadata name on IDisposable.Dispose must yield
+        // the same answer as the source-positional query. This is the gh #737 surface — pre-fix
+        // the metadata-name query returned 0 (silent miss in FindImplementationForInterfaceMember
+        // when the symbol came from a metadata reference) while the source-positional query
+        // returned the impls. Post-fix: both return 0 for overrides (correct), and the impls
+        // live in the sibling-impls bucket regardless of locator strategy.
+        var locatorAtMetadata = SymbolLocator.ByMetadataName("System.IDisposable.Dispose");
+        var findOverridesAtMetadata = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locatorAtMetadata, CancellationToken.None);
+        Assert.AreEqual(0, findOverridesAtMetadata.Count,
+            "find_overrides at IDisposable.Dispose (metadata) must agree with the source-positional query at 0.");
+    }
+
+    [TestMethod]
+    public async Task VirtualOverrideChain_OverridesPopulated_SiblingImplsEmpty_AcrossTools()
+    {
+        // Shape.Describe is a virtual method; Rectangle.Describe is a true `override`. The
+        // override bucket must remain populated; the SiblingInterfaceImplementations bucket
+        // must be empty because Describe is not an interface contract member.
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var shapeFile = solution.Projects
+            .SelectMany(p => p.Documents)
+            .First(d => d.Name == "Shape.cs");
+
+        var locator = SymbolLocator.BySource(shapeFile.FilePath!, 7, 27);
+
+        var overrides = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+        var hierarchy = await SymbolRelationshipService.GetMemberHierarchyAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(hierarchy);
+        Assert.IsTrue(overrides.Count > 0,
+            "find_overrides on virtual Shape.Describe must surface concrete overrides (e.g. Rectangle.Describe).");
+        Assert.AreEqual(
+            hierarchy.Overrides.Count,
+            overrides.Count,
+            "find_overrides and member_hierarchy.overrides must agree on true virtual overrides.");
+        Assert.IsTrue(
+            hierarchy.Overrides.Any(symbol =>
+                symbol.FilePath?.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase) == true),
+            "Rectangle.Describe should remain in the overrides bucket (it really is an `override`).");
+        Assert.AreEqual(0, hierarchy.SiblingInterfaceImplementations.Count,
+            "Shape.Describe is not an interface contract member; SiblingInterfaceImplementations must be empty.");
+    }
+}

--- a/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
+++ b/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
@@ -104,18 +104,24 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
-    public async Task FindOverrides_FromImplicitInterfaceImpl_PromotesToInterfaceMember()
+    public async Task FindSiblingInterfaceImplementations_FromImplicitInterfaceImpl_PromotesToInterfaceMember()
     {
+        // member-hierarchy-overrides-mislabels-sibling-interface-impls (gh #736, gh #737):
+        // After the find_overrides / member_hierarchy semantic split, interface-contract
+        // implementations live in FindSiblingInterfaceImplementationsAsync (NOT FindOverridesAsync —
+        // Dog.Speak is not marked `override` of a virtual member, so it is a sibling impl).
+        // The promotion behavior — caret-at-impl-site resolves to the same interface root as
+        // caret-at-decl-site — is still asserted here, just through the correct bucket.
         var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
         var dogFile = solution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "Dog.cs");
         var animalFile = solution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "IAnimal.cs");
 
-        var fromImpl = await ReferenceService.FindOverridesAsync(
+        var fromImpl = await ReferenceService.FindSiblingInterfaceImplementationsAsync(
             WorkspaceId,
             SymbolLocator.BySource(dogFile.FilePath!, 7, 21),
             CancellationToken.None);
 
-        var fromIface = await ReferenceService.FindOverridesAsync(
+        var fromIface = await ReferenceService.FindSiblingInterfaceImplementationsAsync(
             WorkspaceId,
             SymbolLocator.BySource(animalFile.FilePath!, 6, 13),
             CancellationToken.None);
@@ -124,13 +130,29 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
             fromIface.Any(symbol =>
                 symbol.Name == "Speak" &&
                 symbol.FilePath?.EndsWith("Dog.cs", StringComparison.OrdinalIgnoreCase) == true),
-            "Interface-member FindOverrides must include the implicit Dog.Speak implementation.");
+            "Interface-member FindSiblingInterfaceImplementations must include the implicit Dog.Speak implementation.");
         Assert.AreEqual(fromIface.Count, fromImpl.Count,
             "Implicit interface implementation site should promote to the interface member and match the interface declaration query.");
         CollectionAssert.AreEquivalent(
             fromIface.Select(s => (s.FilePath, s.StartLine, s.StartColumn)).OrderBy(t => t.FilePath).ToList(),
             fromImpl.Select(s => (s.FilePath, s.StartLine, s.StartColumn)).OrderBy(t => t.FilePath).ToList(),
-            "Override/implementation locations should match after promotion.");
+            "Sibling implementation locations should match after promotion.");
+
+        // Cross-check the new semantic boundary: FindOverridesAsync at either site MUST be
+        // empty for IAnimal.Speak because no concrete type uses `override` syntax against
+        // a virtual `Speak()` member — there is no virtual `Speak` anywhere in the chain.
+        var overridesFromImpl = await ReferenceService.FindOverridesAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(dogFile.FilePath!, 7, 21),
+            CancellationToken.None);
+        var overridesFromIface = await ReferenceService.FindOverridesAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(animalFile.FilePath!, 6, 13),
+            CancellationToken.None);
+        Assert.AreEqual(0, overridesFromImpl.Count,
+            "FindOverridesAsync must NOT include sibling interface impls — Dog.Speak isn't marked `override`.");
+        Assert.AreEqual(0, overridesFromIface.Count,
+            "FindOverridesAsync on an interface-only member returns 0; the sibling impls now live in the new bucket.");
     }
 
     // ── find-references-bulk-schema-error-ux ──

--- a/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticExpansionTests.cs
@@ -66,9 +66,13 @@ public class SemanticExpansionTests : SharedWorkspaceTestBase
             "At least one returned base member should carry FilePath=null (metadata-only).");
     }
 
-    // find-base-members-vs-member-hierarchy-metadata-drift: regression — find_overrides and
-    // member_hierarchy.Overrides must agree for a metadata-boundary symbol. The important
-    // invariant is that they AGREE (no silent drift between the two surfaces).
+    // member-hierarchy-overrides-mislabels-sibling-interface-impls (gh #736, gh #737):
+    // find_overrides and member_hierarchy.Overrides must agree on the same definition of
+    // "override" — symbols actually marked `override` of a virtual/abstract declaration.
+    // EquatablePoint.Equals is an IEquatable<T>.Equals implementation (an interface
+    // contract impl), NOT a true override of a virtual member, so both surfaces correctly
+    // return 0. The sibling interface implementations now live in the new
+    // member_hierarchy.SiblingInterfaceImplementations bucket instead.
     [TestMethod]
     public async Task Metadata_Boundary_Find_Overrides_Matches_Member_Hierarchy_Overrides()
     {
@@ -82,12 +86,18 @@ public class SemanticExpansionTests : SharedWorkspaceTestBase
         var overrides = await ReferenceService.FindOverridesAsync(WorkspaceId, locator, CancellationToken.None);
         var hierarchy = await SymbolRelationshipService.GetMemberHierarchyAsync(WorkspaceId, locator, CancellationToken.None);
         Assert.IsNotNull(hierarchy);
-        Assert.IsTrue(overrides.Count > 0,
-            "find_overrides should now find source implementations for metadata-boundary interface members.");
+        Assert.AreEqual(0, overrides.Count,
+            "find_overrides should now correctly return 0 for an IEquatable<T>.Equals implementation (a sibling impl, not a true override).");
         Assert.AreEqual(
             hierarchy.Overrides.Count,
             overrides.Count,
-            "find_overrides must match member_hierarchy.Overrides count for metadata-boundary symbols.");
+            "find_overrides must match member_hierarchy.Overrides count — both surface only true virtual/abstract overrides.");
+        Assert.IsTrue(hierarchy.SiblingInterfaceImplementations.Count > 0,
+            "member_hierarchy.SiblingInterfaceImplementations should surface concrete IEquatable<T>.Equals impls now that they're separated from overrides.");
+        Assert.IsTrue(
+            hierarchy.SiblingInterfaceImplementations.Any(symbol =>
+                symbol.FilePath?.EndsWith("EquatablePoint.cs", StringComparison.OrdinalIgnoreCase) == true),
+            "EquatablePoint.Equals should appear in the SiblingInterfaceImplementations bucket.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- `find_overrides` and `member_hierarchy.overrides` now agree on the canonical definition of "override" — only members actually marked `override` of a virtual/abstract declaration. Sibling interface implementations (e.g., independent `IDisposable.Dispose` impls across a solution) are no longer misclassified as overrides.
- Adds `IReferenceService.FindSiblingInterfaceImplementationsAsync` and a new `member_hierarchy.siblingInterfaceImplementations` bucket so callers can still query for "every type whose member fulfills the same interface contract" — just under the correct name.
- Tool descriptions and the analyzer-checked `ServerSurfaceCatalog` mirror updated to reflect the bucket split.
- **Breaking:** `symbol_relationships.overrides` also loses sibling interface impls because it shares the `FindOverridesAsync` code path (intentional cascading correctness fix).

## Diagnosis recap

Both backlog rows pointed at `MemberHierarchyService.cs` / `OverridesService.cs` which don't exist; the live conflation site is `ReferenceService.FindOverridesAsync` (`src/RoslynMcp.Roslyn/Services/ReferenceService.cs`). That method called `SymbolFinder.FindOverridesAsync` AND `FindInterfaceMemberImplementationsAsync` and merged both results into the `overrides` bucket. `member_hierarchy` and `symbol_relationships` consumed the conflated bucket directly; `find_overrides` consumed it through its own tool wrapper but with a divergent metadata-vs-positional resolution path — explaining the gh #737 "0 vs 14" cross-tool inconsistency on `IDisposable.Dispose`.

The split: `FindOverridesAsync` now returns only `SymbolFinder.FindOverridesAsync`'s output; `FindSiblingInterfaceImplementationsAsync` exposes the old private `FindInterfaceMemberImplementationsAsync` helper; `member_hierarchy` calls both in parallel and surfaces them as two distinct buckets on `MemberHierarchyDto`.

## Test plan

- [x] New `MemberHierarchyCrossToolConsistencyTests` exercises both invariants:
  - `IDisposable.Dispose` fixture (`BacklogDisposableSample.Dispose`) → `find_overrides` = 0, `member_hierarchy.overrides` = 0, `member_hierarchy.SiblingInterfaceImplementations` non-empty. Cross-checks source-positional vs metadata-name resolution.
  - Virtual override chain (`Shape.Describe` → `Rectangle.Describe`) → `overrides` non-empty (Rectangle in the bucket), `SiblingInterfaceImplementations` empty.
- [x] Updated `SemanticExpansionTests.Metadata_Boundary_Find_Overrides_Matches_Member_Hierarchy_Overrides` — the `EquatablePoint.Equals` fixture now correctly reports `overrides.Count == 0` and the impl in `SiblingInterfaceImplementations`.
- [x] Updated `P4BehavioralBundleTests.FindOverrides_FromImplicitInterfaceImpl_PromotesToInterfaceMember` to assert the promotion behavior through the new `FindSiblingInterfaceImplementationsAsync` and verify `FindOverridesAsync` returns 0 for both caret positions.
- [x] All 21 tests across `MemberHierarchyCrossToolConsistencyTests` + `SemanticExpansionTests` + `P4BehavioralBundleTests` pass locally.
- [x] All 153 Symbol/Reference/MemberHierarchy-related tests pass locally.
- [x] All 24 ServerSurfaceCatalog tests pass after the mirror entry update.
- [x] `compile_check` clean. `verify-ai-docs.ps1` passes.
- [ ] Self-hosted CI runs `verify-release.ps1` end-to-end.

Closes: member-hierarchy-overrides-mislabels-sibling-interface-impls, find-overrides-vs-member-hierarchy-cross-tool-inconsistency

Fixes #736
Fixes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)