### PR TITLE
fix(find_overrides): suppress unbounded enumeration on corlib virtuals

### DIFF
--- a/changelog.d/find-overrides-payload-overflow-on-corlib-virtual.md
+++ b/changelog.d/find-overrides-payload-overflow-on-corlib-virtual.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_overrides` returning an unbounded payload when anchored on corlib virtual members (`System.Object.ToString`, `Equals`, `GetHashCode`). The tool now returns `count=0` with an explanatory hint for corlib virtuals, matching the existing `symbol_relationships` suppression behavior. `member_hierarchy.overrides` benefits from the same guard via its shared `FindOverridesAsync` code path. Fixes gh #754.

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Middleware;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -372,11 +373,12 @@ public static class SymbolTools
             ct);
     }
 
-    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find true virtual/abstract overrides for a member — only symbols actually marked `override` of a virtual or abstract declaration. Sibling interface implementations (e.g. independent IDisposable.Dispose impls across a solution) are NOT included here; query member_hierarchy and read the siblingInterfaceImplementations bucket for that. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) surface with FilePath=null so the count matches member_hierarchy.overrides.")]
+    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find true virtual/abstract overrides for a member — only symbols actually marked `override` of a virtual or abstract declaration. Sibling interface implementations (e.g. independent IDisposable.Dispose impls across a solution) are NOT included here; query member_hierarchy and read the siblingInterfaceImplementations bucket for that. Response shape: { count, items } in the normal path, or { count: 0, items: [], hint } when the post-promotion symbol is a corlib virtual (System.Object.ToString / Equals / GetHashCode, System.IDisposable.Dispose, etc.) — the unbounded solution-wide enumeration is suppressed and the hint explains why. Each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) surface with FilePath=null so the count matches member_hierarchy.overrides.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find overrides of a virtual or abstract member.")]
     public static Task<string> FindOverrides(
         IWorkspaceExecutionGate gate,
+        IWorkspaceManager workspaceManager,
         IReferenceService referenceService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
@@ -389,6 +391,30 @@ public static class SymbolTools
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
+
+            // find-overrides-payload-overflow-on-corlib-virtual (gh #754): resolve and promote
+            // the symbol up-front so that callers anchored on a corlib virtual (or on an
+            // override site whose root is a corlib virtual) get an explanatory hint instead of
+            // a silently-empty response. The service-side guard in ReferenceService.FindOverridesAsync
+            // also returns empty for the corlib case (defense-in-depth for member_hierarchy.overrides),
+            // but the service surface returns IReadOnlyList<SymbolDto> with no hint channel, so the
+            // wrapper layer is where the explanatory text lives.
+            var solution = workspaceManager.GetCurrentSolution(workspaceId);
+            var resolved = await SymbolResolver.ResolveAsync(solution, locator, c).ConfigureAwait(false);
+            if (resolved is not null && ReferenceService.IsCorlibVirtualMember(ReferenceService.PromoteToVirtualRoot(resolved)))
+            {
+                var hint =
+                    "Resolved to a corlib virtual member (e.g. System.Object.ToString / Equals / " +
+                    "GetHashCode, System.IDisposable.Dispose) — overrides list suppressed to avoid " +
+                    "an unbounded solution-wide enumeration. To enumerate concrete overrides, use " +
+                    "symbol_search to locate the specific subclass first and then call find_overrides " +
+                    "on a non-corlib virtual in your own hierarchy, or call semantic_grep for the " +
+                    "method signature you need.";
+                return JsonSerializer.Serialize(
+                    new { count = 0, items = Array.Empty<SymbolDto>(), hint },
+                    JsonDefaults.Indented);
+            }
+
             var results = await referenceService.FindOverridesAsync(workspaceId, locator, c);
             return JsonSerializer.Serialize(new { count = results.Count, items = results }, JsonDefaults.Indented);
         }, ct);

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -155,6 +155,20 @@ public sealed class ReferenceService : IReferenceService
         // yield the same (complete) result set.
         var promoted = PromoteToVirtualRoot(symbol);
 
+        // find-overrides-payload-overflow-on-corlib-virtual (gh #754): once promotion lands on
+        // a corlib virtual (System.Object.ToString / Equals / GetHashCode, IDisposable.Dispose,
+        // etc.), SymbolFinder.FindOverridesAsync enumerates every concrete override across the
+        // solution — potentially hundreds of unrelated types, producing an unbounded payload.
+        // Mirror the suppression pattern in SymbolRelationshipService.GetSymbolRelationshipsAsync
+        // (gh #757): return an empty list immediately when the promoted symbol's containing type
+        // is a builtin SpecialType. This is defense-in-depth — the find_overrides wrapper also
+        // emits an explanatory hint at the tool layer. member_hierarchy.overrides (which routes
+        // through this method) silently benefits from the same guard.
+        if (IsCorlibVirtualMember(promoted))
+        {
+            return [];
+        }
+
         // member-hierarchy-overrides-mislabels-sibling-interface-impls (gh #736, gh #737):
         // FindOverridesAsync now returns ONLY true virtual/abstract overrides — symbols
         // actually marked `override` of a virtual/abstract declaration. Sibling interface
@@ -263,7 +277,13 @@ public sealed class ReferenceService : IReferenceService
     /// that <see cref="SymbolFinder.FindOverridesAsync"/> sees the full override chain. Returns
     /// the input symbol unchanged if it is not itself an override.
     /// </summary>
-    private static ISymbol PromoteToVirtualRoot(ISymbol symbol)
+    /// <remarks>
+    /// Exposed for the <c>find_overrides</c> tool wrapper so it can detect corlib-virtual
+    /// suppression (gh #754) and emit an explanatory hint without re-deriving the promotion
+    /// logic. Service-internal callers in this class also use it before invoking
+    /// <see cref="SymbolFinder.FindOverridesAsync"/>.
+    /// </remarks>
+    public static ISymbol PromoteToVirtualRoot(ISymbol symbol)
     {
         switch (symbol)
         {
@@ -318,6 +338,29 @@ public sealed class ReferenceService : IReferenceService
             default:
                 return symbol;
         }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="symbol"/> is a member (method/property/event) whose
+    /// containing type is a builtin corlib <see cref="SpecialType"/> — i.e.
+    /// <c>System.Object.ToString</c> / <c>Equals</c> / <c>GetHashCode</c>, <c>System.IDisposable.Dispose</c>,
+    /// etc. Used to short-circuit <see cref="SymbolFinder.FindOverridesAsync"/> on the corlib path
+    /// (gh #754), where the unbounded enumeration would otherwise return every concrete override
+    /// across the solution and overflow the MCP response cap.
+    /// </summary>
+    /// <remarks>
+    /// Pass the post-<see cref="PromoteToVirtualRoot"/> symbol — promotion is what walks an
+    /// override site (e.g. <c>MyClass.ToString</c>) up to the corlib virtual root the guard
+    /// is meant to suppress.
+    /// </remarks>
+    public static bool IsCorlibVirtualMember(ISymbol symbol)
+    {
+        if (symbol is not (IMethodSymbol or IPropertySymbol or IEventSymbol))
+        {
+            return false;
+        }
+
+        return symbol.ContainingType is { SpecialType: not SpecialType.None };
     }
 
     private static IMethodSymbol? TryFindImplicitlyImplementedInterfaceMember(IMethodSymbol method)

--- a/tests/RoslynMcp.Tests/FindOverridesCorlibSuppressionTests.cs
+++ b/tests/RoslynMcp.Tests/FindOverridesCorlibSuppressionTests.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression tests for <c>find-overrides-payload-overflow-on-corlib-virtual</c> (gh #754):
+/// when <c>find_overrides</c> resolves to a corlib virtual (e.g. <c>System.Object.ToString</c>,
+/// <c>Equals</c>, <c>GetHashCode</c>) — either directly via metadata-name or indirectly via
+/// promotion from an override site — <see cref="Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindOverridesAsync"/>
+/// would otherwise enumerate every concrete override across the solution, producing an
+/// unbounded payload. The fix adds a corlib-virtual guard that mirrors the suppression pattern
+/// in <c>symbol_relationships</c> (gh #757): the service returns an empty list immediately and
+/// the <c>find_overrides</c> tool wrapper emits an explanatory hint. <c>member_hierarchy.overrides</c>
+/// silently benefits from the same guard via its shared <c>FindOverridesAsync</c> code path.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class FindOverridesCorlibSuppressionTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+    private static string EquatablePointPath { get; set; } = null!;
+    private static string ShapePath { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+        var sampleRoot = Path.GetDirectoryName(SampleSolutionPath)!;
+        EquatablePointPath = Path.Combine(sampleRoot, "SampleLib", "Hierarchy", "EquatablePoint.cs");
+        ShapePath = Path.Combine(sampleRoot, "SampleLib", "Hierarchy", "Shape.cs");
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    // -------- Service-layer suppression --------
+
+    /// <summary>
+    /// Verifies the service-level corlib guard for <c>System.Object.ToString</c>. Without the
+    /// fix, <c>FindOverridesAsync</c> would enumerate every <c>ToString</c> override across
+    /// every project in the loaded solution. With the fix, the post-promotion symbol's
+    /// containing type is detected as a builtin <c>SpecialType</c> and an empty list is
+    /// returned immediately.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverridesAsync_ObjectToString_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.ByMetadataName("System.Object.ToString");
+
+        var results = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count,
+            "find_overrides on System.Object.ToString must be empty — pre-fix this enumerated every ToString override across the solution.");
+    }
+
+    /// <summary>
+    /// Verifies the service-level corlib guard for <c>System.Object.Equals</c>. The same
+    /// rationale as the <c>ToString</c> case: every type that overrides <c>Equals</c> would
+    /// otherwise surface here, producing an unbounded payload.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverridesAsync_ObjectEquals_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.ByMetadataName("System.Object.Equals");
+
+        var results = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count,
+            "find_overrides on System.Object.Equals must be empty — pre-fix this enumerated every Equals override across the solution.");
+    }
+
+    /// <summary>
+    /// Verifies the service-level corlib guard for <c>System.Object.GetHashCode</c>. Same
+    /// rationale as <c>ToString</c> / <c>Equals</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverridesAsync_ObjectGetHashCode_ReturnsEmpty()
+    {
+        var locator = SymbolLocator.ByMetadataName("System.Object.GetHashCode");
+
+        var results = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count,
+            "find_overrides on System.Object.GetHashCode must be empty — pre-fix this enumerated every GetHashCode override across the solution.");
+    }
+
+    /// <summary>
+    /// Source-positional anchor on the corlib-override site itself. <c>EquatablePoint.Equals(object?)</c>
+    /// at line 25 of <c>EquatablePoint.cs</c> overrides <c>System.Object.Equals(object?)</c>. After
+    /// the standard <c>PromoteToVirtualRoot</c> walks up to <c>System.Object.Equals</c>, the
+    /// corlib guard fires and suppresses enumeration. This guarantees the suppression behaves
+    /// identically whether the caller anchors on the corlib virtual via metadata name OR on an
+    /// override site that promotes to corlib.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverridesAsync_PositionalAnchorOnCorlibOverride_ReturnsEmpty()
+    {
+        // Line 25, col 30 lands on "Equals" of `public override bool Equals(object? obj) => ...`.
+        var locator = SymbolLocator.BySource(EquatablePointPath, line: 25, column: 30);
+
+        var results = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count,
+            "find_overrides on EquatablePoint.Equals(object?) must promote to System.Object.Equals and then suppress — pre-fix this enumerated every override across the solution.");
+    }
+
+    /// <summary>
+    /// Regression guard: the corlib suppression MUST NOT fire on non-corlib virtuals. Anchoring
+    /// on <c>Shape.Describe</c> (a <c>virtual</c> method declared in user code) must continue to
+    /// return the expected override chain (<c>Rectangle.Describe</c>). This is the test (c) the
+    /// plan calls out: "verifies suppression only fires after promotion" — promotion lands on a
+    /// user-declared virtual whose containing type has <c>SpecialType == None</c>, so the
+    /// guard's <c>IsCorlibVirtualMember</c> check returns <c>false</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverridesAsync_NonCorlibVirtual_ReturnsNonEmptyChain()
+    {
+        // Line 7, col 27 lands on "Describe" of `public virtual string Describe() => ...`. The
+        // same anchor is used by MemberHierarchyCrossToolConsistencyTests.VirtualOverrideChain_*.
+        var locator = SymbolLocator.BySource(ShapePath, line: 7, column: 27);
+
+        var results = await ReferenceService.FindOverridesAsync(
+            WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsTrue(results.Count > 0,
+            "find_overrides on the non-corlib virtual Shape.Describe must surface concrete overrides — the corlib guard must NOT short-circuit user-declared virtuals.");
+        Assert.IsTrue(
+            results.Any(symbol => symbol.FilePath?.EndsWith("Rectangle.cs", StringComparison.OrdinalIgnoreCase) == true),
+            "Rectangle.Describe should remain in the overrides list for Shape.Describe.");
+    }
+
+    // -------- Wrapper-layer hint emission --------
+
+    /// <summary>
+    /// The <c>find_overrides</c> tool wrapper detects the corlib path BEFORE calling the service
+    /// (the service still has the guard as defense-in-depth) and emits an explanatory
+    /// <c>hint</c> field in the JSON envelope. Verifies the hint is present, points at the
+    /// suppression reason, and that <c>count</c> / <c>items</c> are zero / empty so callers can
+    /// programmatically detect the suppression case.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverrides_Wrapper_CorlibMetadataName_EmitsHint()
+    {
+        var json = await SymbolTools.FindOverrides(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            ReferenceService,
+            WorkspaceId,
+            metadataName: "System.Object.ToString",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("count", out var count), $"Envelope must include count. Got: {json}");
+        Assert.AreEqual(0, count.GetInt32(), "Corlib suppression envelope must report count=0.");
+        Assert.IsTrue(root.TryGetProperty("items", out var items), $"Envelope must include items array. Got: {json}");
+        Assert.AreEqual(0, items.GetArrayLength(), "Corlib suppression envelope must have an empty items array.");
+        Assert.IsTrue(root.TryGetProperty("hint", out var hint),
+            $"Corlib suppression envelope MUST include a hint field so the caller understands the empty result. Got: {json}");
+        var hintText = hint.GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(hintText), "Hint must be non-empty.");
+        Assert.IsTrue(hintText!.Contains("corlib", StringComparison.OrdinalIgnoreCase),
+            $"Hint should mention the corlib suppression reason. Got: {hintText}");
+    }
+
+    /// <summary>
+    /// Regression guard for the wrapper: when the locator does NOT resolve to a corlib virtual,
+    /// the wrapper must call the service normally and emit the legacy <c>{ count, items }</c>
+    /// envelope WITHOUT a <c>hint</c> field. Verifies the suppression code path doesn't bleed
+    /// into the normal case.
+    /// </summary>
+    [TestMethod]
+    public async Task FindOverrides_Wrapper_NonCorlibVirtual_NoHint()
+    {
+        var json = await SymbolTools.FindOverrides(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            ReferenceService,
+            WorkspaceId,
+            filePath: ShapePath,
+            line: 7,
+            column: 27,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("count", out var count), $"Envelope must include count. Got: {json}");
+        Assert.IsTrue(count.GetInt32() > 0,
+            "find_overrides on the non-corlib virtual Shape.Describe must surface concrete overrides — the wrapper must NOT short-circuit user-declared virtuals.");
+        Assert.IsFalse(root.TryGetProperty("hint", out _),
+            $"Non-corlib envelope MUST NOT include a hint field — that would indicate the suppression code path leaked into the normal case. Got: {json}");
+    }
+}

--- a/tests/RoslynMcp.Tests/MetadataNameLocatorTests.cs
+++ b/tests/RoslynMcp.Tests/MetadataNameLocatorTests.cs
@@ -63,6 +63,7 @@ public sealed class MetadataNameLocatorTests : SharedWorkspaceTestBase
     {
         var json = await SymbolTools.FindOverrides(
             WorkspaceExecutionGate,
+            WorkspaceManager,
             ReferenceService,
             WorkspaceId,
             metadataName: "SampleLib.IAnimal.Speak",


### PR DESCRIPTION
## Summary

- Adds a corlib-virtual guard to `ReferenceService.FindOverridesAsync` so anchoring on `System.Object.ToString` / `Equals` / `GetHashCode` (directly or via promotion from an override site) no longer enumerates every concrete override across the solution. Returns an empty list immediately.
- The `find_overrides` tool wrapper resolves+promotes the symbol up-front so it can emit `{ count: 0, items: [], hint }` on the corlib path; the hint explains the suppression and points at recovery paths.
- `member_hierarchy.overrides` silently benefits from the same service-side guard via the shared `FindOverridesAsync` code path (no DTO change needed; `MemberHierarchyDto` does not carry a `Hint` field — that would be a follow-on).
- `PromoteToVirtualRoot` is now public alongside a new `IsCorlibVirtualMember` helper so the wrapper layer can detect the suppression case without re-deriving the promotion logic.

Mirrors the existing suppression pattern from `SymbolRelationshipService.GetSymbolRelationshipsAsync` (gh #757).

## Test plan

- [x] `mcp__roslyn__compile_check` on `ReferenceService.cs`, `SymbolTools.cs`, and `FindOverridesCorlibSuppressionTests.cs` — all clean.
- [x] `mcp__roslyn__test_run --filter "FindOverridesCorlibSuppression|MemberHierarchyCrossToolConsistency"` — 9/9 passing.
- [x] Broader regression sweep `FindOverrides|FindBaseMembers|MemberHierarchy|MetadataNameLocator` — 19/19 passing.
- [x] `SymbolRelationships` tests — 3/3 passing (parity check; sibling suppression path unaffected).
- [x] `verify-ai-docs.ps1` — passes.
- [x] `verify-changelog-fragments.ps1` — 8 fragments valid.
- [ ] CI verify-release on the self-hosted runner (deferred to CI; user policy is to not duplicate locally while the runner is active).

## New test coverage (`FindOverridesCorlibSuppressionTests`)

Service layer:
- `FindOverridesAsync_ObjectToString_ReturnsEmpty`
- `FindOverridesAsync_ObjectEquals_ReturnsEmpty`
- `FindOverridesAsync_ObjectGetHashCode_ReturnsEmpty`
- `FindOverridesAsync_PositionalAnchorOnCorlibOverride_ReturnsEmpty` — anchors on `EquatablePoint.Equals(object?)`, verifies promote-then-suppress
- `FindOverridesAsync_NonCorlibVirtual_ReturnsNonEmptyChain` — `Shape.Describe` regression guard

Wrapper layer:
- `FindOverrides_Wrapper_CorlibMetadataName_EmitsHint`
- `FindOverrides_Wrapper_NonCorlibVirtual_NoHint`

Closes: find-overrides-payload-overflow-on-corlib-virtual
Fixes: #754