### PR TITLE
fix(migrate_package_preview): refuse no-op call instead of silently mutating Directory.Packages.props (migrate-package-preview-no-op-silent-mutation)

### DIFF
--- a/changelog.d/migrate-package-preview-no-op-silent-mutation.md
+++ b/changelog.d/migrate-package-preview-no-op-silent-mutation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `migrate_package_preview` no longer silently adds a `<PackageVersion>` entry to `Directory.Packages.props` for the replacement package when the source package has no references in any project file. The preview now throws with "No project references to '...' were found", leaving `Directory.Packages.props` unmodified. Closes `migrate-package-preview-no-op-silent-mutation`. Fixes gh #768 §13.17.

--- a/src/RoslynMcp.Roslyn/Services/PackageMigrationOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/PackageMigrationOrchestrator.cs
@@ -43,7 +43,14 @@ public sealed class PackageMigrationOrchestrator : IPackageMigrationOrchestrator
                 usesCentralPackageManagement, mutations, changes, warnings, ct).ConfigureAwait(false);
         }
 
-        if (usesCentralPackageManagement && packagesPropsPath is not null && File.Exists(packagesPropsPath))
+        // migrate-package-preview-no-op-silent-mutation: only touch Directory.Packages.props when
+        // at least one project actually referenced oldPackageId. Pre-fix, BuildCentralVersionEditAsync
+        // was invoked unconditionally whenever CPM was enabled — even with zero project hits — and
+        // its UpsertCentralPackageVersion call would add a <PackageVersion> entry for newPackageId,
+        // contributing a mutation that bypassed the no-op guard below and silently mutated the
+        // manifest. Gating on mutations.Count > 0 ensures the InvalidOperationException at line 52
+        // fires for the no-op case (the correct failure mode).
+        if (mutations.Count > 0 && usesCentralPackageManagement && packagesPropsPath is not null && File.Exists(packagesPropsPath))
         {
             await BuildCentralVersionEditAsync(
                 packagesPropsPath, oldPackageId, newPackageId, newVersion, mutations, changes, ct).ConfigureAwait(false);

--- a/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
@@ -104,6 +104,52 @@ public sealed class OrchestrationIntegrationTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task Migrate_Package_Preview_Throws_When_Source_Package_Absent()
+    {
+        // migrate-package-preview-no-op-silent-mutation regression (gh #768 §13.17):
+        // Pre-fix, `migrate_package_preview` ran `BuildCentralVersionEditAsync` unconditionally
+        // whenever the loaded workspace had CPM enabled — even when ZERO projects referenced
+        // `oldPackageId`. Inside, `UpsertCentralPackageVersion` upserts the replacement
+        // `<PackageVersion>` entry, which counted as one mutation and bypassed the
+        // `mutations.Count == 0` no-op guard. The result: a silent edit to `Directory.Packages.props`
+        // adding a manifest entry for a package nothing referenced.
+        //
+        // Post-fix, the CPM update block is gated on `mutations.Count > 0`, so the per-project
+        // loop is the single source of truth for whether anything got migrated. When zero projects
+        // matched, the existing `InvalidOperationException("No project references to '...'")`
+        // fires before any manifest write, leaving `Directory.Packages.props` untouched.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        var packagesPropsPath = workspace.GetPath("Directory.Packages.props");
+        Assert.IsTrue(File.Exists(packagesPropsPath),
+            "Test fixture must copy the repository's Directory.Packages.props (CPM enabled).");
+        var originalPropsContent = await File.ReadAllTextAsync(packagesPropsPath, CancellationToken.None);
+
+        // Note: no `InjectPackageReference` calls — no project carries a reference to
+        // `Legacy.NotPresent`. CPM is enabled via the copied Directory.Packages.props but no
+        // `<PackageVersion Include="Legacy.NotPresent">` entry exists either.
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            PackageMigrationOrchestrator.PreviewMigratePackageAsync(
+                workspace.WorkspaceId,
+                "Legacy.NotPresent",
+                "Modern.NotPresent",
+                "2.5.0",
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "No project references to 'Legacy.NotPresent'",
+            $"Rejection message must name the missing source package. Actual: {ex.Message}");
+
+        // The manifest must be byte-identical to the pre-call snapshot. Pre-fix, this assertion
+        // would catch the silently-appended `<PackageVersion Include="Modern.NotPresent" ...>`.
+        var postCallPropsContent = await File.ReadAllTextAsync(packagesPropsPath, CancellationToken.None);
+        Assert.AreEqual(originalPropsContent, postCallPropsContent,
+            $"migrate-package-preview-no-op-silent-mutation regression: Directory.Packages.props must be unmodified when no project references the source package. Pre-call length: {originalPropsContent.Length}, post-call length: {postCallPropsContent.Length}.");
+        Assert.IsFalse(postCallPropsContent.Contains("Modern.NotPresent", StringComparison.Ordinal),
+            $"migrate-package-preview-no-op-silent-mutation regression: replacement package id must not appear in Directory.Packages.props after a no-op call. File:\n{postCallPropsContent}");
+    }
+
+    [TestMethod]
     public async Task FORMAT_BUG_003_Migrate_Package_Preview_Emits_MultiLine_ItemGroup_With_Matching_Indent()
     {
         // FORMAT-BUG-003 regression (dr-9-4-format-bug-003-produces-inline-itemgroup-xml):


### PR DESCRIPTION
## Summary

- **Bug:** `migrate_package_preview` silently appended a `<PackageVersion>` entry to `Directory.Packages.props` for the *replacement* package when the source package had no references in any project. The pre-fix code ran `BuildCentralVersionEditAsync` unconditionally whenever CPM was enabled. Inside, `UpsertCentralPackageVersion` appended the replacement's CPM entry — which counted as one mutation and bypassed the existing `mutations.Count == 0` no-op guard. Result: manifest was silently mutated for a no-op call.
- **Fix:** Gate the CPM update block on `mutations.Count > 0` so the per-project loop becomes the single source of truth for whether anything got migrated. The existing `InvalidOperationException("No project references to '<id>' were found")` now fires for the no-op case, leaving `Directory.Packages.props` byte-identical.
- **Test:** New `Migrate_Package_Preview_Throws_When_Source_Package_Absent` in `OrchestrationIntegrationTests` asserts both the thrown exception and the unmodified manifest content (read before/after).
- **Scope:** prod (1) `src/RoslynMcp.Roslyn/Services/PackageMigrationOrchestrator.cs`. tests (1) `tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs`. fragment (1) `changelog.d/migrate-package-preview-no-op-silent-mutation.md`. No interface or DTO changes.

## Validation

- `mcp__roslyn__compile_check` on both edited files: 0 errors, 0 warnings.
- `mcp__roslyn__test_run --filter FullyQualifiedName~OrchestrationIntegrationTests`: 10/10 pass.
- `mcp__roslyn__test_run --filter FullyQualifiedName~Migrate_Package_Preview_Throws_When_Source_Package_Absent`: 1/1 pass in isolation.
- `./eng/verify-ai-docs.ps1`: passed (32 SKILL.md checked, AI docs validation passed).
- `./eng/verify-release.ps1` deferred to CI (self-hosted runner is active locally per repo standing instructions).

## Closes

Closes: migrate-package-preview-no-op-silent-mutation

(Parent tracker gh #768 §13.17 is intentionally NOT auto-closed — it tracks the full P2 audit batch §13.1-§13.20, of which this is one row.)