### PR TITLE
feat(tools): make workspaceId optional on read-only pilot tools (workspace-id-optional-readonly-surface-flip)

### DIFF
--- a/changelog.d/workspace-id-optional-readonly-surface-flip.md
+++ b/changelog.d/workspace-id-optional-readonly-surface-flip.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** `workspaceId` is now optional (defaults to `null`) on the read-only tools `go_to_definition`, `find_references`, and `document_symbols`. With a single workspace loaded — or one discoverable from the call context — callers may omit it and the server resolves/auto-loads it (see the read-path middleware). Explicit-id callers are unaffected (additive, not a breaking change). This is a pilot subset; the full read-only surface (and `symbol_search`, whose required `query` parameter needs a signature reorder) is a tracked follow-on. Closes `workspace-id-optional-readonly-surface-flip`.

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -168,6 +168,20 @@ public static class SymbolTools
         }, ct);
     }
 
+    // workspace-id-optional-readonly-surface-flip: the read-path middleware
+    // (StructuredCallToolFilter) resolves or auto-loads an omitted workspaceId before these
+    // now-optional tools dispatch. This guard covers the residual case the middleware cannot
+    // resolve — workspaceId omitted, zero workspaces loaded, and no solution discoverable — by
+    // returning a structured InvalidArgument (the filter classifies the throw) that points the
+    // caller at workspace_load. It also narrows workspaceId to non-null for the call below.
+    private static string RequireResolvedWorkspaceId(string? workspaceId) =>
+        string.IsNullOrEmpty(workspaceId)
+            ? throw new ArgumentException(
+                "workspaceId was omitted but no workspace is loaded and none could be discovered. " +
+                "Call workspace_load(path=…) first, or pass workspaceId explicitly.",
+                nameof(workspaceId))
+            : workspaceId;
+
     [McpServerTool(Name = "go_to_definition", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the definition location(s) of a symbol at the given position")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Navigate to the symbol definition.")]
@@ -176,7 +190,7 @@ public static class SymbolTools
         IWorkspaceManager workspaceManager,
         IWorkspaceExecutionGate gate,
         ISymbolNavigationService symbolNavigationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: the workspace session identifier returned by workspace_load. With one workspace loaded you may omit it — the read-path middleware resolves it automatically; pass it explicitly when two or more are loaded.")] string? workspaceId = null,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
         [Description("Optional: 1-based line number")] int? line = null,
         [Description("Optional: 1-based column number")] int? column = null,
@@ -184,6 +198,7 @@ public static class SymbolTools
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
+        workspaceId = RequireResolvedWorkspaceId(workspaceId);
         return gate.RunReadAsync(workspaceId, async c =>
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
@@ -242,7 +257,7 @@ public static class SymbolTools
         IWorkspaceManager workspaceManager,
         IWorkspaceExecutionGate gate,
         IReferenceService referenceService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: the workspace session identifier returned by workspace_load. With one workspace loaded you may omit it — the read-path middleware resolves it automatically; pass it explicitly when two or more are loaded.")] string? workspaceId = null,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
         [Description("Optional: 1-based line number")] int? line = null,
         [Description("Optional: 1-based column number")] int? column = null,
@@ -254,6 +269,7 @@ public static class SymbolTools
         [Description("Optional: case-sensitive Project.Name filter to scope the result; comma-separated for multiple projects (e.g. 'Foo.Core,Foo.Tests'). Null/empty preserves the unfiltered solution-wide walk.")] string? projectFilter = null,
         CancellationToken ct = default)
     {
+        workspaceId = RequireResolvedWorkspaceId(workspaceId);
         return gate.RunReadAsync(workspaceId, async c =>
         {
             ParameterValidation.ValidatePagination(offset, limit);
@@ -354,12 +370,13 @@ public static class SymbolTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         ISymbolSearchService symbolSearchService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: the workspace session identifier returned by workspace_load. With one workspace loaded you may omit it — the read-path middleware resolves it automatically; pass it explicitly when two or more are loaded.")] string? workspaceId = null,
         [Description("Optional: absolute path to the source file")] string? filePath = null,
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         [Description("Optional: fully qualified metadata name, e.g. Namespace.TypeName")] string? metadataName = null,
         CancellationToken ct = default)
     {
+        workspaceId = RequireResolvedWorkspaceId(workspaceId);
         return GetDocumentSymbolsCore(server, gate, symbolSearchService, workspaceId, filePath, symbolHandle, metadataName, deprecation: null, ct);
     }
 

--- a/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
 
@@ -40,6 +41,22 @@ public sealed class WorkspaceIdOptionalSurfaceTests
             Assert.IsFalse(schema.Required,
                 $"{tool}.workspaceId must be Required=false after the flip so agents proactively omit it.");
         }
+    }
+
+    [TestMethod]
+    public void FlippedTool_WithNullWorkspaceId_ThrowsGuidedInvalidArgument()
+    {
+        // The residual case the middleware cannot resolve (omitted id + zero workspaces loaded +
+        // nothing discoverable) reaches the tool body with workspaceId == null. The body guard
+        // must throw a structured ArgumentException (the filter classifies it to InvalidArgument)
+        // pointing the caller at workspace_load — not NRE on the downstream gate call. The guard
+        // runs before any service is touched, so null DI args are safe here.
+        var ex = Assert.ThrowsException<ArgumentException>(() =>
+            SymbolTools.GetDocumentSymbols(server: null!, gate: null!, symbolSearchService: null!, workspaceId: null));
+
+        Assert.AreEqual("workspaceId", ex.ParamName);
+        StringAssert.Contains(ex.Message, "workspace_load",
+            "The guard must steer the caller to workspace_load rather than fail opaquely.");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
@@ -1,0 +1,57 @@
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for the <c>workspace-id-optional-readonly-surface-flip</c> initiative (pilot subset).
+/// Asserts, via the reflection-derived <see cref="ToolParameterIndex"/>, that the pilot read-only
+/// tools now advertise <c>workspaceId</c> as OPTIONAL (so agents proactively omit it and order-1's
+/// read-path middleware resolves it), while write/destructive tools — and the deferred
+/// <c>symbol_search</c> — keep it REQUIRED.
+///
+/// <para>
+/// Pilot scope is 3 tools (<c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>)
+/// whose <c>workspaceId</c> is followed only by optional parameters, so the flip is a pure in-place
+/// default with no parameter reordering and no caller churn. <c>symbol_search</c> is intentionally
+/// EXCLUDED from this pilot: a required <c>query</c> parameter follows its <c>workspaceId</c>, so
+/// making it optional would force a reorder that breaks ~16 positional call sites — it is folded
+/// into the deferred full read-only sweep follow-on alongside the remaining ~45 methods.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class WorkspaceIdOptionalSurfaceTests
+{
+    private static readonly string[] FlippedPilotTools =
+        ["go_to_definition", "find_references", "document_symbols"];
+
+    // Deferred to the follow-on (required query param forces a reorder) + a sample of tools that
+    // must KEEP workspaceId required: writers, destructive, and not-yet-swept read-only tools.
+    private static readonly string[] StillRequiredTools =
+        ["symbol_search", "apply_text_edit", "workspace_close", "symbol_info"];
+
+    [TestMethod]
+    public void PilotReadOnlyTools_ExposeWorkspaceIdAsOptional()
+    {
+        foreach (var tool in FlippedPilotTools)
+        {
+            var schema = ToolParameterIndex.GetParameter(tool, "workspaceId");
+            Assert.IsNotNull(schema, $"{tool} should declare a workspaceId parameter.");
+            Assert.AreEqual("string", schema!.Type, $"{tool}.workspaceId should remain a string.");
+            Assert.IsFalse(schema.Required,
+                $"{tool}.workspaceId must be Required=false after the flip so agents proactively omit it.");
+        }
+    }
+
+    [TestMethod]
+    public void NonPilotTools_KeepWorkspaceIdRequired()
+    {
+        foreach (var tool in StillRequiredTools)
+        {
+            var schema = ToolParameterIndex.GetParameter(tool, "workspaceId");
+            Assert.IsNotNull(schema, $"{tool} should declare a workspaceId parameter.");
+            Assert.IsTrue(schema!.Required,
+                $"{tool}.workspaceId must stay Required=true — only the pilot read-only subset is flipped " +
+                "in this initiative (symbol_search is deferred; mutating tools are out of scope entirely).");
+        }
+    }
+}


### PR DESCRIPTION
Step 3 of 3 (steering linchpin) of the workspace-auto-load sweep. Plan: `ai_docs/plans/20260609T134405Z_backlog-sweep/`. Builds on orders 1 (#957) + 2 (#958), both merged.

## What
Flips `workspaceId` REQUIRED→OPTIONAL (`string workspaceId` → `string? workspaceId = null`) on **3** read-only pilot tools: `go_to_definition`, `find_references`, `document_symbols`. Agents reading the schema will now proactively omit it; order-1's read-path middleware resolves it (single loaded) or order-2 auto-loads (discoverable). Each `[Description]` updated to invite omission. Additive — explicit-id callers unaffected.

## Plan deviations (deliberate, in-scope; spec-compliance + code-quality reviewed)
1. **Pilot reduced 4→3; `symbol_search` deferred.** `symbol_search` has a **required** `query` param after `workspaceId`, so C# forbids an in-place `= null` (CS1737); making it optional needs a parameter reorder that breaks ~16 positional call sites across `SymbolSearchPaginationTests` + `Top10V3RegressionTests`. That exceeds a pilot's budget, so `symbol_search` folds into the deferred full-surface follow-on (which must convert positional callers to named args anyway). The 3 flipped tools have only optional params after `workspaceId` → pure in-place default, zero caller churn.
2. **Body guard added** (`RequireResolvedWorkspaceId`). The plan's "no body change / RunReadAsync handles null" premise was false — `RunReadAsync` takes a non-null `string` (CS8604). Post-flip, the residual case (omitted id + zero loaded + nothing discoverable) lets null reach the body; the guard throws a structured `ArgumentException` (→ filter `InvalidArgument`) steering the caller to `workspace_load`, and narrows the nullable for the compiler.

## Closes
- `workspace-id-optional-readonly-surface-flip` (backlog row removed in the sweep's reconcile PR)

## Follow-on (filed in the reconcile PR)
- The deferred ~45-method full read-only `workspaceId`-optional sweep (incl. `symbol_search` reorder + caller→named-arg refactor, sub-batched by `*Tools.cs`).
- Code-quality medium: `get_symbol_outline` alias (shares `GetDocumentSymbolsCore` with `document_symbols`) stays required → residual-case UX differs from its canonical twin; fold into the follow-on.

## Validation
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → clean (catalog analyzers RMCP001/002 not tripped — no per-param schema in the catalog).
- `WorkspaceIdOptionalSurfaceTests` (3 tests: pilot tools optional, non-pilot/`symbol_search`/mutating tools required, guard throw-branch) + existing SymbolTools caller suites (SymbolSearchPagination, MetadataNameLocator) green. Full `verify-release.ps1` in CI.

## Review
- Cold spec-compliance: pass (re-plan verified sound; 1 prod + 1 test; tool-surface exemption).
- Cold code-quality: pass; low finding (guard test) fixed inline; medium finding (alias parity) deferred to follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)