### PR TITLE
docs(tools): remove internal BUG-007/BUG-008 ids from tool descriptions

### DIFF
--- a/changelog.d/legacy-bug-id-tool-descriptions.md
+++ b/changelog.d/legacy-bug-id-tool-descriptions.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `test_discover` and `get_msbuild_properties` tool descriptions to remove internal bug tracker ids `BUG-007`/`BUG-008`; descriptions now reference only the shipped pagination and filter field names.

--- a/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
@@ -50,7 +50,7 @@ public static class MSBuildTools
     [McpServerTool(Name = "get_msbuild_properties", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("project-mutation", "stable", true, false,
         "Dump evaluated MSBuild properties for a project."),
-     Description("Dump evaluated MSBuild properties for a project. The full set is large (frequently 60KB+ of mostly internal MSBuild state); always pass a propertyNameFilter substring or an explicit includedNames allowlist unless you really need everything (BUG-008). The response includes totalCount/returnedCount/appliedFilter for visibility.")]
+     Description("Dump evaluated MSBuild properties for a project. The full set is large (frequently 60KB+ of mostly internal MSBuild state); always pass a propertyNameFilter substring or an explicit includedNames allowlist unless you really need everything. The response includes totalCount/returnedCount/appliedFilter for visibility.")]
     public static Task<string> GetMsbuildProperties(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -51,7 +51,7 @@ public static class ValidationTools
             c => buildService.BuildProjectAsync(workspaceId, projectName, c),
             ct);
 
-    [McpServerTool(Name = "test_discover", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Discover tests from test projects in the loaded workspace. Results are paginated to keep responses within MCP context budgets — large suites should be filtered with projectName and/or nameFilter (BUG-007). The response includes returnedCount/totalCount/hasMore so you can tell when more pages exist.")]
+    [McpServerTool(Name = "test_discover", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Discover tests from test projects in the loaded workspace. Results are paginated to keep responses within MCP context budgets — large suites should be filtered with projectName and/or nameFilter. The response includes returnedCount/totalCount/hasMore so you can tell when more pages exist.")]
     [McpToolMetadata("validation", "stable", true, false,
         "Discover tests in the loaded workspace.")]
     public static Task<string> DiscoverTests(


### PR DESCRIPTION
Removes internal tracker ids `BUG-007`/`BUG-008` from two shipped MCP tool `[Description]` strings that confuse external consumers.

- `test_discover` (`ValidationTools.cs`): dropped `(BUG-007)`; description still guides `projectName`/`nameFilter` filtering and references `returnedCount`/`totalCount`/`hasMore`.
- `get_msbuild_properties` (`MSBuildTools.cs`): dropped `(BUG-008)`; description still guides `propertyNameFilter`/`includedNames` and references `totalCount`/`returnedCount`/`appliedFilter`.

No functional change. Affected project builds clean in Release (0 warnings/0 errors). Repo-wide grep confirms zero `BUG-007`/`BUG-008` hits in the two shipped tool-surface files.

Note: internal code-comment / XML-doc occurrences remain in `MsBuildEvaluationService.cs` and `IMsBuildEvaluationService.cs` — out of this row's tool-surface-only scope; flagged for a follow-on.

Closes: legacy-bug-id-tool-descriptions