### PR TITLE
fix(backlog-sweep): sync reconcile/recover/draft-changelog skills with global audit fixes

### DIFF
--- a/.claude/skills/draft-changelog-entry/SKILL.md
+++ b/.claude/skills/draft-changelog-entry/SKILL.md
@@ -29,7 +29,7 @@ Refuse and report cleanly — do NOT produce a partial fragment — if any of th
 | Condition | Message |
 |---|---|
 | Active `state.json` cannot be located OR `schemaVersion` ∉ {2, 3, 4} | `"Refusing: unsupported backlog-sweep state schema. This skill requires schemaVersion ∈ {2, 3, 4}. Found: <value> at <path>."` |
-| `gh` CLI is not on PATH (`command -v gh` fails) | `"Refusing: the 'gh' CLI is required to read commit metadata but was not found on PATH."` |
+| `git` CLI is not on PATH (`command -v git` fails) | `"Refusing: the 'git' CLI is required to read commit metadata but was not found on PATH. (gh is preferred for trailers/PR context but git show is a sufficient fallback — see Step 2.)"` |
 | A fragment file `changelog.d/<first-row-id>.md` already exists | `"Refusing: a fragment for row '<id>' already exists at changelog.d/<id>.md. This skill never clobbers existing fragments — edit the existing file by hand if it needs an update, or remove it first."` |
 | The initiative id is not found in `state.json` OR no CHANGELOG category resolves from EITHER `state.json` (`changelogCategory`) OR the plan.md stanza (`\| CHANGELOG category \|` row) | `"Refusing: initiative '<id>' not found, or no CHANGELOG category in state.json or its plan.md stanza. Add a 'CHANGELOG category' row to the initiative's plan.md stanza (or set changelogCategory in state.json)."` |
 | The commit cannot be resolved (`git show <ref>` returns non-zero) | `"Refusing: cannot resolve commit / branch '<ref>'."` |

--- a/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
+++ b/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
@@ -18,13 +18,13 @@ This skill edits repository files and shells out to `gh` + `git`. Roslyn MCP **`
 
 ## Input
 
-`$ARGUMENTS` optionally names the plan directory (relative to repo root, e.g. `ai_docs/plans/20260417T120000Z_backlog-sweep`). If omitted, enumerate `ai_docs/plans/*_backlog-sweep/`, classify each as terminal vs non-terminal (terminal = `completed: true` AND every initiative status in `{merged, obsolete, deferred, cancelled, done, completed}`), and select the **oldest non-terminal** plan (FIFO drain). This mirrors `:execute` Step 0b / `:status` — do NOT default to newest-by-name, which strands older non-terminal plans whose in-review PRs never get reconciled.
+`$ARGUMENTS` optionally names the plan directory (relative to repo root, e.g. `ai_docs/plans/20260417T120000Z_backlog-sweep`). If omitted, enumerate `ai_docs/plans/*_backlog-sweep/`, classify each as terminal vs non-terminal (terminal = `completed: true` AND every initiative status in `{merged, obsolete, deferred}` — the canonical terminal set per `~/.claude/prompts/backlog-sweep-plan.md` § *State machine*), and select the **oldest non-terminal** plan (FIFO drain). This mirrors `:execute` Step 0b / `:status` — do NOT default to newest-by-name, which strands older non-terminal plans whose in-review PRs never get reconciled.
 
 ## Preconditions (HARD GATES — refuse if any fail)
 
 1. **`state.json` exists** at `{plan-dir}/state.json`. If missing, refuse: `"No state.json at {path}. Is this a backlog-sweep plan directory?"`.
 2. **`plan.md` exists** at `{plan-dir}/plan.md`. If missing, refuse.
-3. **`schemaVersion ∈ {2, 3}`** in `state.json` (2 = legacy `/backlog-sweep:plan`; 3 = `/backlog-sweep:prepare`-extended — both valid per the canonical field contract). If neither (or missing), refuse: `"Plan uses schemaVersion {n}; this skill supports 2 and 3. Re-run /backlog-sweep:plan or :prepare to regenerate."`.
+3. **`schemaVersion ∈ {2, 3, 4}`** in `state.json` (2 = legacy `/backlog-sweep:plan`; 3 = legacy `/backlog-sweep:prepare`-extended; 4 = `/backlog-sweep:prepare` status-SSOT, the **current default** — all three valid per the canonical field contract, which states every consumer including this skill MUST accept all three). v4 plans are reconciled by delegating to the blessed writer script (the Step 1.2 v4 fast path); 2/3 plans use the manual path below. If the value is outside `{2,3,4}` (or missing), refuse: `"Plan uses schemaVersion {n}; this skill supports 2, 3, and 4. Re-run /backlog-sweep:plan or :prepare to regenerate."`.
 4. **`gh` CLI is on PATH** (`gh --version` exits 0). If not, refuse: `"gh CLI not available — cannot query PR state. Install gh or run Step 1b manually."`.
 5. **`git` CLI is on PATH** (`git --version` exits 0). If not, refuse.
 6. **Working tree is clean** (`git status --porcelain` is empty) OR the only dirty paths are the two files this skill will edit (`state.json` + `plan.md`). If dirtier, refuse: `"Working tree has unrelated changes — commit or stash before reconciling."`.
@@ -36,7 +36,7 @@ This skill edits repository files and shells out to `gh` + `git`. Roslyn MCP **`
 
 1. Resolve the plan directory per Input above.
 2. Read `{plan-dir}/state.json` into memory. Validate `schemaVersion ∈ {2, 3, 4}`.
-   - **v4 fast path:** if `schemaVersion == 4` AND `~/.claude/scripts/bsweep-state.mjs` exists, delegate the whole reconcile to `node ~/.claude/scripts/bsweep-state.mjs reconcile --plan {plan-dir}` (one batched `gh pr list`, the same MERGED→merged / CLOSED→deferred transitions, plan.md status-table regen), then go straight to Step 5 (commit + PR). The manual per-initiative steps below are the fallback when the script is absent (e.g. an external plugin consumer) or the plan is pre-v4.
+   - **v4 fast path:** if `schemaVersion == 4` AND `~/.claude/scripts/bsweep-state.mjs` exists, delegate the whole reconcile to `node ~/.claude/scripts/bsweep-state.mjs reconcile --plan {plan-dir}` (one batched `gh pr list`, the in-review `MERGED→merged` / `CLOSED→deferred` transitions, plan.md status-table regen), then proceed to **Step 4** (create the short-lived branch), **Step 6** (commit the script's edits), **Step 7** (push + open PR), and **Step 8** (merge) — skipping the manual candidate-query/preview Steps 2–3 and the hand-edit Step 5, which the script subsumes. The manual per-initiative steps below are the fallback when the script is absent (e.g. an external plugin consumer) or the plan is pre-v4.
 3. Read `{plan-dir}/plan.md` into memory.
 4. Build the **reconciliation candidate list**: every initiative whose `status` is `in-review` or `in-progress` AND whose `prUrl` is non-null. Skip `pending`, `merged`, `obsolete`, `deferred`, and `paused-usage-limit` (the last is a mid-flight recovery state with no mergeable PR — resume it via `/backlog-sweep:execute initiative=<id>`, don't reconcile it here).
 5. If the candidate list is empty, report `"Nothing to reconcile — no in-review/in-progress initiatives with a PR URL."` and exit **without** creating a branch or PR.
@@ -102,16 +102,10 @@ For each in-flight transition:
    - For `deferred`: append the "PR #<n> closed without merge — manual triage required" note to `notes` (separator `" | "` if notes already non-empty).
    - Leave other fields (branch, worktreePath, rowsClosedCount, …) untouched — but NEVER null out `prUrl` on a `merged` record.
 
-2. **Update plan.md's Status row** for this initiative. The initiative's header block in `plan.md` looks like:
-   ```
-   ### {order}. `{initiative-id}` — {title}
-
-   **Status:** {status} · **Order:** {order} · **Correctness class:** {class} …
-   ```
-   Rewrite the `**Status:** …` value:
-   - `merged` → `merged (PR #{n}, {YYYY-MM-DD from mergedAt})`
-   - `deferred` → `deferred (PR #{n} closed; see notes)`
-   - Do not touch Order / Correctness class / Schedule hint / Estimated context / CHANGELOG category.
+2. **Update plan.md's Status row** for this initiative (legacy 2/3 plans only — v4 plans have NO per-stanza Status row; the Step 1.2 v4 fast path already regenerated the generated status table via the script). The initiative's stanza in `plan.md` is a markdown table under its `### {order}. \`{initiative-id}\` — {title}` heading (canonical shape: `~/.claude/prompts/backlog-sweep-plan.md` Step 8), with a `| Status | {value} |` row. Rewrite ONLY that row's value cell:
+   - `merged` → `| Status | merged (PR #{n}, {YYYY-MM-DD from mergedAt}) |`
+   - `deferred` → `| Status | deferred (PR #{n} closed; see notes) |`
+   - Do not touch any other table row (Order / Correctness class / Schedule hint / Estimated context / CHANGELOG category).
 
 Write both files back. Keep JSON formatting stable (2-space indent, trailing newline if the original had one).
 
@@ -155,7 +149,7 @@ gh pr create --title "chore(plan): reconcile {plan-timestamp} state" \
 {bulleted list of id: old → new (PR #n, timestamp)}
 
 ## Test plan
-- [x] `state.json` `schemaVersion` unchanged (2 or 3)
+- [x] `state.json` `schemaVersion` unchanged (2, 3, or 4)
 - [x] Only status / mergedAt / notes fields changed per initiative
 - [x] `plan.md` Status rows mirror state.json
 - [x] No unrelated files modified
@@ -203,7 +197,7 @@ If all initiatives are now terminal (`merged` / `obsolete` / `deferred`), additi
 ## Refusal cases (explicit)
 
 - **Plan directory missing / wrong shape** → refuse per Preconditions 1-2.
-- **`schemaVersion ∉ {2, 3}`** → refuse per Precondition 3 with re-plan instruction.
+- **`schemaVersion ∉ {2, 3, 4}`** → refuse per Precondition 3 with re-plan instruction. (v4 is supported via the Step 1.2 script delegation; only values outside `{2,3,4}` are refused.)
 - **`gh` / `git` missing** → refuse per Preconditions 4-5.
 - **Dirty working tree with unrelated paths** → refuse per Precondition 6.
 - **`main` diverged in a way that requires manual merge** during Step 8 rebase and the rebase surfaces conflicts outside `state.json` / `plan.md` → stop and hand off to the user; do not force-push away another contributor's edits.

--- a/.claude/skills/recover-stalled-subagent/SKILL.md
+++ b/.claude/skills/recover-stalled-subagent/SKILL.md
@@ -14,7 +14,7 @@ This skill does **not** query GitHub, reconcile plan state, edit `state.json` / 
 
 ## Why this exists
 
-Cold-subagent stalls (~1 in 10 spawn rate observed across 2026-04-17+18 passes) can emit a thought-fragment final message without the `<<<RESULT>>>` sentinel — see `ai_docs/prompts/backlog-sweep-execute.md` Appendix C's malformed-result detection. The orchestrator then cannot parse a PR URL, but the subagent may have already produced real edits in its worktree. 2026-04-18 pass-3 init-5 stranded 729 insertions across 4 prod files + 1 test file before a 3-turn manual recovery dance.
+Cold-subagent stalls (~1 in 10 spawn rate observed across 2026-04-17+18 passes) can emit a thought-fragment final message without the `<<<RESULT>>>` sentinel — see `~/.claude/prompts/_subagent-result-protocol.md` Appendix B's malformed-result detection (the subagent result protocol extracted from `backlog-sweep-execute.md`). The orchestrator then cannot parse a PR URL, but the subagent may have already produced real edits in its worktree. 2026-04-18 pass-3 init-5 stranded 729 insertions across 4 prod files + 1 test file before a 3-turn manual recovery dance.
 
 Manual recovery steps (each with its own foot-gun):
 
@@ -23,7 +23,7 @@ Manual recovery steps (each with its own foot-gun):
 3. Commit with a well-formed WIP message citing the original branch.
 4. Push to origin (so the WIP is durable before worktree removal).
 5. `cd` back to primary repo root — NOT from inside the worktree, or the next step fails.
-6. `dotnet build-server shutdown` **before** `git worktree remove --force`, or the Windows testhost/VBCSCompiler file lock on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/` leaves a stale `.worktrees/<id>` directory that the orchestrator must `rm -rf` manually (`Device or resource busy` on `git worktree remove`). This is the fix shipped by initiative 5 in PR #288; see `ai_docs/prompts/backlog-sweep-execute.md` Appendix A step 8 for the canonical discipline.
+6. `dotnet build-server shutdown` **before** `git worktree remove --force`, or the Windows testhost/VBCSCompiler file lock on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/` leaves a stale `.worktrees/<id>` directory that the orchestrator must `rm -rf` manually (`Device or resource busy` on `git worktree remove`). This is the fix shipped by initiative 5 in PR #288; see `~/.claude/prompts/backlog-sweep-execute.md` § Worktree cleanup for the canonical discipline.
 7. `git worktree remove --force .worktrees/<id>`.
 8. Emit a STATE_HANDOFF block the orchestrator can paste into `state.json.initiatives[n].notes`.
 
@@ -131,7 +131,7 @@ dotnet build-server shutdown
 
 The command prints one informational line even in the no-op case (e.g. `"Build server didn't shut down due to an error or it wasn't running."`) — ignore this; it is not an error.
 
-See `ai_docs/prompts/backlog-sweep-execute.md` Appendix A step 8 for the canonical shipped discipline (initiative 5 / PR #288).
+See `~/.claude/prompts/backlog-sweep-execute.md` § Worktree cleanup for the canonical shipped discipline (initiative 5 / PR #288).
 
 ### Step 6 — Remove the worktree
 
@@ -145,7 +145,7 @@ Do NOT delete the branch `remediation/<id>`. The orchestrator's retry or defer d
 
 ### Step 7 — Emit STATE_HANDOFF
 
-Print exactly 6 lines, prefixed `STATE_HANDOFF:`, for the orchestrator to paste into `state.json.initiatives[n].notes`. The 6-line shape is load-bearing — the orchestrator's Appendix C parse expects it.
+Print exactly 6 lines, prefixed `STATE_HANDOFF:`, for the orchestrator to paste into `state.json.initiatives[n].notes`. The 6-line shape is a stable visual contract: the orchestrator reads the block to update `notes` — there is **no automated parser** for it. (The orchestrator's malformed-result handling lives in `~/.claude/prompts/_subagent-result-protocol.md` Appendix B, cited above — NOT Appendix C, which is the cold-reviewer briefing and never parses this block.)
 
 ```
 STATE_HANDOFF:


### PR DESCRIPTION
## Summary

Cross-repo follow-up to the `~/.claude` config-toolset audit ([darylmcd/claude-config#6](https://github.com/darylmcd/claude-config/pull/6)). This repo's copies of three backlog-sweep skills had **diverged** from the global ones and carried the same defects the audit fixed — plus a few unique to this repo's partial schema-v4 migration. Cold-reviewed (PASS): every introduced cross-ref resolves; `schemaVersion {2,3,4}` is now consistent end-to-end.

## Fixes

**`reconcile-backlog-sweep-plan`**
- Precondition 3 / PR-checkbox / refusal still hard-gated `schemaVersion {2,3}` — which **dead-locked the v4 fast path** (a HARD GATE checked before it). Widened to `{2,3,4}` with correct version labels (4 = prepare status-SSOT, the current default).
- v4 fast-path mis-pointed to "Step 5 (commit+PR)" — Step 5 is the *hand-edit* step and the ref skipped the **required branch creation** (main is branch-protected). Now routes Step 4 (branch) → Step 6 (commit) → Step 7 (PR) → Step 8 (merge).
- Replaced the phantom `**Status:** · **Order:**` prose format (no planner emits it) with the real `| Status | value |` table cell + the v4-omits-the-row carve-out.
- Narrowed the terminal-status set to the canonical `{merged, obsolete, deferred}` (dropped phantom `cancelled/done/completed`).

**`recover-stalled-subagent`**
- Repointed 3 dangling `ai_docs/prompts/backlog-sweep-execute.md` refs (that file lives globally, not in this repo) to `~/.claude/prompts/...`.
- Fixed the wrong **"Appendix C"** malformed-result citation → Appendix B (now in `_subagent-result-protocol.md`).
- Removed the false **"the orchestrator's Appendix C parse expects it"** claim — no parser exists; `STATE_HANDOFF` is a visual contract.

**`draft-changelog-entry`**
- The `gh` hard-refuse contradicted Step 2's documented `git show` fallback. Require `git` (the real floor); keep `gh` preferred-but-optional.

## Test plan
- [x] Cold adversarial review of the diff — PASS; every introduced cross-ref verified against ground truth (`_subagent-result-protocol.md` Appendix B, execute.md `§ Worktree cleanup`, plan.md Step 8 stanza, Steps 4/6/7/8).
- [x] Residual-signature sweep: 0 remaining `{2,3}`-only gates, 0 phantom Status format, 0 dangling `ai_docs/prompts/` cross-refs, 0 wrong-Appendix citations.
- [x] No changelog fragment — matches precedent (#903 "skill schemaVersion handling" shipped without one; these are internal maintainer-tooling fixes, not MCP-server-surface changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)