### PR TITLE
docs(doc-audit): refresh pass — v12 eight-core directives + v13 husk-GC + Refs cleanup

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -20,8 +20,8 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-05-28
-- **Last audit mode:** initial (2026-05-28 schema 9 -> 10 migration + rule-#5 AGENTS.md propagation; Opus 4.8 handoff session)
+- **Last audit:** 2026-05-30
+- **Last audit mode:** refresh (2026-05-30 standard v11→v13 catch-up: AGENTS.md 5→8 directive cores [v12], v13 husk-GC pass [no deletions], broken-Refs-path cleanup; Opus 4.8 1M)
 - **Next recommended mode:** refresh
 - **ai_docs/ file count:** 43
 - **docs/ file count:** 16
@@ -31,7 +31,7 @@
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| AGENTS.md | present | v9 structural sections all present: File Purpose, Standing Engineering Directives (verbatim 5-rule block — rule #5 added 2026-05-28; repo-local rule #4 PUBLIC-exception framing preserved), Default Behavior, Breaking-change posture (public body). MCP Bootstrap uses numbered declared/documented/verified-live distinction. Required-section order canonical; repo-local Planning Scope last. Next-step protocol matches `planning_index.md` verbatim. |
+| AGENTS.md | present | v9 structural sections all present: File Purpose, Standing Engineering Directives (verbatim **8-core block** — cores #6/#7/#8 appended 2026-05-30 for standard v12; repo-local rule #4 PUBLIC-exception framing + rich #1–5 glosses preserved), Default Behavior, Breaking-change posture (public body). MCP Bootstrap uses numbered declared/documented/verified-live distinction. Required-section order canonical; repo-local Planning Scope last. Next-step protocol matches `planning_index.md` verbatim. |
 | CLAUDE.md | present-pointer | Collapsed pointer to `AGENTS.md` (~27 tokens). |
 | .github/copilot-instructions.md | present | Implementation-quality and safety rules. |
 | .cursor/rules/**/*.md | present | `.cursor/rules/operational-essentials.md` (filename-agnostic per v7). |
@@ -96,7 +96,7 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 ## Known Gaps
 
 - **v10 migration items — RESOLVED 2026-05-28 (operator-approved):** added `<!-- artifact: plan -->` + `<!-- status: active -->` to `plans/audit-21-analyzers/plan.md` and registered that dir in `planning_index.md`'s routing table (kept — not renamed/archived); added the v10 router MUST clauses (plan-bearing markers + reachability) to `planning_index.md`; fixed `workflow.md:49` broken path → `~/.claude/prompts/backlog-sweep-execute.md`; repointed the deleted `maintainer-overlay.md` refs (×3 in `procedures/deep-review-program.md`, ×1 in `items/move-to-git-issues.md:105`) → `skills/mcp-server-surface-test/prompts/full.md`; converted the malformed `status: completed` marker in `items/move-to-git-issues.md:5` to an informational note (items/ files are marker-exempt). Backlog row `promotion-scorecard-execution-batch` left **un-split per operator decision** (accepted oversized; self-routes to `/backlog-sweep:prepare`).
-- `ai_docs/plans/audit-21-analyzers/plan.md` (~12420 tokens) is a dormant **Draft** (Created 2026-04-08, Owner TBD) for the still-open AUDIT-21 analyzer gap (`architecture.md` Known Gaps). Relocated from `procedures/` this pass so long-initiative plans live under `plans/`. Decide: execute, compress to a backlog row, or archive. Not auto-archivable (never shipped/stable).
+- `ai_docs/plans/audit-21-analyzers/plan.md` (~12420 tokens) is a dormant **Draft** (Created 2026-04-08, Owner TBD) for the still-open AUDIT-21 analyzer gap (`architecture.md` Known Gaps). **Disposition is now backlog-tracked** — row `audit-21-analyzer-load-decision` (Medium, added 2026-05-29) captures the execute-vs-restate-superseded decision and the plan's stale §13 closure-criterion reference to the removed row `compile-check-vs-analyzers-doc`. v13 husk-GC classified the plan **healthy/not-a-husk** (router-reachable, names live tracked work). Not auto-archivable (never shipped/stable); resolution rides the backlog row.
 - `ai_docs/runtime.md` remains above warn threshold (~2154/1500). Land future additions in focused `ai_docs/references/` pages.
 - `ai_docs/items/` holds 10 files (down from 18). Items-orphan cascade from the plan GC is resolved: 4 zero-referrer orphans removed (#900); the 3 plan-referenced items still cited by live docs (`workspace-fork-apply-primitive`, `plugin-package-files-allowlist`, `initiative-executor-roslyn-tool-discovery-brief`) were correctly retained. Remaining 10 are all live-referenced or backlog/CHANGELOG-tied.
 - v9 AI-facing density (≤2 sentences/paragraph) is now active. `architecture.md:79` fixed this pass; a focused density pass over the larger `ai_docs/` prose files (`runtime.md`, `bootstrap-read-tool-primer.md`, domain references) is recommended but was not exhaustively run.
@@ -104,6 +104,13 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 
 ## Findings from Last Audit
 
+- **2026-05-30 (refresh — standard v11→v13 catch-up; Opus 4.8 1M):**
+  - **Context:** drift window since the 2026-05-28 schema-9→10 ship is 2 commits (#903 backlog-sweep skill fix, #904 release v2.3.1). Only one in-scope doc changed: `ai_docs/backlog.md`. The shipped doc-audit STANDARD advanced **v11 → v13** since the last pass (v12 = eight directive cores; v13 = Work-Artifact Husk GC); context-file schema stays **10** per the v11/v12/v13 decoupling. 7 `rev-list` commits but only 2 are post-audit; ai_docs/ file count 43 = unchanged. No escalation triggers → refresh.
+  - **`agents-md-standing-directives-drift` (auto-fix):** AGENTS.md carried a stale **5-core** Standing Engineering Directives block ("these five rules"); standard v12 requires **8**. Appended cores #6 (match change size to task value), #7 (verify your own work before declaring done), #8 (no secrets in code) verbatim from `templates/AGENTS.md`, and rewrote the intro line to the canonical core-vs-gloss framing. Cores #1–5 titles already canonical; the repo-local #4 PUBLIC-exception framing and the richer #1–5 glosses were preserved (intentional adaptations, not reverted).
+  - **`broken-path-in-prose` (targeted fix):** `backlog.md` Refs table cited `ai_docs/plans/20260522T132800Z_top5-remediation/plan.md`, a dir GC'd by #899 (recorded in this ledger). Provably-unambiguous dangling pointer (GC'd, not moved/typo) → removed the Refs row; bumped `updated_at` 2026-05-29T06:12:10Z → 2026-05-30T16:53:21Z.
+  - **v13 Work-Artifact Husk GC (first run; no deletions):** eligible set under `ai_docs/**` = `plans/audit-21-analyzers/plan.md` only (artifact:plan + name-matched; sweep trees excluded). Classified **not a husk** — names live work captured in backlog row `audit-21-analyzer-load-decision`, router-reachable via `planning_index.md` routing table, markers intact (`artifact: plan` / `status: active`). No bucket-A/B candidates; no newly-empty dirs in the drift window.
+  - **Bad-code surfacing (drift-window scope, empty):** `git diff 6279524..HEAD ∩ doc-cited source set` = ∅. Only `RoslynBookendPromptTests.cs` changed among source files and it is not doc-cited. 0 findings. The 2 standing smells remain tracked (`swallow-fork-kill-empty-catch`, `workspace-rootdir-vestigial-ternary`).
+  - **Verified compliant (no change):** backlog v5 single-table (columns/IDs/datetime/contract/standing-rules); `changelog.d/` clean (6 fragments consumed by v2.3.1, now in CHANGELOG `## [2.3.1]`); workflow.md Backlog-closure subsection; planning_index.md router (v10 marker + reachability MUSTs); AGENTS.md Next-step protocol matches planning_index.md verbatim; File Purpose / Default Behavior / Breaking-change (public) / MCP Bootstrap numbered distinction; CLAUDE.md pointer. Runner smoke `just --list` passed (new `verify-registry-readiness` recipe from #903 present, additive). `just verify-docs` green after edits.
 - **2026-05-28 (initial — schema 9 -> 10 migration + rule-#5 propagation; Opus 4.8 handoff session):**
   - **Context:** the user-level doc-audit standard advanced to **v11 / context-schema 10** earlier this session (added Standing Engineering Directive #5 "never assume prior agent work is correct"; fixed half-applied v10 schema refs). This pass migrates the repo 9 -> 10.
   - **AGENTS.md rule-#5 propagation (auto-fix):** `## Standing Engineering Directives` was the 4-rule block (`agents-md-standing-directives-drift`); appended canonical rule #5 and fixed the "four" -> "five" count. The repo-local rule #4 PUBLIC-exception framing was preserved (intentional adaptation, not reverted).
@@ -126,6 +133,8 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 
 | Action | Files affected | Approval |
 |--------|----------------|----------|
+| Appended directive cores #6/#7/#8 (5→8-core block, standard v12) | `AGENTS.md` | auto (standing-directives-drift) |
+| Removed dangling Refs row → GC'd top5 plan dir (#899) | `ai_docs/backlog.md` | targeted (provably GC'd, not moved) |
 | Deleted 4 orphaned `ai_docs/items/` files | `test-suite-audit-2026-05-08.md`, `sampling-spike.md`, `dry-run-preview-side-effect-audit.md`, `formatter-check-mode-baseline-policy.md` | user-approved |
 | Relocated audit-21 plan to `ai_docs/plans/` | `procedures/audit-21-implementation-plan.md` -> `plans/audit-21-analyzers/plan.md` | user-approved |
 | Inserted AGENTS.md v8/v9 sections + MCP reword + reorder | `AGENTS.md` | user-approved (auto-fix-eligible) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is a bootstrap router, not a complete instruction set. Always execute 
 
 ## Standing Engineering Directives
 
-Restated from `~/.claude/CLAUDE.md`. These five rules override expedience. Do not summarize, drop, or alter.
+Restated from `~/.claude/CLAUDE.md` (canonical source). These eight directive **cores** (the bold titles) override expedience and are verbatim — do not summarize, drop, or alter them. The one-line gloss after each is a condensed summary for quick reference; the authoritative `Fires`/`Prevents`/`Edge` detail lives in `~/.claude/CLAUDE.md`.
 
 1. **Correct fix > quick fix.** When a quick fix and a correct fix are both viable, choose the correct fix. The correct fix addresses the root cause; the quick fix patches a symptom. Quick fixes are only acceptable when the correct fix is genuinely out of scope for the current task — and when that happens, file a backlog row (per rule #3) for the correct fix before shipping the quick one. "We'll fix it later" without a tracked row = does not exist.
 
@@ -19,6 +19,12 @@ Restated from `~/.claude/CLAUDE.md`. These five rules override expedience. Do no
 4. **Private repos accept breaking changes.** For private repos (everything under `C:/Code-Repo/` EXCEPT this one), breaking changes and large refactors are ALWAYS acceptable when pursuing rule #1 or #3. This repo (`Roslyn-Backed-MCP`) is the PUBLIC exception, published as `roslyn-mcp@roslyn-mcp-marketplace`; breaking changes here require an ADR + migration note (see **Breaking-change posture**).
 
 5. **Never assume prior agent work is correct — re-derive, don't inherit.** Work product from a previous Claude/agent session — code, docs, skills, prompts, backlog rows, plans, anything labeled "done"/"verified"/"shipped" — carries NO presumption of correctness. Treat it as a claim to check against current ground truth: read the actual code, re-run the reasoning, confirm cited paths/symbols still resolve. This fires with special force during model-handoff reviews (a newer model proof-reading an older model's work) and on anything asserted complete. Fix root causes (rule #1) and flag what you find (rule #3) rather than papering over inherited defects.
+
+6. **Match change size to task value.** Correct ≠ maximal. #1 and #4 license root-cause fixes and breaking changes but do not mandate gold-plating — the smallest change that fully fixes the root cause wins. Flag adjacent bad code per #3 rather than fixing it inline.
+
+7. **Verify your own work before declaring done.** Don't claim done/fixed/passing without evidence you generated this session (ran the test, read the output, exercised the path). Can't verify? Say so — don't imply success you didn't observe.
+
+8. **No secrets in code.** Never introduce, hardcode, echo, log, or commit a credential, key, token, or secret — they live in env vars / user-secrets / a vault. Finding an existing one = flag per #3.
 
 ## Canonical Rule Sources
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only; contract for agents syncing backlog on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at: 2026-05-29T06:12:10Z**
+**updated_at: 2026-05-30T16:53:21Z**
 
 ## Agent contract
 
@@ -93,4 +93,3 @@
 | `ai_docs/procedures/deep-review-backlog-intake.md` | Intake procedure for future audit batches |
 | `review-inbox/` | Staging folder for the NEXT audit batch (flat directory; `/backlog-intake` reads here) |
 | `review-inbox/archive/<batch-ts>/` | Processed audit/retro/promotion batches; delete after all actionable items are shipped, rejected, or summarized |
-| `ai_docs/plans/20260522T132800Z_top5-remediation/plan.md` | Shipped 1 code initiative and closed 1 measurement no-go |


### PR DESCRIPTION
`/doc-audit` refresh pass catching the repo up from standard **v11 → v13**.

## Changes
- **AGENTS.md** — appended Standing Engineering Directive cores **#6** (match change size to task value), **#7** (verify your own work before declaring done), **#8** (no secrets in code). Standard v12 requires 8 cores; the block was stale at 5 (`agents-md-standing-directives-drift`). Verbatim from `templates/AGENTS.md`; repo-local #4 PUBLIC-exception framing and rich #1–5 glosses preserved.
- **ai_docs/backlog.md** — removed dangling Refs row pointing at `ai_docs/plans/20260522T132800Z_top5-remediation/plan.md` (GC'd by #899; `broken-path-in-prose`); bumped `updated_at`.
- **.ai-doc-audit.md** — ledger update: last audit 2026-05-30 (refresh), v13 **Work-Artifact Husk GC** first run (no deletions — audit-21 plan classified healthy/router-reachable), AGENTS row + pruning summary + audit-21 gap now backlog-tracked.

## Verification
- `just verify-docs` green after edits.
- v13 husk-GC: eligible set = `plans/audit-21-analyzers/plan.md` only → not a husk (names live tracked work, router-reachable).
- Bad-code surfacing (drift window): ∅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)