### PR TITLE
release: v2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.1.0] - 2026-05-19
+
+### Fixed
+
+- **Fixed:** `analyze_control_flow` no longer emits a spurious "partial-slice" warning when the supplied line range covers an entire method body and the analysis succeeds with zero explicit control-flow exits (void method or complete block with no returns). The warning is now suppressed when `Succeeded = true` and entry/exit/return counts are all zero. Fixes gh #743.
+- **Fixed:** `callers_callees` no longer returns `null` `previewText` on every callee entry while populating it correctly for callers. Callees now use the same per-location source-extract path as callers, with the callee document resolved via `solution.GetDocument(invokedLoc.SourceTree)` and falling back to the caller's document for the invocation-site fallback path. Fixes gh #742.
+- **Fixed:** `format_document_preview` now returns `changes: []` for a no-op format pass (already-formatted document). Previously `DiffGenerator` emitted a header-only unified diff string (`--- a/...` / `+++ b/...` with no `@@` hunks) when the formatted document text was identical to the original, causing callers that check `changes.length > 0` to misidentify the result as pending changes. Fixes gh #739.
+- **Fixed:** `validate_workspace(changedFilePaths=null)` returning stale file paths in `changedFilePaths` after an out-of-band revert (e.g. `git checkout -- <file>`). The ChangeTracker auto-scope list is now reconciled against `git status` before being used as the validation scope; reverted files are excluded. Fixes gh #738.
+- **Fixed:** `workspace_changes` splitting an atomic `apply_multi_file_edit` two-file batch into separate ledger entries: the multi-file apply path now records one consolidated change-tracker entry covering all affected files (matching the `apply_composite_preview` behavior), so `revert_apply_by_sequence` and callers reading `workspace_changes` see the batch as a single atomic unit. Fixes gh #740.
+
+### Changed — BREAKING
+
+- **Changed — BREAKING:** `find_type_mutations`: `MutatingMemberDto.MutationScope` (string, single highest-severity scope) is replaced by `MutationScopes` (`IReadOnlyList<string>`, all detected scopes). Methods performing compound mutations — e.g. both `IO` and `CollectionWrite` — now report every applicable scope rather than only the highest severity. Callers must update from `member.MutationScope == "IO"` to `member.MutationScopes.Contains("IO")`. Fixes gh #741.
+
 ## [2.0.0] - 2026-05-19
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/analyze-control-flow-partial-slice-warning-on-full-method.md
+++ b/changelog.d/analyze-control-flow-partial-slice-warning-on-full-method.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `analyze_control_flow` no longer emits a spurious "partial-slice" warning when the supplied line range covers an entire method body and the analysis succeeds with zero explicit control-flow exits (void method or complete block with no returns). The warning is now suppressed when `Succeeded = true` and entry/exit/return counts are all zero. Fixes gh #743.

--- a/changelog.d/callers-callees-previewtext-asymmetry.md
+++ b/changelog.d/callers-callees-previewtext-asymmetry.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `callers_callees` no longer returns `null` `previewText` on every callee entry while populating it correctly for callers. Callees now use the same per-location source-extract path as callers, with the callee document resolved via `solution.GetDocument(invokedLoc.SourceTree)` and falling back to the caller's document for the invocation-site fallback path. Fixes gh #742.

--- a/changelog.d/find-type-mutations-single-scope-misses-compound-io.md
+++ b/changelog.d/find-type-mutations-single-scope-misses-compound-io.md
@@ -1,5 +1,0 @@
----
-category: Changed — BREAKING
----
-
-- **Changed — BREAKING:** `find_type_mutations`: `MutatingMemberDto.MutationScope` (string, single highest-severity scope) is replaced by `MutationScopes` (`IReadOnlyList<string>`, all detected scopes). Methods performing compound mutations — e.g. both `IO` and `CollectionWrite` — now report every applicable scope rather than only the highest severity. Callers must update from `member.MutationScope == "IO"` to `member.MutationScopes.Contains("IO")`. Fixes gh #741.

--- a/changelog.d/format-document-preview-empty-diff-instead-of-noop.md
+++ b/changelog.d/format-document-preview-empty-diff-instead-of-noop.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `format_document_preview` now returns `changes: []` for a no-op format pass (already-formatted document). Previously `DiffGenerator` emitted a header-only unified diff string (`--- a/...` / `+++ b/...` with no `@@` hunks) when the formatted document text was identical to the original, causing callers that check `changes.length > 0` to misidentify the result as pending changes. Fixes gh #739.

--- a/changelog.d/validate-workspace-changetracker-no-disk-reconcile-after-git-checkout.md
+++ b/changelog.d/validate-workspace-changetracker-no-disk-reconcile-after-git-checkout.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `validate_workspace(changedFilePaths=null)` returning stale file paths in `changedFilePaths` after an out-of-band revert (e.g. `git checkout -- <file>`). The ChangeTracker auto-scope list is now reconciled against `git status` before being used as the validation scope; reverted files are excluded. Fixes gh #738.

--- a/changelog.d/workspace-changes-atomic-batch-split-without-batchid.md
+++ b/changelog.d/workspace-changes-atomic-batch-split-without-batchid.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `workspace_changes` splitting an atomic `apply_multi_file_edit` two-file batch into separate ledger entries: the multi-file apply path now records one consolidated change-tracker entry covering all affected files (matching the `apply_composite_preview` behavior), so `revert_apply_by_sequence` and callers reading `workspace_changes` see the batch as a single atomic unit. Fixes gh #740.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Release v2.1.0 — carries 5 Fixed + 1 Changed — BREAKING entry from the 20260519T145945Z backlog sweep (PRs #842-#847).

- **Changed — BREAKING:** `find_type_mutations`: `MutatingMemberDto.MutationScope` (string) → `MutationScopes` (IReadOnlyList<string>). Callers must update from `member.MutationScope == "IO"` to `member.MutationScopes.Contains("IO")`. Fixes gh #741.
- **Fixed (×5):** `analyze_control_flow` (gh #743), `callers_callees` (gh #742), `format_document_preview` (gh #739), `validate_workspace` (gh #738), `workspace_changes` (gh #740).

Per-tool change diffs already shipped via PRs #842-#847; this PR is the version bump only (5 version files + CHANGELOG.md + 6 changelog.d fragment deletes).

## Test plan

- [x] All 6 implementation PRs already validated.
- [x] Local `eng/verify-release.ps1` green (1370/1370 tests pass; 0 failed).
- [x] Local `eng/verify-ai-docs.ps1` green.
- [x] `eng/verify-version-drift.ps1` reports all 6 version files agree on 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)