### PR TITLE
fix(roslyn): log swallowed Process.Kill failures in WorkspaceValidationService

### DIFF
--- a/changelog.d/workspace-validation-process-kill-failure-observability.md
+++ b/changelog.d/workspace-validation-process-kill-failure-observability.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Swallowed `Process.Kill` cleanup failures in `WorkspaceValidationService`: kill exceptions are now logged at Warning level (with process id) when a logger is present, matching `DotnetCommandRunner`. Validation envelopes unchanged.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 
@@ -21,6 +22,12 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     private static readonly TimeSpan DefaultGitStatusTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan DefaultValidationPhaseTimeout = TimeSpan.FromSeconds(25);
 
+    private static readonly Action<ILogger, int, string, Exception?> LogProcessKillFailed =
+        LoggerMessage.Define<int, string>(
+            LogLevel.Warning,
+            new EventId(1, nameof(LogProcessKillFailed)),
+            "Failed to kill git process tree for process {ProcessId} after {KillReason} while collecting git-changed files.");
+
     private readonly ICompileCheckService _compile;
     private readonly IDiagnosticService _diagnostics;
     private readonly ITestDiscoveryService _testDiscovery;
@@ -29,6 +36,8 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     private readonly IChangeTracker? _changeTracker;
     private readonly TimeSpan _gitStatusTimeout;
     private readonly TimeSpan _validationPhaseTimeout;
+    private readonly ILogger<WorkspaceValidationService>? _logger;
+    private readonly Action<Process> _killProcessTree;
 
     public WorkspaceValidationService(
         ICompileCheckService compile,
@@ -36,7 +45,8 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         ITestDiscoveryService testDiscovery,
         ITestRunnerService testRunner,
         IWorkspaceManager workspace,
-        IChangeTracker? changeTracker = null)
+        IChangeTracker? changeTracker = null,
+        ILogger<WorkspaceValidationService>? logger = null)
         : this(
             compile,
             diagnostics,
@@ -45,7 +55,8 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             workspace,
             changeTracker,
             DefaultGitStatusTimeout,
-            DefaultValidationPhaseTimeout)
+            DefaultValidationPhaseTimeout,
+            logger)
     {
     }
 
@@ -57,7 +68,9 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         IWorkspaceManager workspace,
         IChangeTracker? changeTracker,
         TimeSpan gitStatusTimeout,
-        TimeSpan validationPhaseTimeout)
+        TimeSpan validationPhaseTimeout,
+        ILogger<WorkspaceValidationService>? logger = null,
+        Action<Process>? killProcessTree = null)
     {
         _compile = compile;
         _diagnostics = diagnostics;
@@ -67,7 +80,11 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         _changeTracker = changeTracker;
         _gitStatusTimeout = gitStatusTimeout > TimeSpan.Zero ? gitStatusTimeout : DefaultGitStatusTimeout;
         _validationPhaseTimeout = validationPhaseTimeout > TimeSpan.Zero ? validationPhaseTimeout : DefaultValidationPhaseTimeout;
+        _logger = logger;
+        _killProcessTree = killProcessTree ?? KillProcessTree;
     }
+
+    private static void KillProcessTree(Process process) => process.Kill(entireProcessTree: true);
 
     public async Task<WorkspaceValidationDto> ValidateAsync(
         string workspaceId,
@@ -460,7 +477,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     ///   <item>warnings non-empty → git was unavailable / solution is outside a git repo / git exited with error. Caller should fall back to full-workspace scope.</item>
     /// </list>
     /// </summary>
-    private static async Task<(IReadOnlyList<string> Files, IReadOnlyList<string> Warnings)> CollectGitChangedFilesAsync(
+    private async Task<(IReadOnlyList<string> Files, IReadOnlyList<string> Warnings)> CollectGitChangedFilesAsync(
         string solutionDirectory,
         TimeSpan timeout,
         CancellationToken ct)
@@ -538,7 +555,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            TryKillProcessTree(process, "timeout");
             return (Array.Empty<string>(), new[]
             {
                 $"git status exceeded the timeout of {timeout.TotalSeconds:F0} second(s); retryable=true; validated full workspace."
@@ -547,7 +564,7 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            TryKillProcessTree(process, "failure");
             return (Array.Empty<string>(), new[]
             {
                 $"git status failed: {ex.Message}; validated full workspace."
@@ -564,6 +581,26 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         }
 
         return (ParseGitPorcelainZ(stdout, solutionDirectory), Array.Empty<string>());
+    }
+
+    /// <summary>
+    /// Best-effort termination of the git process tree. A kill failure is logged at
+    /// <see cref="LogLevel.Warning"/> (with the process id and reason) when a logger is present,
+    /// mirroring <c>DotnetCommandRunner.TryKillProcessTree</c>; it is never surfaced to the caller.
+    /// </summary>
+    private void TryKillProcessTree(Process process, string killReason)
+    {
+        try
+        {
+            _killProcessTree(process);
+        }
+        catch (Exception ex)
+        {
+            if (_logger is not null)
+            {
+                LogProcessKillFailed(_logger, process.Id, killReason, ex);
+            }
+        }
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
@@ -290,6 +292,77 @@ public sealed class ValidateRecentGitChangesTests : IsolatedWorkspaceTestBase
         {
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             throw new InvalidOperationException("unreachable");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Observability: a git process-tree kill failure during the
+    // git-status timeout/failure cleanup must be logged at Warning (with the
+    // process id) when a logger is present, never swallowed silently — mirrors
+    // DotnetCommandRunner.TryKillProcessTree. The kill delegate is injected so
+    // the failure path is deterministic (no reliance on a real git timeout race).
+    // ------------------------------------------------------------------
+    [TestMethod]
+    public void TryKillProcessTree_KillThrows_LogsWarningWithProcessId()
+    {
+        var logger = new ListLogger<WorkspaceValidationService>();
+        var killException = new InvalidOperationException("simulated kill failure");
+
+        var service = new WorkspaceValidationService(
+            CompileCheckService,
+            DiagnosticService,
+            TestDiscoveryService,
+            TestRunnerService,
+            WorkspaceManager,
+            ChangeTracker,
+            gitStatusTimeout: TimeSpan.FromSeconds(5),
+            validationPhaseTimeout: TimeSpan.FromSeconds(5),
+            logger: logger,
+            killProcessTree: _ => throw killException);
+
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c exit" : "-c \"exit 0\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.IsNotNull(process, "Could not start a host process for the test.");
+        process.WaitForExit(5_000);
+
+        var helper = typeof(WorkspaceValidationService).GetMethod(
+            "TryKillProcessTree", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(helper, "TryKillProcessTree should exist as a private instance method.");
+
+        // Must not throw — the kill failure is best-effort and swallowed for the caller.
+        helper.Invoke(service, new object[] { process, "timeout" });
+
+        var entry = logger.Entries.SingleOrDefault(candidate =>
+            candidate.Level == LogLevel.Warning &&
+            candidate.Message.Contains("Failed to kill git process tree", StringComparison.Ordinal) &&
+            candidate.Message.Contains(process.Id.ToString(), StringComparison.Ordinal) &&
+            ReferenceEquals(candidate.Exception, killException));
+
+        Assert.IsNotNull(entry,
+            "A git kill failure must be observable at Warning level with the process id; "
+            + $"got [{string.Join("; ", logger.Entries.Select(e => $"{e.Level}:{e.Message}"))}].");
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception), exception));
         }
     }
 }


### PR DESCRIPTION
## Summary

`WorkspaceValidationService.CollectGitChangedFilesAsync` had two `try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }` empty catches that silently discarded git process-tree kill failures. The class had no logger.

This change mirrors the canonical `DotnetCommandRunner` pattern:
- Inject optional `ILogger<WorkspaceValidationService>? logger` (passed through both public and internal constructors).
- Add a `LoggerMessage.Define<int, string>` static delegate `LogProcessKillFailed`.
- Replace both empty catches with a private `TryKillProcessTree(process, reason)` helper that logs at `Warning` (process id + reason) when a logger is present; the failure remains best-effort and is never surfaced to the caller.
- Validation envelopes / warning strings are unchanged.

An injectable `Action<Process>? killProcessTree` test seam (internal ctor only, defaults to the real kill) mirrors `DotnetCommandRunner`'s seam so the kill-failure path is deterministically testable without relying on a git timeout race.

## Test

New `TryKillProcessTree_KillThrows_LogsWarningWithProcessId` injects a throwing kill delegate + a list-logger sink and asserts a single Warning entry carrying the process id and the original exception. Targeted suite: 20/20 passing (`dotnet test --filter "...ValidateRecentGitChanges|...WorkspaceValidation"`).

Closes: workspace-validation-process-kill-failure-observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)