### PR TITLE
fix(symbols): qualified-signature fallback for symbol_signature_help

### DIFF
--- a/changelog.d/symbol-signature-help-returns-bare-null-for-resolvable-method-metadata.md
+++ b/changelog.d/symbol-signature-help-returns-bare-null-for-resolvable-method-metadata.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `symbol_signature_help` returning bare null for method metadataName inputs containing parenthesized parameter types (e.g. `Namespace.Type.Method(ParamType, CancellationToken)`). Adds the same qualified-signature fallback resolver that `callers_callees` received in gh #616. Fixes gh #747.

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -226,6 +226,19 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         _logger.LogDebug("SymbolRelationshipService.GetSignatureHelpAsync: workspaceId={WorkspaceId} locator={Locator} preferDeclaringMember={PreferDeclaringMember}", workspaceId, locator, preferDeclaringMember);
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
+
+        // `symbol-signature-help-returns-bare-null-for-resolvable-method-metadata` (gh #747):
+        // mirrors the gh #616 fallback for `callers_callees`. When the caller supplies a fully
+        // qualified method signature like `Ns.Type.Method(Ns.ParamType, System.Threading.CancellationToken)`,
+        // `SymbolResolver.ResolveByMetadataNameAsync` returns null because it splits on the LAST dot —
+        // which lands inside the parenthesized parameter list (`System.Threading.CancellationToken`),
+        // producing a bogus containing-type name. The qualified-signature fallback strips the parameter
+        // list, retries the resolve, and picks the matching overload.
+        if (symbol is null && locator.HasMetadataName)
+        {
+            symbol = await TryResolveByQualifiedSignatureAsync(solution, locator.MetadataName!, ct).ConfigureAwait(false);
+        }
+
         if (symbol is null)
         {
             return null;

--- a/tests/RoslynMcp.Tests/MetadataNameLocatorTests.cs
+++ b/tests/RoslynMcp.Tests/MetadataNameLocatorTests.cs
@@ -159,6 +159,52 @@ public sealed class MetadataNameLocatorTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task SignatureHelp_Accepts_Fully_Qualified_Method_Signature_With_Parameter_Types()
+    {
+        // gh #747 / `symbol-signature-help-returns-bare-null-for-resolvable-method-metadata`:
+        // identical failure mode to gh #616 but on a sibling tool. `symbol_signature_help`
+        // returned bare `null` when the supplied `metadataName` contained a parenthesized
+        // parameter list because `ResolveByMetadataNameAsync` splits on the LAST dot —
+        // which lands inside the parameter list — producing a bogus containing-type name.
+        // The qualified-signature fallback mirrors the fix applied to `callers_callees`.
+        var json = await SymbolTools.GetSignatureHelp(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            metadataName: "SampleLib.AnimalService.CountAnimals(System.Collections.Generic.List<SampleLib.IAnimal>)",
+            ct: CancellationToken.None);
+
+        // Critical regression guard: before the fix, `symbol_signature_help` returned bare
+        // `null` (serialized as the literal JSON token `null`) rather than a structured
+        // SignatureHelpDto. Assert the payload is a JSON object first.
+        Assert.AreNotEqual("null", json.Trim(), "symbol_signature_help returned bare null for a resolvable metadataName (regression of gh #747).");
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(JsonValueKind.Object, doc.RootElement.ValueKind,
+            $"symbol_signature_help with a fully-qualified signature should return a SignatureHelpDto object. Got: {json}");
+        Assert.IsFalse(
+            doc.RootElement.TryGetProperty("error", out _),
+            $"symbol_signature_help should accept a fully-qualified signature. Got: {json}");
+
+        // Validate the resolved overload's shape — proves signature matching picked the
+        // `List<IAnimal>` overload, not the `IEnumerable<IAnimal>` sibling.
+        Assert.IsTrue(doc.RootElement.TryGetProperty("displaySignature", out var displaySignature),
+            "Expected `displaySignature` field in SignatureHelpDto response.");
+        var displayText = displaySignature.GetString() ?? string.Empty;
+        Assert.IsTrue(displayText.Contains("CountAnimals", StringComparison.Ordinal),
+            $"Expected displaySignature to reference CountAnimals. Got: '{displayText}'.");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("returnType", out _),
+            "Expected `returnType` field in SignatureHelpDto response.");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("parameters", out var parameters),
+            "Expected `parameters` field in SignatureHelpDto response.");
+        Assert.AreEqual(1, parameters.GetArrayLength(),
+            "Expected exactly one parameter on the resolved overload.");
+        var firstParam = parameters[0].GetString() ?? string.Empty;
+        Assert.IsTrue(firstParam.Contains("List", StringComparison.Ordinal),
+            $"Expected resolved overload's parameter to be a List<IAnimal>. Got: '{firstParam}'.");
+    }
+
+    [TestMethod]
     public async Task FindReferences_Error_When_No_Locator_Provided()
     {
         // Preserve the legacy "no locator at all" error path. The factory's message now


### PR DESCRIPTION
## Summary

`symbol_signature_help` returned bare JSON `null` when the caller supplied a `metadataName` containing a parenthesized parameter list (e.g. `Ns.Type.Method(Ns.ParamType, System.Threading.CancellationToken)`). Root cause: `SymbolResolver.ResolveByMetadataNameAsync` splits on the LAST dot — when that dot sits inside the parameter list it produces a bogus containing-type name and returns null.

The sibling tool `callers_callees` suffered the identical failure mode and was fixed in gh #616 by adding a `TryResolveByQualifiedSignatureAsync` fallback. `symbol_signature_help` never received that fallback. This PR mirrors the gh #616 fix one-to-one: after the initial `SymbolResolver.ResolveAsync` call, if the symbol is null AND the locator has a `metadataName`, retry via the qualified-signature fallback (which strips the parameter list, retries the resolve, and matches the parameter types when multiple overloads exist).

## Changes

- `src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs` — `GetSignatureHelpAsync` gets the qualified-signature fallback after the initial resolve attempt, before the early-return-null guard. Mirrors `GetCallersCalleesAsync` lines 265-268 exactly. `TryResolveByQualifiedSignatureAsync` is already `internal static`; no visibility change.
- `tests/RoslynMcp.Tests/MetadataNameLocatorTests.cs` — adds `SignatureHelp_Accepts_Fully_Qualified_Method_Signature_With_Parameter_Types` mirroring the existing callers-callees test. Asserts (1) the response is a JSON object — not the bare `null` token, which is the exact bug the symptom report flagged — and (2) signature matching picked the `List<IAnimal>` overload (parameters length 1, parameter type contains `List`).
- `changelog.d/symbol-signature-help-returns-bare-null-for-resolvable-method-metadata.md` — Fixed-category fragment.

## Validation

- `mcp__roslyn__compile_check` on `SymbolRelationshipService.cs`: 0 errors, 0 warnings.
- `mcp__roslyn__compile_check` on `MetadataNameLocatorTests.cs`: 0 errors, 0 warnings.
- `mcp__roslyn__test_run --filter "FullyQualifiedName~MetadataNameLocatorTests"`: 8/8 passed (including the new test).
- `mcp__roslyn__test_run --filter "FullyQualifiedName~Symbol_Signature_Help_Returns_Parameters_And_Return_Type"`: 1/1 passed — the existing source-position regression guard from `SemanticExpansionTests` still works.
- Full CI executes on the self-hosted runner after merge (local `verify-release.ps1` is skipped per repo policy).

## Risk

`TryResolveByQualifiedSignatureAsync` is `internal static` — no visibility change. The fallback only fires when (a) the initial resolve returned null AND (b) the locator has a `metadataName`. Plain `metadataName` (no parens) still works via the original path because `SymbolResolver.ResolveByMetadataNameAsync` returns a non-null result first. The `preferDeclaringMember` and type-promotion paths run AFTER the new fallback, so they are reached for both fallback-resolved and original-path-resolved symbols.

Closes: symbol-signature-help-returns-bare-null-for-resolvable-method-metadata
Fixes #747