### PR TITLE
fix(validate_workspace): always populate errorCount on validation DTO

### DIFF
--- a/changelog.d/validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics.md
+++ b/changelog.d/validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `validate_workspace` / `validate_recent_git_changes` returning `overallStatus=analyzer-error` with empty `errorDiagnostics` and no count when `summary=true`. A new `errorCount` field on the response DTO is now always populated (mirrors the existing `warningCount` pattern) so callers in summary mode can see how many errors drove the verdict without needing the full per-item list. Closes gh #751.

--- a/src/RoslynMcp.Core/Services/IWorkspaceValidationService.cs
+++ b/src/RoslynMcp.Core/Services/IWorkspaceValidationService.cs
@@ -60,7 +60,20 @@ public interface IWorkspaceValidationService
 /// tracker supplied the path set (in which case they are guaranteed to exist).
 /// </param>
 /// <param name="CompileResult">Result of the compile-check stage.</param>
-/// <param name="ErrorDiagnostics">All compiler/analyzer diagnostics with severity <c>Error</c> across the validated scope.</param>
+/// <param name="ErrorDiagnostics">
+/// All compiler/analyzer diagnostics with severity <c>Error</c> across the validated scope.
+/// validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics: when
+/// <c>summary=true</c> on <see cref="IWorkspaceValidationService.ValidateAsync"/> this list is
+/// dropped to keep the response under the MCP cap — use <see cref="ErrorCount"/> to recover
+/// the number of errors that drove the verdict.
+/// </param>
+/// <param name="ErrorCount">
+/// validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics: count of
+/// error-severity compiler/analyzer diagnostics in scope. Always populated (mirrors the
+/// existing <see cref="WarningCount"/> pattern) so callers can see how many errors drove
+/// the <see cref="OverallStatus"/> verdict even when <c>summary=true</c> suppressed
+/// <see cref="ErrorDiagnostics"/>.
+/// </param>
 /// <param name="WarningCount">Count of warning-severity diagnostics in scope (not surfaced individually to keep response size bounded).</param>
 /// <param name="DiscoveredTests">Test cases discovered for the changed files; empty list when no related tests were found.</param>
 /// <param name="DotnetTestFilter">The combined <c>dotnet test --filter</c> expression to re-run just the related tests; <see langword="null"/> when none.</param>
@@ -78,6 +91,7 @@ public sealed record WorkspaceValidationDto(
     IReadOnlyList<string> UnknownFilePaths,
     CompileCheckDto CompileResult,
     IReadOnlyList<DiagnosticDto> ErrorDiagnostics,
+    int ErrorCount,
     int WarningCount,
     IReadOnlyList<RelatedTestCaseDto> DiscoveredTests,
     string? DotnetTestFilter,

--- a/src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs
+++ b/src/RoslynMcp.Host.Stdio/Formatters/ValidateWorkspaceMarkdownFormatter.cs
@@ -72,7 +72,10 @@ internal static class ValidateWorkspaceMarkdownFormatter
         AppendRow(sb, "Overall status", dto.OverallStatus);
         AppendRow(sb, "Compile errors", dto.CompileResult.ErrorCount.ToString(CultureInfo.InvariantCulture));
         AppendRow(sb, "Compile warnings", dto.CompileResult.WarningCount.ToString(CultureInfo.InvariantCulture));
-        AppendRow(sb, "Analyzer/compile error diagnostics", dto.ErrorDiagnostics.Count.ToString(CultureInfo.InvariantCulture));
+        // validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics:
+        // read ErrorCount (always populated) instead of ErrorDiagnostics.Count — the latter
+        // reports 0 when summary=true suppressed the list, which contradicted overallStatus.
+        AppendRow(sb, "Analyzer/compile error diagnostics", dto.ErrorCount.ToString(CultureInfo.InvariantCulture));
         AppendRow(sb, "Warning diagnostics", dto.WarningCount.ToString(CultureInfo.InvariantCulture));
         AppendRow(sb, "Changed file paths (resolved)", dto.ChangedFilePaths.Count.ToString(CultureInfo.InvariantCulture));
         AppendRow(sb, "Unknown file paths", dto.UnknownFilePaths.Count.ToString(CultureInfo.InvariantCulture));

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -249,6 +249,11 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             UnknownFilePaths: unknownFiles,
             CompileResult: compile,
             ErrorDiagnostics: emittedErrors,
+            // validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics:
+            // ErrorCount mirrors the always-populated WarningCount field below. Counted off
+            // allErrors (the full merged set), NOT emittedErrors, so summary=true callers
+            // still see the count that drove the OverallStatus verdict.
+            ErrorCount: allErrors.Length,
             WarningCount: compile.WarningCount,
             DiscoveredTests: emittedTests,
             DotnetTestFilter: string.IsNullOrWhiteSpace(related.DotnetTestFilter) ? null : related.DotnetTestFilter,
@@ -680,6 +685,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
                 ElapsedMs: (long)timeout.Timeout.TotalMilliseconds,
                 Cancelled: true),
             ErrorDiagnostics: Array.Empty<DiagnosticDto>(),
+            ErrorCount: 0,
             WarningCount: 0,
             DiscoveredTests: Array.Empty<RelatedTestCaseDto>(),
             DotnetTestFilter: null,

--- a/tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateWorkspaceMarkdownFormatterTests.cs
@@ -201,6 +201,7 @@ public sealed class ValidateWorkspaceMarkdownFormatterTests
         string overallStatus = "clean",
         CompileCheckDto? compile = null,
         IReadOnlyList<DiagnosticDto>? errorDiagnostics = null,
+        int? errorCount = null,
         int warningCount = 0,
         IReadOnlyList<RelatedTestCaseDto>? discoveredTests = null,
         string? dotnetTestFilter = null,
@@ -219,12 +220,20 @@ public sealed class ValidateWorkspaceMarkdownFormatterTests
             Diagnostics: Array.Empty<DiagnosticDto>(),
             ElapsedMs: 1);
 
+        var diagnostics = errorDiagnostics ?? Array.Empty<DiagnosticDto>();
+
         return new WorkspaceValidationDto(
             OverallStatus: overallStatus,
             ChangedFilePaths: Array.Empty<string>(),
             UnknownFilePaths: Array.Empty<string>(),
             CompileResult: compile,
-            ErrorDiagnostics: errorDiagnostics ?? Array.Empty<DiagnosticDto>(),
+            ErrorDiagnostics: diagnostics,
+            // validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics:
+            // ErrorCount defaults to the supplied diagnostics list length so existing test
+            // cases that exercise the full-detail shape continue to render the same row;
+            // tests that need to repro the summary-mode mismatch can pass errorCount
+            // explicitly (typically alongside an empty errorDiagnostics list).
+            ErrorCount: errorCount ?? diagnostics.Count,
             WarningCount: warningCount,
             DiscoveredTests: discoveredTests ?? Array.Empty<RelatedTestCaseDto>(),
             DotnetTestFilter: dotnetTestFilter,

--- a/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
@@ -83,6 +83,7 @@ public sealed class ValidationBundleToolsTests
                 Diagnostics: Array.Empty<DiagnosticDto>(),
                 ElapsedMs: 0),
             ErrorDiagnostics: Array.Empty<DiagnosticDto>(),
+            ErrorCount: 0,
             WarningCount: 0,
             DiscoveredTests: Array.Empty<RelatedTestCaseDto>(),
             DotnetTestFilter: null,

--- a/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -208,6 +209,60 @@ public sealed class WorkspaceValidationOverallStatusTests
             "test-zero-run",
             status,
             "runTests=true with Total=0 must surface 'test-zero-run' — not 'clean' — so callers don't silently treat a filter-resolution failure as a pass.");
+    }
+
+    /// <summary>
+    /// validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics (gh #751):
+    /// when <c>summary=true</c> the service drops the per-diagnostic <see cref="WorkspaceValidationDto.ErrorDiagnostics"/>
+    /// list but the verdict was already computed from the full error set, so the caller saw
+    /// <c>overallStatus=analyzer-error</c> with an empty list and no count — leaving them
+    /// unable to tell <em>how many</em> errors drove the verdict. The new <see cref="WorkspaceValidationDto.ErrorCount"/>
+    /// field always carries the count (mirrors <see cref="WorkspaceValidationDto.WarningCount"/>)
+    /// so summary callers can see the magnitude of the analyzer-error verdict without re-running
+    /// with <c>summary=false</c>.
+    ///
+    /// This test pins the DTO-shape contract directly: a record constructed with
+    /// <c>OverallStatus="analyzer-error"</c>, <c>ErrorCount=1</c>, and an empty
+    /// <c>ErrorDiagnostics</c> list (exactly the summary-mode wire shape) MUST round-trip those
+    /// three fields independently.
+    /// </summary>
+    [TestMethod]
+    public void WorkspaceValidationDto_AnalyzerError_SummaryMode_ErrorCountNonZero_ErrorDiagnosticsEmpty()
+    {
+        var compileClean = new CompileCheckDto(
+            Success: true,
+            ErrorCount: 0,
+            WarningCount: 0,
+            TotalDiagnostics: 0,
+            ReturnedDiagnostics: 0,
+            Offset: 0,
+            Limit: 200,
+            HasMore: false,
+            Diagnostics: Array.Empty<DiagnosticDto>(),
+            ElapsedMs: 0,
+            Cancelled: false,
+            CompletedProjects: 1,
+            TotalProjects: 1);
+
+        // Construct the DTO directly with the summary-mode wire shape: ErrorCount > 0 alongside
+        // an empty ErrorDiagnostics list. Pre-fix this combination was unrepresentable because
+        // the only count came from ErrorDiagnostics.Count (always 0 in summary mode).
+        var dto = new WorkspaceValidationDto(
+            OverallStatus: "analyzer-error",
+            ChangedFilePaths: Array.Empty<string>(),
+            UnknownFilePaths: Array.Empty<string>(),
+            CompileResult: compileClean,
+            ErrorDiagnostics: Array.Empty<DiagnosticDto>(),
+            ErrorCount: 1,
+            WarningCount: 0,
+            DiscoveredTests: Array.Empty<RelatedTestCaseDto>(),
+            DotnetTestFilter: null,
+            TestRunResult: null,
+            Warnings: Array.Empty<string>());
+
+        Assert.AreEqual("analyzer-error", dto.OverallStatus, "verdict must surface even when the list is suppressed");
+        Assert.AreEqual(1, dto.ErrorCount, "ErrorCount must carry the count that drove the verdict");
+        Assert.AreEqual(0, dto.ErrorDiagnostics.Count, "ErrorDiagnostics is empty in the summary-mode wire shape");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Adds `ErrorCount` as a positional field on `WorkspaceValidationDto` (between `ErrorDiagnostics` and `WarningCount`), mirroring the existing `WarningCount` pattern so callers can see the error magnitude even when `summary=true` suppresses the per-diagnostic list.
- `WorkspaceValidationService.ValidateInternalAsync` populates `ErrorCount: allErrors.Length` from the full merged error set (before list suppression), so the count is independent of `summary` mode. `CreateTimeoutResult` passes `ErrorCount: 0` for the timeout shape.
- `ValidateWorkspaceMarkdownFormatter` reads `dto.ErrorCount` instead of `dto.ErrorDiagnostics.Count` for the "Analyzer/compile error diagnostics" metrics row — both JSON and markdown response modes now agree with `overallStatus`.

## Diagnosis

Pre-fix, calling `validate_workspace` with `summary=true` against a workspace with analyzer errors returned a self-contradictory response shape: `overallStatus=analyzer-error` alongside `errorDiagnostics: []` with no count field. `ComputeOverallStatus` correctly classified the verdict from the full `allErrors` set, but the summary-mode branch dropped the list (to keep the response under the MCP cap on multi-project solutions) and the DTO had no companion count field to explain the magnitude. The markdown formatter's metrics row inherited the same gap because it read `dto.ErrorDiagnostics.Count` directly.

## Validation

- `mcp__roslyn__compile_check`: 0 errors across all 5 projects.
- `mcp__roslyn__test_run` targeting the impacted suites: 24/24 passing (`WorkspaceValidationOverallStatusTests`, `ValidateWorkspaceMarkdownFormatterTests`, `ValidationBundleToolsTests`, `ValidateWorkspaceSummaryTests`).
- `dotnet test` regression sweep across `ValidateRecentGitChangesTests` + `ValidationIntegrationTests` + `ValidationToolsIntegrationTests`: 26/26 passing.
- New regression test `WorkspaceValidationDto_AnalyzerError_SummaryMode_ErrorCountNonZero_ErrorDiagnosticsEmpty` pins the DTO-shape contract: `OverallStatus="analyzer-error"`, `ErrorCount=1`, `ErrorDiagnostics.Count==0` round-trip independently.

## Test plan

- [x] `mcp__roslyn__compile_check` — 0 errors
- [x] Targeted `dotnet test` regression sweep — 26/26 pass
- [x] New regression test asserts `ErrorCount > 0` + `ErrorDiagnostics.Count == 0` + `OverallStatus == "analyzer-error"`
- [ ] CI gate (self-hosted runner): `verify-release.ps1` + `verify-ai-docs.ps1` on PR push

## Compatibility

Breaking change to the positional `WorkspaceValidationDto` record signature. All in-tree construction sites are updated:
- Production: `WorkspaceValidationService.ValidateInternalAsync`, `WorkspaceValidationService.CreateTimeoutResult`.
- Tests: `ValidateWorkspaceMarkdownFormatterTests.MakeDto` (now accepts optional `errorCount` that defaults to the supplied diagnostics list length), `ValidationBundleToolsTests`.

No external callers construct this DTO directly — it is a response-only shape; only the server produces instances, and the JSON wire shape simply gains a new `errorCount` field that consumers can ignore.

Closes: validate-workspace-overallstatus-analyzer-error-with-empty-errordiagnostics
Fixes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)