### PR TITLE
fix(analyze_control_flow): suppress partial-slice warning on succeeded zero-count void method

### DIFF
--- a/changelog.d/analyze-control-flow-partial-slice-warning-on-full-method.md
+++ b/changelog.d/analyze-control-flow-partial-slice-warning-on-full-method.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `analyze_control_flow` no longer emits a spurious "partial-slice" warning when the supplied line range covers an entire method body and the analysis succeeds with zero explicit control-flow exits (void method or complete block with no returns). The warning is now suppressed when `Succeeded = true` and entry/exit/return counts are all zero. Fixes gh #743.

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
@@ -114,9 +114,15 @@ public sealed class FlowAnalysisService : IFlowAnalysisService
             .ToList();
 
         string? warning = null;
-        if (!result.Succeeded ||
-            (entryPoints.Count == 0 && exitPoints.Count == 0 && returnStatements.Count == 0))
+        if (!result.Succeeded)
         {
+            // analyze-control-flow-partial-slice-warning-on-full-method (gh #743):
+            // Emit the partial-slice warning only when Roslyn's analysis genuinely failed
+            // (Succeeded=false). A succeeded result with zero entry/exit/return counts is
+            // structurally correct for a complete void method body with no explicit
+            // control-flow exits (e.g. `public void Foo() { int x = 1; }`) — suppress
+            // the warning entirely in that case rather than misreporting a successful
+            // analysis as incomplete.
             warning =
                 "Control-flow results may be incomplete for this line range. Prefer a range that covers full statement blocks within a single method body (not a partial slice of a method).";
         }

--- a/tests/RoslynMcp.Tests/FlowAnalysisServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FlowAnalysisServiceTests.cs
@@ -113,6 +113,64 @@ public class ExpressionBodiedSamples
     }
 
     [TestMethod]
+    public async Task AnalyzeControlFlow_FullMethodRange_NoSpuriousPartialSliceWarning()
+    {
+        // analyze-control-flow-partial-slice-warning-on-full-method (gh #743): pre-fix, a
+        // complete void method body whose range was supplied in full produced a succeeded
+        // analysis with zero entry/exit/return counts, and the unified warning branch
+        // misreported the result as "incomplete for this line range. Prefer a range that
+        // covers full statement blocks within a single method body (not a partial slice of
+        // a method)." Post-fix, that branch fires only when Succeeded == false; a succeeded
+        // zero-count result for a void block now returns Warning == null.
+
+        // Inject a void method fixture into the same target file. Append to the existing
+        // class body just before the closing brace so the existing tests at fixed line
+        // numbers stay valid.
+        var originalContent = await File.ReadAllTextAsync(TargetFilePath, CancellationToken.None);
+        var augmented = originalContent.TrimEnd().TrimEnd('}', '\r', '\n')
+            + Environment.NewLine
+            + Environment.NewLine
+            + "    public void VoidMethod() { int x = 1; }" + Environment.NewLine
+            + "}" + Environment.NewLine;
+
+        try
+        {
+            await File.WriteAllTextAsync(TargetFilePath, augmented, CancellationToken.None);
+            await WorkspaceManager.ReloadAsync(WorkspaceId, CancellationToken.None);
+
+            // VoidMethod lands on line 16 of the augmented fixture (original 15 lines + blank line + method line).
+            // Locate it dynamically so a small fixture shift cannot break the test.
+            var lines = augmented.Split('\n');
+            int methodLine = -1;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Contains("VoidMethod()"))
+                {
+                    methodLine = i + 1; // 1-based
+                    break;
+                }
+            }
+            Assert.IsTrue(methodLine > 0, "Could not locate VoidMethod in augmented fixture.");
+
+            var result = await FlowAnalysisService.AnalyzeControlFlowAsync(
+                WorkspaceId, TargetFilePath, startLine: methodLine, endLine: methodLine, CancellationToken.None);
+
+            Assert.IsTrue(result.Succeeded, "Roslyn should succeed on a complete void method body.");
+            Assert.AreEqual(0, result.EntryPoints.Count);
+            Assert.AreEqual(0, result.ExitPoints.Count);
+            Assert.AreEqual(0, result.ReturnStatements.Count, "Void body has no explicit returns.");
+            Assert.IsNull(result.Warning,
+                $"Expected no warning on a succeeded zero-count void method analysis. Actual: {result.Warning}");
+        }
+        finally
+        {
+            // Restore the fixture so other tests in this class continue to see fixed line offsets.
+            await File.WriteAllTextAsync(TargetFilePath, originalContent, CancellationToken.None);
+            await WorkspaceManager.ReloadAsync(WorkspaceId, CancellationToken.None);
+        }
+    }
+
+    [TestMethod]
     public async Task AnalyzeDataFlow_InvertedRange_ThrowsArgumentException()
     {
         // analyze-data-flow-inverted-range: pre-fix, inverted ranges fell through to the


### PR DESCRIPTION
## Summary

`analyze_control_flow` was emitting a misleading "Control-flow results may be incomplete for this line range. Prefer a range that covers full statement blocks within a single method body (not a partial slice of a method)." warning whenever a void method body with no explicit control-flow exits was analyzed in full. Roslyn's analysis genuinely succeeded with zero entry/exit/return counts — that is structurally correct for `public void Foo() { int x = 1; }`, not a partial-slice failure.

The unified `if (!result.Succeeded || (all-counts-zero))` guard in `FlowAnalysisService.AnalyzeControlFlowAsync` is split into two distinct cases:

- `!result.Succeeded` — emit the partial-slice warning (analysis genuinely failed).
- `result.Succeeded && entryPoints.Count == 0 && exitPoints.Count == 0 && returnStatements.Count == 0` — suppress the warning entirely.

The `EndPointIsReachable` warning branch and the expression-bodied synthesis path are unchanged.

## Test plan

- [x] `mcp__roslyn__compile_check` clean on `FlowAnalysisService.cs` and `FlowAnalysisServiceTests.cs`.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~FlowAnalysisServiceTests` — 8/8 pass (7 existing + 1 new).
- [x] New `AnalyzeControlFlow_FullMethodRange_NoSpuriousPartialSliceWarning` test asserts `Succeeded == true`, zero entry/exit/return counts, and `Warning == null` for the gh #743 repro shape.
- [x] Existing `AnalyzeControlFlow_StatementBodiedMethod_StillUsesStatementPath` and `AnalyzeControlFlow_ExpressionBodiedMethod_ReturnsSyntheticImplicitReturn` still pass — both warning branches preserve their prior behavior for their intended shapes.

Closes: analyze-control-flow-partial-slice-warning-on-full-method
Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)