### PR TITLE
release: v2.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 31 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.3.1",
+  "version": "2.3.2",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.3.2] - 2026-06-01
+
+### Fixed
+
+- **Fixed:** `set_editorconfig_option` no longer appends a duplicate key when the target key already exists under a different C#-applicable section. The writer previously searched only its canonical `[*.{cs,csx,cake}]` section, so a key living under `[*.cs]` (or `[*]`) was never matched and a second copy was appended — leaving the key present twice (EditorConfig last-wins kept it functional but the file malformed, and `get_editorconfig_options` could report the stale first value). The writer now searches every C#-applicable section the reader enumerates and updates the matching line in place, only appending genuinely-new keys to the canonical section.
+
+### Changed
+
+- **Changed:** `get_code_actions` / `apply_code_action` and `fix_all` previews now compute their solution diffs through the shared `SolutionDiffHelper.ComputeChangesAsync` instead of per-service copies. `CodeActionService` and `FixAllService` each carried a byte-identical 27-LOC `ComputeChangesAsync` (changed-documents only) that duplicated — and lagged — the canonical helper next to `DiffGenerator`. Consolidating onto `SolutionDiffHelper` removes the duplication and brings both preview paths up to the helper's behavior: added/removed documents now appear in previews, the 64 KB total-diff truncation cap (FLAG-6A) applies, and no-op (empty) diffs are skipped (gh #739). The existing code-action + fix-all preview tests stay green. Closes `solution-diff-projection-dedup`.
+
+### Maintenance
+
+- **Maintenance:** Extracted the duplicated `FormatTypeName` (Nullable-unwrap + generic-arity strip + primitive-to-C#-keyword map) into a shared `RoslynMcp.Host.Stdio.Catalog.CatalogTypeNameFormatter`. The 29-LOC method was byte-identical in `PromptParameterIndex` and `ToolParameterIndex` (same `Catalog/` folder); both now delegate to the helper. Behavior is unchanged. Closes `catalog-formattypename-dedup`.
+- **Maintenance:** Read-side analysis services `CouplingAnalysisService`, `ExceptionFlowService`, and `AnalyzerInfoService` now obtain project compilations through the shared version-keyed `ICompilationCache` instead of calling `project.GetCompilationAsync` directly, so they share warm compilations (plus analyzer-bound caching and in-flight dedup) with the rest of the read-side tools. First bounded batch of `compilation-cache-adoption-read-side` (3 of the ~24 call sites); the row is re-scoped to the remaining follow-on sites.
+- **Maintenance:** Documented the deliberate exception swallow on the workspace-fork restore timeout path. `RestoreForkAsync`'s best-effort `try { process.Kill(entireProcessTree: true); } catch { }` (killing a timed-out `dotnet restore` fork) now carries a boundary comment explaining the swallow is intentional — a Kill failure is non-actionable because a `TimeoutException` is already being thrown — matching the deliberate-boundary convention in `WorkspaceTools.cs`. Closes `swallow-fork-kill-empty-catch`.
+- **Maintenance:** Collapsed three near-identical base-enumeration methods in `SymbolServiceHelpers` — `EnumerateMethodBases` / `EnumeratePropertyBases` / `EnumerateEventBases` (~28 LOC each, differing only by symbol type and the `Overridden{Method,Property,Event}` accessor) — into one generic `EnumerateOverrideBases<T>` that takes the override accessor as a `Func<T, T?>` selector (C# exposes no common `IOverridableSymbol`, hence the delegate). Removes ~55 LOC of triplicated override + interface-implementation walking so the implicit-interface logic lives in one place. `EnumerateTypeBases` (a different shape) is unchanged; behavior is identical. Closes `symbol-base-enumeration-dedup`.
+- **Maintenance:** Converted the two compile-time-constant DI-registration regexes in `SymbolRefactorService` (the `split_service_with_di_preview` rewrite path) from per-call `new Regex(...)` to `[GeneratedRegex]` source-generated partials, resolving SYSLIB1045. Match behavior is unchanged (identical patterns and `RegexOptions`). Closes `symbolrefactor-static-regex-generatedregex`.
+- **Maintenance:** Extracted the duplicated using-directive synthesis cluster into a shared `RoslynMcp.Roslyn.Helpers.UsingDirectiveSynthesizer`. `BuildUsingDirectives` and its six helpers (`PreserveSpecialAndRequiredSourceUsings`, `AddMissingRequiredUsingDirectives`, `SortUsingDirectives`, `GetUsingNamespace`, `IsSystemUsingDirective`, `IsSpecialUsingDirective`) were byte-identical in `InterfaceExtractionService` and `CrossProjectRefactoringService` — the source doc-comment literally said "Mirrors `InterfaceExtractionService.BuildUsingDirectives`" — and the two copies could drift independently. Both services now delegate to the shared helper; behavior is unchanged. Closes `using-directive-synthesis-dedup`.
+- **Maintenance:** Collapsed a dead conditional in `WorkspaceManager.WaitForStableRestoreArtifactsAsync`. The `fullPath.EndsWith(".csproj") ? Path.GetDirectoryName(fullPath) : Path.GetDirectoryName(fullPath)` ternary had two identical branches, so the `.csproj` check never affected the result; reduced to a single `Path.GetDirectoryName(fullPath)`. Behavior unchanged. Closes `workspace-rootdir-vestigial-ternary`.
+
 ## [2.3.1] - 2026-05-29
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/catalog-formattypename-dedup.md
+++ b/changelog.d/catalog-formattypename-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted the duplicated `FormatTypeName` (Nullable-unwrap + generic-arity strip + primitive-to-C#-keyword map) into a shared `RoslynMcp.Host.Stdio.Catalog.CatalogTypeNameFormatter`. The 29-LOC method was byte-identical in `PromptParameterIndex` and `ToolParameterIndex` (same `Catalog/` folder); both now delegate to the helper. Behavior is unchanged. Closes `catalog-formattypename-dedup`.

--- a/changelog.d/compilation-cache-adoption-read-side-batch1.md
+++ b/changelog.d/compilation-cache-adoption-read-side-batch1.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Read-side analysis services `CouplingAnalysisService`, `ExceptionFlowService`, and `AnalyzerInfoService` now obtain project compilations through the shared version-keyed `ICompilationCache` instead of calling `project.GetCompilationAsync` directly, so they share warm compilations (plus analyzer-bound caching and in-flight dedup) with the rest of the read-side tools. First bounded batch of `compilation-cache-adoption-read-side` (3 of the ~24 call sites); the row is re-scoped to the remaining follow-on sites.

--- a/changelog.d/editorconfig-cross-section-duplicate-key.md
+++ b/changelog.d/editorconfig-cross-section-duplicate-key.md
@@ -1,4 +1,0 @@
----
-category: Fixed
----
-`set_editorconfig_option` no longer appends a duplicate key when the target key already exists under a different C#-applicable section. The writer previously searched only its canonical `[*.{cs,csx,cake}]` section, so a key living under `[*.cs]` (or `[*]`) was never matched and a second copy was appended — leaving the key present twice (EditorConfig last-wins kept it functional but the file malformed, and `get_editorconfig_options` could report the stale first value). The writer now searches every C#-applicable section the reader enumerates and updates the matching line in place, only appending genuinely-new keys to the canonical section.

--- a/changelog.d/solution-diff-projection-dedup.md
+++ b/changelog.d/solution-diff-projection-dedup.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** `get_code_actions` / `apply_code_action` and `fix_all` previews now compute their solution diffs through the shared `SolutionDiffHelper.ComputeChangesAsync` instead of per-service copies. `CodeActionService` and `FixAllService` each carried a byte-identical 27-LOC `ComputeChangesAsync` (changed-documents only) that duplicated — and lagged — the canonical helper next to `DiffGenerator`. Consolidating onto `SolutionDiffHelper` removes the duplication and brings both preview paths up to the helper's behavior: added/removed documents now appear in previews, the 64 KB total-diff truncation cap (FLAG-6A) applies, and no-op (empty) diffs are skipped (gh #739). The existing code-action + fix-all preview tests stay green. Closes `solution-diff-projection-dedup`.

--- a/changelog.d/swallow-fork-kill-empty-catch.md
+++ b/changelog.d/swallow-fork-kill-empty-catch.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Documented the deliberate exception swallow on the workspace-fork restore timeout path. `RestoreForkAsync`'s best-effort `try { process.Kill(entireProcessTree: true); } catch { }` (killing a timed-out `dotnet restore` fork) now carries a boundary comment explaining the swallow is intentional — a Kill failure is non-actionable because a `TimeoutException` is already being thrown — matching the deliberate-boundary convention in `WorkspaceTools.cs`. Closes `swallow-fork-kill-empty-catch`.

--- a/changelog.d/symbol-base-enumeration-dedup.md
+++ b/changelog.d/symbol-base-enumeration-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Collapsed three near-identical base-enumeration methods in `SymbolServiceHelpers` — `EnumerateMethodBases` / `EnumeratePropertyBases` / `EnumerateEventBases` (~28 LOC each, differing only by symbol type and the `Overridden{Method,Property,Event}` accessor) — into one generic `EnumerateOverrideBases<T>` that takes the override accessor as a `Func<T, T?>` selector (C# exposes no common `IOverridableSymbol`, hence the delegate). Removes ~55 LOC of triplicated override + interface-implementation walking so the implicit-interface logic lives in one place. `EnumerateTypeBases` (a different shape) is unchanged; behavior is identical. Closes `symbol-base-enumeration-dedup`.

--- a/changelog.d/symbolrefactor-static-regex-generatedregex.md
+++ b/changelog.d/symbolrefactor-static-regex-generatedregex.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Converted the two compile-time-constant DI-registration regexes in `SymbolRefactorService` (the `split_service_with_di_preview` rewrite path) from per-call `new Regex(...)` to `[GeneratedRegex]` source-generated partials, resolving SYSLIB1045. Match behavior is unchanged (identical patterns and `RegexOptions`). Closes `symbolrefactor-static-regex-generatedregex`.

--- a/changelog.d/using-directive-synthesis-dedup.md
+++ b/changelog.d/using-directive-synthesis-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Extracted the duplicated using-directive synthesis cluster into a shared `RoslynMcp.Roslyn.Helpers.UsingDirectiveSynthesizer`. `BuildUsingDirectives` and its six helpers (`PreserveSpecialAndRequiredSourceUsings`, `AddMissingRequiredUsingDirectives`, `SortUsingDirectives`, `GetUsingNamespace`, `IsSystemUsingDirective`, `IsSpecialUsingDirective`) were byte-identical in `InterfaceExtractionService` and `CrossProjectRefactoringService` — the source doc-comment literally said "Mirrors `InterfaceExtractionService.BuildUsingDirectives`" — and the two copies could drift independently. Both services now delegate to the shared helper; behavior is unchanged. Closes `using-directive-synthesis-dedup`.

--- a/changelog.d/workspace-rootdir-vestigial-ternary.md
+++ b/changelog.d/workspace-rootdir-vestigial-ternary.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Collapsed a dead conditional in `WorkspaceManager.WaitForStableRestoreArtifactsAsync`. The `fullPath.EndsWith(".csproj") ? Path.GetDirectoryName(fullPath) : Path.GetDirectoryName(fullPath)` ternary had two identical branches, so the `.csproj` check never affected the result; reduced to a single `Path.GetDirectoryName(fullPath)`. Behavior unchanged. Closes `workspace-rootdir-vestigial-ternary`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
Patch release **v2.3.2**. Consumes 9 `changelog.d/` fragments into the `## [2.3.2]` CHANGELOG section.

### Fixed
- `set_editorconfig_option` duplicate-key across C#-applicable sections.

### Changed
- `get_code_actions` / `apply_code_action` / `fix_all` previews now share `SolutionDiffHelper.ComputeChangesAsync` (added/removed docs in previews, 64 KB cap, empty-diff skip — gh #739).

### Maintenance (7)
- Dedups/cleanups: `CatalogTypeNameFormatter`, compilation-cache read-side batch 1 (3 sites), fork-kill swallow doc, `EnumerateOverrideBases<T>`, `[GeneratedRegex]` for SymbolRefactor (SYSLIB1045), `UsingDirectiveSynthesizer`, WorkspaceManager vestigial ternary.

All 6 version files bumped 2.3.1 → 2.3.2 (verify-version-drift green). Local `verify-release.ps1` intentionally skipped — this PR's CI on the self-hosted runner is the verification gate. Tag `v2.3.2` + both-layer reinstall follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)