### PR TITLE
release: v2.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.2.2] - 2026-05-21
+
+### Fixed
+
+- **Fixed:** `find_duplicate_helpers` now filters common framework glue wrappers for Serilog hosting, CORS service registration, and HTTP resilience extension APIs while still reporting true local duplicate helpers. Closes `find-duplicate-helpers-framework-wrapper-filter-leak`.
+- **Fixed:** Metadata-name NotFound responses can now include structured `closestMatches` suggestions so near-miss `symbol_info` and shared resolver paths point agents at likely symbols instead of forcing a separate search round trip. Closes `symbol-search-nearest-fuzzy-fallback`.
+- **Fixed:** Hardened test runner failure envelopes, added `recommend_workflow`, refreshed fast-path prompt guidance, ranked direct `test_related_files` references first, and exposed resource server-name hints. Closes `test-run-bare-exception-envelope`, `agent-workflow-router-first-hop`, `discover-capabilities-quick-path-steering`, `test-related-files-direct-reference-ranking`, and `mcp-resource-server-name-aliasing`.
+
+### Added
+
+- **Added:** `/mcp-server-surface-test` now documents `--cleanup-only` crash recovery and a per-phase checkpoint/resume contract for full audits, reducing manual recovery after interrupted surface-test runs. Closes `surface-test-resumability-cleanup-skill`.
+
+### Maintenance
+
+- **Maintenance:** Added the `plugin-package-files-allowlist` design note, verified the Claude Code plugin schema has no package `files` allowlist field, and split the release-side allowlist enforcement follow-up row.
+- **Maintenance:** Added the `workspace-fork-apply-primitive` design note and split the concrete `workspace-fork-apply-tool` implementation row, covering forked apply/validate tool shape, retention semantics, cleanup, and restart recovery.
+
 ## [2.2.1] - 2026-05-21
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/find-duplicate-helpers-framework-wrapper-filter-leak.md
+++ b/changelog.d/find-duplicate-helpers-framework-wrapper-filter-leak.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_duplicate_helpers` now filters common framework glue wrappers for Serilog hosting, CORS service registration, and HTTP resilience extension APIs while still reporting true local duplicate helpers. Closes `find-duplicate-helpers-framework-wrapper-filter-leak`.

--- a/changelog.d/plugin-package-files-allowlist.md
+++ b/changelog.d/plugin-package-files-allowlist.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Added the `plugin-package-files-allowlist` design note, verified the Claude Code plugin schema has no package `files` allowlist field, and split the release-side allowlist enforcement follow-up row.

--- a/changelog.d/surface-test-resumability-cleanup-skill.md
+++ b/changelog.d/surface-test-resumability-cleanup-skill.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `/mcp-server-surface-test` now documents `--cleanup-only` crash recovery and a per-phase checkpoint/resume contract for full audits, reducing manual recovery after interrupted surface-test runs. Closes `surface-test-resumability-cleanup-skill`.

--- a/changelog.d/symbol-search-nearest-fuzzy-fallback.md
+++ b/changelog.d/symbol-search-nearest-fuzzy-fallback.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Metadata-name NotFound responses can now include structured `closestMatches` suggestions so near-miss `symbol_info` and shared resolver paths point agents at likely symbols instead of forcing a separate search round trip. Closes `symbol-search-nearest-fuzzy-fallback`.

--- a/changelog.d/test-run-bare-exception-envelope.md
+++ b/changelog.d/test-run-bare-exception-envelope.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Hardened test runner failure envelopes, added `recommend_workflow`, refreshed fast-path prompt guidance, ranked direct `test_related_files` references first, and exposed resource server-name hints. Closes `test-run-bare-exception-envelope`, `agent-workflow-router-first-hop`, `discover-capabilities-quick-path-steering`, `test-related-files-direct-reference-ranking`, and `mcp-resource-server-name-aliasing`.

--- a/changelog.d/workspace-fork-apply-primitive.md
+++ b/changelog.d/workspace-fork-apply-primitive.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Added the `workspace-fork-apply-primitive` design note and split the concrete `workspace-fork-apply-tool` implementation row, covering forked apply/validate tool shape, retention semantics, cleanup, and restart recovery.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary

Version bump to v2.2.2 (patch). Consumes 6 `changelog.d/` fragments into the new `## [2.2.2] - 2026-05-21` section of `CHANGELOG.md`.

- **Fixed (3):** `find_duplicate_helpers` framework-wrapper filter leak; `closestMatches` suggestions on metadata-name `NotFound` envelopes; hardened test-runner failure envelopes + workflow router + reference ranking + resource server-name hints.
- **Added (1):** `/mcp-server-surface-test` `--cleanup-only` + per-phase checkpoint/resume contract.
- **Maintenance (2):** `plugin-package-files-allowlist` design note; `workspace-fork-apply-primitive` design note.

See `CHANGELOG.md` § [2.2.2] for the full bullet text.

## Test plan

- [x] All 6 version files agree (Directory.Build.props, plugin.json, marketplace.json, manifest.json, server.json x2, CHANGELOG.md) — verified locally via `eng/verify-version-drift.ps1`.
- [x] `eng/verify-ai-docs.ps1` passes locally (32 shipped skills generic).
- [ ] CI `validate` job (self-hosted runner) — full `verify-release.ps1` gate.

Generated with [Claude Code](https://claude.com/claude-code)