### PR TITLE
refactor(workspace): extract cache coordinator

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at: 2026-05-22T07:35:36Z**
+**updated_at: 2026-05-22T19:06:35Z**
 
 ## Agent contract
 
@@ -57,8 +57,6 @@
 | id | pri | deps | do |
 |----|-----|------|-----|
 | `tool-surface-pagination-or-tool-sets` | Low | none | 171 tools is approaching small-model discovery saturation, but current evidence points to a routing/steering problem more than a raw-count problem. Now that `recommend_workflow` exists, wait for fresh post-router evidence before adding tool-set catalog resources (for example `roslyn://server/catalog/tool-sets` and `roslyn://server/catalog/tools/{toolSet}/{offset}/{limit}`) that expose bounded subsets such as `navigation`, `refactoring`, `validation`, and `analysis` without hiding tools from clients that can handle the full surface. Do not change MCP tool registration or default `tools/list` visibility in this row unless the implementation note proves the client supports that safely. Anchors: `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs`, `src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs`, `tests/RoslynMcp.Tests/SurfaceCatalogTests.cs`. Regression test shape: catalog summary advertises the tool-set resource; each named set returns only matching categories with offset/limit/hasMore metadata; unknown set returns structured `InvalidArgument`; existing full and paginated catalog resources remain unchanged. Evidence: surface count drift across recent versions (`server_info.surface.registered.tools` 151 -> 171 since v1.27); MCP spec tools/list pagination; 2026-05-20 no-context subagent probe showed correctly steered agents chose Roslyn primitives without needing a full catalog dump. **Weaker evidence - N until small-model discovery friction is reported after the router lands externally.** Source: 2026-05-05 MCP-best-practices comparison §3 rec J plus 2026-05-20 agent-view review. |
-| `workspace-cache-coordinator-extraction` | Low | none | Extract workspace-cache probe/writeback policy from `WorkspaceManager` into an internal `WorkspaceCacheCoordinator` without changing public workspace or cache-store contracts. Anchors: `src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs`, new `src/RoslynMcp.Roslyn/Services/WorkspaceCacheCoordinator.cs`, `src/RoslynMcp.Roslyn/Services/WorkspaceCacheStore.cs`, `src/RoslynMcp.Core/Services/IWorkspaceCacheStore.cs`, `tests/RoslynMcp.Tests/Workspace/WorkspaceLoadCacheFastPathTests.cs`, `tests/RoslynMcp.Tests/Services/WorkspaceCacheStoreInvalidationTests.cs`. Regression/output shape: existing warm/cold cache fast-path tests still pass; add focused coordinator tests for cache miss, stale metadata-reference rejection, matching graph hit, graph mismatch writeback, and fail-soft store exceptions. Evidence: `ai_docs/items/workspace-manager-cache-store-extraction-design.md`. |
-| `initiative-executor-roslyn-tool-discovery-experiment` | Low | none | Measure whether refactoring initiative executors still bypass Roslyn semantic first-hop tools after `recommend_workflow`; only then edit the executor brief. Anchors: `.claude/agents/initiative-executor.md`, `ai_docs/reports/20260521T043918Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md`, `src/RoslynMcp.Host.Stdio/Prompts/RoslynPrompts.GuidedWorkflows.cs`, `skills/refactor/SKILL.md`, `skills/semantic-find/SKILL.md`. Regression/output shape: create a measurement note with sample source, semantic-first-hop counts, generic `Read`/`Grep`/`Edit` counts, workspace_reload counts, and a go/no-go decision; if go, add one follow-on implementation row to inject the Roslyn-first stanza and validate it with a controlled refactor rerun. Evidence: `ai_docs/items/initiative-executor-roslyn-tool-discovery-brief.md`. |
 
 ## Defer
 
@@ -90,3 +88,4 @@
 | `ai_docs/plans/20260518T221744Z_backlog-sweep/plan.md` | Shipped 15 initiatives, 15 PRs (#823–#838), 15 rows closed |
 | `ai_docs/plans/20260519T145945Z_backlog-sweep/plan.md` | Shipped 6 initiatives, 6 PRs (#842–#847), 6 rows closed |
 | `ai_docs/plans/20260519T193650Z_backlog-sweep/plan.md` | Shipped 15 initiatives, 15 PRs (#852–#871), 15 rows closed |
+| `ai_docs/plans/20260522T132800Z_top5-remediation/plan.md` | Shipped 1 code initiative and closed 1 measurement no-go |

--- a/ai_docs/items/initiative-executor-roslyn-tool-discovery-measurement.md
+++ b/ai_docs/items/initiative-executor-roslyn-tool-discovery-measurement.md
@@ -1,0 +1,55 @@
+# Initiative Executor Roslyn Tool Discovery Measurement
+
+<!-- purpose: Decide whether to edit the initiative-executor brief after recommend_workflow shipped. -->
+<!-- scope: in-repo -->
+
+## Question
+
+Do refactoring initiative executors still bypass Roslyn semantic first-hop tools
+after `recommend_workflow` exists?
+
+## Sources Checked
+
+- `ai_docs/reports/20260521T043918Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md`
+- `src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs`
+- `tests/RoslynMcp.Tests/WorkflowRecommendationToolsTests.cs`
+- `.claude/agents/initiative-executor.md`
+
+`recommend_workflow` landed in commit
+`2def1918aa16c30b5ae67f45360b8bd7d2db44f1` on
+2026-05-21 18:34:18 -0500. The available multi-session retro was generated at
+2026-05-21T04:39:18Z, so its refactoring-subagent sample is pre-router
+evidence, not post-router evidence.
+
+## Measurement
+
+The available pre-router sample covered five `initiative-executor` refactoring
+subagents:
+
+| Sample | Value |
+|---|---:|
+| Refactoring initiative-executor sessions | 5 |
+| Sessions with no core semantic first-hop calls (`find_references`, `symbol_search`, `rename_preview`, move/extract previews) | 4 of 5 |
+| Sessions dominated by generic `Read` / `Grep` / `Edit` / `Bash` | 5 of 5 |
+| `workspace_reload` calls per sampled subagent | 4-7 |
+| Generic `Read` calls per sampled subagent | 27-41 |
+| Generic `Grep` calls per sampled subagent | 18-19 |
+| Generic `Bash` calls per sampled subagent | 18-41 |
+| Generic `Edit` calls per sampled subagent | 7 in the explicitly counted samples |
+
+That confirms the original discovery problem before the router existed. It does
+not prove the behavior persists after `recommend_workflow`.
+
+## Decision
+
+No-go for editing `.claude/agents/initiative-executor.md` in this session.
+
+The current evidence is strong enough to explain why `recommend_workflow` was
+added, but it is not a valid post-router sample. There are no implementation
+changes to the executor brief to make from this row without inventing evidence.
+Do not add the follow-on brief-injection row yet.
+
+If a future refactoring-only retro samples post-`2def1918` sessions and still
+finds semantic first-hop bypass or high reload churn, re-add a bounded backlog
+row to inject a Roslyn-first stanza into `.claude/agents/initiative-executor.md`
+and validate it with a controlled refactor rerun.

--- a/ai_docs/plans/20260522T132800Z_top5-remediation/plan.md
+++ b/ai_docs/plans/20260522T132800Z_top5-remediation/plan.md
@@ -1,0 +1,70 @@
+# Top 5 Backlog Remediation Plan
+
+<!-- scope: in-repo -->
+
+Created: 2026-05-22T13:28:00Z
+
+## Selection
+
+Source: `ai_docs/backlog.md` as of `updated_at: 2026-05-22T07:35:36Z`.
+
+Selection rule: inspect the five remaining canonical rows in priority order and
+select only rows whose current deliverable is implementation-ready in this
+session. Rows whose own wording requires future evidence, an external driver, or
+future worse-profile data are classified but not forced into code changes.
+
+Selected rows:
+
+1. `workspace-cache-coordinator-extraction`
+2. `initiative-executor-roslyn-tool-discovery-experiment`
+
+Classified but skipped:
+
+- `tool-surface-pagination-or-tool-sets` - externally blocked by its own
+  requirement for fresh post-router evidence of small-model discovery friction.
+- `http-streamable-host-project` - intentionally deferred pending a concrete
+  remote-deployment driver with named users and an approved auth/observability
+  plan.
+- `workspace-process-pool-or-daemon` - intentionally deferred pending worse
+  large-solution profile evidence.
+
+## Plan
+
+1. Add focused red tests around an internal `WorkspaceCacheCoordinator`:
+   cache miss, stale metadata-reference rejection, matching graph hit, graph
+   mismatch writeback, and fail-soft store exceptions.
+2. Extract cache probe/writeback policy from `WorkspaceManager` into
+   `src/RoslynMcp.Roslyn/Services/WorkspaceCacheCoordinator.cs`, preserving
+   `IWorkspaceCacheStore`, `WorkspaceCacheStore`, public workspace contracts,
+   cache key format, and `AmbientGateMetrics.CacheHit` semantics.
+3. Keep `WorkspaceManager` responsible for load/session lifecycle, restore-race
+   waiting, stale tracking, session replacement, and metrics orchestration.
+4. Complete the initiative-executor measurement row by recording the current
+   available sample source, semantic first-hop/generic tool/reload counts, and a
+   go/no-go decision. If the sample is insufficient, close the row with a
+   documented no-edit decision rather than editing `.claude/agents/`.
+5. Add focused validation:
+   - new coordinator test filter;
+   - existing cache fast-path/store invalidation tests;
+   - `compile_check`;
+   - `./eng/verify-ai-docs.ps1`;
+   - merge-ready `just ci`.
+6. backlog: sync `ai_docs/backlog.md` by removing completed selected rows or
+   replacing them with bounded follow-on rows only if the shipped evidence
+   requires follow-up.
+7. changelog: add a fragment covering the completed selected rows.
+
+## Execution Notes
+
+- `workspace-cache-coordinator-extraction`: implemented. Cache probing,
+  graph/metadata hashing, metadata-reference freshness, and writeback moved to
+  `WorkspaceCacheCoordinator`; `WorkspaceManager` now owns only load lifecycle
+  orchestration and cache-hit metric stamping.
+- `initiative-executor-roslyn-tool-discovery-experiment`: measured and closed
+  as no-go for executor-brief edits. The only available refactoring-subagent
+  sample predates `recommend_workflow`, so it confirms the pre-router problem
+  but cannot justify a post-router `.claude/agents/initiative-executor.md`
+  change. Measurement recorded in
+  `ai_docs/items/initiative-executor-roslyn-tool-discovery-measurement.md`.
+- `ai_docs/backlog.md` synced by removing both completed rows from open work.
+- `changelog.d/workspace-cache-coordinator-extraction.md` added for the batch.

--- a/changelog.d/workspace-cache-coordinator-extraction.md
+++ b/changelog.d/workspace-cache-coordinator-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extracted workspace cache probe/writeback policy into `WorkspaceCacheCoordinator`, added focused cache-coordinator regression coverage, and closed the initiative-executor post-router measurement with a no-go decision pending fresh evidence.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceCacheCoordinator.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceCacheCoordinator.cs
@@ -1,0 +1,284 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+internal sealed class WorkspaceCacheCoordinator
+{
+    private readonly IWorkspaceCacheStore _cacheStore;
+    private readonly ILogger? _logger;
+
+    public WorkspaceCacheCoordinator(IWorkspaceCacheStore cacheStore, ILogger? logger = null)
+    {
+        _cacheStore = cacheStore ?? throw new ArgumentNullException(nameof(cacheStore));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Probe-stage cache lookup performed before MSBuild opens the solution. Captures the
+    /// (solutionHash, sdkVersion) prefix of the cache-key triple; the graph hash is validated
+    /// after load by <see cref="ResolveAndWriteAsync"/>.
+    /// </summary>
+    public async Task<WorkspaceCacheProbe?> TryProbeAsync(string fullPath, CancellationToken ct)
+    {
+        try
+        {
+            var solutionHash = await ComputeSolutionContentHashAsync(fullPath, ct).ConfigureAwait(false);
+            if (solutionHash is null) return null;
+
+            var sdkVersion = ResolveSdkVersionForCacheKey();
+            var candidate = await TryEnumerateNewestCacheEntryAsync(solutionHash, sdkVersion, ct).ConfigureAwait(false);
+            if (candidate is null)
+            {
+                return new WorkspaceCacheProbe(
+                    solutionHash, sdkVersion, CachedEntry: null, MetadataReferencesStillStable: false);
+            }
+
+            var stable = MetadataReferencesStillStableOnDisk(candidate);
+            return new WorkspaceCacheProbe(solutionHash, sdkVersion, candidate, stable);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogDebug(ex, "Workspace cache probe failed for '{Path}'; cold-load path will run.", fullPath);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Post-load reconciliation. Confirms a probe-stage candidate against the actual graph and
+    /// writes the current graph/metadata entry under the canonical graph key.
+    /// </summary>
+    public async Task<WorkspaceCacheWriteResult?> ResolveAndWriteAsync(
+        Solution solution,
+        WorkspaceCacheProbe probe,
+        CancellationToken ct)
+    {
+        try
+        {
+            var actualGraph = BuildCachedGraphFromSolution(solution);
+            var actualMetadataRefs = BuildCachedMetadataRefsFromSolution(solution);
+            var actualGraphHash = ComputeMsbuildGraphHash(actualGraph);
+            var canonicalKey = new WorkspaceCacheKey(probe.SolutionHash, probe.SdkVersion, actualGraphHash);
+            var cacheHit = false;
+
+            if (probe.CachedEntry is not null)
+            {
+                var cachedGraphHash = ComputeMsbuildGraphHash(probe.CachedEntry.ProjectGraph);
+                if (string.Equals(cachedGraphHash, actualGraphHash, StringComparison.Ordinal)
+                    && probe.MetadataReferencesStillStable)
+                {
+                    cacheHit = true;
+                }
+            }
+
+            var entryToWrite = new WorkspaceCacheEntry(actualGraph, actualMetadataRefs, DateTime.UtcNow);
+            _ = await _cacheStore.PutAsync(canonicalKey, entryToWrite, ct).ConfigureAwait(false);
+            return new WorkspaceCacheWriteResult(cacheHit);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogDebug(ex, "Workspace cache write failed for '{SolutionHash}'; cold path stands.", probe.SolutionHash);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Cold-path cache write used when the probe found no candidate for the solution/sdk pair.
+    /// </summary>
+    public async Task<WorkspaceCacheWriteResult?> WriteFreshEntryAsync(
+        Solution solution,
+        string fullPath,
+        CancellationToken ct)
+    {
+        try
+        {
+            var solutionHash = await ComputeSolutionContentHashAsync(fullPath, ct).ConfigureAwait(false);
+            if (solutionHash is null) return null;
+
+            var sdkVersion = ResolveSdkVersionForCacheKey();
+            var graph = BuildCachedGraphFromSolution(solution);
+            var metadataRefs = BuildCachedMetadataRefsFromSolution(solution);
+            var graphHash = ComputeMsbuildGraphHash(graph);
+
+            var key = new WorkspaceCacheKey(solutionHash, sdkVersion, graphHash);
+            var entry = new WorkspaceCacheEntry(graph, metadataRefs, DateTime.UtcNow);
+
+            _ = await _cacheStore.PutAsync(key, entry, ct).ConfigureAwait(false);
+            return new WorkspaceCacheWriteResult(CacheHit: false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogDebug(ex, "Workspace cache write failed for '{Path}'; cold path stands.", fullPath);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates cache entries under the concrete store's solution/sdk directory and returns
+    /// the most recently written entry. Custom store implementations cannot expose a root
+    /// layout, so they skip this probe and still receive post-load writes through the interface.
+    /// </summary>
+    private async Task<WorkspaceCacheEntry?> TryEnumerateNewestCacheEntryAsync(
+        string solutionHash,
+        string sdkVersion,
+        CancellationToken ct)
+    {
+        if (_cacheStore is not WorkspaceCacheStore concreteStore)
+        {
+            return null;
+        }
+
+        var probeKey = new WorkspaceCacheKey(solutionHash, sdkVersion, "probe");
+        var probePath = concreteStore.ResolveEntryPath(probeKey);
+        var graphHashDir = Path.GetDirectoryName(probePath);
+        var sdkDir = graphHashDir is null ? null : Path.GetDirectoryName(graphHashDir);
+
+        if (sdkDir is null || !Directory.Exists(sdkDir))
+        {
+            return null;
+        }
+
+        try
+        {
+            string? newestEntryPath = null;
+            DateTime newestMtime = DateTime.MinValue;
+
+            foreach (var graphDir in Directory.EnumerateDirectories(sdkDir))
+            {
+                ct.ThrowIfCancellationRequested();
+                var entryPath = Path.Combine(graphDir, "entry.json");
+                if (!File.Exists(entryPath)) continue;
+                var mtime = File.GetLastWriteTimeUtc(entryPath);
+                if (mtime > newestMtime)
+                {
+                    newestMtime = mtime;
+                    newestEntryPath = entryPath;
+                }
+            }
+
+            if (newestEntryPath is null) return null;
+
+            return await concreteStore.TryGetEntryAtPathAsync(newestEntryPath, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogDebug(ex, "Workspace cache enumeration failed under '{Dir}'; treating as miss.", sdkDir);
+            return null;
+        }
+    }
+
+    internal static async Task<string?> ComputeSolutionContentHashAsync(string fullPath, CancellationToken ct)
+    {
+        try
+        {
+            var bytes = await File.ReadAllBytesAsync(fullPath, ct).ConfigureAwait(false);
+            var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _ = ex;
+            return null;
+        }
+    }
+
+    internal static string ResolveSdkVersionForCacheKey() =>
+        System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+
+    internal static string ComputeMsbuildGraphHash(IReadOnlyList<CachedProjectGraphNode> graph)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var node in graph.OrderBy(n => n.ProjectPath, StringComparer.OrdinalIgnoreCase))
+        {
+            sb.Append(node.ProjectPath);
+            sb.Append('\t');
+            foreach (var refPath in node.ProjectReferences.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.Append(refPath);
+                sb.Append('|');
+            }
+            sb.Append('\n');
+        }
+        var bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    internal static IReadOnlyList<CachedProjectGraphNode> BuildCachedGraphFromSolution(Solution solution)
+    {
+        var byId = solution.Projects.ToDictionary(p => p.Id);
+        var graph = new List<CachedProjectGraphNode>(solution.ProjectIds.Count);
+        foreach (var project in solution.Projects.OrderBy(p => p.FilePath, StringComparer.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(project.FilePath)) continue;
+            var refs = new List<string>(project.ProjectReferences.Count());
+            foreach (var pref in project.ProjectReferences)
+            {
+                if (byId.TryGetValue(pref.ProjectId, out var refProj) && !string.IsNullOrEmpty(refProj.FilePath))
+                {
+                    refs.Add(refProj.FilePath);
+                }
+            }
+            graph.Add(new CachedProjectGraphNode(project.FilePath, refs));
+        }
+        return graph;
+    }
+
+    internal static IReadOnlyList<CachedProjectMetadataReferences> BuildCachedMetadataRefsFromSolution(Solution solution)
+    {
+        var result = new List<CachedProjectMetadataReferences>(solution.ProjectIds.Count);
+        foreach (var project in solution.Projects.OrderBy(p => p.FilePath, StringComparer.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(project.FilePath)) continue;
+            var refs = new List<CachedMetadataReference>(project.MetadataReferences.Count);
+            foreach (var mref in project.MetadataReferences.OfType<PortableExecutableReference>())
+            {
+                if (string.IsNullOrEmpty(mref.FilePath)) continue;
+                DateTime mtime;
+                try
+                {
+                    mtime = File.GetLastWriteTimeUtc(mref.FilePath);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    _ = ex;
+                    continue;
+                }
+                refs.Add(new CachedMetadataReference(mref.FilePath, mtime));
+            }
+            result.Add(new CachedProjectMetadataReferences(project.FilePath, refs));
+        }
+        return result;
+    }
+
+    internal static bool MetadataReferencesStillStableOnDisk(WorkspaceCacheEntry entry)
+    {
+        foreach (var projectRefs in entry.MetadataReferences)
+        {
+            foreach (var mref in projectRefs.References)
+            {
+                try
+                {
+                    if (!File.Exists(mref.AssemblyPath)) return false;
+                    var mtime = File.GetLastWriteTimeUtc(mref.AssemblyPath);
+                    if (mtime != mref.LastWriteTimeUtc) return false;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    _ = ex;
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}
+
+internal sealed record WorkspaceCacheProbe(
+    string SolutionHash,
+    string SdkVersion,
+    WorkspaceCacheEntry? CachedEntry,
+    bool MetadataReferencesStillStable);
+
+internal sealed record WorkspaceCacheWriteResult(bool CacheHit);

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -53,13 +53,10 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     private readonly IFileWatcherService _fileWatcher;
     private readonly WorkspaceManagerOptions _options;
     /// <summary>
-    /// workspace-load-uses-cache-fast-path: optional persistent cache for the heavy parts of
-    /// MSBuild evaluation. <see langword="null"/> when not wired (legacy callers / tests that
-    /// don't exercise the cache) — the load path still functions identically, just without the
-    /// warm-cache fast path. When non-null, <see cref="LoadIntoSessionAsync"/> consults it
-    /// before the restore-race wait and writes a fresh entry after a successful cold load.
+    /// workspace-load-uses-cache-fast-path: optional persistent-cache coordinator. Null when
+    /// not wired, preserving legacy no-cache load behavior.
     /// </summary>
-    private readonly IWorkspaceCacheStore? _cacheStore;
+    private readonly WorkspaceCacheCoordinator? _cacheCoordinator;
     private readonly ConcurrentDictionary<string, WorkspaceSession> _sessions = new(StringComparer.Ordinal);
     /// <summary>
     /// mcp-error-category-workspace-evicted-on-host-recycle + workspace-id-recovery-hints:
@@ -93,7 +90,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         _previewStore = previewStore;
         _fileWatcher = fileWatcher;
         _options = options ?? new WorkspaceManagerOptions();
-        _cacheStore = cacheStore;
+        _cacheCoordinator = cacheStore is null ? null : new WorkspaceCacheCoordinator(cacheStore, logger);
         var max = _options.MaxConcurrentWorkspaces > 0 ? _options.MaxConcurrentWorkspaces : 8;
         _workspaceSlots = new SemaphoreSlim(max, max);
     }
@@ -757,374 +754,13 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         _workspaceSlots.Dispose();
     }
 
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: probe-stage cache lookup performed before MSBuild
-    /// opens the solution. Captures the (solutionHash, sdkVersion) prefix of the cache-key
-    /// triple — the third component (msbuildGraphHash) requires the post-load graph and is
-    /// validated in <see cref="ResolveAndWriteCacheAsync"/>.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The probe is best-effort. Any failure (unreadable solution file, hashing exception,
-    /// store-side IO error) leaves the result as a cache miss and the cold-load path runs
-    /// unchanged. The probe stage also pre-computes whether every cached metadata-reference
-    /// is still on disk with the same mtime; that boolean drives the
-    /// <c>WaitForStableRestoreArtifactsAsync</c>-skipping decision, since a warm process that
-    /// observed stable metadata references on the prior load implies a settled obj/ tree.
-    /// </para>
-    /// <para>
-    /// Because the cache-key triple uses the post-load graph hash, the probe enumerates ALL
-    /// entries under (solutionHash, sdkVersion) and picks the most-recently-written one as the
-    /// candidate. If the post-load graph hash doesn't match it, the entry is invalidated and
-    /// rewritten — the cost of a missed bet is at most one extra cache write, plus the missed
-    /// restore-race wait that the (incorrectly) skipped path elided. Both bounded.
-    /// </para>
-    /// </remarks>
-    private async Task<CachedSolutionProbe?> TryProbeWorkspaceCacheAsync(string fullPath, CancellationToken ct)
+    private static void StampCacheHitMetric(WorkspaceCacheWriteResult? result)
     {
-        if (_cacheStore is null) return null;
-
-        try
+        if (result is not null && AmbientGateMetrics.Current is { } metrics)
         {
-            var solutionHash = await ComputeSolutionContentHashAsync(fullPath, ct).ConfigureAwait(false);
-            if (solutionHash is null) return null;
-
-            var sdkVersion = ResolveSdkVersionForCacheKey();
-
-            // We don't yet know the graph hash. The probe-stage approach picks the
-            // most-recent entry under (solution, sdk, *) by enumerating the on-disk directory
-            // tree. This is best-effort — if the implementation can't enumerate, we just skip
-            // the probe and treat as cache miss. A FileWatcher race (entry written between
-            // enumeration and read) at worst returns null and we treat as miss.
-            var candidate = await TryEnumerateNewestCacheEntryAsync(solutionHash, sdkVersion, ct).ConfigureAwait(false);
-            if (candidate is null)
-            {
-                return new CachedSolutionProbe(
-                    solutionHash, sdkVersion, CachedEntry: null, MetadataReferencesStillStable: false);
-            }
-
-            var stable = MetadataReferencesStillStableOnDisk(candidate);
-            return new CachedSolutionProbe(solutionHash, sdkVersion, candidate, stable);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "Workspace cache probe failed for '{Path}'; cold-load path will run.", fullPath);
-            return null;
+            metrics.CacheHit = result.CacheHit;
         }
     }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: enumerate cache entries under
-    /// <c>~/.roslyn-mcp/cache/&lt;solutionHash&gt;/&lt;sdkVersion&gt;/</c> and return the most
-    /// recently written entry. Returns <see langword="null"/> when no entries exist or when
-    /// enumeration fails (e.g. directory missing).
-    /// </summary>
-    /// <remarks>
-    /// Because <see cref="WorkspaceCacheStore"/> hashes each key component into a fixed-width
-    /// hex segment, the cache directory tree shape is stable across platforms. We enumerate the
-    /// graph-hash subdirectories and pick the one whose <c>entry.json</c> has the newest mtime.
-    /// This is heuristic — a correct cache hit is only confirmed after the post-load graph hash
-    /// comparison in <see cref="ResolveAndWriteCacheAsync"/>.
-    /// </remarks>
-    private async Task<WorkspaceCacheEntry?> TryEnumerateNewestCacheEntryAsync(
-        string solutionHash, string sdkVersion, CancellationToken ct)
-    {
-        if (_cacheStore is null) return null;
-
-        // Query a synthetic key to learn the on-disk root layout. The store hashes each key
-        // component, so we need to use the same hashing path the store does — the simplest
-        // way is to ask the store to resolve a known key and walk up to its grandparent
-        // directory.
-        if (_cacheStore is not WorkspaceCacheStore concreteStore)
-        {
-            // Custom IWorkspaceCacheStore implementations (test fakes / DI overrides) may not
-            // expose a directory layout. We can't enumerate without the on-disk structure, so
-            // skip the probe; the post-load path still writes a fresh entry through the
-            // interface and the next load picks it up via this same fast path.
-            return null;
-        }
-
-        var probeKey = new WorkspaceCacheKey(solutionHash, sdkVersion, "probe");
-        var probePath = concreteStore.ResolveEntryPath(probeKey);
-        var graphHashDir = Path.GetDirectoryName(probePath); // .../solution/sdk/probe-hash
-        var sdkDir = graphHashDir is null ? null : Path.GetDirectoryName(graphHashDir); // .../solution/sdk
-
-        if (sdkDir is null || !Directory.Exists(sdkDir))
-        {
-            return null;
-        }
-
-        try
-        {
-            string? newestEntryPath = null;
-            DateTime newestMtime = DateTime.MinValue;
-
-            foreach (var graphDir in Directory.EnumerateDirectories(sdkDir))
-            {
-                ct.ThrowIfCancellationRequested();
-                var entryPath = Path.Combine(graphDir, "entry.json");
-                if (!File.Exists(entryPath)) continue;
-                var mtime = File.GetLastWriteTimeUtc(entryPath);
-                if (mtime > newestMtime)
-                {
-                    newestMtime = mtime;
-                    newestEntryPath = entryPath;
-                }
-            }
-
-            if (newestEntryPath is null) return null;
-
-            // The graph directory name is already the hashed graph segment; the original graph
-            // hash is intentionally unrecoverable from that one-way segment. Reading the selected
-            // entry.json path directly avoids double-hashing the segment through ResolveEntryPath.
-            return await concreteStore.TryGetEntryAtPathAsync(newestEntryPath, ct).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            _logger.LogDebug(ex, "Workspace cache enumeration failed under '{Dir}'; treating as miss.", sdkDir);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: SHA-256 hash of the solution file's content. Stable
-    /// across timestamp updates; only changes when project list / configurations change. Returns
-    /// <see langword="null"/> when the file isn't readable (cache miss path runs).
-    /// </summary>
-    private static async Task<string?> ComputeSolutionContentHashAsync(string fullPath, CancellationToken ct)
-    {
-        try
-        {
-            var bytes = await File.ReadAllBytesAsync(fullPath, ct).ConfigureAwait(false);
-            var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-            return Convert.ToHexString(hash).ToLowerInvariant();
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            _ = ex;
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: SDK identifier used as the second cache-key
-    /// component. <see cref="System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription"/>
-    /// is stable across same-SDK invocations and rolls forward automatically when a new SDK is
-    /// installed (which invalidates the cache cleanly per design).
-    /// </summary>
-    private static string ResolveSdkVersionForCacheKey() =>
-        System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: returns the canonical hash of the post-load
-    /// MSBuild project graph (project paths + project-references). Stable across loads of an
-    /// unchanged solution; differentiates same-SDK states where a project was added/removed.
-    /// </summary>
-    private static string ComputeMsbuildGraphHash(IReadOnlyList<CachedProjectGraphNode> graph)
-    {
-        // Canonical form: sorted by ProjectPath; for each node, ProjectPath + sorted ProjectReferences
-        // joined by tab. Newlines separate nodes. Hashing this canonical bytes gives a path-style-
-        // stable digest (paths are passed through verbatim — but the cache root itself is hashed
-        // via the same SHA-256, so per-platform path differences don't bleed into sibling caches).
-        var sb = new System.Text.StringBuilder();
-        foreach (var node in graph.OrderBy(n => n.ProjectPath, StringComparer.OrdinalIgnoreCase))
-        {
-            sb.Append(node.ProjectPath);
-            sb.Append('\t');
-            foreach (var refPath in node.ProjectReferences.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
-            {
-                sb.Append(refPath);
-                sb.Append('|');
-            }
-            sb.Append('\n');
-        }
-        var bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
-        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-        return Convert.ToHexString(hash).ToLowerInvariant();
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: build a <see cref="CachedProjectGraphNode"/> list
-    /// from a Roslyn <see cref="Solution"/>. Each node carries the project's absolute path and
-    /// the absolute paths of its &lt;ProjectReference&gt; targets.
-    /// </summary>
-    private static IReadOnlyList<CachedProjectGraphNode> BuildCachedGraphFromSolution(Solution solution)
-    {
-        var byId = solution.Projects.ToDictionary(p => p.Id);
-        var graph = new List<CachedProjectGraphNode>(solution.ProjectIds.Count);
-        foreach (var project in solution.Projects.OrderBy(p => p.FilePath, StringComparer.OrdinalIgnoreCase))
-        {
-            if (string.IsNullOrEmpty(project.FilePath)) continue;
-            var refs = new List<string>(project.ProjectReferences.Count());
-            foreach (var pref in project.ProjectReferences)
-            {
-                if (byId.TryGetValue(pref.ProjectId, out var refProj) && !string.IsNullOrEmpty(refProj.FilePath))
-                {
-                    refs.Add(refProj.FilePath);
-                }
-            }
-            graph.Add(new CachedProjectGraphNode(project.FilePath, refs));
-        }
-        return graph;
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: build a per-project metadata-reference list capturing
-    /// each on-disk assembly path and its current file mtime. Used to detect upstream-build
-    /// invalidation between cache write and cache read.
-    /// </summary>
-    private static IReadOnlyList<CachedProjectMetadataReferences> BuildCachedMetadataRefsFromSolution(Solution solution)
-    {
-        var result = new List<CachedProjectMetadataReferences>(solution.ProjectIds.Count);
-        foreach (var project in solution.Projects.OrderBy(p => p.FilePath, StringComparer.OrdinalIgnoreCase))
-        {
-            if (string.IsNullOrEmpty(project.FilePath)) continue;
-            var refs = new List<CachedMetadataReference>(project.MetadataReferences.Count);
-            foreach (var mref in project.MetadataReferences.OfType<PortableExecutableReference>())
-            {
-                if (string.IsNullOrEmpty(mref.FilePath)) continue;
-                DateTime mtime;
-                try
-                {
-                    mtime = File.GetLastWriteTimeUtc(mref.FilePath);
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    // Skip references we can't stat; the missing entry will surface on the next
-                    // probe as a "metadata reference no longer on disk" miss, which falls
-                    // through to the cold-load path correctly.
-                    _ = ex;
-                    continue;
-                }
-                refs.Add(new CachedMetadataReference(mref.FilePath, mtime));
-            }
-            result.Add(new CachedProjectMetadataReferences(project.FilePath, refs));
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: validate a candidate cache entry's metadata-reference
-    /// list against the current disk state. Returns <see langword="true"/> only when every
-    /// referenced assembly still exists on disk with the same mtime as captured at cache-write
-    /// time. Drift triggers cache invalidation and a fresh cold-load write.
-    /// </summary>
-    private static bool MetadataReferencesStillStableOnDisk(WorkspaceCacheEntry entry)
-    {
-        foreach (var projectRefs in entry.MetadataReferences)
-        {
-            foreach (var mref in projectRefs.References)
-            {
-                try
-                {
-                    if (!File.Exists(mref.AssemblyPath)) return false;
-                    var mtime = File.GetLastWriteTimeUtc(mref.AssemblyPath);
-                    if (mtime != mref.LastWriteTimeUtc) return false;
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    _ = ex;
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: post-load reconciliation. The probe-stage candidate
-    /// is now compared against the actual loaded graph. On match: stamp <c>CacheHit=true</c> and
-    /// refresh the entry's metadata-reference timestamps in place (handles the case where a
-    /// downstream build touched references between the probe and the load). On mismatch: write
-    /// a fresh entry and stamp <c>CacheHit=false</c>.
-    /// </summary>
-    private async Task ResolveAndWriteCacheAsync(Solution solution, CachedSolutionProbe probe, CancellationToken ct)
-    {
-        if (_cacheStore is null) return;
-
-        try
-        {
-            var actualGraph = BuildCachedGraphFromSolution(solution);
-            var actualMetadataRefs = BuildCachedMetadataRefsFromSolution(solution);
-            var actualGraphHash = ComputeMsbuildGraphHash(actualGraph);
-
-            var canonicalKey = new WorkspaceCacheKey(probe.SolutionHash, probe.SdkVersion, actualGraphHash);
-            var cacheHit = false;
-
-            if (probe.CachedEntry is not null)
-            {
-                var cachedGraphHash = ComputeMsbuildGraphHash(probe.CachedEntry.ProjectGraph);
-                if (string.Equals(cachedGraphHash, actualGraphHash, StringComparison.Ordinal)
-                    && probe.MetadataReferencesStillStable)
-                {
-                    cacheHit = true;
-                }
-            }
-
-            var entryToWrite = new WorkspaceCacheEntry(actualGraph, actualMetadataRefs, DateTime.UtcNow);
-            _ = await _cacheStore.PutAsync(canonicalKey, entryToWrite, ct).ConfigureAwait(false);
-
-            // Stamp the metric (best-effort — null when no AmbientGateMetrics scope is active,
-            // e.g. direct WorkspaceManager.LoadAsync calls in tests not routed through the gate).
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.CacheHit = cacheHit;
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Best-effort: any post-load cache write failure must NOT abort the load. Log at
-            // debug; the next load picks up via the cache-miss path.
-            _logger.LogDebug(ex, "Workspace cache write failed for '{SolutionHash}'; cold path stands.", probe.SolutionHash);
-        }
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: cold-path cache write. Used when the probe stage
-    /// found no candidate at all (first-ever load of this (solution, sdk) pair).
-    /// </summary>
-    private async Task WriteFreshCacheEntryAsync(Solution solution, string fullPath, CancellationToken ct)
-    {
-        if (_cacheStore is null) return;
-
-        try
-        {
-            var solutionHash = await ComputeSolutionContentHashAsync(fullPath, ct).ConfigureAwait(false);
-            if (solutionHash is null) return;
-
-            var sdkVersion = ResolveSdkVersionForCacheKey();
-            var graph = BuildCachedGraphFromSolution(solution);
-            var metadataRefs = BuildCachedMetadataRefsFromSolution(solution);
-            var graphHash = ComputeMsbuildGraphHash(graph);
-
-            var key = new WorkspaceCacheKey(solutionHash, sdkVersion, graphHash);
-            var entry = new WorkspaceCacheEntry(graph, metadataRefs, DateTime.UtcNow);
-
-            _ = await _cacheStore.PutAsync(key, entry, ct).ConfigureAwait(false);
-
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.CacheHit = false;
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "Workspace cache write failed for '{Path}'; cold path stands.", fullPath);
-        }
-    }
-
-    /// <summary>
-    /// workspace-load-uses-cache-fast-path: probe-stage state passed from
-    /// <see cref="TryProbeWorkspaceCacheAsync"/> into <see cref="ResolveAndWriteCacheAsync"/>.
-    /// Holds the cache-key prefix (solution + sdk) plus the candidate entry (if any) and a
-    /// pre-computed flag for whether the cached metadata references are still on disk with
-    /// matching mtimes. The flag is the input to the restore-race-wait skip decision.
-    /// </summary>
-    private sealed record CachedSolutionProbe(
-        string SolutionHash,
-        string SdkVersion,
-        WorkspaceCacheEntry? CachedEntry,
-        bool MetadataReferencesStillStable);
 
     private Task LoadIntoSessionAsync(WorkspaceSession session, string path, CancellationToken ct)
         => LoadIntoSessionAsync(session, path, globalProperties: null, ct);
@@ -1209,15 +845,15 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // OpenSolutionAsync, so the cache-key triple is finalized post-load and we look up
             // by (solution, sdk) here as a candidate-set probe. The probe is best-effort: any
             // failure leaves cachedCandidate null and the cold path runs unchanged.
-            CachedSolutionProbe? cachedProbe = null;
+            WorkspaceCacheProbe? cachedProbe = null;
             // Skip cache probe when caller passed global property overrides — different
             // Configuration / RuntimeIdentifier / etc. produce different MSBuild graph hashes
             // and the post-load comparison would invalidate any hit anyway. Probing under
             // overrides also risks short-circuiting the restore-race wait against a graph that
             // was captured under different globals.
-            if (_cacheStore is not null && globalProperties is not { Count: > 0 })
+            if (_cacheCoordinator is not null && globalProperties is not { Count: > 0 })
             {
-                cachedProbe = await TryProbeWorkspaceCacheAsync(fullPath, ct).ConfigureAwait(false);
+                cachedProbe = await _cacheCoordinator.TryProbeAsync(fullPath, ct).ConfigureAwait(false);
             }
 
             // dr-9-10-initial-does-not-wait-for-concurrent-to-finaliz: if a concurrent
@@ -1288,13 +924,17 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             var restoreRequired = DetectRestoreRequired(projectStatuses) ||
                                   HasRestoreRequiredWorkspaceDiagnostics(newDiagnostics);
 
-            if (_cacheStore is not null && cachedProbe is not null)
+            if (_cacheCoordinator is not null && cachedProbe is not null)
             {
-                await ResolveAndWriteCacheAsync(newWorkspace.CurrentSolution, cachedProbe, ct).ConfigureAwait(false);
+                var result = await _cacheCoordinator.ResolveAndWriteAsync(newWorkspace.CurrentSolution, cachedProbe, ct)
+                    .ConfigureAwait(false);
+                StampCacheHitMetric(result);
             }
-            else if (_cacheStore is not null)
+            else if (_cacheCoordinator is not null)
             {
-                await WriteFreshCacheEntryAsync(newWorkspace.CurrentSolution, fullPath, ct).ConfigureAwait(false);
+                var result = await _cacheCoordinator.WriteFreshEntryAsync(newWorkspace.CurrentSolution, fullPath, ct)
+                    .ConfigureAwait(false);
+                StampCacheHitMetric(result);
             }
 
             // autoreload-cascade-stdio-host-crash: atomic swap. Assign all session state AFTER

--- a/tests/RoslynMcp.Tests/Services/WorkspaceCacheCoordinatorTests.cs
+++ b/tests/RoslynMcp.Tests/Services/WorkspaceCacheCoordinatorTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests.Services;
+
+[TestClass]
+public sealed class WorkspaceCacheCoordinatorTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(
+            Path.GetTempPath(),
+            "RoslynMcpTests",
+            "WorkspaceCacheCoordinator",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; temp files are safe to leak until OS cleanup.
+        }
+    }
+
+    [TestMethod]
+    public async Task TryProbeAsync_EmptyStore_ReturnsMissProbe()
+    {
+        var solutionPath = WriteSolutionFile("empty.slnx", "<Solution></Solution>");
+        var coordinator = CreateCoordinator(new WorkspaceCacheStore(_root));
+
+        var probe = await coordinator.TryProbeAsync(solutionPath, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.IsNull(probe.CachedEntry);
+        Assert.IsFalse(probe.MetadataReferencesStillStable);
+        Assert.AreEqual(
+            await WorkspaceCacheCoordinator.ComputeSolutionContentHashAsync(solutionPath, CancellationToken.None),
+            probe.SolutionHash);
+        Assert.AreEqual(WorkspaceCacheCoordinator.ResolveSdkVersionForCacheKey(), probe.SdkVersion);
+    }
+
+    [TestMethod]
+    public async Task TryProbeAsync_StaleMetadataReference_ReturnsProbeWithStableFalse()
+    {
+        var solutionPath = WriteSolutionFile("stale.slnx", "<Solution><Project Path=\"A.csproj\" /></Solution>");
+        var referencePath = Path.Combine(_root, "ref.dll");
+        File.WriteAllText(referencePath, "v1");
+        var capturedMtime = File.GetLastWriteTimeUtc(referencePath);
+
+        var store = new WorkspaceCacheStore(_root);
+        var solutionHash = await WorkspaceCacheCoordinator.ComputeSolutionContentHashAsync(solutionPath, CancellationToken.None);
+        Assert.IsNotNull(solutionHash);
+        var sdkVersion = WorkspaceCacheCoordinator.ResolveSdkVersionForCacheKey();
+        var graph = new[]
+        {
+            new CachedProjectGraphNode(Path.Combine(_root, "A.csproj"), Array.Empty<string>()),
+        };
+        var graphHash = WorkspaceCacheCoordinator.ComputeMsbuildGraphHash(graph);
+        var entry = new WorkspaceCacheEntry(
+            graph,
+            new[]
+            {
+                new CachedProjectMetadataReferences(
+                    Path.Combine(_root, "A.csproj"),
+                    new[]
+                    {
+                        new CachedMetadataReference(referencePath, capturedMtime),
+                    }),
+            },
+            DateTime.UtcNow);
+        Assert.IsTrue(await store.PutAsync(new WorkspaceCacheKey(solutionHash, sdkVersion, graphHash), entry, CancellationToken.None));
+        File.SetLastWriteTimeUtc(referencePath, capturedMtime.AddMinutes(1));
+
+        var probe = await CreateCoordinator(store).TryProbeAsync(solutionPath, CancellationToken.None);
+
+        Assert.IsNotNull(probe);
+        Assert.IsNotNull(probe.CachedEntry);
+        Assert.IsFalse(probe.MetadataReferencesStillStable);
+    }
+
+    [TestMethod]
+    public async Task ResolveAndWriteAsync_MatchingGraphAndStableMetadata_ReturnsCacheHitTrue()
+    {
+        var solutionPath = WriteSolutionFile("matching.slnx", "<Solution><Project Path=\"App.csproj\" /></Solution>");
+        var projectPath = Path.Combine(_root, "App.csproj");
+        var solution = CreateSolution(projectPath);
+        var graph = WorkspaceCacheCoordinator.BuildCachedGraphFromSolution(solution);
+        var graphHash = WorkspaceCacheCoordinator.ComputeMsbuildGraphHash(graph);
+        var solutionHash = await WorkspaceCacheCoordinator.ComputeSolutionContentHashAsync(solutionPath, CancellationToken.None);
+        Assert.IsNotNull(solutionHash);
+        var sdkVersion = WorkspaceCacheCoordinator.ResolveSdkVersionForCacheKey();
+        var cachedEntry = new WorkspaceCacheEntry(graph, Array.Empty<CachedProjectMetadataReferences>(), DateTime.UtcNow.AddMinutes(-5));
+        var store = new WorkspaceCacheStore(_root);
+        var coordinator = CreateCoordinator(store);
+        var probe = new WorkspaceCacheProbe(solutionHash, sdkVersion, cachedEntry, MetadataReferencesStillStable: true);
+
+        var result = await coordinator.ResolveAndWriteAsync(solution, probe, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.CacheHit);
+        var written = await store.TryGetAsync(new WorkspaceCacheKey(solutionHash, sdkVersion, graphHash), CancellationToken.None);
+        Assert.IsNotNull(written);
+    }
+
+    [TestMethod]
+    public async Task ResolveAndWriteAsync_GraphMismatch_ReturnsCacheHitFalseAndWritesActualGraph()
+    {
+        var solutionPath = WriteSolutionFile("mismatch.slnx", "<Solution><Project Path=\"App.csproj\" /></Solution>");
+        var projectPath = Path.Combine(_root, "App.csproj");
+        var solution = CreateSolution(projectPath);
+        var actualGraph = WorkspaceCacheCoordinator.BuildCachedGraphFromSolution(solution);
+        var actualGraphHash = WorkspaceCacheCoordinator.ComputeMsbuildGraphHash(actualGraph);
+        var solutionHash = await WorkspaceCacheCoordinator.ComputeSolutionContentHashAsync(solutionPath, CancellationToken.None);
+        Assert.IsNotNull(solutionHash);
+        var sdkVersion = WorkspaceCacheCoordinator.ResolveSdkVersionForCacheKey();
+        var staleEntry = new WorkspaceCacheEntry(
+            new[] { new CachedProjectGraphNode(Path.Combine(_root, "Old.csproj"), Array.Empty<string>()) },
+            Array.Empty<CachedProjectMetadataReferences>(),
+            DateTime.UtcNow.AddMinutes(-5));
+        var store = new WorkspaceCacheStore(_root);
+        var coordinator = CreateCoordinator(store);
+        var probe = new WorkspaceCacheProbe(solutionHash, sdkVersion, staleEntry, MetadataReferencesStillStable: true);
+
+        var result = await coordinator.ResolveAndWriteAsync(solution, probe, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.CacheHit);
+        var written = await store.TryGetAsync(new WorkspaceCacheKey(solutionHash, sdkVersion, actualGraphHash), CancellationToken.None);
+        Assert.IsNotNull(written);
+        Assert.AreEqual(projectPath, written.ProjectGraph.Single().ProjectPath);
+    }
+
+    [TestMethod]
+    public async Task WriteFreshEntryAsync_WhenStoreThrows_ReturnsNullInsteadOfThrowing()
+    {
+        var solutionPath = WriteSolutionFile("throwing.slnx", "<Solution><Project Path=\"App.csproj\" /></Solution>");
+        var solution = CreateSolution(Path.Combine(_root, "App.csproj"));
+        var coordinator = CreateCoordinator(new ThrowingCacheStore());
+
+        var result = await coordinator.WriteFreshEntryAsync(solution, solutionPath, CancellationToken.None);
+
+        Assert.IsNull(result);
+    }
+
+    private string WriteSolutionFile(string fileName, string contents)
+    {
+        var path = Path.Combine(_root, fileName);
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    private static Solution CreateSolution(string projectPath)
+    {
+        using var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "App",
+            assemblyName: "App",
+            language: LanguageNames.CSharp,
+            filePath: projectPath);
+        workspace.AddProject(projectInfo);
+        return workspace.CurrentSolution;
+    }
+
+    private static WorkspaceCacheCoordinator CreateCoordinator(IWorkspaceCacheStore store) =>
+        new(store, NullLogger<WorkspaceCacheCoordinator>.Instance);
+
+    private sealed class ThrowingCacheStore : IWorkspaceCacheStore
+    {
+        public Task<WorkspaceCacheEntry?> TryGetAsync(WorkspaceCacheKey key, CancellationToken ct) =>
+            throw new IOException("read failed");
+
+        public Task<bool> PutAsync(WorkspaceCacheKey key, WorkspaceCacheEntry entry, CancellationToken ct) =>
+            throw new IOException("write failed");
+
+        public Task InvalidateAsync(WorkspaceCacheKey key, CancellationToken ct) =>
+            throw new IOException("invalidate failed");
+    }
+}


### PR DESCRIPTION
## Summary
- Extract workspace cache probe/writeback policy into an internal `WorkspaceCacheCoordinator` while preserving public workspace/cache-store contracts.
- Add focused coordinator coverage for miss probes, stale metadata, graph hits/mismatches, and fail-soft store exceptions.
- Record the initiative-executor post-router measurement no-go and sync open backlog/changelog artifacts.

## Validation
- `compile_check` -> 0 errors
- `test_run --filter "FullyQualifiedName~WorkspaceCacheCoordinatorTests|FullyQualifiedName~WorkspaceLoadCacheFastPathTests|FullyQualifiedName~WorkspaceCacheStoreInvalidationTests"` -> 16 passed, 0 failed
- `git diff --check` and `git diff --cached --check` -> clean
- `./eng/verify-ai-docs.ps1` -> passed
- `just ci` -> passed; release build succeeded, 1448 tests passed, vulnerability audit clean

Closes: workspace-cache-coordinator-extraction, initiative-executor-roslyn-tool-discovery-experiment