### PR TITLE
docs(plan): persist top-n-remediation session plan + retrospective (5/5) + 4 spillover rows

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-06-20T04:02:45Z
+**updated_at:** 2026-06-20T04:18:39Z
 
 ## Agent contract
 
@@ -84,6 +84,10 @@
 | `backlog-d-fragment-schema` | Low | — | **Relocate the backlog.d fragment-schema doc out of items/** — it is a canonical cross-repo schema (cited by shipped `skills/mcp-server-surface-test` prompt + `.claude/skills/backlog-intake`), not row detail; move it and update referrers in one PR. [type: docs] [source: v15-migration-20260611] | S | items/backlog-d-fragment-schema.md |
 | `workspace-auto-load-on-demand-design` | Low | — | **Retire the shipped auto-load design spec** — after `/reconcile-plans` GCs plan `20260609T134405Z`, fold residual unimplemented sections into the full-sweep row and delete the doc. [type: docs] [source: v15-migration-20260611] | S | items/workspace-auto-load-on-demand-design.md |
 | `move-to-git-issues` | Low | — | **Disposition the parked move-to-git-issues design** — rows 1-3 shipped v1.35.1; decide row 4 + the doc's 4 open questions (file rows or record won't-do), then retire the doc. [type: docs] [source: v15-migration-20260611] | S | items/move-to-git-issues.md |
+| `filewatcher-watcherentry-watchers-unguarded-mutation` | Low | — | **WatcherEntry._watchers mutated without synchronization** — `AddWatcher` does `_watchers.Add` on an unguarded `List<FileSystemWatcher>` while the rest of the type is `_reasonLock`-guarded. Benign today (single-threaded `Watch()`); document the invariant or guard. [type: bug] [source: 2026-06-20 top-n row-1 finding] | S | items/filewatcher-watcherentry-watchers-unguarded-mutation.md |
+| `filewatcher-class-xmldoc-truncated` | Low | — | **FileWatcherService class XML doc clause is truncated** — the class-level `<para>` (`FileWatcherService.cs:~25`) ends "…server apply paths that want to preserve their attribution mark after the on-disk commit settles." with no main verb — a dropped clause. Complete or trim it. [type: docs] [source: 2026-06-20 top-n row-1 implementer finding] | S | items/filewatcher-class-xmldoc-truncated.md |
+| `ci-policy-cache-version-stale-cite` | Low | — | **CI_POLICY.md cites a stale actions/cache version** — `CI_POLICY.md:12` says `actions/cache@v4` but `ci.yml:96` uses `actions/cache@v5`; sync the cite. [type: docs] [source: 2026-06-20 top-n row-2 implementer finding] | S | items/ci-policy-cache-version-stale-cite.md |
+| `nuget-checker-timeout-test-bound-couple-to-httptimeout` | Low | — | **Couple the NuGet timeout-test wait bound to HttpTimeout** — the 30s hang-guard literal's `>> HttpTimeout(3s)` coupling is prose-only; derive it from a multiple of HttpTimeout, or close won't-fix. [type: test] [source: 2026-06-20 top-n row-4 cq] | S | items/nuget-checker-timeout-test-bound-couple-to-httptimeout.md |
 
 ## Defer
 

--- a/ai_docs/items/ci-policy-cache-version-stale-cite.md
+++ b/ai_docs/items/ci-policy-cache-version-stale-cite.md
@@ -1,0 +1,20 @@
+# ci-policy-cache-version-stale-cite — CI_POLICY.md cites a stale actions/cache version
+
+**row:** `ci-policy-cache-version-stale-cite` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `CI_POLICY.md:12` (`The NuGet-packages cache (`actions/cache@v4` against ~/.nuget/packages) …`)
+- `.github/workflows/ci.yml:96` (`uses: actions/cache@v5`)
+
+## Acceptance
+
+- [ ] `CI_POLICY.md`'s cache cite matches the version actually pinned in `ci.yml` (`actions/cache@v5`), so the validation doc no longer describes a stale action version.
+
+## Evidence
+
+- Row-2 implementer finding (2026-06-20 top-n-remediation, `ci-vuln-gate-format-json-hardening`): `CI_POLICY.md:12` references `actions/cache@v4` while `ci.yml:96` uses `actions/cache@v5`. Pre-existing drift, unrelated to the vuln-gate change.
+
+## Context
+
+One-line doc cite fix. `verify-ai-docs.ps1` does not flag this (the cache key description is prose, not a tracked symbol), so it persisted. Trivial; bundle with the next CI-doc touch.

--- a/ai_docs/items/filewatcher-class-xmldoc-truncated.md
+++ b/ai_docs/items/filewatcher-class-xmldoc-truncated.md
@@ -1,0 +1,19 @@
+# filewatcher-class-xmldoc-truncated — FileWatcherService class XML doc clause is truncated
+
+**row:** `filewatcher-class-xmldoc-truncated` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Roslyn/Services/FileWatcherService.cs` — the class-level `<para>` block (~lines 22-27), ending: "…server apply paths that want to preserve their attribution mark after the on-disk commit settles."
+
+## Acceptance
+
+- [ ] The class XML-doc sentence is completed (supply the missing main clause) or trimmed so it reads as a grammatical statement; no dropped-clause fragment remains.
+
+## Evidence
+
+- Row-1 implementer finding (2026-06-20 top-n-remediation, `filewatcher-waitforstale-clearstale-stranded-awaiter`): the clause "…server apply paths that want to preserve their attribution mark after the on-disk commit settles." has no main verb — it sets up a subject ("server apply paths that want to preserve…") and trails off, reading as if a clause was dropped during an edit.
+
+## Context
+
+Cosmetic doc-comment fix, 1 file. Worth doing when next editing `FileWatcherService` to keep the (otherwise detailed and load-bearing) class documentation accurate.

--- a/ai_docs/items/filewatcher-watcherentry-watchers-unguarded-mutation.md
+++ b/ai_docs/items/filewatcher-watcherentry-watchers-unguarded-mutation.md
@@ -1,0 +1,21 @@
+# filewatcher-watcherentry-watchers-unguarded-mutation — WatcherEntry._watchers mutated without synchronization
+
+**row:** `filewatcher-watcherentry-watchers-unguarded-mutation` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Roslyn/Services/FileWatcherService.cs:181` (`private readonly List<FileSystemWatcher> _watchers = [];`)
+- `src/RoslynMcp.Roslyn/Services/FileWatcherService.cs:208` (`public void AddWatcher(FileSystemWatcher watcher) => _watchers.Add(watcher);`)
+
+## Acceptance
+
+- [ ] `WatcherEntry._watchers` mutation is either documented as single-threaded-by-construction (a load-bearing comment on `AddWatcher` stating it is only called from `Watch()` before `EnableRaisingEvents`), OR guarded consistently with the rest of the type (`_reasonLock` or a dedicated lock) if any concurrent-mutation path is introduced.
+- [ ] If guarding: a regression test exercises concurrent `AddWatcher`/`Dispose` and asserts no `InvalidOperationException`/torn state.
+
+## Evidence
+
+- Row-1 implementer finding (2026-06-20 top-n-remediation, `filewatcher-waitforstale-clearstale-stranded-awaiter`): `AddWatcher` does `_watchers.Add(...)` on a plain `List<FileSystemWatcher>` with no synchronization, while `Dispose` and the `FileSystemWatcher` event callbacks touch entry state from dispatch threads. The rest of `WatcherEntry` is explicitly `_reasonLock`-protected — this is the lone unguarded mutable collection on the type.
+
+## Context
+
+Currently benign: `AddWatcher` is only ever called single-threaded from `Watch()` before `EnableRaisingEvents` matters, so no concurrent mutation occurs today. The risk is an inconsistency a future caller could trip. Smallest fix is likely a load-bearing comment documenting the invariant; full guarding only if a concurrent path is added.

--- a/ai_docs/items/nuget-checker-timeout-test-bound-couple-to-httptimeout.md
+++ b/ai_docs/items/nuget-checker-timeout-test-bound-couple-to-httptimeout.md
@@ -1,0 +1,21 @@
+# nuget-checker-timeout-test-bound-couple-to-httptimeout — couple the test wait bound to HttpTimeout instead of a literal
+
+**row:** `nuget-checker-timeout-test-bound-couple-to-httptimeout` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `tests/RoslynMcp.Tests/NuGetVersionCheckerTests.cs:122` (`await pending.WaitAsync(TimeSpan.FromSeconds(30))` — the hang-guard bound in `WaitForCompletionAsync`)
+- `src/RoslynMcp.Host.Stdio/Services/NuGetVersionChecker.cs:58` (`private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(3);`)
+
+## Acceptance
+
+- [ ] `WaitForCompletionAsync`'s hang-guard bound is derived mechanically from `NuGetVersionChecker.HttpTimeout` (e.g. a fixed multiple) rather than a standalone `30` literal, so the documented `>> HttpTimeout` invariant survives a future `HttpTimeout` change without a silent margin erosion.
+- [ ] OR: if exposing `HttpTimeout` (currently `private static`) as `internal` + `[InternalsVisibleTo]` is judged not worth the production-visibility widening, close won't-fix with that rationale recorded — the existing load-bearing prose comment is then the accepted control.
+
+## Evidence
+
+- Row-4 code-quality finding (2026-06-20 top-n-remediation, `nuget-version-checker-timeout-test-wallclock-race`): the de-flake fix raised the bound to a `30 s` literal; its `>> HttpTimeout (3 s)` coupling is documented in a comment but cannot be enforced in code because `HttpTimeout` is `private static` (not test-visible). A future `HttpTimeout` bump silently erodes the margin with no compile-time link.
+
+## Context
+
+Deferred from row 4 (a test-only size-S row) because the structurally-tighter fix touches **production visibility** — out of that row's scope (Directive #6). The 30 s bound is ~10× the 3 s internal timeout, so the margin is robust today; this row is a hardening/maintainability follow-on, not a correctness gap.

--- a/ai_docs/plans/20260620T021145Z_top-n-remediation/plan.md
+++ b/ai_docs/plans/20260620T021145Z_top-n-remediation/plan.md
@@ -1,0 +1,91 @@
+# Top-N Remediation Session Plan — 20260620T021145Z
+
+**Invocation:** `/top-n-remediation` (no args) → N=5, autonomous (no `gate=ask`), no `budget-minutes`, no `resume`, no `contextPct`.
+**Backlog snapshot:** `ai_docs/backlog.md` `updated_at: 2026-06-19T21:59:45Z` (35 open rows).
+**Preflight:** `main` clean + synced; no rebase/merge; `gh` authed (`repo` scope); coreutils on PATH. Orphan-PR sweep: 5 open PRs (#981–985) all Dependabot NuGet bumps — **no backlog-id PRs**, exclusion set empty. Plan-collision: `20260618T143921Z_backlog-sweep` all 8 initiatives `merged`/terminal → `OWNED_BY_ACTIVE_PLAN` empty.
+
+## Selection
+
+| id | rank | reasons | estimated file touches |
+|----|------|---------|------------------------|
+| `filewatcher-waitforstale-clearstale-stranded-awaiter` | 1 | Medium, shovel-ready S bug (0/0 signals). `ClearStale` swaps `_staleSignal` TCS without completing it → awaiter stranded to its CT deadline. Latent prod trap. | 2 (`FileWatcherService.cs` + staleness test) |
+| `ci-vuln-gate-format-json-hardening` | 2 | Medium, shovel-ready S ci (0/0). Blocking vuln gate keys on English substring → locale/SDK-wording drift silently fails-open. Switch to `--format json`. | 1 (`.github/workflows/ci.yml`) |
+| `publish-nuget-verify-package-types` | 3 | Medium, shovel-ready S ci (0/0). Verify step only size-checks nupkg; a csproj regression dropping `<PackageType>McpServer</PackageType>` / `.mcp/server.json` ships a tool-only pkg on green CI. | 1–2 (`publish-nuget.yml`; reads csproj) |
+| `nuget-version-checker-timeout-test-wallclock-race` | 4 | Medium, shovel-ready S test (0/0). Release-gating flake **recurrence**: helper's 5 s wall-clock `WaitAsync` races checker's internal timeout. Root-cause = event-driven wait, not constant bump. | 1 (`NuGetVersionCheckerTests.cs`) |
+| `dependabot-groups-batching` | 5 | Low, shovel-ready S ci (0/0). No `groups:` → every minor/patch bump = own PR. Add per-ecosystem grouping; keep majors individual. | 1 (`.github/dependabot.yml`) |
+
+## Per-row state
+
+- `filewatcher-waitforstale-clearstale-stranded-awaiter`: landed (PR #994 squash-merged → main ef6aad6; CI validate PASS 15m37s; branch+worktree clean)
+- `ci-vuln-gate-format-json-hardening`: landed (PR #995 squash-merged → main 08d8c46; CI validate PASS 14m39s, new JSON gate ran live; clean)
+- `publish-nuget-verify-package-types`: landed (PR #996 squash-merged → main 87c16ef; CI validate PASS 13m29s; clean)
+- `nuget-version-checker-timeout-test-wallclock-race`: landed (PR #997 squash-merged → main 0e989d0; CI validate PASS 14m5s, de-flaked test passed; clean)
+- `dependabot-groups-batching`: landed (PR #998 squash-merged → main 13420d2; CI validate PASS 11m40s; clean)
+
+States: `selected → implemented → reviewed → pr-open → landed`; terminal `skipped:<why>` / `ship-failed:<why>`.
+
+## Ship strategy
+
+**Immediate-land per row, rank order 1→5** (ship-loop §Autonomous batch policy, default mode). Rationale: rows touch fully disjoint files (no conflict-ordering benefit from batch-land); single self-hosted runner serializes CI regardless; immediate-land keeps the runner idle during each row's local impl work (honors the no-double-load constraint) and cuts each branch from a fresh `main`.
+
+**Validation:** light targeted local checks per row (Roslyn `compile_check` + targeted `test_run --filter` for C# rows; YAML logic review for workflow rows) — **the PR CI on the self-hosted runner is the authoritative gate** (`watch-pr` to green before merge). Full `verify-release.ps1` is NOT run locally (single-runner no-double-load).
+
+**Batch-aware expected-reds:** row #4 fixes a known transient flake (`NuGetVersionCheckerTests.GetLatestVersion_OnTimeout_...`) that runs in `verify-release.ps1` and gates every PR. Until #4 lands, it may transiently redden siblings' CI → classify as **known-flake**, re-run, do not treat as a real red. No other cross-row reds (disjoint files).
+
+**Excluded from autonomous batch (surfaced for operator):** `parameter-naming-canonicalization-migration` and `apply-composite-preview-destructive-misnomer` are size-safe but BREAKING published-surface (Directive #4 → ADR + migration note + operator timing).
+
+## Spillover backlog rows to file (Directive #3 — file in session-end docs PR)
+
+Discovered while implementing selected rows; kept out of per-row PRs to preserve scope.
+
+- **(from row 1)** `filewatcher-watcherentry-watchers-unguarded-mutation` — Low/S: `WatcherEntry.AddWatcher` (`FileWatcherService.cs:208`) mutates a plain `List<FileSystemWatcher>` with no lock while the rest of the type is `_reasonLock`-guarded; benign today (single-threaded `Watch()` caller) but an inconsistency a future caller could trip. ≤1 prod + ≤1 test, one regression shape.
+- **(from row 1)** `filewatcher-class-xmldoc-truncated` — Low/XS docs: `FileWatcherService` class XML doc (lines ~22-26) ends mid-sentence ("…after the on-disk commit settles.") — a dropped clause; stale/incomplete doc comment.
+- **(from row 2)** `ci-policy-cache-version-stale-cite` — Low/XS docs: `CI_POLICY.md:12` cites `actions/cache@v4` but `ci.yml:96` uses `actions/cache@v5` — stale version reference in the policy doc (pre-existing, unrelated to the vuln-gate change).
+- **(from row 4)** `nuget-checker-timeout-test-bound-couple-to-httptimeout` — Low/S: `WaitForCompletionAsync`'s 30s hang-guard bound (`NuGetVersionCheckerTests.cs:122`) is a standalone literal; the `>> HttpTimeout(3s)` coupling is prose-only. Optionally make `HttpTimeout` internal + InternalsVisibleTo and derive the bound as a multiple, OR close won't-fix (comment as accepted control). Touches prod visibility → out of the test-only row's scope.
+
+## Final step
+
+After all rows land: confirm `ai_docs/backlog.md` rows closed (each via `/close-backlog-rows` during its ship), `updated_at` bumped, zero open PRs, clean tracking `main`. Append `## Retrospective` here.
+
+## Retrospective
+
+**Outcome: 5/5 shipped.** Zero open PRs; `main` clean + synced at `13420d2`; every feature branch (local + remote) pruned and verified gone.
+
+### Shipped table
+
+| Rank | Row id | PR | Squash-merge commit | CI validate | Reviews |
+|------|--------|----|--------------------|-------------|---------|
+| 1 | `filewatcher-waitforstale-clearstale-stranded-awaiter` | [#994](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/994) | `ef6aad6` | PASS 15m37s | spec PASS · cq PASS |
+| 2 | `ci-vuln-gate-format-json-hardening` | [#995](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/995) | `08d8c46` | PASS 14m39s (new JSON gate ran live) | spec PASS · cq PASS (after in-PR stderr-isolation fix) |
+| 3 | `publish-nuget-verify-package-types` | [#996](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/996) | `87c16ef` | PASS 13m29s | spec PASS · cq PASS (after in-PR disposal-nit fix) |
+| 4 | `nuget-version-checker-timeout-test-wallclock-race` | [#997](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/997) | `0e989d0` | PASS 14m5s (de-flaked test ran live) | spec PASS · cq PASS |
+| 5 | `dependabot-groups-batching` | [#998](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/998) | `13420d2` | PASS 11m40s | spec PASS · cq PASS |
+
+Skipped: none of the selected 5. (Selection-stage skips: see §Selection rationale — 5 sweep-shaped L/plan-pointer rows + 2 BREAKING published-surface rows excluded.)
+
+### Gate evidence (Directive #7)
+
+- **Per-row local pre-check:** targeted `dotnet build` + `dotnet test --filter` (rows 1, 4) / `dotnet package list --format json` + synthetic-fail pwsh (row 2) / local `dotnet pack` + unzip pass+both-fail-path proofs (row 3) / `yaml.safe_load` schema parse (row 5). Outputs are in each implementer's returned report (transcript) + summarized in each PR body.
+- **Authoritative gate:** each PR's `verify-release.ps1` `validate` job on the self-hosted runner (times above), polled green via `gh pr checks --watch` before merge. Full `verify-release.ps1` was NOT run locally (single-self-hosted-runner no-double-load).
+- **Batch expected-reds:** row 4's known NuGetVersionChecker timeout flake was the only cross-row red risk (runs in `verify-release.ps1`, gates every PR). It did NOT trip on any sibling PR's CI this session, and row 4's fix (now landed) removes it structurally. No red required known-flake reclassification.
+
+### Budget accounting (vs §Session budget ceilings, N=5)
+
+- **Rows implemented:** 5 / 5 ceiling. ✅
+- **Subagent spawns:** 18 / ≈19 ceiling (3N+4). Breakdown: prep 1 + selector 1 + [row1 3, row2 4 (one cq re-review after the in-PR stderr fix), row3 3, row4 3, row5 3]. ✅ (just under)
+- **gh operations:** ~26 (5× pr-create + 5× watch + 5× merge + ~11 view/checks/ls-remote/orphan-sweep) / ≈40 ceiling (8N). ✅
+- **Wall clock:** unbounded (no `budget-minutes`); dominated by 5 serial `validate` runs (~69 min CI) on the single self-hosted runner.
+
+### Directive #3 call-outs filed (this docs PR)
+
+4 spillover backlog rows added (Low), discovered during implementation, kept out of per-row PRs to preserve scope:
+1. `filewatcher-watcherentry-watchers-unguarded-mutation` (S) — `FileWatcherService.cs:181/208` unguarded `_watchers` List mutation vs lock-protected rest of type.
+2. `filewatcher-class-xmldoc-truncated` (XS docs) — `FileWatcherService.cs:~25` class XML doc clause ends with no verb.
+3. `ci-policy-cache-version-stale-cite` (XS docs) — `CI_POLICY.md:12` cites `actions/cache@v4`; `ci.yml:96` uses `@v5`.
+4. `nuget-checker-timeout-test-bound-couple-to-httptimeout` (S) — `NuGetVersionCheckerTests.cs:122` 30s bound is a literal; `>> HttpTimeout(3s)` coupling is prose-only (fixing requires prod-visibility widening, out of the test-only row's scope).
+
+### Notes / handoffs
+
+- **Operator-decision rows (NOT shipped — Directive #4):** `parameter-naming-canonicalization-migration` + `apply-composite-preview-destructive-misnomer` are size-safe but BREAKING published-surface changes needing an ADR + migration note + operator timing. Surfaced, not touched.
+- **Plan-cleanup candidates** (`/reconcile-plans`): `20260618T143921Z_backlog-sweep` (all 8 merged), `20260619T180315Z_top-n-remediation` (prior run, complete), `audit-21-analyzers` (stale May-28 Draft). This plan dir joins the GC pool once its rows are confirmed shipped.
+- **Upstream-refresh recommendation:** None — backlog still has implementation-ready rows.


### PR DESCRIPTION
Session-close artifact for the `20260620T021145Z` top-n-remediation run (**5/5 shipped**, PRs #994–#998).

## What this adds (all docs-only)
- **`ai_docs/plans/20260620T021145Z_top-n-remediation/plan.md`** — the persisted session plan with the `## Selection` table, per-row state lines (all `landed`), and the required `## Retrospective` (shipped table with PR + merge-commit pointers, gate evidence, subagent/gh budget accounting, Directive #3 call-outs). Dir name matches the `*remediation/` glob so `/backlog-sweep:status` + `/reconcile-plans` recognize it.
- **4 Directive #3 spillover backlog rows** (Low) + their `items/<id>.md`, surfaced during implementation and kept out of the per-row PRs to preserve scope:
  - `filewatcher-watcherentry-watchers-unguarded-mutation` (S) — unguarded `_watchers` List mutation vs the lock-protected rest of the type.
  - `filewatcher-class-xmldoc-truncated` (S docs) — class XML-doc clause ends with no verb.
  - `ci-policy-cache-version-stale-cite` (S docs) — `CI_POLICY.md` cites `actions/cache@v4`; `ci.yml` uses `@v5`.
  - `nuget-checker-timeout-test-bound-couple-to-httptimeout` (S) — 30s test bound's coupling to `HttpTimeout(3s)` is prose-only (a tighter fix needs prod-visibility widening, deferred from the test-only row 4).

## Validation
Docs-only diff (every path is `.md`) → CI skips `verify-release.ps1`. `verify-ai-docs.ps1` + skills-genericity run locally green; `backlog-lint` 0 ERROR; all 4 new ids resolve via `backlog.mjs get`.