### PR TITLE
fix(get_source_text): align totalLineCount with source_file_lines resource marker

### DIFF
--- a/changelog.d/source-file-lines-off-by-one-marker-count.md
+++ b/changelog.d/source-file-lines-off-by-one-marker-count.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `get_source_text` reporting `totalLineCount` one higher than the `source_file_lines` resource marker for files ending with a newline; both surfaces now route through `SourceTextSlicer.CountLines` so the counts are consistent. Fixes gh #769 §13.26.

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -282,7 +282,7 @@ public static class WorkspaceTools
             var text = await workspace.GetSourceTextAsync(workspaceId, filePath, c);
             if (text is null) throw new KeyNotFoundException($"Document not found: {filePath}");
 
-            var totalLineCount = text.Count(ch => ch == '\n') + 1;
+            var totalLineCount = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.CountLines(text);
             var requestedStart = startLine ?? 1;
             var requestedEnd = endLine ?? totalLineCount;
 

--- a/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using RoslynMcp.Host.Stdio.Resources;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Tests.Helpers;
 
@@ -194,6 +196,53 @@ public sealed class WorkspaceToolsIntegrationTests : SharedWorkspaceTestBase
         var returnedEnd = doc.RootElement.GetProperty("returnedEndLine").GetInt32();
         Assert.AreEqual(total, returnedEnd, "endLine should clamp to total line count, not error.");
         Assert.AreEqual(99999, doc.RootElement.GetProperty("requestedEndLine").GetInt32());
+    }
+
+    // source-file-lines-off-by-one-marker-count: regression for gh #769 §13.26.
+    // Pre-fix, `WorkspaceTools.GetSourceText` computed `totalLineCount` inline as
+    // `text.Count('\n') + 1`, which over-counted files ending with a trailing newline
+    // by one line. The `source_file_lines` resource correctly used
+    // `SourceTextSlicer.CountLines(text)` (which subtracts 1 when the last char is '\n').
+    // The two surfaces therefore disagreed on N for newline-terminated files — e.g. on
+    // Program.cs (43 lines per `wc -l`, ends with '\n'), `get_source_text.totalLineCount`
+    // returned 44 while the resource marker printed `of 43`. The fix routes both through
+    // `SourceTextSlicer.CountLines` so the counts agree.
+    [TestMethod]
+    public async Task WorkspaceTools_GetSourceText_TotalLineCount_MatchesResourceMarker()
+    {
+        var programPath = FindProgramPath();
+
+        // Tool: read the JSON envelope and grab totalLineCount.
+        var toolJson = await WorkspaceTools.GetSourceText(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            WorkspaceId,
+            programPath,
+            startLine: null,
+            endLine: null,
+            ct: CancellationToken.None);
+        using var doc = JsonDocument.Parse(toolJson);
+        var toolTotal = doc.RootElement.GetProperty("totalLineCount").GetInt32();
+
+        // Resource: read the marker-prefixed body and parse the `of N` suffix on the marker line.
+        // Marker shape (see WorkspaceResources.GetSourceFileLines):
+        //   // roslyn://workspace/{workspaceId}/file/.../lines/{startLine}-{clampedEnd} of {totalLineCount}
+        var resourceBody = await WorkspaceResources.GetSourceFileLines(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            WorkspaceId,
+            programPath,
+            "1-1",
+            CancellationToken.None);
+        var match = Regex.Match(resourceBody, @"of (?<n>\d+)");
+        Assert.IsTrue(match.Success, $"Resource marker must include 'of N'; got: {resourceBody}");
+        var resourceTotal = int.Parse(match.Groups["n"].Value);
+
+        Assert.AreEqual(
+            resourceTotal,
+            toolTotal,
+            $"get_source_text.totalLineCount must match the source_file_lines resource marker " +
+            $"(file: {programPath}). Tool reported {toolTotal}, resource reported {resourceTotal}.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- Routes `WorkspaceTools.GetSourceText` through `SourceTextSlicer.CountLines` so it agrees with the `source_file_lines` resource on `totalLineCount` for newline-terminated files
- Pre-fix the tool inlined `text.Count('\n') + 1`, which over-counted by one when the last char was `\n` (e.g. Program.cs returned 44 vs the resource marker's `of 43`)
- Adds `WorkspaceTools_GetSourceText_TotalLineCount_MatchesResourceMarker` to lock in agreement between the two surfaces against the shared sample fixture
- One-line code change; existing `EndPastEof_ClampsToFileEnd` keeps passing (clamp logic uses the corrected value)

Closes: source-file-lines-off-by-one-marker-count

Parent tracker gh #769 §13.26 — split task; do NOT auto-close.

## Test plan

- [x] `mcp__roslyn__compile_check` clean on `WorkspaceTools.cs` and `WorkspaceToolsIntegrationTests.cs` after restore + analyzer build
- [x] `mcp__roslyn__compile_check` clean across `RoslynMcp.Host.Stdio` and `RoslynMcp.Tests` projects
- [ ] CI: `verify-release.ps1` runs the new `WorkspaceTools_GetSourceText_TotalLineCount_MatchesResourceMarker` test plus the existing `EndPastEof_ClampsToFileEnd` clamp regression