### PR TITLE
fix(middleware): decouple IsWorkspaceIdRecoveryAllowedFor from Required flag for flipped tools

### DIFF
--- a/changelog.d/workspace-id-omitted-residual-recovery-coherence.md
+++ b/changelog.d/workspace-id-omitted-residual-recovery-coherence.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** residual-case elicitation recovery (`IsWorkspaceIdRecoveryAllowedFor`) now fires for tools with `workspaceId` flipped to `Required:false` (e.g. `go_to_definition`, `find_references`, `document_symbols`), matching the design intent documented on `IsWorkspaceIdAutoResolveAllowedFor`; stale comment in `TryAutoLoadWorkspaceAsync` corrected.

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -91,7 +91,7 @@ internal static class StructuredCallToolFilter
     /// Adding to this list requires explicit policy review: the parameter must be
     /// non-sensitive, naturally bounded (a path, an id, a select-from-N), and the recovery
     /// shape (one-shot retry with the elicited value patched in) must be safe for the tool's
-    /// idempotency semantics. Required <c>workspaceId</c> parameters for read-only,
+    /// idempotency semantics. <c>workspaceId</c> parameters (Required or optional) for read-only,
     /// non-destructive tools are handled by
     /// <see cref="IsWorkspaceIdRecoveryAllowedFor"/> because the concrete elicited field is
     /// <c>workspace_load.path</c>; <c>workspaceId</c> itself is a path-derived session token,
@@ -133,8 +133,9 @@ internal static class StructuredCallToolFilter
                 // before the SDK binder runs: exactly one workspace loaded => patch it in;
                 // two-or-more => structured fast-fail listing the candidates; zero => left for
                 // on-demand discovery / the binder. This is intentionally NOT gated on the
-                // schema's Required flag (unlike IsWorkspaceIdRecoveryAllowedFor) so it keeps
-                // working after read-only tools flip workspaceId to optional.
+                // schema's Required flag (like IsWorkspaceIdRecoveryAllowedFor, which is also
+                // Required-independent) so it keeps working after read-only tools flip
+                // workspaceId to optional.
                 var workspaceManager = context.Services?.GetService<IWorkspaceManager>();
                 if (workspaceManager is not null && IsWorkspaceIdAutoResolveAllowedFor(toolName))
                 {
@@ -474,10 +475,11 @@ internal static class StructuredCallToolFilter
     /// <paramref name="toolName"/> is a read-only, non-destructive tool that declares a string
     /// <c>workspaceId</c> parameter, making it eligible for pre-dispatch auto-resolution.
     /// Distinct from <see cref="IsWorkspaceIdRecoveryAllowedFor"/>: that predicate gates the
-    /// exception-path elicitation recovery and requires <c>Required:true</c> (it only fires when
-    /// the binder threw on a missing required arg); this one is <b>independent of the Required
-    /// flag</b> so auto-resolution keeps working after a read-only tool flips <c>workspaceId</c>
-    /// to optional. Public so tests can pin the policy.
+    /// exception-path elicitation recovery (it fires when a tool-call surfaces a missing
+    /// <c>workspaceId</c>); both predicates are now <b>independent of the Required flag</b> so
+    /// they keep working after a read-only tool flips <c>workspaceId</c> to optional. This one
+    /// gates pre-dispatch auto-resolution rather than the exception-path recovery. Public so
+    /// tests can pin the policy.
     /// </summary>
     public static bool IsWorkspaceIdAutoResolveAllowedFor(string? toolName)
     {

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -438,6 +438,17 @@ internal static class StructuredCallToolFilter
         return await next(context, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// workspace-id-omitted-residual-recovery-coherence: returns <see langword="true"/> when
+    /// <paramref name="toolName"/> is a read-only, non-destructive tool and <paramref name="paramName"/>
+    /// is the non-sensitive string <c>workspaceId</c> parameter, making it eligible for the
+    /// exception-path elicitation recovery. <b>Independent of the Required flag</b> (mirrors
+    /// <see cref="IsWorkspaceIdAutoResolveAllowedFor"/>): the recovery only fires from the
+    /// exception-catch block, and the binder never throws for a missing <em>optional</em> arg, so a
+    /// relaxed gate cannot fire spuriously — but keeping it Required-independent ensures recovery
+    /// stays live for read-only tools that flip <c>workspaceId</c> to optional
+    /// (e.g. <c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>).
+    /// </summary>
     internal static bool IsWorkspaceIdRecoveryAllowedFor(string toolName, string paramName)
     {
         if (!string.Equals(paramName, WorkspaceIdParameterName, StringComparison.Ordinal))
@@ -454,7 +465,7 @@ internal static class StructuredCallToolFilter
         var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
             string.Equals(entry.Name, toolName, StringComparison.Ordinal));
 
-        return schema is { Type: "string", Required: true }
+        return schema is { Type: "string" }
                && tool is { ReadOnly: true, Destructive: false };
     }
 
@@ -601,8 +612,11 @@ internal static class StructuredCallToolFilter
     ///   <see langword="null"/> to fall back to the existing recovery path.</item>
     ///   <item><b>Ambiguous</b> → return a structured fast-fail listing the candidate solutions
     ///   with a ready-to-run <c>workspace_load(path=…)</c> hint (records <c>fast-fail</c>).</item>
-    ///   <item><b>None</b> → return <see langword="null"/>; the binder/elicitation path handles it
-    ///   (the elicitation fallback when the client supports it).</item>
+    ///   <item><b>None</b> → return <see langword="null"/> to fall through to <c>next()</c>; the
+    ///   downstream tool then either binds the supplied <c>workspaceId</c> or, when it is omitted on
+    ///   an auto-resolve-eligible read-only tool, throws and triggers the exception-path elicitation
+    ///   recovery gated by <see cref="IsWorkspaceIdRecoveryAllowedFor"/> (which is Required-independent,
+    ///   so it stays live for tools that flipped <c>workspaceId</c> to optional).</item>
     /// </list>
     /// A non-null return is a terminal fast-fail; <see langword="null"/> means "fall through to
     /// <c>next()</c>" (whether or not the arguments were patched).

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
@@ -84,6 +84,18 @@ public sealed class StructuredCallToolFilterElicitationTests
     }
 
     [TestMethod]
+    public void IsWorkspaceIdRecoveryAllowedFor_OptionalWorkspaceIdReadOnlyTool_ReturnsTrue()
+    {
+        // workspace-id-omitted-residual-recovery-coherence: the recovery gate is decoupled from
+        // the Required flag, so read-only tools that flipped workspaceId to Required:false keep a
+        // live exception-path elicitation recovery (matching IsWorkspaceIdAutoResolveAllowedFor).
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("go_to_definition", "workspaceId"),
+            "Recovery must stay eligible for go_to_definition after workspaceId flipped to optional.");
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("find_references", "workspaceId"));
+        Assert.IsTrue(StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("document_symbols", "workspaceId"));
+    }
+
+    [TestMethod]
     public void IsElicitationAllowedFor_WriteOrDestructiveWorkspaceId_ReturnsFalse()
     {
         Assert.IsFalse(StructuredCallToolFilter.IsElicitationAllowedFor("apply_text_edit", "workspaceId"),

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
@@ -14,9 +14,10 @@ namespace RoslynMcp.Tests;
 ///   <item><b>eligibility</b> — <see cref="StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor"/>
 ///         fires for read-only workspace-scoped tools <i>regardless of the schema Required flag</i>,
 ///         which is the property that keeps the feature alive after a tool flips
-///         <c>workspaceId</c> to optional (the surface-flip initiative). Contrast with
-///         <see cref="StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor"/>, which is
-///         Required-gated because it only covers the binder-threw exception path.</item>
+///         <c>workspaceId</c> to optional (the surface-flip initiative). Its sibling
+///         <see cref="StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor"/> is now also
+///         Required-independent; it differs only in covering the exception-path elicitation
+///         recovery rather than the pre-dispatch auto-resolution path.</item>
 ///   <item><b>classification</b> — omit + 1 loaded resolves to that workspace; omit + ≥2 loaded
 ///         fast-fails listing the candidates; omit + 0 loaded is left for on-demand discovery;
 ///         an explicit id passes through untouched.</item>
@@ -51,12 +52,14 @@ public sealed class StructuredCallToolFilterResolutionTests
             "Auto-resolution must fire for read-only tools whose workspaceId is optional; " +
             "otherwise the feature dies the moment a tool flips workspaceId to a default.");
 
-        // Distinction witness: the Required-gated recovery predicate does NOT fire for the same
-        // optional tool — proving the two predicates are intentionally different.
-        Assert.IsFalse(
+        // Coherence witness: the exception-path recovery predicate is now ALSO Required-independent
+        // (decoupled to match auto-resolve), so it fires for the same optional read-only tool. The
+        // two predicates differ in WHICH path they gate (pre-dispatch auto-resolution vs the
+        // exception-path elicitation recovery), not in Required-gating.
+        Assert.IsTrue(
             StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("workspace_readiness_report", "workspaceId"),
-            "The exception-path recovery predicate is Required-gated and must stay false for an " +
-            "optional-workspaceId tool — only the auto-resolve predicate covers that case.");
+            "The exception-path recovery predicate is Required-independent and must fire for an " +
+            "optional-workspaceId read-only tool, mirroring the auto-resolve predicate.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
`IsWorkspaceIdRecoveryAllowedFor` gated on `schema is { Type: "string", Required: true }`, so the 3 read-only tools flipped to `Required:false` (`go_to_definition`, `find_references`, `document_symbols`) failed the gate and their exception-path elicitation recovery was silently dead. This decouples the recovery gate from the Required flag (option A), matching the deliberate design of the sibling `IsWorkspaceIdAutoResolveAllowedFor`.

## Changes
- `StructuredCallToolFilter.cs`: predicate at `IsWorkspaceIdRecoveryAllowedFor` drops `, Required: true` (keeps the `ReadOnly:true, Destructive:false` half); added XML doc noting Required-independence; corrected the stale `TryAutoLoadWorkspaceAsync` None-branch comment.
- Added `IsWorkspaceIdRecoveryAllowedFor_OptionalWorkspaceIdReadOnlyTool_ReturnsTrue` test.

## Safety
Relaxing the gate returns true for optional tools, but the recovery path only fires from the exception-catch block and the binder never throws for a missing optional arg, so the relaxation is structurally safe (a true gate doesn't cause spurious firing).

## Validation
- `dotnet build tests/RoslynMcp.Tests -c Release` — 0 warnings, 0 errors
- `dotnet test --filter StructuredCallToolFilterElicitationTests` — 16/16 passed

Closes: workspace-id-omitted-residual-recovery-coherence

🤖 Generated with [Claude Code](https://claude.com/claude-code)