### PR TITLE
fix(scaffold_first_test_file_preview): apply name-suffix tiebreaker (scaffold-first-test-file-preview-single-target-heuristic)

### DIFF
--- a/changelog.d/scaffold-first-test-file-preview-single-target-heuristic.md
+++ b/changelog.d/scaffold-first-test-file-preview-single-target-heuristic.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `scaffold_first_test_file_preview` failing with "Multiple test projects reference" when several test projects transitively reference a domain library but only one follows the `<Library>.Tests` naming convention. The service now applies a name-suffix tiebreaker (case-sensitive `StringComparison.Ordinal`) and selects the unambiguous candidate automatically. Variants like `MyLib.UnitTests` or `MyLib.IntegrationTests` still require explicit `testProjectName` — the heuristic is conservative by design. Fixes gh #768 §13.18.

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.TestBatchAndFirstTestPreview.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.TestBatchAndFirstTestPreview.cs
@@ -395,6 +395,14 @@ public sealed partial class ScaffoldingService
     /// project and (b) has a project name ending in <c>.Tests</c> — the canonical convention
     /// used across this repo and most .NET solutions. Throws when no candidate is found.
     /// </summary>
+    /// <remarks>
+    /// When more than one candidate matches (a domain library referenced by several test
+    /// projects), we apply a single conservative tiebreaker: prefer the candidate whose name
+    /// is exactly <c>&lt;SourceProjectName&gt;.Tests</c> (case-sensitive). Variants like
+    /// <c>MyLib.UnitTests</c> or <c>MyLib.IntegrationTests</c> are intentionally NOT matched —
+    /// callers in those topologies still need to pass <c>testProjectName</c> explicitly. See
+    /// initiative <c>scaffold-first-test-file-preview-single-target-heuristic</c>.
+    /// </remarks>
     private ProjectStatusDto ResolveDestinationTestProject(string workspaceId, string? requestedName, Project sourceProject)
     {
         if (!string.IsNullOrWhiteSpace(requestedName))
@@ -416,14 +424,36 @@ public sealed partial class ScaffoldingService
                 "No project ending in '.Tests' references this project. Pass testProjectName explicitly.");
         }
 
+        Project picked;
         if (candidates.Count > 1)
         {
-            var names = string.Join(", ", candidates.Select(c => c.Name));
-            throw new InvalidOperationException(
-                $"Multiple test projects reference '{sourceProject.Name}': {names}. Pass testProjectName explicitly.");
+            // Suffix tiebreaker: when several test projects reference the same library, prefer
+            // the one whose name follows the canonical `<Library>.Tests` convention. This
+            // resolves the common topology where a domain library is referenced both by its
+            // own unit-test project AND by a higher-level integration-test project — only the
+            // unit-test project will follow the convention, so picking it is unambiguous.
+            var expectedName = sourceProject.Name + ".Tests";
+            var suffixMatches = candidates
+                .Where(c => string.Equals(c.Name, expectedName, StringComparison.Ordinal))
+                .ToList();
+
+            if (suffixMatches.Count == 1)
+            {
+                picked = suffixMatches[0];
+            }
+            else
+            {
+                var names = string.Join(", ", candidates.Select(c => c.Name));
+                throw new InvalidOperationException(
+                    $"Multiple test projects reference '{sourceProject.Name}': {names}. " +
+                    $"Pass testProjectName explicitly, or rename a candidate to '{expectedName}' to leverage the suffix tiebreaker.");
+            }
+        }
+        else
+        {
+            picked = candidates[0];
         }
 
-        var picked = candidates[0];
         return status.Projects.FirstOrDefault(p => string.Equals(p.Name, picked.Name, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Inferred test project '{picked.Name}' is not in workspace status — cannot resolve file path.");
     }

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Core.Models;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -151,6 +152,110 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task FirstTestFile_InfersSuffix_When_MultipleTestProjects_Reference_Same_Library()
+    {
+        // scaffold-first-test-file-preview-single-target-heuristic: when multiple test projects
+        // transitively reference the same library, the inference must apply a name-suffix
+        // tiebreaker — pick the candidate whose Name is exactly `<Library>.Tests`. The shipping
+        // SampleLib.Tests is the canonical match; we plant a sibling SampleLib.IntegrationTests
+        // that also references SampleLib and assert the scaffolder still lands the new file in
+        // SampleLib.Tests.
+        var workspace = CreateIsolatedWorkspaceCopy();
+        try
+        {
+            await WriteSiblingTestProjectAsync(workspace, "SampleLib.IntegrationTests", CancellationToken.None);
+            await RestoreWorkspaceAsync(workspace, CancellationToken.None);
+            await workspace.LoadAsync(CancellationToken.None);
+
+            var winningPath = workspace.GetPath("SampleLib.Tests", "DogTests.cs");
+            var losingPath = workspace.GetPath("SampleLib.IntegrationTests", "DogTests.cs");
+            Assert.IsFalse(File.Exists(winningPath),
+                $"Test precondition violated: '{winningPath}' must NOT exist for this scenario.");
+            Assert.IsFalse(File.Exists(losingPath),
+                $"Test precondition violated: '{losingPath}' must NOT exist for this scenario.");
+
+            // Note: testProjectName is null — exercise the inference path with TWO candidates.
+            // Without the suffix tiebreaker, this previously threw
+            // "Multiple test projects reference 'SampleLib': SampleLib.Tests, SampleLib.IntegrationTests."
+            var preview = await ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
+                workspace.WorkspaceId,
+                new ScaffoldFirstTestFileDto(
+                    ServiceMetadataName: "SampleLib.Dog",
+                    TestProjectName: null),
+                CancellationToken.None);
+            var applyResult = await RefactoringService.ApplyRefactoringAsync(
+                preview.PreviewToken, "test_apply", CancellationToken.None);
+
+            Assert.IsTrue(applyResult.Success, applyResult.Error);
+            Assert.IsTrue(File.Exists(winningPath),
+                "Suffix tiebreaker should have selected SampleLib.Tests (matches '<Library>.Tests' convention).");
+            Assert.IsFalse(File.Exists(losingPath),
+                "Non-matching candidate SampleLib.IntegrationTests must not receive the scaffolded fixture.");
+
+            var contents = await File.ReadAllTextAsync(winningPath, CancellationToken.None);
+            StringAssert.Contains(contents, "namespace SampleLib.Tests;",
+                "Scaffolded namespace should be the canonical-suffix test project's namespace.");
+        }
+        finally
+        {
+            await workspace.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task FirstTestFile_StillFails_When_Multiple_Suffix_Matches_OR_Zero_Suffix_Match()
+    {
+        // scaffold-first-test-file-preview-single-target-heuristic: the suffix tiebreaker is
+        // intentionally conservative. The existing pre-filter (line ~408 of
+        // ScaffoldingService.TestBatchAndFirstTestPreview.cs) only admits candidates whose Name
+        // ends with `.Tests`. Within that pool, the tiebreaker prefers the candidate whose Name
+        // is exactly `<SourceProject>.Tests`. When NO candidate matches the exact suffix (e.g.
+        // sibling apps `WebApi.Tests` and `ConsoleHost.Tests` both reference the shared domain
+        // library `SampleLib`), the service must still surface a clear error rather than
+        // picking arbitrarily. Workspace topology: replace the shipping SampleLib.Tests so the
+        // ONLY candidates are non-matching siblings (and `SampleLib.Tests` itself is absent
+        // from the candidate pool, so the suffix-match set is empty).
+        var workspace = CreateIsolatedWorkspaceCopy();
+        try
+        {
+            ReplaceSolutionFile(workspace, new[]
+            {
+                "SampleApp/SampleApp.csproj",
+                "SampleLib/SampleLib.csproj",
+                "WebApi.Tests/WebApi.Tests.csproj",
+                "ConsoleHost.Tests/ConsoleHost.Tests.csproj",
+            });
+            await WriteSiblingTestProjectAsync(workspace, "WebApi.Tests", CancellationToken.None);
+            await WriteSiblingTestProjectAsync(workspace, "ConsoleHost.Tests", CancellationToken.None);
+            await RestoreWorkspaceAsync(workspace, CancellationToken.None);
+            await workspace.LoadAsync(CancellationToken.None);
+
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
+                    workspace.WorkspaceId,
+                    new ScaffoldFirstTestFileDto(
+                        ServiceMetadataName: "SampleLib.Dog",
+                        TestProjectName: null),
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "Multiple test projects reference",
+                "Error must explain ambiguity is the root cause.");
+            StringAssert.Contains(ex.Message, "WebApi.Tests",
+                "Error must enumerate the ambiguous candidates so callers can choose explicitly.");
+            StringAssert.Contains(ex.Message, "ConsoleHost.Tests",
+                "Error must enumerate the ambiguous candidates so callers can choose explicitly.");
+            StringAssert.Contains(ex.Message, "Pass testProjectName explicitly",
+                "Error must point callers at the explicit-disambiguation escape hatch.");
+            StringAssert.Contains(ex.Message, "SampleLib.Tests",
+                "Error must surface the canonical suffix name that would have unlocked the tiebreaker.");
+        }
+        finally
+        {
+            await workspace.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
     public async Task FirstTestFile_EmitsUsings_ForCtorParamNamespaces()
     {
         // scaffold-test-preview-missing-usings: scaffold_first_test_file_preview previously
@@ -186,5 +291,105 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
             "System.Text must be emitted for the StringBuilder ctor parameter.");
         StringAssert.Contains(contents, "using System.Collections.Generic;",
             "System.Collections.Generic must be emitted for the IList<string> ctor parameter.");
+    }
+
+    /// <summary>
+    /// Writes a sibling test project under <paramref name="workspace"/>.RootPath that mirrors
+    /// the shape of <c>SampleLib.Tests</c> (project-references <c>SampleLib</c>, uses the same
+    /// central-package test-SDK dependencies) but is named <paramref name="projectName"/>.
+    /// Caller must call <see cref="RestoreWorkspaceAsync"/> AND, if the new project should be
+    /// part of the loaded solution, ensure the .slnx file references it (the helper handles
+    /// folder creation + csproj writing; .slnx wiring is the caller's responsibility because
+    /// some tests want the project on disk but excluded from the workspace).
+    /// </summary>
+    private static async Task WriteSiblingTestProjectAsync(
+        IsolatedWorkspaceScope workspace,
+        string projectName,
+        CancellationToken ct)
+    {
+        var projectDir = workspace.GetPath(projectName);
+        Directory.CreateDirectory(projectDir);
+
+        var csprojPath = Path.Combine(projectDir, $"{projectName}.csproj");
+        // Mirrors SampleLib.Tests.csproj — same SDK packages so the temp workspace's existing
+        // Directory.Packages.props central versions cover the new project too, keeping the
+        // follow-up `dotnet restore` to a single pass.
+        const string csprojContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <IsTestProject>true</IsTestProject>
+                <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" />
+                <PackageReference Include="MSTest.TestAdapter" />
+                <PackageReference Include="MSTest.TestFramework" />
+              </ItemGroup>
+
+              <ItemGroup>
+                <ProjectReference Include="..\SampleLib\SampleLib.csproj" />
+              </ItemGroup>
+            </Project>
+            """;
+        await File.WriteAllTextAsync(csprojPath, csprojContent, ct).ConfigureAwait(false);
+
+        // The .slnx is only touched if the project should join the solution. By default we add
+        // the new project to the existing .slnx via simple text append (the format is a single
+        // <Project Path="..."/> per line, terminated by </Solution>). Tests that want a wholesale
+        // .slnx rewrite call ReplaceSolutionFile instead AND skip this slnx-merge step.
+        var slnxContents = await File.ReadAllTextAsync(workspace.SolutionPath, ct).ConfigureAwait(false);
+        var projectLine = $"  <Project Path=\"{projectName}/{projectName}.csproj\" />";
+        if (!slnxContents.Contains(projectLine, StringComparison.Ordinal))
+        {
+            // Defensive: only insert when the .slnx still has the closing tag we expect. If a
+            // prior helper has already rewritten the .slnx (e.g. via ReplaceSolutionFile), the
+            // expected closing tag may be absent and the caller is responsible for wiring.
+            var closingTag = "</Solution>";
+            var closeIndex = slnxContents.LastIndexOf(closingTag, StringComparison.Ordinal);
+            if (closeIndex >= 0)
+            {
+                var prefix = slnxContents[..closeIndex].TrimEnd('\r', '\n', ' ');
+                var updated = $"{prefix}{Environment.NewLine}{projectLine}{Environment.NewLine}{closingTag}{Environment.NewLine}";
+                await File.WriteAllTextAsync(workspace.SolutionPath, updated, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rewrites <paramref name="workspace"/>.SolutionPath with a fresh .slnx whose &lt;Project&gt;
+    /// entries are exactly <paramref name="relativeProjectPaths"/>. Used by tests that need to
+    /// exclude shipping projects (e.g. removing <c>SampleLib.Tests</c> so the suffix-match set is
+    /// empty). Caller must invoke <see cref="RestoreWorkspaceAsync"/> after wiring all relevant
+    /// project files on disk.
+    /// </summary>
+    private static void ReplaceSolutionFile(IsolatedWorkspaceScope workspace, IEnumerable<string> relativeProjectPaths)
+    {
+        var lines = new List<string> { "<Solution>" };
+        foreach (var path in relativeProjectPaths)
+        {
+            lines.Add($"  <Project Path=\"{path}\" />");
+        }
+        lines.Add("</Solution>");
+        File.WriteAllText(workspace.SolutionPath, string.Join(Environment.NewLine, lines) + Environment.NewLine);
+    }
+
+    /// <summary>
+    /// Runs <c>dotnet restore</c> on <paramref name="workspace"/>.SolutionPath so newly-written
+    /// sibling test projects acquire their <c>obj/project.assets.json</c> before the workspace
+    /// is loaded. The shipping sample-solution copy is restored ahead-of-time by
+    /// <c>verify-release.ps1</c>; tests that mutate the project graph must restore the deltas.
+    /// </summary>
+    private static async Task RestoreWorkspaceAsync(IsolatedWorkspaceScope workspace, CancellationToken ct)
+    {
+        var execution = await DotnetCommandRunner.RunAsync(
+            workingDirectory: workspace.RootPath,
+            targetPath: workspace.SolutionPath,
+            arguments: ["restore", workspace.SolutionPath, "--nologo"],
+            ct).ConfigureAwait(false);
+
+        Assert.IsTrue(
+            execution.Succeeded,
+            $"dotnet restore failed for test fixture. ExitCode={execution.ExitCode} StdOut={execution.StdOut} StdErr={execution.StdErr}");
     }
 }


### PR DESCRIPTION
## Summary

- `ResolveDestinationTestProject` previously threw "Multiple test projects reference '<lib>': X, Y, Z. Pass testProjectName explicitly." whenever more than one test project transitively referenced the source library — even when the canonical `<Library>.Tests` convention made one candidate unambiguous. This blocked `scaffold_first_test_file_preview` on common topologies like `FirewallAnalyzer.Domain` referenced by 5 sibling `*.Tests` projects.
- The service now applies a single conservative tiebreaker: when multiple candidates pass the existing `.Tests`-suffix pre-filter, prefer the candidate whose Name equals `<SourceProject>.Tests` exactly (case-sensitive `StringComparison.Ordinal`). When the tiebreaker yields exactly one match, the scaffolder proceeds without requiring `testProjectName`.
- Variants like `MyLib.UnitTests` or `MyLib.IntegrationTests` are intentionally NOT broadened to — those topologies still require explicit `testProjectName`. The heuristic is conservative by design. The error message now also surfaces the canonical name that would have unlocked the tiebreaker, so callers know which rename would auto-resolve.

## Test plan

- [x] `mcp__roslyn__compile_check` clean on `ScaffoldingService.TestBatchAndFirstTestPreview.cs` and `ScaffoldingFirstTestFileTests.cs`
- [x] `ScaffoldingFirstTestFileTests` — 7/7 pass (5 existing + 2 new)
  - New: `FirstTestFile_InfersSuffix_When_MultipleTestProjects_Reference_Same_Library` plants a sibling `SampleLib.IntegrationTests` that also references `SampleLib`; asserts the scaffolder still lands the file in `SampleLib.Tests` (the convention-matching candidate) WITHOUT explicit `testProjectName`.
  - New: `FirstTestFile_StillFails_When_Multiple_Suffix_Matches_OR_Zero_Suffix_Match` removes `SampleLib.Tests` from the .slnx and adds `WebApi.Tests` + `ConsoleHost.Tests`; asserts the error still fires (zero suffix matches) AND now mentions both candidates AND the canonical `SampleLib.Tests` name that would have unlocked the tiebreaker.
- [x] `ScaffoldingIntegrationTests` — 24/24 pass (no regression on the broader scaffolding surface)

Closes: scaffold-first-test-file-preview-single-target-heuristic