### PR TITLE
feat(middleware): auto-resolve omitted workspaceId for read-only tools (workspace-id-omitted-single-resolve)

### DIFF
--- a/changelog.d/workspace-id-omitted-single-resolve.md
+++ b/changelog.d/workspace-id-omitted-single-resolve.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** workspace-id auto-resolution in the read-path middleware (`StructuredCallToolFilter`) — a read-only, non-destructive tool called with `workspaceId` omitted/empty now resolves to the single loaded workspace, or fast-fails with a structured error listing the loaded ids when two or more are loaded. New `_meta.autoResolution` field (`explicit` | `single-workspace` | `fast-fail`) makes adoption measurable. No schema change; explicit-id callers are unaffected. Closes `workspace-id-omitted-single-resolve`.

--- a/src/RoslynMcp.Core/Models/GateMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/GateMetricsDto.cs
@@ -54,6 +54,17 @@ namespace RoslynMcp.Core.Models;
 /// <c>WorkspaceReloadedDuringCall</c> so callers routing on category see the correct signal.
 /// <see langword="null"/> in all other cases (common path: no retry, or retry succeeded).
 /// </param>
+/// <param name="AutoResolution">
+/// workspace-id-omitted-single-resolve: records how the read-path middleware resolved an
+/// omitted/empty <c>workspaceId</c> on a read-only, non-destructive tool before dispatch:
+/// <c>explicit</c> (the caller supplied an id; left untouched), <c>single-workspace</c> (id
+/// omitted and exactly one workspace was loaded, so the middleware patched it in), or
+/// <c>fast-fail</c> (id omitted and two or more workspaces were loaded, so the middleware
+/// returned a structured error listing the candidates instead of guessing).
+/// <see langword="null"/> when the call did not go through the auto-resolution path (a
+/// write/destructive tool, a tool with no <c>workspaceId</c> parameter, or zero workspaces
+/// loaded — the last case is left for on-demand discovery / the binder).
+/// </param>
 public sealed record GateMetricsDto(
     string? GateMode,
     long QueuedMs,
@@ -64,4 +75,5 @@ public sealed record GateMetricsDto(
     long? StaleReloadMs = null,
     bool? RetriedAfterReload = null,
     bool? CacheHit = null,
-    bool? ReloadConfirmedNotFound = null);
+    bool? ReloadConfirmedNotFound = null,
+    string? AutoResolution = null);

--- a/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
+++ b/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
@@ -107,5 +107,14 @@ public sealed class GateMetricsBuilder
     /// </summary>
     public bool? CacheHit { get; set; }
 
-    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload, CacheHit, ReloadConfirmedNotFound);
+    /// <summary>
+    /// workspace-id-omitted-single-resolve: set by <c>StructuredCallToolFilter</c> when a
+    /// read-only, non-destructive tool is dispatched with <c>workspaceId</c> omitted/empty.
+    /// <c>explicit</c> (caller supplied an id), <c>single-workspace</c> (resolved to the one
+    /// loaded workspace), or <c>fast-fail</c> (≥2 loaded — structured error returned).
+    /// <see langword="null"/> when the request did not pass through the auto-resolution path.
+    /// </summary>
+    public string? AutoResolution { get; set; }
+
+    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload, CacheHit, ReloadConfirmedNotFound, AutoResolution);
 }

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -5,9 +5,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
 
@@ -125,6 +127,60 @@ internal static class StructuredCallToolFilter
 
             try
             {
+                // workspace-id-omitted-single-resolve: pre-dispatch workspaceId auto-resolution.
+                // For read-only, non-destructive tools that declare a workspaceId parameter, a
+                // call with workspaceId omitted/empty is resolved here — at the chokepoint —
+                // before the SDK binder runs: exactly one workspace loaded => patch it in;
+                // two-or-more => structured fast-fail listing the candidates; zero => left for
+                // on-demand discovery / the binder. This is intentionally NOT gated on the
+                // schema's Required flag (unlike IsWorkspaceIdRecoveryAllowedFor) so it keeps
+                // working after read-only tools flip workspaceId to optional.
+                var workspaceManager = context.Services?.GetService<IWorkspaceManager>();
+                if (workspaceManager is not null && IsWorkspaceIdAutoResolveAllowedFor(toolName))
+                {
+                    var loadedWorkspaces = workspaceManager.ListWorkspaces()
+                        .Select(WorkspaceStatusSummaryDto.From)
+                        .ToArray();
+                    var resolution = ClassifyWorkspaceIdResolution(
+                        context.Params?.Arguments,
+                        loadedWorkspaces,
+                        out var resolvedWorkspaceId,
+                        out var fastFailMessage);
+
+                    switch (resolution)
+                    {
+                        case WorkspaceIdAutoResolution.Explicit:
+                            RecordAutoResolution("explicit");
+                            break;
+
+                        case WorkspaceIdAutoResolution.SingleWorkspace:
+                            context.Params!.Arguments =
+                                WithWorkspaceId(context.Params.Arguments, resolvedWorkspaceId!);
+                            RecordAutoResolution("single-workspace");
+                            logger?.LogInformation(
+                                "Tool {ToolName} called without workspaceId; resolved to the single " +
+                                "loaded workspace {WorkspaceId}.", toolName, resolvedWorkspaceId);
+                            break;
+
+                        case WorkspaceIdAutoResolution.FastFail:
+                            RecordAutoResolution("fast-fail");
+                            stopwatch.Stop();
+                            RecordElapsed(stopwatch.ElapsedMilliseconds);
+                            logger?.LogWarning(
+                                "Tool {ToolName} called without workspaceId while {Count} workspaces " +
+                                "are loaded; returning a structured fast-fail.",
+                                toolName, loadedWorkspaces.Length);
+                            return BuildErrorResult(
+                                toolName,
+                                new ArgumentException(fastFailMessage, WorkspaceIdParameterName));
+
+                        case WorkspaceIdAutoResolution.NotApplicable:
+                            // workspaceId omitted with zero workspaces loaded — leave for
+                            // on-demand discovery / the binder. Do not patch.
+                            break;
+                    }
+                }
+
                 var result = await next(context, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
                 RecordElapsed(stopwatch.ElapsedMilliseconds);
@@ -376,6 +432,130 @@ internal static class StructuredCallToolFilter
 
         return schema is { Type: "string", Required: true }
                && tool is { ReadOnly: true, Destructive: false };
+    }
+
+    /// <summary>
+    /// workspace-id-omitted-single-resolve: returns <see langword="true"/> when
+    /// <paramref name="toolName"/> is a read-only, non-destructive tool that declares a string
+    /// <c>workspaceId</c> parameter, making it eligible for pre-dispatch auto-resolution.
+    /// Distinct from <see cref="IsWorkspaceIdRecoveryAllowedFor"/>: that predicate gates the
+    /// exception-path elicitation recovery and requires <c>Required:true</c> (it only fires when
+    /// the binder threw on a missing required arg); this one is <b>independent of the Required
+    /// flag</b> so auto-resolution keeps working after a read-only tool flips <c>workspaceId</c>
+    /// to optional. Public so tests can pin the policy.
+    /// </summary>
+    public static bool IsWorkspaceIdAutoResolveAllowedFor(string? toolName)
+    {
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return false;
+        }
+
+        var schema = ToolParameterIndex.GetParameter(toolName, WorkspaceIdParameterName);
+        if (schema is not { Type: "string" })
+        {
+            return false;
+        }
+
+        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
+            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
+        return tool is { ReadOnly: true, Destructive: false };
+    }
+
+    /// <summary>
+    /// The outcome of pre-dispatch <c>workspaceId</c> resolution for an auto-resolve-eligible
+    /// read-only tool. Mirrors the <c>_meta.autoResolution</c> values minus the implicit
+    /// "no resolution path" case (<see cref="NotApplicable"/>).
+    /// </summary>
+    internal enum WorkspaceIdAutoResolution
+    {
+        /// <summary>workspaceId omitted and zero workspaces loaded — leave for discovery/binder.</summary>
+        NotApplicable,
+        /// <summary>Caller supplied a non-empty workspaceId — left untouched.</summary>
+        Explicit,
+        /// <summary>workspaceId omitted and exactly one workspace loaded — patch it in.</summary>
+        SingleWorkspace,
+        /// <summary>workspaceId omitted and ≥2 workspaces loaded — structured fast-fail.</summary>
+        FastFail,
+    }
+
+    /// <summary>
+    /// workspace-id-omitted-single-resolve: classifies how an auto-resolve-eligible tool's
+    /// <c>workspaceId</c> should be handled given the supplied <paramref name="arguments"/> and
+    /// the currently <paramref name="loadedWorkspaces"/>. Reuses
+    /// <see cref="WorkspaceTools.ResolveOptionalWorkspaceId"/> for the single-workspace decision
+    /// so the chokepoint applies the exact same semantics the workspace tools do. Public so the
+    /// pre-dispatch branch can be unit-tested without standing up a live MCP transport.
+    /// </summary>
+    /// <param name="resolvedWorkspaceId">
+    /// Set to the resolved id when the result is <see cref="WorkspaceIdAutoResolution.SingleWorkspace"/>;
+    /// otherwise <see langword="null"/>.
+    /// </param>
+    /// <param name="fastFailMessage">
+    /// Set to a candidate-listing message when the result is
+    /// <see cref="WorkspaceIdAutoResolution.FastFail"/>; otherwise <see langword="null"/>.
+    /// </param>
+    public static WorkspaceIdAutoResolution ClassifyWorkspaceIdResolution(
+        IDictionary<string, JsonElement>? arguments,
+        IReadOnlyList<WorkspaceStatusSummaryDto> loadedWorkspaces,
+        out string? resolvedWorkspaceId,
+        out string? fastFailMessage)
+    {
+        resolvedWorkspaceId = null;
+        fastFailMessage = null;
+
+        if (HasNonEmptyWorkspaceId(arguments))
+        {
+            return WorkspaceIdAutoResolution.Explicit;
+        }
+
+        var resolved = WorkspaceTools.ResolveOptionalWorkspaceId(null, loadedWorkspaces);
+        if (resolved is not null)
+        {
+            resolvedWorkspaceId = resolved;
+            return WorkspaceIdAutoResolution.SingleWorkspace;
+        }
+
+        if (loadedWorkspaces.Count >= 2)
+        {
+            var ids = string.Join(", ", loadedWorkspaces.Select(workspace => workspace.WorkspaceId));
+            fastFailMessage =
+                $"workspaceId was omitted but {loadedWorkspaces.Count} workspaces are loaded ({ids}). " +
+                "Pass workspaceId explicitly to choose one.";
+            return WorkspaceIdAutoResolution.FastFail;
+        }
+
+        return WorkspaceIdAutoResolution.NotApplicable;
+    }
+
+    private static bool HasNonEmptyWorkspaceId(IDictionary<string, JsonElement>? arguments)
+    {
+        if (arguments is null || !arguments.TryGetValue(WorkspaceIdParameterName, out var value))
+        {
+            return false;
+        }
+
+        return value.ValueKind == JsonValueKind.String
+               && !string.IsNullOrWhiteSpace(value.GetString());
+    }
+
+    private static IDictionary<string, JsonElement> WithWorkspaceId(
+        IDictionary<string, JsonElement>? existing, string workspaceId)
+    {
+        var newArgs = existing is null
+            ? new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            : new Dictionary<string, JsonElement>(existing, StringComparer.Ordinal);
+        newArgs[WorkspaceIdParameterName] =
+            JsonSerializer.SerializeToElement(workspaceId, JsonDefaults.Indented);
+        return newArgs;
+    }
+
+    private static void RecordAutoResolution(string value)
+    {
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.AutoResolution = value;
+        }
     }
 
     internal static async Task<CallToolResult?> TryRecoverMissingWorkspaceIdAsync(

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -138,46 +138,53 @@ internal static class StructuredCallToolFilter
                 var workspaceManager = context.Services?.GetService<IWorkspaceManager>();
                 if (workspaceManager is not null && IsWorkspaceIdAutoResolveAllowedFor(toolName))
                 {
-                    var loadedWorkspaces = workspaceManager.ListWorkspaces()
-                        .Select(WorkspaceStatusSummaryDto.From)
-                        .ToArray();
-                    var resolution = ClassifyWorkspaceIdResolution(
-                        context.Params?.Arguments,
-                        loadedWorkspaces,
-                        out var resolvedWorkspaceId,
-                        out var fastFailMessage);
-
-                    switch (resolution)
+                    if (HasNonEmptyWorkspaceId(context.Params?.Arguments))
                     {
-                        case WorkspaceIdAutoResolution.Explicit:
-                            RecordAutoResolution("explicit");
-                            break;
+                        // Explicit id supplied — record it and skip the loaded-workspace
+                        // enumeration entirely (the common path; avoids per-call DTO projection).
+                        RecordAutoResolution("explicit");
+                    }
+                    else
+                    {
+                        var loadedWorkspaces = workspaceManager.ListWorkspaces()
+                            .Select(WorkspaceStatusSummaryDto.From)
+                            .ToArray();
+                        var resolution = ClassifyWorkspaceIdResolution(
+                            context.Params?.Arguments,
+                            loadedWorkspaces,
+                            out var resolvedWorkspaceId,
+                            out var fastFailMessage);
 
-                        case WorkspaceIdAutoResolution.SingleWorkspace:
-                            context.Params!.Arguments =
-                                WithWorkspaceId(context.Params.Arguments, resolvedWorkspaceId!);
-                            RecordAutoResolution("single-workspace");
-                            logger?.LogInformation(
-                                "Tool {ToolName} called without workspaceId; resolved to the single " +
-                                "loaded workspace {WorkspaceId}.", toolName, resolvedWorkspaceId);
-                            break;
+                        switch (resolution)
+                        {
+                            case WorkspaceIdAutoResolution.SingleWorkspace:
+                                context.Params!.Arguments =
+                                    WithWorkspaceId(context.Params.Arguments, resolvedWorkspaceId!);
+                                RecordAutoResolution("single-workspace");
+                                logger?.LogInformation(
+                                    "Tool {ToolName} called without workspaceId; resolved to the single " +
+                                    "loaded workspace {WorkspaceId}.", toolName, resolvedWorkspaceId);
+                                break;
 
-                        case WorkspaceIdAutoResolution.FastFail:
-                            RecordAutoResolution("fast-fail");
-                            stopwatch.Stop();
-                            RecordElapsed(stopwatch.ElapsedMilliseconds);
-                            logger?.LogWarning(
-                                "Tool {ToolName} called without workspaceId while {Count} workspaces " +
-                                "are loaded; returning a structured fast-fail.",
-                                toolName, loadedWorkspaces.Length);
-                            return BuildErrorResult(
-                                toolName,
-                                new ArgumentException(fastFailMessage, WorkspaceIdParameterName));
+                            case WorkspaceIdAutoResolution.FastFail:
+                                RecordAutoResolution("fast-fail");
+                                stopwatch.Stop();
+                                RecordElapsed(stopwatch.ElapsedMilliseconds);
+                                logger?.LogWarning(
+                                    "Tool {ToolName} called without workspaceId while {Count} workspaces " +
+                                    "are loaded; returning a structured fast-fail.",
+                                    toolName, loadedWorkspaces.Length);
+                                return BuildErrorResult(
+                                    toolName,
+                                    new ArgumentException(fastFailMessage, WorkspaceIdParameterName));
 
-                        case WorkspaceIdAutoResolution.NotApplicable:
-                            // workspaceId omitted with zero workspaces loaded — leave for
-                            // on-demand discovery / the binder. Do not patch.
-                            break;
+                            case WorkspaceIdAutoResolution.Explicit:
+                            case WorkspaceIdAutoResolution.NotApplicable:
+                                // Explicit cannot occur here (id already confirmed absent above);
+                                // zero workspaces loaded is left for on-demand discovery / the
+                                // binder. Either way, do not patch.
+                                break;
+                        }
                     }
                 }
 
@@ -545,8 +552,7 @@ internal static class StructuredCallToolFilter
         var newArgs = existing is null
             ? new Dictionary<string, JsonElement>(StringComparer.Ordinal)
             : new Dictionary<string, JsonElement>(existing, StringComparer.Ordinal);
-        newArgs[WorkspaceIdParameterName] =
-            JsonSerializer.SerializeToElement(workspaceId, JsonDefaults.Indented);
+        newArgs[WorkspaceIdParameterName] = JsonSerializer.SerializeToElement(workspaceId);
         return newArgs;
     }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -557,7 +557,15 @@ public static class WorkspaceTools
     private static bool ShouldPrewarmAfterLoad(bool? prewarm, WorkspaceStatusDto status) =>
         prewarm ?? status.ProjectCount > AutoPrewarmProjectThreshold;
 
-    private static string? ResolveOptionalWorkspaceId(
+    /// <summary>
+    /// workspace-id-omitted-single-resolve: canonical single-workspace resolution shared by the
+    /// workspace tools and the read-path middleware (<c>StructuredCallToolFilter</c>). Returns
+    /// the requested id when supplied; otherwise the sole loaded workspace's id when exactly one
+    /// is loaded; otherwise <see langword="null"/> (zero or ≥2 loaded — the caller decides
+    /// between on-demand discovery and a structured fast-fail). <c>internal</c> so the middleware
+    /// applies the same logic at the chokepoint rather than re-deriving it.
+    /// </summary>
+    internal static string? ResolveOptionalWorkspaceId(
         string? requestedWorkspaceId,
         IReadOnlyList<WorkspaceStatusSummaryDto> loadedWorkspaces)
     {

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the <c>workspace-id-omitted-single-resolve</c> initiative: the
+/// <see cref="StructuredCallToolFilter"/> pre-dispatch path that resolves an omitted/empty
+/// <c>workspaceId</c> on read-only, non-destructive tools before the SDK binder runs. Pins:
+/// <list type="bullet">
+///   <item><b>eligibility</b> — <see cref="StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor"/>
+///         fires for read-only workspace-scoped tools <i>regardless of the schema Required flag</i>,
+///         which is the property that keeps the feature alive after a tool flips
+///         <c>workspaceId</c> to optional (the surface-flip initiative). Contrast with
+///         <see cref="StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor"/>, which is
+///         Required-gated because it only covers the binder-threw exception path.</item>
+///   <item><b>classification</b> — omit + 1 loaded resolves to that workspace; omit + ≥2 loaded
+///         fast-fails listing the candidates; omit + 0 loaded is left for on-demand discovery;
+///         an explicit id passes through untouched.</item>
+///   <item><b>observability</b> — the <c>_meta.autoResolution</c> field round-trips through the
+///         metrics snapshot and onto the error envelope.</item>
+/// </list>
+/// The full <see cref="StructuredCallToolFilter.Create"/> delegate needs a live MCP transport to
+/// drive end-to-end, so (as with the elicitation tests) the contract asserted here is the gate
+/// logic + classification that the pre-dispatch branch is a thin wrapper over.
+/// </summary>
+[TestClass]
+public sealed class StructuredCallToolFilterResolutionTests
+{
+    // ── eligibility (Required-independent) ──────────────────────────────────
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_RequiredReadOnlyTool_ReturnsTrue()
+    {
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("symbol_search"));
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("find_references"));
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("compile_check"));
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_OptionalReadOnlyTool_ReturnsTrue()
+    {
+        // workspace_readiness_report declares `string? workspaceId = null` (Required:false) at HEAD.
+        // Auto-resolution MUST still apply — this is the exact post-surface-flip shape, and the
+        // whole point of decoupling auto-resolution from the Required flag.
+        Assert.IsTrue(
+            StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("workspace_readiness_report"),
+            "Auto-resolution must fire for read-only tools whose workspaceId is optional; " +
+            "otherwise the feature dies the moment a tool flips workspaceId to a default.");
+
+        // Distinction witness: the Required-gated recovery predicate does NOT fire for the same
+        // optional tool — proving the two predicates are intentionally different.
+        Assert.IsFalse(
+            StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("workspace_readiness_report", "workspaceId"),
+            "The exception-path recovery predicate is Required-gated and must stay false for an " +
+            "optional-workspaceId tool — only the auto-resolve predicate covers that case.");
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_WriteOrDestructiveTool_ReturnsFalse()
+    {
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("apply_text_edit"),
+            "Mutating tools must never have workspaceId auto-resolved at the chokepoint.");
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("revert_last_apply"),
+            "Destructive tools must never have workspaceId auto-resolved.");
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("workspace_close"),
+            "Destructive workspace-lifecycle tools must never auto-resolve workspaceId.");
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_UnknownOrEmpty_ReturnsFalse()
+    {
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor("not_a_real_tool"));
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor(""));
+        Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor(null));
+    }
+
+    // ── classification ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ClassifyWorkspaceIdResolution_ExplicitId_ReturnsExplicit()
+    {
+        var args = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["workspaceId"] = JsonSerializer.SerializeToElement("ws-1"),
+        };
+
+        var result = StructuredCallToolFilter.ClassifyWorkspaceIdResolution(
+            args, new[] { Summary("ws-1"), Summary("ws-2") }, out var resolvedId, out var failMessage);
+
+        Assert.AreEqual(StructuredCallToolFilter.WorkspaceIdAutoResolution.Explicit, result);
+        Assert.IsNull(resolvedId);
+        Assert.IsNull(failMessage);
+    }
+
+    [TestMethod]
+    public void ClassifyWorkspaceIdResolution_OmittedWithOneLoaded_ResolvesToSingle()
+    {
+        var result = StructuredCallToolFilter.ClassifyWorkspaceIdResolution(
+            arguments: null, new[] { Summary("ws-only") }, out var resolvedId, out var failMessage);
+
+        Assert.AreEqual(StructuredCallToolFilter.WorkspaceIdAutoResolution.SingleWorkspace, result);
+        Assert.AreEqual("ws-only", resolvedId);
+        Assert.IsNull(failMessage);
+    }
+
+    [TestMethod]
+    public void ClassifyWorkspaceIdResolution_BlankIdWithOneLoaded_ResolvesToSingle()
+    {
+        // A whitespace-only id counts as omitted — same as the workspace tools' own resolver.
+        var args = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["workspaceId"] = JsonSerializer.SerializeToElement("   "),
+        };
+
+        var result = StructuredCallToolFilter.ClassifyWorkspaceIdResolution(
+            args, new[] { Summary("ws-only") }, out var resolvedId, out _);
+
+        Assert.AreEqual(StructuredCallToolFilter.WorkspaceIdAutoResolution.SingleWorkspace, result);
+        Assert.AreEqual("ws-only", resolvedId);
+    }
+
+    [TestMethod]
+    public void ClassifyWorkspaceIdResolution_OmittedWithTwoLoaded_FastFailsNamingBoth()
+    {
+        var result = StructuredCallToolFilter.ClassifyWorkspaceIdResolution(
+            arguments: null,
+            new[] { Summary("ws-alpha"), Summary("ws-beta") },
+            out var resolvedId,
+            out var failMessage);
+
+        Assert.AreEqual(StructuredCallToolFilter.WorkspaceIdAutoResolution.FastFail, result);
+        Assert.IsNull(resolvedId);
+        Assert.IsNotNull(failMessage);
+        StringAssert.Contains(failMessage, "ws-alpha");
+        StringAssert.Contains(failMessage, "ws-beta");
+    }
+
+    [TestMethod]
+    public void ClassifyWorkspaceIdResolution_OmittedWithZeroLoaded_NotApplicable()
+    {
+        var result = StructuredCallToolFilter.ClassifyWorkspaceIdResolution(
+            arguments: null, Array.Empty<WorkspaceStatusSummaryDto>(), out var resolvedId, out var failMessage);
+
+        Assert.AreEqual(StructuredCallToolFilter.WorkspaceIdAutoResolution.NotApplicable, result);
+        Assert.IsNull(resolvedId);
+        Assert.IsNull(failMessage);
+    }
+
+    // ── observability (_meta.autoResolution) ────────────────────────────────
+
+    [TestMethod]
+    public void GateMetricsDto_RoundTripsAutoResolution()
+    {
+        var builder = new GateMetricsBuilder { AutoResolution = "single-workspace" };
+        Assert.AreEqual("single-workspace", builder.ToDto().AutoResolution);
+    }
+
+    [TestMethod]
+    public void BuildErrorResult_WhenFastFailRecorded_EnvelopeMetaCarriesAutoResolution()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        AmbientGateMetrics.Current!.AutoResolution = "fast-fail";
+
+        var result = StructuredCallToolFilter.BuildErrorResult(
+            "symbol_search",
+            new ArgumentException("workspaceId was omitted but 2 workspaces are loaded.", "workspaceId"));
+
+        Assert.IsTrue(result.IsError);
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var payload = JsonDocument.Parse(text).RootElement;
+        Assert.AreEqual("InvalidArgument", payload.GetProperty("category").GetString());
+        Assert.IsTrue(payload.TryGetProperty("_meta", out var meta), $"Expected _meta. Actual: {payload}");
+        Assert.AreEqual("fast-fail", meta.GetProperty("autoResolution").GetString(),
+            "The fast-fail envelope must surface autoResolution so callers can distinguish a " +
+            "structured 'pick a workspace' error from an ordinary InvalidArgument.");
+    }
+
+    private static WorkspaceStatusSummaryDto Summary(string workspaceId) => new(
+        WorkspaceId: workspaceId,
+        LoadedPath: null,
+        WorkspaceVersion: 0,
+        SnapshotToken: string.Empty,
+        LoadedAtUtc: default,
+        ProjectCount: 0,
+        DocumentCount: 0,
+        IsLoaded: true,
+        IsStale: false,
+        WorkspaceDiagnosticCount: 0,
+        WorkspaceErrorCount: 0,
+        WorkspaceWarningCount: 0,
+        IsReady: true,
+        AnalyzersReady: true,
+        RestoreRequired: false,
+        RestoreHint: null,
+        SolutionFileName: null);
+}


### PR DESCRIPTION
Step 1 of 3 of the workspace-auto-load sweep (`ai_docs/items/workspace-auto-load-on-demand-design.md`). Plan: `ai_docs/plans/20260609T134405Z_backlog-sweep/`.

## What
Adds **pre-dispatch `workspaceId` auto-resolution** at the read-path chokepoint (`StructuredCallToolFilter`). For a read-only, non-destructive tool dispatched with `workspaceId` omitted/empty:
- exactly **one** workspace loaded → patch it in and proceed (`_meta.autoResolution=single-workspace`);
- **≥2** loaded → structured fast-fail listing the loaded ids (`_meta.autoResolution=fast-fail`), reusing the existing `ToolErrorHandler.ClassifyAndFormat` `InvalidArgument` envelope;
- explicit id → passthrough (`_meta.autoResolution=explicit`), short-circuited before any workspace enumeration;
- **zero** loaded → left for on-demand discovery (order 2) / the binder.

New `_meta.autoResolution` field on `GateMetricsDto` so adoption is measurable. `WorkspaceTools.ResolveOptionalWorkspaceId` promoted `private`→`internal` and reused at the chokepoint (no duplicate logic). No per-tool schema change; explicit-id callers unaffected.

## Plan deviation (deliberate, in-scope)
Gated on a **new** predicate `IsWorkspaceIdAutoResolveAllowedFor` (ReadOnly && !Destructive + has a string `workspaceId` param), **independent of the schema `Required` flag** — NOT the plan's literal `IsWorkspaceIdRecoveryAllowedFor` (which requires `Required:true`). Order 3 flips the pilot tools to `Required:false`; gating on `Required:true` would silently disable auto-resolution after order 3 ships, contradicting order 3's own handoff note ("order-1's resolution is the ONLY thing handling a null id" post-flip). Adds no files; recovery/elicitation path untouched.

## Closes
- `workspace-id-omitted-single-resolve` (backlog row removed in the sweep's reconcile PR)

## Validation
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → clean (0 warnings).
- New `StructuredCallToolFilterResolutionTests` (12 tests) + existing filter suites green (36 filter tests). Covers: explicit/single/fast-fail(names both ids)/zero/blank-id; write+destructive exclusion; Required-independence witness (`workspace_readiness_report`); `_meta.autoResolution` round-trip onto the error envelope.
- Full `verify-release.ps1` runs in CI.

## Review
- Cold spec-compliance review: pass (4 prod + 1 test file; Rule 3 holds; deviation judged in-scope).
- Cold code-quality review: pass; 2 advisory findings (hot-path enumeration short-circuit, scalar serialization) fixed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)