### PR TITLE
fix(extract_interface): skip document-add when target already implements named interface

### DIFF
--- a/changelog.d/extract-interface-preview-duplicate-interface-when-already-implements.md
+++ b/changelog.d/extract-interface-preview-duplicate-interface-when-already-implements.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_interface_preview` emitting a duplicate interface file when the target type already implements a covering interface. Previously the preview diff included a new `IFoo.cs` even when the type's base list already contained `IFoo`; the apply would create a conflicting file. The base list is also correctly left unmodified in this case. Fixes gh #748.

--- a/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
@@ -51,7 +51,24 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         // source file) as the authoritative using list.
         var requiredNamespaces = CollectReferencedNamespaces(candidateMembers, typeSymbol.ContainingNamespace);
 
-        await ValidateNoConflictsAsync(solution, typeSymbol, interfaceName, ct).ConfigureAwait(false);
+        // Compute alreadyImplements BEFORE the conflict check so we can short-circuit
+        // when the target type already implements a covering interface of the same name.
+        // Bug fix (extract-interface-preview-duplicate-interface-when-already-implements):
+        // previously the document-add path and the base-list rewrite were gated
+        // independently — the document-add was unconditional, producing a duplicate
+        // IFoo.cs even when the type's base list already contained IFoo (from a
+        // sibling namespace). When alreadyImplements==true, return a no-op preview
+        // with a warning so callers see why no changes were produced.
+        var alreadyImplements = typeSymbol.AllInterfaces.Any(i =>
+            string.Equals(i.Name, interfaceName, StringComparison.Ordinal));
+
+        // Short-circuit ONLY when alreadyImplements==true. Otherwise still run the
+        // conflict check so a same-name-but-different-namespace collision is reported
+        // before we synthesize a new file.
+        if (!alreadyImplements)
+        {
+            await ValidateNoConflictsAsync(solution, typeSymbol, interfaceName, ct).ConfigureAwait(false);
+        }
 
         // BUG-003: Match the interface accessibility to the source type so an internal class
         // does not produce a public interface that escapes its assembly boundary.
@@ -61,11 +78,6 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
             .WithMembers(SyntaxFactory.List(interfaceMembers));
 
         var interfaceFileRoot = BuildInterfaceFile(interfaceDecl, typeDecl, sourceRoot, requiredNamespaces);
-
-        // Add interface to type's base list only if the type does not already implement it.
-        // Skipping this guard produced CS0528 (duplicate interface in base list).
-        var alreadyImplements = typeSymbol.AllInterfaces.Any(i =>
-            string.Equals(i.Name, interfaceName, StringComparison.Ordinal));
 
         TypeDeclarationSyntax updatedTypeDecl;
         if (alreadyImplements)
@@ -130,26 +142,41 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
 
         var newSolution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, updatedSourceRoot);
 
-        // Add interface document. Item #1 — pass folders so MSBuildWorkspace's
-        // TryApplyChanges resolves the disk path consistently with our explicit write.
-        var sourceDir = Path.GetDirectoryName(sourceDocument.FilePath!)!;
-        var interfaceFilePath = Path.Combine(sourceDir, $"{interfaceName}.cs");
-        var targetProject = newSolution.GetProject(sourceDocument.Project.Id)!;
-        var folders = ProjectMetadataParser.ComputeDocumentFolders(targetProject.FilePath, interfaceFilePath);
-        var interfaceDoc = targetProject.AddDocument($"{interfaceName}.cs", interfaceFileRoot.ToFullString(), folders: folders, filePath: interfaceFilePath);
-        newSolution = interfaceDoc.Project.Solution;
-
-        if (replaceUsages)
+        var warnings = new List<string>();
+        if (!alreadyImplements)
         {
-            newSolution = await ReplaceConcreteUsagesAsync(
-                newSolution, sourceDocument.Project.Id, typeSymbol, interfaceName, ct).ConfigureAwait(false);
+            // Add interface document. Item #1 — pass folders so MSBuildWorkspace's
+            // TryApplyChanges resolves the disk path consistently with our explicit write.
+            var sourceDir = Path.GetDirectoryName(sourceDocument.FilePath!)!;
+            var interfaceFilePath = Path.Combine(sourceDir, $"{interfaceName}.cs");
+            var targetProject = newSolution.GetProject(sourceDocument.Project.Id)!;
+            var folders = ProjectMetadataParser.ComputeDocumentFolders(targetProject.FilePath, interfaceFilePath);
+            var interfaceDoc = targetProject.AddDocument($"{interfaceName}.cs", interfaceFileRoot.ToFullString(), folders: folders, filePath: interfaceFilePath);
+            newSolution = interfaceDoc.Project.Solution;
+
+            if (replaceUsages)
+            {
+                newSolution = await ReplaceConcreteUsagesAsync(
+                    newSolution, sourceDocument.Project.Id, typeSymbol, interfaceName, ct).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // No-op preview: the type already implements an interface of this name.
+            // Surface a warning so callers see why no changes were produced. The base-list
+            // rewrite, document-add, and usage-replacement paths are all skipped — the
+            // computed newSolution is byte-identical to the input solution.
+            warnings.Add(
+                $"Type '{typeName}' already implements an interface named '{interfaceName}'. " +
+                $"No file changes were produced. " +
+                $"If you intended to extract a cross-project interface contract, use extract_interface_cross_project_preview instead.");
         }
 
         var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
         var description = $"Extract interface '{interfaceName}' from '{typeName}' with {candidateMembers.Count} member(s)";
         var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
 
-        return new RefactoringPreviewDto(token, description, changes, null);
+        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
     }
 
     private static async Task<(Document SourceDocument, CompilationUnitSyntax SourceRoot, TypeDeclarationSyntax TypeDecl, INamedTypeSymbol TypeSymbol)>

--- a/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
@@ -405,6 +405,86 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
         }
     }
 
+    [TestMethod]
+    public async Task ExtractInterface_Preview_NoOp_When_Type_Already_Implements_SameNamed_Interface()
+    {
+        // Regression for extract-interface-preview-duplicate-interface-when-already-implements (gh #748).
+        // Repro: a class already implements IFoo (defined in a sibling namespace). Calling
+        // PreviewExtractInterfaceAsync with interfaceName: "IFoo" should produce a no-op
+        // preview — zero file changes and zero base-list mutations — with a warning surfaced
+        // via RefactoringPreviewDto.Warnings explaining the no-op. Pre-fix: the base-list
+        // rewrite was correctly skipped, but the document-add path was unconditional, producing
+        // a duplicate IFoo.cs even though the type's base list already contained IFoo.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var contractsDir = Path.Combine(sampleLibDir, "Contracts");
+        Directory.CreateDirectory(contractsDir);
+
+        // The sibling-namespace interface the type already implements.
+        await File.WriteAllTextAsync(Path.Combine(contractsDir, "IItem748Service.cs"),
+            """
+            namespace SampleLib.Contracts;
+
+            public interface IItem748Service
+            {
+                int Compute();
+            }
+            """);
+
+        // The type that already implements IItem748Service from the sibling namespace.
+        var servicePath = Path.Combine(sampleLibDir, "Item748Service.cs");
+        await File.WriteAllTextAsync(servicePath,
+            """
+            using SampleLib.Contracts;
+
+            namespace SampleLib;
+
+            public class Item748Service : IItem748Service
+            {
+                public int Compute() => 42;
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+
+        try
+        {
+            var previewDto = await InterfaceExtractionService.PreviewExtractInterfaceAsync(
+                workspaceId,
+                servicePath,
+                typeName: "Item748Service",
+                interfaceName: "IItem748Service",
+                memberNames: null,
+                replaceUsages: false,
+                CancellationToken.None);
+
+            // (1) Preview MUST contain zero file changes — no new IItem748Service.cs document,
+            // no base-list mutation on Item748Service.cs.
+            Assert.AreEqual(
+                0,
+                previewDto.Changes.Count,
+                $"Preview must produce zero file changes when the type already implements the named interface. " +
+                $"Actual changes: {string.Join("; ", previewDto.Changes.Select(c => c.FilePath))}");
+
+            // (2) Warnings MUST surface the no-op so callers see why no changes were produced.
+            Assert.IsNotNull(
+                previewDto.Warnings,
+                "Warnings must be populated on the no-op path.");
+            Assert.IsTrue(
+                previewDto.Warnings!.Any(w => w.Contains("already implements", StringComparison.Ordinal)
+                    && w.Contains("IItem748Service", StringComparison.Ordinal)),
+                $"Warning must explain that the type already implements the named interface. " +
+                $"Actual warnings: {string.Join(" | ", previewDto.Warnings)}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try


### PR DESCRIPTION
## Summary

Bug: `extract_interface_preview` produced a duplicate interface file when the target type already implemented an interface with the same simple name (typically from a sibling namespace).

In `InterfaceExtractionService.PreviewExtractInterfaceAsync`, the `alreadyImplements` guard correctly skipped the base-list rewrite, but the interface document-add path was unconditional. Result: even when `Item748Service` already had `IItem748Service` in its base list (declared in `SampleLib.Contracts`), the preview diff still included a freshly synthesized `IItem748Service.cs`, and the apply would create a conflicting file.

Fix:
- Compute `alreadyImplements` BEFORE `ValidateNoConflictsAsync` and short-circuit the conflict check ONLY when `alreadyImplements==true` (so same-name-different-namespace collisions are still detected on the regular path).
- Gate the document-add block and the `replaceUsages` path inside `if (!alreadyImplements)`, mirroring the existing base-list-rewrite pattern.
- Surface the no-op via `RefactoringPreviewDto.Warnings` so callers see why no changes were produced — pattern mirrored from `DeadCodeService.cs`.
- Does NOT touch `ExtractAndWireOrchestrator.cs:158-173` (that path throws by design and is test-covered in `OrchestrationIntegrationTests.Extract_And_Wire_Interface_Preview_Declines_When_Type_Already_Implements_Same_Named_Interface`).

Tests added:
- `ExtractInterface_Preview_NoOp_When_Type_Already_Implements_SameNamed_Interface` — fixture where `Item748Service` already implements `IItem748Service` from sibling `SampleLib.Contracts`; asserts `previewDto.Changes.Count == 0` AND `previewDto.Warnings` contains the no-op note.

## Validation

- `mcp__roslyn__compile_check`: clean on both `InterfaceExtractionService.cs` and `ExtractInterfaceSemanticUsingsTests.cs`.
- `mcp__roslyn__test_run` filter `ExtractInterfaceSemanticUsingsTests|Extract_And_Wire_Interface_Preview_Declines_When_Type_Already_Implements_Same_Named_Interface`: 6/6 passed.
- `mcp__roslyn__test_run` filter `OrchestrationIntegrationTests`: 8/8 passed (orchestrator's throw-by-design guard preserved).

CI will execute the full verify-release gate via GitHub Actions.

## Test plan
- [x] New regression test passes
- [x] Existing `ExtractInterfaceSemanticUsingsTests` (4) all pass
- [x] `OrchestrationIntegrationTests` (8) all pass
- [x] Production and test code compile clean

Closes: extract-interface-preview-duplicate-interface-when-already-implements
Fixes #748

Generated with [Claude Code](https://claude.com/claude-code)