### PR TITLE
fix(code_fix_preview): return structured envelope when no provider registered (code-fix-preview-vs-fix-all-preview-shape-inconsistency)

### DIFF
--- a/changelog.d/code-fix-preview-vs-fix-all-preview-shape-inconsistency.md
+++ b/changelog.d/code-fix-preview-vs-fix-all-preview-shape-inconsistency.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `code_fix_preview` returning an unhandled `InvalidOperationException` when no code fix provider is registered for the requested diagnostic ID. The tool now returns a structured envelope with empty `previewToken` and a `guidanceMessage`, consistent with `fix_all_preview`. Closes `code-fix-preview-vs-fix-all-preview-shape-inconsistency`. Fixes gh #768 §13.9.

--- a/src/RoslynMcp.Core/Models/RefactoringPreviewDto.cs
+++ b/src/RoslynMcp.Core/Models/RefactoringPreviewDto.cs
@@ -11,9 +11,19 @@ namespace RoslynMcp.Core.Models;
 /// parsing every <see cref="Changes"/> diff. Null when the producing tool does not
 /// emit per-callsite info.
 /// </param>
+/// <param name="GuidanceMessage">
+/// Optional caller-facing guidance describing why the preview is empty (e.g.
+/// <c>code_fix_preview</c> when no <c>CodeFixProvider</c> is registered for the
+/// requested diagnostic id). When set, <see cref="PreviewToken"/> is empty and
+/// <see cref="Changes"/> is empty — the caller is expected to act on the guidance
+/// rather than apply the (empty) preview. Mirrors <c>FixAllPreviewDto.GuidanceMessage</c>
+/// so <c>code_fix_preview</c> and <c>fix_all_preview</c> share a consistent
+/// empty-envelope shape (code-fix-preview-vs-fix-all-preview-shape-inconsistency).
+/// </param>
 public sealed record RefactoringPreviewDto(
     string PreviewToken,
     string Description,
     IReadOnlyList<FileChangeDto> Changes,
     IReadOnlyList<string>? Warnings,
-    IReadOnlyList<CallsiteUpdateDto>? CallsiteUpdates = null);
+    IReadOnlyList<CallsiteUpdateDto>? CallsiteUpdates = null,
+    string? GuidanceMessage = null);

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -608,9 +608,20 @@ public sealed class RefactoringService : IRefactoringService
                 .ConfigureAwait(false);
         }
 
-        throw new InvalidOperationException(
-            $"No code fix provider is loaded for diagnostic '{diagnosticId}'. " +
-            "Run list_analyzers to see which analyzers are loaded, or restore analyzer NuGet packages.");
+        // code-fix-preview-vs-fix-all-preview-shape-inconsistency — mirror FixAllService:78-87's
+        // structured empty envelope when no provider is registered. Previously this branch threw
+        // InvalidOperationException, forcing callers to catch a generic exception to discover the
+        // same "no provider loaded" condition that fix_all_preview returns as data. Returning an
+        // envelope with empty PreviewToken/Changes + a non-null GuidanceMessage keeps the two
+        // tools' shape consistent. Reuses FixAllService.BuildNoProviderGuidance so the guidance
+        // text (suppression / severity-bump hints + id-specific tool pointers) stays unified.
+        return new RefactoringPreviewDto(
+            PreviewToken: string.Empty,
+            Description: $"No code fix provider for '{diagnosticId}'.",
+            Changes: Array.Empty<FileChangeDto>(),
+            Warnings: null,
+            CallsiteUpdates: null,
+            GuidanceMessage: FixAllService.BuildNoProviderGuidance(diagnosticId));
     }
 
     private async Task<RefactoringPreviewDto> PreviewRemoveUnusedUsingFallbackAsync(

--- a/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs
@@ -201,6 +201,50 @@ public class DiagnosticFixIntegrationTests : SharedWorkspaceTestBase
         }
     }
 
+    /// <summary>
+    /// code-fix-preview-vs-fix-all-preview-shape-inconsistency: when no <c>CodeFixProvider</c>
+    /// is registered for the requested diagnostic id, <c>code_fix_preview</c> must return a
+    /// structured envelope (empty <c>PreviewToken</c> + empty <c>Changes</c> +
+    /// <c>GuidanceMessage</c>) rather than throwing <c>InvalidOperationException</c>. Mirrors
+    /// the shape <see cref="RoslynMcp.Roslyn.Services.FixAllService.PreviewFixAllAsync"/>
+    /// already emits in the same condition (see
+    /// <c>FixAllServiceGuidanceTests.PreviewFixAll_NoProviderRegistered_ReturnsGuidance</c>).
+    ///
+    /// <para>
+    /// To exercise this branch we use CS8019 + a non-default fixId. The static
+    /// <c>CodeFixProviderRegistry</c> does not ship a CS8019 provider (covered by the CS8019
+    /// diagnostic_details test above), so the registry path returns null. With fixId set to
+    /// something other than "remove_unused_using", the legacy CS8019 fallback condition fails
+    /// and control falls through to the new structured-return branch.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task CodeFixPreview_NoProviderRegistered_ReturnsGuidance()
+    {
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var animalServiceFile = solution.Projects
+            .SelectMany(project => project.Documents)
+            .First(document => document.Name == "AnimalService.cs");
+
+        var preview = await RefactoringService.PreviewCodeFixAsync(
+            WorkspaceId,
+            diagnosticId: "CS8019",
+            filePath: animalServiceFile.FilePath!,
+            line: 1,
+            column: 1,
+            fixId: "non_default_fix_id_to_skip_fallback",
+            CancellationToken.None);
+
+        Assert.AreEqual(string.Empty, preview.PreviewToken,
+            "When no provider is registered, PreviewToken must be empty so callers do not try to apply.");
+        Assert.AreEqual(0, preview.Changes.Count,
+            "When no provider is registered, Changes must be empty.");
+        Assert.IsNotNull(preview.GuidanceMessage,
+            "When no provider is registered, GuidanceMessage must be set — mirrors fix_all_preview.");
+        StringAssert.Contains(preview.GuidanceMessage!, "No code fix provider is loaded");
+        StringAssert.Contains(preview.GuidanceMessage!, "CS8019");
+    }
+
     [TestMethod]
     public async Task Code_Fix_Preview_And_Apply_Removes_Unused_Using_In_Isolated_Copy()
     {


### PR DESCRIPTION
## Summary

`RefactoringService.PreviewCodeFixAsync` was throwing `InvalidOperationException` when no `CodeFixProvider` was registered for the requested diagnostic id, while the sibling `FixAllService.PreviewFixAllAsync` returned a structured envelope (empty `PreviewToken` + non-null `GuidanceMessage`) for the same condition. This forced callers to catch a generic exception to discover the same "no provider loaded" condition that `fix_all_preview` returns as data.

## Changes

- **`src/RoslynMcp.Core/Models/RefactoringPreviewDto.cs`** — added nullable `GuidanceMessage` field as a positional default-valued record parameter (last position). Non-breaking for existing callers; no exhaustive pattern-match callers in the repo (verified via `Grep` for `is RefactoringPreviewDto` / `switch ... { RefactoringPreviewDto`).
- **`src/RoslynMcp.Roslyn/Services/RefactoringService.cs`** — replaced the `throw new InvalidOperationException(...)` at the end of `PreviewCodeFixAsync` (previously lines 611-613) with a structured return mirroring `FixAllService.cs:78-87`. Reuses `FixAllService.BuildNoProviderGuidance(diagnosticId)` so the guidance text (suppression / severity-bump hints + id-specific tool pointers) stays unified across both tools.
- **`tests/RoslynMcp.Tests/DiagnosticFixIntegrationTests.cs`** — added `CodeFixPreview_NoProviderRegistered_ReturnsGuidance`. Uses `CS8019` + a non-default `fixId` (`"non_default_fix_id_to_skip_fallback"`) to skip the CS8019 fallback at lines 599-609 and exercise the new structured-return branch. The fabricated-id approach suggested in the plan's Sonnet handoff would fail the diagnostic-existence guard at lines 570-575 (which has no analog in `PreviewFixAllAsync`) before reaching the no-provider branch — the CS8019-with-different-fixId path is the only way to land in the new code.

The CS8019 / `remove_unused_using` fallback (lines 599-609) is preserved intact for legacy callers that do not wire a `CodeFixProviderRegistry`.

## Validation

- **`mcp__roslyn__compile_check`** — `RefactoringService.cs`, `RefactoringPreviewDto.cs`, `DiagnosticFixIntegrationTests.cs` all clean (0 errors).
- **`mcp__roslyn__test_run --filter FullyQualifiedName~DiagnosticFixIntegrationTests`** — 8/8 passed (was 7 before this PR; the new test plus the 7 existing `DiagnosticFixIntegrationTests` cases — 8 total — all pass).
- **`mcp__roslyn__test_run --filter FullyQualifiedName~FixAllServiceGuidanceTests`** — 8/8 passed (mirror pattern's tests still pass).
- **`mcp__roslyn__test_run --filter "FullyQualifiedName~RefactoringService|FullyQualifiedName~FixAllService|FullyQualifiedName~CodeFix"`** — 27/27 passed.
- **`mcp__roslyn__test_run --filter "FullyQualifiedName~SuppressionServiceTests|FullyQualifiedName~ExpandedSurfaceIntegrationTests_ToolContract"`** — 8/8 passed (direct consumers of `RefactoringPreviewDto` per `test_related_files`).
- **`./eng/verify-release.ps1`** — deferred to the self-hosted-runner CI per user-level standing instructions ("Roslyn-Backed-MCP CI runs on a self-hosted runner on this box; never kick off `verify-release.ps1` / full `dotnet test` locally while the runner is active"). The PR-open CI run will exercise the full Release-config verify pipeline.

Test counts (DiagnosticFixIntegrationTests): **7 → 8**.

## Performance

N/A — the structured-return branch is a single allocation that replaces a throw; if anything it is slightly cheaper than the exception-throw it replaces.

## Closes

Closes: code-fix-preview-vs-fix-all-preview-shape-inconsistency

(Parent tracker gh #768 §13.9 is a multi-row tracker — not auto-closed by this PR.)