### PR TITLE
fix(get_completions): promote in-scope members at member-access positions (get-completions-filtertext-doesnt-promote-in-scope-members)

### DIFF
--- a/changelog.d/get-completions-filtertext-doesnt-promote-in-scope-members.md
+++ b/changelog.d/get-completions-filtertext-doesnt-promote-in-scope-members.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `get_completions` in-scope member ranking at member-access positions — added optional `triggerCharacter` parameter that, when set to `'.'`, passes `CompletionTrigger.CreateInsertionTrigger('.')` to Roslyn so method-tier candidates (locals, parameters, members) are included in the result and ranked before namespace-qualified external types. Without a trigger Roslyn returns only the position's general accessible-type set, so the existing `InScopeRank` sort had no method-tier candidates to promote. Tool description updated to document the member-access requirement. Fixes gh #768 §13.14.

--- a/src/RoslynMcp.Core/Services/ICompletionService.cs
+++ b/src/RoslynMcp.Core/Services/ICompletionService.cs
@@ -22,6 +22,15 @@ public interface ICompletionService
     /// <param name="maxItems">
     /// Maximum number of completion items to return. Defaults to 100, must be greater than zero (UX-007).
     /// </param>
+    /// <param name="triggerCharacter">
+    /// Optional trigger character (e.g. <c>'.'</c>) signalling that completion was invoked by typing a
+    /// character at the cursor position. When non-null, the value is passed to Roslyn as a
+    /// <see cref="Microsoft.CodeAnalysis.Completion.CompletionTrigger"/> insertion trigger so that
+    /// member-access positions return instance-member candidates (locals, parameters, methods,
+    /// properties) in addition to the global accessible-type set. When <see langword="null"/>,
+    /// completions are requested with the default trigger and Roslyn returns the position's
+    /// general candidate set (typically global types only at a statement boundary).
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
     Task<CompletionResultDto> GetCompletionsAsync(
         string workspaceId,
@@ -30,5 +39,6 @@ public interface ICompletionService
         int column,
         string? filterText,
         int maxItems,
+        char? triggerCharacter,
         CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -746,7 +746,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file. Use filterText for case-insensitive prefix narrowing and maxItems for paging (UX-007). The response IsIncomplete flag indicates that the filtered list is longer than maxItems — raise maxItems or refine filterText to see the rest. InlineDescription may be empty when Roslyn does not supply inline text for an item.")]
+    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file. Use filterText for case-insensitive prefix narrowing and maxItems for paging (UX-007). To get instance-member candidates at a member-access position (e.g. right after typing `foo.`), pass triggerCharacter='.' — without it Roslyn returns only the position's general accessible-type set and method-tier candidates are NOT emitted, so the in-scope ranking has nothing to promote. The response IsIncomplete flag indicates that the filtered list is longer than maxItems — raise maxItems or refine filterText to see the rest. InlineDescription may be empty when Roslyn does not supply inline text for an item.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Return IntelliSense-style completion items at a position.")]
     public static Task<string> GetCompletions(
@@ -759,12 +759,13 @@ public static class SymbolTools
         [Description("1-based column number")] int column,
         [Description("Optional: case-insensitive prefix filter applied to candidate FilterText/DisplayText (UX-007)")] string? filterText = null,
         [Description("Maximum number of completion items to return (default: 100, must be > 0)")] int maxItems = 100,
+        [Description("Optional: trigger character (e.g. '.') that signals completion was invoked by typing this character. When supplied, Roslyn returns the member-access candidate set (instance members on the receiver expression) alongside the global accessible-type set; null returns only the position's general candidate set.")] char? triggerCharacter = null,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
-            var result = await completionService.GetCompletionsAsync(workspaceId, filePath, line, column, filterText, maxItems, c);
+            var result = await completionService.GetCompletionsAsync(workspaceId, filePath, line, column, filterText, maxItems, triggerCharacter, c);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Roslyn/Services/CompletionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompletionService.cs
@@ -22,6 +22,7 @@ public sealed class CompletionService : ICompletionService
         int column,
         string? filterText,
         int maxItems,
+        char? triggerCharacter,
         CancellationToken ct)
     {
         if (maxItems <= 0)
@@ -50,7 +51,16 @@ public sealed class CompletionService : ICompletionService
 
         var position = text.Lines[line - 1].Start + (column - 1);
 
-        var completions = await completionService.GetCompletionsAsync(document, position, cancellationToken: ct).ConfigureAwait(false);
+        // get-completions-filtertext-doesnt-promote-in-scope-members: when a triggerCharacter
+        // is supplied (typically '.'), pass an explicit CompletionTrigger.CreateInsertionTrigger
+        // so Roslyn returns the member-access candidate set (instance members on the receiver
+        // expression) in addition to the global accessible-type set. Without a trigger Roslyn
+        // returns only the position's general candidate set, which at a member-access boundary
+        // omits the very method/property candidates the caller expects InScopeRank to promote.
+        var trigger = triggerCharacter.HasValue
+            ? CompletionTrigger.CreateInsertionTrigger(triggerCharacter.Value)
+            : CompletionTrigger.Invoke;
+        var completions = await completionService.GetCompletionsAsync(document, position, trigger, cancellationToken: ct).ConfigureAwait(false);
         if (completions is null)
         {
             return new CompletionResultDto([], false);

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -37,6 +37,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
             column: 9,
             filterText: null,
             maxItems: 100,
+            triggerCharacter: null,
             CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);

--- a/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCoverageTests.cs
@@ -218,7 +218,7 @@ public class ServiceCoverageTests : SharedWorkspaceTestBase
 
         // Line 20 column 30 is inside method body where completions are available
         var result = await CompletionService.GetCompletionsAsync(
-            WorkspaceId, animalServicePath, 20, 30, filterText: null, maxItems: 100, CancellationToken.None);
+            WorkspaceId, animalServicePath, 20, 30, filterText: null, maxItems: 100, triggerCharacter: null, CancellationToken.None);
 
         Assert.IsTrue(result.Items.Count > 0,
             "Expected completion items at a valid position in AnimalService.cs");
@@ -235,7 +235,7 @@ public class ServiceCoverageTests : SharedWorkspaceTestBase
         var animalServicePath = FindDocumentPath("AnimalService.cs");
 
         var result = await CompletionService.GetCompletionsAsync(
-            WorkspaceId, animalServicePath, 20, 30, filterText: "To", maxItems: 100, CancellationToken.None);
+            WorkspaceId, animalServicePath, 20, 30, filterText: "To", maxItems: 100, triggerCharacter: null, CancellationToken.None);
 
         Assert.IsTrue(result.Items.Count >= 2,
             "Expected at least two completion candidates starting with 'To'.");
@@ -264,6 +264,63 @@ public class ServiceCoverageTests : SharedWorkspaceTestBase
                     Assert.IsTrue(toStringIndex < i,
                         $"In-scope ToString (rank=method) should appear before type-tier candidate '{item.DisplayText}' (rank=type).");
                 }
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCompletions_WithDotTrigger_AtMemberAccess_PromotesInstanceMembersBeforeExternalTypes()
+    {
+        // BUG fix (get-completions-filtertext-doesnt-promote-in-scope-members): at a member-
+        // access position (right after a '.'), the CompletionService must pass an explicit
+        // CompletionTrigger.CreateInsertionTrigger('.') to Roslyn — otherwise Roslyn returns
+        // only the global accessible-type set and the InScopeRank sort has no method-tier
+        // candidates to promote. With triggerCharacter='.', instance members on the receiver
+        // (e.g. animal.ToString from System.Object) must be ranked before namespace-qualified
+        // external types like System.Security.Cryptography.ToBase64Transform.
+        var animalServicePath = FindDocumentPath("AnimalService.cs");
+
+        // Line 20: "            var sound = animal.Speak();"
+        // Column 32 is the position immediately after the '.' between 'animal' and 'Speak()'.
+        var result = await CompletionService.GetCompletionsAsync(
+            WorkspaceId, animalServicePath, 20, 32, filterText: "To", maxItems: 100, triggerCharacter: '.', CancellationToken.None);
+
+        Assert.IsTrue(result.Items.Count >= 1,
+            "Expected at least one completion candidate starting with 'To' at a member-access position.");
+
+        // Method-tier rank (rank=1 per InScopeRank): Tags contain Method/Property/Field/Event/ExtensionMethod.
+        var firstMethodTierIndex = -1;
+        for (var i = 0; i < result.Items.Count; i++)
+        {
+            var item = result.Items[i];
+            var isMethodTier = item.Tags is not null && (item.Tags.Contains("Method") || item.Tags.Contains("Property")
+                || item.Tags.Contains("Field") || item.Tags.Contains("Event") || item.Tags.Contains("ExtensionMethod"));
+            if (isMethodTier)
+            {
+                firstMethodTierIndex = i;
+                break;
+            }
+        }
+
+        Assert.IsTrue(firstMethodTierIndex >= 0,
+            "Expected at least one method-tier candidate (Method/Property/Field/Event/ExtensionMethod) " +
+            "with triggerCharacter='.' — without the explicit insertion trigger Roslyn omits instance " +
+            "members and the in-scope ranking has nothing to promote.");
+
+        // For each type-tier candidate (Class/Struct/Interface/Enum/Delegate) in the result,
+        // the first method-tier candidate must appear before it. This is the contract the
+        // bug fix restores: with the '.' trigger, Roslyn emits instance methods on the
+        // receiver AND InScopeRank then orders them ahead of namespace-qualified externals.
+        for (var i = 0; i < result.Items.Count; i++)
+        {
+            var item = result.Items[i];
+            var isType = item.Tags is not null && (item.Tags.Contains("Class") || item.Tags.Contains("Structure")
+                || item.Tags.Contains("Interface") || item.Tags.Contains("Enum") || item.Tags.Contains("Delegate"));
+            if (isType)
+            {
+                Assert.IsTrue(firstMethodTierIndex < i,
+                    $"First method-tier candidate (index {firstMethodTierIndex}) should appear before " +
+                    $"type-tier candidate '{item.DisplayText}' (index {i}).");
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes `get_completions` so instance-member candidates are surfaced (and outrank namespace-qualified externals) when the caller asks for completion at a member-access position.

**Root cause:** `CompletionService.GetCompletionsAsync` called Roslyn's `Microsoft.CodeAnalysis.Completion.CompletionService.GetCompletionsAsync(document, position, cancellationToken: ct)` with **no** `CompletionTrigger`. At a member-access position Roslyn requires an explicit insertion trigger (`'.'`) to emit the receiver's instance members; without it the result is the general accessible-type set only. The existing `InScopeRank` sort correctly ranks Methods > Classes — but it had nothing method-tier to promote.

**Fix:**
- Add optional `char? triggerCharacter` parameter to `ICompletionService.GetCompletionsAsync`.
- In `CompletionService.cs`, when `triggerCharacter` is non-null pass `CompletionTrigger.CreateInsertionTrigger(triggerCharacter.Value)` to Roslyn; otherwise pass `CompletionTrigger.Invoke` (the documented default, preserves the previous behavior exactly for callers that don't opt in).
- Surface the parameter on the `get_completions` MCP tool with a `[Description]` that documents the member-access constraint.

**Fanout:** plan estimated `1 production call site + 1 implementation + 2 test call sites`. Actual reconciled fanout: same prod surface, but an additional test in `ExpandedSurfaceIntegrationTests.cs` calls `SymbolTools.GetCompletions` positionally and also needed `triggerCharacter: null` threaded — caught by the compile-check loop and fixed in the same commit.

**Test:** new `GetCompletions_WithDotTrigger_AtMemberAccess_PromotesInstanceMembersBeforeExternalTypes` in `ServiceCoverageTests.cs` exercises the bug-fix contract: at line 20 col 32 of the `AnimalService.cs` fixture (immediately after `animal.`) with `filterText="To"` and `triggerCharacter='.'`, the first method-tier candidate (Tags ∈ {Method, Property, Field, Event, ExtensionMethod}) must precede every type-tier candidate (Tags ∈ {Class, Structure, Interface, Enum, Delegate}). Per plan Risk 3, the assertion is *not* coupled to specific BCL member names; it asserts the rank-bucket ordering generically, so the test is robust against Roslyn-version drift.

## Validation

- `mcp__roslyn__compile_check` (whole-solution, severity=Error): 0 errors across 5 projects.
- `mcp__roslyn__project_diagnostics` (severity=Warning) on the 4 touched files: 0 warnings.
- `mcp__roslyn__format_check`: no format violations introduced by these edits (the 9 pre-existing violations in unrelated files are untouched).
- `mcp__roslyn__test_run --filter ServiceCoverageTests`: 16/16 passing (includes the new test).
- `mcp__roslyn__test_run --filter ExpandedSurfaceIntegrationTests`: 17/17 passing.

## Closes

Closes: get-completions-filtertext-doesnt-promote-in-scope-members

Note: backlog row references `gh #768` §13.14 as the parent tracker — per the plan stanza this PR does **NOT** auto-close #768.