### PR TITLE
fix(namespace-relocation): IsAmbientTo no longer treats ancestor consumers as ambient

### DIFF
--- a/changelog.d/change-type-namespace-preview-omits-consumer-using-additions.md
+++ b/changelog.d/change-type-namespace-preview-omits-consumer-using-additions.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `change_type_namespace_preview` omitting `using` additions on consumer files whose namespace is an ancestor of the destination namespace (e.g., consumer in `A.B` when type moves to `A.B.C`). The `IsAmbientTo` helper incorrectly treated ancestor namespaces as having ambient access to descendant namespaces, causing the consumer-side using-directive pass to skip the required `using toNamespace;` addition. Closes gh #749.

--- a/src/RoslynMcp.Roslyn/Services/NamespaceRelocationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/NamespaceRelocationService.cs
@@ -13,8 +13,8 @@ namespace RoslynMcp.Roslyn.Services;
 /// Provides preview operations for relocating a type between namespaces inside the same
 /// project. Rewrites the type's <c>namespace</c> declaration, optionally moves the file to a
 /// new path inside the project, and adjusts consumer <c>using</c> directives respecting
-/// ambient-namespace resolution (consumers in an ancestor/descendant of the source or target
-/// namespace may need no <c>using</c> change at all).
+/// ambient-namespace resolution (consumers whose own namespace equals or is a descendant of the
+/// source or target namespace may need no <c>using</c> change at all).
 /// </summary>
 /// <remarks>
 /// Pairs with <c>get_namespace_dependencies</c> to close circular namespace dependencies.
@@ -493,7 +493,7 @@ public sealed class NamespaceRelocationService : INamespaceRelocationService
     /// <summary>
     /// Ambient-resolution-aware using rewrite. Rules:
     /// <list type="bullet">
-    ///   <item><description>If the consumer's namespace is an ancestor/descendant of <paramref name="toNamespace"/> (ambient resolution covers the new location), no <c>using toNamespace</c> is needed.</description></item>
+    ///   <item><description>If the consumer's namespace equals or is a descendant of <paramref name="toNamespace"/> (ambient resolution covers the new location), no <c>using toNamespace</c> is needed. Ancestor consumers (e.g. consumer in <c>A.B</c>, target <c>A.B.C</c>) DO need the using — C# lookup climbs ancestors only.</description></item>
     ///   <item><description>Otherwise: add <c>using toNamespace</c> if missing.</description></item>
     ///   <item><description>Remove <c>using fromNamespace</c> ONLY if no sibling types remain in that namespace and the consumer's own namespace is NOT ambient to <paramref name="fromNamespace"/> (avoids flagging a using that was already redundant before the move).</description></item>
     ///   <item><description>When in doubt, keep the <c>using</c> — band-aid removals risk breaking compile.</description></item>
@@ -568,9 +568,10 @@ public sealed class NamespaceRelocationService : INamespaceRelocationService
     /// <summary>
     /// C# ambient-namespace resolution: a file whose namespace is <c>A.B.C</c> can resolve
     /// symbols declared in <c>A.B.C</c>, <c>A.B</c>, <c>A</c>, and the global namespace without
-    /// any <c>using</c>. We also treat descendant namespaces as ambient when they contain the
-    /// target (for example <c>A.B.C.D</c> is visible from <c>A.B.C</c>) — a conservative
-    /// extension that matches the plan's "when in doubt keep the using" rule.
+    /// any <c>using</c>. Lookup climbs ancestors only — a file in <c>A.B</c> cannot resolve
+    /// <c>A.B.C</c> symbols ambiently and still requires <c>using A.B.C;</c>. Returns
+    /// <see langword="true"/> only when the consumer's namespace equals the target or is a
+    /// strict descendant of it.
     /// </summary>
     private static bool IsAmbientTo(string consumerNamespace, string targetNamespace)
     {
@@ -582,13 +583,11 @@ public sealed class NamespaceRelocationService : INamespaceRelocationService
         {
             return true;
         }
-        // Consumer's namespace is an ancestor of the target.
+        // Consumer's namespace is a strict descendant of the target (e.g. consumer A.B.C sees A.B).
+        // Note: a consumer that is an ANCESTOR of the target (e.g. consumer A.B referencing a type
+        // in A.B.C) is NOT ambient — C# lookup climbs ancestors, it does not descend — so the
+        // consumer still needs `using A.B.C;`.
         if (consumerNamespace.StartsWith(targetNamespace + ".", StringComparison.Ordinal))
-        {
-            return true;
-        }
-        // Consumer's namespace is a descendant of the target (e.g. consumer A.B.C.D sees A.B.C).
-        if (targetNamespace.StartsWith(consumerNamespace + ".", StringComparison.Ordinal))
         {
             return true;
         }

--- a/tests/RoslynMcp.Tests/NamespaceRelocationTests.cs
+++ b/tests/RoslynMcp.Tests/NamespaceRelocationTests.cs
@@ -123,6 +123,69 @@ public sealed class NamespaceRelocationTests : IsolatedWorkspaceTestBase
             "ChildConsumer.cs should need no changes — ambient-namespace resolution covers the new location.");
     }
 
+    /// <summary>
+    /// Regression: a consumer file whose namespace is an <em>ancestor</em> of the destination
+    /// namespace (e.g. consumer in <c>A.B</c>, type moved into <c>A.B.Child</c>) is NOT covered
+    /// by ambient resolution — C# lookup climbs ancestors, it does not descend. The preview must
+    /// add <c>using A.B.Child;</c> on that consumer file. Closes gh #749.
+    /// </summary>
+    [TestMethod]
+    public async Task Preview_Adds_Using_On_Ancestor_Consumer_When_Type_Moves_Into_Descendant_Namespace()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var libDir = workspace.GetPath("SampleLib");
+        var fixtureDir = Path.Combine(libDir, "AncestorAmbientFixture");
+        Directory.CreateDirectory(fixtureDir);
+
+        // Type lives in A.B.Sub initially and will move to A.B.Child.
+        var typePath = Path.Combine(fixtureDir, "TypeX.cs");
+        await File.WriteAllTextAsync(typePath,
+            "namespace A.B.Sub;\n\n" +
+            "public sealed class TypeX\n" +
+            "{\n" +
+            "    public string Name { get; set; } = \"\";\n" +
+            "}\n",
+            CancellationToken.None);
+
+        // Consumer file is in A.B — an ANCESTOR of the destination A.B.Child. C# ambient lookup
+        // only climbs ancestors, so A.B cannot resolve A.B.Child symbols without a using. The
+        // preview must add `using A.B.Child;` here.
+        var consumerPath = Path.Combine(fixtureDir, "AncestorConsumer.cs");
+        await File.WriteAllTextAsync(consumerPath,
+            "using A.B.Sub;\n\n" +
+            "namespace A.B;\n\n" +
+            "public sealed class AncestorConsumer\n" +
+            "{\n" +
+            "    public TypeX? Value { get; set; }\n" +
+            "}\n",
+            CancellationToken.None);
+
+        var wsId = await workspace.LoadAsync(CancellationToken.None);
+
+        var service = CreateService();
+        var preview = await service.PreviewChangeTypeNamespaceAsync(
+            wsId,
+            typeName: "TypeX",
+            fromNamespace: "A.B.Sub",
+            toNamespace: "A.B.Child",
+            newFilePath: null,
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(preview.PreviewToken));
+
+        var consumerChange = preview.Changes.FirstOrDefault(c =>
+            c.FilePath.EndsWith("AncestorConsumer.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(
+            consumerChange,
+            "AncestorConsumer.cs MUST appear in the preview — the ancestor consumer needs `using A.B.Child;`.");
+        StringAssert.Contains(
+            consumerChange!.UnifiedDiff,
+            "+using A.B.Child;",
+            $"Expected `+using A.B.Child;` in consumer diff (regression: ancestor-consumer ambient mis-classification). Diff:\n{consumerChange.UnifiedDiff}");
+    }
+
     [TestMethod]
     public async Task Preview_Rejects_Mismatched_Namespaces()
     {


### PR DESCRIPTION
## Summary

Fixes `change_type_namespace_preview` omitting `using` additions on consumer files whose namespace is an ancestor of the destination namespace.

C# ambient namespace lookup climbs ancestors only — a file in `A.B` cannot resolve `A.B.C` symbols without `using A.B.C;`. The `IsAmbientTo` helper in `NamespaceRelocationService` incorrectly returned `true` when the consumer's namespace was an ancestor of the target (the buggy branch was `targetNamespace.StartsWith(consumerNamespace + "."`)), causing `AdjustUsings` to skip the required `using toNamespace;` addition on those consumer files.

## Changes

- **`src/RoslynMcp.Roslyn/Services/NamespaceRelocationService.cs`** — remove the buggy ancestor-as-ambient branch from `IsAmbientTo`. Fix XML doc and the misleading inline comments on the remaining branches (the equal-namespace and strict-descendant-consumer cases were correctly handled but commented backwards). Update the `AdjustUsings` docstring item 1 to spell out the ancestor-consumer rule.
- **`tests/RoslynMcp.Tests/NamespaceRelocationTests.cs`** — add regression test `Preview_Adds_Using_On_Ancestor_Consumer_When_Type_Moves_Into_Descendant_Namespace`. Consumer in `A.B` references `TypeX` which moves from `A.B.Sub` to `A.B.Child`; assert preview contains `+using A.B.Child;` on the consumer file.

The existing `Preview_Moves_Type_Up_Namespace_Chain_And_Adjusts_Consumers` test still passes — the legitimate strict-descendant ambient case (consumer in `Child.Sub` after type moves into `Child`) is preserved.

## Test plan

- [x] `mcp__roslyn__compile_check` on `NamespaceRelocationService.cs` — zero errors / warnings.
- [x] `mcp__roslyn__compile_check` on `NamespaceRelocationTests.cs` — zero errors / warnings.
- [x] `dotnet test --filter FullyQualifiedName~NamespaceRelocationTests` — 5/5 passed (4 existing + 1 new regression), 10s runtime.
- [ ] CI on self-hosted runner runs full `verify-release.ps1`.

Closes: change-type-namespace-preview-omits-consumer-using-additions
Fixes #749