### PR TITLE
docs(doc-audit): refresh ledger after plan/item GC

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -21,9 +21,9 @@
 ## Documentation State
 
 - **Last audit:** 2026-05-28
-- **Last audit mode:** initial (schema 6 -> 9 migration)
+- **Last audit mode:** refresh (2026-05-28 ledger sync after plan/item GC; preceded same-day by the schema 6 -> 9 initial migration)
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 51
+- **ai_docs/ file count:** 43
 - **docs/ file count:** 16
 - **Agent instruction files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/operational-essentials.md`, `CI_POLICY.md`
 
@@ -45,8 +45,8 @@
 | ai_docs/planning_index.md | present | In-repo router with Agent contract, Next-step protocol, scope routing table. |
 | ai_docs/domains/ | present | Domain references match source layout. |
 | ai_docs/references/ | present | Cross-cutting references indexed and current. |
-| ai_docs/items/ | present | 14 long-form depth files (4 orphans deleted this pass). |
-| ai_docs/plans/ | present | 4 top5-remediation dirs (<30d) + `audit-21-analyzers/` (relocated this pass). |
+| ai_docs/items/ | present | 10 long-form depth files (8 orphans GC'd across #898/#900). |
+| ai_docs/plans/ | present | `audit-21-analyzers/` only (4 completed top5-remediation dirs GC'd via #899). |
 | docs/ | present | Human docs index covers topic files and `.mcp.json` examples. |
 | docs/adr/ | not-used | No ADR directory. Breaking-change posture references recorded-decision + `CHANGELOG.md` migration note + `docs/release-policy.md` instead (operator choice, 2026-05-28). |
 | runner | present | tool: `just`; required commands (build/test/ci/default-list) all present; `just --list` smoke passed. |
@@ -97,12 +97,13 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 
 - `ai_docs/plans/audit-21-analyzers/plan.md` (~12420 tokens) is a dormant **Draft** (Created 2026-04-08, Owner TBD) for the still-open AUDIT-21 analyzer gap (`architecture.md` Known Gaps). Relocated from `procedures/` this pass so long-initiative plans live under `plans/`. Decide: execute, compress to a backlog row, or archive. Not auto-archivable (never shipped/stable).
 - `ai_docs/runtime.md` remains above warn threshold (~2154/1500). Land future additions in focused `ai_docs/references/` pages.
-- `ai_docs/items/` holds 14 files; the 7 referenced only by top5-remediation plan dirs will orphan when those plans are reconciled/removed. Re-run the items orphan scan after the next `reconcile-plans`.
+- `ai_docs/items/` holds 10 files (down from 18). Items-orphan cascade from the plan GC is resolved: 4 zero-referrer orphans removed (#900); the 3 plan-referenced items still cited by live docs (`workspace-fork-apply-primitive`, `plugin-package-files-allowlist`, `initiative-executor-roslyn-tool-discovery-brief`) were correctly retained. Remaining 10 are all live-referenced or backlog/CHANGELOG-tied.
 - v9 AI-facing density (≤2 sentences/paragraph) is now active. `architecture.md:79` fixed this pass; a focused density pass over the larger `ai_docs/` prose files (`runtime.md`, `bootstrap-read-tool-primer.md`, domain references) is recommended but was not exhaustively run.
 - Live-surface snapshot is stale (2026-05-06). Run `/surface-audit` to refresh tool/resource/prompt/skill counts before the next release cut.
 
 ## Findings from Last Audit
 
+- **2026-05-28 (refresh — post-GC ledger sync):** Reconciled 4 completed top5-remediation plan dirs (PR #899, `4b5a6e5`) and 4 zero-referrer orphan items (PR #900, `b8db652`). ai_docs/ file count 51 → 43; items 14 → 10; plan dirs → `audit-21-analyzers/` only. The 3 plan-referenced items still cited by live docs were correctly retained (verified via repo-wide referrer grep). Also enhanced the user-level `/reconcile-plans` skill (Step 4.5 orphaned-item hand-off to doc-audit's items-orphan scan; not tracked in this repo). No code/contract drift since the schema-9 ship — `verify-docs`, runner smoke, and AGENTS.md v9 sections all green from earlier this session.
 - **2026-05-28 (initial — schema 6 -> 9 migration):**
   - **AGENTS.md v8/v9 structural migration:** inserted `## File Purpose (Critical)`, `## Standing Engineering Directives` (verbatim 4-rule block from `~/.claude/CLAUDE.md`), `## Default Behavior (When Ambiguous or Incomplete)`, and `## Breaking-change posture` (public body). Reworded MCP Bootstrap to the numbered declared/documented/verified-live distinction. Reordered to canonical v9 order (repo-local Planning Scope moved last). Breaking-change posture references recorded-decision + `CHANGELOG.md` + `docs/release-policy.md` instead of a `docs/adr/` path (operator choice — repo has no ADR dir).
   - **Bad-code surfacing scan (v9):** scanned the backlog-anchor C# set in full. 2 warn, 0 block (no credentials, no TODO/FIXME, no commented-out code). Filed `swallow-fork-kill-empty-catch` (`ValidationBundleTools.cs:355` empty catch) and `workspace-rootdir-vestigial-ternary` (`WorkspaceManager.cs:985` identical-branch ternary) as Low backlog rows.
@@ -124,13 +125,15 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 | Added 2 bad-code-surfacing backlog rows | `ai_docs/backlog.md` | user-approved |
 | AI-facing density fix (3 -> 2 sentences) | `ai_docs/architecture.md` | auto (density rule) |
 | Migrated audit context to schema 9 | `.ai-doc-audit.md` | auto (migration) |
+| GC'd 4 completed top5-remediation plan dirs (#899) | `ai_docs/plans/2026052*_top5-remediation/` | user-approved |
+| GC'd 4 zero-referrer orphan items (#900) | `ai_docs/items/{validate-locator-preflight-measurement,workspace-manager-cache-store-extraction-design,scripting-service-runtime-state-extraction-design,initiative-executor-roslyn-tool-discovery-measurement}.md` | user-approved |
 
 ## Retention State
 
 - **Audit reports:** `ai_docs/audit-reports/` = 1 raw report + README + checklist + scorecard json (under limit 3). Root `audit-reports/` = 2 raw surface-test reports + 2 json + brainstorm (under limit 3).
 - **Reports rollups:** `ai_docs/reports/` = 1 retro + README.
-- **Shipped plans pending archival:** 4 top5-remediation dirs (2026-05-21/22), all <30 days — re-evaluate after 2026-06-21. `audit-21-analyzers/` is a never-shipped Draft (not archival-eligible; disposition pending).
-- **Orphaned items deleted this pass:** 4. Remaining 14 tracked (7 plan-referenced will orphan on plan reconcile).
+- **Shipped plans pending archival:** none. 4 completed top5-remediation dirs GC'd via #899. `audit-21-analyzers/` is a never-shipped Draft (not archival-eligible; disposition pending).
+- **Orphaned items deleted:** 8 total — 4 in the schema-9 pass (#898), 4 plan-orphans post-#899 (#900). 10 items remain, all live-referenced or backlog/CHANGELOG-tied.
 - **README.md token budget:** ~2685 / 2500 warn / 5000 hard.
 
 ## Codebase Domains


### PR DESCRIPTION
## Summary
Same-day `/doc-audit refresh` syncing `.ai-doc-audit.md` to the state left by #899 (plan GC) and #900 (orphan-item GC):

- ai_docs/ file count **51 → 43**; items **14 → 10**; plan dirs → `audit-21-analyzers/` only.
- Items-orphan-cascade Known Gap **resolved** — 4 zero-referrer orphans removed, 3 live-referenced items retained.
- Findings + Pruning Summary + Retention State updated.

No code/contract drift since the schema-9 migration earlier today (verify-docs, runner smoke, AGENTS.md v9 sections all green this session), so contract checks were not re-run.

## Test plan
- [x] Counts verified against working tree (43 / 10 / 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)