### PR TITLE
fix(find_type_mutations)!: report every applicable mutation scope on compound mutators (find-type-mutations-single-scope-misses-compound-io)

### DIFF
--- a/changelog.d/find-type-mutations-single-scope-misses-compound-io.md
+++ b/changelog.d/find-type-mutations-single-scope-misses-compound-io.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** `find_type_mutations`: `MutatingMemberDto.MutationScope` (string, single highest-severity scope) is replaced by `MutationScopes` (`IReadOnlyList<string>`, all detected scopes). Methods performing compound mutations — e.g. both `IO` and `CollectionWrite` — now report every applicable scope rather than only the highest severity. Callers must update from `member.MutationScope == "IO"` to `member.MutationScopes.Contains("IO")`. Fixes gh #741.

--- a/skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md
+++ b/skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md
@@ -151,7 +151,7 @@ For each key type:
 7. `find_consumers` — dependency-kind classification.
 7b. `find_type_consumers` on the same type — type-scoped consumer enumeration; cross-check against `find_consumers`. Discrepancies between symbol-scoped and type-scoped surfaces are FLAG worthy.
 8. `find_shared_members` — private members shared across public methods.
-9. `find_type_mutations`. v1.8+ classifies each mutating member by `MutationScope` (`FieldWrite` / `CollectionWrite` / `IO` / `Network` / `Process` / `Database`). Types whose whole purpose is IO (e.g. a snapshot store) should now report their `WriteAllText` / `Delete` methods with `MutationScope=IO`, even without instance-field reassignment.
+9. `find_type_mutations`. v1.8+ classifies each mutating member by `MutationScopes` (a list whose entries are drawn from `FieldWrite` / `CollectionWrite` / `IO` / `Network` / `Process` / `Database`). Methods performing compound mutations (e.g. both `IO` and `CollectionWrite`) report every applicable scope rather than only the highest-severity one. Types whose whole purpose is IO (e.g. a snapshot store) should now report their `WriteAllText` / `Delete` methods with `MutationScopes` containing `IO`, even without instance-field reassignment.
 10. `find_type_usages` — return types, parameters, fields, casts.
 11. `callers_callees` on 2–3 methods.
 12. `find_property_writes` on settable properties (init vs post-construction).

--- a/src/RoslynMcp.Core/Models/TypeMutationDto.cs
+++ b/src/RoslynMcp.Core/Models/TypeMutationDto.cs
@@ -1,13 +1,15 @@
 namespace RoslynMcp.Core.Models;
 
 /// <summary>
-/// Represents a member that mutates state on a target type. <see cref="MutationScope"/>
-/// classifies the kind of mutation: <c>FieldWrite</c> (settable property or instance-field
-/// reassignment), <c>CollectionWrite</c> (Add/Remove/Clear-style call), <c>IO</c>
-/// (System.IO.File / Directory / FileStream / StreamWriter), <c>Network</c>
-/// (HttpClient / TcpClient / UdpClient), <c>Process</c> (System.Diagnostics.Process),
-/// or <c>Database</c> (DbCommand.Execute*). Defaults to <c>FieldWrite</c> for backward
-/// compatibility with callers that did not previously inspect the field.
+/// Represents a member that mutates state on a target type. <see cref="MutationScopes"/>
+/// classifies every kind of mutation detected on the member: <c>FieldWrite</c> (settable
+/// property or instance-field reassignment), <c>CollectionWrite</c> (Add/Remove/Clear-style
+/// call), <c>IO</c> (System.IO.File / Directory / FileStream / StreamWriter),
+/// <c>Network</c> (HttpClient / TcpClient / UdpClient), <c>Process</c>
+/// (System.Diagnostics.Process), or <c>Database</c> (DbCommand.Execute*). A single member
+/// that performs compound mutations (e.g. both <c>IO</c> and <c>CollectionWrite</c>)
+/// reports every applicable scope rather than only the highest severity. The list is
+/// always non-empty for mutating members.
 /// </summary>
 public sealed record MutatingMemberDto(
     string Name,
@@ -16,7 +18,7 @@ public sealed record MutatingMemberDto(
     string? FilePath,
     int? Line,
     IReadOnlyList<MutationCallerDto> ExternalCallers,
-    string MutationScope = "FieldWrite");
+    IReadOnlyList<string> MutationScopes);
 
 /// <summary>
 /// Represents a caller that invokes a mutating member.

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -92,7 +92,7 @@ Catalog `2026.04` ships **162 tools** (108 stable / 54 experimental), **9 resour
 | **Diagnostics** | `project_diagnostics`, `compile_check` (in-memory, with optional emit validation), `diagnostic_details`, `security_diagnostics`, `nuget_vulnerability_scan`, `list_analyzers`. |
 | **Refactoring (preview / apply)** | `rename_*`, `extract_interface_*`, `extract_type_*`, `move_type_to_file_*`, `bulk_replace_type_*`, `code_fix_*`, `fix_all_*`, `format_document_*`, `organize_usings_*`, `split_class_*`, dead-code removal. |
 | **Build / test** | `build_workspace`, `build_project`, `test_discover`, `test_run`, `test_related`, `test_related_files`, `test_coverage`. |
-| **Cohesion / complexity** | `get_cohesion_metrics` (LCOM4, source-gen aware), `get_complexity_metrics`, `find_unused_symbols`, `find_type_mutations` (with `MutationScope` for IO/Network/Process/Database side effects). |
+| **Cohesion / complexity** | `get_cohesion_metrics` (LCOM4, source-gen aware), `get_complexity_metrics`, `find_unused_symbols`, `find_type_mutations` (with `MutationScopes` for IO/Network/Process/Database side effects; compound mutations report every applicable scope). |
 | **Flow analysis** | `analyze_data_flow`, `analyze_control_flow` — supports both statement-bodied and `=> expr` expression-bodied members. |
 | **Snippets / scripting** | `analyze_snippet`, `evaluate_csharp` (with configurable script timeout). |
 | **Resources** | `roslyn://server/catalog`, `roslyn://workspaces`, `roslyn://workspace/{id}/status` (lean summary defaults; `/verbose` siblings for full payloads), `roslyn://workspace/{id}/projects`, `roslyn://workspace/{id}/diagnostics`, `roslyn://workspace/{id}/file/{filePath}`. |

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -366,12 +366,11 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
     {
         // Filter to mutating members up front so we can fan out the expensive
         // SymbolFinder.FindReferencesAsync calls in parallel while preserving declaration order.
-        // Each candidate carries its computed scope so we don't recompute it inside the parallel
+        // Each candidate carries its computed scope list so we don't recompute it inside the parallel
         // member tasks.
         return namedType.GetMembers()
-            .Select(member => new MutationCandidate(member, ClassifyMutationScope(member, namedType, compilation)))
-            .Where(candidate => candidate.Scope is not null)
-            .Select(candidate => candidate with { Scope = candidate.Scope! })
+            .Select(member => new MutationCandidate(member, ClassifyMutationScopes(member, namedType, compilation)))
+            .Where(candidate => candidate.Scopes is not null && candidate.Scopes.Count > 0)
             .ToArray();
     }
 
@@ -445,7 +444,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
                 FilePath: memberLoc?.GetLineSpan().Path,
                 Line: memberLoc?.GetLineSpan().StartLinePosition.Line + 1,
                 ExternalCallers: callers,
-                MutationScope: candidate.Scope!);
+                MutationScopes: candidate.Scopes!);
         }
         finally
         {
@@ -544,7 +543,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
 
     private sealed record MethodMutationAnalysisContext(SyntaxTree SourceTree, SyntaxNode MethodNode);
 
-    private sealed record MutationCandidate(ISymbol Member, string? Scope);
+    private sealed record MutationCandidate(ISymbol Member, IReadOnlyList<string>? Scopes);
 
     /// <summary>
     /// Classifies a property reference as a write and returns the bucket name, or
@@ -666,24 +665,25 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
     }
 
     /// <summary>
-    /// Classifies a member as mutating and returns the highest-severity scope of the mutation.
-    /// Returns <see langword="null"/> if the member does not mutate at all. The scope follows
+    /// Classifies a member as mutating and returns the full list of detected mutation scopes.
+    /// Returns <see langword="null"/> if the member does not mutate at all. Each scope follows
     /// <see cref="SideEffectClassifier.Scopes"/>: FieldWrite (settable property or instance-field
     /// reassignment), CollectionWrite (Add/Remove/Clear-style call), IO/Network/Process/Database
-    /// (calls into the catalogued side-effect APIs).
+    /// (calls into the catalogued side-effect APIs). A method performing compound mutations
+    /// (e.g. both <c>IO</c> and <c>CollectionWrite</c>) returns every applicable scope.
     ///
     /// Side-effect detection requires a <see cref="SemanticModel"/> for the method body. When
     /// none is available (e.g. method has no source location), only the field-write and
     /// collection-write heuristics run.
     /// </summary>
-    private static string? ClassifyMutationScope(ISymbol member, INamedTypeSymbol containingType, Compilation? compilation)
+    private static IReadOnlyList<string>? ClassifyMutationScopes(ISymbol member, INamedTypeSymbol containingType, Compilation? compilation)
     {
         if (member.IsStatic) return null;
         if (member.DeclaredAccessibility == Accessibility.Private) return null;
 
-        if (TryClassifyPropertyMutationScope(member, out var propertyScope))
+        if (TryClassifyPropertyMutationScopes(member, out var propertyScopes))
         {
-            return propertyScope;
+            return propertyScopes;
         }
 
         if (member is not IMethodSymbol method ||
@@ -692,12 +692,12 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
             return null;
         }
 
-        return ClassifyMethodMutationScope(method, containingType, compilation);
+        return ClassifyMethodMutationScopes(method, containingType, compilation);
     }
 
-    private static bool TryClassifyPropertyMutationScope(ISymbol member, out string? scope)
+    private static bool TryClassifyPropertyMutationScopes(ISymbol member, out IReadOnlyList<string>? scopes)
     {
-        scope = null;
+        scopes = null;
         if (member is not IPropertySymbol property ||
             property.SetMethod is null ||
             property.SetMethod.IsInitOnly ||
@@ -706,11 +706,11 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
             return false;
         }
 
-        scope = SideEffectClassifier.Scopes.FieldWrite;
+        scopes = new[] { SideEffectClassifier.Scopes.FieldWrite };
         return true;
     }
 
-    private static string? ClassifyMethodMutationScope(
+    private static IReadOnlyList<string>? ClassifyMethodMutationScopes(
         IMethodSymbol method,
         INamedTypeSymbol containingType,
         Compilation? compilation)
@@ -720,29 +720,40 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         var analysisContext = TryCreateMethodMutationAnalysisContext(method);
         if (analysisContext is null)
         {
-            return byName ? SideEffectClassifier.Scopes.FieldWrite : null;
+            return byName ? new[] { SideEffectClassifier.Scopes.FieldWrite } : null;
         }
 
-        // Side-effect detection: highest severity wins. Requires the right SemanticModel
-        // for the syntax tree containing the method body — fall back to the field/collection
-        // heuristics when one is not available.
+        // Accumulate every applicable scope across the three independent dimensions:
+        //   1. Side-effect APIs (IO/Network/Process/Database) — highest-severity-wins inside
+        //      SideEffectClassifier, but here it sits alongside the field/collection signals.
+        //   2. Instance field assignment (FieldWrite).
+        //   3. Mutating collection call / indexer-write (CollectionWrite).
+        // Pre-fix this method returned at the first hit, masking compound mutations such as
+        // a method that performs both `_dict.TryAdd(...)` and `File.WriteAllText(...)`.
+        var scopes = new List<string>();
+
         var sideEffectScope = TryClassifyMethodSideEffects(compilation, analysisContext.SourceTree, analysisContext.MethodNode);
         if (sideEffectScope is not null)
         {
-            return sideEffectScope;
+            scopes.Add(sideEffectScope);
         }
 
         if (HasInstanceFieldAssignment(analysisContext.MethodNode, containingType))
         {
-            return SideEffectClassifier.Scopes.FieldWrite;
+            scopes.Add(SideEffectClassifier.Scopes.FieldWrite);
         }
 
         if (HasMutatingCollectionCall(analysisContext.MethodNode))
         {
-            return SideEffectClassifier.Scopes.CollectionWrite;
+            scopes.Add(SideEffectClassifier.Scopes.CollectionWrite);
         }
 
-        return byName ? SideEffectClassifier.Scopes.FieldWrite : null;
+        if (scopes.Count == 0)
+        {
+            return byName ? new[] { SideEffectClassifier.Scopes.FieldWrite } : null;
+        }
+
+        return scopes;
     }
 
     private static MethodMutationAnalysisContext? TryCreateMethodMutationAnalysisContext(IMethodSymbol method)

--- a/tests/RoslynMcp.Tests/MutationAnalysisSideEffectsTests.cs
+++ b/tests/RoslynMcp.Tests/MutationAnalysisSideEffectsTests.cs
@@ -23,7 +23,7 @@ public sealed class MutationAnalysisSideEffectsTests : SharedWorkspaceTestBase
         // returned zero mutating members because IsMutatingMember only checked
         // IAssignmentOperation on instance fields. After the side-effect classifier lands,
         // every public method that calls File.WriteAllText/Delete/etc. is reported with
-        // MutationScope=IO.
+        // MutationScopes containing IO.
         var ioPath = Path.Combine(CopiedRoot, "SampleLib", "FileSnapshotStoreSample.cs");
         await File.WriteAllTextAsync(ioPath, """
 namespace SampleLib;
@@ -120,6 +120,34 @@ public class PureComputeSample
 }
 """, CancellationToken.None);
 
+        // Fixture #4: a compound-mutation class whose SyncEntryAsync performs BOTH a
+        // ConcurrentDictionary.TryAdd (CollectionWrite) AND a File.WriteAllText (IO).
+        // Pre-fix ClassifyMethodMutationScope short-circuited on the side-effect scope and
+        // returned only "IO", masking the CollectionWrite signal. Regression guard for
+        // gh #741 — MutationScopes must surface every applicable scope rather than only
+        // the highest-severity one.
+        var compoundPath = Path.Combine(CopiedRoot, "SampleLib", "CompoundMutationSample.cs");
+        await File.WriteAllTextAsync(compoundPath, """
+namespace SampleLib;
+
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class CompoundMutationSample
+{
+    private readonly ConcurrentDictionary<string, string> _entries = new();
+
+    public async Task SyncEntryAsync(string path, string content, CancellationToken ct)
+    {
+        await Task.Yield();
+        File.WriteAllText(path, content);
+        _entries.TryAdd(path, content);
+    }
+}
+""", CancellationToken.None);
+
         var status = await WorkspaceManager.LoadAsync(CopiedSolutionPath, CancellationToken.None);
         WorkspaceId = status.WorkspaceId;
     }
@@ -145,13 +173,37 @@ public class PureComputeSample
 
         var writeManifest = result.MutatingMembers.FirstOrDefault(m => m.Name == "WriteManifest");
         Assert.IsNotNull(writeManifest, "WriteManifest should be flagged as a mutating member after the side-effect classifier lands.");
-        Assert.AreEqual(SideEffectClassifier.Scopes.IO, writeManifest.MutationScope,
+        CollectionAssert.Contains(writeManifest.MutationScopes.ToList(), SideEffectClassifier.Scopes.IO,
             "File.WriteAllText should classify as IO.");
 
         var deleteManifest = result.MutatingMembers.FirstOrDefault(m => m.Name == "DeleteManifest");
         Assert.IsNotNull(deleteManifest);
-        Assert.AreEqual(SideEffectClassifier.Scopes.IO, deleteManifest.MutationScope,
+        CollectionAssert.Contains(deleteManifest.MutationScopes.ToList(), SideEffectClassifier.Scopes.IO,
             "File.Delete should classify as IO.");
+    }
+
+    [TestMethod]
+    public async Task FindTypeMutations_CompoundIOAndCollectionWrite_ReportsBothScopes()
+    {
+        // Regression guard for gh #741: ClassifyMethodMutationScope pre-fix returned at the
+        // first non-null result from TryClassifyMethodSideEffects, so a method performing
+        // BOTH IO (File.WriteAllText) and CollectionWrite (ConcurrentDictionary.TryAdd)
+        // reported only "IO". The single-scope `MutationScope` string field has been
+        // replaced by `MutationScopes` (IReadOnlyList<string>) which must surface every
+        // applicable scope.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.CompoundMutationSample");
+        var result = await MutationAnalysisService.FindTypeMutationsAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result, "CompoundMutationSample should resolve to a named type.");
+
+        var syncEntry = result.MutatingMembers.FirstOrDefault(m => m.Name == "SyncEntryAsync");
+        Assert.IsNotNull(syncEntry, "SyncEntryAsync should be flagged as a mutating member (File.WriteAllText + TryAdd).");
+
+        var scopes = syncEntry.MutationScopes.ToList();
+        CollectionAssert.Contains(scopes, SideEffectClassifier.Scopes.IO,
+            $"SyncEntryAsync should report IO for File.WriteAllText. Got: [{string.Join(", ", scopes)}]");
+        CollectionAssert.Contains(scopes, SideEffectClassifier.Scopes.CollectionWrite,
+            $"SyncEntryAsync should report CollectionWrite for _entries.TryAdd. Got: [{string.Join(", ", scopes)}]");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- **BREAKING:** `MutatingMemberDto.MutationScope` (string, single highest-severity scope) is replaced by `MutationScopes` (`IReadOnlyList<string>`, all detected scopes). Callers must migrate from `member.MutationScope == "IO"` to `member.MutationScopes.Contains("IO")`.
- `ClassifyMethodMutationScope` previously returned at the first non-null result from `TryClassifyMethodSideEffects`, so a method performing both `File.WriteAllText` (IO) and `_dict.TryAdd` (CollectionWrite) reported only `"IO"`. The classifier now accumulates across the three independent dimensions (side-effect catalog, instance-field assignment, mutating collection call) before returning.
- Mirrors `SideEffectClassifier.cs:36-70` accumulator pattern. `SideEffectClassifier.ClassifyMethodSideEffects` keeps its highest-severity-wins single-string return (severity ordering inside the IO/Network/Process/Database catalog is still the contract); the orthogonal field-write / collection-write / side-effect combination lives one layer up in `ClassifyMethodMutationScopes`.

## Scope

- `src/RoslynMcp.Core/Models/TypeMutationDto.cs` — `MutatingMemberDto.MutationScope` -> required `MutationScopes` (`IReadOnlyList<string>`); default value dropped.
- `src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs` — accumulator rewrite of `ClassifyMutationScopes` / `TryClassifyPropertyMutationScopes` / `ClassifyMethodMutationScopes`; `MutationCandidate.Scope` -> `Scopes`.
- `tests/RoslynMcp.Tests/MutationAnalysisSideEffectsTests.cs` — two existing `Assert.AreEqual` -> `CollectionAssert.Contains`; added compound-scope fixture (`CompoundMutationSample`) and `FindTypeMutations_CompoundIOAndCollectionWrite_ReportsBothScopes` test.
- `src/RoslynMcp.Host.Stdio/README.md` — user-facing tool catalog line updated to reference `MutationScopes`.
- `skills/mcp-server-surface-test/prompts/phases/setup-and-analysis.md` — user-facing audit prompt updated to reference `MutationScopes` (documentation accuracy fix beyond the planner's 4-file fanout list).

## Test plan

- [x] `mcp__roslyn__compile_check` — zero errors, zero warnings.
- [x] `MutationAnalysisSideEffectsTests` — 4/4 pass (existing `FlagsWriteMethodsAsIO`, `FlagsAsyncCollectionMutators`, `PureComputeClass_ReportsZeroMutations`; new `CompoundIOAndCollectionWrite_ReportsBothScopes`).
- [x] Broader related tests (`MutationAnalysis` / `find_type_mutations` / `ImpactAnalysis`) — 10/10 pass.
- [x] `find_references` against `MutatingMemberDto` — 6 references, all in-repo; no external consumers.

Closes: find-type-mutations-single-scope-misses-compound-io
Fixes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)