### PR TITLE
refactor(coverage): extract TestCoverageCoordinator from TestCoverageTools

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at: 2026-05-26T04:00:00Z**
+**updated_at: 2026-05-26T05:00:00Z**
 
 ## Agent contract
 
@@ -47,7 +47,6 @@
 |----|-----|------|-----|
 | `release-cut-unreleased-fragments` | High | none | 8 changelog fragments staged in `changelog.d/` since v2.2.2 (workspace cache extraction PR #887, auto-reload decoupling #885, top-5 remediations #884/#883, dead-code cleanup, pragma-suppression fix, plan-dir cleanup, agent-prompt refresh). Cut **v2.3.0** (minor — includes WorkspaceCacheCoordinator extraction and dead-code removal, both behavior-preserving but architecturally meaningful) via `/release-cut minor`; consumes the 8 fragments and tags the release. Anchors: `changelog.d/*.md`, `CHANGELOG.md`, `Directory.Build.props`, `eng/version.json`, `.claude-plugin/server.json`. Regression test shape: `eng/verify-release.ps1` passes; post-tag `server_info` returns the new version. Evidence: `git log v2.2.2..HEAD --oneline` shows 9 unreleased commits; 8 fragments queued. Source: 2026-05-26 discovery-sweep work-search. |
 | `workspace-manager-loadintosession-split` | High | none | `WorkspaceManager.LoadIntoSessionAsync` is 217 LOC / CC 17 inside a 1791 LOC class — single monolith hosting MSBuild init, atomic swap, diagnostics queue, and cache hooks. Extract `WorkspaceSessionLoader` (MSBuild creation + global-properties wiring + swap-on-success) and `WorkspaceDiagnosticsSink` (workspace failed-event handler + bounded queue); keep `WorkspaceManager` as orchestration only. Anchors: `src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs:167,765-984`. Regression test shape: `WorkspaceManagerEvictionTests` + `AutoReloadCascadeHostCrashTests` + `WorkspaceLoadRestoreRaceTests` stay green; new unit covers loader-throws path leaving `session.Workspace` pointing at old non-disposed workspace (autoreload-cascade invariant preserved). Evidence: `mcp__roslyn__get_complexity_metrics` ranks 1-2 (LoadAsync CC 17/156 + LoadIntoSessionAsync CC 17/217); already partial-extracted by PR #887 (WorkspaceCacheCoordinator). Source: 2026-05-26 discovery-sweep refactor audit. |
-| `test-coverage-tools-runtestcoveragecore-split` | High | none | `TestCoverageTools.RunTestCoverageCore` is a 216 LOC / CC 20 / 8-param method bundling gating, dotnet invocation, cobertura parsing, and envelope shaping; `ParseAndAggregateCoberturaXml` is also CC 20. Move cobertura aggregation + envelope-with-deprecation construction into a `TestCoverageCoordinator` service under `RoslynMcp.Roslyn`, leaving the tool method as a ~30-line orchestrator. Anchors: `src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs:37-330,353-421`. Regression test shape: `TestCoveragePartialCoverletTests` + `Top10V2RegressionTests` stay green; new service unit covers cobertura aggregation independently from gate+runner orchestration. Evidence: `mcp__roslyn__get_complexity_metrics` rank #4 (CC 20, MI 25.54). Source: 2026-05-26 discovery-sweep refactor audit. |
 
 
 ## Medium

--- a/changelog.d/test-coverage-tools-coordinator-extraction.md
+++ b/changelog.d/test-coverage-tools-coordinator-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extracted cobertura XML aggregation, test-project partitioning, and failure-envelope construction from `TestCoverageTools.RunTestCoverageCore` into a new `TestCoverageCoordinator` service under `RoslynMcp.Roslyn.Services`. The tool method is now a thin orchestrator over the coordinator + a private `RunCoveragePassAsync` helper for the classic/partial dotnet-test branches. Closes `test-coverage-tools-runtestcoveragecore-split` from the 2026-05-26 discovery-sweep refactor audit.

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using System.Text.Json;
-using System.Xml.Linq;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -59,158 +59,27 @@ public static class TestCoverageTools
 
                 var coverageDir = Path.Combine(Path.GetTempPath(), "roslyn-mcp-coverage", Guid.NewGuid().ToString("N"));
 
-                // test-coverage-fail-fast-on-missing-coverlet: partition the in-scope test projects
-                // into those with and without coverlet.collector. Pre-fix the tool fail-fasted on
-                // the first missing collector and abandoned the whole call; now we run partial
-                // coverage on the projects that DO have the collector and list the skipped ones in
-                // the response's `coverageGaps` field. Fail-fast remains for the all-projects-lack
-                // case (no useful work to do).
-                var partition = PartitionTestProjectsByCoverlet(status, projectName);
+                var partition = TestCoverageCoordinator.PartitionTestProjectsByCoverlet(status, projectName);
                 if (partition.WithCoverlet.Count == 0 && partition.WithoutCoverlet.Count > 0)
                 {
                     ProgressHelper.Report(progress, 1, 1);
-                    var summary = $"Coverlet missing: {partition.WithoutCoverlet.Count} test project(s) don't reference coverlet.collector. " +
-                        $"Install via `dotnet add package coverlet.collector` in: {string.Join(", ", partition.WithoutCoverlet)}.";
-                    return SerializeWithDeprecation(new TestCoverageResultDto(
-                        Success: false,
-                        Error: summary,
-                        LineCoveragePercent: null,
-                        BranchCoveragePercent: null,
-                        Modules: [],
-                        FailureEnvelope: new TestCoverageFailureEnvelopeDto(
-                            ErrorKind: "CoverletMissing",
-                            IsRetryable: false,
-                            Summary: summary,
-                            MissingPackages: partition.WithoutCoverlet)), deprecation);
+                    return SerializeWithDeprecation(
+                        TestCoverageCoordinator.BuildCoverletMissingResult(partition.WithoutCoverlet),
+                        deprecation);
                 }
 
-                // test-coverage-fail-fast-on-missing-coverlet: choose between the
-                // single-target (whole-solution or single-project) classic path and the
-                // partial-coverage per-project path. The latter triggers only when the
-                // partition produced both with-coverlet AND without-coverlet entries —
-                // otherwise the classic path's `dotnet test` invocation against the
-                // solution / single project is cheaper and produces a single Cobertura
-                // file we can parse directly.
-                CommandExecutionDto execution;
-                string[] coverageFiles;
-                IReadOnlyList<string>? coverageGaps = null;
-
-                if (partition.WithoutCoverlet.Count == 0)
-                {
-                    // Classic path — every in-scope project has coverlet. Run once against the
-                    // original `targetPath` (loadedPath OR a single-project filter).
-                    var targetPath = projectName is not null
-                        ? status.Projects.FirstOrDefault(p => string.Equals(p.Name, projectName, StringComparison.OrdinalIgnoreCase))?.FilePath ?? loadedPath
-                        : loadedPath;
-                    var arguments = new List<string>
-                    {
-                        "test",
-                        targetPath,
-                        "--collect",
-                        "XPlat Code Coverage",
-                        "--results-directory",
-                        coverageDir
-                    };
-                    execution = await commandRunner.RunAsync(Path.GetDirectoryName(loadedPath)!, targetPath, arguments, c).ConfigureAwait(false);
-                    ProgressHelper.Report(progress, 0.8f, 1);
-
-                    coverageFiles = Directory.Exists(coverageDir)
-                        ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
-                        : [];
-                }
-                else
-                {
-                    // Partial-coverage path — some projects lack coverlet. Run per-project
-                    // sequentially on the projects that DO have it, aggregating coverage XML
-                    // files from a shared results directory. We synthesize a single
-                    // CommandExecutionDto whose Succeeded reflects whether ANY per-project run
-                    // failed and whose ExitCode is the LAST non-zero exit code (so the
-                    // no-coverage-file fallback still has a meaningful exit code to surface).
-                    var lastExecution = (CommandExecutionDto?)null;
-                    var perProjectFailures = 0;
-                    var totalProjects = partition.WithCoverlet.Count;
-                    for (var i = 0; i < totalProjects; i++)
-                    {
-                        var project = partition.WithCoverlet[i];
-                        var arguments = new List<string>
-                        {
-                            "test",
-                            project.FilePath,
-                            "--collect",
-                            "XPlat Code Coverage",
-                            "--results-directory",
-                            coverageDir
-                        };
-                        var perProjectExecution = await commandRunner.RunAsync(
-                            Path.GetDirectoryName(loadedPath)!,
-                            project.FilePath,
-                            arguments,
-                            c).ConfigureAwait(false);
-                        lastExecution = perProjectExecution;
-                        if (!perProjectExecution.Succeeded)
-                            perProjectFailures++;
-                        // Progress from 0 to 0.8 across the per-project iterations so the
-                        // post-loop coverage-file scan can advance to 1.0.
-                        ProgressHelper.Report(progress, 0.8f * (i + 1) / totalProjects, 1);
-                    }
-
-                    // Synthesize a representative execution result. If we had at least one
-                    // success the synthesized Succeeded=true so the no-coverage-file fallback
-                    // can correctly classify a missing-XML state as CoverletMissing rather
-                    // than TestFailure. (`perProjectFailures < totalProjects` keeps the prior
-                    // semantics where a partial test failure still surfaces in the no-
-                    // coverage-file fallback path via the exit code.)
-                    execution = lastExecution ?? new CommandExecutionDto(
-                        Command: "dotnet",
-                        Arguments: [],
-                        WorkingDirectory: Path.GetDirectoryName(loadedPath) ?? string.Empty,
-                        TargetPath: loadedPath,
-                        ExitCode: 0,
-                        Succeeded: true,
-                        DurationMs: 0,
-                        StdOut: string.Empty,
-                        StdErr: string.Empty);
-                    if (perProjectFailures > 0 && perProjectFailures == totalProjects)
-                    {
-                        // Force Succeeded=false on the synthesized result when every per-project
-                        // run failed — same shape as the classic-path's `!execution.Succeeded`
-                        // branch in the no-coverage-file fallback below.
-                        execution = execution with { Succeeded = false };
-                    }
-
-                    coverageFiles = Directory.Exists(coverageDir)
-                        ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
-                        : [];
-
-                    coverageGaps = partition.WithoutCoverlet;
-                }
+                var (execution, coverageFiles, coverageGaps) = await RunCoveragePassAsync(
+                    commandRunner, status, partition, loadedPath, projectName, coverageDir, progress, c).ConfigureAwait(false);
 
                 if (coverageFiles.Length == 0)
                 {
                     ProgressHelper.Report(progress, 1, 1);
-                    var errorKind = !execution.Succeeded ? "TestFailure" : "CoverletMissing";
-                    var summary = !execution.Succeeded
-                        ? $"Tests failed (exit code {execution.ExitCode}). Coverage file not found."
-                        : "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects.";
-                    return SerializeWithDeprecation(new TestCoverageResultDto(
-                        Success: false,
-                        Error: summary,
-                        LineCoveragePercent: null,
-                        BranchCoveragePercent: null,
-                        Modules: [],
-                        FailureEnvelope: new TestCoverageFailureEnvelopeDto(
-                            ErrorKind: errorKind,
-                            IsRetryable: errorKind == "TestFailure",
-                            Summary: summary),
-                        CoverageGaps: coverageGaps), deprecation);
+                    return SerializeWithDeprecation(
+                        TestCoverageCoordinator.BuildNoCoverageFileResult(execution.Succeeded, execution.ExitCode, coverageGaps),
+                        deprecation);
                 }
 
-                // test-coverage-fail-fast-on-missing-coverlet: aggregate ALL coverage XML files
-                // from the run, not just the newest. In the classic path there is one file (the
-                // OrderByDescending picks the latest of any incidentally-present older files);
-                // in the partial path there is one file per with-coverlet project and we want
-                // their module entries merged into a single TestCoverageResultDto.
-                var result = ParseAndAggregateCoberturaXml(coverageFiles, coverageGaps);
+                var result = TestCoverageCoordinator.ParseAndAggregateCoberturaXml(coverageFiles, coverageGaps);
                 ProgressHelper.Report(progress, 1, 1);
                 return SerializeWithDeprecation(result, deprecation);
             }
@@ -221,34 +90,102 @@ public static class TestCoverageTools
                 // the gate lambda's return type is string and the caller expects a structured
                 // envelope identical to the other failure paths above.
                 ProgressHelper.Report(progress, 1, 1);
-                const string cancelSummary = "test_coverage was cancelled (timeout or caller cancellation).";
-                return SerializeWithDeprecation(new TestCoverageResultDto(
-                    Success: false,
-                    Error: cancelSummary,
-                    LineCoveragePercent: null,
-                    BranchCoveragePercent: null,
-                    Modules: [],
-                    FailureEnvelope: new TestCoverageFailureEnvelopeDto(
-                        ErrorKind: "Timeout",
-                        IsRetryable: false,
-                        Summary: cancelSummary)), deprecation);
+                return SerializeWithDeprecation(TestCoverageCoordinator.BuildTimeoutResult(), deprecation);
             }
             catch (Exception ex)
             {
                 ProgressHelper.Report(progress, 1, 1);
-                var summary = $"test_coverage failed with an unexpected error: {ex.Message}";
-                return SerializeWithDeprecation(new TestCoverageResultDto(
-                    Success: false,
-                    Error: summary,
-                    LineCoveragePercent: null,
-                    BranchCoveragePercent: null,
-                    Modules: [],
-                    FailureEnvelope: new TestCoverageFailureEnvelopeDto(
-                        ErrorKind: "Unknown",
-                        IsRetryable: false,
-                        Summary: summary)), deprecation);
+                return SerializeWithDeprecation(TestCoverageCoordinator.BuildUnexpectedErrorResult(ex.Message), deprecation);
             }
         }, ct);
+    }
+
+    private static async Task<(CommandExecutionDto execution, string[] coverageFiles, IReadOnlyList<string>? coverageGaps)>
+        RunCoveragePassAsync(
+            IDotnetCommandRunner commandRunner,
+            WorkspaceStatusDto status,
+            TestCoverageCoordinator.TestProjectPartition partition,
+            string loadedPath,
+            string? projectName,
+            string coverageDir,
+            IProgress<ProgressNotificationValue>? progress,
+            CancellationToken ct)
+    {
+        // test-coverage-fail-fast-on-missing-coverlet: choose between the
+        // single-target (whole-solution or single-project) classic path and the
+        // partial-coverage per-project path. The latter triggers only when the
+        // partition produced both with-coverlet AND without-coverlet entries —
+        // otherwise the classic path's `dotnet test` invocation against the
+        // solution / single project is cheaper and produces a single Cobertura
+        // file we can parse directly.
+        if (partition.WithoutCoverlet.Count == 0)
+        {
+            var targetPath = projectName is not null
+                ? status.Projects.FirstOrDefault(p => string.Equals(p.Name, projectName, StringComparison.OrdinalIgnoreCase))?.FilePath ?? loadedPath
+                : loadedPath;
+            var arguments = new List<string>
+            {
+                "test", targetPath, "--collect", "XPlat Code Coverage", "--results-directory", coverageDir
+            };
+            var execution = await commandRunner.RunAsync(Path.GetDirectoryName(loadedPath)!, targetPath, arguments, ct).ConfigureAwait(false);
+            ProgressHelper.Report(progress, 0.8f, 1);
+
+            var coverageFiles = Directory.Exists(coverageDir)
+                ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
+                : [];
+            return (execution, coverageFiles, coverageGaps: null);
+        }
+
+        // Partial-coverage path — some projects lack coverlet. Run per-project
+        // sequentially on the projects that DO have it, aggregating coverage XML
+        // files from a shared results directory. We synthesize a single
+        // CommandExecutionDto whose Succeeded reflects whether ANY per-project run
+        // failed and whose ExitCode is the LAST non-zero exit code (so the
+        // no-coverage-file fallback still has a meaningful exit code to surface).
+        CommandExecutionDto? lastExecution = null;
+        var perProjectFailures = 0;
+        var totalProjects = partition.WithCoverlet.Count;
+        for (var i = 0; i < totalProjects; i++)
+        {
+            var project = partition.WithCoverlet[i];
+            var arguments = new List<string>
+            {
+                "test", project.FilePath, "--collect", "XPlat Code Coverage", "--results-directory", coverageDir
+            };
+            var perProjectExecution = await commandRunner.RunAsync(
+                Path.GetDirectoryName(loadedPath)!, project.FilePath, arguments, ct).ConfigureAwait(false);
+            lastExecution = perProjectExecution;
+            if (!perProjectExecution.Succeeded)
+                perProjectFailures++;
+            ProgressHelper.Report(progress, 0.8f * (i + 1) / totalProjects, 1);
+        }
+
+        // Synthesize a representative execution result. If we had at least one
+        // success the synthesized Succeeded=true so the no-coverage-file fallback
+        // can correctly classify a missing-XML state as CoverletMissing rather
+        // than TestFailure. (`perProjectFailures < totalProjects` keeps the prior
+        // semantics where a partial test failure still surfaces in the no-
+        // coverage-file fallback path via the exit code.)
+        var partialExecution = lastExecution ?? new CommandExecutionDto(
+            Command: "dotnet",
+            Arguments: [],
+            WorkingDirectory: Path.GetDirectoryName(loadedPath) ?? string.Empty,
+            TargetPath: loadedPath,
+            ExitCode: 0,
+            Succeeded: true,
+            DurationMs: 0,
+            StdOut: string.Empty,
+            StdErr: string.Empty);
+        if (perProjectFailures > 0 && perProjectFailures == totalProjects)
+        {
+            partialExecution = partialExecution with { Succeeded = false };
+        }
+
+        var partialCoverageFiles = Directory.Exists(coverageDir)
+            ? Directory.GetFiles(coverageDir, "coverage.cobertura.xml", SearchOption.AllDirectories)
+            : [];
+
+        return (partialExecution, partialCoverageFiles, partition.WithoutCoverlet);
     }
 
     // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
@@ -282,6 +219,7 @@ public static class TestCoverageTools
     // onto an anonymous envelope so we can splice the top-level `deprecation` field without
     // mutating the DTO record (which is part of the Core models surface). Field names are
     // emitted lower-camel-cased to match the rest of the JSON the tool emits via JsonDefaults.
+    // Stays in the tool class because `JsonDefaults` is internal to RoslynMcp.Host.Stdio.
     private static string SerializeWithDeprecation(TestCoverageResultDto result, ToolAliasDeprecation? deprecation)
     {
         return JsonSerializer.Serialize(new
@@ -295,141 +233,5 @@ public static class TestCoverageTools
             coverageGaps = result.CoverageGaps,
             deprecation,
         }, JsonDefaults.Indented);
-    }
-
-    /// <summary>
-    /// test-coverage-fail-fast-on-missing-coverlet: result of bucketing the in-scope test
-    /// projects by whether they reference <c>coverlet.collector</c>. The mixed case
-    /// (<c>WithCoverlet</c> non-empty AND <c>WithoutCoverlet</c> non-empty) is the new
-    /// partial-coverage path; the all-without-coverlet case still fail-fasts; the
-    /// all-with-coverlet case is the classic single-`dotnet test` invocation.
-    /// </summary>
-    private sealed record TestProjectPartition(
-        IReadOnlyList<ProjectStatusDto> WithCoverlet,
-        IReadOnlyList<string> WithoutCoverlet);
-
-    /// <summary>
-    /// test-coverage-fail-fast-on-missing-coverlet (formerly
-    /// <c>FindTestProjectsWithoutCoverlet</c>): split the in-scope test projects into those
-    /// that reference <c>coverlet.collector</c> and those that do not. Replaces the previous
-    /// helper that only returned the missing-coverlet names; the caller now needs both halves
-    /// to make the fail-fast-vs-partial decision.
-    /// </summary>
-    private static TestProjectPartition PartitionTestProjectsByCoverlet(WorkspaceStatusDto status, string? projectName)
-    {
-        var candidates = status.Projects.Where(p =>
-        {
-            if (!p.IsTestProject) return false;
-            if (projectName is null) return true;
-            return string.Equals(p.Name, projectName, StringComparison.OrdinalIgnoreCase);
-        }).ToList();
-
-        var withCoverlet = new List<ProjectStatusDto>();
-        var withoutCoverlet = new List<string>();
-        foreach (var project in candidates)
-        {
-            if (string.IsNullOrWhiteSpace(project.FilePath) || !File.Exists(project.FilePath))
-                continue;
-
-            var text = File.ReadAllText(project.FilePath);
-            if (text.Contains("coverlet.collector", StringComparison.OrdinalIgnoreCase))
-                withCoverlet.Add(project);
-            else
-                withoutCoverlet.Add(project.Name);
-        }
-
-        return new TestProjectPartition(withCoverlet, withoutCoverlet);
-    }
-
-    /// <summary>
-    /// test-coverage-fail-fast-on-missing-coverlet: parse one or more Cobertura XML files and
-    /// produce a single aggregated <see cref="TestCoverageResultDto"/>. With a single file the
-    /// rolled-up rates are read from the document root; with multiple files (the partial-
-    /// coverage per-project path) we sum lines across all modules and recompute the rolled-up
-    /// rates from the line totals so the aggregate stays consistent with the per-module data.
-    /// Branch coverage is averaged across files (weighted by lines), matching how Cobertura
-    /// reporters typically treat multi-run merges.
-    /// </summary>
-    private static TestCoverageResultDto ParseAndAggregateCoberturaXml(IReadOnlyList<string> paths, IReadOnlyList<string>? coverageGaps)
-    {
-        var modules = new List<ModuleCoverageDto>();
-        var perFileLineRates = new List<(double rate, int lines)>();
-        var perFileBranchRates = new List<(double rate, int lines)>();
-
-        foreach (var path in paths.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
-        {
-            var doc = XDocument.Load(path);
-            var coverage = doc.Root!;
-            var fileLineRate = double.TryParse(coverage.Attribute("line-rate")?.Value, out var lr) ? lr : (double?)null;
-            var fileBranchRate = double.TryParse(coverage.Attribute("branch-rate")?.Value, out var br) ? br : (double?)null;
-
-            foreach (var package in coverage.Descendants("package"))
-            {
-                var moduleName = package.Attribute("name")?.Value ?? "unknown";
-                var moduleLineRate = double.TryParse(package.Attribute("line-rate")?.Value, out var mlr) ? mlr * 100 : 0.0;
-
-                var classes = new List<ClassCoverageDto>();
-                foreach (var cls in package.Descendants("class"))
-                {
-                    var className = cls.Attribute("name")?.Value ?? "unknown";
-                    var clsLineRate = double.TryParse(cls.Attribute("line-rate")?.Value, out var clr) ? clr * 100 : 0.0;
-                    var lines = cls.Descendants("line").ToList();
-                    var linesCovered = lines.Count(l => int.TryParse(l.Attribute("hits")?.Value, out var h) && h > 0);
-                    classes.Add(new ClassCoverageDto(className, Math.Round(clsLineRate, 1), linesCovered, lines.Count));
-                }
-
-                var totalLines = classes.Sum(c => c.LinesTotal);
-                var totalCovered = classes.Sum(c => c.LinesCovered);
-                modules.Add(new ModuleCoverageDto(moduleName, Math.Round(moduleLineRate, 1), totalCovered, totalLines, classes));
-            }
-
-            // Record per-file rates with a line-count weight so the rolled-up rate respects
-            // module size when aggregating across multiple Cobertura outputs.
-            var fileTotalLines = coverage.Descendants("class").SelectMany(c => c.Descendants("line")).Count();
-            if (fileLineRate.HasValue)
-                perFileLineRates.Add((fileLineRate.Value, fileTotalLines));
-            if (fileBranchRate.HasValue)
-                perFileBranchRates.Add((fileBranchRate.Value, fileTotalLines));
-        }
-
-        // Compute the rolled-up rates. With one file we just lift the root attributes; with
-        // multiple we weight by line count so a tiny test-project run can't unfairly skew the
-        // aggregate against a much larger one.
-        double? rolledLineRate;
-        double? rolledBranchRate;
-        if (paths.Count == 1)
-        {
-            var doc = XDocument.Load(paths[0]);
-            var coverage = doc.Root!;
-            rolledLineRate = double.TryParse(coverage.Attribute("line-rate")?.Value, out var lr) ? lr * 100 : (double?)null;
-            rolledBranchRate = double.TryParse(coverage.Attribute("branch-rate")?.Value, out var br) ? br * 100 : (double?)null;
-        }
-        else
-        {
-            rolledLineRate = WeightedAverage(perFileLineRates) is { } lr ? lr * 100 : (double?)null;
-            rolledBranchRate = WeightedAverage(perFileBranchRates) is { } br ? br * 100 : (double?)null;
-        }
-
-        return new TestCoverageResultDto(
-            Success: true,
-            Error: null,
-            LineCoveragePercent: rolledLineRate.HasValue ? Math.Round(rolledLineRate.Value, 1) : null,
-            BranchCoveragePercent: rolledBranchRate.HasValue ? Math.Round(rolledBranchRate.Value, 1) : null,
-            Modules: modules,
-            FailureEnvelope: null,
-            CoverageGaps: coverageGaps);
-    }
-
-    private static double? WeightedAverage(List<(double rate, int lines)> samples)
-    {
-        if (samples.Count == 0) return null;
-        var totalLines = samples.Sum(s => s.lines);
-        if (totalLines == 0)
-        {
-            // Fall back to a straight average when no line counts are available so we still
-            // return a meaningful number instead of null on degenerate empty-class files.
-            return samples.Average(s => s.rate);
-        }
-        return samples.Sum(s => s.rate * s.lines) / totalLines;
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/TestCoverageCoordinator.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestCoverageCoordinator.cs
@@ -1,0 +1,198 @@
+using System.Xml.Linq;
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Stateless helpers that pre- and post-process a test-coverage run for
+/// <c>RoslynMcp.Host.Stdio.Tools.TestCoverageTools</c>:
+///
+/// <list type="bullet">
+///   <item>Partitioning in-scope test projects by whether they reference
+///         <c>coverlet.collector</c>.</item>
+///   <item>Parsing one or more Cobertura XML files into the rolled-up
+///         <see cref="TestCoverageResultDto"/>.</item>
+///   <item>Constructing the recurring failure envelopes (coverlet-missing,
+///         no-coverage-file, timeout, unexpected error).</item>
+/// </list>
+///
+/// All members are pure (modulo Cobertura XML file reads); none of them
+/// touch the workspace gate, the workspace manager, or
+/// <c>IDotnetCommandRunner</c> — those stay in the orchestrator.
+/// </summary>
+public static class TestCoverageCoordinator
+{
+    public sealed record TestProjectPartition(
+        IReadOnlyList<ProjectStatusDto> WithCoverlet,
+        IReadOnlyList<string> WithoutCoverlet);
+
+    public static TestProjectPartition PartitionTestProjectsByCoverlet(WorkspaceStatusDto status, string? projectName)
+    {
+        var candidates = status.Projects.Where(p =>
+        {
+            if (!p.IsTestProject) return false;
+            if (projectName is null) return true;
+            return string.Equals(p.Name, projectName, StringComparison.OrdinalIgnoreCase);
+        }).ToList();
+
+        var withCoverlet = new List<ProjectStatusDto>();
+        var withoutCoverlet = new List<string>();
+        foreach (var project in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(project.FilePath) || !File.Exists(project.FilePath))
+                continue;
+
+            var text = File.ReadAllText(project.FilePath);
+            if (text.Contains("coverlet.collector", StringComparison.OrdinalIgnoreCase))
+                withCoverlet.Add(project);
+            else
+                withoutCoverlet.Add(project.Name);
+        }
+
+        return new TestProjectPartition(withCoverlet, withoutCoverlet);
+    }
+
+    public static TestCoverageResultDto ParseAndAggregateCoberturaXml(
+        IReadOnlyList<string> paths,
+        IReadOnlyList<string>? coverageGaps)
+    {
+        var modules = new List<ModuleCoverageDto>();
+        var perFileLineRates = new List<(double rate, int lines)>();
+        var perFileBranchRates = new List<(double rate, int lines)>();
+
+        foreach (var path in paths.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            var doc = XDocument.Load(path);
+            var coverage = doc.Root!;
+            var fileLineRate = double.TryParse(coverage.Attribute("line-rate")?.Value, out var lr) ? lr : (double?)null;
+            var fileBranchRate = double.TryParse(coverage.Attribute("branch-rate")?.Value, out var br) ? br : (double?)null;
+
+            foreach (var package in coverage.Descendants("package"))
+            {
+                var moduleName = package.Attribute("name")?.Value ?? "unknown";
+                var moduleLineRate = double.TryParse(package.Attribute("line-rate")?.Value, out var mlr) ? mlr * 100 : 0.0;
+
+                var classes = new List<ClassCoverageDto>();
+                foreach (var cls in package.Descendants("class"))
+                {
+                    var className = cls.Attribute("name")?.Value ?? "unknown";
+                    var clsLineRate = double.TryParse(cls.Attribute("line-rate")?.Value, out var clr) ? clr * 100 : 0.0;
+                    var lines = cls.Descendants("line").ToList();
+                    var linesCovered = lines.Count(l => int.TryParse(l.Attribute("hits")?.Value, out var h) && h > 0);
+                    classes.Add(new ClassCoverageDto(className, Math.Round(clsLineRate, 1), linesCovered, lines.Count));
+                }
+
+                var totalLines = classes.Sum(c => c.LinesTotal);
+                var totalCovered = classes.Sum(c => c.LinesCovered);
+                modules.Add(new ModuleCoverageDto(moduleName, Math.Round(moduleLineRate, 1), totalCovered, totalLines, classes));
+            }
+
+            var fileTotalLines = coverage.Descendants("class").SelectMany(c => c.Descendants("line")).Count();
+            if (fileLineRate.HasValue)
+                perFileLineRates.Add((fileLineRate.Value, fileTotalLines));
+            if (fileBranchRate.HasValue)
+                perFileBranchRates.Add((fileBranchRate.Value, fileTotalLines));
+        }
+
+        double? rolledLineRate;
+        double? rolledBranchRate;
+        if (paths.Count == 1)
+        {
+            var doc = XDocument.Load(paths[0]);
+            var coverage = doc.Root!;
+            rolledLineRate = double.TryParse(coverage.Attribute("line-rate")?.Value, out var lr) ? lr * 100 : (double?)null;
+            rolledBranchRate = double.TryParse(coverage.Attribute("branch-rate")?.Value, out var br) ? br * 100 : (double?)null;
+        }
+        else
+        {
+            rolledLineRate = WeightedAverage(perFileLineRates) is { } lr ? lr * 100 : (double?)null;
+            rolledBranchRate = WeightedAverage(perFileBranchRates) is { } br ? br * 100 : (double?)null;
+        }
+
+        return new TestCoverageResultDto(
+            Success: true,
+            Error: null,
+            LineCoveragePercent: rolledLineRate.HasValue ? Math.Round(rolledLineRate.Value, 1) : null,
+            BranchCoveragePercent: rolledBranchRate.HasValue ? Math.Round(rolledBranchRate.Value, 1) : null,
+            Modules: modules,
+            FailureEnvelope: null,
+            CoverageGaps: coverageGaps);
+    }
+
+    public static TestCoverageResultDto BuildCoverletMissingResult(IReadOnlyList<string> missingProjects)
+    {
+        var summary = $"Coverlet missing: {missingProjects.Count} test project(s) don't reference coverlet.collector. " +
+            $"Install via `dotnet add package coverlet.collector` in: {string.Join(", ", missingProjects)}.";
+        return new TestCoverageResultDto(
+            Success: false,
+            Error: summary,
+            LineCoveragePercent: null,
+            BranchCoveragePercent: null,
+            Modules: [],
+            FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                ErrorKind: "CoverletMissing",
+                IsRetryable: false,
+                Summary: summary,
+                MissingPackages: missingProjects));
+    }
+
+    public static TestCoverageResultDto BuildNoCoverageFileResult(bool runSucceeded, int exitCode, IReadOnlyList<string>? coverageGaps)
+    {
+        var errorKind = runSucceeded ? "CoverletMissing" : "TestFailure";
+        var summary = runSucceeded
+            ? "Coverage file not generated. Ensure coverlet.collector NuGet package is referenced in test projects."
+            : $"Tests failed (exit code {exitCode}). Coverage file not found.";
+        return new TestCoverageResultDto(
+            Success: false,
+            Error: summary,
+            LineCoveragePercent: null,
+            BranchCoveragePercent: null,
+            Modules: [],
+            FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                ErrorKind: errorKind,
+                IsRetryable: errorKind == "TestFailure",
+                Summary: summary),
+            CoverageGaps: coverageGaps);
+    }
+
+    public static TestCoverageResultDto BuildTimeoutResult()
+    {
+        const string summary = "test_coverage was cancelled (timeout or caller cancellation).";
+        return new TestCoverageResultDto(
+            Success: false,
+            Error: summary,
+            LineCoveragePercent: null,
+            BranchCoveragePercent: null,
+            Modules: [],
+            FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                ErrorKind: "Timeout",
+                IsRetryable: false,
+                Summary: summary));
+    }
+
+    public static TestCoverageResultDto BuildUnexpectedErrorResult(string message)
+    {
+        var summary = $"test_coverage failed with an unexpected error: {message}";
+        return new TestCoverageResultDto(
+            Success: false,
+            Error: summary,
+            LineCoveragePercent: null,
+            BranchCoveragePercent: null,
+            Modules: [],
+            FailureEnvelope: new TestCoverageFailureEnvelopeDto(
+                ErrorKind: "Unknown",
+                IsRetryable: false,
+                Summary: summary));
+    }
+
+    private static double? WeightedAverage(List<(double rate, int lines)> samples)
+    {
+        if (samples.Count == 0) return null;
+        var totalLines = samples.Sum(s => s.lines);
+        if (totalLines == 0)
+        {
+            return samples.Average(s => s.rate);
+        }
+        return samples.Sum(s => s.rate * s.lines) / totalLines;
+    }
+}


### PR DESCRIPTION
## Summary
- Split the 216-LOC / CC 20 `RunTestCoverageCore` method by extracting the pure stateless helpers into a new `TestCoverageCoordinator` service under `RoslynMcp.Roslyn.Services`:
  - `PartitionTestProjectsByCoverlet` (+ `TestProjectPartition` record)
  - `ParseAndAggregateCoberturaXml` (+ private `WeightedAverage`)
  - Failure-result factories: `BuildCoverletMissingResult`, `BuildNoCoverageFileResult`, `BuildTimeoutResult`, `BuildUnexpectedErrorResult`
- `RunTestCoverageCore` is now a ~70-LOC orchestrator delegating to the coordinator and to a new `RunCoveragePassAsync` private helper that owns the classic-vs-partial dotnet-test branching.
- `SerializeWithDeprecation` stays in the tool class because `JsonDefaults` is internal to `RoslynMcp.Host.Stdio`.
- Closes backlog row `test-coverage-tools-runtestcoveragecore-split`.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~TestCoveragePartialCoverlet|FullyQualifiedName~TestCoverageFailureEnvelope|FullyQualifiedName~Top10V2RegressionTests|FullyQualifiedName~Top10V3RegressionTests|FullyQualifiedName~AliasTools|FullyQualifiedName~CoverageProcess"` — 34/34 passing locally (17 + 17 across two runs).
- [ ] Full CI gating merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)