### PR TITLE
release: v2.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 32 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.3.2",
+  "version": "2.3.3",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.3.3] - 2026-06-08
+
+### Fixed
+
+- **Fixed:** `add_pragma_suppression` is now idempotent — when the target line is already covered by an active `#pragma warning disable <id>`, it no-ops (returns `EditsApplied: 0`) instead of appending a second identical pragma. Previously a retry (e.g. after an auto-reload) at the same site accumulated duplicate `#pragma warning disable` directives. Coverage detection reuses the same predicate `verify_pragma_suppresses` uses, so the two cannot drift. Closes `add-pragma-suppression-duplicate-on-retry`.
+- **Fixed:** Logged `dotnet` process-tree kill failures during command cancellation and early file-lock fast-fail cleanup without changing timeout/cancellation envelopes. Closes `dotnet-command-runner-kill-failure-observability`.
+- **Fixed:** Missing `workspaceId` calls on eligible read-only workspace tools can now elicit a workspace path, load it, and retry once with the recovered workspace id. Closes `elicitation-allowlist-workspaceid-recovery`.
+- **Fixed:** `find_implementations` now returns a structured `hint` (telling the caller to source-anchor the query) instead of a bare, possibly-empty result when a `metadataName` resolves to a corlib/BCL interface or abstract root (e.g. `System.IDisposable`). Such metadata-anchored roots bind to a single project's corlib reference, so cross-project implementers could silently drop out and read as `count: 0` — indistinguishable from "no implementers." Mirrors the `find_overrides` corlib-virtual guard (gh #754). The normal (non-corlib, source-anchored) path is unchanged. Closes `find-implementations-corlib-metadataname-zero`.
+- **Fixed:** `find_implementations` now reuses the symbol resolved for the corlib hint guard instead of resolving the same locator a second time on the normal path.
+- **Fixed:** `find_references` metadata-name disambiguation now dedupes indistinguishable candidates by `symbolHandle` before returning an ambiguity envelope. Closes `find-references-identical-ambiguous-candidates`.
+- **Fixed:** `member_hierarchy` now returns the standard `{error, category: "NotFound", message}` envelope when the locator resolves no symbol, instead of a bare JSON `null` that was ambiguous to callers (no-result vs failure). The message names the locator field supplied and echoes the unresolved value, matching the `symbol_relationships` / `symbol_info` convention. Closes `member-hierarchy-bare-null`.
+- **Fixed:** `get_code_actions` now flattens nested Roslyn code-action groups into previewable leaf actions so `preview_code_action` can preview the returned indices. Closes `preview-code-action-nested-notsupported`.
+- **Fixed:** `verify_pragma_suppresses` now reports a bounded confirmation-unavailable reason when live diagnostic confirmation cannot run, while preserving the structural pragma result.
+
+### Changed
+
+- **Changed:** `server_info.update` now carries latest-version check status (`checkStatus`) and completion time (`lastCheckedAt`) so operators can distinguish pending, failed, timed-out, and succeeded-with-no-update states even when `latest` is `null`. Closes `latest-version-status-surface`.
+
+### Added
+
+- **Added:** `server_catalog_version_diff` now exposes `roslyn://server/catalog-diff/{fromVersion}/{toVersion}` for the supported `v2.3.1` -> current `v2.3.2` release pair, backed by an embedded v2.3.1 catalog snapshot and structured added/removed/promoted/changed entries. Closes `surface-catalog-version-diff`.
+- **Added:** `workspace_readiness_report`, a stable read-only first-run readiness tool that reports `ready`, `restore-needed`, `build-needed`, or `analyzer-limited` with limitations and next workflows without running tests by default. Closes `workspace-readiness-report`.
+- **Added:** `workspace_support_bundle`, a stable read-only incident bundle for loaded workspaces that reports readiness, drift, capped change history, version metadata, diagnostic totals, and recovery hints without source snippets. Closes `workspace-support-bundle`.
+
+### Maintenance
+
+- **Maintenance:** Route `TypeConsumersService`, `CodePatternAnalyzer`, and `SymbolSearchService` read-side compilations through the shared `ICompilationCache` instead of calling `project.GetCompilationAsync` directly (batch 2 of the `compilation-cache-adoption-read-side` adoption sweep; batch 1 shipped in PR #913). Guarantees cross-call compilation sharing under GC pressure, analyzer-bound caching, and in-flight dedup for these read-side analysis paths.
+- **Maintenance:** De-flaked the `WorkspaceExecutionGate` auto-reload timeout-budget tests by injecting a `TimeProvider` into the gate (optional ctor parameter, defaults to `TimeProvider.System` — production behaviour and the DI registration are unchanged) so the per-request timeout CTS, and its post-auto-reload `CancelAfter` reset, arm on a controllable clock. The three `AutoReload_ResetsTimeoutBudget*` / `AutoReload_ParallelFanout_AllReadersSucceedAfterReload` tests now drive a `FakeTimeProvider` instead of racing real `Task.Delay` calls against a real 2-second timeout — the wall-clock race that intermittently threw `TaskCanceledException` under full-suite CI CPU contention (it failed the v2.3.2 release `validate` job and needed a re-run). A mutation check confirms the rewritten tests still fail when the budget reset is removed. Closes `flaky-gate-timeout-virtual-clock`.
+- **Maintenance:** `NuGetVersionChecker` now records an observable check status (`NeverChecked`/`Pending`/`Succeeded`/`Failed`/`TimedOut` via `LastCheckStatus`/`LastCheckedAt`) and logs fetch failures at Debug instead of silently swallowing them, distinguishing a timed-out check from other failures. The non-blocking, never-throws contract of `GetLatestVersion()` is unchanged; `latest-version-status-surface` subsequently exposes the status through `server_info.update`. Closes `nuget-version-check-observability`.
+- **Maintenance:** Removed the stale duplicate promotion scorecard at `ai_docs/audit-reports/_latest-promotion-scorecard.json` (serverVersion 1.34.2, from the retired `/audit-deep` writer). The canonical scorecard is the repo-root `audit-reports/_latest-promotion-scorecard.json` (serverVersion 1.38.1), written by the surface-test prompt and read by `eng/aggregate-promotion-scorecards.ps1`. Partial close of `promotion-scorecard-execution-batch` — source-of-truth dedup only; the tier-promotion re-run against the v2.3.x surface remains a tracked follow-on.
+- **Maintenance:** extracted script worker-thread, deadline, heartbeat, and abandonment accounting into `ScriptExecutionSupervisor` while keeping script DTO formatting in `ScriptingService`. Closes `scripting-service-execution-supervisor-extraction`.
+- **Maintenance:** Added a regression guard that keeps README, plugin, and backlog surface/skill count claims aligned with the live catalog and shipped skills. Closes `surface-count-doc-drift-guard`.
+- **Maintenance:** removed dead `SymbolRefactorService` DI fields and pinned concrete/interface singleton aliasing for its refactor collaborators. Closes `symbolrefactorservice-dead-di-fields`.
+- **Maintenance:** Added Debug-level observability for non-fatal `workspace_close(drainProcesses=true)` drain failures and workspace resource-list notification failures while preserving successful close/load/reload semantics. Closes `workspace-close-notification-drain-observability`.
+
 ## [2.3.2] - 2026-06-01
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.3.2</Version>
+    <Version>2.3.3</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/add-pragma-suppression-idempotent.md
+++ b/changelog.d/add-pragma-suppression-idempotent.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `add_pragma_suppression` is now idempotent — when the target line is already covered by an active `#pragma warning disable <id>`, it no-ops (returns `EditsApplied: 0`) instead of appending a second identical pragma. Previously a retry (e.g. after an auto-reload) at the same site accumulated duplicate `#pragma warning disable` directives. Coverage detection reuses the same predicate `verify_pragma_suppresses` uses, so the two cannot drift. Closes `add-pragma-suppression-duplicate-on-retry`.

--- a/changelog.d/compilation-cache-adoption-batch-2.md
+++ b/changelog.d/compilation-cache-adoption-batch-2.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Route `TypeConsumersService`, `CodePatternAnalyzer`, and `SymbolSearchService` read-side compilations through the shared `ICompilationCache` instead of calling `project.GetCompilationAsync` directly (batch 2 of the `compilation-cache-adoption-read-side` adoption sweep; batch 1 shipped in PR #913). Guarantees cross-call compilation sharing under GC pressure, analyzer-bound caching, and in-flight dedup for these read-side analysis paths.

--- a/changelog.d/dotnet-command-runner-kill-failure-observability.md
+++ b/changelog.d/dotnet-command-runner-kill-failure-observability.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Logged `dotnet` process-tree kill failures during command cancellation and early file-lock fast-fail cleanup without changing timeout/cancellation envelopes. Closes `dotnet-command-runner-kill-failure-observability`.

--- a/changelog.d/elicitation-allowlist-workspaceid-recovery.md
+++ b/changelog.d/elicitation-allowlist-workspaceid-recovery.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** Missing `workspaceId` calls on eligible read-only workspace tools can now elicit a workspace path, load it, and retry once with the recovered workspace id. Closes `elicitation-allowlist-workspaceid-recovery`.

--- a/changelog.d/find-implementations-corlib-hint.md
+++ b/changelog.d/find-implementations-corlib-hint.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_implementations` now returns a structured `hint` (telling the caller to source-anchor the query) instead of a bare, possibly-empty result when a `metadataName` resolves to a corlib/BCL interface or abstract root (e.g. `System.IDisposable`). Such metadata-anchored roots bind to a single project's corlib reference, so cross-project implementers could silently drop out and read as `count: 0` — indistinguishable from "no implementers." Mirrors the `find_overrides` corlib-virtual guard (gh #754). The normal (non-corlib, source-anchored) path is unchanged. Closes `find-implementations-corlib-metadataname-zero`.

--- a/changelog.d/find-implementations-double-symbol-resolution.md
+++ b/changelog.d/find-implementations-double-symbol-resolution.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_implementations` now reuses the symbol resolved for the corlib hint guard instead of resolving the same locator a second time on the normal path.

--- a/changelog.d/find-references-identical-ambiguous-candidates.md
+++ b/changelog.d/find-references-identical-ambiguous-candidates.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `find_references` metadata-name disambiguation now dedupes indistinguishable candidates by `symbolHandle` before returning an ambiguity envelope. Closes `find-references-identical-ambiguous-candidates`.

--- a/changelog.d/flaky-gate-timeout-virtual-clock.md
+++ b/changelog.d/flaky-gate-timeout-virtual-clock.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** De-flaked the `WorkspaceExecutionGate` auto-reload timeout-budget tests by injecting a `TimeProvider` into the gate (optional ctor parameter, defaults to `TimeProvider.System` — production behaviour and the DI registration are unchanged) so the per-request timeout CTS, and its post-auto-reload `CancelAfter` reset, arm on a controllable clock. The three `AutoReload_ResetsTimeoutBudget*` / `AutoReload_ParallelFanout_AllReadersSucceedAfterReload` tests now drive a `FakeTimeProvider` instead of racing real `Task.Delay` calls against a real 2-second timeout — the wall-clock race that intermittently threw `TaskCanceledException` under full-suite CI CPU contention (it failed the v2.3.2 release `validate` job and needed a re-run). A mutation check confirms the rewritten tests still fail when the budget reset is removed. Closes `flaky-gate-timeout-virtual-clock`.

--- a/changelog.d/latest-version-status-surface.md
+++ b/changelog.d/latest-version-status-surface.md
@@ -1,5 +1,0 @@
----
-category: Changed
----
-
-- **Changed:** `server_info.update` now carries latest-version check status (`checkStatus`) and completion time (`lastCheckedAt`) so operators can distinguish pending, failed, timed-out, and succeeded-with-no-update states even when `latest` is `null`. Closes `latest-version-status-surface`.

--- a/changelog.d/member-hierarchy-notfound-envelope.md
+++ b/changelog.d/member-hierarchy-notfound-envelope.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `member_hierarchy` now returns the standard `{error, category: "NotFound", message}` envelope when the locator resolves no symbol, instead of a bare JSON `null` that was ambiguous to callers (no-result vs failure). The message names the locator field supplied and echoes the unresolved value, matching the `symbol_relationships` / `symbol_info` convention. Closes `member-hierarchy-bare-null`.

--- a/changelog.d/nuget-version-check-observability.md
+++ b/changelog.d/nuget-version-check-observability.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** `NuGetVersionChecker` now records an observable check status (`NeverChecked`/`Pending`/`Succeeded`/`Failed`/`TimedOut` via `LastCheckStatus`/`LastCheckedAt`) and logs fetch failures at Debug instead of silently swallowing them, distinguishing a timed-out check from other failures. The non-blocking, never-throws contract of `GetLatestVersion()` is unchanged; `latest-version-status-surface` subsequently exposes the status through `server_info.update`. Closes `nuget-version-check-observability`.

--- a/changelog.d/preview-code-action-nested-notsupported.md
+++ b/changelog.d/preview-code-action-nested-notsupported.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `get_code_actions` now flattens nested Roslyn code-action groups into previewable leaf actions so `preview_code_action` can preview the returned indices. Closes `preview-code-action-nested-notsupported`.

--- a/changelog.d/promotion-scorecard-dedup.md
+++ b/changelog.d/promotion-scorecard-dedup.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Removed the stale duplicate promotion scorecard at `ai_docs/audit-reports/_latest-promotion-scorecard.json` (serverVersion 1.34.2, from the retired `/audit-deep` writer). The canonical scorecard is the repo-root `audit-reports/_latest-promotion-scorecard.json` (serverVersion 1.38.1), written by the surface-test prompt and read by `eng/aggregate-promotion-scorecards.ps1`. Partial close of `promotion-scorecard-execution-batch` — source-of-truth dedup only; the tier-promotion re-run against the v2.3.x surface remains a tracked follow-on.

--- a/changelog.d/scripting-service-execution-supervisor-extraction.md
+++ b/changelog.d/scripting-service-execution-supervisor-extraction.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** extracted script worker-thread, deadline, heartbeat, and abandonment accounting into `ScriptExecutionSupervisor` while keeping script DTO formatting in `ScriptingService`. Closes `scripting-service-execution-supervisor-extraction`.

--- a/changelog.d/suppression-pragma-confirmation-failure-reason.md
+++ b/changelog.d/suppression-pragma-confirmation-failure-reason.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `verify_pragma_suppresses` now reports a bounded confirmation-unavailable reason when live diagnostic confirmation cannot run, while preserving the structural pragma result.

--- a/changelog.d/surface-catalog-version-diff.md
+++ b/changelog.d/surface-catalog-version-diff.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `server_catalog_version_diff` now exposes `roslyn://server/catalog-diff/{fromVersion}/{toVersion}` for the supported `v2.3.1` -> current `v2.3.2` release pair, backed by an embedded v2.3.1 catalog snapshot and structured added/removed/promoted/changed entries. Closes `surface-catalog-version-diff`.

--- a/changelog.d/surface-count-doc-drift-guard.md
+++ b/changelog.d/surface-count-doc-drift-guard.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Added a regression guard that keeps README, plugin, and backlog surface/skill count claims aligned with the live catalog and shipped skills. Closes `surface-count-doc-drift-guard`.

--- a/changelog.d/symbolrefactorservice-dead-di-fields.md
+++ b/changelog.d/symbolrefactorservice-dead-di-fields.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** removed dead `SymbolRefactorService` DI fields and pinned concrete/interface singleton aliasing for its refactor collaborators. Closes `symbolrefactorservice-dead-di-fields`.

--- a/changelog.d/workspace-close-notification-drain-observability.md
+++ b/changelog.d/workspace-close-notification-drain-observability.md
@@ -1,5 +1,0 @@
----
-category: Maintenance
----
-
-- **Maintenance:** Added Debug-level observability for non-fatal `workspace_close(drainProcesses=true)` drain failures and workspace resource-list notification failures while preserving successful close/load/reload semantics. Closes `workspace-close-notification-drain-observability`.

--- a/changelog.d/workspace-readiness-report.md
+++ b/changelog.d/workspace-readiness-report.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `workspace_readiness_report`, a stable read-only first-run readiness tool that reports `ready`, `restore-needed`, `build-needed`, or `analyzer-limited` with limitations and next workflows without running tests by default. Closes `workspace-readiness-report`.

--- a/changelog.d/workspace-support-bundle.md
+++ b/changelog.d/workspace-support-bundle.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** `workspace_support_bundle`, a stable read-only incident bundle for loaded workspaces that reports readiness, drift, capped change history, version metadata, diagnostic totals, and recovery hints without source snippets. Closes `workspace-support-bundle`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
Version bump **2.3.2 → 2.3.3** (patch). Consumes 21 `changelog.d/` fragments into the `## [2.3.3]` CHANGELOG section.

## Fixed (9)
- `add_pragma_suppression` idempotent (no duplicate pragma on retry)
- `dotnet` process-tree kill-failure logging on cancel/file-lock cleanup
- Missing `workspaceId` elicitation + load + single retry on read-only tools
- `find_implementations` corlib/BCL metadataName → structured `hint` (no silent `count: 0`)
- `find_implementations` reuses the corlib-guard-resolved symbol (no double resolution)
- `find_references` dedupes indistinguishable ambiguity candidates by `symbolHandle`
- `member_hierarchy` returns standard `NotFound` envelope instead of bare `null`
- `get_code_actions` flattens nested code-action groups for previewability
- `verify_pragma_suppresses` reports bounded confirmation-unavailable reason

## Changed (1)
- `server_info.update` carries `checkStatus` / `lastCheckedAt` latest-version state

## Added (3)
- `server_catalog_version_diff` resource (catalog-diff/{from}/{to})
- `workspace_readiness_report` tool
- `workspace_support_bundle` tool

## Maintenance (8)
- Compilation-cache adoption batch 2 (TypeConsumers / CodePattern / SymbolSearch)
- De-flaked `WorkspaceExecutionGate` timeout tests via injected `TimeProvider`
- `NuGetVersionChecker` observable check status
- Removed stale duplicate promotion scorecard
- Extracted `ScriptExecutionSupervisor`
- Surface/skill count doc-drift regression guard
- Removed dead `SymbolRefactorService` DI fields
- `workspace_close` drain-failure observability

See CHANGELOG.md for full entries.