### PR TITLE
chore(doc-audit): commit pending 2026-06-04 refresh

### DIFF
--- a/.ai-doc-audit.md
+++ b/.ai-doc-audit.md
@@ -20,10 +20,10 @@
 
 ## Documentation State
 
-- **Last audit:** 2026-05-30
-- **Last audit mode:** refresh (2026-05-30 standard v11→v13 catch-up: AGENTS.md 5→8 directive cores [v12], v13 husk-GC pass [no deletions], broken-Refs-path cleanup; Opus 4.8 1M)
+- **Last audit:** 2026-06-04
+- **Last audit mode:** refresh (2026-06-04 drift window: 19 commits; added sweep tree [+3 files], scope/artifact/status markers on sweep plan.md, compatibility.md indexed in docs/README.md; Sonnet 4.6)
 - **Next recommended mode:** refresh
-- **ai_docs/ file count:** 43
+- **ai_docs/ file count:** 46
 - **docs/ file count:** 16
 - **Agent instruction files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/operational-essentials.md`, `CI_POLICY.md`
 
@@ -68,6 +68,7 @@
 | ai_docs/known-flakes.md | 797 | 2500/5000 | ok |
 | docs/README.md | 565 | 800/1600 | ok |
 | ai_docs/plans/audit-21-analyzers/plan.md | 12420 | — | relocated from procedures/ — long initiative plan; dormant Draft (see Known Gaps) |
+| ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md | ~3500 | — | generated sweep plan; 2 pending initiatives; markers added 2026-06-04 |
 
 Tokens estimated via `char_count / 4` per STANDARD size-matrix fallback.
 
@@ -101,9 +102,15 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 - `ai_docs/items/` holds 10 files (down from 18). Items-orphan cascade from the plan GC is resolved: 4 zero-referrer orphans removed (#900); the 3 plan-referenced items still cited by live docs (`workspace-fork-apply-primitive`, `plugin-package-files-allowlist`, `initiative-executor-roslyn-tool-discovery-brief`) were correctly retained. Remaining 10 are all live-referenced or backlog/CHANGELOG-tied.
 - v9 AI-facing density (≤2 sentences/paragraph) is now active. `architecture.md:79` fixed this pass; a focused density pass over the larger `ai_docs/` prose files (`runtime.md`, `bootstrap-read-tool-primer.md`, domain references) is recommended but was not exhaustively run.
 - Live-surface snapshot is stale (2026-05-06). Run `/surface-audit` to refresh tool/resource/prompt/skill counts before the next release cut.
+- **`ai_docs/plans/20260530T233522Z_backlog-sweep/`** sweep tree added 2026-05-30: 2 pending initiatives (`compilation-cache-adoption-read-side`, `promotion-scorecard-execution-batch`). Scope/artifact/status markers added 2026-06-04. Not a husk; exempt from router registration; not archival-eligible until both ship.
 
 ## Findings from Last Audit
 
+- **2026-06-04 (refresh — 19-commit drift window; Sonnet 4.6):**
+  - **Context:** 19 commits since 2026-05-30 audit. ai_docs/ file count 43 → 46 (+3: new `20260530T233522Z_backlog-sweep/` sweep tree added by the `/backlog-sweep` skill). Drift window doc changes: `README.md`, `ai_docs/backlog.md` (many updates), `docs/compatibility.md` (new), `docs/product-contract.md`, `docs/release-policy.md`, `docs/stdio-client-integration.md`. STANDARD remains v14 / schema 10.
+  - **Missing markers on sweep plan (auto-fix + user-approved):** `ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md` lacked `<!-- scope: in-repo -->`, `<!-- artifact: plan -->`, `<!-- status: active -->` per v10 Planning-Doc-Scope-Rules. Added all three. `verify-docs` green.
+  - **`docs/compatibility.md` missing from `docs/README.md` (targeted fix):** new `compatibility.md` file (MCP client compatibility matrix) added in drift window but not indexed. Added entry between `stdio-client-integration.md` and `product-contract.md`.
+  - **Compliant (no change):** AGENTS.md 8-core block, Next-step protocol, MCP Bootstrap numbered distinction, section order, CLAUDE.md pointer; backlog v5 contract + structural integrity (no fusion/dupes/blank-rows); planning_index.md router; new sweep tree correctly exempt from router registration; runner smoke `just --list` passed; bad-code scan on drift-window doc-cited files (`WorkspaceTools.cs`, `SymbolTools.cs`) clean; existing known smells (`swallow-fork-kill-empty-catch`, `workspace-rootdir-vestigial-ternary`) still tracked in backlog.
 - **2026-05-30 (refresh — standard v11→v13 catch-up; Opus 4.8 1M):**
   - **Context:** drift window since the 2026-05-28 schema-9→10 ship is 2 commits (#903 backlog-sweep skill fix, #904 release v2.3.1). Only one in-scope doc changed: `ai_docs/backlog.md`. The shipped doc-audit STANDARD advanced **v11 → v13** since the last pass (v12 = eight directive cores; v13 = Work-Artifact Husk GC); context-file schema stays **10** per the v11/v12/v13 decoupling. 7 `rev-list` commits but only 2 are post-audit; ai_docs/ file count 43 = unchanged. No escalation triggers → refresh.
   - **`agents-md-standing-directives-drift` (auto-fix):** AGENTS.md carried a stale **5-core** Standing Engineering Directives block ("these five rules"); standard v12 requires **8**. Appended cores #6 (match change size to task value), #7 (verify your own work before declaring done), #8 (no secrets in code) verbatim from `templates/AGENTS.md`, and rewrote the intro line to the canonical core-vs-gloss framing. Cores #1–5 titles already canonical; the repo-local #4 PUBLIC-exception framing and the richer #1–5 glosses were preserved (intentional adaptations, not reverted).
@@ -133,6 +140,8 @@ Snapshot not re-measured this pass (doc-audit does not load the Roslyn workspace
 
 | Action | Files affected | Approval |
 |--------|----------------|----------|
+| Added scope/artifact/status markers to sweep plan.md | `ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md` | auto (scope + artifact) + user-approved (status: active) |
+| Added `compatibility.md` to docs index | `docs/README.md` | targeted |
 | Appended directive cores #6/#7/#8 (5→8-core block, standard v12) | `AGENTS.md` | auto (standing-directives-drift) |
 | Removed dangling Refs row → GC'd top5 plan dir (#899) | `ai_docs/backlog.md` | targeted (provably GC'd, not moved) |
 | Deleted 4 orphaned `ai_docs/items/` files | `test-suite-audit-2026-05-08.md`, `sampling-spike.md`, `dry-run-preview-side-effect-audit.md`, `formatter-check-mode-baseline-policy.md` | user-approved |

--- a/ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md
@@ -1,4 +1,7 @@
 # Backlog sweep plan — 20260530T233522Z
+<!-- scope: in-repo -->
+<!-- artifact: plan -->
+<!-- status: active -->
 
 **Generated:** 2026-05-30T23:35:22Z
 **Backlog snapshot:** 2026-05-30T23:10:00Z

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Human-facing documentation for the Roslyn-Backed MCP Server.
 | `setup.md` | Prerequisites, build/test/run, global tool and Docker, CI artifacts |
 | `reinstall.md` | Step-by-step Layer 1 (global tool) + Layer 2 (Claude Code plugin) reinstall workflow after a code change |
 | `stdio-client-integration.md` | NDJSON framing, handshake order, and minimal Python/C# examples for custom MCP clients |
+| `compatibility.md` | MCP client compatibility matrix — tested/likely clients, install-path × client table, known gotchas |
 | `product-contract.md` | Session operating contract, stable vs experimental surface tiers, supported tool families |
 | `release-policy.md` | Release gates, compatibility rules, deprecation policy, versioning |
 | `upgrade-matrix.md` | SDK, Roslyn, MSBuild, analyzers, and related dependency coupling; what to bump together |


### PR DESCRIPTION
Lands the uncommitted 2026-06-04 doc-audit pass that was sitting in the working tree before a `/backlog-sweep:execute` run (which requires a clean `main`).

Changes:
- `ai_docs/plans/20260530T233522Z_backlog-sweep/plan.md` — scope/artifact/status markers
- `docs/README.md` — `compatibility.md` index entry
- `.ai-doc-audit.md` — ledger refresh

Closes backlog row `doc-audit-changes-uncommitted` (this commit IS the work it tracked). The row is removed in the immediate follow-on discovery-sweep backlog PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)