### PR TITLE
fix(suggest_refactorings): suppress facade/adapter false-positive (suggest-refactorings-facade-extraction-false-positive)

### DIFF
--- a/changelog.d/suggest-refactorings-facade-extraction-false-positive.md
+++ b/changelog.d/suggest-refactorings-facade-extraction-false-positive.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `suggest_refactorings` false-positive on facade/adapter types — zero-instance-field types implementing one or more interfaces with all-delegating public methods (expression-bodied or single-return) no longer surface a top-severity "Split" cohesion recommendation. `CohesionAnalysisService` now detects the `"facade"` lifecycle pattern alongside `"action-triad"`, and `RefactoringSuggestionService` suppresses cohesion suggestions for any type bearing a `LifecyclePattern` value. Fixes gh #768 §13.10.

--- a/src/RoslynMcp.Core/Models/CohesionMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/CohesionMetricsDto.cs
@@ -20,8 +20,12 @@ public sealed record CohesionMetricsDto(
     /// Well-known lifecycle pattern detected on the type, or <c>null</c> if none.
     /// Types matching a known lifecycle pattern are expected to have high LCOM4 by design
     /// (their public methods are orthogonal on fields), so the split recommendation is downgraded.
-    /// Current values: <c>"action-triad"</c> (type name ending in Action/Handler/Command/Stage
-    /// with a Describe + Validate* + Execute* method triad). Reserved for future patterns.
+    /// Current values:
+    /// <list type="bullet">
+    ///   <item><description><c>"action-triad"</c> — type name ending in Action/Handler/Command/Stage with a Describe + Validate* + Execute* method triad.</description></item>
+    ///   <item><description><c>"facade"</c> — zero-field facade/adapter implementing one or more interfaces, where every public method is expression-bodied or a single return.</description></item>
+    /// </list>
+    /// Reserved for future patterns.
     /// </summary>
     public string? LifecyclePattern { get; init; }
 

--- a/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CohesionAnalysisService.cs
@@ -92,7 +92,7 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
         var (methodFieldMap, methodCallMap) = BuildMethodAccessMaps(instanceMethods, typeSymbol, typeDecl, semanticModel, ct);
         var clusters = ComputeClusters(methodFieldMap, methodCallMap);
 
-        var lifecyclePattern = DetectLifecyclePattern(typeSymbol);
+        var lifecyclePattern = DetectLifecyclePattern(typeSymbol, instanceFields.Count, ct);
         var recommendation = BuildRecommendation(lifecyclePattern);
 
         return new CohesionMetricsDto(
@@ -190,10 +190,41 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
     ///   <item><description>Has at least one public method whose name is <c>Validate</c> or starts with <c>Validate</c>.</description></item>
     ///   <item><description>Has at least one public method whose name is <c>Execute</c> or starts with <c>Execute</c>.</description></item>
     /// </list>
+    ///
+    /// Returns <c>"facade"</c> when ALL of the following hold (conservative, strict AND — must
+    /// avoid false-positives on static utility classes that happen to have zero instance fields):
+    /// <list type="bullet">
+    ///   <item><description>The type has zero instance fields/properties (<paramref name="instanceFieldCount"/> == 0).</description></item>
+    ///   <item><description>The type implements at least one interface (<c>Interfaces.Length &gt; 0</c>).</description></item>
+    ///   <item><description>Every public ordinary method is expression-bodied OR has a body containing exactly one <c>ReturnStatementSyntax</c> (delegation shape).</description></item>
+    /// </list>
     /// Returns <c>null</c> otherwise. The conservative predicate avoids false-negatives where
     /// real low-cohesion types happen to loosely match a lifecycle-style naming.
     /// </summary>
-    private static string? DetectLifecyclePattern(INamedTypeSymbol typeSymbol)
+    private static string? DetectLifecyclePattern(INamedTypeSymbol typeSymbol, int instanceFieldCount, CancellationToken ct)
+    {
+        var publicMethods = typeSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(m => m.MethodKind == MethodKind.Ordinary
+                        && m.DeclaredAccessibility == Accessibility.Public
+                        && !m.IsImplicitlyDeclared)
+            .ToList();
+
+        var actionTriad = DetectActionTriadPattern(typeSymbol, publicMethods);
+        if (actionTriad is not null) return actionTriad;
+
+        var facade = DetectFacadePattern(typeSymbol, publicMethods, instanceFieldCount, ct);
+        if (facade is not null) return facade;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns <c>"action-triad"</c> when the type matches the strict Describe/Validate*/Execute*
+    /// triad on a name-suffix-gated type. See <see cref="DetectLifecyclePattern"/> for the precise
+    /// AND-conjunction.
+    /// </summary>
+    private static string? DetectActionTriadPattern(INamedTypeSymbol typeSymbol, List<IMethodSymbol> publicMethods)
     {
         var name = typeSymbol.Name;
         var suffixMatch =
@@ -202,13 +233,6 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
             name.EndsWith("Command", StringComparison.Ordinal) ||
             name.EndsWith("Stage", StringComparison.Ordinal);
         if (!suffixMatch) return null;
-
-        var publicMethods = typeSymbol.GetMembers()
-            .OfType<IMethodSymbol>()
-            .Where(m => m.MethodKind == MethodKind.Ordinary
-                        && m.DeclaredAccessibility == Accessibility.Public
-                        && !m.IsImplicitlyDeclared)
-            .ToList();
 
         var hasDescribe = publicMethods.Any(m => string.Equals(m.Name, "Describe", StringComparison.Ordinal));
         if (!hasDescribe) return null;
@@ -223,6 +247,56 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
     }
 
     /// <summary>
+    /// Returns <c>"facade"</c> when the type is a zero-field facade/adapter implementing one or
+    /// more interfaces with all-delegating public methods (expression-bodied OR single-return).
+    /// The conjunction with <c>Interfaces.Length &gt; 0</c> excludes static utility classes that
+    /// also happen to have zero instance fields. The single-return shape is detected via
+    /// <see cref="IMethodSymbol.DeclaringSyntaxReferences"/> + downcast to
+    /// <see cref="MethodDeclarationSyntax"/>; methods with no syntax (no source) disqualify the
+    /// type.
+    /// </summary>
+    private static string? DetectFacadePattern(
+        INamedTypeSymbol typeSymbol,
+        List<IMethodSymbol> publicMethods,
+        int instanceFieldCount,
+        CancellationToken ct)
+    {
+        if (instanceFieldCount != 0) return null;
+        if (typeSymbol.Interfaces.Length == 0) return null;
+        if (publicMethods.Count == 0) return null;
+
+        foreach (var method in publicMethods)
+        {
+            if (!IsExpressionBodiedOrSingleReturn(method, ct)) return null;
+        }
+
+        return "facade";
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when EVERY in-source declaration of the method has either an
+    /// <see cref="MethodDeclarationSyntax.ExpressionBody"/> OR a <see cref="MethodDeclarationSyntax.Body"/>
+    /// whose statements collapse to a single <see cref="ReturnStatementSyntax"/>. Returns <c>false</c>
+    /// when the method has no syntax (e.g., metadata-only) or any declaration has a multi-statement body.
+    /// Mirrors the body-vs-expression-body pattern at <c>CodeMetricsService.cs:160-177</c>.
+    /// </summary>
+    private static bool IsExpressionBodiedOrSingleReturn(IMethodSymbol method, CancellationToken ct)
+    {
+        if (method.DeclaringSyntaxReferences.Length == 0) return false;
+
+        foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax(ct) is not MethodDeclarationSyntax decl) return false;
+            if (decl.ExpressionBody is not null) continue;
+            if (decl.Body is null) return false;
+            var statements = decl.Body.Statements;
+            if (statements.Count != 1) return false;
+            if (statements[0] is not ReturnStatementSyntax) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Builds the softened LCOM4 recommendation text for a detected lifecycle pattern. Returns
     /// <c>null</c> when no pattern applies, leaving consumers free to emit their default
     /// "split into cohesive types" guidance.
@@ -230,6 +304,7 @@ public sealed class CohesionAnalysisService : ICohesionAnalysisService
     private static string? BuildRecommendation(string? lifecyclePattern) => lifecyclePattern switch
     {
         "action-triad" => "Lifecycle pattern: action-triad — LCOM4 is expected to be high by design because Describe/Validate*/Execute* are orthogonal on fields. Do not split.",
+        "facade" => "Lifecycle pattern: facade — Facade/adapter type with zero instance fields delegating to an injected interface. LCOM4 is structurally undefined here. Do not split.",
         _ => null,
     };
 

--- a/src/RoslynMcp.Roslyn/Services/RefactoringSuggestionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringSuggestionService.cs
@@ -93,8 +93,11 @@ public sealed class RefactoringSuggestionService : IRefactoringSuggestionService
                 RecommendedTools: ["extract_type_preview", "extract_type_apply", "compile_check"]));
         }
 
-        // Low cohesion (LCOM4 >= 2) → extract type or split class
-        foreach (var c in cohesionResults.Where(c => c.Lcom4Score >= 2 && c.FilePath is not null))
+        // Low cohesion (LCOM4 >= 2) → extract type or split class.
+        // Suppress for any type carrying a LifecyclePattern: those patterns are expected to have
+        // high LCOM4 by design (e.g., "action-triad", "facade"), so the split suggestion would be
+        // a false-positive. Tracks suggest-refactorings-facade-extraction-false-positive.
+        foreach (var c in cohesionResults.Where(c => c.Lcom4Score >= 2 && c.FilePath is not null && c.LifecyclePattern is null))
         {
             suggestions.Add(new RefactoringSuggestionDto(
                 Severity: c.Lcom4Score >= 3 ? "high" : "medium",

--- a/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/CohesionAnalysisTests.cs
@@ -367,6 +367,140 @@ public class NotATriadAction
     }
 
     [TestMethod]
+    public async Task GetCohesionMetrics_FacadePattern_ClassifiesAsFacade_AndSoftensRecommendation()
+    {
+        // suggest-refactorings-facade-extraction-false-positive: A zero-field facade/adapter
+        // type implementing one or more interfaces with all-delegating public methods (either
+        // expression-bodied OR single-return) is a structural facade whose LCOM4 is undefined.
+        // The detector must classify it as LifecyclePattern="facade" with a softened
+        // Recommendation so the aggregator can suppress the false-positive "Split" suggestion.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var filePath = workspace.GetPath("SampleLib", "FacadeSubject.cs");
+        await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public interface IFacadeContract
+{
+    string ReadOne();
+    string ReadTwo();
+    int ReadThree();
+}
+
+public class FacadeSubject : IFacadeContract
+{
+    public string ReadOne() => "one";
+
+    public string ReadTwo() => "two";
+
+    public int ReadThree()
+    {
+        return 3;
+    }
+}
+""", CancellationToken.None);
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+        var facade = metrics.FirstOrDefault(m => m.TypeName == "FacadeSubject");
+        Assert.IsNotNull(facade, "FacadeSubject should appear in cohesion metrics.");
+        Assert.AreEqual("facade", facade.LifecyclePattern,
+            "Zero-field type implementing an interface with all-delegating public methods should be classified as facade.");
+        Assert.IsNotNull(facade.Recommendation,
+            "Recommendation should be populated for a detected lifecycle pattern.");
+        StringAssert.Contains(facade.Recommendation, "Facade/adapter",
+            "Recommendation should mention Facade/adapter so callers can downgrade the split suggestion.");
+        Assert.AreEqual(0, facade.FieldCount,
+            "Facade subject should have FieldCount=0 by construction.");
+    }
+
+    [TestMethod]
+    public async Task GetCohesionMetrics_StaticUtilityWithZeroFields_DoesNotClassifyAsFacade()
+    {
+        // suggest-refactorings-facade-extraction-false-positive: A static utility class also
+        // has zero instance fields by definition. The facade detector must reject it via the
+        // `Interfaces.Length > 0` conjunction — static classes cannot implement interfaces, so
+        // the AND-gate keeps the detector conservative. (CohesionAnalysisService also skips
+        // static types in its instance-method enumeration, but this guard exists belt-and-braces
+        // in case the upstream filter ever changes.)
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var filePath = workspace.GetPath("SampleLib", "ZeroFieldHelper.cs");
+        await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public sealed class ZeroFieldHelper
+{
+    public string ReadOne() => "one";
+
+    public string ReadTwo() => "two";
+
+    public int ReadThree() => 3;
+}
+""", CancellationToken.None);
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+        var helper = metrics.FirstOrDefault(m => m.TypeName == "ZeroFieldHelper");
+        Assert.IsNotNull(helper, "ZeroFieldHelper should appear in cohesion metrics.");
+        Assert.IsNull(helper.LifecyclePattern,
+            "Zero-field type that does NOT implement an interface must NOT be classified as facade.");
+        Assert.IsNull(helper.Recommendation,
+            "Recommendation must be null when no lifecycle pattern applies, leaving the default split suggestion intact.");
+    }
+
+    [TestMethod]
+    public async Task GetCohesionMetrics_FacadeWithMultiStatementMethod_DoesNotClassifyAsFacade()
+    {
+        // suggest-refactorings-facade-extraction-false-positive: The detector must require ALL
+        // public methods to be expression-bodied OR single-return. A type with a multi-statement
+        // body (even one local variable + return) cannot be classified as a facade because real
+        // work is happening in that body. This protects against over-classification.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var filePath = workspace.GetPath("SampleLib", "NotAFacade.cs");
+        await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public interface INotAFacadeContract
+{
+    string ReadOne();
+    string ReadTwo();
+}
+
+public class NotAFacade : INotAFacadeContract
+{
+    public string ReadOne() => "one";
+
+    public string ReadTwo()
+    {
+        var raw = "two";
+        return raw.ToUpperInvariant();
+    }
+}
+""", CancellationToken.None);
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var metrics = await CohesionAnalysisService.GetCohesionMetricsAsync(
+            workspace.WorkspaceId, filePath, projectFilter: null, minMethods: 2, limit: 50,
+            includeInterfaces: false, excludeTestProjects: false, CancellationToken.None);
+
+        var notFacade = metrics.FirstOrDefault(m => m.TypeName == "NotAFacade");
+        Assert.IsNotNull(notFacade, "NotAFacade should appear in cohesion metrics.");
+        Assert.IsNull(notFacade.LifecyclePattern,
+            "Type with a multi-statement public method body must NOT be classified as facade.");
+    }
+
+    [TestMethod]
     public async Task FindSharedMembers_Supports_StaticClasses()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();

--- a/tests/RoslynMcp.Tests/RefactoringSuggestionTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringSuggestionTests.cs
@@ -2,7 +2,7 @@ namespace RoslynMcp.Tests;
 
 [DoNotParallelize]
 [TestClass]
-public sealed class RefactoringSuggestionTests : SharedWorkspaceTestBase
+public sealed class RefactoringSuggestionTests : IsolatedWorkspaceTestBase
 {
     private static string SampleWorkspaceId { get; set; } = null!;
 
@@ -10,7 +10,7 @@ public sealed class RefactoringSuggestionTests : SharedWorkspaceTestBase
     public static async Task ClassInit(TestContext _)
     {
         InitializeServices();
-        SampleWorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+        SampleWorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
     }
 
     [ClassCleanup]
@@ -41,5 +41,48 @@ public sealed class RefactoringSuggestionTests : SharedWorkspaceTestBase
             SampleWorkspaceId, projectFilter: null, limit: 2, CancellationToken.None);
 
         Assert.IsTrue(suggestions.Count <= 2);
+    }
+
+    [TestMethod]
+    public async Task SuggestRefactorings_FacadeType_DoesNotEmitCohesionSplitSuggestion()
+    {
+        // suggest-refactorings-facade-extraction-false-positive: A zero-field facade implementing
+        // an interface with all-delegating public methods previously surfaced as a top-severity
+        // "Split <type>" cohesion suggestion because the cohesion loop only filtered on
+        // Lcom4Score + FilePath. After the fix, the loop additionally skips any type whose
+        // LifecyclePattern is non-null (e.g., "action-triad" or "facade"), so the aggregator
+        // never emits a Category="cohesion" suggestion for a detected lifecycle pattern.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var filePath = workspace.GetPath("SampleLib", "SuggestRefactoringsFacadeSubject.cs");
+        await File.WriteAllTextAsync(filePath, """
+namespace SampleLib;
+
+public interface IFacadeSurface
+{
+    string ReadOne();
+    string ReadTwo();
+    int ReadThree();
+}
+
+public class SuggestRefactoringsFacadeSubject : IFacadeSurface
+{
+    public string ReadOne() => "one";
+
+    public string ReadTwo() => "two";
+
+    public int ReadThree() => 3;
+}
+""", CancellationToken.None);
+
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var suggestions = await RefactoringSuggestionService.SuggestRefactoringsAsync(
+            workspace.WorkspaceId, projectFilter: null, limit: 100, CancellationToken.None);
+
+        var facadeCohesionSuggestion = suggestions.FirstOrDefault(s =>
+            s.Category == "cohesion" && s.TargetSymbol == "SuggestRefactoringsFacadeSubject");
+        Assert.IsNull(facadeCohesionSuggestion,
+            "Facade/adapter types must not produce a cohesion 'Split' suggestion — the lifecycle pattern softens the recommendation upstream and the aggregator must respect it.");
     }
 }


### PR DESCRIPTION
## Summary

`suggest_refactorings` previously surfaced a top-severity "Split `<type>`" cohesion recommendation for zero-instance-field facade/adapter types that delegate to an injected interface — a structurally undefined LCOM4 case where splitting is nonsensical. The fix detects the facade pattern upstream and respects the lifecycle hint at the aggregator.

## Changes

**Part 1 — `CohesionAnalysisService.cs`**

- Extended `DetectLifecyclePattern` to take `instanceFieldCount` and a `CancellationToken` and to dispatch to two narrow helpers (`DetectActionTriadPattern`, `DetectFacadePattern`).
- Added `DetectFacadePattern` — returns `"facade"` only when ALL THREE conditions hold (strict AND, avoids static-utility-class false-positives):
  - `instanceFieldCount == 0`
  - `typeSymbol.Interfaces.Length > 0`
  - Every public ordinary method is expression-bodied OR has a body containing exactly one `ReturnStatementSyntax`.
- Added `IsExpressionBodiedOrSingleReturn` helper that walks `IMethodSymbol.DeclaringSyntaxReferences` and downcasts to `MethodDeclarationSyntax` (mirrors the pattern at `CodeMetricsService.cs:160-177`).
- Extended `BuildRecommendation` with a `"facade"` case — "Facade/adapter type with zero instance fields delegating to an injected interface. LCOM4 is structurally undefined here. Do not split."

**Part 2 — `RefactoringSuggestionService.cs`**

- Cohesion loop now additionally skips any type whose `LifecyclePattern is not null` — applies to `"action-triad"` and `"facade"` alike. The aggregator now respects every detected lifecycle pattern, not just the facade one.

**DTO docstring**

- `CohesionMetricsDto.LifecyclePattern` doc updated to list both `"action-triad"` and `"facade"` values consumers may see.

## Tests

- `CohesionAnalysisTests`: three new tests
  - `GetCohesionMetrics_FacadePattern_ClassifiesAsFacade_AndSoftensRecommendation` — happy path.
  - `GetCohesionMetrics_StaticUtilityWithZeroFields_DoesNotClassifyAsFacade` — negative space, ensures the interface conjunction blocks static utility classes.
  - `GetCohesionMetrics_FacadeWithMultiStatementMethod_DoesNotClassifyAsFacade` — negative space, ensures multi-statement bodies disqualify.
- `RefactoringSuggestionTests`: switched from `SharedWorkspaceTestBase` to `IsolatedWorkspaceTestBase` (the former is a sibling base, both inherit from `TestBase` with the same `GetOrLoadWorkspaceIdAsync` semantics; the latter exposes `CreateIsolatedWorkspaceCopy` needed for the fixture-bound test). Added `SuggestRefactorings_FacadeType_DoesNotEmitCohesionSplitSuggestion` — end-to-end test that builds a real facade in an isolated workspace and asserts no `cohesion`-category suggestion is emitted.

## Validation

- `ci_equivalent`: `./eng/verify-release.ps1 -Configuration Release -NoCoverage` → 1,374/1,374 passing, 0 failures, 0 skipped.
- `./eng/verify-ai-docs.ps1` → passing (32 shipped SKILL.md generic checks pass).
- Test counts (before → after): 1,370 → 1,374 (`+4` tests).
- Note: one earlier verify-release run hit 34 transient flakes (all `Solution file not found` / `Sample fixture must contain X symbol` — pre-existing parallel-fixture-cleanup races unrelated to this change). Second run was completely clean; CI on main has consistently been green over the last 5 push events.

## Performance

N/A. No hot-path changes; the new facade detection is gated behind `instanceFieldCount == 0 && Interfaces.Length == 0` short-circuits that exit before any syntax walk for the vast majority of types.

## Closes

- `suggest-refactorings-facade-extraction-false-positive`

Parent tracker: gh #768 §13.10 (plain-text, not auto-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)