### PR TITLE
test(nuget): deterministic task-await seam replacing wall-clock poll

### DIFF
--- a/changelog.d/nuget-version-checker-test-wallclock-poll.md
+++ b/changelog.d/nuget-version-checker-test-wallclock-poll.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Replace wall-clock poll in NuGet version checker tests with a deterministic task-await seam, eliminating timing sensitivity under heavy CI parallel load.

--- a/src/RoslynMcp.Host.Stdio/Services/NuGetVersionChecker.cs
+++ b/src/RoslynMcp.Host.Stdio/Services/NuGetVersionChecker.cs
@@ -97,6 +97,17 @@ public sealed class NuGetVersionChecker : ILatestVersionProvider
     }
 
     /// <summary>
+    /// Test-only seam exposing the in-flight background fetch task so tests can await its
+    /// completion deterministically instead of polling <see cref="LastCheckStatus"/> on a
+    /// wall-clock loop. Captured under <c>_lock</c> to avoid a torn read; null when no fetch
+    /// has been started. No production behavior depends on this.
+    /// </summary>
+    internal Task? PendingCheckForTest
+    {
+        get { lock (_lock) { return _pendingCheck; } }
+    }
+
+    /// <summary>
     /// Returns the latest stable version string from NuGet, or null if the check
     /// hasn't completed yet / failed / is stale and a refresh is in progress.
     /// Calling this kicks off a background fetch on first access and after cache expiry.

--- a/tests/RoslynMcp.Tests/NuGetVersionCheckerTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetVersionCheckerTests.cs
@@ -106,18 +106,15 @@ public sealed class NuGetVersionCheckerTests
 
     private static async Task WaitForCompletionAsync(NuGetVersionChecker checker)
     {
-        // The background fetch is a fire-and-forget Task.Run; poll the observable status
-        // with a bounded timeout rather than reaching into private state.
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline)
-        {
-            var status = checker.LastCheckStatus;
-            if (status is not VersionCheckStatus.NeverChecked and not VersionCheckStatus.Pending)
-                return;
-            await Task.Delay(25).ConfigureAwait(false);
-        }
+        // Await the in-flight background fetch directly via the internal test seam rather than
+        // spin-looping on the observable status — deterministic and free of timing sensitivity
+        // under heavy CI parallel load. The bounded WaitAsync guards against a hung handler.
+        var pending = checker.PendingCheckForTest;
+        Assert.IsNotNull(pending, "Expected a background version check to be in flight.");
+        await pending.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-        Assert.Fail("Background version check did not complete within the timeout.");
+        Assert.AreNotEqual(VersionCheckStatus.Pending, checker.LastCheckStatus,
+            "Background version check should have reached a terminal status.");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/ServerInfoUpdateLatestTests.cs
+++ b/tests/RoslynMcp.Tests/ServerInfoUpdateLatestTests.cs
@@ -231,16 +231,16 @@ public sealed class ServerInfoUpdateLatestTests
 
     private static async Task WaitForTerminalStatusAsync(NuGetVersionChecker checker)
     {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline)
-        {
-            if (checker.LastCheckStatus is VersionCheckStatus.Failed or VersionCheckStatus.TimedOut or VersionCheckStatus.Succeeded)
-                return;
+        // Await the in-flight background fetch directly via the internal test seam rather than
+        // spin-looping on the observable status — deterministic and free of timing sensitivity
+        // under heavy CI parallel load. The bounded WaitAsync guards against a hung handler.
+        var pending = checker.PendingCheckForTest;
+        Assert.IsNotNull(pending, "Expected a background version check to be in flight.");
+        await pending.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
-            await Task.Delay(25).ConfigureAwait(false);
-        }
-
-        Assert.Fail("Background version check did not reach a terminal status within the timeout.");
+        Assert.IsTrue(
+            checker.LastCheckStatus is VersionCheckStatus.Failed or VersionCheckStatus.TimedOut or VersionCheckStatus.Succeeded,
+            "Background version check should have reached a terminal status.");
     }
 
     private static void ForceCacheExpired(NuGetVersionChecker checker)


### PR DESCRIPTION
Replaces the 10s wall-clock poll (`Task.Delay(25)` spin-loop on `LastCheckStatus`) in two NuGet-version-checker test helpers with a deterministic await on the in-flight background fetch task, eliminating timing sensitivity under heavy CI parallel load.

## Change
- `NuGetVersionChecker.cs`: add an `internal Task? PendingCheckForTest` seam returning `_pendingCheck` under `_lock` (test-only, no production behavior change). `InternalsVisibleTo("RoslynMcp.Tests")` already present.
- `NuGetVersionCheckerTests.WaitForCompletionAsync` and `ServerInfoUpdateLatestTests.WaitForTerminalStatusAsync`: await `checker.PendingCheckForTest` guarded by `WaitAsync(5s)`, then a single terminal-status assertion. No `Task.Delay(25)` remains.

## Validation
- `dotnet build tests/RoslynMcp.Tests -c Release` — clean (0 warnings, 0 errors).
- `dotnet test --filter "NuGetVersionCheckerTests|ServerInfoUpdateLatestTests"` — 12/12 passed.

Closes: nuget-version-checker-test-wallclock-poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)