### PR TITLE
fix(find_property_writes): emit locator-aware hint when metadataName resolves to non-property

### DIFF
--- a/changelog.d/find-property-writes-metadataname-hint-mismatches-input-shape.md
+++ b/changelog.d/find-property-writes-metadataname-hint-mismatches-input-shape.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_property_writes` returning position-shaped hint text (`"Position resolved to a Field"`, `"Verify the column points at the symbol identifier"`) when the caller supplied `metadataName` instead of `filePath+line+column`. The `hint` field in the response now reflects the locator mode that was actually used, matching the behavior of other locator-aware error messages in the server. Closes gh #758.

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -650,16 +650,30 @@ public static class SymbolTools
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var (results, resolvedKind) = await mutationAnalysisService.FindPropertyWritesWithMetadataAsync(workspaceId, locator, c);
-            // FLAG-3C: when the position resolves to a field or other non-property symbol,
-            // return a structured disambiguation hint instead of a silent empty array.
+            // FLAG-3C: when the resolve target turns out to be a field or other non-property
+            // symbol, return a structured disambiguation hint instead of a silent empty array.
+            // find-property-writes-metadataname-hint-mismatches-input-shape (gh #758): the hint
+            // wording must reflect the locator mode the caller actually supplied — pre-fix the
+            // strings hardcoded "Position" / "column" even when the caller passed only
+            // metadataName or symbolHandle, pointing the agent at a non-existent source position
+            // to debug. Mirrors the locator-aware branching in
+            // SymbolLocatorFactory.FormatSymbolNotFoundMessage.
             string? hint = null;
             if (results.Count == 0 && resolvedKind is not null && resolvedKind != "Property")
             {
-                hint = $"Position resolved to a {resolvedKind}, not a property. Use find_references for fields and other symbol kinds.";
+                hint = locator.HasMetadataName
+                    ? $"metadataName resolved to a {resolvedKind}, not a property. Use find_references for fields and other symbol kinds."
+                    : locator.HasHandle
+                        ? $"Symbol handle resolved to a {resolvedKind}, not a property. Use find_references for fields and other symbol kinds."
+                        : $"Position resolved to a {resolvedKind}, not a property. Use find_references for fields and other symbol kinds.";
             }
             else if (results.Count == 0 && resolvedKind is null)
             {
-                hint = "No symbol resolved at the given position. Verify the column points at the symbol identifier.";
+                hint = locator.HasMetadataName
+                    ? "No symbol resolved for the given metadataName. Verify the fully qualified name (e.g. Namespace.TypeName.PropertyName) and that the containing type is loaded in this workspace."
+                    : locator.HasHandle
+                        ? "No symbol resolved for the given symbol handle. Re-acquire the handle from a current semantic tool call — handles may stale after a workspace reload."
+                        : "No symbol resolved at the given position. Verify the column points at the symbol identifier.";
             }
             return JsonSerializer.Serialize(new { count = results.Count, resolvedSymbolKind = resolvedKind, hint, writes = results }, JsonDefaults.Indented);
         }, ct);

--- a/tests/RoslynMcp.Tests/FindPropertyWritesHintLocatorShapeTests.cs
+++ b/tests/RoslynMcp.Tests/FindPropertyWritesHintLocatorShapeTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression coverage for <c>find-property-writes-metadataname-hint-mismatches-input-shape</c> (gh #758).
+/// Pre-fix, the <c>find_property_writes</c> tool wrapper hardcoded "Position" / "column" in the
+/// soft hint emitted when <c>resolvedSymbolKind</c> indicated a non-property symbol or a null
+/// resolution — even when the caller supplied <c>metadataName</c> (no source position at all).
+/// The hint must reflect the locator mode actually used so agents debug the right input field.
+/// Mirrors the locator-aware branching in <see cref="SymbolLocatorFactory.FormatSymbolNotFoundMessage"/>.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class FindPropertyWritesHintLocatorShapeTests : SharedWorkspaceTestBase
+{
+    private static string CopiedRoot { get; set; } = null!;
+    private static string CopiedSolutionPath { get; set; } = null!;
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        CopiedSolutionPath = CreateSampleSolutionCopy();
+        CopiedRoot = Path.GetDirectoryName(CopiedSolutionPath)!;
+
+        // Fixture: a class with a public instance field. FindPropertyWritesWithMetadataAsync
+        // resolves the field symbol but rejects it (`symbol is not IPropertySymbol`), returning
+        // (empty, "Field"). The wrapper's non-property branch then fires.
+        var fixturePath = Path.Combine(CopiedRoot, "SampleLib", "HintLocatorShapeFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, """
+namespace SampleLib;
+
+public sealed class HintLocatorShapeProbe
+{
+    public int Counter;
+}
+""", CancellationToken.None);
+
+        var status = await WorkspaceManager.LoadAsync(CopiedSolutionPath, CancellationToken.None);
+        WorkspaceId = status.WorkspaceId;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        if (WorkspaceId is not null)
+        {
+            try { WorkspaceManager.Close(WorkspaceId); } catch { }
+        }
+        DeleteDirectoryIfExists(CopiedRoot);
+        DisposeServices();
+    }
+
+    /// <summary>
+    /// metadataName + non-property resolution: caller passed only <c>metadataName</c>, the symbol
+    /// resolves to a Field, the wrapper emits a hint. The hint must name <c>metadataName</c> as
+    /// the locator field to verify and MUST NOT mention "position" / "column" — those refer to a
+    /// locator mode the caller never used.
+    /// </summary>
+    [TestMethod]
+    public async Task FindPropertyWrites_MetadataName_NonPropertySymbol_HintNamesMetadataNotPosition()
+    {
+        var json = await SymbolTools.FindPropertyWrites(
+            WorkspaceExecutionGate,
+            MutationAnalysisService,
+            WorkspaceId,
+            metadataName: "SampleLib.HintLocatorShapeProbe.Counter",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(0, root.GetProperty("count").GetInt32(),
+            $"Field anchor must produce zero writes (the service rejects non-property symbols). Got: {json}");
+        Assert.AreEqual("Field", root.GetProperty("resolvedSymbolKind").GetString(),
+            $"resolvedSymbolKind must reflect the actual symbol kind. Got: {json}");
+
+        Assert.IsTrue(root.TryGetProperty("hint", out var hint),
+            $"Wrapper must emit a hint when resolvedSymbolKind is non-Property. Got: {json}");
+        var hintText = hint.GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(hintText), $"Hint must be non-empty. Got: {json}");
+
+        // The hint must name the locator mode the caller actually used.
+        Assert.IsTrue(
+            hintText!.Contains("metadataName", StringComparison.Ordinal),
+            $"Hint must mention 'metadataName' so the caller knows which locator field to debug. Got: {hintText}");
+
+        // Pre-fix wording leaked: "Position resolved to a Field..." / "...the column points...".
+        // Both substrings point the agent at a source position they never supplied, so they must
+        // be absent from the metadataName-mode hint.
+        Assert.IsFalse(
+            hintText.Contains("Position", StringComparison.OrdinalIgnoreCase),
+            $"Hint must NOT mention 'Position' when the caller supplied metadataName. Got: {hintText}");
+        Assert.IsFalse(
+            hintText.Contains("column", StringComparison.OrdinalIgnoreCase),
+            $"Hint must NOT mention 'column' when the caller supplied metadataName. Got: {hintText}");
+    }
+
+    /// <summary>
+    /// metadataName + no resolution: caller passed a bogus <c>metadataName</c> the resolver
+    /// cannot match, so the service returns (empty, null) and the wrapper's null-resolve branch
+    /// fires. Same invariant: the hint must name <c>metadataName</c> and avoid "position" /
+    /// "column" — the legacy "Verify the column points at the symbol identifier" wording leaked
+    /// here too.
+    /// </summary>
+    [TestMethod]
+    public async Task FindPropertyWrites_MetadataName_NoResolution_HintNamesMetadataNotPosition()
+    {
+        var json = await SymbolTools.FindPropertyWrites(
+            WorkspaceExecutionGate,
+            MutationAnalysisService,
+            WorkspaceId,
+            metadataName: "SampleLib.HintLocatorShapeProbe.NonExistentMember",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(0, root.GetProperty("count").GetInt32(),
+            $"Unresolved metadataName must produce zero writes. Got: {json}");
+        Assert.AreEqual(JsonValueKind.Null, root.GetProperty("resolvedSymbolKind").ValueKind,
+            $"resolvedSymbolKind must be null when the symbol cannot be resolved. Got: {json}");
+
+        Assert.IsTrue(root.TryGetProperty("hint", out var hint),
+            $"Wrapper must emit a hint when the symbol does not resolve. Got: {json}");
+        var hintText = hint.GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(hintText), $"Hint must be non-empty. Got: {json}");
+
+        Assert.IsTrue(
+            hintText!.Contains("metadataName", StringComparison.Ordinal),
+            $"Null-resolve hint must mention 'metadataName' so the caller knows which locator field to debug. Got: {hintText}");
+
+        Assert.IsFalse(
+            hintText.Contains("position", StringComparison.OrdinalIgnoreCase),
+            $"Null-resolve hint must NOT mention 'position' when the caller supplied metadataName. Got: {hintText}");
+        Assert.IsFalse(
+            hintText.Contains("column", StringComparison.OrdinalIgnoreCase),
+            $"Null-resolve hint must NOT mention 'column' when the caller supplied metadataName. Got: {hintText}");
+    }
+}


### PR DESCRIPTION
## Summary

`find_property_writes` returned position-shaped hint text — `\"Position resolved to a Field\"` and `\"Verify the column points at the symbol identifier\"` — even when the caller supplied only `metadataName` (no source position at all). The hint pointed agents at a locator field they never used.

This PR replaces the hardcoded wording in the `find_property_writes` tool wrapper with locator-aware variants that mirror `SymbolLocatorFactory.FormatSymbolNotFoundMessage`:

- **Non-property branch:** names \`metadataName\` / \`symbol handle\` / \`Position\` depending on which mode the locator carries.
- **Null-resolve branch:** guides toward the correct field to verify (FQN for \`metadataName\`, re-acquire for \`symbolHandle\`, position for source location).

No service-layer changes — the fix is purely in the tool wrapper's hint-string selection.

## Test plan

- [x] New test file \`tests/RoslynMcp.Tests/FindPropertyWritesHintLocatorShapeTests.cs\` covers both branches:
  - \`FindPropertyWrites_MetadataName_NonPropertySymbol_HintNamesMetadataNotPosition\` — \`metadataName\` → Field, hint contains \"metadataName\", excludes \"Position\"/\"column\".
  - \`FindPropertyWrites_MetadataName_NoResolution_HintNamesMetadataNotPosition\` — bogus \`metadataName\` → null resolve, same invariant.
- [x] Existing \`FindPropertyWritesPositionalRecordTests\` still pass — position-mode hint untouched.
- [x] \`mcp__roslyn__compile_check\` on both edited files: zero errors.
- [x] \`mcp__roslyn__test_run --filter\` on both classes: 4/4 pass.

Closes: find-property-writes-metadataname-hint-mismatches-input-shape
Fixes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)