### PR TITLE
fix(workspace_changes): consolidate multi-file apply into single ledger entry (workspace-changes-atomic-batch-split-without-batchid)

### DIFF
--- a/changelog.d/workspace-changes-atomic-batch-split-without-batchid.md
+++ b/changelog.d/workspace-changes-atomic-batch-split-without-batchid.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_changes` splitting an atomic `apply_multi_file_edit` two-file batch into separate ledger entries: the multi-file apply path now records one consolidated change-tracker entry covering all affected files (matching the `apply_composite_preview` behavior), so `revert_apply_by_sequence` and callers reading `workspace_changes` see the batch as a single atomic unit. Fixes gh #740.

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -176,12 +176,26 @@ public sealed class EditService : IEditService
             }
 
             var result = await ApplyTextEditsCoreAsync(
-                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, document, sourceText, merged, toolName, ct).ConfigureAwait(false);
+                workspaceId, fileEdit.FilePath, fileEdit.Edits, current, document, sourceText, merged, toolName, ct,
+                suppressChangeTrackerRecord: true).ConfigureAwait(false);
             var diff = result.Changes.Count > 0
                 ? string.Join("\n", result.Changes.Select(ch => ch.UnifiedDiff))
                 : null;
             results.Add(new FileEditSummaryDto(fileEdit.FilePath, result.EditsApplied, diff));
         }
+
+        // workspace-changes-atomic-batch-split-without-batchid (gh #740): emit ONE
+        // change-tracker entry covering the whole batch, mirroring
+        // CompositeApplyOrchestrator's post-loop single-entry pattern at
+        // CompositeApplyOrchestrator.cs:82-83. The per-file Core path's RecordChange is
+        // suppressed via suppressChangeTrackerRecord:true above so a 2-file batch
+        // produces a single workspace_changes / IUndoService.CommitPendingCapture
+        // pair rather than splitting into N independent ledger entries.
+        var batchAffectedFiles = results.Select(r => r.FilePath).ToList();
+        _changeTracker?.RecordChange(workspaceId,
+            $"Apply text edits to {fileEdits.Count} file(s)",
+            batchAffectedFiles,
+            toolName);
 
         VerifyOutcomeDto? verification = null;
         if (verify)
@@ -537,6 +551,14 @@ public sealed class EditService : IEditService
     /// responsible for snapshotting before invoking this method (single-file path
     /// snapshots once; multi-file path snapshots once at the batch boundary).
     /// </summary>
+    /// <param name="suppressChangeTrackerRecord">
+    /// When true, skip the per-file <c>_changeTracker.RecordChange(...)</c> call so the
+    /// caller can emit a single batch-level entry covering all affected files. Used by
+    /// <see cref="ApplyMultiFileTextEditsAsync"/> so a 2-file batch produces ONE ledger
+    /// entry rather than splitting into per-file entries
+    /// (<c>workspace-changes-atomic-batch-split-without-batchid</c>, gh #740).
+    /// Mirrors <see cref="CompositeApplyOrchestrator"/>'s post-loop single-entry pattern.
+    /// </param>
     private async Task<TextEditResultDto> ApplyTextEditsCoreAsync(
         string workspaceId,
         string filePath,
@@ -546,7 +568,8 @@ public sealed class EditService : IEditService
         SourceText sourceText,
         SourceText newSourceText,
         string toolName,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool suppressChangeTrackerRecord = false)
     {
         var normalizedPath = Path.GetFullPath(filePath);
         var originalText = sourceText.ToString();
@@ -574,9 +597,12 @@ public sealed class EditService : IEditService
         var unified = DiffGenerator.GenerateUnifiedDiff(originalText, newText, filePath);
         var fileChange = new FileChangeDto(filePath, unified);
 
-        _changeTracker?.RecordChange(workspaceId,
-            $"Apply text edit to {Path.GetFileName(filePath)}",
-            [filePath], toolName);
+        if (!suppressChangeTrackerRecord)
+        {
+            _changeTracker?.RecordChange(workspaceId,
+                $"Apply text edit to {Path.GetFileName(filePath)}",
+                [filePath], toolName);
+        }
 
         return new TextEditResultDto(true, filePath, edits.Count, [fileChange], null);
     }

--- a/tests/RoslynMcp.Tests/ChangeTrackerTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeTrackerTests.cs
@@ -90,6 +90,53 @@ public sealed class ChangeTrackerTests : IsolatedWorkspaceTestBase
         Assert.AreEqual("apply_text_edit", changes[0].ToolName);
     }
 
+    /// <summary>
+    /// Regression test for workspace-changes-atomic-batch-split-without-batchid (gh #740):
+    /// an <c>apply_multi_file_edit</c> batch covering N files must produce exactly ONE
+    /// <see cref="ChangeTracker"/> entry whose <c>AffectedFiles</c> spans the whole batch,
+    /// mirroring <see cref="CompositeApplyOrchestrator"/>'s post-loop single-entry pattern.
+    /// Previously each per-file <see cref="EditService.ApplyTextEditsCoreAsync"/> emitted
+    /// its own entry, so a 2-file batch surfaced as 2 separate ledger rows and downstream
+    /// callers (<c>workspace_changes</c>, <c>revert_apply_by_sequence</c>) could not see
+    /// the batch as a single atomic unit.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyMultiFileEdit_TwoFileBatch_ProducesOneChangeTrackerEntry()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync();
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+
+        var dogEdit = new TextEditDto(1, 1, 1, 1, "// dog batch\n");
+        var catEdit = new TextEditDto(1, 1, 1, 1, "// cat batch\n");
+
+        var fileEdits = new[]
+        {
+            new FileEditsDto(dogFilePath, new[] { dogEdit }),
+            new FileEditsDto(catFilePath, new[] { catEdit }),
+        };
+
+        var dto = await EditService.ApplyMultiFileTextEditsAsync(
+            wsId, fileEdits, "apply_multi_file_edit", CancellationToken.None);
+        Assert.IsTrue(dto.Success, "Multi-file edit should apply.");
+        Assert.AreEqual(2, dto.FilesModified);
+
+        var changes = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, changes.Count,
+            "A 2-file apply_multi_file_edit batch must produce ONE consolidated " +
+            "ChangeTracker entry, not one per file — mirrors apply_composite_preview.");
+        Assert.AreEqual("apply_multi_file_edit", changes[0].ToolName,
+            "The single consolidated entry must surface with the originating tool name.");
+        Assert.AreEqual(2, changes[0].AffectedFiles.Count,
+            "The consolidated entry's AffectedFiles must span both files in the batch.");
+        CollectionAssert.Contains(changes[0].AffectedFiles.ToList(), dogFilePath);
+        CollectionAssert.Contains(changes[0].AffectedFiles.ToList(), catFilePath);
+    }
+
     [TestMethod]
     public async Task SetEditorConfigOption_RecordsEditorConfigToolName()
     {


### PR DESCRIPTION
## Summary

`apply_multi_file_edit` batches were splitting into per-file ledger entries because `ApplyTextEditsCoreAsync`'s per-file `_changeTracker?.RecordChange(...)` ran inside the multi-file `foreach` loop. A 2-file batch produced 2 separate `workspace_changes` rows, so `revert_apply_by_sequence` and callers reading the change-tracker could not see the batch as a single atomic unit (gh #740).

The fix mirrors `CompositeApplyOrchestrator`'s post-loop single-entry pattern (`CompositeApplyOrchestrator.cs:82-83`):

- Add `bool suppressChangeTrackerRecord = false` parameter to private `ApplyTextEditsCoreAsync` in `src/RoslynMcp.Roslyn/Services/EditService.cs`; gate the existing per-file `RecordChange` call on `!suppressChangeTrackerRecord`.
- `ApplyMultiFileTextEditsAsync` now passes `suppressChangeTrackerRecord: true` to the core path and emits a single batch-level `RecordChange(... "Apply text edits to N file(s)" ...)` covering all affected files after the per-file loop.
- The single-file `ApplyTextEditsAsync` path keeps the default (`false`) — its behavior is unchanged and it continues to emit one entry per call.

## Test plan

- [x] `mcp__roslyn__compile_check` on `EditService.cs` — 0 errors, 0 warnings
- [x] `mcp__roslyn__compile_check` on `ChangeTrackerTests.cs` — 0 errors, 0 warnings
- [x] New regression test `ChangeTrackerTests.ApplyMultiFileEdit_TwoFileBatch_ProducesOneChangeTrackerEntry` passes — asserts a 2-file `apply_multi_file_edit` batch produces exactly 1 ledger entry with `AffectedFiles.Count == 2` and `ToolName == "apply_multi_file_edit"`
- [x] All 10 `ChangeTrackerTests` pass (8 prior + the renamed-then-correct count of 9 existing + 1 new)
- [x] `EditUndoIntegrationTests.ApplyMultiFileEdit_ThenRevert_RestoresAllFiles` passes — the single batch-level undo snapshot still revert-correctly restores both files
- [x] `EditUndoIntegrationTests.ApplyTextEdit_RegistersUndoEntry` passes in isolation (the suite-level run flaked twice on a `DirectoryNotFoundException` on `Dog.cs` in two different tests of `EditUndoIntegrationTests` — a known parallel-cleanup race in `IsolatedWorkspaceTestBase`; both individual tests pass in isolation)
- [ ] CI on the self-hosted runner will exercise the full suite

Closes: `workspace-changes-atomic-batch-split-without-batchid`
Fixes #740