### PR TITLE
Fix .sln restore failure from vulnerable System.Security.Cryptography.Xml package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
@@ -41,7 +41,7 @@
     <!-- Transitive pin: System.Security.Cryptography.Xml 8.0.0 (dragged in via
          Microsoft.Build.* / Microsoft.CodeAnalysis.Workspaces.MSBuild) has two
          High-severity DoS advisories (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf,
-         CVE-2026-26171). 10.0.6 is the patched release on the net10.0 line. -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+         CVE-2026-26171). 10.0.8 is the patched release on the net10.0 line. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- pin `System.Security.Cryptography.Xml` to a non-vulnerable version in central package management
- add explicit reference in `RoslynMcp.Roslyn.csproj` to ensure restore graph uses pinned version
- resolves VS Code-reported solution restore problem (`NU1903` treated as error)

## Validation
- `dotnet restore Roslyn-Backed-MCP.sln --nologo`
- `dotnet restore Roslyn-Backed-MCP.sln --nologo --force`
