### PR TITLE
fix(symbol_info)!: align record kind with document_symbols

### DIFF
--- a/changelog.d/document-symbols-vs-symbol-info-record-kind-disagreement.md
+++ b/changelog.d/document-symbols-vs-symbol-info-record-kind-disagreement.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** `symbol_info` and the nested `document_symbols` member-walk now return `kind="Record"` (or `"RecordStruct"`) for positional record types, where `symbol_info` previously returned `kind="Class"` for record classes. Callers switching on `"Class"` for records must update. Fixes gh #769 §13.20.

--- a/samples/SampleSolution/SampleLib/AnimalRecords.cs
+++ b/samples/SampleSolution/SampleLib/AnimalRecords.cs
@@ -1,0 +1,13 @@
+namespace SampleLib;
+
+/// <summary>
+/// Positional record class. Used by SymbolMapperTests to verify <c>kind == "Record"</c>
+/// (regression cover for the historical bug where <see cref="INamedTypeSymbol.TypeKind"/>
+/// returned <c>"Class"</c> for record classes).
+/// </summary>
+public record AnimalRecord(string Name, int Legs);
+
+/// <summary>
+/// Record struct. Used by SymbolMapperTests to verify <c>kind == "RecordStruct"</c>.
+/// </summary>
+public readonly record struct AnimalCoord(double Latitude, double Longitude);

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolMapper.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolMapper.cs
@@ -245,6 +245,11 @@ public static class SymbolMapper
     private static string GetKind(ISymbol symbol) =>
         symbol switch
         {
+            // Records masquerade as Class/Struct in TypeKind; check IsRecord first so the
+            // record_class → "Record" and record_struct → "RecordStruct" labels agree with
+            // document_symbols' syntax-side switch (see SymbolSearchService.CollectSymbols).
+            INamedTypeSymbol { IsRecord: true, TypeKind: TypeKind.Struct } => "RecordStruct",
+            INamedTypeSymbol { IsRecord: true, TypeKind: TypeKind.Class } => "Record",
             INamedTypeSymbol namedType => namedType.TypeKind.ToString(),
             _ => symbol.Kind.ToString()
         };

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -405,7 +405,9 @@ public sealed class SymbolSearchService : ISymbolSearchService
                         ClassDeclarationSyntax => "Class",
                         InterfaceDeclarationSyntax => "Interface",
                         StructDeclarationSyntax => "Struct",
-                        RecordDeclarationSyntax => "Record",
+                        // Mirror the top-level CollectSymbols switch so a nested `record struct`
+                        // surfaces as "RecordStruct" instead of being collapsed to "Record".
+                        RecordDeclarationSyntax r => r.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword) ? "RecordStruct" : "Record",
                         _ => "Type"
                     };
                     members.Add(new DocumentSymbolDto(

--- a/tests/RoslynMcp.Tests/SymbolMapperTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolMapperTests.cs
@@ -52,6 +52,82 @@ public sealed class SymbolMapperTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task ToDto_PositionalRecordClass_MapsKindAsRecord()
+    {
+        // Regression cover for the historical bug where SymbolMapper.GetKind returned
+        // "Class" for record classes (TypeKind.Class.ToString()), disagreeing with
+        // document_symbols' syntax-side "Record" label. After the fix the symbol_info
+        // surface returns "Record", matching the document_symbols surface.
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(
+            solution,
+            SymbolLocator.ByMetadataName("SampleLib.AnimalRecord"),
+            CancellationToken.None).ConfigureAwait(false);
+        var dto = SymbolMapper.ToDto(symbol, solution);
+        Assert.AreEqual("Record", dto.Kind);
+        StringAssert.Contains(dto.FullyQualifiedName ?? "", "AnimalRecord");
+    }
+
+    [TestMethod]
+    public async Task ToDto_RecordStruct_MapsKindAsRecordStruct()
+    {
+        // Regression cover: record struct previously surfaced as "Struct" via
+        // TypeKind.Struct.ToString(). After the fix it maps to "RecordStruct",
+        // disambiguating it from a plain struct AND from a record class.
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+        var symbol = await SymbolResolver.ResolveOrThrowAsync(
+            solution,
+            SymbolLocator.ByMetadataName("SampleLib.AnimalCoord"),
+            CancellationToken.None).ConfigureAwait(false);
+        var dto = SymbolMapper.ToDto(symbol, solution);
+        Assert.AreEqual("RecordStruct", dto.Kind);
+        StringAssert.Contains(dto.FullyQualifiedName ?? "", "AnimalCoord");
+    }
+
+    [TestMethod]
+    public async Task SymbolInfo_And_DocumentSymbols_Agree_On_RecordKinds()
+    {
+        // Cross-surface agreement: prior to the fix, symbol_info.kind on a record class
+        // returned "Class" (semantic-side TypeKind.ToString()) while document_symbols.kind
+        // returned "Record" (syntax-side RecordDeclarationSyntax check). After the fix both
+        // surfaces must report the same label for the same source. The same agreement must
+        // hold for record struct ("RecordStruct"). Reading from the shared sample workspace
+        // exercises the same code path a real symbol_info / document_symbols MCP call uses.
+        var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);
+
+        // symbol_info side via SymbolMapper.ToDto.
+        var animalRecordSymbol = await SymbolResolver.ResolveOrThrowAsync(
+            solution,
+            SymbolLocator.ByMetadataName("SampleLib.AnimalRecord"),
+            CancellationToken.None).ConfigureAwait(false);
+        var animalCoordSymbol = await SymbolResolver.ResolveOrThrowAsync(
+            solution,
+            SymbolLocator.ByMetadataName("SampleLib.AnimalCoord"),
+            CancellationToken.None).ConfigureAwait(false);
+        var animalRecordInfo = SymbolMapper.ToDto(animalRecordSymbol, solution);
+        var animalCoordInfo = SymbolMapper.ToDto(animalCoordSymbol, solution);
+
+        // document_symbols side via SymbolSearchService.GetDocumentSymbolsAsync.
+        var sourcePath = animalRecordSymbol.Locations.First(l => l.IsInSource).GetLineSpan().Path;
+        var docSymbols = await SymbolSearchService.GetDocumentSymbolsAsync(
+            WorkspaceId, sourcePath, CancellationToken.None).ConfigureAwait(false);
+
+        // AnimalRecords.cs uses file-scoped namespace, so CollectSymbols hoists the
+        // types to the top level — no children-flattening required.
+        var animalRecordDoc = docSymbols.Single(s => s.Name == "AnimalRecord");
+        var animalCoordDoc = docSymbols.Single(s => s.Name == "AnimalCoord");
+
+        Assert.AreEqual(animalRecordDoc.Kind, animalRecordInfo.Kind,
+            $"symbol_info and document_symbols disagree on AnimalRecord: " +
+            $"document_symbols='{animalRecordDoc.Kind}' symbol_info='{animalRecordInfo.Kind}'");
+        Assert.AreEqual(animalCoordDoc.Kind, animalCoordInfo.Kind,
+            $"symbol_info and document_symbols disagree on AnimalCoord: " +
+            $"document_symbols='{animalCoordDoc.Kind}' symbol_info='{animalCoordInfo.Kind}'");
+        Assert.AreEqual("Record", animalRecordInfo.Kind);
+        Assert.AreEqual("RecordStruct", animalCoordInfo.Kind);
+    }
+
+    [TestMethod]
     public async Task ToDto_Method_MapsReturnTypeAndParameters()
     {
         var solution = WorkspaceManager.GetCurrentSolution(WorkspaceId);


### PR DESCRIPTION
## Summary

**BREAKING:** `symbol_info` and the nested `document_symbols` member-walk now return `kind="Record"` (or `"RecordStruct"`) for positional record types, where `symbol_info` previously returned `kind="Class"` for record classes. Callers switching on `"Class"` for records must update.

## Diagnosis

- `SymbolMapper.GetKind` (semantic-side, used by `symbol_info`) returned `INamedTypeSymbol.TypeKind.ToString()` — and a record class has `TypeKind == TypeKind.Class`, so it surfaced as `"Class"`.
- The top-level `SymbolSearchService.CollectSymbols` switch (syntax-side, used by `document_symbols`) already correctly detected `RecordDeclarationSyntax` and emitted `"Record"`/`"RecordStruct"`.
- The **nested** `CollectMembers` arm at line 408 had the buggy `RecordDeclarationSyntax => "Record"` collapse — a nested `record struct` was being labeled `"Record"` instead of `"RecordStruct"`.

Result: downstream switch consumers that branched on `kind` for the same source file would see disagreement between the two surfaces, and a nested record struct would lose its struct-ness.

## Fix

1. **`SymbolMapper.cs` `GetKind`** — added two pattern arms before the generic `TypeKind.ToString()` fallback:
   - `INamedTypeSymbol { IsRecord: true, TypeKind: TypeKind.Struct } => "RecordStruct"`
   - `INamedTypeSymbol { IsRecord: true, TypeKind: TypeKind.Class } => "Record"`
2. **`SymbolSearchService.cs` `CollectMembers`** (nested-type arm) — replaced `RecordDeclarationSyntax => "Record"` with the same `ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword)` check as the top-level switch.
3. **SampleLib** gains `AnimalRecord` (positional record class) and `AnimalCoord` (`readonly record struct`) so existing-pattern `SharedWorkspaceTestBase` tests can resolve them by metadata name.
4. **`SymbolMapperTests.cs`** gains 3 new fixtures:
   - `ToDto_PositionalRecordClass_MapsKindAsRecord`
   - `ToDto_RecordStruct_MapsKindAsRecordStruct`
   - `SymbolInfo_And_DocumentSymbols_Agree_On_RecordKinds` — cross-surface agreement test proving the bug class is dead.

## Negative space (deliberately untouched)

- The top-level `SymbolSearchService.CollectSymbols` switch (lines 305-313) — already correct.
- `symbol_search.kind` filter logic (`MatchesKind` at line 274) — already two-level (checks both `symbol.Kind` and `TypeKind`); not affected by this change since `IsRecord` was never in the filter set.

## Test plan

- [x] `mcp__roslyn__compile_check` — 0 errors, 0 warnings
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~SymbolMapperTests` — 10/10 pass (7 original + 3 new)
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~ServiceCoverageTests|FullyQualifiedName~DocumentSymbolsSymbolHandleTests` — 19/19 pass
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~SymbolInfo|FullyQualifiedName~SymbolSearch|FullyQualifiedName~DocumentSymbol` — 29/29 pass
- [x] `./eng/verify-ai-docs.ps1` — passed
- [ ] Self-hosted runner CI: `verify-release.ps1` (deferred to CI per local-skip policy)

## CHANGELOG

`changelog.d/document-symbols-vs-symbol-info-record-kind-disagreement.md` filed under category `Changed — BREAKING`.

Closes: document-symbols-vs-symbol-info-record-kind-disagreement

Parent tracker gh #769 §13.20 remains open (other sub-rows still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)