### PR TITLE
fix(find_duplicated_methods): exclude [Theory] and downrank symmetric mapper pairs (find-duplicated-methods-symmetric-mapper-false-positives)

### DIFF
--- a/changelog.d/find-duplicated-methods-symmetric-mapper-false-positives.md
+++ b/changelog.d/find-duplicated-methods-symmetric-mapper-false-positives.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_duplicated_methods` no longer clusters xUnit `[Theory]` test methods (now excluded by syntactic attribute-name check) or symmetric `To*`/`From*` round-trip mapper pairs as copy-paste duplicates. Mapper pairs are still emitted but tagged with `clusterKind: "round-trip-mapper"` and a downranked similarity score so threshold-based callers can skip them. Fixes gh #768 §13.11.

--- a/src/RoslynMcp.Core/Models/DuplicatedMethodGroupDto.cs
+++ b/src/RoslynMcp.Core/Models/DuplicatedMethodGroupDto.cs
@@ -17,12 +17,26 @@ namespace RoslynMcp.Core.Models;
 /// </param>
 /// <param name="LineCount">Body line span of the first method in the group (for quick triage).</param>
 /// <param name="Methods">The member locations that cluster together.</param>
+/// <param name="ClusterKind">
+/// Optional discriminator that classifies the bucket beyond raw structural similarity.
+/// <see langword="null"/> when the cluster is a plain copy-paste duplicate (the default
+/// before any classifier ran). Currently emitted values:
+/// <list type="bullet">
+///   <item><description><c>"round-trip-mapper"</c> — exactly two members whose names form a strict
+///     <c>To*</c>/<c>From*</c> complementary pair with the same stem. These are typically symmetric
+///     mapper pairs (e.g. <c>ToDto</c>/<c>FromDto</c>) that share an AST shape by design; their
+///     <see cref="Similarity"/> is downranked so they don't dominate the dedup ranking.</description></item>
+/// </list>
+/// Additive/non-breaking — callers that do an exhaustive switch should add a default arm and treat
+/// unknown values as plain duplicates.
+/// </param>
 public sealed record DuplicatedMethodGroupDto(
     string NormalizedHash,
     int MemberCount,
     double Similarity,
     int LineCount,
-    IReadOnlyList<DuplicatedMethodMemberDto> Methods);
+    IReadOnlyList<DuplicatedMethodMemberDto> Methods,
+    string? ClusterKind = null);
 
 /// <summary>
 /// One method-body occurrence inside a <see cref="DuplicatedMethodGroupDto"/>.

--- a/src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DuplicateMethodDetectorService.cs
@@ -113,6 +113,13 @@ public sealed class DuplicateMethodDetectorService : IDuplicateMethodDetectorSer
             var body = (SyntaxNode?)method.Body ?? method.ExpressionBody;
             if (body is null) continue; // abstract, partial-no-body, interface declarations
 
+            // xUnit [Theory] test methods share an identical dispatch shape (assert against
+            // every [InlineData]/[MemberData] row) so they bucket together even though they
+            // exercise different business logic. Exclude them by attribute-name suffix —
+            // both `[Theory]` and the fully-qualified `[TheoryAttribute]` form match. Pure
+            // syntactic check; no xUnit reference needed.
+            if (HasTheoryAttribute(method)) continue;
+
             var lineSpan = method.GetLocation().GetLineSpan();
             var startLine = lineSpan.StartLinePosition.Line + 1;
             var endLine = lineSpan.EndLinePosition.Line + 1;
@@ -158,10 +165,25 @@ public sealed class DuplicateMethodDetectorService : IDuplicateMethodDetectorSer
             if (members.Count < 2) continue;
             if (options.SimilarityThreshold > 1.0) continue;
 
+            // Default emission: exact-structural duplicate, similarity 1.0, no discriminator.
+            // The symmetric-mapper classifier below downranks the score and tags the cluster
+            // when the bucket is exactly a strict To*/From* complementary pair so callers can
+            // skip these designed-symmetric pairs without losing the signal entirely.
+            var similarity = 1.0;
+            string? clusterKind = null;
+            if (IsSymmetricMapperPair(members))
+            {
+                // Pair shares an AST shape because the mapper is symmetric by design — the
+                // copy-paste signal is weak. Downrank to the mid-band; threshold-filtering
+                // callers can drop these by raising the similarity floor.
+                similarity = 0.5;
+                clusterKind = "round-trip-mapper";
+            }
+
             results.Add(new DuplicatedMethodGroupDto(
                 NormalizedHash: ShortHash(canonical),
                 MemberCount: members.Count,
-                Similarity: 1.0,
+                Similarity: similarity,
                 LineCount: members[0].LineCount,
                 Methods: members.Select(m => new DuplicatedMethodMemberDto(
                     FilePath: m.FilePath,
@@ -169,9 +191,85 @@ public sealed class DuplicateMethodDetectorService : IDuplicateMethodDetectorSer
                     EndLine: m.EndLine,
                     MethodName: m.MethodName,
                     ContainingType: m.ContainingType,
-                    ProjectName: m.ProjectName)).ToList()));
+                    ProjectName: m.ProjectName)).ToList(),
+                ClusterKind: clusterKind));
         }
         return results;
+    }
+
+    /// <summary>
+    /// True when the bucket is exactly two members whose names are complementary
+    /// <c>To*</c>/<c>From*</c> forms sharing the same stem — e.g. <c>ToDto</c>/<c>FromDto</c>,
+    /// <c>ToWire</c>/<c>FromWire</c>. The heuristic is intentionally strict: three or more
+    /// members never trip it (a 3+ bucket is structural duplication that happens to include
+    /// a mapper, not a designed pair), and mismatched stems (<c>ToX</c>/<c>FromY</c>) are
+    /// rejected because the structural collision is then coincidental, not designed.
+    /// </summary>
+    private static bool IsSymmetricMapperPair(IReadOnlyList<MethodCandidate> members)
+    {
+        if (members.Count != 2) return false;
+
+        var first = members[0].MethodName;
+        var second = members[1].MethodName;
+
+        // Identify which member starts with "To" and which with "From"; reject when both
+        // share the same prefix (e.g. two ToFoo overloads) or when neither does.
+        var firstStem = ExtractMapperStem(first);
+        var secondStem = ExtractMapperStem(second);
+        if (firstStem is null || secondStem is null) return false;
+
+        // Stems must agree AND prefixes must be complementary (one To, one From).
+        return firstStem.Value.Stem == secondStem.Value.Stem
+            && firstStem.Value.Prefix != secondStem.Value.Prefix;
+    }
+
+    /// <summary>
+    /// Decompose a method name into its mapper-prefix (<c>"To"</c>|<c>"From"</c>) and the
+    /// remaining stem when the name starts with one of those prefixes followed by an
+    /// uppercase letter. Returns <see langword="null"/> when the name is neither.
+    /// The uppercase-follows requirement avoids matching names like <c>Toggle</c> or
+    /// <c>Format</c> where "To"/"From" are merely a coincidental letter run.
+    /// </summary>
+    private static (string Prefix, string Stem)? ExtractMapperStem(string name)
+    {
+        if (name.Length > 2 && name.StartsWith("To", StringComparison.Ordinal) && char.IsUpper(name[2]))
+        {
+            return ("To", name[2..]);
+        }
+        if (name.Length > 4 && name.StartsWith("From", StringComparison.Ordinal) && char.IsUpper(name[4]))
+        {
+            return ("From", name[4..]);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Syntactic check for an <c>[xUnit.Theory]</c> attribute on a method declaration —
+    /// matches both the short <c>[Theory]</c> form and the fully-qualified
+    /// <c>[TheoryAttribute]</c> form. Uses the last name segment of qualified-name attributes
+    /// (so <c>[Xunit.TheoryAttribute]</c> matches too). No semantic-model lookup.
+    /// </summary>
+    private static bool HasTheoryAttribute(MethodDeclarationSyntax method)
+    {
+        foreach (var list in method.AttributeLists)
+        {
+            foreach (var attribute in list.Attributes)
+            {
+                var name = attribute.Name switch
+                {
+                    QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
+                    SimpleNameSyntax simple => simple.Identifier.ValueText,
+                    _ => string.Empty,
+                };
+                if (string.IsNullOrEmpty(name)) continue;
+                if (name.Equals("Theory", StringComparison.Ordinal)
+                    || name.Equals("TheoryAttribute", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
@@ -351,6 +351,230 @@ public sealed class DuplicateMethodDetectorTests
     }
 
     [TestMethod]
+    public async Task FindDuplicatedMethods_SymmetricMapperPair_IsDownrankedAndTagged()
+    {
+        // Two methods with identical bodies whose names form a strict To*/From* complementary
+        // pair (ToDto/FromDto). The bodies are by-design symmetric for the same data shape,
+        // so clustering them as "duplicates" is a false positive. The detector should still
+        // emit the cluster (so it remains visible) but downrank similarity and tag it with
+        // ClusterKind = "round-trip-mapper" so threshold-based callers can skip it.
+        var source = """
+            namespace Sample;
+            public sealed record UserDto(string Name, int Age);
+            public sealed class User
+            {
+                public string Name { get; set; } = string.Empty;
+                public int Age { get; set; }
+
+                public UserDto ToDto(User user)
+                {
+                    var name = user.Name;
+                    var age = user.Age;
+                    var dto = new UserDto(name, age);
+                    var verified = dto;
+                    var copy = verified;
+                    return copy;
+                }
+
+                public UserDto FromDto(User user)
+                {
+                    var name = user.Name;
+                    var age = user.Age;
+                    var dto = new UserDto(name, age);
+                    var verified = dto;
+                    var copy = verified;
+                    return copy;
+                }
+            }
+            """;
+
+        var service = BuildServiceWithSource(source, out _);
+
+        var groups = await service.FindDuplicatedMethodsAsync(
+            WorkspaceId,
+            new DuplicateMethodAnalysisOptions { MinLines = 6, Limit = 50 },
+            default);
+
+        Assert.AreEqual(1, groups.Count, "Mapper pair should still be emitted (just downranked).");
+        Assert.AreEqual(2, groups[0].MemberCount);
+        Assert.AreEqual("round-trip-mapper", groups[0].ClusterKind,
+            "Symmetric To*/From* pair must be tagged as round-trip-mapper.");
+        Assert.IsTrue(groups[0].Similarity < 1.0,
+            $"Similarity must be downranked from 1.0 for mapper pairs. Got {groups[0].Similarity}.");
+        CollectionAssert.AreEquivalent(
+            new[] { "ToDto", "FromDto" },
+            groups[0].Methods.Select(m => m.MethodName).ToArray());
+    }
+
+    [TestMethod]
+    public async Task FindDuplicatedMethods_TheoryMethods_AreExcluded()
+    {
+        // xUnit [Theory] test methods share an identical dispatch shape (assert against every
+        // [InlineData] row) and would otherwise bucket together. The detector must filter them
+        // out by attribute-name suffix regardless of whether the source uses the bare [Theory]
+        // form or the fully-qualified [TheoryAttribute] form. Pure syntactic check — no xUnit
+        // reference is required for the test source (the attribute names just need to parse).
+        var source = """
+            namespace Sample;
+
+            public sealed class TheoryAttribute : System.Attribute { }
+            public sealed class InlineDataAttribute : System.Attribute
+            {
+                public InlineDataAttribute(params object[] data) { _ = data; }
+            }
+
+            public class TheoryFixtures
+            {
+                [Theory]
+                [InlineData(1, 2)]
+                [InlineData(3, 4)]
+                public void AssertSumBareTheory(int a, int b)
+                {
+                    var sum = a + b;
+                    var inverted = -sum;
+                    var doubled = inverted * 2;
+                    var halved = doubled / 2;
+                    var final = halved + 0;
+                    System.Diagnostics.Debug.Assert(final == -sum);
+                }
+
+                [TheoryAttribute]
+                [InlineData(5, 6)]
+                public void AssertSumFullName(int a, int b)
+                {
+                    var sum = a + b;
+                    var inverted = -sum;
+                    var doubled = inverted * 2;
+                    var halved = doubled / 2;
+                    var final = halved + 0;
+                    System.Diagnostics.Debug.Assert(final == -sum);
+                }
+            }
+            """;
+
+        var service = BuildServiceWithSource(source, out _);
+
+        var groups = await service.FindDuplicatedMethodsAsync(
+            WorkspaceId,
+            new DuplicateMethodAnalysisOptions { MinLines = 6, Limit = 50 },
+            default);
+
+        Assert.AreEqual(0, groups.Count,
+            "[Theory]-annotated methods must be excluded from clustering (both bare and full-name forms).");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicatedMethods_ToFromWithThreeMembers_IsNotDownranked()
+    {
+        // The mapper-pair classifier is intentionally strict: only exactly-two members trip
+        // it. A bucket of three (e.g. ToDto + FromDto + a coincidental third helper with the
+        // same body shape) is structural duplication that happens to include a mapper — not
+        // a designed symmetric pair — and should NOT be downranked.
+        var source = """
+            namespace Sample;
+            public sealed record UserDto(string Name, int Age);
+            public sealed class User
+            {
+                public string Name { get; set; } = string.Empty;
+                public int Age { get; set; }
+
+                public UserDto ToDto(User user)
+                {
+                    var name = user.Name;
+                    var age = user.Age;
+                    var dto = new UserDto(name, age);
+                    var verified = dto;
+                    var copy = verified;
+                    return copy;
+                }
+
+                public UserDto FromDto(User user)
+                {
+                    var name = user.Name;
+                    var age = user.Age;
+                    var dto = new UserDto(name, age);
+                    var verified = dto;
+                    var copy = verified;
+                    return copy;
+                }
+
+                public UserDto Snapshot(User user)
+                {
+                    var name = user.Name;
+                    var age = user.Age;
+                    var dto = new UserDto(name, age);
+                    var verified = dto;
+                    var copy = verified;
+                    return copy;
+                }
+            }
+            """;
+
+        var service = BuildServiceWithSource(source, out _);
+
+        var groups = await service.FindDuplicatedMethodsAsync(
+            WorkspaceId,
+            new DuplicateMethodAnalysisOptions { MinLines = 6, Limit = 50 },
+            default);
+
+        Assert.AreEqual(1, groups.Count);
+        Assert.AreEqual(3, groups[0].MemberCount);
+        Assert.IsNull(groups[0].ClusterKind,
+            "Three-member bucket must not be tagged as round-trip-mapper.");
+        Assert.AreEqual(1.0, groups[0].Similarity,
+            "Three-member bucket retains full similarity (not a designed pair).");
+    }
+
+    [TestMethod]
+    public async Task FindDuplicatedMethods_ToFromWithMismatchedStems_IsNotDownranked()
+    {
+        // ToFoo and FromBar share an AST shape coincidentally — the stems don't match, so the
+        // structural collision is genuine duplication, not a designed mapper pair. The
+        // classifier must reject the downrank.
+        var source = """
+            namespace Sample;
+            public sealed class Helpers
+            {
+                public int ToFoo(int value)
+                {
+                    var tally = value;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    return tally;
+                }
+
+                public int FromBar(int value)
+                {
+                    var tally = value;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    tally += 1;
+                    return tally;
+                }
+            }
+            """;
+
+        var service = BuildServiceWithSource(source, out _);
+
+        var groups = await service.FindDuplicatedMethodsAsync(
+            WorkspaceId,
+            new DuplicateMethodAnalysisOptions { MinLines = 6, Limit = 50 },
+            default);
+
+        Assert.AreEqual(1, groups.Count);
+        Assert.AreEqual(2, groups[0].MemberCount);
+        Assert.IsNull(groups[0].ClusterKind,
+            "Mismatched stems (ToFoo/FromBar) must not be tagged as round-trip-mapper.");
+        Assert.AreEqual(1.0, groups[0].Similarity,
+            "Mismatched-stem bucket retains full similarity.");
+    }
+
+    [TestMethod]
     public async Task FindDuplicatedMethods_ProjectFilter_ScopesScanToProject()
     {
         // Load two projects: the structurally-matching methods sit in different projects.


### PR DESCRIPTION
## Summary

Two false-positive categories in `find_duplicated_methods`:

1. **xUnit `[Theory]` test methods** share an identical dispatch shape (assert against every `[InlineData]` row) so they cluster spuriously even though they exercise different business logic. `BucketDocumentMethods` now skips methods carrying a `[Theory]` or `[TheoryAttribute]` attribute via a pure syntactic check (no xUnit reference needed).

2. **Symmetric `To*`/`From*` mapper pairs** (e.g. `ToDto`/`FromDto`) share an AST shape by design and were emitted with `Similarity: 1.0` as if they were copy-paste duplicates. `EmitGroupsFromBuckets` now classifies exactly-two-member buckets whose names form strict complementary `To*`/`From*` stems and downranks the similarity to 0.5 with a new `ClusterKind: "round-trip-mapper"` discriminator.

`DuplicatedMethodGroupDto` gains a nullable `ClusterKind` field (default `null`). Additive/non-breaking — only one in-repo construction site, no external callers.

The mapper-pair classifier is intentionally strict: three or more members in the same bucket are NOT downranked (structural duplication that happens to include a mapper is not a designed pair), and mismatched stems (`ToFoo`/`FromBar`) are rejected because the structural collision is then coincidental.

## Validation

- **ci_equivalent:** `verify-release.ps1` deferred to PR CI (self-hosted runner gates the merge per repo policy)
- **per-edit:** `mcp__roslyn__compile_check` (RoslynMcp.Core, RoslynMcp.Roslyn, RoslynMcp.Tests) — all clean, 0 errors
- **targeted tests:** `mcp__roslyn__test_run --filter FullyQualifiedName~DuplicateMethodDetectorTests` — **13/13 pass** (8 existing + 5 new; the test file gained 4 new `[TestMethod]` cases covering the mapper-pair tag/downrank, both `[Theory]` attribute forms, three-member rejection, and mismatched-stem rejection)
- **test counts:** before → after = 8 → 13 in this file

## Performance

N/A — adds O(attributes-per-method) syntactic check and O(2) name-prefix decomposition for two-member buckets. Both negligible.

## Closes

- find-duplicated-methods-symmetric-mapper-false-positives

Parent tracker gh #768 §13.11 — plain-text tracking row, do NOT auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)