### PR TITLE
fix(validate_workspace): reconcile ChangeTracker auto-scope against git status

### DIFF
--- a/changelog.d/validate-workspace-changetracker-no-disk-reconcile-after-git-checkout.md
+++ b/changelog.d/validate-workspace-changetracker-no-disk-reconcile-after-git-checkout.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `validate_workspace(changedFilePaths=null)` returning stale file paths in `changedFilePaths` after an out-of-band revert (e.g. `git checkout -- <file>`). The ChangeTracker auto-scope list is now reconciled against `git status` before being used as the validation scope; reverted files are excluded. Fixes gh #738.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -153,6 +153,52 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     {
         var (changedFiles, unknownFiles) = ResolveChangedFiles(workspaceId, changedFilePaths);
 
+        // validate-workspace-changetracker-no-disk-reconcile-after-git-checkout (gh #738):
+        // when the caller omits changedFilePaths we fall back to the ChangeTracker's
+        // append-only log. The tracker has no mechanism to drop entries for files that
+        // were subsequently reverted out-of-band (e.g. `git checkout -- foo.cs`), so the
+        // raw fallback list can include files that are now clean on disk. Reconcile the
+        // tracker-derived list against `git status` and keep only files git still reports
+        // as dirty. On git-unavailable / non-git-repo conditions we degrade gracefully:
+        // the unfiltered tracker list is used as before so the no-git path keeps its
+        // existing semantics.
+        if (changedFilePaths is null or { Count: 0 } && changedFiles.Count > 0)
+        {
+            string? solutionDir;
+            try
+            {
+                solutionDir = ResolveSolutionDirectory(workspaceId);
+            }
+            catch
+            {
+                solutionDir = null;
+            }
+
+            if (solutionDir is not null)
+            {
+                var (gitFiles, gitWarnings) = await CollectGitChangedFilesAsync(solutionDir, _gitStatusTimeout, ct)
+                    .ConfigureAwait(false);
+
+                if (gitWarnings.Count == 0)
+                {
+                    // Build the dirty set with case-insensitive normalized paths so the
+                    // intersection survives platform path-separator + casing differences.
+                    var dirty = new HashSet<string>(
+                        gitFiles.Select(NormalizePathForReconcile),
+                        StringComparer.OrdinalIgnoreCase);
+                    var reconciled = changedFiles
+                        .Where(p => dirty.Contains(NormalizePathForReconcile(p)))
+                        .ToArray();
+                    changedFiles = reconciled;
+                }
+                // else: git unavailable / repo not found / git error — preserve existing
+                // unfiltered behavior (do NOT add a warning here; this branch is the
+                // default validate_workspace path, not validate_recent_git_changes; the
+                // git-status reconcile is a best-effort precision improvement, not a
+                // mandatory step).
+            }
+        }
+
         // Stage 1: in-memory compile check across the whole workspace.
         var compile = await RunValidationPhaseAsync(
             "compile_check",
@@ -620,6 +666,30 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             || normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
             || normalized.StartsWith("obj/", StringComparison.OrdinalIgnoreCase)
             || normalized.StartsWith("bin/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// validate-workspace-changetracker-no-disk-reconcile-after-git-checkout (gh #738):
+    /// path normalization for ChangeTracker reconciliation. Both sides (tracker list
+    /// and git-derived list) come back as absolute paths via different code paths; the
+    /// tracker stores whatever the writer passed in (e.g. <c>Path.GetFullPath</c>'d
+    /// during apply), while git emits forward-slash relative paths that we
+    /// <c>Path.GetFullPath(Path.Combine(...))</c> into absolute form. On Windows the
+    /// resulting strings can disagree on (1) path separator style and (2) intermediate
+    /// dot-segments. Normalize via <c>GetFullPath</c> so segments collapse, then replace
+    /// backslashes with forward slashes; case is handled by the caller's
+    /// <see cref="StringComparer.OrdinalIgnoreCase"/> HashSet.
+    /// </summary>
+    private static string NormalizePathForReconcile(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path).Replace('\\', '/');
+        }
+        catch
+        {
+            return path.Replace('\\', '/');
+        }
     }
 
     private static bool HasValidationRelevantExtension(string path)

--- a/tests/RoslynMcp.Tests/ValidateWorkspaceChangeTrackerReconcileTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateWorkspaceChangeTrackerReconcileTests.cs
@@ -1,0 +1,362 @@
+using System.Diagnostics;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// validate-workspace-changetracker-no-disk-reconcile-after-git-checkout (gh #738):
+/// when <c>ValidateAsync</c> is called with <c>changedFilePaths=null</c> the service
+/// falls back to <see cref="ChangeTracker"/>'s append-only log. Pre-fix that log
+/// included files that had been reverted out-of-band (<c>git checkout -- foo.cs</c>)
+/// because the tracker has no mechanism to drop reverted entries. The reconcile path
+/// intersects the tracker list against <c>git status --porcelain</c> so reverted
+/// files no longer leak into <c>ChangedFilePaths</c>; non-git directories preserve
+/// the existing unfiltered behavior.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public sealed class ValidateWorkspaceChangeTrackerReconcileTests : IsolatedWorkspaceTestBase
+{
+    private static WorkspaceValidationService _validationService = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        InitializeServices();
+        _validationService = new WorkspaceValidationService(
+            CompileCheckService,
+            DiagnosticService,
+            TestDiscoveryService,
+            TestRunnerService,
+            WorkspaceManager,
+            ChangeTracker);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    // ------------------------------------------------------------------
+    // Repro for gh #738: a file mutated through the tracker is then reverted
+    // on disk (simulating `git checkout -- foo.cs`); the validate-workspace
+    // call with changedFilePaths=null must no longer include that reverted
+    // file in ChangedFilePaths.
+    // ------------------------------------------------------------------
+    [TestMethod]
+    public async Task ValidateAsync_NullChangedFilePaths_RevertedFile_ExcludedFromScope()
+    {
+        if (!IsGitAvailable())
+        {
+            Assert.Inconclusive("git not on PATH — cannot run the reconcile path test.");
+            return;
+        }
+
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath);
+
+        await workspace.LoadAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        // Record the file in the tracker via a real apply, then revert the disk
+        // contents back to HEAD so git considers it clean. Pre-fix the tracker
+        // entry leaked through and the file showed up in ChangedFilePaths.
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalContent = await File.ReadAllTextAsync(dogPath);
+
+        var edit = new TextEditDto(1, 1, 1, 1, "// reconcile-marker\n");
+        var editResult = await EditService.ApplyTextEditsAsync(
+            wsId, dogPath, [edit], "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(editResult.Success, "Sanity: the seed edit must apply.");
+
+        // Confirm the tracker has the entry (this is the pre-fix bug surface).
+        var tracked = ChangeTracker.GetChanges(wsId);
+        Assert.AreEqual(1, tracked.Count,
+            "Sanity: the tracker should hold exactly one entry after the seed edit.");
+
+        // Revert on disk — this is the out-of-band operation the bug never reconciled.
+        // The tracker still holds the original entry; only the disk content matches HEAD.
+        await File.WriteAllTextAsync(dogPath, originalContent);
+
+        // Sanity: git agrees the file is now clean.
+        Assert.AreEqual("", RunGitCapture(workspace.RootPath, "status", "--porcelain", "SampleLib/Dog.cs").Trim(),
+            "Sanity: after the revert, git status must report the file clean.");
+
+        // Call ValidateAsync with changedFilePaths=null. Post-fix the reverted file
+        // must NOT appear in ChangedFilePaths because git reports it clean.
+        var result = await _validationService.ValidateAsync(
+            wsId, changedFilePaths: null, runTests: false, CancellationToken.None);
+
+        var normalizedScope = result.ChangedFilePaths
+            .Select(p => Path.GetFullPath(p).Replace('\\', '/').ToLowerInvariant())
+            .ToList();
+        var normalizedDog = Path.GetFullPath(dogPath).Replace('\\', '/').ToLowerInvariant();
+
+        CollectionAssert.DoesNotContain(normalizedScope, normalizedDog,
+            $"Reverted file must be excluded from validation scope; got [{string.Join("; ", result.ChangedFilePaths)}].");
+    }
+
+    // ------------------------------------------------------------------
+    // Negative space: a file that is still dirty on disk must remain in the
+    // validation scope. The reconcile must not suppress legitimately-dirty
+    // tracker entries.
+    // ------------------------------------------------------------------
+    [TestMethod]
+    public async Task ValidateAsync_NullChangedFilePaths_StillDirtyFile_KeptInScope()
+    {
+        if (!IsGitAvailable())
+        {
+            Assert.Inconclusive("git not on PATH — cannot run the still-dirty test.");
+            return;
+        }
+
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath);
+
+        await workspace.LoadAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+        var edit = new TextEditDto(1, 1, 1, 1, "// still-dirty-marker\n");
+        var editResult = await EditService.ApplyTextEditsAsync(
+            wsId, dogPath, [edit], "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(editResult.Success, "Sanity: the seed edit must apply.");
+
+        // Do NOT revert — file remains dirty. git status will report it Modified.
+        var statusOutput = RunGitCapture(workspace.RootPath, "status", "--porcelain", "SampleLib/Dog.cs").Trim();
+        Assert.IsFalse(string.IsNullOrEmpty(statusOutput),
+            $"Sanity: git should report the edited file dirty; got [{statusOutput}].");
+
+        var result = await _validationService.ValidateAsync(
+            wsId, changedFilePaths: null, runTests: false, CancellationToken.None);
+
+        var normalizedScope = result.ChangedFilePaths
+            .Select(p => Path.GetFullPath(p).Replace('\\', '/').ToLowerInvariant())
+            .ToList();
+        var normalizedDog = Path.GetFullPath(dogPath).Replace('\\', '/').ToLowerInvariant();
+
+        CollectionAssert.Contains(normalizedScope, normalizedDog,
+            $"A still-dirty file must remain in validation scope; got [{string.Join("; ", result.ChangedFilePaths)}].");
+    }
+
+    // ------------------------------------------------------------------
+    // Negative space: in a non-git directory the reconcile path degrades
+    // gracefully — the unfiltered tracker list is used. This preserves
+    // the existing ValidateAsync_NullChangedFilePaths_NoUnknownSurfaced
+    // behavior covered in ValidateWorkspaceSummaryTests.
+    // ------------------------------------------------------------------
+    [TestMethod]
+    public async Task ValidateAsync_NullChangedFilePaths_NoGitRepo_FallsBackToUnfilteredTracker()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        // Explicitly DO NOT git init. The isolated workspace defaults to a
+        // non-git temp dir, but be belt-and-suspenders against ancestor repos.
+        RemoveAnyAncestorGitDir(workspace.RootPath);
+
+        await workspace.LoadAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+        var edit = new TextEditDto(1, 1, 1, 1, "// no-git-marker\n");
+        var editResult = await EditService.ApplyTextEditsAsync(
+            wsId, dogPath, [edit], "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(editResult.Success, "Sanity: the seed edit must apply.");
+
+        var result = await _validationService.ValidateAsync(
+            wsId, changedFilePaths: null, runTests: false, CancellationToken.None);
+
+        // Without git, the reconcile branch is bypassed and the unfiltered tracker
+        // list is used. The edited file must surface in ChangedFilePaths.
+        var normalizedScope = result.ChangedFilePaths
+            .Select(p => Path.GetFullPath(p).Replace('\\', '/').ToLowerInvariant())
+            .ToList();
+        var normalizedDog = Path.GetFullPath(dogPath).Replace('\\', '/').ToLowerInvariant();
+
+        CollectionAssert.Contains(normalizedScope, normalizedDog,
+            "Without git the tracker list is unfiltered; the edited file must appear in scope. "
+            + $"Got [{string.Join("; ", result.ChangedFilePaths)}].");
+    }
+
+    // ------------------------------------------------------------------
+    // Caller-supplied scope: the reconcile MUST NOT fire when changedFilePaths
+    // is non-null. The caller passed an explicit scope; silently filtering
+    // those entries would lie about what was validated.
+    // ------------------------------------------------------------------
+    [TestMethod]
+    public async Task ValidateAsync_NonNullChangedFilePaths_ReconcileDoesNotFire()
+    {
+        if (!IsGitAvailable())
+        {
+            Assert.Inconclusive("git not on PATH — cannot run the caller-scope guard test.");
+            return;
+        }
+
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        StageAndCommitAll(workspace.RootPath);
+
+        await workspace.LoadAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(wsId);
+
+        // The file is clean on disk (we did not edit it), but the caller passes
+        // it in changedFilePaths anyway. The reconcile path is the wrong layer
+        // to drop it — the caller asked for that scope explicitly.
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var result = await _validationService.ValidateAsync(
+            wsId, changedFilePaths: [dogPath], runTests: false, CancellationToken.None);
+
+        // The caller-supplied path lands in ChangedFilePaths via the standard
+        // workspace-membership partition; reconcile is bypassed.
+        var normalizedScope = result.ChangedFilePaths
+            .Select(p => Path.GetFullPath(p).Replace('\\', '/').ToLowerInvariant())
+            .ToList();
+        var normalizedDog = Path.GetFullPath(dogPath).Replace('\\', '/').ToLowerInvariant();
+
+        CollectionAssert.Contains(normalizedScope, normalizedDog,
+            "Caller-supplied scope must not be filtered by the reconcile path. "
+            + $"Got [{string.Join("; ", result.ChangedFilePaths)}].");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static bool IsGitAvailable()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (process is null) return false;
+            process.WaitForExit(5_000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void InitializeGitRepo(string directory)
+    {
+        // `-b main` forces an initial branch name — mirrors the helper in
+        // ValidateRecentGitChangesTests; see comments there for rationale.
+        RunGit(directory, "init", "-q", "-b", "main");
+        if (!Directory.Exists(Path.Combine(directory, ".git")))
+        {
+            throw new InvalidOperationException(
+                $"git init appeared to succeed but '.git' is missing in '{directory}'.");
+        }
+        RunGit(directory, "config", "--local", "user.email", "ci@example.invalid");
+        RunGit(directory, "config", "--local", "user.name", "CI");
+        RunGit(directory, "config", "--local", "commit.gpgsign", "false");
+    }
+
+    private static void StageAndCommitAll(string directory)
+    {
+        RunGit(directory, "add", "-A");
+        RunGit(directory, "commit", "-q", "-m", "seed");
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start git {string.Join(' ', arguments)}.");
+        process.WaitForExit(30_000);
+        if (process.ExitCode != 0)
+        {
+            var stderr = process.StandardError.ReadToEnd();
+            var stdout = process.StandardOutput.ReadToEnd();
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} exited {process.ExitCode}. stdout=[{stdout}] stderr=[{stderr}]");
+        }
+    }
+
+    /// <summary>
+    /// Capturing variant of <see cref="RunGit"/> — used for inspecting the porcelain
+    /// output during sanity assertions ("is this file actually clean / dirty?").
+    /// </summary>
+    private static string RunGitCapture(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start git {string.Join(' ', arguments)}.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        process.WaitForExit(30_000);
+        if (process.ExitCode != 0)
+        {
+            var stderr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} exited {process.ExitCode}. stdout=[{stdout}] stderr=[{stderr}]");
+        }
+        return stdout;
+    }
+
+    /// <summary>
+    /// Walks upward from <paramref name="directory"/> removing any <c>.git</c> entry we
+    /// find so we can prove the "not inside a git repo" fallback. Same belt-and-braces
+    /// strategy as <c>ValidateRecentGitChangesTests.RemoveAnyAncestorGitDir</c>.
+    /// </summary>
+    private static void RemoveAnyAncestorGitDir(string directory)
+    {
+        DirectoryInfo? current = new(directory);
+        while (current is not null)
+        {
+            var gitEntry = Path.Combine(current.FullName, ".git");
+            try
+            {
+                if (Directory.Exists(gitEntry))
+                    Directory.Delete(gitEntry, recursive: true);
+                else if (File.Exists(gitEntry))
+                    File.Delete(gitEntry);
+            }
+            catch
+            {
+                // Best-effort: the primary repo's `.git` is locked by the running test
+                // host; the nested sample-solution-copy directory we care about sits
+                // under %TEMP% and never contains a `.git` so this loop is purely
+                // belt-and-braces.
+                break;
+            }
+            current = current.Parent;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `validate_workspace(changedFilePaths=null)` falls back to the `ChangeTracker`'s append-only log. The tracker has no mechanism to drop entries for files that were reverted out-of-band (e.g. `git checkout -- foo.cs`), so the fallback list silently leaked stale paths that were now clean on disk.
- Reconcile the tracker-derived list against `git status --porcelain` inside `ValidateInternalAsync` and keep only files git still reports as dirty.
- Non-git directories / git-on-PATH absent preserve the existing unfiltered behavior — the reconcile is a best-effort precision improvement, not a mandatory step.
- Caller-supplied non-null `changedFilePaths` bypasses the reconcile (the caller asked for that scope explicitly).

## Test plan

- [x] New `ValidateWorkspaceChangeTrackerReconcileTests` (4 tests, all passing):
  - `ValidateAsync_NullChangedFilePaths_RevertedFile_ExcludedFromScope` — repro from gh #738
  - `ValidateAsync_NullChangedFilePaths_StillDirtyFile_KeptInScope` — no false suppression
  - `ValidateAsync_NullChangedFilePaths_NoGitRepo_FallsBackToUnfilteredTracker` — graceful degradation
  - `ValidateAsync_NonNullChangedFilePaths_ReconcileDoesNotFire` — caller-scope respected
- [x] Existing `ValidateWorkspaceSummaryTests` (8 tests) — all pass; `ValidateAsync_NullChangedFilePaths_NoUnknownSurfaced` still passes (the non-git temp workspace falls through unfiltered as before).
- [x] Existing `ValidateRecentGitChangesTests` (4 tests) — all pass.
- [x] Existing `ChangeTrackerTests` (9 tests) — all pass.
- [x] `WorkspaceValidationOverallStatusTests` + `ValidationBundleToolsTests` + `WorkspaceValidationTimeoutTests` (15 tests) — all pass.
- [x] `mcp__roslyn__compile_check` clean across the full solution.

Closes: validate-workspace-changetracker-no-disk-reconcile-after-git-checkout
Fixes #738