### PR TITLE
fix(middleware): structured error envelope for elicitation-retry dispatch failures (elicitation-retry-exception-envelope)

### DIFF
--- a/changelog.d/elicitation-retry-exception-envelope.md
+++ b/changelog.d/elicitation-retry-exception-envelope.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** exceptions thrown by `workspace_load` or the retried tool dispatch during elicitation-based `workspaceId` recovery now return the standard structured `CallToolResult` error envelope instead of escaping the filter as unhandled transport errors.

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -708,7 +708,19 @@ internal static class StructuredCallToolFilter
         {
             [PathParameterName] = pathValue,
         };
-        var loadResult = await dispatchAsync(WorkspaceLoadToolName, loadArgs).ConfigureAwait(false);
+        CallToolResult loadResult;
+        try
+        {
+            loadResult = await dispatchAsync(WorkspaceLoadToolName, loadArgs).ConfigureAwait(false);
+        }
+        catch (Exception loadEx)
+        {
+            logger?.LogWarning(loadEx,
+                "workspace_load dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
+
         var workspaceId = TryExtractWorkspaceId(loadResult);
         if (string.IsNullOrWhiteSpace(workspaceId))
         {
@@ -728,7 +740,17 @@ internal static class StructuredCallToolFilter
         }
 
         retryArgs[WorkspaceIdParameterName] = JsonSerializer.SerializeToElement(workspaceId, JsonDefaults.Indented);
-        return await dispatchAsync(toolName, retryArgs).ConfigureAwait(false);
+        try
+        {
+            return await dispatchAsync(toolName, retryArgs).ConfigureAwait(false);
+        }
+        catch (Exception retryEx)
+        {
+            logger?.LogWarning(retryEx,
+                "Retried tool dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
@@ -301,4 +301,86 @@ public sealed class StructuredCallToolFilterElicitationTests
             "Recovery must load the workspace before retrying the original workspace-scoped tool.");
         Assert.AreEqual("""{"state":"ready"}""", ((TextContentBlock)result.Content![0]).Text);
     }
+
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_WorkspaceLoadDispatchThrows_ReturnsNullWithoutEscaping()
+    {
+        const string solutionPath = "C:/repo/SampleSolution.slnx";
+
+        var result = await StructuredCallToolFilter.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: _ =>
+            {
+                var pathElement = JsonSerializer.SerializeToElement(solutionPath, JsonDefaults.Indented);
+                return ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement>
+                    {
+                        ["path"] = pathElement,
+                    },
+                });
+            },
+            dispatchAsync: (toolName, _) =>
+            {
+                Assert.AreEqual("workspace_load", toolName,
+                    "A throw from the workspace_load dispatch must stop recovery before retrying the original tool.");
+                throw new InvalidOperationException("workspace_load blew up");
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result,
+            "A throwing workspace_load dispatch must be caught and surface as a null fall-through, not escape the filter.");
+    }
+
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_RetriedToolDispatchThrows_ReturnsNullWithoutEscaping()
+    {
+        const string solutionPath = "C:/repo/SampleSolution.slnx";
+        const string recoveredWorkspaceId = "ws-recovered";
+
+        var result = await StructuredCallToolFilter.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: _ =>
+            {
+                var pathElement = JsonSerializer.SerializeToElement(solutionPath, JsonDefaults.Indented);
+                return ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement>
+                    {
+                        ["path"] = pathElement,
+                    },
+                });
+            },
+            dispatchAsync: (toolName, _) =>
+            {
+                if (toolName == "workspace_load")
+                {
+                    return Task.FromResult(new CallToolResult
+                    {
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text = JsonSerializer.Serialize(
+                                    new { WorkspaceId = recoveredWorkspaceId },
+                                    JsonDefaults.Indented),
+                            },
+                        ],
+                    });
+                }
+
+                Assert.AreEqual("workspace_status", toolName);
+                throw new InvalidOperationException("retried tool blew up");
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result,
+            "A throwing retried-tool dispatch must be caught and surface as a null fall-through, not escape the filter.");
+    }
 }


### PR DESCRIPTION
## Summary

`TryRecoverMissingWorkspaceIdAsync` had two unguarded `dispatchAsync` awaits (the `workspace_load` dispatch and the retried original-tool dispatch). A throw from either propagated out of the recovery helper, which is awaited inside the outer `catch` of the filter — a throw from within a catch handler escaped the filter as an unhandled transport error instead of a structured `CallToolResult`.

Both dispatches are now wrapped in try/catch; on throw they log a Warning and return null, letting the caller's null check fall through to `BuildErrorResult` (structured envelope), mirroring the existing `elicitAsync` failure path.

## Tests

Added 2 MSTest cases:
- `workspace_load` dispatch throws → assert null (no escape)
- workspace_load succeeds but retried-tool dispatch throws → assert null (no escape)

`dotnet build -c Release` + `dotnet test --filter "StructuredCallToolFilterElicitation"` → 15/15 pass.

Closes: elicitation-retry-exception-envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)