### PR TITLE
fix(callers_callees): populate previewText on callee entries (callers-callees-previewtext-asymmetry)

### DIFF
--- a/changelog.d/callers-callees-previewtext-asymmetry.md
+++ b/changelog.d/callers-callees-previewtext-asymmetry.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `callers_callees` no longer returns `null` `previewText` on every callee entry while populating it correctly for callers. Callees now use the same per-location source-extract path as callers, with the callee document resolved via `solution.GetDocument(invokedLoc.SourceTree)` and falling back to the caller's document for the invocation-site fallback path. Fixes gh #742.

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -355,7 +355,12 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
                     $"{invokedSymbol.ToDisplayString()}|{lineSpan.Path}|{lineSpan.StartLinePosition.Line}|{lineSpan.StartLinePosition.Character}";
                 if (!seenCalleeKeys.Add(dedupeKey)) continue;
 
-                callees.Add(SymbolMapper.ToLocationDto(invokedLoc, invokedSymbol));
+                var calleeDoc = invokedLoc.SourceTree is { } calleeTree ? solution.GetDocument(calleeTree) : doc;
+                var previewText = calleeDoc is not null
+                    ? await SymbolResolver.GetPreviewTextAsync(calleeDoc, invokedLoc, ct).ConfigureAwait(false)
+                    : null;
+
+                callees.Add(SymbolMapper.ToLocationDto(invokedLoc, invokedSymbol, previewText));
             }
         }
         return callees;

--- a/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
@@ -173,6 +173,42 @@ public class ServiceCoverageTests : SharedWorkspaceTestBase
             "MakeThemSpeak should have callers or callees");
     }
 
+    [TestMethod]
+    public async Task GetCallersCallees_Callees_Populate_PreviewText()
+    {
+        // Regression guard for gh #742 (callers-callees-previewtext-asymmetry):
+        // before the fix, CollectCalleesAsync passed no previewText argument to
+        // SymbolMapper.ToLocationDto, so every callee entry had PreviewText == null
+        // while callers had it populated. Post-fix, in-source callees (e.g. IAnimal.Speak
+        // resolved by MakeThemSpeak) must surface a non-empty PreviewText extracted
+        // from the callee's declaration site.
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 16 column 17 is MakeThemSpeak declaration; MakeThemSpeak invokes
+        // animal.Speak() (in-source IAnimal.Speak) and Console.WriteLine (external).
+        var result = await SymbolRelationshipService.GetCallersCalleesAsync(
+            WorkspaceId,
+            SymbolLocator.BySource(animalServicePath, 16, 17),
+            CancellationToken.None);
+
+        Assert.IsNotNull(result, "CallerCallee result should not be null");
+        Assert.IsTrue(result.Callees.Count > 0, "MakeThemSpeak should have at least one callee");
+
+        // Scope the assertion to in-source callees only — external callees (Console.WriteLine
+        // resolved via the invocation-site fallback) may legitimately yield a preview, but
+        // metadata-only edge cases are not in scope. The asymmetry repro is the in-source
+        // case: at least one callee whose FilePath points at a workspace document must
+        // have a non-empty PreviewText.
+        var inSourceCallees = result.Callees
+            .Where(c => !string.IsNullOrEmpty(c.FilePath) && File.Exists(c.FilePath))
+            .ToList();
+        Assert.IsTrue(inSourceCallees.Count > 0,
+            "Expected at least one in-source callee for MakeThemSpeak (IAnimal.Speak).");
+        Assert.IsTrue(inSourceCallees.All(c => !string.IsNullOrEmpty(c.PreviewText)),
+            $"Every in-source callee must have a non-empty PreviewText. " +
+            $"Null callees: [{string.Join(", ", inSourceCallees.Where(c => string.IsNullOrEmpty(c.PreviewText)).Select(c => c.ContainingMember))}]");
+    }
+
     // ── CompletionService ────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fix `callers_callees` returning `null` `previewText` on every callee entry while populating it correctly for callers. The fix mirrors the existing per-location preview-extraction pattern from `CollectCallersAsync` (`SymbolRelationshipService.cs:320-322`) in `CollectCalleesAsync`.

## Changes

- **`src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs`** — Inside `CollectCalleesAsync`, after the dedupe check, resolve the callee document via `solution.GetDocument(invokedLoc.SourceTree)` when the location is in-source, fall back to the caller's `doc` for the `invocation.GetLocation()` fallback path, and pass the extracted `previewText` to `SymbolMapper.ToLocationDto`. Document-null guard mirrors the pattern at `SymbolRelationshipService.cs:185`, `ReferenceService.cs:104`, and `SymbolNavigationService.cs:36`.
- **`tests/RoslynMcp.Tests/ServiceCoverageTests.cs`** — Add `GetCallersCallees_Callees_Populate_PreviewText` regression test. Asserts that for `AnimalService.MakeThemSpeak` (which invokes `IAnimal.Speak` in-source and `Console.WriteLine` externally), every in-source callee surfaces a non-empty `PreviewText`. Scoped to in-source callees only so metadata-only edge cases don't false-fail the test.
- **`changelog.d/callers-callees-previewtext-asymmetry.md`** — New `Fixed` fragment.

## Notes

The Sonnet handoff in the plan flagged the dedupe-aware sequencing: compute `calleeDoc` and `previewText` AFTER the dedupe `seenCalleeKeys.Add` check so duplicate invocations don't pay the preview-read cost. Implemented at `SymbolRelationshipService.cs:358-361`.

The backlog row originally cited `src/RoslynMcp.Roslyn/Services/CallersCalleesService.cs` (stale anchor); the live code lives in `SymbolRelationshipService.cs`.

Closes: callers-callees-previewtext-asymmetry
Fixes #742

## Test plan

- [x] `mcp__roslyn__compile_check` against the worktree workspace — 0 errors / 0 warnings on both modified files.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~ServiceCoverageTests.GetCallersCallees` — 2 passed (new + existing).
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~SymbolRelationships|FullyQualifiedName~SymbolNavigation|FullyQualifiedName~ServiceCoverageTests` — 32 passed.
- [ ] CI green on the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)