### PR TITLE
feat(middleware): on-demand workspace discovery + auto-load (workspace-auto-load-on-demand)

### DIFF
--- a/changelog.d/workspace-auto-load-on-demand.md
+++ b/changelog.d/workspace-auto-load-on-demand.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** automatic workspace discovery + on-demand load for read-only tools. When a read-only, non-destructive tool is called with `workspaceId` omitted and no workspace is loaded, the server discovers the implied solution — file-anchored (walk up from a `filePath` argument to the nearest `.slnx`/`.sln`/`.csproj`) or query-anchored (a bounded scan of the client's declared roots) — and auto-loads it via `workspace_load` before retrying. A unique match loads and proceeds (`_meta.autoResolution=auto-loaded`, `_meta.autoLoadElapsedMs`); two or more candidates return a structured fast-fail listing them with a ready-to-run `workspace_load(path=…)` hint; none falls back to the existing guidance/elicitation path. Mutating, preview, and apply tools never auto-load. Closes `workspace-auto-load-on-demand`.

--- a/src/RoslynMcp.Core/Models/GateMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/GateMetricsDto.cs
@@ -59,11 +59,18 @@ namespace RoslynMcp.Core.Models;
 /// omitted/empty <c>workspaceId</c> on a read-only, non-destructive tool before dispatch:
 /// <c>explicit</c> (the caller supplied an id; left untouched), <c>single-workspace</c> (id
 /// omitted and exactly one workspace was loaded, so the middleware patched it in), or
-/// <c>fast-fail</c> (id omitted and two or more workspaces were loaded, so the middleware
-/// returned a structured error listing the candidates instead of guessing).
+/// <c>fast-fail</c> (id omitted and two-or-more workspaces — or two-or-more discoverable
+/// candidate solutions — so the middleware returned a structured error listing them instead
+/// of guessing), or <c>auto-loaded</c> (id omitted, zero workspaces loaded, and a single
+/// solution was discovered from the call context and loaded on demand before dispatch).
 /// <see langword="null"/> when the call did not go through the auto-resolution path (a
 /// write/destructive tool, a tool with no <c>workspaceId</c> parameter, or zero workspaces
-/// loaded — the last case is left for on-demand discovery / the binder).
+/// loaded with no discoverable solution — that last case is left for the binder/elicitation).
+/// </param>
+/// <param name="AutoLoadElapsedMs">
+/// workspace-auto-load-on-demand: milliseconds spent discovering and loading a workspace on
+/// demand when <paramref name="AutoResolution"/> is <c>auto-loaded</c>. <see langword="null"/>
+/// otherwise. Lets profiling isolate the cold on-demand-load cost from ordinary request timing.
 /// </param>
 public sealed record GateMetricsDto(
     string? GateMode,
@@ -76,4 +83,5 @@ public sealed record GateMetricsDto(
     bool? RetriedAfterReload = null,
     bool? CacheHit = null,
     bool? ReloadConfirmedNotFound = null,
-    string? AutoResolution = null);
+    string? AutoResolution = null,
+    long? AutoLoadElapsedMs = null);

--- a/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
+++ b/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
@@ -116,5 +116,12 @@ public sealed class GateMetricsBuilder
     /// </summary>
     public string? AutoResolution { get; set; }
 
-    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload, CacheHit, ReloadConfirmedNotFound, AutoResolution);
+    /// <summary>
+    /// workspace-auto-load-on-demand: milliseconds spent discovering + loading a workspace on
+    /// demand, set by <c>StructuredCallToolFilter</c> when <see cref="AutoResolution"/> is
+    /// <c>auto-loaded</c>. <see langword="null"/> otherwise.
+    /// </summary>
+    public long? AutoLoadElapsedMs { get; set; }
+
+    public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload, CacheHit, ReloadConfirmedNotFound, AutoResolution, AutoLoadElapsedMs);
 }

--- a/src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs
@@ -1,0 +1,255 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// workspace-auto-load-on-demand: discovers the single solution/project a read-only tool call
+/// implies, so <see cref="StructuredCallToolFilter"/> can auto-load it when <c>workspaceId</c>
+/// is omitted and no workspace is loaded. Two strategies, file-anchored first:
+/// <list type="number">
+///   <item><b>File-anchored</b> — if the call carries a <c>filePath</c>-like argument, walk up
+///   from that file's directory to the nearest <c>.slnx</c>/<c>.sln</c> (preferred) or
+///   <c>.csproj</c>.</item>
+///   <item><b>Query-anchored</b> — otherwise, ask the client for its declared roots
+///   (<c>roots/list</c>, mirroring <see cref="ClientRootPathValidator"/>) and scan each root's
+///   top level plus one level down for solution files.</item>
+/// </list>
+/// Discovery is deliberately conservative: it reports <see cref="DiscoveryStatus.Unique"/> only
+/// when exactly one candidate is found, <see cref="DiscoveryStatus.Ambiguous"/> when two or more
+/// are found (the caller fast-fails listing them rather than guessing), and
+/// <see cref="DiscoveryStatus.None"/> when nothing is found or no roots are declared (the caller
+/// falls back to the binder/elicitation path). It never assumes the process CWD.
+/// </summary>
+internal static class SolutionDiscoveryHelper
+{
+    // Argument keys that carry a source-file path, in preference order. `filePath` is the
+    // dominant convention across the read-only tool surface; `path`/`file` are rarer variants.
+    private static readonly string[] FilePathArgumentKeys = ["filePath", "path", "file"];
+
+    // Solution files preferred over projects; .slnx before .sln when both somehow coexist.
+    private static readonly string[] SolutionExtensions = [".slnx", ".sln"];
+    private static readonly string[] ProjectExtensions = [".csproj"];
+
+    internal enum DiscoveryStatus
+    {
+        /// <summary>No candidate found (or no roots declared) — fall back to binder/elicitation.</summary>
+        None,
+        /// <summary>Exactly one candidate — safe to auto-load.</summary>
+        Unique,
+        /// <summary>Two or more candidates — fast-fail listing them rather than guessing.</summary>
+        Ambiguous,
+    }
+
+    internal readonly record struct DiscoveryResult(
+        DiscoveryStatus Status,
+        string? UniquePath,
+        IReadOnlyList<string> Candidates)
+    {
+        internal static DiscoveryResult None { get; } =
+            new(DiscoveryStatus.None, null, []);
+
+        internal static DiscoveryResult Unique(string path) =>
+            new(DiscoveryStatus.Unique, path, [path]);
+
+        internal static DiscoveryResult FromCandidates(IReadOnlyList<string> candidates) => candidates.Count switch
+        {
+            0 => None,
+            1 => Unique(candidates[0]),
+            _ => new DiscoveryResult(DiscoveryStatus.Ambiguous, null, candidates),
+        };
+    }
+
+    /// <summary>
+    /// Runs file-anchored discovery first, then query-anchored discovery if the former finds
+    /// nothing. Returns the first non-<see cref="DiscoveryStatus.None"/> result.
+    /// </summary>
+    internal static async Task<DiscoveryResult> TryDiscoverAsync(
+        IDictionary<string, JsonElement>? arguments,
+        McpServer? server,
+        CancellationToken cancellationToken)
+    {
+        var fileAnchored = TryDiscoverFromFilePath(arguments);
+        if (fileAnchored.Status != DiscoveryStatus.None)
+        {
+            return fileAnchored;
+        }
+
+        return await TryDiscoverFromRootsAsync(server, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// File-anchored discovery: walk up from the directory of the call's <c>filePath</c>-like
+    /// argument, preferring a solution file at each level, falling back to a project file.
+    /// </summary>
+    internal static DiscoveryResult TryDiscoverFromFilePath(IDictionary<string, JsonElement>? arguments)
+    {
+        var filePath = ExtractFilePath(arguments);
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return DiscoveryResult.None;
+        }
+
+        string? directory;
+        try
+        {
+            directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return DiscoveryResult.None;
+        }
+
+        while (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        {
+            var solutions = EnumerateByExtensions(directory, SolutionExtensions);
+            if (solutions.Count > 0)
+            {
+                return DiscoveryResult.FromCandidates(solutions);
+            }
+
+            var projects = EnumerateByExtensions(directory, ProjectExtensions);
+            if (projects.Count > 0)
+            {
+                return DiscoveryResult.FromCandidates(projects);
+            }
+
+            var parent = Path.GetDirectoryName(directory);
+            if (string.IsNullOrEmpty(parent) || string.Equals(parent, directory, StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            directory = parent;
+        }
+
+        return DiscoveryResult.None;
+    }
+
+    /// <summary>
+    /// Query-anchored discovery: fetch the client's declared roots and scan them. Returns
+    /// <see cref="DiscoveryStatus.None"/> when the client declares no roots capability, returns
+    /// no roots, or the roots request fails (advertised-but-unsupported clients).
+    /// </summary>
+    private static async Task<DiscoveryResult> TryDiscoverFromRootsAsync(
+        McpServer? server, CancellationToken cancellationToken)
+    {
+        if (server is null || server.ClientCapabilities?.Roots is null)
+        {
+            return DiscoveryResult.None;
+        }
+
+        IReadOnlyList<string> rootDirectories;
+        try
+        {
+            var rootsResult = await server.RequestRootsAsync(new ListRootsRequestParams(), cancellationToken)
+                .ConfigureAwait(false);
+            rootDirectories = rootsResult.Roots
+                .Where(root => root.Uri.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+                .Select(TryDecodeLocalPath)
+                .Where(path => path is not null)
+                .Select(path => path!)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Advertised-but-unsupported roots, transport hiccup, etc. — treat as zero candidates.
+            return DiscoveryResult.None;
+        }
+
+        return ScanDirectoriesForSolutions(rootDirectories, cancellationToken);
+    }
+
+    /// <summary>
+    /// Pure, testable scan: for each root directory, collect solution files at the top level and
+    /// one level down. Distinct, case-insensitive. Bounded (one level of recursion only) so the
+    /// cold-path scan cannot walk an arbitrarily deep tree.
+    /// </summary>
+    internal static DiscoveryResult ScanDirectoriesForSolutions(
+        IReadOnlyList<string> rootDirectories, CancellationToken cancellationToken)
+    {
+        var found = new List<string>();
+        foreach (var rootDirectory in rootDirectories)
+        {
+            if (string.IsNullOrEmpty(rootDirectory) || !Directory.Exists(rootDirectory))
+            {
+                continue;
+            }
+
+            found.AddRange(EnumerateByExtensions(rootDirectory, SolutionExtensions));
+
+            IEnumerable<string> subdirectories;
+            try
+            {
+                subdirectories = Directory.EnumerateDirectories(rootDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            foreach (var subdirectory in subdirectories)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                found.AddRange(EnumerateByExtensions(subdirectory, SolutionExtensions));
+            }
+        }
+
+        var distinct = found.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        return DiscoveryResult.FromCandidates(distinct);
+    }
+
+    private static IReadOnlyList<string> EnumerateByExtensions(string directory, string[] extensions)
+    {
+        var matches = new List<string>();
+        foreach (var extension in extensions)
+        {
+            try
+            {
+                matches.AddRange(Directory.EnumerateFiles(directory, "*" + extension));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Unreadable directory — skip it; discovery is best-effort.
+            }
+        }
+
+        return matches;
+    }
+
+    private static string? ExtractFilePath(IDictionary<string, JsonElement>? arguments)
+    {
+        if (arguments is null)
+        {
+            return null;
+        }
+
+        foreach (var key in FilePathArgumentKeys)
+        {
+            if (arguments.TryGetValue(key, out var value)
+                && value.ValueKind == JsonValueKind.String)
+            {
+                var candidate = value.GetString();
+                if (!string.IsNullOrWhiteSpace(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryDecodeLocalPath(Root root)
+    {
+        try
+        {
+            return new Uri(root.Uri).LocalPath;
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -178,11 +178,28 @@ internal static class StructuredCallToolFilter
                                     toolName,
                                     new ArgumentException(fastFailMessage, WorkspaceIdParameterName));
 
-                            case WorkspaceIdAutoResolution.Explicit:
                             case WorkspaceIdAutoResolution.NotApplicable:
-                                // Explicit cannot occur here (id already confirmed absent above);
-                                // zero workspaces loaded is left for on-demand discovery / the
-                                // binder. Either way, do not patch.
+                            {
+                                // workspace-auto-load-on-demand: zero workspaces loaded — try to
+                                // discover the implied solution and load it on demand before
+                                // dispatch. A unique discovery patches the id and falls through to
+                                // next(); an ambiguous one returns a structured fast-fail; nothing
+                                // discovered falls through to the binder/elicitation path.
+                                var autoLoadFastFail = await TryAutoLoadWorkspaceAsync(
+                                    context, next, toolName, logger, cancellationToken).ConfigureAwait(false);
+                                if (autoLoadFastFail is not null)
+                                {
+                                    stopwatch.Stop();
+                                    RecordElapsed(stopwatch.ElapsedMilliseconds);
+                                    return autoLoadFastFail;
+                                }
+
+                                break;
+                            }
+
+                            case WorkspaceIdAutoResolution.Explicit:
+                                // Cannot occur here (explicit id is short-circuited before
+                                // enumeration above). Defensive no-op.
                                 break;
                         }
                     }
@@ -561,6 +578,94 @@ internal static class StructuredCallToolFilter
         if (AmbientGateMetrics.Current is { } metrics)
         {
             metrics.AutoResolution = value;
+        }
+    }
+
+    private static void RecordAutoLoadElapsed(long elapsedMs)
+    {
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.AutoLoadElapsedMs = elapsedMs;
+        }
+    }
+
+    /// <summary>
+    /// workspace-auto-load-on-demand: invoked from the pre-dispatch path when an auto-resolve
+    /// eligible tool is called with <c>workspaceId</c> omitted and ZERO workspaces loaded.
+    /// Discovers the implied solution (<see cref="SolutionDiscoveryHelper"/>):
+    /// <list type="bullet">
+    ///   <item><b>Unique</b> → load it via the <c>workspace_load</c> tool (reusing its dedup /
+    ///   cap / eviction / progress), patch the returned id into the call, record
+    ///   <c>auto-loaded</c> + <c>autoLoadElapsedMs</c>, and return <see langword="null"/> so the
+    ///   caller falls through to dispatch the original tool. If the load yields no id, returns
+    ///   <see langword="null"/> to fall back to the existing recovery path.</item>
+    ///   <item><b>Ambiguous</b> → return a structured fast-fail listing the candidate solutions
+    ///   with a ready-to-run <c>workspace_load(path=…)</c> hint (records <c>fast-fail</c>).</item>
+    ///   <item><b>None</b> → return <see langword="null"/>; the binder/elicitation path handles it
+    ///   (the elicitation fallback when the client supports it).</item>
+    /// </list>
+    /// A non-null return is a terminal fast-fail; <see langword="null"/> means "fall through to
+    /// <c>next()</c>" (whether or not the arguments were patched).
+    /// </summary>
+    private static async Task<CallToolResult?> TryAutoLoadWorkspaceAsync(
+        RequestContext<CallToolRequestParams> context,
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next,
+        string toolName,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        var discovery = await SolutionDiscoveryHelper.TryDiscoverAsync(
+            context.Params?.Arguments, context.Server, cancellationToken).ConfigureAwait(false);
+
+        switch (discovery.Status)
+        {
+            case SolutionDiscoveryHelper.DiscoveryStatus.Unique:
+            {
+                var stopwatch = Stopwatch.StartNew();
+                var loadArguments = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+                {
+                    [PathParameterName] = JsonSerializer.SerializeToElement(discovery.UniquePath!),
+                };
+                var loadResult = await DispatchWithTemporaryArgumentsAsync(
+                    context, next, WorkspaceLoadToolName, loadArguments, cancellationToken).ConfigureAwait(false);
+                var workspaceId = TryExtractWorkspaceId(loadResult);
+                stopwatch.Stop();
+
+                if (string.IsNullOrWhiteSpace(workspaceId))
+                {
+                    logger?.LogWarning(
+                        "Auto-load discovered {Path} for {Tool} but workspace_load returned no id; " +
+                        "falling back to the recovery path.", discovery.UniquePath, toolName);
+                    return null;
+                }
+
+                context.Params!.Arguments = WithWorkspaceId(context.Params.Arguments, workspaceId);
+                RecordAutoResolution("auto-loaded");
+                RecordAutoLoadElapsed(stopwatch.ElapsedMilliseconds);
+                logger?.LogInformation(
+                    "Tool {ToolName} called without workspaceId and none loaded; auto-loaded {Path} " +
+                    "as {WorkspaceId} in {ElapsedMs}ms.",
+                    toolName, discovery.UniquePath, workspaceId, stopwatch.ElapsedMilliseconds);
+                return null;
+            }
+
+            case SolutionDiscoveryHelper.DiscoveryStatus.Ambiguous:
+            {
+                RecordAutoResolution("fast-fail");
+                var candidates = string.Join(", ", discovery.Candidates);
+                logger?.LogWarning(
+                    "Tool {ToolName} called without workspaceId and none loaded; {Count} candidate " +
+                    "solutions discovered ({Candidates}).", toolName, discovery.Candidates.Count, candidates);
+                return BuildErrorResult(toolName, new ArgumentException(
+                    $"workspaceId was omitted and no workspace is loaded. {discovery.Candidates.Count} " +
+                    $"candidate solutions were discovered ({candidates}). Call workspace_load(path=…) with " +
+                    "one of them, then retry — or pass workspaceId explicitly.",
+                    WorkspaceIdParameterName));
+            }
+
+            case SolutionDiscoveryHelper.DiscoveryStatus.None:
+            default:
+                return null;
         }
     }
 

--- a/tests/RoslynMcp.Tests/SolutionDiscoveryHelperTests.cs
+++ b/tests/RoslynMcp.Tests/SolutionDiscoveryHelperTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the <c>workspace-auto-load-on-demand</c> initiative's discovery layer
+/// (<see cref="SolutionDiscoveryHelper"/>). Pins the deterministic, filesystem-driven strategies:
+/// file-anchored walk-up (solution preferred over project), the conservative unique/ambiguous/none
+/// classification, the bounded top-level + one-level scan used by query-anchored discovery, and the
+/// <c>filePath</c>-like argument extraction. The query-anchored RPC wrapper itself
+/// (<c>roots/list</c>) needs a live transport and is covered at the scan seam
+/// (<see cref="SolutionDiscoveryHelper.ScanDirectoriesForSolutions"/>) plus the server-null guard.
+/// </summary>
+[TestClass]
+public sealed class SolutionDiscoveryHelperTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rmcp-disc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* best-effort temp cleanup */ }
+    }
+
+    // ── file-anchored walk-up ───────────────────────────────────────────────
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_WalksUpToNearestSolution()
+    {
+        var nested = Path.Combine(_root, "src", "Project");
+        Directory.CreateDirectory(nested);
+        var sln = Path.Combine(_root, "Sample.slnx");
+        File.WriteAllText(sln, "<Solution />");
+        var source = Path.Combine(nested, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, result.Status);
+        Assert.AreEqual(sln, result.UniquePath);
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_PrefersSolutionOverProjectAtSameLevel()
+    {
+        var sln = Path.Combine(_root, "Sample.slnx");
+        var csproj = Path.Combine(_root, "Sample.csproj");
+        File.WriteAllText(sln, "<Solution />");
+        File.WriteAllText(csproj, "<Project />");
+        var source = Path.Combine(_root, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, result.Status);
+        Assert.AreEqual(sln, result.UniquePath, "Solution files must win over project files at the same level.");
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_FallsBackToProjectWhenNoSolution()
+    {
+        var csproj = Path.Combine(_root, "Only.csproj");
+        File.WriteAllText(csproj, "<Project />");
+        var source = Path.Combine(_root, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, result.Status);
+        Assert.AreEqual(csproj, result.UniquePath);
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_TwoSolutions_IsAmbiguous()
+    {
+        File.WriteAllText(Path.Combine(_root, "A.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(_root, "B.slnx"), "<Solution />");
+        var source = Path.Combine(_root, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Ambiguous, result.Status);
+        Assert.AreEqual(2, result.Candidates.Count);
+        Assert.IsNull(result.UniquePath);
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_NoSolutionAnywhere_IsNone()
+    {
+        var nested = Path.Combine(_root, "src");
+        Directory.CreateDirectory(nested);
+        var source = Path.Combine(nested, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None, result.Status);
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_NoFilePathArgument_IsNone()
+    {
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
+            SolutionDiscoveryHelper.TryDiscoverFromFilePath(null).Status);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
+            SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("query", "Foo"))).Status);
+    }
+
+    [TestMethod]
+    public void TryDiscoverFromFilePath_AcceptsPathAndFileKeysToo()
+    {
+        var sln = Path.Combine(_root, "Sample.slnx");
+        File.WriteAllText(sln, "<Solution />");
+        var source = Path.Combine(_root, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        Assert.AreEqual(sln, SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("path", source))).UniquePath);
+        Assert.AreEqual(sln, SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("file", source))).UniquePath);
+    }
+
+    // ── scan seam (query-anchored core) ─────────────────────────────────────
+
+    [TestMethod]
+    public void ScanDirectoriesForSolutions_FindsTopLevelAndOneLevelDown()
+    {
+        var sub = Path.Combine(_root, "nested");
+        Directory.CreateDirectory(sub);
+        var deep = Path.Combine(sub, "deeper");
+        Directory.CreateDirectory(deep);
+
+        File.WriteAllText(Path.Combine(sub, "Found.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(deep, "TooDeep.slnx"), "<Solution />"); // 2 levels down — must NOT be found
+
+        var result = SolutionDiscoveryHelper.ScanDirectoriesForSolutions(new[] { _root }, CancellationToken.None);
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, result.Status,
+            "Only the top-level + one-level-down .slnx should be discovered; deeper trees are out of bounds.");
+        StringAssert.Contains(result.UniquePath!, "Found.slnx");
+    }
+
+    [TestMethod]
+    public void ScanDirectoriesForSolutions_TwoDistinct_IsAmbiguous()
+    {
+        File.WriteAllText(Path.Combine(_root, "Top.slnx"), "<Solution />");
+        var sub = Path.Combine(_root, "child");
+        Directory.CreateDirectory(sub);
+        File.WriteAllText(Path.Combine(sub, "Child.slnx"), "<Solution />");
+
+        var result = SolutionDiscoveryHelper.ScanDirectoriesForSolutions(new[] { _root }, CancellationToken.None);
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Ambiguous, result.Status);
+        Assert.AreEqual(2, result.Candidates.Count);
+    }
+
+    [TestMethod]
+    public void ScanDirectoriesForSolutions_EmptyOrMissing_IsNone()
+    {
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
+            SolutionDiscoveryHelper.ScanDirectoriesForSolutions(new[] { _root }, CancellationToken.None).Status);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
+            SolutionDiscoveryHelper.ScanDirectoriesForSolutions(
+                new[] { Path.Combine(_root, "does-not-exist") }, CancellationToken.None).Status);
+    }
+
+    [TestMethod]
+    public async Task TryDiscoverAsync_NullServerAndNoFilePath_IsNone()
+    {
+        // No filePath argument and no server (so no roots) → discovery yields nothing, leaving the
+        // caller to fall back to the binder/elicitation path rather than guessing.
+        var result = await SolutionDiscoveryHelper.TryDiscoverAsync(
+            Args(("query", "Foo")), server: null, CancellationToken.None);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None, result.Status);
+    }
+
+    private static Dictionary<string, JsonElement> Args(params (string Key, string Value)[] pairs)
+    {
+        var dict = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+        {
+            dict[key] = JsonSerializer.SerializeToElement(value);
+        }
+
+        return dict;
+    }
+}

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterAutoLoadTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterAutoLoadTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Middleware;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the <c>workspace-auto-load-on-demand</c> initiative's observability + guided
+/// fast-fail surface in <see cref="StructuredCallToolFilter"/>. The end-to-end auto-load branch in
+/// the <c>Create</c> delegate drives the <c>workspace_load</c> tool over a live dispatcher, so (as
+/// with the sibling resolution/elicitation tests) the contract pinned here is: (a) the new
+/// <c>_meta.autoResolution=auto-loaded</c> + <c>_meta.autoLoadElapsedMs</c> fields round-trip from
+/// the metrics builder onto a real response envelope, and (b) an ambiguous discovery yields the
+/// structured fast-fail envelope that lists candidate solutions.
+/// </summary>
+[TestClass]
+public sealed class StructuredCallToolFilterAutoLoadTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rmcp-autoload-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* best-effort temp cleanup */ }
+    }
+
+    [TestMethod]
+    public void GateMetricsDto_RoundTripsAutoLoadFields()
+    {
+        var builder = new GateMetricsBuilder { AutoResolution = "auto-loaded", AutoLoadElapsedMs = 123 };
+        var dto = builder.ToDto();
+        Assert.AreEqual("auto-loaded", dto.AutoResolution);
+        Assert.AreEqual(123L, dto.AutoLoadElapsedMs);
+    }
+
+    [TestMethod]
+    public void SuccessEnvelope_WhenAutoLoaded_CarriesAutoResolutionAndElapsedMeta()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        AmbientGateMetrics.Current!.AutoResolution = "auto-loaded";
+        AmbientGateMetrics.Current.AutoLoadElapsedMs = 42;
+
+        var injected = ToolErrorHandler.InjectMetaIfPossible("""{"ok":true}""", "symbol_search");
+        var meta = JsonDocument.Parse(injected).RootElement.GetProperty("_meta");
+
+        Assert.AreEqual("auto-loaded", meta.GetProperty("autoResolution").GetString());
+        Assert.AreEqual(42L, meta.GetProperty("autoLoadElapsedMs").GetInt64(),
+            "On-demand load latency must surface in _meta so profiling can isolate the cold-load cost.");
+    }
+
+    [TestMethod]
+    public void AmbiguousDiscovery_ProducesFastFailEnvelopeListingCandidates()
+    {
+        // Two discoverable solutions → the filter's auto-load path records fast-fail and returns a
+        // structured InvalidArgument envelope naming the candidates with a workspace_load hint.
+        File.WriteAllText(Path.Combine(_root, "Alpha.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(_root, "Beta.slnx"), "<Solution />");
+        var source = Path.Combine(_root, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var args = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["filePath"] = JsonSerializer.SerializeToElement(source),
+        };
+        var discovery = SolutionDiscoveryHelper.TryDiscoverFromFilePath(args);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Ambiguous, discovery.Status);
+
+        using var scope = AmbientGateMetrics.BeginRequest();
+        AmbientGateMetrics.Current!.AutoResolution = "fast-fail";
+        var message =
+            $"workspaceId was omitted and no workspace is loaded. {discovery.Candidates.Count} candidate " +
+            $"solutions were discovered ({string.Join(", ", discovery.Candidates)}). Call workspace_load(path=…).";
+        var result = StructuredCallToolFilter.BuildErrorResult(
+            "symbol_search", new ArgumentException(message, "workspaceId"));
+
+        Assert.IsTrue(result.IsError);
+        var payload = JsonDocument.Parse(((TextContentBlock)result.Content![0]).Text).RootElement;
+        Assert.AreEqual("InvalidArgument", payload.GetProperty("category").GetString());
+        Assert.AreEqual("fast-fail", payload.GetProperty("_meta").GetProperty("autoResolution").GetString());
+        StringAssert.Contains(payload.GetProperty("message").GetString(), "Alpha.slnx");
+        StringAssert.Contains(payload.GetProperty("message").GetString(), "Beta.slnx");
+        StringAssert.Contains(payload.GetProperty("message").GetString(), "workspace_load");
+    }
+}


### PR DESCRIPTION
Step 2 of 3 of the workspace-auto-load sweep (`ai_docs/items/workspace-auto-load-on-demand-design.md`). Plan: `ai_docs/plans/20260609T134405Z_backlog-sweep/`. Builds on order 1 (#957, merged).

## What
Extends order-1's pre-dispatch path to handle the **zero-workspaces-loaded** case. When a read-only, non-destructive tool is called with `workspaceId` omitted and nothing loaded, the filter discovers the implied solution and auto-loads it before dispatch:
- **file-anchored** — walk up from a `filePath`/`path`/`file` argument to the nearest `.slnx`/`.sln` (preferred) or `.csproj`;
- **query-anchored** — bounded scan (top level + one level down) of the client's declared roots (`roots/list`, mirroring `ClientRootPathValidator`); no CWD assumption;
- **unique** → load via the `workspace_load` tool (reusing its dedup / 16-slot cap / eviction / progress), patch the returned id, retry (`_meta.autoResolution=auto-loaded`, `_meta.autoLoadElapsedMs`);
- **ambiguous** (≥2 candidates) → structured fast-fail listing them with a ready-to-run `workspace_load(path=…)` hint;
- **none** → fall through to the existing binder/elicitation path (the elicitation fallback).

New `src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs`. Mutating/preview/apply tools never reach this path (order-1's `ReadOnly && !Destructive` gate). `WorkspaceManager` untouched (load goes through the tool dispatch).

## Plan deviations (deliberate, in-scope)
1. **Placement:** discovery+auto-load lives in order-1's **pre-dispatch** `NotApplicable` (zero-loaded) branch, not the plan's literal "extend the `IsWorkspaceIdRecoveryAllowedFor` branch (exception/elicitation path)". Rationale: order-2's own handoff note (CRITICAL) requires zero-workspaces discovery to fire for **non-eliciting** clients and (post-order-3) for optional tools that no longer throw — only the pre-dispatch seam satisfies that.
2. **File count:** 4 prod files (plan Scope listed 3). The 4th, `AmbientGateMetrics.cs`, is the mechanical builder-field threading for the planned `autoLoadElapsedMs` (exactly parallel to order-1's `AutoResolution`). Within Rule 3's cap of 4.

## Closes
- `workspace-auto-load-on-demand` (backlog row removed in the sweep's reconcile PR)

## Validation
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → clean.
- New `SolutionDiscoveryHelperTests` + `StructuredCallToolFilterAutoLoadTests` (13 tests) green; existing filter/metrics suites (45 tests) green. Covers: file-anchored walk-up, solution-over-project preference, project fallback, ambiguous/none, path/file key variants, bounded top+one-level scan, `_meta.autoResolution=auto-loaded`/`autoLoadElapsedMs` round-trip, ambiguous fast-fail envelope.
- Full `verify-release.ps1` runs in CI.

## Review
- Cold spec-compliance review: pass (4 prod + 2 test; Rule 3 holds; placement + 4th-file judged in-scope).
- Cold code-quality review: pass, no findings (narrow justified catches, enforced scan bound + cancellation, correct dispatch save/restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)