### PR TITLE
feat(registry): automate official MCP Registry publish on release tags

### DIFF
--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.darylmcd/roslyn-mcp",
-  "description": "Local-first MCP server for semantic C# analysis, navigation, validation, and refactoring on real .sln / .slnx / .csproj workspaces. Powered by Roslyn and MSBuildWorkspace; runs over stdio; ships as a .NET global tool.",
+  "description": "Local-first MCP server for semantic C# analysis & refactoring via Roslyn & MSBuildWorkspace.",
   "repository": {
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -77,3 +77,69 @@ jobs:
         with:
           name: nuget-packages
           path: nupkg/
+
+  # Publishes .claude-plugin/server.json to the official MCP Registry
+  # (registry.modelcontextprotocol.io) after the NuGet package is live. Uses
+  # GitHub OIDC to prove ownership of the io.github.darylmcd/* namespace — no PAT
+  # or secret required. Runs only on a real tag/release publish, never on a
+  # workflow_dispatch dry run. See https://modelcontextprotocol.io/registry/github-actions
+  publish-registry:
+    needs: publish
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+    permissions:
+      id-token: write   # required for `mcp-publisher login github-oidc`
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Resolve package version
+        id: ver
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            v="${{ github.event.release.tag_name }}"
+          else
+            v="${GITHUB_REF_NAME}"
+          fi
+          v="${v#v}"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved package version: $v"
+
+      - name: Wait for package README to be live on NuGet
+        # The registry verifies ownership by fetching the packed README from NuGet
+        # and checking for the `mcp-name` marker. The flat-container README endpoint
+        # returns 200 only once NuGet has finished validating + indexing the package.
+        shell: bash
+        run: |
+          id="darylmcd.roslynmcp"   # flat-container ids are lowercased
+          ver="${{ steps.ver.outputs.version }}"
+          url="https://api.nuget.org/v3-flatcontainer/${id}/${ver}/readme"
+          echo "Polling $url"
+          for i in $(seq 1 80); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            if [ "$code" = "200" ]; then
+              echo "README live after ~$((i*15))s"; exit 0
+            fi
+            echo "attempt $i: HTTP $code; sleeping 15s"; sleep 15
+          done
+          echo "Timed out waiting for the NuGet package README to become available"; exit 1
+
+      - name: Install mcp-publisher
+        shell: bash
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        # `mcp-publisher publish` defaults to ./server.json; our canonical manifest
+        # lives at .claude-plugin/server.json, so copy it to the expected location
+        # (version-agnostic vs. relying on a positional path argument).
+        shell: bash
+        run: |
+          cp .claude-plugin/server.json server.json
+          ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -553,3 +553,6 @@ audit-reports/
 # repos and get archived into review-inbox/archive/<batch-id>/ after intake. The flat
 # files are transient; the archive (with citation paths from backlog rows) is tracked.
 review-inbox/*.md
+
+# Playwright MCP session artifacts (ephemeral page snapshots).
+.playwright-mcp/

--- a/changelog.d/mcp-registry-submission.md
+++ b/changelog.d/mcp-registry-submission.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Automated publishing to the official [MCP Registry](https://registry.modelcontextprotocol.io/) (`io.github.darylmcd/roslyn-mcp`) on release tags via GitHub OIDC — the `publish-nuget` workflow now publishes `server.json` once the NuGet package is live. Adds the registry ownership marker to the packaged README, trims the manifest `description` to the 100-char schema limit, and hardens `eng/verify-registry-readiness.ps1` to catch both gaps. Closes `mcp-registry-submission`.

--- a/eng/verify-registry-readiness.ps1
+++ b/eng/verify-registry-readiness.ps1
@@ -13,6 +13,9 @@
   Checks performed:
     - server.json structural fields (name, description, repository, version,
       packages[], _meta)
+    - description within the registry schema's 100-char maxLength
+    - packed NuGet README (src/RoslynMcp.Host.Stdio/README.md) carries the
+      `<!-- mcp-name: <server.name> -->` ownership marker the registry requires
     - name format `io.github.<owner>/<repo>` matches repository.url
     - packages[0] shape: registryType, registryBaseUrl, identifier, version,
       runtimeHint, transport.type
@@ -132,6 +135,12 @@ if ($serverJson) {
 
     if ($serverJson.description) {
         Add-Check -Id 'description-present' -Status 'pass' -Message "description present ($($serverJson.description.Length) chars)"
+        # The registry schema caps description at 100 chars; mcp-publisher rejects longer.
+        if ($serverJson.description.Length -le 100) {
+            Add-Check -Id 'description-length' -Status 'pass' -Message "description within 100-char schema limit ($($serverJson.description.Length) chars)"
+        } else {
+            Add-Check -Id 'description-length' -Status 'fail' -Message "description is $($serverJson.description.Length) chars; MCP registry schema maxLength is 100 - trim it"
+        }
     } else {
         Add-Check -Id 'description-present' -Status 'fail' -Message 'description missing'
     }
@@ -206,6 +215,22 @@ if ($serverJson) {
         Add-Check -Id 'meta-present' -Status 'pass' -Message '_meta block present'
     } else {
         Add-Check -Id 'meta-present' -Status 'warn' -Message '_meta block missing (optional but conventional)'
+    }
+
+    # The registry verifies NuGet ownership by fetching the PACKED README from
+    # NuGet.org and requiring an `<!-- mcp-name: <server.name> -->` marker. The
+    # packed README is the project-local one (PackageReadmeFile), not the repo root.
+    $packedReadmePath = Join-Path $repoRoot 'src' 'RoslynMcp.Host.Stdio' 'README.md'
+    if (-not (Test-Path $packedReadmePath)) {
+        Add-Check -Id 'nuget-readme-mcp-name-marker' -Status 'fail' -Message "packed README not found at src/RoslynMcp.Host.Stdio/README.md"
+    } else {
+        $expectedMarker = "<!-- mcp-name: $($serverJson.name) -->"
+        $readmeText = Get-Content $packedReadmePath -Raw
+        if ($readmeText -match [regex]::Escape($expectedMarker)) {
+            Add-Check -Id 'nuget-readme-mcp-name-marker' -Status 'pass' -Message "packed README carries ownership marker '$expectedMarker'"
+        } else {
+            Add-Check -Id 'nuget-readme-mcp-name-marker' -Status 'fail' -Message "packed README (src/RoslynMcp.Host.Stdio/README.md) is missing the registry ownership marker '$expectedMarker'"
+        }
     }
 }
 

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.darylmcd/roslyn-mcp -->
+
 # Darylmcd.RoslynMcp
 
 A production-usable **Model Context Protocol (MCP) server** providing semantic C# analysis powered by Roslyn — designed for AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.


### PR DESCRIPTION
## What

Closes the long-standing `mcp-registry-submission` row by making the official MCP Registry (`registry.modelcontextprotocol.io`) publish **automatic on every release tag** — not a one-time manual action.

## Why

The server is the most capable Roslyn MCP server but is invisible in the channels MCP users actually browse. The official registry is the upstream hub that cascades to the GitHub MCP Registry → VS Code / Visual Studio MCP galleries → aggregators (PulseMCP, Glama, mcp.so). None of the competing Roslyn MCP servers are on it yet.

## Changes

- **`.github/workflows/publish-nuget.yml`** — new `publish-registry` job (`needs: publish`): waits for the NuGet package README to go live, installs `mcp-publisher`, authenticates via **GitHub OIDC** (no PAT/secret), and publishes `.claude-plugin/server.json`. Runs only on real tag/release pushes.
- **`src/RoslynMcp.Host.Stdio/README.md`** — adds the `<!-- mcp-name: io.github.darylmcd/roslyn-mcp -->` ownership marker the registry requires in the packed NuGet README.
- **`.claude-plugin/server.json`** — trims `description` from 222 → 92 chars (registry schema hard-caps it at 100; `mcp-publisher` would otherwise reject the submission).
- **`eng/verify-registry-readiness.ps1`** — adds `description-length` (≤100) and `nuget-readme-mcp-name-marker` checks. The script previously reported `ready` on a manifest the registry rejects (checked description *presence* but never length, and never checked the marker). Directive #3 fix.
- **`.gitignore`** — ignores `.playwright-mcp/` session artifacts (surfaced while staging this change).

## Validation

- `eng/verify-registry-readiness.ps1` → **ready (26 pass / 0 fail / 1 warn)**; both new checks pass.
- The OIDC publish path cannot be exercised pre-release; it runs (and is proven) when the `v2.3.5` tag is cut. Schema constraint (`description` maxLength 100) and GitHub-namespace scoping (`io.github.darylmcd/*`, server name need not match repo name) verified against the live registry schema + auth docs.

## Note

The 1 readiness WARN (`repository-url-matches-name`) is a false positive — it assumes the server-name segment must equal the repo name, but GitHub auth grants the whole `io.github.darylmcd/*` namespace. Minor follow-up to relax that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)