### PR TITLE
fix: decouple auto-reload recovery from telemetry

### DIFF
--- a/changelog.d/workspace-gate-autoreload-telemetry-coupling.md
+++ b/changelog.d/workspace-gate-autoreload-telemetry-coupling.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `WorkspaceExecutionGate` no longer depends on ambient telemetry to reset post-reload timeout budgets or retry transient stale-snapshot errors after a successful auto-reload; also closed the remaining CA2016 cancellation-token propagation diagnostic in `ParameterObjectService`.

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -56,7 +56,7 @@ public sealed class ParameterObjectService : IParameterObjectService
         var (dtoProject, dtoVisibilityIsPublic) = ResolveDtoProject(solution, method, request);
 
         var callerLocations = await CollectCallerSpansAsync(solution, method, ct).ConfigureAwait(false);
-        var methodProject = solution.GetProject(method.ContainingAssembly)!;
+        var methodProject = solution.GetProject(method.ContainingAssembly, ct)!;
         EnforceCrossProjectReferences(solution, methodProject, dtoProject, callerLocations);
 
         var defaultValueWarnings = await CollectDefaultValueWarningsAsync(

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -167,9 +167,10 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
         // workspace_reload calls — the reload's own write-locking is handled by WorkspaceManager.
         // workspace_close skips this: reloading requires the on-disk solution, which may already
         // be deleted while the in-memory session is still registered (F21 / missing worktree).
+        var autoReloaded = false;
         if (applyStalenessPolicy)
         {
-            await ApplyStalenessPolicyAsync(workspaceId, linked).ConfigureAwait(false);
+            autoReloaded = await ApplyStalenessPolicyAsync(workspaceId, linked).ConfigureAwait(false);
 
             // parallel-fanout-auto-reload-timeout-floor: when an auto-reload just completed,
             // the timeout CTS has consumed some (possibly all) of the _requestTimeout budget
@@ -178,13 +179,12 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
             // reads from hitting the 5-second floor when the reload finishes in <2s but the
             // remaining budget is already exhausted.
             //
-            // The extension fires only when StaleAction == "auto-reloaded" (i.e. the reload
-            // succeeded). A reload that threw KeyNotFoundException leaves StaleAction unset
-            // and the original deadline stands. The token must not already be cancelled
-            // (e.g. the caller cancelled, or the reload itself used all budget) — in that case
-            // we let the existing OperationCanceledException propagate unchanged.
-            if (AmbientGateMetrics.Current?.StaleAction == "auto-reloaded" &&
-                !linked.IsCancellationRequested)
+            // The extension fires only when ApplyStalenessPolicyAsync reports a successful
+            // reload. A reload that threw KeyNotFoundException leaves autoReloaded=false and
+            // the original deadline stands. The token must not already be cancelled (e.g. the
+            // caller cancelled, or the reload itself used all budget) — in that case we let the
+            // existing OperationCanceledException propagate unchanged.
+            if (autoReloaded && !linked.IsCancellationRequested)
             {
                 timeoutCts.CancelAfter(_requestTimeout);
             }
@@ -198,14 +198,14 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 using (await rwLock.WriterLockAsync(linked).ConfigureAwait(false))
                 {
                     EnsureWorkspaceStillExists(workspaceId);
-                    return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked)).ConfigureAwait(false);
+                    return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked, autoReloaded)).ConfigureAwait(false);
                 }
             }
 
             using (await rwLock.ReaderLockAsync(linked).ConfigureAwait(false))
             {
                 EnsureWorkspaceStillExists(workspaceId);
-                return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked)).ConfigureAwait(false);
+                return await RunWithMetricsAsync("rw-lock", queueStopwatch, () => RunActionWithPostReloadRetryAsync(action, linked, autoReloaded)).ConfigureAwait(false);
             }
         }, linked).ConfigureAwait(false);
     }
@@ -243,13 +243,14 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     /// </remarks>
     private static async Task<T> RunActionWithPostReloadRetryAsync<T>(
         Func<CancellationToken, Task<T>> action,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool autoReloaded)
     {
         try
         {
             return await action(ct).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ShouldRetryAfterAutoReload(ex))
+        catch (Exception ex) when (ShouldRetryAfterAutoReload(ex, autoReloaded))
         {
             // Stamp the retry flag BEFORE the second attempt so the response envelope shows
             // retriedAfterReload=true on both the success path AND the eventual-failure path.
@@ -303,9 +304,9 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     /// error <i>and</i> the current request just auto-reloaded the workspace. The intersection
     /// is deliberately narrow: any one condition alone is not enough to justify a retry.
     /// </summary>
-    private static bool ShouldRetryAfterAutoReload(Exception ex)
+    private static bool ShouldRetryAfterAutoReload(Exception ex, bool autoReloaded)
     {
-        if (AmbientGateMetrics.Current?.StaleAction != "auto-reloaded")
+        if (!autoReloaded)
         {
             return false;
         }
@@ -340,16 +341,16 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     /// leaves the snapshot alone but stamps <see cref="AmbientGateMetrics"/> so the response
     /// envelope surfaces a structured signal, Off is a no-op.
     /// </summary>
-    private async Task ApplyStalenessPolicyAsync(string workspaceId, CancellationToken ct)
+    private async Task<bool> ApplyStalenessPolicyAsync(string workspaceId, CancellationToken ct)
     {
         if (_onStale == StalenessPolicy.Off)
         {
-            return;
+            return false;
         }
 
         if (!_workspaceManager.IsStale(workspaceId))
         {
-            return;
+            return false;
         }
 
         var metrics = AmbientGateMetrics.Current;
@@ -360,7 +361,7 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
             {
                 metrics.StaleAction = "warn";
             }
-            return;
+            return false;
         }
 
         // AutoReload: reload under the existing load-gate path so writes can't race with us.
@@ -391,6 +392,8 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 metrics.StaleReloadMs = reloadStopwatch.ElapsedMilliseconds;
             }
         }
+
+        return reloaded;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -556,6 +556,36 @@ public class WorkspaceExecutionGateTests
             "Successful retry after auto-reload must stamp retriedAfterReload=true so callers can correlate the recovered call.");
     }
 
+    [TestMethod]
+    public async Task StalenessPolicy_AutoReload_ActionFailsWithDocumentNotFoundWithoutMetrics_RetriesOnceAndSucceeds()
+    {
+        var manager = new FakeGateWorkspaceManager();
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { OnStale = StalenessPolicy.AutoReload },
+            manager);
+
+        Assert.IsNull(AmbientGateMetrics.Current);
+
+        var attempts = 0;
+        var result = await gate.RunReadAsync(WorkspaceA, _ =>
+        {
+            attempts++;
+            if (attempts == 1)
+            {
+                throw new InvalidOperationException("Document not found: C:/path/to/File.cs");
+            }
+
+            return Task.FromResult(42);
+        }, CancellationToken.None);
+
+        Assert.AreEqual(42, result);
+        Assert.AreEqual(2, attempts, "Action must retry once after an auto-reload even when no metrics scope exists.");
+        Assert.AreEqual(1, manager.ReloadCount, "Retry should reuse the completed reload, not reload again.");
+        Assert.IsNull(AmbientGateMetrics.Current);
+    }
+
     /// <summary>
     /// auto-reload-retry-inside-call: cap the retry at 1. If the second attempt also fails
     /// with the same transient error, the original exception propagates. The retry flag stays
@@ -729,6 +759,41 @@ public class WorkspaceExecutionGateTests
         var metrics = AmbientGateMetrics.Current;
         Assert.IsNotNull(metrics);
         Assert.AreEqual("auto-reloaded", metrics!.StaleAction);
+    }
+
+    [TestMethod]
+    public async Task AutoReload_ResetsTimeoutBudgetWithoutAmbientMetrics_ToolActionGetsFullBudget()
+    {
+        // The timeout reset is part of the gate contract, not a side effect of telemetry.
+        // Without an ambient metrics scope, this test spends enough of the original budget
+        // on reload that reload+action would exceed it. The timeout is intentionally wider
+        // than the reload itself so full-suite CPU contention does not cancel before the
+        // reset point.
+        var reloadDelay = TimeSpan.FromMilliseconds(500);
+        var toolTimeout = TimeSpan.FromSeconds(2);
+
+        var manager = new FakeGateWorkspaceManager(reloadDelayMs: (int)reloadDelay.TotalMilliseconds);
+        manager.MarkStale(WorkspaceA);
+
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions
+            {
+                RequestTimeout = toolTimeout,
+                OnStale = StalenessPolicy.AutoReload,
+            },
+            manager);
+
+        Assert.IsNull(AmbientGateMetrics.Current);
+
+        var result = await gate.RunReadAsync(WorkspaceA, async ct =>
+        {
+            await Task.Delay(1600, ct);
+            return 99;
+        }, CancellationToken.None);
+
+        Assert.AreEqual(99, result, "Tool action must receive a fresh timeout budget after auto-reload even when no metrics scope exists.");
+        Assert.AreEqual(1, manager.ReloadCount, "Auto-reload should fire exactly once.");
+        Assert.IsNull(AmbientGateMetrics.Current);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Decouples WorkspaceExecutionGate auto-reload timeout reset and stale-snapshot retry decisions from ambient telemetry.
- Adds regressions for direct gate callers without an AmbientGateMetrics scope.
- Forwards cancellation through ParameterObjectService.GetProject and records the fix in changelog.d.

## Test plan
- [x] `dotnet test tests\RoslynMcp.Tests\RoslynMcp.Tests.csproj --configuration Release --no-build --nologo --filter "FullyQualifiedName~RoslynMcp.Tests.WorkspaceExecutionGateTests"`
- [x] Related `ParameterObjectPreviewTests` via Roslyn MCP `test_run`
- [x] Roslyn MCP `compile_check`
- [x] `dotnet format whitespace RoslynMcp.slnx --verify-no-changes --no-restore --include src\RoslynMcp.Roslyn\Services\WorkspaceExecutionGate.cs src\RoslynMcp.Roslyn\Services\ParameterObjectService.cs tests\RoslynMcp.Tests\WorkspaceExecutionGateTests.cs`
- [x] `just ci`

Generated with [Codex](https://Codex.com/Codex)