### PR TITLE
release: v2.3.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 32 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "2.3.4",
+  "version": "2.3.5",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [2.3.5] - 2026-06-19
+
+### Added
+
+- **Added:** Automated publishing to the official [MCP Registry](https://registry.modelcontextprotocol.io/) (`io.github.darylmcd/roslyn-mcp`) on release tags via GitHub OIDC — the `publish-nuget` workflow now publishes `server.json` once the NuGet package is live. Adds the registry ownership marker to the packaged README, trims the manifest `description` to the 100-char schema limit, and hardens `eng/verify-registry-readiness.ps1` to catch both gaps. Closes `mcp-registry-submission`.
+
 ## [2.3.4] - 2026-06-18
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>2.3.4</Version>
+    <Version>2.3.5</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/mcp-registry-submission.md
+++ b/changelog.d/mcp-registry-submission.md
@@ -1,5 +1,0 @@
----
-category: Added
----
-
-- **Added:** Automated publishing to the official [MCP Registry](https://registry.modelcontextprotocol.io/) (`io.github.darylmcd/roslyn-mcp`) on release tags via GitHub OIDC — the `publish-nuget` workflow now publishes `server.json` once the NuGet package is live. Adds the registry ownership marker to the packaged README, trims the manifest `description` to the 100-char schema limit, and hardens `eng/verify-registry-readiness.ps1` to catch both gaps. Closes `mcp-registry-submission`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
Version bump 2.3.4 → 2.3.5.

Ships the MCP Registry publish automation merged in #975: the `v2.3.5` tag will push `Darylmcd.RoslynMcp` to NuGet and then publish `io.github.darylmcd/roslyn-mcp` to the official MCP Registry via GitHub OIDC.

See CHANGELOG.md `## [2.3.5]` for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)