### PR TITLE
fix(format_document_preview): return empty changes for no-op format pass

### DIFF
--- a/changelog.d/format-document-preview-empty-diff-instead-of-noop.md
+++ b/changelog.d/format-document-preview-empty-diff-instead-of-noop.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `format_document_preview` now returns `changes: []` for a no-op format pass (already-formatted document). Previously `DiffGenerator` emitted a header-only unified diff string (`--- a/...` / `+++ b/...` with no `@@` hunks) when the formatted document text was identical to the original, causing callers that check `changes.length > 0` to misidentify the result as pending changes. Fixes gh #739.

--- a/src/RoslynMcp.Roslyn/Helpers/DiffGenerator.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DiffGenerator.cs
@@ -100,6 +100,16 @@ public static class DiffGenerator
             sb.AppendLine($"# Re-read the full file with the Read tool or rerun with a smaller scope.");
         }
 
+        // format-document-preview-empty-diff-instead-of-noop (gh #739): when both texts are
+        // identical (or yielded only Unchanged lines), return string.Empty rather than the
+        // header-only string. This honors the docstring contract ("or an empty string if
+        // there are no differences") and lets callers — including SolutionDiffHelper.TryAdd
+        // and downstream `changes.length` checks — treat no-op formatter passes as no-ops.
+        if (hunksWritten == 0 && !truncated)
+        {
+            return string.Empty;
+        }
+
         return sb.ToString();
     }
 

--- a/src/RoslynMcp.Roslyn/Helpers/SolutionDiffHelper.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SolutionDiffHelper.cs
@@ -45,6 +45,15 @@ internal static class SolutionDiffHelper
 
         bool TryAdd(FileChangeDto change)
         {
+            // format-document-preview-empty-diff-instead-of-noop (gh #739): belt-and-suspenders
+            // guard — if DiffGenerator returned string.Empty (no net changes after a no-op
+            // formatter pass, despite distinct SourceText instances that bypassed the
+            // oldText == newText guard above), skip the entry so callers see an empty
+            // changes[] rather than a header-only diff with no hunks.
+            if (string.IsNullOrEmpty(change.UnifiedDiff))
+            {
+                return false;
+            }
             if (totalChars + change.UnifiedDiff.Length > DefaultMaxTotalChars)
             {
                 truncatedFiles.Add(change.FilePath);

--- a/tests/RoslynMcp.Tests/DiffGeneratorTests.cs
+++ b/tests/RoslynMcp.Tests/DiffGeneratorTests.cs
@@ -8,10 +8,40 @@ public class DiffGeneratorTests
     [TestMethod]
     public void Identical_Texts_Returns_Header_Only()
     {
+        // format-document-preview-empty-diff-instead-of-noop (gh #739): identical inputs now
+        // produce string.Empty rather than a header-only string. This aligns the impl with the
+        // <returns> docstring ("or an empty string if there are no differences") and prevents
+        // callers (e.g. SolutionDiffHelper.TryAdd) from misreading no-op formatter passes as
+        // pending changes. Pre-fix this test asserted the broken header-only behavior.
         var result = DiffGenerator.GenerateUnifiedDiff("hello\n", "hello\n", "test.cs");
-        StringAssert.Contains(result, "--- a/test.cs");
-        StringAssert.Contains(result, "+++ b/test.cs");
-        Assert.IsFalse(result.Contains("@@") && result.Contains("-hello"), "No diff hunks expected for identical text");
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    [TestMethod]
+    public void GenerateUnifiedDiff_IdenticalContent_ReturnsEmptyString()
+    {
+        // format-document-preview-empty-diff-instead-of-noop (gh #739): explicit assertion
+        // that the empty-string contract is honored across line endings and multi-line inputs.
+        var result = DiffGenerator.GenerateUnifiedDiff("line one\nline two\nline three\n", "line one\nline two\nline three\n", "file.cs");
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    [TestMethod]
+    public void GenerateUnifiedDiff_NoOpFormat_ProducesNoChangesEntry()
+    {
+        // format-document-preview-empty-diff-instead-of-noop (gh #739) repro: a Roslyn-formatted
+        // pass where the formatted text is identical to the input still produces distinct
+        // SourceText instances; SolutionDiffHelper.ComputeChangesAsync extracts strings and
+        // calls DiffGenerator. Even if the upstream `oldText == newText` guard misses (e.g.
+        // due to SourceText-level identity differences that materialize as identical strings
+        // here), DiffGenerator now returns string.Empty so the resulting FileChangeDto never
+        // makes it past SolutionDiffHelper.TryAdd's IsNullOrEmpty guard. Callers see
+        // `changes: []` for no-op format passes.
+        const string text = "namespace N { class C { void M() { } } }\n";
+        var result = DiffGenerator.GenerateUnifiedDiff(text, text, "C.cs");
+        Assert.AreEqual(string.Empty, result);
+        Assert.IsFalse(result.Contains("--- a/"), "Header lines must not appear when there are no differences.");
+        Assert.IsFalse(result.Contains("+++ b/"), "Header lines must not appear when there are no differences.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- `DiffGenerator.GenerateUnifiedDiff` now returns `string.Empty` when no hunks are written (identical-content / Unchanged-only diff), aligning the impl with the docstring contract ("or an empty string if there are no differences").
- `SolutionDiffHelper.TryAdd` skips empty `UnifiedDiff` entries as a belt-and-suspenders guard for the distinct-`SourceText`-identity path that bypasses the existing `oldText == newText` guard upstream.
- Updated the pre-existing `DiffGeneratorTests.Identical_Texts_Returns_Header_Only` test that asserted the OLD broken behavior; added two new tests covering the contract (`GenerateUnifiedDiff_IdenticalContent_ReturnsEmptyString`, `GenerateUnifiedDiff_NoOpFormat_ProducesNoChangesEntry`).

Result: `format_document_preview` returns `changes: []` for a no-op format pass (already-formatted document) instead of `changes: [{filePath, unifiedDiff: "<headers only>"}]`.

## Test plan

- [x] `DiffGeneratorTests` (13/13 pass) — includes the 2 new tests + the rewritten `Identical_Texts_Returns_Header_Only`.
- [x] `SolutionDiffHelperTests` (6/6 pass) — confirms existing `IdenticalText_ReturnsEmptyList`, `NoChanges_ReturnsEmptyList`, and truncation-sentinel paths are unaffected.
- [x] `RefactoringToolsIntegrationTests.FormatDocument_Preview_Returns_PreviewToken` (1/1 pass) — regression guard for the full `format_document_preview` integration path.
- [x] `TruncatedPreviewApplyGateTests` (4/4 pass) — confirms truncation-sentinel path is unaffected by the new `IsNullOrEmpty` filter in `TryAdd`.
- [x] `mcp__roslyn__compile_check` clean across all 3 modified files.

Closes: format-document-preview-empty-diff-instead-of-noop
Fixes #739