### PR TITLE
refactor(compcache): route TestReferenceMapService + ReferenceService reads through ICompilationCache (compcache-batch-a-core-reference-reads)

### DIFF
--- a/changelog.d/compcache-batch-a-core-reference-reads.md
+++ b/changelog.d/compcache-batch-a-core-reference-reads.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Routed `TestReferenceMapService` and `ReferenceService` live-solution compilation reads through the shared `ICompilationCache` (3 sites) — batch a of the ongoing compilation-cache read-side adoption, for guaranteed cross-call compilation sharing under GC pressure + in-flight dedup. Covered by two new recording-cache adoption tests (`compilation-cache-adoption-read-side`, partial).

--- a/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ReferenceService.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,11 +15,13 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class ReferenceService : IReferenceService, IPreResolvedReferenceService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<ReferenceService> _logger;
 
-    public ReferenceService(IWorkspaceManager workspace, ILogger<ReferenceService> logger)
+    public ReferenceService(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<ReferenceService> logger)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -216,7 +219,7 @@ public sealed class ReferenceService : IReferenceService, IPreResolvedReferenceS
         // interface declaration (`IAnimal.Speak`) and produces the same sibling set.
         var promoted = PromoteToVirtualRoot(symbol);
 
-        var siblings = await FindInterfaceMemberImplementationsAsync(promoted, solution, ct).ConfigureAwait(false);
+        var siblings = await FindInterfaceMemberImplementationsAsync(workspaceId, promoted, solution, ct).ConfigureAwait(false);
 
         return siblings
             .Distinct(SymbolEqualityComparer.Default)
@@ -228,7 +231,8 @@ public sealed class ReferenceService : IReferenceService, IPreResolvedReferenceS
             .ToList();
     }
 
-    private static async Task<IReadOnlyList<ISymbol>> FindInterfaceMemberImplementationsAsync(
+    private async Task<IReadOnlyList<ISymbol>> FindInterfaceMemberImplementationsAsync(
+        string workspaceId,
         ISymbol symbol,
         Solution solution,
         CancellationToken ct)
@@ -242,7 +246,7 @@ public sealed class ReferenceService : IReferenceService, IPreResolvedReferenceS
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null)
             {
                 continue;

--- a/src/RoslynMcp.Roslyn/Services/TestReferenceMapService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TestReferenceMapService.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -14,10 +15,12 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class TestReferenceMapService : ITestReferenceMapService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
 
-    public TestReferenceMapService(IWorkspaceManager workspace)
+    public TestReferenceMapService(IWorkspaceManager workspace, ICompilationCache compilationCache)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
     }
 
     public async Task<TestReferenceMapDto> BuildAsync(
@@ -38,13 +41,13 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
         // Phase 2: collect every public/internal productive-symbol declaration from the
         // productive-scope projects (all non-test projects by default, or the named project
         // when projectName identifies a productive project).
-        var allProductive = await CollectProductiveSymbolsAsync(productiveScopeProjects, ct)
+        var allProductive = await CollectProductiveSymbolsAsync(workspaceId, productiveScopeProjects, ct)
             .ConfigureAwait(false);
 
         // Phase 3: walk each test project's test methods and record references to
         // productive symbols.
         var (productiveSymbols, scannedTestProjects) = await RecordTestProjectReferencesAsync(
-            solution, testScanProjects, testProjectIds, allProductive, ct).ConfigureAwait(false);
+            workspaceId, solution, testScanProjects, testProjectIds, allProductive, ct).ConfigureAwait(false);
 
         var notes = new List<string>();
         if (scannedTestProjects.Count == 0)
@@ -140,14 +143,15 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
     /// source. Projects that cannot produce a compilation are skipped (matches the pre-refactor
     /// behavior).
     /// </summary>
-    private static async Task<HashSet<string>> CollectProductiveSymbolsAsync(
+    private async Task<HashSet<string>> CollectProductiveSymbolsAsync(
+        string workspaceId,
         IReadOnlyList<Project> productiveScopeProjects,
         CancellationToken ct)
     {
         var allProductive = new HashSet<string>(StringComparer.Ordinal);
         foreach (var project in productiveScopeProjects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
             CollectProductiveSymbols(compilation.GlobalNamespace, allProductive);
         }
@@ -161,7 +165,8 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
     /// public/internal/protected accessibility and appears in <paramref name="allProductive"/>.
     /// Returns the symbol→testMethodNames map plus the list of test projects actually scanned.
     /// </summary>
-    private static async Task<(Dictionary<string, HashSet<string>> ProductiveSymbols, List<string> ScannedTestProjects)> RecordTestProjectReferencesAsync(
+    private async Task<(Dictionary<string, HashSet<string>> ProductiveSymbols, List<string> ScannedTestProjects)> RecordTestProjectReferencesAsync(
+        string workspaceId,
         Solution solution,
         IReadOnlyList<Project> scopedProjects,
         HashSet<ProjectId> testProjectIds,
@@ -175,7 +180,7 @@ public sealed class TestReferenceMapService : ITestReferenceMapService
         {
             ct.ThrowIfCancellationRequested();
             scannedTestProjects.Add(testProject.Name);
-            var compilation = await testProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, testProject, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var document in testProject.Documents)

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Services;
 
@@ -13,7 +14,8 @@ namespace RoslynMcp.Tests;
 /// rather than calling <c>project.GetCompilationAsync</c> directly. Batch 1 covered
 /// <see cref="CouplingAnalysisService"/>, <see cref="ExceptionFlowService"/>, and
 /// <see cref="AnalyzerInfoService"/>; batch 2 adds <see cref="TypeConsumersService"/>,
-/// <see cref="CodePatternAnalyzer"/>, and <see cref="SymbolSearchService"/>.
+/// <see cref="CodePatternAnalyzer"/>, and <see cref="SymbolSearchService"/>; group-a core adds
+/// <see cref="TestReferenceMapService"/> and <see cref="ReferenceService"/>.
 /// <para>
 /// A reference-equality check alone cannot prove adoption — Roslyn memoizes a
 /// <see cref="Compilation"/> on its owning <see cref="Project"/>, so two direct calls would also
@@ -135,6 +137,50 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
                 kindFilter: null,
                 namespaceFilter: null,
                 maxResults: 100,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task TestReferenceMapService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new TestReferenceMapService(WorkspaceManager, cache);
+
+        // BuildAsync routes BOTH converted sites: CollectProductiveSymbolsAsync (productive-scope
+        // projects) and RecordTestProjectReferencesAsync (the test projects). Either path alone
+        // is enough to drive the call count above zero.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.BuildAsync(
+                workspace.WorkspaceId,
+                projectName: null,
+                offset: 0,
+                limit: 500,
+                maxMockDriftWarnings: 50,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task ReferenceService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new ReferenceService(WorkspaceManager, cache, NullLogger<ReferenceService>.Instance);
+
+        // FindSiblingInterfaceImplementationsAsync -> FindInterfaceMemberImplementationsAsync is the
+        // converted site. Anchor on the IAnimal.Speak interface member so the walk runs the
+        // per-project compilation fetch through the cache (SampleLib.Dog implements IAnimal.Speak).
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var animalFile = solution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "IAnimal.cs");
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.FindSiblingInterfaceImplementationsAsync(
+                workspace.WorkspaceId,
+                SymbolLocator.BySource(animalFile.FilePath!, 6, 13),
                 CancellationToken.None));
 
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -88,6 +88,7 @@ internal sealed class TestServiceContainer
             NullLogger<GatedCommandExecutor>.Instance);
         var referenceService = new ReferenceService(
             workspaceManager,
+            compilationCache,
             NullLogger<ReferenceService>.Instance);
         var mutationAnalysisService = new MutationAnalysisService(workspaceManager);
         var codeFixRegistry = new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance);

--- a/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
+++ b/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     {
         InitializeServices();
         WorkspaceId = await GetOrLoadWorkspaceIdAsync(SampleSolutionPath, CancellationToken.None);
-        Service = new TestReferenceMapService(WorkspaceManager);
+        Service = new TestReferenceMapService(WorkspaceManager, new CompilationCache(WorkspaceManager));
     }
 
     [TestMethod]


### PR DESCRIPTION
Backlog-sweep initiative `compcache-batch-a-core-reference-reads` — batch **a** (group-a core) of the open row `compilation-cache-adoption-read-side`.

**Closes:** none — this is a deliberate **partial** adoption batch; the parent row stays open for the remaining a-tail / group-b / group-c (forked-solution hazard) work (operator-scoped to the low-risk subset this run).

## Change
Route the three live-solution `project.GetCompilationAsync(ct)` reads in `TestReferenceMapService` (2 sites) and `ReferenceService` (1 site) through the shared `ICompilationCache` (`_compilationCache.GetCompilationAsync(workspaceId, project, ct)`), mirroring the already-shipped batch-1 `CouplingAnalysisService` pattern. Both call paths were verified live-solution-only (`GetCurrentSolution(workspaceId)`), so the group-c forked-solution gating does not apply here. The three private helpers dropped `static` and thread `workspaceId`; no DI edit (type-based registrations resolve the new ctor param).

## Validation
- `dotnet build` (Release) of `RoslynMcp.Roslyn` + `RoslynMcp.Tests`: 0 warnings / 0 errors.
- Targeted: `dotnet test --filter "CompilationCacheAdoptionTests|TestReferenceMapServiceTests"` → **18 passed / 0 failed** (incl. 2 new recording-cache adoption tests asserting cache routing + warm reuse).
- Zero remaining raw `project.GetCompilationAsync` in both prod files.
- Full `verify-release.ps1` runs here as the PR CI gate.

## Review
Plan adversarial-reviewed (passed, 0 findings); diff spec-compliance + code-quality reviewed (both pass, no findings). Scope: 2 prod + 3 test files (Rules 3/4).

Plan: `ai_docs/plans/20260620T215409Z_backlog-sweep/`.