### PR TITLE
refactor: route 3 read-side services through ICompilationCache (batch 2 of compilation-cache-adoption-read-side)

### DIFF
--- a/changelog.d/compilation-cache-adoption-batch-2.md
+++ b/changelog.d/compilation-cache-adoption-batch-2.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Route `TypeConsumersService`, `CodePatternAnalyzer`, and `SymbolSearchService` read-side compilations through the shared `ICompilationCache` instead of calling `project.GetCompilationAsync` directly (batch 2 of the `compilation-cache-adoption-read-side` adoption sweep; batch 1 shipped in PR #913). Guarantees cross-call compilation sharing under GC pressure, analyzer-bound caching, and in-flight dedup for these read-side analysis paths.

--- a/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodePatternAnalyzer.cs
@@ -12,11 +12,13 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<CodePatternAnalyzer> _logger;
 
-    public CodePatternAnalyzer(IWorkspaceManager workspace, ILogger<CodePatternAnalyzer> logger)
+    public CodePatternAnalyzer(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<CodePatternAnalyzer> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -31,7 +33,7 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         {
             if (ct.IsCancellationRequested) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var tree in compilation.SyntaxTrees)
@@ -152,7 +154,7 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         var parse = ParseSemanticQuery(decodedQuery);
         bool Combined(ISymbol s) => parse.Predicates.All(p => p(s));
         await CollectSemanticSearchMatchesAsync(
-            solution, projects, Combined, limit, results, seenHandles, "structured", ct)
+            solution, workspaceId, _compilationCache, projects, Combined, limit, results, seenHandles, "structured", ct)
             .ConfigureAwait(false);
 
         string? warning = null;
@@ -164,7 +166,7 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
             var term = decodedQuery.Trim();
             bool NameMatch(ISymbol s) => s.Name.Contains(term, StringComparison.OrdinalIgnoreCase);
             await CollectSemanticSearchMatchesAsync(
-                solution, projects, NameMatch, limit, results, seenHandles, "name-substring", ct)
+                solution, workspaceId, _compilationCache, projects, NameMatch, limit, results, seenHandles, "name-substring", ct)
                 .ConfigureAwait(false);
             if (results.Count > 0)
             {
@@ -190,7 +192,7 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
                 return false;
             }
             await CollectSemanticSearchMatchesAsync(
-                solution, projects, TokenOrMatch, limit, results, seenHandles, "token-or-match", ct)
+                solution, workspaceId, _compilationCache, projects, TokenOrMatch, limit, results, seenHandles, "token-or-match", ct)
                 .ConfigureAwait(false);
             if (results.Count > 0)
             {
@@ -214,6 +216,8 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
 
     private static async Task CollectSemanticSearchMatchesAsync(
         Solution solution,
+        string workspaceId,
+        ICompilationCache compilationCache,
         IEnumerable<Project> projects,
         Func<ISymbol, bool> symbolMatches,
         int limit,
@@ -226,7 +230,7 @@ public sealed partial class CodePatternAnalyzer : ICodePatternAnalyzer
         {
             if (ct.IsCancellationRequested || results.Count >= limit) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var tree in compilation.SyntaxTrees)

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -12,11 +12,13 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class SymbolSearchService : ISymbolSearchService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<SymbolSearchService> _logger;
 
-    public SymbolSearchService(IWorkspaceManager workspace, ILogger<SymbolSearchService> logger)
+    public SymbolSearchService(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<SymbolSearchService> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -55,7 +57,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
         if (results.Count < maxResults && !ct.IsCancellationRequested)
         {
             await RunFqnSubstringFallbackAsync(
-                solution, query, maxResults, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
+                solution, workspaceId, _compilationCache, query, maxResults, kindFilter, namespaceFilter, allowedProjectPaths, results, seenKeys, ct).ConfigureAwait(false);
         }
 
         return results;
@@ -100,6 +102,8 @@ public sealed class SymbolSearchService : ISymbolSearchService
 
     private static async Task RunFqnSubstringFallbackAsync(
         Solution solution,
+        string workspaceId,
+        ICompilationCache compilationCache,
         string query,
         int limit,
         string? kindFilter,
@@ -114,7 +118,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
             if (ct.IsCancellationRequested) break;
             if (results.Count >= limit) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             if (!CollectFqnMatchesForCompilation(

--- a/src/RoslynMcp.Roslyn/Services/TypeConsumersService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeConsumersService.cs
@@ -19,11 +19,13 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class TypeConsumersService : ITypeConsumersService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<TypeConsumersService> _logger;
 
-    public TypeConsumersService(IWorkspaceManager workspace, ILogger<TypeConsumersService> logger)
+    public TypeConsumersService(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<TypeConsumersService> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -44,7 +46,7 @@ public sealed class TypeConsumersService : ITypeConsumersService
         }
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
-        var symbol = await ResolveTypeAsync(solution, typeName, ct).ConfigureAwait(false)
+        var symbol = await ResolveTypeAsync(solution, workspaceId, _compilationCache, typeName, ct).ConfigureAwait(false)
             ?? throw new KeyNotFoundException(
                 $"No type found matching '{typeName}'. Pass a fully qualified metadata name "
                 + "(e.g. 'SampleLib.IAnimal') or a short type name; generic arity uses backtick "
@@ -100,12 +102,13 @@ public sealed class TypeConsumersService : ITypeConsumersService
     /// <see cref="Compilation.GetTypeByMetadataName"/>) or a short/partial name (fallback via
     /// <see cref="SymbolFinder.FindDeclarationsAsync"/>). Returns the first match.
     /// </summary>
-    private static async Task<INamedTypeSymbol?> ResolveTypeAsync(Solution solution, string typeName, CancellationToken ct)
+    private static async Task<INamedTypeSymbol?> ResolveTypeAsync(
+        Solution solution, string workspaceId, ICompilationCache compilationCache, string typeName, CancellationToken ct)
     {
         // Fast path: try metadata name resolution against every project.
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
             var typeSymbol = compilation.GetTypeByMetadataName(typeName);
             if (typeSymbol is not null)

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -9,10 +9,11 @@ namespace RoslynMcp.Tests;
 
 /// <summary>
 /// Regression coverage for <c>compilation-cache-adoption-read-side</c>: the read-side analysis
-/// services <see cref="CouplingAnalysisService"/>, <see cref="ExceptionFlowService"/>, and
-/// <see cref="AnalyzerInfoService"/> must obtain project compilations through the shared
-/// <see cref="ICompilationCache"/> rather than calling <c>project.GetCompilationAsync</c>
-/// directly.
+/// services must obtain project compilations through the shared <see cref="ICompilationCache"/>
+/// rather than calling <c>project.GetCompilationAsync</c> directly. Batch 1 covered
+/// <see cref="CouplingAnalysisService"/>, <see cref="ExceptionFlowService"/>, and
+/// <see cref="AnalyzerInfoService"/>; batch 2 adds <see cref="TypeConsumersService"/>,
+/// <see cref="CodePatternAnalyzer"/>, and <see cref="SymbolSearchService"/>.
 /// <para>
 /// A reference-equality check alone cannot prove adoption — Roslyn memoizes a
 /// <see cref="Compilation"/> on its owning <see cref="Project"/>, so two direct calls would also
@@ -77,6 +78,64 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
 
         var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
             service.ListAnalyzersAsync(workspace.WorkspaceId, projectFilter: null, CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task TypeConsumersService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new TypeConsumersService(WorkspaceManager, cache, NullLogger<TypeConsumersService>.Instance);
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.FindTypeConsumersAsync(
+                workspace.WorkspaceId,
+                "SampleLib.IAnimal",
+                limit: 100,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task CodePatternAnalyzer_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new CodePatternAnalyzer(WorkspaceManager, cache, NullLogger<CodePatternAnalyzer>.Instance);
+
+        // Exercises BOTH converted call paths in one method: FindReflectionUsagesAsync (the
+        // instance-method site) and SemanticSearchAsync -> CollectSemanticSearchMatchesAsync
+        // (the private static helper site).
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, async () =>
+        {
+            await service.FindReflectionUsagesAsync(workspace.WorkspaceId, projectFilter: null, CancellationToken.None);
+            await service.SemanticSearchAsync(workspace.WorkspaceId, "Dog", projectFilter: null, limit: 50, CancellationToken.None);
+        });
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task SymbolSearchService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new SymbolSearchService(WorkspaceManager, cache, NullLogger<SymbolSearchService>.Instance);
+
+        // maxResults is deliberately high so the primary pattern search leaves budget under the
+        // cap and the FQN-substring fallback (the converted GetCompilationAsync site) runs.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.SearchSymbolsAsync(
+                workspace.WorkspaceId,
+                "IAnimal",
+                projectFilter: null,
+                kindFilter: null,
+                namespaceFilter: null,
+                maxResults: 100,
+                CancellationToken.None));
 
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
     }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -140,11 +140,13 @@ internal sealed class TestServiceContainer
                 NullLogger<SymbolNavigationService>.Instance),
             SymbolSearchService = new SymbolSearchService(
                 workspaceManager,
+                compilationCache,
                 NullLogger<SymbolSearchService>.Instance),
             ReferenceService = referenceService,
             MutationAnalysisService = mutationAnalysisService,
             TypeConsumersService = new TypeConsumersService(
                 workspaceManager,
+                compilationCache,
                 NullLogger<TypeConsumersService>.Instance),
             SemanticGrepService = new SemanticGrepService(
                 workspaceManager,
@@ -192,6 +194,7 @@ internal sealed class TestServiceContainer
             NuGetDependencyService = nuGetDependencyService,
             CodePatternAnalyzer = new CodePatternAnalyzer(
                 workspaceManager,
+                compilationCache,
                 NullLogger<CodePatternAnalyzer>.Instance),
             EditService = new EditService(
                 workspaceManager,


### PR DESCRIPTION
Batch 2 of the `compilation-cache-adoption-read-side` adoption sweep (plan `20260530T233522Z_backlog-sweep`, initiative 1). Routes the group-(a) clean read-side sites in three services through the singleton `ICompilationCache` instead of calling `project.GetCompilationAsync` directly.

**Production (3):**
- `TypeConsumersService` — thread `workspaceId`+cache into static `ResolveTypeAsync` (was line 108)
- `CodePatternAnalyzer` — instance `FindReflectionUsagesAsync` (was line 34) + static `CollectSemanticSearchMatchesAsync` (was line 229, 3 call-sites updated)
- `SymbolSearchService` — static `RunFqnSubstringFallbackAsync` (was line 117)

**Tests (2 extended):** 3 new `RecordingCompilationCache` regression tests (one per service; the CodePatternAnalyzer test drives both converted sites) + the test-DI ctor update in `TestServiceContainer`.

**Partial close:** the `compilation-cache-adoption-read-side` backlog row stays OPEN — group-(c) forked-solution HAZARD sites and the remaining group-(a) sites (`TestReferenceMapService`, `ReferenceService`) are deferred to a later batch. The row is updated (not removed) in the plan's combined reconcile.

**Validation:** Release build clean with `-p:TreatWarningsAsErrors=true`; `CompilationCacheAdoptionTests` 6/6 green (3 batch-1 + 3 new). Full `verify-release.ps1` runs as the PR check.

Cold spec-compliance + code-quality review: both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)