### PR TITLE
fix(workspace_status): drop LoadLock acquire from GetStatus/GetStatusAsync

### DIFF
--- a/changelog.d/workspace-status-verbose-5s-timeout-race-on-ready-workspace.md
+++ b/changelog.d/workspace-status-verbose-5s-timeout-race-on-ready-workspace.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_status(verbose=true)` timing out at 5 s on a ready workspace when a concurrent or recently-completed load held `session.LoadLock`. `GetStatus` and `GetStatusAsync` no longer acquire `LoadLock`; `BuildStatus` reads only thread-safe fields (`ImmutableArray`, `ConcurrentQueue`, scalar references) that do not require the lock, and the outer `gate.RunReadAsync` already serializes against concurrent writes. Fixes gh #761.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -433,44 +433,30 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     {
         var session = GetRequiredSession(workspaceId);
 
-        // Acquire LoadLock to avoid reading partially-updated session state
-        // during a concurrent LoadIntoSessionAsync.
-        if (!session.LoadLock.Wait(TimeSpan.FromSeconds(5)))
-        {
-            _logger.LogWarning("GetStatus timed out waiting for LoadLock on {WorkspaceId}", workspaceId);
-            throw new TimeoutException(
-                $"Workspace '{workspaceId}' is currently loading. Try again shortly.");
-        }
-
-        try
-        {
-            return BuildStatus(session);
-        }
-        finally
-        {
-            session.LoadLock.Release();
-        }
+        // workspace-status-verbose-5s-timeout-race-on-ready-workspace: do NOT acquire LoadLock here.
+        // BuildStatus only reads thread-safe fields: ProjectStatuses is an ImmutableArray (atomic
+        // reference replacement), WorkspaceDiagnostics is a ConcurrentQueue (concurrent-read safe),
+        // and the remaining scalar reads (LoadedPath, Workspace, Version, LoadedAtUtc, RestoreRequired)
+        // are individual reference/value reads that the field types and Volatile.Read on Version
+        // already make safe. Any cross-field "snapshot consistency" the lock might have preserved
+        // is illusory — other callers of BuildStatus (LoadAsync's race-winner path, fresh-load return,
+        // ReloadAsync return, ListWorkspaces enumeration) already invoke it WITHOUT the lock, and the
+        // outer gate.RunReadAsync at the tool layer already serializes against concurrent writes via
+        // the per-workspace reader/writer lock. Pre-fix, this Wait(5s) raced an in-flight
+        // LoadIntoSessionAsync (which holds LoadLock for the entire MSBuild load — 30+ seconds on
+        // medium solutions) and timed out on a workspace that workspace_status had just reported
+        // isReady=true moments earlier.
+        return BuildStatus(session);
     }
 
-    public async Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default)
+    public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default)
     {
         var session = GetRequiredSession(workspaceId);
 
-        if (!await session.LoadLock.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false))
-        {
-            _logger.LogWarning("GetStatus timed out waiting for LoadLock on {WorkspaceId}", workspaceId);
-            throw new TimeoutException(
-                $"Workspace '{workspaceId}' is currently loading. Try again shortly.");
-        }
-
-        try
-        {
-            return BuildStatus(session);
-        }
-        finally
-        {
-            session.LoadLock.Release();
-        }
+        // See GetStatus above: BuildStatus reads only thread-safe fields, so no LoadLock is required.
+        // The outer gate.RunReadAsync already serializes against concurrent writes.
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(BuildStatus(session));
     }
 
     public ProjectGraphDto GetProjectGraph(string workspaceId)

--- a/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Tests.Helpers;
@@ -259,6 +261,84 @@ public sealed class WorkspaceToolsIntegrationTests : SharedWorkspaceTestBase
                 "ffffffffffffffffffffffffffffffff",
                 _ => Task.FromResult("x"),
                 CancellationToken.None));
+    }
+
+    // workspace-status-verbose-5s-timeout-race-on-ready-workspace: regression test for gh #761.
+    // Pre-fix, `workspace_status(verbose=true)` acquired the per-session `LoadLock` (SemaphoreSlim)
+    // with a 5-second hard timeout before calling `BuildStatus`. When a concurrent
+    // `LoadIntoSessionAsync` held the lock for the duration of an MSBuild workspace load (30+ s on
+    // medium solutions), the verbose-status call timed out and threw `TimeoutException` — even
+    // though the workspace had reported `isReady=true` to a `verbose=false` call moments earlier.
+    // The fix removes the lock acquire entirely: `BuildStatus` reads only thread-safe fields
+    // (ImmutableArray, ConcurrentQueue, scalar refs) and the outer `gate.RunReadAsync` already
+    // serializes against concurrent writes. This test simulates the contention by holding the
+    // session's LoadLock via reflection and asserting the verbose-status call completes in well
+    // under the pre-fix 5-second timeout window.
+    [TestMethod]
+    public async Task WorkspaceTools_GetWorkspaceStatus_Verbose_DoesNotBlockOnConcurrentLoadLock()
+    {
+        var session = GetWorkspaceSession(WorkspaceManager, WorkspaceId);
+        var loadLock = GetLoadLock(session);
+
+        // Hold the LoadLock to simulate an in-flight LoadIntoSessionAsync. Pre-fix, the verbose
+        // status path would wait 5 s on this semaphore and then throw TimeoutException.
+        await loadLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var json = await WorkspaceTools.GetWorkspaceStatus(
+                WorkspaceExecutionGate,
+                WorkspaceManager,
+                WorkspaceId,
+                verbose: true,
+                CancellationToken.None);
+            stopwatch.Stop();
+
+            // Generous upper bound: BuildStatus itself is sub-millisecond, but the outer gate
+            // (rate-limit, throttle, per-workspace reader lock, staleness check) adds overhead.
+            // 1000 ms is two orders of magnitude below the pre-fix 5005 ms ceiling and still well
+            // clear of any realistic gate overhead on a healthy workspace.
+            Assert.IsTrue(
+                stopwatch.ElapsedMilliseconds < 1000,
+                $"workspace_status(verbose=true) should not block on a held LoadLock; took {stopwatch.ElapsedMilliseconds} ms.");
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("projects", out var projects),
+                "Verbose mode must include the per-project tree.");
+            Assert.IsTrue(projects.GetArrayLength() >= 1);
+        }
+        finally
+        {
+            loadLock.Release();
+        }
+    }
+
+    private static object GetWorkspaceSession(object workspaceManager, string workspaceId)
+    {
+        // WorkspaceSession is a private nested type; access via the `_sessions` field on
+        // WorkspaceManager. We deliberately use reflection to drive the precise race condition
+        // (LoadLock held while a status call runs) — production code never reaches into the
+        // session directly.
+        var sessionsField = workspaceManager.GetType().GetField(
+            "_sessions", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(sessionsField, "WorkspaceManager._sessions field must exist.");
+        var sessions = sessionsField.GetValue(workspaceManager);
+        Assert.IsNotNull(sessions, "WorkspaceManager._sessions must be initialised.");
+        var indexer = sessions.GetType().GetProperty("Item", new[] { typeof(string) });
+        Assert.IsNotNull(indexer, "ConcurrentDictionary indexer must be discoverable via reflection.");
+        var session = indexer.GetValue(sessions, new object[] { workspaceId });
+        Assert.IsNotNull(session, $"Workspace session for '{workspaceId}' must be present.");
+        return session;
+    }
+
+    private static SemaphoreSlim GetLoadLock(object session)
+    {
+        var loadLockProperty = session.GetType().GetProperty(
+            "LoadLock", BindingFlags.Public | BindingFlags.Instance);
+        Assert.IsNotNull(loadLockProperty, "WorkspaceSession.LoadLock property must exist.");
+        var loadLock = loadLockProperty.GetValue(session) as SemaphoreSlim;
+        Assert.IsNotNull(loadLock, "WorkspaceSession.LoadLock must be a SemaphoreSlim instance.");
+        return loadLock;
     }
 
     private static string FindProgramPath()


### PR DESCRIPTION
## Summary

- `WorkspaceManager.GetStatus` and `GetStatusAsync` previously acquired the per-session `LoadLock` (`SemaphoreSlim(1,1)`) with a 5-second timeout before calling `BuildStatus`. `LoadIntoSessionAsync` holds the same lock for the entire MSBuild workspace load — 30+ seconds on medium solutions — so `workspace_status(verbose=true)` would throw `TimeoutException` on a workspace that had just reported `isReady=true` to a `verbose=false` call moments earlier (gh #761).
- The defense the lock provided is illusory: `BuildStatus` only reads `session.ProjectStatuses` (atomic `ImmutableArray` reference replacement), `session.WorkspaceDiagnostics` (`ConcurrentQueue` — concurrent-read safe), and simple scalar/reference reads. Other callers of `BuildStatus` (`LoadAsync` race-winner dedup, fresh-load return, `ReloadAsync` return, `ListWorkspaces` enumeration) already invoke it WITHOUT the lock, and the outer `gate.RunReadAsync` already serializes against concurrent writes via the per-workspace reader/writer lock.
- The fix removes both `LoadLock.Wait(5s)` / `LoadLock.WaitAsync(5s)` calls (plus their try/finally + Release) and reduces each method to a direct `BuildStatus(session)` call. A regression test in `WorkspaceToolsIntegrationTests` holds the `LoadLock` via reflection and asserts `workspace_status(verbose=true)` completes in under 1 second instead of timing out at 5005 ms.

## Test plan

- [x] `mcp__roslyn__compile_check` against `WorkspaceManager.cs` — 0 errors / 0 warnings
- [x] `mcp__roslyn__compile_check` against `WorkspaceToolsIntegrationTests.cs` — 0 errors / 0 warnings
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~WorkspaceToolsIntegrationTests"` — 16/16 pass (15 pre-existing + 1 new regression test)
- [x] `WorkspaceTools_GetWorkspaceStatus_Verbose_Includes_Projects` still passes
- [x] New `WorkspaceTools_GetWorkspaceStatus_Verbose_DoesNotBlockOnConcurrentLoadLock` test passes (would fail pre-fix with either `TimeoutException` or 5005 ms duration)
- [ ] Self-hosted CI runner: full `verify-release.ps1` + `verify-ai-docs.ps1`

Closes: workspace-status-verbose-5s-timeout-race-on-ready-workspace
Fixes #761

Generated with [Claude Code](https://claude.com/claude-code)