### PR TITLE
fix(review_test_coverage): cap discovered-tests list at 50 via SerializeTruncatedList

### DIFF
--- a/changelog.d/review-test-coverage-prompt-payload-overflow.md
+++ b/changelog.d/review-test-coverage-prompt-payload-overflow.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `review_test_coverage` prompt payload overflow: the rendered prompt now caps the embedded test-discovery list at 50 entries (previously up to 200) using the existing `SerializeTruncatedList` helper, keeping prompt payloads well under the MCP inline cap for large test suites. Closes gh #756.

--- a/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.AnalysisWorkflows.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.AnalysisWorkflows.cs
@@ -216,13 +216,17 @@ public static partial class RoslynPrompts
         try
         {
             var discovered = await testDiscoveryService.DiscoverTestsAsync(workspaceId, ct).ConfigureAwait(false);
-            var totalTests = discovered.TestProjects.Sum(p => p.Tests.Count);
-            var perProject = Math.Max(1, 200 / Math.Max(1, discovered.TestProjects.Count));
-            var truncatedProjects = discovered.TestProjects.Select(p =>
-                new Core.Models.TestProjectDto(p.ProjectName, p.ProjectFilePath, p.Tests.Take(perProject).ToList())).ToList();
-            var discoveredJson = JsonSerializer.Serialize(new Core.Models.TestDiscoveryDto(truncatedProjects), JsonDefaults.Indented);
-            if (totalTests > 200)
-                discoveredJson += $"\n[Showing ~200 of {totalTests} test cases]";
+            // review-test-coverage-prompt-payload-overflow (gh #756): the prompt previously
+            // applied a per-project cap of `200 / project_count` and embedded the resulting
+            // TestDiscoveryDto verbatim, so single-project solutions kept all 200 cases and
+            // pushed the JSON body past 100 KB on large test suites. Flatten the test cases
+            // into a single list, cap at 50 entries (consistent with the SerializeTruncatedList
+            // helper used elsewhere — see guided_extract_interface, analyze_dependencies), and
+            // let the helper emit the `[Showing N of M items]` footer. Callers needing the
+            // full list invoke `test_discover` directly; this section is orientation-only.
+            const int testCaseCap = 50;
+            var allTestCases = discovered.TestProjects.SelectMany(p => p.Tests).ToList();
+            var discoveredJson = PromptMessageBuilder.SerializeTruncatedList(allTestCases, testCaseCap, JsonDefaults.Indented);
 
             return
             [

--- a/tests/RoslynMcp.Tests/PromptSmokeTests.cs
+++ b/tests/RoslynMcp.Tests/PromptSmokeTests.cs
@@ -634,4 +634,83 @@ public sealed class PromptSmokeTests : SharedWorkspaceTestBase
             string workspaceId, string? projectFilter, bool includeTransitive, CancellationToken ct) =>
             throw new NotSupportedException();
     }
+
+    // review-test-coverage-prompt-payload-overflow (gh #756): the prompt previously
+    // applied a per-project cap of `200 / project_count` and serialized the full
+    // TestDiscoveryDto verbatim, so a single-project solution kept all 200 cases and
+    // pushed the JSON body past 100 KB on large suites. The fix flattens the test
+    // cases into a single list and caps at 50 entries via SerializeTruncatedList. This
+    // test exercises a 300-case single-project synthetic suite to guard the cap and
+    // bound the rendered prompt length so future template growth cannot silently
+    // re-open the regression. Note: the plan stanza cited a 25 000 char threshold but
+    // — mirroring the sibling AnalyzeDependencies test's 50 000 deviation from a 25 000
+    // budget — realistic indented JSON for 50 TestCaseDto items with ~120-150 char
+    // FullyQualifiedName values produces a body in the 22-28 KB range, so we set the
+    // bound at 30 000 to leave headroom against drift while still meaningfully
+    // guarding against the pre-cap regression (which would have produced ~150 KB).
+    [TestMethod]
+    public async Task ReviewTestCoverage_LargeTestSuite_PromptFitsInlineCap()
+    {
+        const int totalTestCases = 300;
+        const string fakeWorkspaceId = "fake-large-test-discovery-workspace";
+
+        var stubDiscovery = new StubTestDiscoveryServiceForReviewTestCoverage(
+            testCaseCount: totalTestCases);
+
+        var messages = (await RoslynPrompts.ReviewTestCoverage(
+            stubDiscovery,
+            workspaceId: fakeWorkspaceId,
+            projectName: null,
+            CancellationToken.None)).ToList();
+
+        Assert.AreEqual(1, messages.Count);
+        var text = GetText(messages[0]);
+
+        Assert.IsTrue(text.Length < 30_000,
+            $"Prompt body must fit under the inline payload cap. Actual length: {text.Length} chars.");
+
+        StringAssert.Contains(text, $"[Showing 50 of {totalTestCases} items]",
+            "Discovered test cases must be capped at 50 entries with a count footer.");
+        StringAssert.Contains(text, "test_coverage",
+            "Prompt must direct callers to test_coverage for coverage collection.");
+    }
+
+    // review-test-coverage-prompt-payload-overflow (gh #756): stub that returns a
+    // synthetic TestDiscoveryDto with a single project containing the requested number
+    // of test cases. Each TestCaseDto uses realistic field lengths
+    // (DisplayName ~30 chars, FullyQualifiedName ~120-150 chars, FilePath ~80 chars,
+    // Line int) so the post-cap rendered body approximates production payload weight.
+    // The Find* members are unreachable from ReviewTestCoverage and throw to surface
+    // mis-wiring.
+    private sealed class StubTestDiscoveryServiceForReviewTestCoverage : ITestDiscoveryService
+    {
+        private readonly TestDiscoveryDto _discovery;
+
+        public StubTestDiscoveryServiceForReviewTestCoverage(int testCaseCount)
+        {
+            var tests = Enumerable.Range(0, testCaseCount).Select(i => new TestCaseDto(
+                DisplayName: $"TestMethod_{i:D4}_VerifiesExpectedBehavior",
+                FullyQualifiedName: $"Contoso.Application.SubsystemAlpha.Module{i % 20:D3}.UnitTests.TestClass{i % 50:D3}Tests.TestMethod_{i:D4}_VerifiesExpectedBehavior",
+                FilePath: $@"C:\fake\path\Contoso.Application\Module{i % 20:D3}\TestClass{i % 50:D3}Tests.cs",
+                Line: 50 + (i % 200))).ToList();
+
+            var project = new TestProjectDto(
+                ProjectName: "Contoso.Application.UnitTests",
+                ProjectFilePath: @"C:\fake\path\Contoso.Application.UnitTests\Contoso.Application.UnitTests.csproj",
+                Tests: tests);
+
+            _discovery = new TestDiscoveryDto(TestProjects: new[] { project });
+        }
+
+        public Task<TestDiscoveryDto> DiscoverTestsAsync(string workspaceId, CancellationToken ct) =>
+            Task.FromResult(_discovery);
+
+        public Task<RelatedTestsForSymbolDto> FindRelatedTestsAsync(
+            string workspaceId, SymbolLocator locator, int maxResults, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<RelatedTestsForFilesDto> FindRelatedTestsForFilesAsync(
+            string workspaceId, IReadOnlyList<string> filePaths, int maxResults, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
 }


### PR DESCRIPTION
## Summary

- `review_test_coverage` prompt previously embedded the full `TestDiscoveryDto` with a per-project cap of `200 / project_count`, so single-project solutions kept all 200 cases and the JSON body crossed 100 KB on large suites.
- Replace the inline `JsonSerializer.Serialize` with `PromptMessageBuilder.SerializeTruncatedList(allTestCases, 50, JsonDefaults.Indented)` — same helper / same 50-cap pattern as the sibling `guided_extract_interface` and `analyze_dependencies` prompts. The helper auto-appends `[Showing 50 of N items]` so the prior bespoke truncation footer is dropped.
- New regression test `ReviewTestCoverage_LargeTestSuite_PromptFitsInlineCap` exercises a 300-case single-project synthetic suite, asserts the rendered body is < 30 000 chars (post-cap), and verifies the footer / `test_coverage` callout are present.

## Implementation notes

- Threshold deviates from the plan's 25 000-char bound: realistic indented JSON for 50 `TestCaseDto` items with ~120-150 char FullyQualifiedNames produces a body in the 22-28 KB range, mirroring the sibling `AnalyzeDependencies_LargeWorkspace_PromptFitsInlineCap` test's 50 000-char deviation from a similar 25 000 budget. 30 000 leaves headroom while still meaningfully guarding the pre-cap ~150 KB regression.
- Adjacent `review_complexity` prompt (line 263) also embeds raw `JsonSerializer.Serialize(metrics, ...)` with no cap — separate method, different service, separate row; not bundled per Rule 1.

## Test plan

- [x] `mcp__roslyn__compile_check` — 0 errors on both modified files
- [x] `mcp__roslyn__test_run --filter PromptSmokeTests` — 15/15 passed (including new test)
- [ ] CI `verify-release.ps1` (self-hosted runner)
- [ ] CI `verify-ai-docs.ps1`

Closes: `review-test-coverage-prompt-payload-overflow`
Fixes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)