### PR TITLE
fix(test_discover): use declared namespace prefix instead of project name (test-run-fqdn-drift-vs-test-discover)

### DIFF
--- a/changelog.d/test-run-fqdn-drift-vs-test-discover.md
+++ b/changelog.d/test-run-fqdn-drift-vs-test-discover.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `test_discover` reporting incorrect `fullyQualifiedName` for test classes declared inside a sub-namespace (folder-infix drift). Previously the FQDN used the MSBuild project name as its namespace prefix; it now uses the class's actual declared namespace. Passing a `test_discover` FQDN as a `test_run --filter` expression will no longer produce silent zero-hits when the project name and namespace diverge. Closes gh #752.

--- a/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs
@@ -66,14 +66,9 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
                         }
 
                         var lineSpan = method.Identifier.GetLocation().GetLineSpan();
-                        var containingType = method.Parent switch
-                        {
-                            ClassDeclarationSyntax cls => cls.Identifier.Text,
-                            _ => "Unknown"
-                        };
                         tests.Add(new TestCaseDto(
                             DisplayName: method.Identifier.Text,
-                            FullyQualifiedName: $"{project.Name}.{containingType}.{method.Identifier.Text}",
+                            FullyQualifiedName: BuildFullyQualifiedTestName(project.Name, method),
                             FilePath: document.FilePath,
                             Line: lineSpan.StartLinePosition.Line + 1));
                     }
@@ -900,5 +895,58 @@ public sealed class TestDiscoveryService : ITestDiscoveryService
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// test-run-fqdn-drift-vs-test-discover: build the fully-qualified test name using the
+    /// method's actual declared namespace (read from the syntax tree) rather than the
+    /// MSBuild project name. Test runners (xunit / MSTest / NUnit) register tests under
+    /// <c>{declared-namespace}.{containing-type}.{method}</c>; using the project name as the
+    /// prefix produced silent zero-hits when a test class lived in a sub-namespace (e.g.
+    /// <c>SampleLib.Tests.Unit.AnimalServiceTests</c> in a project named
+    /// <c>SampleLib.Tests</c>) because <c>--filter "FullyQualifiedName~..."</c> never matched.
+    /// Falls back to <paramref name="projectName"/> when no enclosing namespace is found
+    /// (test class declared in the global namespace).
+    /// </summary>
+    internal static string BuildFullyQualifiedTestName(string projectName, MethodDeclarationSyntax method)
+    {
+        var containingType = method.Parent switch
+        {
+            ClassDeclarationSyntax cls => cls.Identifier.Text,
+            _ => "Unknown"
+        };
+        var namespacePrefix = GetEnclosingNamespace(method) ?? projectName;
+        return $"{namespacePrefix}.{containingType}.{method.Identifier.Text}";
+    }
+
+    /// <summary>
+    /// Walks ancestors of <paramref name="node"/> to find every enclosing
+    /// <see cref="BaseNamespaceDeclarationSyntax"/> (covers both classic
+    /// <see cref="NamespaceDeclarationSyntax"/> and
+    /// <see cref="FileScopedNamespaceDeclarationSyntax"/>) and concatenates their names
+    /// outer-to-inner. Returns <see langword="null"/> when no enclosing namespace exists
+    /// (declaration in the global namespace).
+    /// </summary>
+    internal static string? GetEnclosingNamespace(SyntaxNode node)
+    {
+        var parts = new List<string>();
+        // Walk from the node upward; collect every namespace declaration so nested namespace
+        // declarations like `namespace A { namespace B { class C { } } }` produce "A.B".
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is BaseNamespaceDeclarationSyntax ns)
+            {
+                parts.Add(ns.Name.ToString());
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return null;
+        }
+
+        // Ancestor walk produces inner-to-outer; reverse for outer-to-inner concatenation.
+        parts.Reverse();
+        return string.Join(".", parts);
     }
 }

--- a/tests/RoslynMcp.Tests/TestDiscoverFqdnDriftTests.cs
+++ b/tests/RoslynMcp.Tests/TestDiscoverFqdnDriftTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// test-run-fqdn-drift-vs-test-discover: covers the fully-qualified-name composition path in
+/// <see cref="TestDiscoveryService"/>. Before the fix, the FQDN was synthesized as
+/// <c>{projectName}.{class}.{method}</c>; that produced silent zero-hits when a test class
+/// lived inside a sub-namespace (e.g. <c>MyProject.SubFolder.MyTestClass</c> in a project
+/// named <c>MyProject</c>) because <c>dotnet test --filter "FullyQualifiedName~..."</c> with
+/// the project-name prefix never matched the actual test-runner-registered name (which uses
+/// the declared namespace). The fix reads the declared namespace from the syntax tree.
+///
+/// These tests drive the production helper directly (it is <c>internal static</c> and
+/// <c>RoslynMcp.Roslyn</c> grants <c>InternalsVisibleTo("RoslynMcp.Tests")</c>) so they run
+/// in milliseconds without needing an MSBuild workspace. The disk-backed end-to-end behaviour
+/// is already exercised by <c>ValidationIntegrationTests.Test_Discover_Returns_Test_Methods_For_Test_Project</c>,
+/// which continues to pass because <c>SampleLib.Tests</c> happens to use a namespace identical
+/// to its project name.
+/// </summary>
+[TestClass]
+public class TestDiscoverFqdnDriftTests
+{
+    [TestMethod]
+    public void BuildFullyQualifiedTestName_UsesDeclaredSubNamespace_NotProjectName()
+    {
+        // Project name "SampleLib.Tests" but class declared inside the "Unit" sub-namespace.
+        // The runner registers this as "SampleLib.Tests.Unit.AnimalServiceTests.CountAnimals",
+        // so test_discover MUST emit that — not "SampleLib.Tests.AnimalServiceTests.CountAnimals".
+        var method = ParseTestMethod(
+            """
+            namespace SampleLib.Tests.Unit;
+
+            [TestClass]
+            public class AnimalServiceTests
+            {
+                [TestMethod]
+                public void CountAnimals() { }
+            }
+            """);
+
+        var fqn = TestDiscoveryService.BuildFullyQualifiedTestName("SampleLib.Tests", method);
+
+        Assert.AreEqual("SampleLib.Tests.Unit.AnimalServiceTests.CountAnimals", fqn);
+    }
+
+    [TestMethod]
+    public void BuildFullyQualifiedTestName_ClassicNamespace_UsesDeclaredNamespace()
+    {
+        // Classic block-scoped namespace; same expectation as the file-scoped case.
+        var method = ParseTestMethod(
+            """
+            namespace MyProject.Integration
+            {
+                public class WidgetTests
+                {
+                    [TestMethod]
+                    public void Widget_Builds() { }
+                }
+            }
+            """);
+
+        var fqn = TestDiscoveryService.BuildFullyQualifiedTestName("MyProject", method);
+
+        Assert.AreEqual("MyProject.Integration.WidgetTests.Widget_Builds", fqn);
+    }
+
+    [TestMethod]
+    public void BuildFullyQualifiedTestName_NestedNamespaces_ConcatenatedOuterToInner()
+    {
+        // Nested `namespace A { namespace B { ... } }` should produce "A.B.Class.Method",
+        // not "B.Class.Method" (innermost only) and not "B.A.Class.Method" (reversed order).
+        var method = ParseTestMethod(
+            """
+            namespace Outer
+            {
+                namespace Inner
+                {
+                    public class NestedTests
+                    {
+                        [TestMethod]
+                        public void Nested_Works() { }
+                    }
+                }
+            }
+            """);
+
+        var fqn = TestDiscoveryService.BuildFullyQualifiedTestName("SomeProject", method);
+
+        Assert.AreEqual("Outer.Inner.NestedTests.Nested_Works", fqn);
+    }
+
+    [TestMethod]
+    public void BuildFullyQualifiedTestName_GlobalNamespace_FallsBackToProjectName()
+    {
+        // No enclosing namespace declaration → fall back to the MSBuild project name so we
+        // never emit a fragment like ".ClassName.Method" with an empty prefix.
+        var method = ParseTestMethod(
+            """
+            public class GlobalTests
+            {
+                [TestMethod]
+                public void Global_Works() { }
+            }
+            """);
+
+        var fqn = TestDiscoveryService.BuildFullyQualifiedTestName("MyProject", method);
+
+        Assert.AreEqual("MyProject.GlobalTests.Global_Works", fqn);
+    }
+
+    [TestMethod]
+    public void GetEnclosingNamespace_GlobalNamespace_ReturnsNull()
+    {
+        // Direct helper check: confirms the null-namespace branch the fallback relies on.
+        var method = ParseTestMethod(
+            """
+            public class C
+            {
+                [TestMethod]
+                public void M() { }
+            }
+            """);
+
+        Assert.IsNull(TestDiscoveryService.GetEnclosingNamespace(method));
+    }
+
+    [TestMethod]
+    public void GetEnclosingNamespace_FileScopedNamespace_ReturnsName()
+    {
+        var method = ParseTestMethod(
+            """
+            namespace Acme.Tooling.Tests;
+
+            public class T
+            {
+                [TestMethod]
+                public void M() { }
+            }
+            """);
+
+        Assert.AreEqual("Acme.Tooling.Tests", TestDiscoveryService.GetEnclosingNamespace(method));
+    }
+
+    [TestMethod]
+    public void SynthesizeDotnetTestFilter_AcceptsSubNamespaceFqn_WithoutSilentZeroHits()
+    {
+        // End-to-end: when the FQDN is correctly built from a sub-namespace declaration,
+        // the dotnet-test filter string must include that sub-namespace prefix verbatim —
+        // otherwise `dotnet test --filter` passes but matches zero tests at runtime.
+        var method = ParseTestMethod(
+            """
+            namespace SampleLib.Tests.Unit;
+
+            public class AnimalServiceTests
+            {
+                [TestMethod]
+                public void CountAnimals() { }
+            }
+            """);
+
+        var fqn = TestDiscoveryService.BuildFullyQualifiedTestName("SampleLib.Tests", method);
+        var filter = TestDiscoveryService.SynthesizeDotnetTestFilter([fqn]);
+
+        Assert.AreEqual("FullyQualifiedName~SampleLib.Tests.Unit.AnimalServiceTests.CountAnimals", filter);
+    }
+
+    private static MethodDeclarationSyntax ParseTestMethod(string source)
+    {
+        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
+        return root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+    }
+}


### PR DESCRIPTION
## Summary

`TestDiscoveryService.DiscoverTestsAsync` synthesized `fullyQualifiedName` as `{project.Name}.{containingType}.{method}` — using the MSBuild project name as the namespace prefix rather than the test class's actual declared namespace. When a test class lived inside a folder-scoped sub-namespace (e.g. `SampleLib.Tests.Unit.AnimalServiceTests` in a project named `SampleLib.Tests`), the emitted FQDN was `SampleLib.Tests.AnimalServiceTests.CountAnimals` while xunit/MSTest registered the test under `SampleLib.Tests.Unit.AnimalServiceTests.CountAnimals`. Passing a `FullyQualifiedName~<discover-fqdn>` filter to `dotnet test --filter` then produced zero matches — silent zero-hits, with no diagnostic.

The fix walks ancestors of each `MethodDeclarationSyntax` to collect every enclosing `BaseNamespaceDeclarationSyntax` (covers both classic and file-scoped namespaces) and concatenates them outer-to-inner. Falls back to the MSBuild project name when no enclosing namespace is found (global-namespace case).

FQDN-composition logic extracted as `internal static BuildFullyQualifiedTestName` / `internal static GetEnclosingNamespace` so the path can be unit-tested in isolation against `CSharpSyntaxTree.ParseText` trees — no MSBuild workspace round-trip needed.

## Changes

- **`src/RoslynMcp.Roslyn/Services/TestDiscoveryService.cs`** — replace the inlined `$"{project.Name}.{containingType}.{method.Identifier.Text}"` expression with a call to the new `BuildFullyQualifiedTestName` helper; extract a `GetEnclosingNamespace` ancestor walker.
- **`tests/RoslynMcp.Tests/TestDiscoverFqdnDriftTests.cs`** (new) — 7 unit tests covering file-scoped sub-namespace, classic block namespace, nested namespace concatenation, global-namespace fallback, and a `SynthesizeDotnetTestFilter` end-to-end assertion confirming the synthesized `--filter` string includes the sub-namespace prefix.

## Validation

- `mcp__roslyn__compile_check` on `TestDiscoveryService.cs` and `TestDiscoverFqdnDriftTests.cs`: zero diagnostics.
- `mcp__roslyn__test_run --filter "TestDiscoverFqdnDriftTests"`: **7 passed, 0 failed**.
- `mcp__roslyn__test_run --filter "Test_Discover_Returns_Test_Methods_For_Test_Project"` (pre-existing `ValidationIntegrationTests` regression check): **1 passed**.
- Full CI gate runs on the self-hosted runner via `verify-release.ps1` + `verify-ai-docs.ps1` after merge.

## Test plan

- [x] New test class `TestDiscoverFqdnDriftTests` covers (a) sub-namespace FQDN composition, (b) classic block-scoped namespace, (c) nested namespaces concatenated outer-to-inner, (d) global-namespace fallback to project name, (e) `GetEnclosingNamespace` returns null for global namespace, (f) `GetEnclosingNamespace` returns name for file-scoped namespace, (g) end-to-end `SynthesizeDotnetTestFilter` round-trip.
- [x] Existing `ValidationIntegrationTests.Test_Discover_Returns_Test_Methods_For_Test_Project` still passes (asserts `DisplayName` only; FQDN change is additive and `SampleLib.Tests` happens to use namespace identical to project name).

Closes: test-run-fqdn-drift-vs-test-discover
Fixes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)