### PR TITLE
fix(tools): structured NotFound envelope for symbol_signature_help (signature-help-bare-null)

### DIFF
--- a/changelog.d/signature-help-bare-null.md
+++ b/changelog.d/signature-help-bare-null.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `symbol_signature_help` now returns a structured `{error, category: NotFound, message}` envelope for unresolvable locators instead of a bare JSON `null`, matching its sibling tools.

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -564,6 +564,11 @@ public static class SymbolTools
         {
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var result = await symbolRelationshipService.GetSignatureHelpAsync(workspaceId, locator, preferDeclaringMember, c);
+            // signature-help-bare-null: an unresolvable locator previously serialized to a bare
+            // JSON `null`, ambiguous to callers (no-result vs failure). Throw KeyNotFoundException so
+            // the tool layer returns the standard NotFound envelope, matching the sibling tools
+            // (symbol_relationships, member_hierarchy).
+            if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }

--- a/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
@@ -176,4 +176,31 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
         Assert.AreNotEqual("null", ex.Message,
             "member_hierarchy must surface a structured NotFound error, never the bare serialized \"null\".");
     }
+
+    /// <summary>
+    /// signature-help-bare-null regression: an unresolvable metadata-name locator must throw
+    /// <see cref="KeyNotFoundException"/> so the tool layer returns the standard NotFound envelope,
+    /// matching the sibling <c>member_hierarchy</c>/<c>symbol_relationships</c> tools — not the bare
+    /// serialized "null" that the unguarded site previously emitted.
+    /// </summary>
+    [TestMethod]
+    public async Task SignatureHelp_MetadataNameOnly_NotFound_ThrowsKeyNotFound_NotBareNull()
+    {
+        const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
+
+        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.GetSignatureHelp(
+                WorkspaceExecutionGate,
+                SymbolRelationshipService,
+                WorkspaceId,
+                metadataName: bogusName,
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "metadata name",
+            $"Error must name the locator field that was supplied. Got: {ex.Message}");
+        StringAssert.Contains(ex.Message, bogusName,
+            $"Error must echo the offending metadata name so the caller can correlate. Got: {ex.Message}");
+        Assert.AreNotEqual("null", ex.Message,
+            "symbol_signature_help must surface a structured NotFound error, never the bare serialized \"null\".");
+    }
 }


### PR DESCRIPTION
## Summary
`GetSignatureHelp` in `SymbolTools.cs` was the last unguarded sibling: it serialized the nullable `GetSignatureHelpAsync` return unconditionally, so an unresolvable locator produced a bare JSON `null` instead of the standard `{error, category: NotFound, message}` envelope. Added the `if (result is null) throw new KeyNotFoundException(...)` guard mirroring `GetMemberHierarchy`/`GetSymbolRelationships`.

## Changes
- `src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs` — null guard on `symbol_signature_help`.
- `tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs` — `SignatureHelp_MetadataNameOnly_NotFound_ThrowsKeyNotFound_NotBareNull` regression test.

## Validation
- `dotnet build` Host.Stdio (Release): succeeded, 0 warnings.
- `dotnet test --filter NavigationToolsNotFoundMessageTests`: 6/6 passed.

Closes: signature-help-bare-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)