### PR TITLE
fix(find_consumers): aggregate member-level consumers for static extension-host classes (find-references-static-extension-host-blind-spot)

### DIFF
--- a/changelog.d/find-references-static-extension-host-blind-spot.md
+++ b/changelog.d/find-references-static-extension-host-blind-spot.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_consumers` and `symbol_impact_sweep` returning empty results for static extension-host classes whose members are consumed exclusively via extension-method syntax (e.g. `app.MapImportEndpoints()`). `find_consumers` now aggregates member-level consumers as a fallback; `symbol_impact_sweep` emits a `suggestedTasks` hint pointing to `callers_callees`. Fixes gh #768 §13.3.

--- a/samples/SampleSolution/SampleApp/Program.cs
+++ b/samples/SampleSolution/SampleApp/Program.cs
@@ -33,3 +33,11 @@ var formatted = AnimalFormatter.Format(animals.First());
 Console.WriteLine(formatted);
 var allFormatted = AnimalFormatter.FormatAll(animals);
 Console.WriteLine(allFormatted);
+
+// Extension-method invocation against IAnimalNamingExtensions — the type-name token is
+// ABSENT at these call sites, exercising the find-references-static-extension-host-blind-spot
+// fallback in ConsumerAnalysisService.FindConsumersAsync.
+var loud = animals.First().LoudName();
+Console.WriteLine(loud);
+var quiet = animals.First().QuietName();
+Console.WriteLine(quiet);

--- a/samples/SampleSolution/SampleLib/ExtensionHostFixture.cs
+++ b/samples/SampleSolution/SampleLib/ExtensionHostFixture.cs
@@ -1,0 +1,44 @@
+namespace SampleLib;
+
+/// <summary>
+/// Fixture for <c>find-references-static-extension-host-blind-spot</c>: a static
+/// extension-host class whose members are consumed EXCLUSIVELY via extension-method
+/// invocation syntax (e.g. <c>animal.LoudName()</c>). The type-name token never
+/// appears at the call sites, so Roslyn's type-level reference index returns 0
+/// locations on the class itself — exposing the blind spot that
+/// <see cref="RoslynMcp.Roslyn.Services.ConsumerAnalysisService.FindConsumersAsync"/>
+/// must paper over by aggregating per-member references.
+///
+/// Distinct from <see cref="AnimalExtensions"/>: that fixture's <c>Describe</c> is
+/// also consumed via extension-method syntax, but it shares a file with other
+/// fixtures whose call patterns vary; this one is purpose-built so the test can
+/// assert on the metadata name of the host without conflating siblings.
+/// </summary>
+public static class IAnimalNamingExtensions
+{
+    public static string LoudName(this IAnimal animal) =>
+        animal.Name.ToUpperInvariant();
+
+    public static string QuietName(this IAnimal animal) =>
+        animal.Name.ToLowerInvariant();
+}
+
+/// <summary>
+/// Consumer of the static extension-host above via extension-method syntax — the
+/// type-name token never appears in this class's source, only the receiver-style
+/// call <c>animal.LoudName()</c>. This is the canonical pattern that the type-level
+/// reference index is blind to; the member-union fallback in
+/// <c>ConsumerAnalysisService</c> is what surfaces this consumer in
+/// <c>find_consumers</c> output.
+///
+/// Intentionally avoids a <c>cref</c> to the host class so the regression fixture
+/// keeps the type-name token strictly absent at the syntactic level — a stray
+/// XML-doc cref would create a type-level reference and mask the blind spot the
+/// test exists to assert against.
+/// </summary>
+public sealed class AnimalNameAnnouncer
+{
+    public string AnnounceLoud(IAnimal animal) => animal.LoudName();
+
+    public string AnnounceQuiet(IAnimal animal) => animal.QuietName();
+}

--- a/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ConsumerAnalysisService.cs
@@ -4,6 +4,7 @@ using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -26,6 +27,42 @@ public sealed class ConsumerAnalysisService : IConsumerAnalysisService
 
         var references = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
         var refLocations = references.SelectMany(r => r.Locations).ToList();
+
+        // find-references-static-extension-host-blind-spot: when the symbol is a static
+        // class whose members are exclusively consumed via extension-method invocation
+        // syntax (e.g. `animal.LoudName()`), Roslyn's type-level reference index returns 0
+        // locations — the type-name token never appears at the call site. Fall back to
+        // unioning per-member references so the consumer classification can still classify
+        // call sites that bind to the extension method (which carries a `ContainingType`
+        // back to the static host). Gate on public-only extension members to avoid pulling
+        // in references to non-extension static members (those would already have been
+        // captured by the type-level walk above when prefixed `Host.Member()`-style).
+        // Deduplicate by `(FilePath, SourceSpan)` since multiple members may resolve to
+        // overlapping locations in pathological cases.
+        if (refLocations.Count == 0 &&
+            symbol is INamedTypeSymbol { IsStatic: true } host &&
+            host.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsExtensionMethod))
+        {
+            var seen = new HashSet<(string?, TextSpan)>();
+            foreach (var member in host.GetMembers()
+                .OfType<IMethodSymbol>()
+                .Where(m => m.DeclaredAccessibility == Accessibility.Public))
+            {
+                if (ct.IsCancellationRequested) break;
+                var memberRefs = await SymbolFinder
+                    .FindReferencesAsync(member, solution, ct)
+                    .ConfigureAwait(false);
+                foreach (var loc in memberRefs.SelectMany(r => r.Locations))
+                {
+                    var key = (loc.Document?.FilePath, loc.Location.SourceSpan);
+                    if (seen.Add(key))
+                    {
+                        refLocations.Add(loc);
+                    }
+                }
+            }
+        }
+
         // find-references-project-filter: scope consumer classification to the supplied projects.
         // Case-sensitive Project.Name match (matches semantic_grep + ReferenceService semantics).
         // Null/empty filter preserves unfiltered behavior byte-for-byte.

--- a/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
@@ -54,8 +54,18 @@ public sealed class ImpactSweepService : IImpactSweepService
         // or enclosing type name contains a mapper suffix.
         var mapperCallsites = FilterMapperCallsites(references);
 
-        // Resolve the symbol display name for the response header.
-        var symbolDisplay = await ResolveSymbolDisplayAsync(workspaceId, locator, ct).ConfigureAwait(false);
+        // Resolve the symbol once for the response header AND the static-extension-host
+        // detection — saves a second SymbolResolver.ResolveAsync round-trip for the hint.
+        var resolvedSymbol = await ResolveSymbolAsync(workspaceId, locator, ct).ConfigureAwait(false);
+        var symbolDisplay = resolvedSymbol?.ToDisplayString() ?? "<unresolved>";
+
+        // find-references-static-extension-host-blind-spot: when the target is a static class
+        // whose only consumption pattern is `obj.ExtensionMethod()` syntax, the type-level
+        // reference index returns 0 hits even though every extension call binds to a member
+        // of the host. Surface this as an explicit `callers_callees` hint in the suggested
+        // tasks so reviewers don't conclude the type is dead.
+        var isStaticExtensionHost = resolvedSymbol is INamedTypeSymbol { IsStatic: true } host &&
+            host.GetMembers().OfType<IMethodSymbol>().Any(m => m.IsExtensionMethod);
 
         // Item 10: when the swept symbol is a property carrying a JSON/DataMember attribute,
         // surface paired-DTO mapper findings (To*/From* asymmetry).
@@ -81,7 +91,8 @@ public sealed class ImpactSweepService : IImpactSweepService
             diagnostics = diagnostics.Take(cap).ToList();
         }
 
-        var tasks = BuildSuggestedTasks(totalReferenceCount, totalDiagnosticCount, totalMapperCount, persistenceFindings.Count);
+        var tasks = BuildSuggestedTasks(
+            totalReferenceCount, totalDiagnosticCount, totalMapperCount, persistenceFindings.Count, isStaticExtensionHost);
 
         return new SymbolImpactSweepDto(
             SymbolDisplay: symbolDisplay,
@@ -290,15 +301,15 @@ public sealed class ImpactSweepService : IImpactSweepService
         return mapperHits;
     }
 
-    private async Task<string> ResolveSymbolDisplayAsync(
+    private async Task<ISymbol?> ResolveSymbolAsync(
         string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
-        return symbol?.ToDisplayString() ?? "<unresolved>";
+        return await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
     }
 
-    private static IReadOnlyList<string> BuildSuggestedTasks(int refCount, int switchCount, int mapperCount, int persistenceCount)
+    private static IReadOnlyList<string> BuildSuggestedTasks(
+        int refCount, int switchCount, int mapperCount, int persistenceCount, bool isStaticExtensionHost)
     {
         var tasks = new List<string>();
         if (refCount > 0)
@@ -310,7 +321,24 @@ public sealed class ImpactSweepService : IImpactSweepService
         if (persistenceCount > 0)
             tasks.Add($"Resolve {persistenceCount} persistence-layer asymmetry finding(s): a paired DTO mapper omits one direction (To*/From*).");
         if (tasks.Count == 0)
-            tasks.Add("No impact detected. Consider running project_diagnostics to confirm.");
+        {
+            // find-references-static-extension-host-blind-spot: when the target is a static
+            // extension-host class with zero detected impact, the most likely explanation is
+            // that every consumer binds via `obj.ExtensionMethod()` syntax — which the
+            // type-level reference index does NOT capture. Point reviewers at
+            // `callers_callees` per member so they don't conclude the type is unused.
+            if (isStaticExtensionHost)
+            {
+                tasks.Add(
+                    "Static extension-host class — type-level reference index is blind to " +
+                    "extension-method call sites. Use callers_callees(<MemberName>) on each " +
+                    "public member to find consumers.");
+            }
+            else
+            {
+                tasks.Add("No impact detected. Consider running project_diagnostics to confirm.");
+            }
+        }
         return tasks;
     }
 }

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -82,4 +82,29 @@ public sealed class ConsumerAnalysisTests : SharedWorkspaceTestBase
         CollectionAssert.DoesNotContain(allKinds, "Other",
             $"'Other' kind must not appear for static-class consumers. Actual kinds: [{string.Join(", ", allKinds)}]");
     }
+
+    [TestMethod]
+    public async Task FindConsumers_ExtensionHostClass_AggregatesToMemberConsumers()
+    {
+        // find-references-static-extension-host-blind-spot: when every call site to a static
+        // extension-host class binds via `obj.ExtensionMethod()` syntax, the type-level
+        // reference index is BLIND — Roslyn records syntactic sites where the *type-name
+        // token* appears, and at extension-method call sites the token is absent. Without
+        // a fallback, FindConsumersAsync returns zero consumers even though the type IS
+        // consumed.
+        //
+        // SampleApp/Program.cs calls `animals.First().LoudName()` and `.QuietName()` —
+        // both bind to members of SampleLib.IAnimalNamingExtensions but never name the
+        // host class at the call site. The fallback in ConsumerAnalysisService unions
+        // per-member references so the consumer (Program.cs's compiler-generated host
+        // type) shows up here.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimalNamingExtensions");
+        var result = await ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Consumers.Count >= 1,
+            $"Expected at least 1 consumer of IAnimalNamingExtensions via the member-union " +
+            $"fallback, got {result.Consumers.Count}. The fallback should have unioned references " +
+            $"to LoudName/QuietName and surfaced the calling type.");
+    }
 }

--- a/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
@@ -96,6 +96,35 @@ public sealed class SymbolImpactSweepBudgetTests : SharedWorkspaceTestBase
     }
 
     /// <summary>
+    /// Regression for `find-references-static-extension-host-blind-spot`: when the swept
+    /// target is a static class whose members are exclusively consumed via extension-method
+    /// invocation syntax (e.g. `animal.LoudName()`), the type-level reference walk via
+    /// `ReferenceService.FindReferencesAsync` returns 0 hits because the type-name token is
+    /// absent from the call sites. Without the hint, reviewers would conclude the type is
+    /// dead and miss real consumers. The hint points them at `callers_callees(<member>)`
+    /// per public member so they can find the actual call sites.
+    /// </summary>
+    [TestMethod]
+    public async Task SweepAsync_StaticExtensionHost_EmitsCallersCalleesHint()
+    {
+        // IAnimalNamingExtensions is the dedicated fixture for this regression — its
+        // members LoudName/QuietName are called only via obj.Method() syntax in
+        // SampleApp/Program.cs, so the type-level reference index is blind to them.
+        var locator = SymbolLocator.ByMetadataName("SampleLib.IAnimalNamingExtensions");
+        var result = await _impactSweepService.SweepAsync(WorkspaceId, locator, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.References.Count,
+            "guard: type-level reference walk must report 0 refs for a static extension-host whose call sites use obj.Method() syntax — otherwise the hint path is not exercised.");
+
+        var hint = result.SuggestedTasks.FirstOrDefault(t => t.Contains("callers_callees", StringComparison.Ordinal));
+        Assert.IsNotNull(hint,
+            $"Expected a callers_callees(<MemberName>) hint in SuggestedTasks for a static extension-host class with zero detected impact. Actual tasks: [{string.Join(" | ", result.SuggestedTasks)}]");
+        StringAssert.Contains(hint, "Static extension-host class",
+            "hint must label the symbol as a static extension-host class so reviewers understand WHY the index returned 0.");
+    }
+
+    /// <summary>
     /// Regression for `symbol-impact-sweep-suggested-tasks-count-drift` (P4): the
     /// suggested-tasks string was previously built from the truncated list length
     /// (`references.Count` after `Take(cap)`), so a 193-ref symbol capped at 10 reported


### PR DESCRIPTION
## Summary

`find_consumers` and `symbol_impact_sweep` returned 0 hits for static classes whose members are consumed exclusively via extension-method syntax (e.g. `app.MapImportEndpoints()`). Root cause: Roslyn's type-level reference index records only sites where the type-name token appears, but extension call sites bind to the method and never name the host type.

- **`ConsumerAnalysisService.FindConsumersAsync`** — when the type-level walk yields 0 refs AND the symbol is a `static INamedTypeSymbol` with public extension methods, iterate public `IMethodSymbol` members and union per-member `SymbolFinder.FindReferencesAsync` results into `refLocations`. Dedupe by `(FilePath, SourceSpan)`. Runs before the existing `projectFilter` block so filtering still applies to the unioned set.
- **`ImpactSweepService.SweepAsync`** — resolve the symbol once for both `symbolDisplay` and the static-extension-host detection. `BuildSuggestedTasks` now accepts an `isStaticExtensionHost` flag and, in the zero-impact branch, emits an explicit `callers_callees(<MemberName>)` hint instead of the generic "No impact detected" line.
- **Fixture** — `samples/SampleSolution/SampleLib/ExtensionHostFixture.cs` adds `IAnimalNamingExtensions` (static extension host with `LoudName` / `QuietName`) and `AnimalNameAnnouncer` (consumer inside a real `TypeDeclarationSyntax` calling `animal.LoudName()`). `SampleApp/Program.cs` adds extension-method invocation lines too, exercising the top-level-statement path.
- **Tests** — `ConsumerAnalysisTests.FindConsumers_ExtensionHostClass_AggregatesToMemberConsumers` asserts the fallback surfaces the consumer; `SymbolImpactSweepBudgetTests.SweepAsync_StaticExtensionHost_EmitsCallersCalleesHint` guards that the type-level walk reports 0 refs (so the hint path is exercised) and asserts the hint string contains `callers_callees` and `Static extension-host class`.

`find_type_consumers` / `find_type_usages` / `find_references` / `find_type_mutations` / `symbol_impact_sweep`'s `_references.FindReferencesAsync` retain the type-level blind spot — deferred to a follow-on initiative per the plan's Rule 3 sizing.

Closes: find-references-static-extension-host-blind-spot

## Validation

- `mcp__roslyn__compile_check` on `ConsumerAnalysisService.cs`, `ImpactSweepService.cs`, and full `RoslynMcp.Tests` project — 0 errors, 0 warnings.
- `mcp__roslyn__test_run --filter "ConsumerAnalysis|ImpactSweep|SymbolImpactSweep"` — 10 → 10 passing (added 1 new test in each class; pre-fix saw the new ConsumerAnalysis test fail, post-fix passes).
- Broader sweep `test_run --filter "Consumer|DeadCode|MutationAnalysis|ImpactSweep|SymbolImpactSweep|TypeConsumers|FindReferences"` — 47/47 passing.
- `eng/verify-changelog-fragments.ps1` — 1 fragment valid.
- `eng/verify-ai-docs.ps1` — pass; 32 shipped SKILL.md generic.
- `eng/verify-release.ps1` deferred to self-hosted runner on PR push (user CLAUDE.md: "never kick off verify-release.ps1 / full dotnet test locally while the runner is active"); the fallback compile-check + targeted `test_run` substitute is documented in `ai_docs/prompts/backlog-sweep-addenda.md`.

ci_equivalent outcome: deferred to runner; targeted-test substitute green.

## Performance

N/A — the new fallback only runs when `refLocations.Count == 0`, which is the path that previously returned an empty result anyway. Cost is bounded by the number of public extension methods on the host (typically 1–5). The `ImpactSweepService` change saves one `SymbolResolver.ResolveAsync` round-trip by reusing the symbol for both display and detection.

## Test plan

- [x] New consumer-fallback test asserts >= 1 consumer for the new static extension-host fixture.
- [x] New impact-sweep test asserts the `callers_callees` hint is emitted and the type-level walk still returns 0 refs (guards the fixture).
- [x] Existing `FindConsumers_StaticClass_ClassifiesAsStaticMemberAccess` still passes (verifies the fallback does NOT fire when type-prefix consumers exist).
- [x] `DeadCodeIntegrationTests.Extension_Method_With_Callers_Not_Reported_As_Unused` still passes (regression guard on adjacent extension-method classification).
- [x] Other suggested-task / budget regression tests in `SymbolImpactSweepBudgetTests` still pass (capping + pre-cap totals preserved).