### PR TITLE
fix(security): nuget_vulnerability_scan progress stage + cache-hit regression test

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
@@ -65,6 +65,10 @@ public static class SecurityTools
         return gate.RunReadAsync(workspaceId, async c =>
         {
             ProgressHelper.Report(progress, 0, 1);
+            // nuget_vulnerability_scan shells out to `dotnet list package --vulnerable`, which is
+            // network-bound (api.nuget.org). Emit a stage label between the start and the await so
+            // MCP clients can distinguish an active scan from a hang while the CLI runs.
+            ProgressHelper.ReportStage(progress, 0, 1, "scanning-nuget");
             var result = await nuGetDependencyService.ScanNuGetVulnerabilitiesAsync(workspaceId, projectName, includeTransitive, c);
             ProgressHelper.Report(progress, 1, 1);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);

--- a/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs
@@ -176,6 +176,59 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : SharedWorkspaceTest
         Assert.IsTrue(transitivePackage.IsTransitive);
     }
 
+    [TestMethod]
+    public async Task ScanNuGetVulnerabilities_WithStubbedExecutor_WarmCallHitsCache()
+    {
+        // nuget-vuln-scan-caching regression: a second scan with identical (projectFilter,
+        // includeTransitive) on the same workspace version must short-circuit on the cache and
+        // NOT shell out to `dotnet list package --vulnerable` a second time. Asserting on the
+        // executor invocation count (not equal results) is the discriminating check — equal
+        // results could also arise from a re-run that returns the same canned payload.
+        const string cannedJson = """
+{
+  "version": 1,
+  "parameters": "--vulnerable --format json",
+  "projects": [
+    {
+      "path": "/repo/SampleApp/SampleApp.csproj",
+      "frameworks": [
+        {
+          "framework": "net10.0",
+          "topLevelPackages": [
+            {
+              "id": "Vulnerable.PackageA",
+              "resolvedVersion": "1.0.0",
+              "vulnerabilities": [
+                { "severity": "High", "advisoryurl": "https://example/A" }
+              ]
+            }
+          ],
+          "transitivePackages": []
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        var stubExecutor = new StubGatedCommandExecutor(cannedJson);
+        var service = new NuGetDependencyService(
+            WorkspaceManager,
+            stubExecutor,
+            new MsBuildEvaluationService(WorkspaceManager),
+            NullLogger<NuGetDependencyService>.Instance);
+
+        var cold = await service.ScanNuGetVulnerabilitiesAsync(
+            WorkspaceId, projectFilter: null, includeTransitive: false, CancellationToken.None);
+        var warm = await service.ScanNuGetVulnerabilitiesAsync(
+            WorkspaceId, projectFilter: null, includeTransitive: false, CancellationToken.None);
+
+        Assert.AreEqual(1, stubExecutor.ExecuteCallCount,
+            "The warm call must hit the cache and not re-invoke the dotnet CLI.");
+        Assert.AreSame(cold, warm,
+            "The warm call should return the cached result instance from the cold call.");
+    }
+
     /// <summary>
     /// Hand-rolled stub for <see cref="IGatedCommandExecutor"/> that returns a canned
     /// stdout payload without invoking the dotnet CLI. Used by the air-gapped vulnerability
@@ -191,6 +244,13 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : SharedWorkspaceTest
             _cannedStdOut = cannedStdOut;
         }
 
+        /// <summary>
+        /// Number of times <see cref="ExecuteAsync"/> was invoked. The cache-hit regression test
+        /// asserts this stays at 1 across two identical scan calls — a warm call must short-circuit
+        /// before shelling out to <c>dotnet list package --vulnerable</c>.
+        /// </summary>
+        public int ExecuteCallCount { get; private set; }
+
         public Task<CommandExecutionDto> ExecuteAsync(
             string workspaceId,
             string targetPath,
@@ -198,6 +258,7 @@ public sealed class NuGetVulnerabilityScanIntegrationTests : SharedWorkspaceTest
             TimeSpan timeout,
             CancellationToken ct)
         {
+            ExecuteCallCount++;
             return Task.FromResult(new CommandExecutionDto(
                 Command: "dotnet",
                 Arguments: arguments,


### PR DESCRIPTION
## Summary

Closes the two remaining gaps on the `nuget_vulnerability_scan` budget row. The caching layer (result cache keyed on `(workspaceVersion, projectFilter, includeTransitive, lockfileHash)`) and configurable timeout already shipped in an earlier remediation pass; this PR adds the missing progress-stage signal and a cache-hit regression test.

## Changes

- **`src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs`** — emit `ProgressHelper.ReportStage(progress, 0, 1, "scanning-nuget")` between the initial `Report(0,1)` and the network-bound `ScanNuGetVulnerabilitiesAsync` await, matching the `workspace_load` / `workspace_warm` / `build_workspace` / `test_run` stage-label pattern. Clients can now distinguish an active scan from a hang. Progress emission goes from 2 → 3 notifications (advisory only).
- **`tests/RoslynMcp.Tests/NuGetVulnerabilityScanIntegrationTests.cs`** — add `ScanNuGetVulnerabilities_WithStubbedExecutor_WarmCallHitsCache`: a counting `StubGatedCommandExecutor` proves a second identical scan short-circuits on the cache (`ExecuteAsync` invoked exactly once), locking in the already-shipped caching layer. Asserts on invocation count + result identity, not equal-results.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors).
- `dotnet test --filter "FullyQualifiedName~NuGetVulnerabilityScanIntegrationTests&TestCategory!=Network"` — 3/3 pass (the live `[TestCategory("Network")]` test is excluded; air-gapped CI parity).
- Stage ordering verified: `Report(0,1)` → `ReportStage(scanning-nuget)` → await → `Report(1,1)`.

Closes: nuget-vuln-scan-exceeds-budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)