### PR TITLE
release: v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.2.2",
+  "version": "2.3.0",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.3.0] - 2026-05-26
+
+### Fixed
+
+- **Fixed:** Closed top-5 remediation rows for pragma line-ending preservation, canonical `find_type_mutations` unresolved-symbol errors, dependency-inversion interface-list comma formatting, off-identifier `go_to_definition` guidance, and promotion-scorecard blocked/evidence backlog proposals; also removed stale repo-local tests for the deleted `backlog-sweep-execute.md` prompt. Closes `add-pragma-suppression-crlf-in-lf-file`, `find-type-mutations-error-template-diverges-from-siblings`, `dependency-inversion-preview-newline-before-comma-formatting`, `go-to-definition-off-identifier-misleading-message`, and `scorecard-blocked-to-backlog-row`.
+- **Fixed:** Closed the top remediation batch by returning structured errors for zero-project `compile_check` filters, excluding single-delegation MCP tool wrappers from duplicate-method clusters by default, listing all missing `get_prompt_text` parameters in one response, mapping metadata-only `goto_type_definition` failures to `NotFound`, and recording the formatter check-mode baseline policy. Closes `compile-check-project-filter-miss-no-error-envelope`, `find-duplicated-methods-mcp-wrapper-false-positive`, `get-prompt-text-multi-step-required-param-errors`, `goto-type-definition-builtins-invalidoperation`, and `formatter-check-mode-baseline-policy`.
+- **Fixed:** `WorkspaceExecutionGate` no longer depends on ambient telemetry to reset post-reload timeout budgets or retry transient stale-snapshot errors after a successful auto-reload; also closed the remaining CA2016 cancellation-token propagation diagnostic in `ParameterObjectService`.
+
+### Added
+
+- **Added:** Experimental `workspace_fork_apply` validation-bundle tool, plugin package allowlist enforcement, compile-check file-scope narrowing, resolved CPM versions in NuGet summaries, and deterministic cohesion recommendations. Closes `workspace-fork-apply-tool`, `plugin-package-allowlist-enforcement`, `compile-check-file-filter-scope-narrowing-inconsistency`, `get-nuget-dependencies-summary-cpm-literal`, and `get-cohesion-metrics-recommendation-null-for-unclassified-types`.
+
+### Maintenance
+
+- **Maintenance:** Removed completed backlog-sweep plan directories and stale backlog references after verifying all initiatives were merged or explicitly deferred.
+- **Maintenance:** Extracted duplicated `WouldCreateProjectReferenceCycle` from `CrossProjectRefactoringService` and `ProjectMutationService` into a shared `ProjectGraphHelpers` helper. Closes `cycle-detection-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.
+- **Maintenance:** Extracted duplicated `AddType` namespace-walker from `CrossProjectRefactoringService` and `InterfaceExtractionService` into a shared `TypeNamespaceWalker.Collect` helper. Closes `namespace-addtype-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.
+- **Maintenance:** Removed stale prompt-helper and dead-local code surfaced by the codebase refactor audit, and recorded formatter check-mode policy follow-up in the backlog. Closes `remove-dead-code-cleanup`.
+- **Maintenance:** Extracted cobertura XML aggregation, test-project partitioning, and failure-envelope construction from `TestCoverageTools.RunTestCoverageCore` into a new `TestCoverageCoordinator` service under `RoslynMcp.Roslyn.Services`. The tool method is now a thin orchestrator over the coordinator + a private `RunCoveragePassAsync` helper for the classic/partial dotnet-test branches. Closes `test-coverage-tools-runtestcoveragecore-split` from the 2026-05-26 discovery-sweep refactor audit.
+- **Maintenance:** Extracted duplicated `RunGit` + `StageFixtureBaseline` test helpers from `ValidateRecentGitChangesTests` and `ValidateWorkspaceChangeTrackerReconcileTests` into a shared `GitFixtureRunner` static under `tests/RoslynMcp.Tests/Support/`. Closes `test-git-fixture-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.
+- **Maintenance:** Closed the 2026-05-22 top remediation batch by normalizing the first Host.Stdio formatter whitespace slice, retiring the obsolete locator preflight idea with post-schemaHint measurement, deciding the WorkspaceManager cache-policy extraction boundary, rejecting premature ScriptingService runtime-state extraction, and replacing the initiative-executor Roslyn-first brief with a measurement follow-up.
+- **Maintenance:** Extracted workspace cache probe/writeback policy into `WorkspaceCacheCoordinator`, added focused cache-coordinator regression coverage, and closed the initiative-executor post-router measurement with a no-go decision pending fresh evidence.
+
 ## [2.2.2] - 2026-05-21
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.2.2</Version>
+    <Version>2.3.0</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/add-pragma-suppression-crlf-in-lf-file.md
+++ b/changelog.d/add-pragma-suppression-crlf-in-lf-file.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Closed top-5 remediation rows for pragma line-ending preservation, canonical `find_type_mutations` unresolved-symbol errors, dependency-inversion interface-list comma formatting, off-identifier `go_to_definition` guidance, and promotion-scorecard blocked/evidence backlog proposals; also removed stale repo-local tests for the deleted `backlog-sweep-execute.md` prompt. Closes `add-pragma-suppression-crlf-in-lf-file`, `find-type-mutations-error-template-diverges-from-siblings`, `dependency-inversion-preview-newline-before-comma-formatting`, `go-to-definition-off-identifier-misleading-message`, and `scorecard-blocked-to-backlog-row`.

--- a/changelog.d/cleanup-complete-backlog-sweep-plans.md
+++ b/changelog.d/cleanup-complete-backlog-sweep-plans.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Removed completed backlog-sweep plan directories and stale backlog references after verifying all initiatives were merged or explicitly deferred.

--- a/changelog.d/cycle-detection-helper-dedup.md
+++ b/changelog.d/cycle-detection-helper-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted duplicated `WouldCreateProjectReferenceCycle` from `CrossProjectRefactoringService` and `ProjectMutationService` into a shared `ProjectGraphHelpers` helper. Closes `cycle-detection-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.

--- a/changelog.d/namespace-addtype-helper-dedup.md
+++ b/changelog.d/namespace-addtype-helper-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted duplicated `AddType` namespace-walker from `CrossProjectRefactoringService` and `InterfaceExtractionService` into a shared `TypeNamespaceWalker.Collect` helper. Closes `namespace-addtype-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.

--- a/changelog.d/remove-dead-code-cleanup.md
+++ b/changelog.d/remove-dead-code-cleanup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Removed stale prompt-helper and dead-local code surfaced by the codebase refactor audit, and recorded formatter check-mode policy follow-up in the backlog. Closes `remove-dead-code-cleanup`.

--- a/changelog.d/test-coverage-tools-coordinator-extraction.md
+++ b/changelog.d/test-coverage-tools-coordinator-extraction.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted cobertura XML aggregation, test-project partitioning, and failure-envelope construction from `TestCoverageTools.RunTestCoverageCore` into a new `TestCoverageCoordinator` service under `RoslynMcp.Roslyn.Services`. The tool method is now a thin orchestrator over the coordinator + a private `RunCoveragePassAsync` helper for the classic/partial dotnet-test branches. Closes `test-coverage-tools-runtestcoveragecore-split` from the 2026-05-26 discovery-sweep refactor audit.

--- a/changelog.d/test-git-fixture-helper-dedup.md
+++ b/changelog.d/test-git-fixture-helper-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted duplicated `RunGit` + `StageFixtureBaseline` test helpers from `ValidateRecentGitChangesTests` and `ValidateWorkspaceChangeTrackerReconcileTests` into a shared `GitFixtureRunner` static under `tests/RoslynMcp.Tests/Support/`. Closes `test-git-fixture-helper-dedup` from the 2026-05-26 discovery-sweep refactor audit.

--- a/changelog.d/top-5-remediation-20260522.md
+++ b/changelog.d/top-5-remediation-20260522.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Closed the 2026-05-22 top remediation batch by normalizing the first Host.Stdio formatter whitespace slice, retiring the obsolete locator preflight idea with post-schemaHint measurement, deciding the WorkspaceManager cache-policy extraction boundary, rejecting premature ScriptingService runtime-state extraction, and replacing the initiative-executor Roslyn-first brief with a measurement follow-up.

--- a/changelog.d/top-5-remediation-agent-prompt.md
+++ b/changelog.d/top-5-remediation-agent-prompt.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Closed the top remediation batch by returning structured errors for zero-project `compile_check` filters, excluding single-delegation MCP tool wrappers from duplicate-method clusters by default, listing all missing `get_prompt_text` parameters in one response, mapping metadata-only `goto_type_definition` failures to `NotFound`, and recording the formatter check-mode baseline policy. Closes `compile-check-project-filter-miss-no-error-envelope`, `find-duplicated-methods-mcp-wrapper-false-positive`, `get-prompt-text-multi-step-required-param-errors`, `goto-type-definition-builtins-invalidoperation`, and `formatter-check-mode-baseline-policy`.

--- a/changelog.d/workspace-cache-coordinator-extraction.md
+++ b/changelog.d/workspace-cache-coordinator-extraction.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted workspace cache probe/writeback policy into `WorkspaceCacheCoordinator`, added focused cache-coordinator regression coverage, and closed the initiative-executor post-router measurement with a no-go decision pending fresh evidence.

--- a/changelog.d/workspace-fork-apply-tool.md
+++ b/changelog.d/workspace-fork-apply-tool.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** Experimental `workspace_fork_apply` validation-bundle tool, plugin package allowlist enforcement, compile-check file-scope narrowing, resolved CPM versions in NuGet summaries, and deterministic cohesion recommendations. Closes `workspace-fork-apply-tool`, `plugin-package-allowlist-enforcement`, `compile-check-file-filter-scope-narrowing-inconsistency`, `get-nuget-dependencies-summary-cpm-literal`, and `get-cohesion-metrics-recommendation-null-for-unclassified-types`.

--- a/changelog.d/workspace-gate-autoreload-telemetry-coupling.md
+++ b/changelog.d/workspace-gate-autoreload-telemetry-coupling.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `WorkspaceExecutionGate` no longer depends on ambient telemetry to reset post-reload timeout budgets or retry transient stale-snapshot errors after a successful auto-reload; also closed the remaining CA2016 cancellation-token propagation diagnostic in `ParameterObjectService`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
## Summary
Version bump to **2.3.0** (minor — new experimental `workspace_fork_apply` tool + WorkspaceCacheCoordinator extraction + 7 other Maintenance/Fixed entries from the 2026-05-26 discovery-sweep + top-5 remediation rounds).

Consumed 12 changelog fragments — see `CHANGELOG.md` § `[2.3.0] - 2026-05-26` for the full grouped list.

## Test plan
- [x] Local `eng/verify-release.ps1 -Configuration Release -NoCoverage` — 1456/1456 tests pass, build + publish + hash manifest clean.
- [x] Local `eng/verify-ai-docs.ps1` — passes; 32 shipped SKILL.md files generic.
- [x] `eng/verify-version-drift.ps1` — all 6 version files agree on 2.3.0.
- [ ] Full CI gating merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)