### PR TITLE
fix(project_mutation): expand property allowlist for common per-config properties

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs
@@ -112,7 +112,7 @@ public static class ProjectMutationTools
         IProjectMutationService projectMutationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Project name or project file path within the loaded workspace")] string projectName,
-        [Description("Allowlisted property name (Nullable, LangVersion, ImplicitUsings, TargetFramework)")] string propertyName,
+        [Description("Allowlisted property name (Nullable, LangVersion, ImplicitUsings, TargetFramework, DefineConstants, Optimize, DebugType, NoWarn, TreatWarningsAsErrors)")] string propertyName,
         [Description("Property value to set")] string value,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(
@@ -173,7 +173,7 @@ public static class ProjectMutationTools
         IProjectMutationService projectMutationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Project name or project file path within the loaded workspace")] string projectName,
-        [Description("Allowlisted property name (Nullable, LangVersion, ImplicitUsings, TargetFramework)")] string propertyName,
+        [Description("Allowlisted property name (Nullable, LangVersion, ImplicitUsings, TargetFramework, DefineConstants, Optimize, DebugType, NoWarn, TreatWarningsAsErrors)")] string propertyName,
         [Description("Property value to set")] string value,
         [Description("Condition expression using $(Configuration), $(TargetFramework), or $(Platform)")] string condition,
         CancellationToken ct = default)

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -19,7 +19,12 @@ public sealed class ProjectMutationService : IProjectMutationService
         "Nullable",
         "LangVersion",
         "ImplicitUsings",
-        "TargetFramework"
+        "TargetFramework",
+        "DefineConstants",
+        "Optimize",
+        "DebugType",
+        "NoWarn",
+        "TreatWarningsAsErrors"
     };
 
     private readonly IWorkspaceManager _workspace;

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -345,6 +345,50 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task Set_Conditional_Property_Preview_Accepts_Expanded_Allowlist_Properties()
+    {
+        // set-conditional-property-preview-allowlist-narrowness: pre-fix, the AllowedProperties
+        // HashSet contained only {Nullable, LangVersion, ImplicitUsings, TargetFramework} so common
+        // per-config properties (DefineConstants, Optimize, NoWarn, DebugType, TreatWarningsAsErrors)
+        // were rejected with "not in allowlist". Post-fix, all five additions are accepted by the
+        // shared ValidateAllowedProperty gate that fronts both set_conditional_property_preview
+        // and set_project_property_preview.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var projectFilePath = workspace.GetPath("SampleLib", "SampleLib.csproj");
+        const string condition = "'$(Configuration)'=='Release'";
+
+        var defineConstantsPreview = await ProjectMutationService.PreviewSetConditionalPropertyAsync(
+            workspace.WorkspaceId,
+            new SetConditionalPropertyDto("SampleLib", "DefineConstants", "RELEASE;FEATURE_X", condition),
+            CancellationToken.None);
+        var defineConstantsApply = await ProjectMutationService.ApplyProjectMutationAsync(defineConstantsPreview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(defineConstantsApply.Success, defineConstantsApply.Error);
+
+        var optimizePreview = await ProjectMutationService.PreviewSetConditionalPropertyAsync(
+            workspace.WorkspaceId,
+            new SetConditionalPropertyDto("SampleLib", "Optimize", "true", condition),
+            CancellationToken.None);
+        var optimizeApply = await ProjectMutationService.ApplyProjectMutationAsync(optimizePreview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(optimizeApply.Success, optimizeApply.Error);
+
+        var noWarnPreview = await ProjectMutationService.PreviewSetConditionalPropertyAsync(
+            workspace.WorkspaceId,
+            new SetConditionalPropertyDto("SampleLib", "NoWarn", "CS1591;CS0168", condition),
+            CancellationToken.None);
+        var noWarnApply = await ProjectMutationService.ApplyProjectMutationAsync(noWarnPreview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(noWarnApply.Success, noWarnApply.Error);
+
+        var projectXml = XDocument.Load(projectFilePath);
+        var propertyGroup = projectXml.Root?.Elements("PropertyGroup")
+            .FirstOrDefault(element => string.Equals((string?)element.Attribute("Condition"), condition, StringComparison.Ordinal));
+
+        Assert.IsNotNull(propertyGroup);
+        Assert.AreEqual("RELEASE;FEATURE_X", propertyGroup.Element("DefineConstants")?.Value);
+        Assert.AreEqual("true", propertyGroup.Element("Optimize")?.Value);
+        Assert.AreEqual("CS1591;CS0168", propertyGroup.Element("NoWarn")?.Value);
+    }
+
+    [TestMethod]
     public async Task Add_And_Remove_Central_Package_Version_Preview_And_Apply_Updates_Directory_Packages_Props()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

Expand the `AllowedProperties` HashSet at `src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs:17-23` to include 5 common per-config properties (`DefineConstants`, `Optimize`, `DebugType`, `NoWarn`, `TreatWarningsAsErrors`) that were previously rejected with `"not in allowlist"`.

Because both `set_conditional_property_preview` and `set_project_property_preview` route through the shared `ValidateAllowedProperty` gate (line 640), this single allowlist expansion unblocks the common config-specific scenarios for BOTH tools — intentional and called out in the plan stanza.

Updated tool `[Description]` strings at `src/RoslynMcp.Host.Stdio/Tools/ProjectMutationTools.cs:115,176` so the LLM client sees the expanded list of valid property names instead of discovering them by trial-and-error rejection.

## Test plan

- [x] `mcp__roslyn__compile_check` clean across all 5 projects (errorCount=0)
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~ProjectMutationIntegrationTests` → 21/21 passed (20 prior + 1 new)
- [x] `./eng/verify-ai-docs.ps1` → passed (32 SKILL.md checked)
- [ ] New test `Set_Conditional_Property_Preview_Accepts_Expanded_Allowlist_Properties` exercises DefineConstants + Optimize + NoWarn against an isolated `SampleLib.csproj` and asserts each `<PropertyGroup Condition='...'>` child is created with the expected value.
- [ ] CI verify-release green (self-hosted runner)

## Notes

- **`DefineConstants` merge semantics intentionally NOT added.** The semicolon-delimited value is set as-is; callers who need to preserve inherited values must read first and merge. Documenting this as a separate row would be future work; the audit row asked for allowlist expansion, not merge logic.
- **Chose expand-allowlist over `force=true` opt-in.** These properties are all standard MSBuild SDK properties that are commonly set per-configuration; gating them behind an opt-in flag would just push the friction one level deeper without preventing misuse.
- **Wave-conflict note:** shares `ProjectMutationService.cs` with initiative #12 (different parallel wave; #12 is NOT running this wave). My edit region is lines 17-23 (HashSet) — disjoint from #12's lines 109/165/330/354/370/465.
- **Parent tracker `gh #768 §13.13` deliberately NOT auto-closed** (per plan stanza directive). The row was split out from gh #768's P2 audit batch and the parent tracker should remain open until the broader audit batch is fully addressed.

Closes: set-conditional-property-preview-allowlist-narrowness