### PR TITLE
test(gate): de-flake auto-reload timeout-budget tests with a virtual clock

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,9 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <!-- Test-only: FakeTimeProvider for deterministic clock control in WorkspaceExecutionGateTests
+         (timeout-budget reset verified on a virtual clock, no wall-clock Task.Delay races). -->
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="DiffPlex" Version="1.7.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
     <PackageVersion Include="Microsoft.Build" Version="17.11.48" />

--- a/changelog.d/flaky-gate-timeout-virtual-clock.md
+++ b/changelog.d/flaky-gate-timeout-virtual-clock.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** De-flaked the `WorkspaceExecutionGate` auto-reload timeout-budget tests by injecting a `TimeProvider` into the gate (optional ctor parameter, defaults to `TimeProvider.System` — production behaviour and the DI registration are unchanged) so the per-request timeout CTS, and its post-auto-reload `CancelAfter` reset, arm on a controllable clock. The three `AutoReload_ResetsTimeoutBudget*` / `AutoReload_ParallelFanout_AllReadersSucceedAfterReload` tests now drive a `FakeTimeProvider` instead of racing real `Task.Delay` calls against a real 2-second timeout — the wall-clock race that intermittently threw `TaskCanceledException` under full-suite CI CPU contention (it failed the v2.3.2 release `validate` job and needed a re-run). A mutation check confirms the rewritten tests still fail when the budget reset is removed. Closes `flaky-gate-timeout-virtual-clock`.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -38,6 +38,14 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     private readonly TimeSpan _rateLimitWindow;
     private readonly StalenessPolicy _onStale;
 
+    /// <summary>
+    /// Clock used to arm per-request timeout cancellation. Defaults to
+    /// <see cref="TimeProvider.System"/> in production; tests inject a fake provider so the
+    /// timeout-budget contract (including the post-auto-reload reset) is verified against a
+    /// virtual clock instead of racing real <c>Task.Delay</c> calls under CI CPU contention.
+    /// </summary>
+    private readonly TimeProvider _timeProvider;
+
     private readonly SemaphoreSlim _loadGate = new(1, 1);
     private readonly SemaphoreSlim _globalThrottle = new(MaxGlobalConcurrency, MaxGlobalConcurrency);
     private readonly AsyncReaderWriterLockRegistry _rwLocks = new();
@@ -53,13 +61,17 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     /// <summary>Sliding window rate limiter — stores timestamps of recent requests.</summary>
     private readonly ConcurrentQueue<long> _requestTimestamps = new();
 
-    public WorkspaceExecutionGate(ExecutionGateOptions options, IWorkspaceManager workspaceManager)
+    public WorkspaceExecutionGate(
+        ExecutionGateOptions options,
+        IWorkspaceManager workspaceManager,
+        TimeProvider? timeProvider = null)
     {
         _workspaceManager = workspaceManager;
         _requestTimeout = options.RequestTimeout;
         _rateLimitMax = options.RateLimitMaxRequests;
         _rateLimitWindow = options.RateLimitWindow;
         _onStale = options.OnStale;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
@@ -81,9 +93,13 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
         var queueStopwatch = Stopwatch.StartNew();
         EnforceRateLimit();
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(_requestTimeout);
-        var linked = timeoutCts.Token;
+        // Provider-backed timeout source so the deadline (and the post-auto-reload reset via
+        // CancelAfter below) is armed on _timeProvider's clock — TimeProvider.System in
+        // production, a fake clock under test. CreateLinkedTokenSource has no TimeProvider
+        // overload, so the linked token observes both the caller's ct and this timeout source.
+        using var timeoutCts = new CancellationTokenSource(_requestTimeout, _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        var linked = linkedCts.Token;
 
         return await WithGlobalThrottle(async () =>
         {
@@ -158,9 +174,13 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 $"Workspace '{workspaceId}' not found or has been closed. Active workspace IDs are listed by workspace_list.");
         }
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(_requestTimeout);
-        var linked = timeoutCts.Token;
+        // Provider-backed timeout source so the deadline (and the post-auto-reload reset via
+        // CancelAfter below) is armed on _timeProvider's clock — TimeProvider.System in
+        // production, a fake clock under test. CreateLinkedTokenSource has no TimeProvider
+        // overload, so the linked token observes both the caller's ct and this timeout source.
+        using var timeoutCts = new CancellationTokenSource(_requestTimeout, _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        var linked = linkedCts.Token;
 
         // Item 1: stale-gate policy. Checked once per call, before the per-workspace lock is
         // acquired, so an auto-reload path runs under the same load gate as explicit

--- a/tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj
+++ b/tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="coverlet.collector" />
+    <!-- FakeTimeProvider — deterministic virtual clock for WorkspaceExecutionGateTests. -->
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <!-- ServerSurfaceCatalogAnalyzerTests: AnalyzerVerifier<T> harness for RMCP001/RMCP002.
          PrivateAssets="all" keeps the harness's Roslyn binaries scoped to the test host. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" PrivateAssets="all" />

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
@@ -727,12 +728,14 @@ public class WorkspaceExecutionGateTests
     [TestMethod]
     public async Task AutoReload_ResetsTimeoutBudget_ToolActionGetsFullBudget()
     {
-        // Budget is tight enough that the reload itself would exhaust it, but generous enough
-        // for the action to run if the budget is correctly reset post-reload.
-        var reloadDelay = TimeSpan.FromMilliseconds(200);
-        var toolTimeout = TimeSpan.FromMilliseconds(250);
+        // Deterministic virtual clock (no wall-clock Task.Delay). The reload consumes 1500ms of
+        // the 2000ms budget; the action then consumes 1000ms — more than the 500ms that would
+        // remain WITHOUT a reset, but well within a fresh 2000ms budget. So the action's token is
+        // cancelled iff the budget was NOT reset after auto-reload.
+        var clock = new FakeTimeProvider();
+        var toolTimeout = TimeSpan.FromSeconds(2);
 
-        var manager = new FakeGateWorkspaceManager(reloadDelayMs: (int)reloadDelay.TotalMilliseconds);
+        var manager = new FakeGateWorkspaceManager(reloadClock: clock, reloadAdvanceMs: 1500);
         manager.MarkStale(WorkspaceA);
 
         var gate = new WorkspaceExecutionGate(
@@ -741,17 +744,16 @@ public class WorkspaceExecutionGateTests
                 RequestTimeout = toolTimeout,
                 OnStale = StalenessPolicy.AutoReload,
             },
-            manager);
+            manager,
+            clock);
 
         using var scope = AmbientGateMetrics.BeginRequest();
 
-        // The action itself is fast — only the reload is slow. Without the budget reset,
-        // the timeout would fire inside the tool action because ~200ms of the 250ms budget
-        // was consumed by the reload. With the fix the budget resets and the action succeeds.
-        var result = await gate.RunReadAsync(WorkspaceA, async ct =>
+        var result = await gate.RunReadAsync(WorkspaceA, ct =>
         {
-            await Task.Delay(50, ct); // fast tool work well within the fresh budget
-            return 99;
+            clock.Advance(TimeSpan.FromMilliseconds(1000));
+            ct.ThrowIfCancellationRequested(); // mirrors a real Task.Delay(..., ct) throwing on timeout
+            return Task.FromResult(99);
         }, CancellationToken.None);
 
         Assert.AreEqual(99, result, "Tool action must succeed — timeout budget must be reset after auto-reload.");
@@ -764,15 +766,14 @@ public class WorkspaceExecutionGateTests
     [TestMethod]
     public async Task AutoReload_ResetsTimeoutBudgetWithoutAmbientMetrics_ToolActionGetsFullBudget()
     {
-        // The timeout reset is part of the gate contract, not a side effect of telemetry.
-        // Without an ambient metrics scope, this test spends enough of the original budget
-        // on reload that reload+action would exceed it. The timeout is intentionally wider
-        // than the reload itself so full-suite CPU contention does not cancel before the
-        // reset point.
-        var reloadDelay = TimeSpan.FromMilliseconds(500);
+        // The timeout reset is part of the gate contract, not a side effect of telemetry. Same
+        // budget arithmetic as the metrics-scoped test, but with no AmbientGateMetrics scope.
+        // Deterministic virtual clock — this test previously flaked under CI CPU contention
+        // because it raced a real Task.Delay(1600) against a real 2s timeout.
+        var clock = new FakeTimeProvider();
         var toolTimeout = TimeSpan.FromSeconds(2);
 
-        var manager = new FakeGateWorkspaceManager(reloadDelayMs: (int)reloadDelay.TotalMilliseconds);
+        var manager = new FakeGateWorkspaceManager(reloadClock: clock, reloadAdvanceMs: 1500);
         manager.MarkStale(WorkspaceA);
 
         var gate = new WorkspaceExecutionGate(
@@ -781,14 +782,16 @@ public class WorkspaceExecutionGateTests
                 RequestTimeout = toolTimeout,
                 OnStale = StalenessPolicy.AutoReload,
             },
-            manager);
+            manager,
+            clock);
 
         Assert.IsNull(AmbientGateMetrics.Current);
 
-        var result = await gate.RunReadAsync(WorkspaceA, async ct =>
+        var result = await gate.RunReadAsync(WorkspaceA, ct =>
         {
-            await Task.Delay(1600, ct);
-            return 99;
+            clock.Advance(TimeSpan.FromMilliseconds(1000));
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(99);
         }, CancellationToken.None);
 
         Assert.AreEqual(99, result, "Tool action must receive a fresh timeout budget after auto-reload even when no metrics scope exists.");
@@ -798,38 +801,41 @@ public class WorkspaceExecutionGateTests
 
     /// <summary>
     /// parallel-fanout-auto-reload-timeout-floor: three concurrent reads against the same
-    /// stale workspace all succeed — none time out at the 5s floor while the reload is in
-    /// flight. This is the parallel fan-out scenario from the backlog row.
+    /// stale workspace all succeed — none time out while the reload is in flight. This is the
+    /// parallel fan-out scenario from the backlog row. Deterministic virtual clock: a generous
+    /// budget plus bounded reload advancement means no timer can fire regardless of how the
+    /// three readers interleave, so the test cannot flake on CI CPU contention.
     /// </summary>
     [TestMethod]
     public async Task AutoReload_ParallelFanout_AllReadersSucceedAfterReload()
     {
-        var reloadDelay = TimeSpan.FromMilliseconds(200);
-        var toolTimeout = TimeSpan.FromMilliseconds(500);
+        var clock = new FakeTimeProvider();
 
-        var manager = new FakeGateWorkspaceManager(reloadDelayMs: (int)reloadDelay.TotalMilliseconds);
+        // Each reload advances the virtual clock 200ms; even if all three readers race and each
+        // reloads, total advancement (600ms) stays far under the 10s budget — no spurious timeout.
+        var manager = new FakeGateWorkspaceManager(reloadClock: clock, reloadAdvanceMs: 200);
         manager.MarkStale(WorkspaceA);
 
         var gate = new WorkspaceExecutionGate(
             new ExecutionGateOptions
             {
-                RequestTimeout = toolTimeout,
+                RequestTimeout = TimeSpan.FromSeconds(10),
                 OnStale = StalenessPolicy.AutoReload,
             },
-            manager);
+            manager,
+            clock);
 
         // Launch three concurrent reads. All three hit ApplyStalenessPolicyAsync; the first
         // triggers the reload (and resets its budget), the others observe a fresh workspace
-        // (IsStale returns false after the first reload) so they never consume budget on a
-        // reload. All three should complete without timeout.
+        // (IsStale returns false after the first reload). All three should complete without timeout.
         var tasks = Enumerable.Range(0, 3).Select(i =>
-            gate.RunReadAsync(WorkspaceA, async ct =>
+            gate.RunReadAsync(WorkspaceA, ct =>
             {
-                await Task.Delay(30, ct);
-                return i;
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(i);
             }, CancellationToken.None)).ToArray();
 
-        var results = await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(5));
+        var results = await Task.WhenAll(tasks);
         CollectionAssert.AreEquivalent(new[] { 0, 1, 2 }, results,
             "All three parallel readers must return their expected values without timing out.");
     }
@@ -855,6 +861,8 @@ public class WorkspaceExecutionGateTests
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _stale = new();
         private readonly bool _containsAny;
         private readonly int _reloadDelayMs;
+        private readonly FakeTimeProvider? _reloadClock;
+        private readonly int _reloadAdvanceMs;
 
         public int ReloadCount;
 
@@ -875,14 +883,26 @@ public class WorkspaceExecutionGateTests
 
         /// <param name="containsAny">When false, <see cref="ContainsWorkspace"/> always returns false.</param>
         /// <param name="reloadDelayMs">
-        /// Artificial delay injected into <see cref="ReloadAsync"/> to simulate a slow workspace
-        /// reload. Used by <c>parallel-fanout-auto-reload-timeout-floor</c> tests to verify that
-        /// the held-time budget is reset after the reload so tool actions are not unfairly starved.
+        /// Real <see cref="Task.Delay(int, CancellationToken)"/> injected into <see cref="ReloadAsync"/>
+        /// to simulate a slow workspace reload. Wall-clock based — prefer <paramref name="reloadClock"/>
+        /// + <paramref name="reloadAdvanceMs"/> for deterministic timeout-budget tests.
         /// </param>
-        public FakeGateWorkspaceManager(bool containsAny = true, int reloadDelayMs = 0)
+        /// <param name="reloadClock">
+        /// When supplied (with a positive <paramref name="reloadAdvanceMs"/>), <see cref="ReloadAsync"/>
+        /// advances this virtual clock instead of sleeping — letting timeout-budget tests verify the
+        /// post-reload deadline reset without racing real timers under CI CPU contention.
+        /// </param>
+        /// <param name="reloadAdvanceMs">Virtual-clock advance applied during reload when <paramref name="reloadClock"/> is set.</param>
+        public FakeGateWorkspaceManager(
+            bool containsAny = true,
+            int reloadDelayMs = 0,
+            FakeTimeProvider? reloadClock = null,
+            int reloadAdvanceMs = 0)
         {
             _containsAny = containsAny;
             _reloadDelayMs = reloadDelayMs;
+            _reloadClock = reloadClock;
+            _reloadAdvanceMs = reloadAdvanceMs;
         }
 
         public void RemoveWorkspace(string workspaceId) => _removed.TryAdd(workspaceId, 0);
@@ -911,7 +931,12 @@ public class WorkspaceExecutionGateTests
                     workspaceId);
             }
 
-            if (_reloadDelayMs > 0)
+            if (_reloadClock is not null && _reloadAdvanceMs > 0)
+            {
+                // Deterministic: consume reload "budget" on the virtual clock instead of real time.
+                _reloadClock.Advance(TimeSpan.FromMilliseconds(_reloadAdvanceMs));
+            }
+            else if (_reloadDelayMs > 0)
             {
                 await Task.Delay(_reloadDelayMs, ct).ConfigureAwait(false);
             }


### PR DESCRIPTION
## Problem
`WorkspaceExecutionGateTests.AutoReload_ResetsTimeoutBudgetWithoutAmbientMetrics_ToolActionGetsFullBudget` (and two siblings) raced a real `Task.Delay` against a real per-request timeout (`CancellationTokenSource.CancelAfter` on the system clock). Under full-suite CI CPU contention it intermittently threw `TaskCanceledException` — it **failed the v2.3.2 release `validate` job** and needed a re-run. The author's own comment acknowledged the contention risk; widening the margin was a band-aid that still flaked.

## Fix (root cause)
- **`WorkspaceExecutionGate`** gains an optional `TimeProvider` ctor parameter (defaults to `TimeProvider.System`). The timeout CTS is constructed via the provider, so both the initial deadline and the post-auto-reload `CancelAfter` reset arm on the injected clock. **Production behaviour and the DI registration site are unchanged** — the default resolves to the system clock.
- The three `AutoReload_ResetsTimeoutBudget*` / `AutoReload_ParallelFanout` tests drive a **`FakeTimeProvider`** (`Microsoft.Extensions.TimeProvider.Testing`, added test-only via CPM). Reload and the tool action advance a virtual clock — the budget-reset contract is verified with zero wall-clock dependence.

## Verification
- 28/28 `WorkspaceExecutionGateTests` pass; class runtime dropped from multi-second real delays to ~0.6s.
- **Mutation check**: disabling the budget reset makes the two reset tests fail as expected (red-green proof they still guard the contract).

Files: 1 production (gate testability seam) · 1 test · 2 package-infra (CPM) · 1 changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)