### PR TITLE
fix(workspace): split build-required from restore-required state (restore-required-vs-build-conflation)

### DIFF
--- a/src/RoslynMcp.Core/Models/WorkspaceStatusDto.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceStatusDto.cs
@@ -39,7 +39,12 @@ public sealed record WorkspaceStatusDto(
     [property: JsonPropertyName("staleReason")]
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? StaleReason = null,
-    bool RestoreRequired = false);
+    bool RestoreRequired = false,
+    // restore-required-vs-build-conflation: a missing analyzer BUILD output (e.g. an analyzer dll
+    // not yet produced by `dotnet build`) is distinct from a missing NuGet package. Tracked
+    // separately from RestoreRequired so the readiness verdict and summary hint route callers to
+    // `dotnet build` rather than a no-op `dotnet restore`.
+    bool BuildRequired = false);
 
 /// <summary>
 /// Represents the status of a project within a loaded workspace.

--- a/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
+++ b/src/RoslynMcp.Core/Models/WorkspaceStatusSummaryDto.cs
@@ -18,6 +18,7 @@ namespace RoslynMcp.Core.Models;
 ///   <item><description><see cref="AnalyzersReady"/> — every required analyzer reference resolved.</description></item>
 ///   <item><description><see cref="WorkspaceErrorCount"/> is zero.</description></item>
 ///   <item><description><see cref="RestoreRequired"/> is false — package-restore inputs still match the loaded assets snapshot.</description></item>
+///   <item><description><see cref="BuildRequired"/> is false — no analyzer build output is missing (remedied by <c>dotnet build</c>, not <c>dotnet restore</c>).</description></item>
 /// </list>
 /// <para>
 /// Pre-bundle the formula was just <c>IsLoaded &amp;&amp; !IsStale &amp;&amp; errors == 0</c>; analyzer-resolution
@@ -43,6 +44,7 @@ public sealed record WorkspaceStatusSummaryDto(
     bool IsReady,
     bool AnalyzersReady,
     bool RestoreRequired,
+    bool BuildRequired,
     string? RestoreHint,
     string? SolutionFileName)
 {
@@ -89,13 +91,15 @@ public sealed record WorkspaceStatusSummaryDto(
         var analyzersReady = unresolvedAnalyzerWarnings == 0 && !vsMsbuildRequired;
         var solutionFileName = GetSolutionOrProjectFileName(status.LoadedPath);
         var restoreRequired = status.RestoreRequired;
-        var isReady = status.IsLoaded && !status.IsStale && analyzersReady && errors == 0 && !restoreRequired;
+        var buildRequired = status.BuildRequired;
+        var isReady = status.IsLoaded && !status.IsStale && analyzersReady && errors == 0 && !restoreRequired && !buildRequired;
         var restoreHint = BuildRestoreHint(
             status.WorkspaceDiagnostics,
             isStale: status.IsStale,
             errors: errors,
             unresolvedAnalyzerWarnings: unresolvedAnalyzerWarnings,
             restoreRequired: restoreRequired,
+            buildRequired: buildRequired,
             vsMsbuildRequired: vsMsbuildRequired);
 
         return new WorkspaceStatusSummaryDto(
@@ -114,15 +118,18 @@ public sealed record WorkspaceStatusSummaryDto(
             IsReady: isReady,
             AnalyzersReady: analyzersReady,
             RestoreRequired: restoreRequired,
+            BuildRequired: buildRequired,
             RestoreHint: restoreHint,
             SolutionFileName: solutionFileName);
     }
 
     /// <summary>
     /// Builds an actionable hint string explaining why the workspace is not ready.
-    /// Four cases, in priority order:
+    /// Five cases, in priority order:
     /// <list type="number">
     ///   <item><description>VS-MSBuild required (COM references, .NET Core MSBuild limitation) → tell caller this project needs Visual Studio MSBuild on PATH.</description></item>
+    ///   <item><description>Build required (missing analyzer build output) → suggest <c>dotnet build</c>, NOT <c>dotnet restore</c>.</description></item>
+    ///   <item><description>Restore required (missing NuGet package inputs) → suggest <c>dotnet restore</c>.</description></item>
     ///   <item><description>Unresolved analyzer warnings → tell caller analyzer-driven tools will under-report.</description></item>
     ///   <item><description>Many "could not be found" / CS0234 style errors → suggest <c>dotnet restore</c>.</description></item>
     ///   <item><description>Workspace is stale with no errors → likely transient post-apply; suggest a brief retry before reload.</description></item>
@@ -135,6 +142,7 @@ public sealed record WorkspaceStatusSummaryDto(
         int errors,
         int unresolvedAnalyzerWarnings,
         bool restoreRequired,
+        bool buildRequired,
         bool vsMsbuildRequired)
     {
         // Highest priority: COM references / .NET Core MSBuild limitations cannot be fixed by
@@ -143,6 +151,14 @@ public sealed record WorkspaceStatusSummaryDto(
         if (vsMsbuildRequired)
         {
             return "This project requires Visual Studio MSBuild (e.g. COM references or .NET Framework-only tasks). The .NET Core MSBuild bundled with this server cannot resolve these. Remediation: (a) remove or interop-wrap COM references, or (b) load this project from an environment where msbuild.exe (Visual Studio) is on PATH.";
+        }
+
+        // restore-required-vs-build-conflation: a missing analyzer build output is fixed by
+        // `dotnet build`, not `dotnet restore`. Check it BEFORE restoreRequired so callers do not
+        // get sent into a no-op restore loop.
+        if (buildRequired)
+        {
+            return "Missing analyzer build output (e.g. an analyzer project's dll has not been produced). Run `dotnet build` on the analyzer project, then `workspace_reload`.";
         }
 
         if (restoreRequired)

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -884,6 +884,11 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             var projectStatuses = BuildProjectStatuses(newWorkspace.CurrentSolution);
             var restoreRequired = DetectRestoreRequired(projectStatuses) ||
                                   HasRestoreRequiredWorkspaceDiagnostics(diagnosticsSink.Queue);
+            // restore-required-vs-build-conflation: an unresolved-analyzer warning is a missing
+            // BUILD output, distinct from a missing NuGet package. Track it separately so the
+            // summary hint, readiness verdict, and autoRestore gate route to `dotnet build`
+            // rather than a no-op `dotnet restore`.
+            var buildRequired = HasBuildRequiredWorkspaceDiagnostics(diagnosticsSink.Queue);
 
             if (_cacheCoordinator is not null && cachedProbe is not null)
             {
@@ -906,6 +911,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             session.ProjectStatuses = projectStatuses;
             session.LoadedPath = path;
             session.RestoreRequired = restoreRequired;
+            session.BuildRequired = buildRequired;
             session.LoadedAtUtc = DateTimeOffset.UtcNow;
             session.IncrementVersion();
             // format-range-apply-preview-token-lifetime: drop only the tokens whose pinned
@@ -1406,16 +1412,16 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             string.Equals(child.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase))?.Value?.Trim();
     }
 
+    // restore-required-vs-build-conflation: a WORKSPACE_UNRESOLVED_ANALYZER warning indicates a
+    // missing BUILD output (e.g. an analyzer dll not yet produced by `dotnet build`), NOT a
+    // missing NuGet package. It must NOT set restoreRequired (which routes callers to a no-op
+    // `dotnet restore` loop and arms autoRestore for a pointless restore). It is detected
+    // separately by HasBuildRequiredWorkspaceDiagnostics and surfaced via the BuildRequired flag.
     private static bool HasRestoreRequiredWorkspaceDiagnostics(IEnumerable<DiagnosticDto> diagnostics)
     {
         var suspiciousDiagnostics = 0;
         foreach (var diagnostic in diagnostics)
         {
-            if (string.Equals(diagnostic.Id, "WORKSPACE_UNRESOLVED_ANALYZER", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
             if (string.Equals(diagnostic.Id, "CS0234", StringComparison.OrdinalIgnoreCase))
             {
                 suspiciousDiagnostics++;
@@ -1437,6 +1443,23 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         }
 
         return suspiciousDiagnostics >= 3;
+    }
+
+    // restore-required-vs-build-conflation: a WORKSPACE_UNRESOLVED_ANALYZER warning means a build
+    // output (analyzer dll) is missing — the remedy is `dotnet build`, not `dotnet restore`. Kept
+    // distinct from HasRestoreRequiredWorkspaceDiagnostics so callers can route to the correct hint
+    // and verdict (build-needed vs restore-needed).
+    private static bool HasBuildRequiredWorkspaceDiagnostics(IEnumerable<DiagnosticDto> diagnostics)
+    {
+        foreach (var diagnostic in diagnostics)
+        {
+            if (string.Equals(diagnostic.Id, "WORKSPACE_UNRESOLVED_ANALYZER", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1572,7 +1595,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 IsStale: isStale,
                 WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray(),
                 StaleReason: staleReason,
-                RestoreRequired: session.RestoreRequired);
+                RestoreRequired: session.RestoreRequired,
+                BuildRequired: session.BuildRequired);
         }
 
         var projects = session.ProjectStatuses;
@@ -1590,7 +1614,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             IsStale: isStale,
             WorkspaceDiagnostics: session.WorkspaceDiagnostics.ToArray(),
             StaleReason: staleReason,
-            RestoreRequired: session.RestoreRequired);
+            RestoreRequired: session.RestoreRequired,
+            BuildRequired: session.BuildRequired);
     }
 
     private WorkspaceSession GetRequiredSession(string workspaceId)
@@ -1732,6 +1757,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         public MSBuildWorkspace? Workspace { get; set; }
         public string? LoadedPath { get; set; }
         public bool RestoreRequired { get; set; }
+        public bool BuildRequired { get; set; }
         public DateTimeOffset LoadedAtUtc { get; set; } = DateTimeOffset.UtcNow;
         public DateTimeOffset LastAccessedUtc { get; set; } = DateTimeOffset.UtcNow;
         public int Version => Volatile.Read(ref _version);

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
@@ -198,6 +198,7 @@ public sealed class StructuredCallToolFilterResolutionTests
         IsReady: true,
         AnalyzersReady: true,
         RestoreRequired: false,
+        BuildRequired: false,
         RestoreHint: null,
         SolutionFileName: null);
 }

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -158,16 +158,33 @@ public sealed class SurfaceCatalogTests
             diff.Tools.Added.Select(entry => entry.Name).ToArray());
         CollectionAssert.Contains(diff.Resources.Added.Select(entry => entry.Name).ToArray(), "server_catalog_version_diff");
 
+        // The full changed-tool set: get_completions (summary) and server_info (outputSchema)
+        // pre-date this catalog version; the three workspace-status-family tools below changed
+        // their outputSchema because restore-required-vs-build-conflation added `buildRequired`
+        // to WorkspaceStatusSummaryDto, which every workspace-status tool serializes.
+        CollectionAssert.AreEquivalent(
+            new[] { "get_completions", "server_info", "workspace_status", "workspace_health", "workspace_list" },
+            diff.Tools.Changed.Select(entry => entry.Name).ToArray());
+
         var changedTool = diff.Tools.Changed.Single(entry => entry.Name == "get_completions");
         CollectionAssert.AreEqual(new[] { "summary" }, changedTool.ChangedFields.Select(field => field.Field).ToArray());
 
         var changedServerInfo = diff.Tools.Changed.Single(entry => entry.Name == "server_info");
         CollectionAssert.AreEqual(new[] { "outputSchema" }, changedServerInfo.ChangedFields.Select(field => field.Field).ToArray());
 
+        foreach (var workspaceToolName in new[] { "workspace_status", "workspace_health", "workspace_list" })
+        {
+            var changedWorkspaceTool = diff.Tools.Changed.Single(entry => entry.Name == workspaceToolName);
+            CollectionAssert.AreEqual(
+                new[] { "outputSchema" },
+                changedWorkspaceTool.ChangedFields.Select(field => field.Field).ToArray(),
+                $"{workspaceToolName} changed only its outputSchema (buildRequired added to WorkspaceStatusSummaryDto).");
+        }
+
         Assert.AreEqual(3, diff.Summary.Added);
         Assert.AreEqual(0, diff.Summary.Removed);
         Assert.AreEqual(0, diff.Summary.Promoted);
-        Assert.AreEqual(2, diff.Summary.Changed);
+        Assert.AreEqual(5, diff.Summary.Changed);
     }
 
     [TestMethod]
@@ -183,7 +200,7 @@ public sealed class SurfaceCatalogTests
         Assert.IsTrue(document.RootElement.TryGetProperty("tools", out var tools));
         Assert.IsTrue(tools.TryGetProperty("changed", out var changed));
         CollectionAssert.AreEquivalent(
-            new[] { "get_completions", "server_info" },
+            new[] { "get_completions", "server_info", "workspace_status", "workspace_health", "workspace_list" },
             changed.EnumerateArray().Select(entry => entry.GetProperty("name").GetString()).ToArray());
     }
 

--- a/tests/RoslynMcp.Tests/WorkspaceReadinessReportTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceReadinessReportTests.cs
@@ -63,12 +63,38 @@ public sealed class WorkspaceReadinessReportTests
                 null, null, null, null, null)
         ];
 
-        var json = await CreateReportAsync(CreateStatus(diagnostics, restoreRequired: true));
+        // restore-required-vs-build-conflation: a missing analyzer build output sets buildRequired,
+        // NOT restoreRequired — the remedy is `dotnet build`, not a no-op `dotnet restore`. The
+        // verdict must be build-needed with restoreRequired surfaced as false.
+        var json = await CreateReportAsync(CreateStatus(diagnostics, buildRequired: true));
 
         using var doc = JsonDocument.Parse(json);
         Assert.AreEqual("build-needed", GetVerdict(doc));
         StringAssert.Contains(ReadSignals(doc), "buildRequired=true");
+        StringAssert.Contains(ReadSignals(doc), "restoreRequired=false");
         StringAssert.Contains(ReadWorkflows(doc), "dotnet build");
+    }
+
+    [TestMethod]
+    public async Task ReadinessReport_NuGetRestoreWithoutAnalyzerWarning_ReturnsRestoreNeededAndNotBuildRequired()
+    {
+        // restore-required-vs-build-conflation regression: a genuine missing-NuGet-package case
+        // (no WORKSPACE_UNRESOLVED_ANALYZER warning) must still route to restore-needed and must
+        // NOT be misclassified as build-required. Proves the restore path is unaffected by the
+        // build/restore split.
+        DiagnosticDto[] diagnostics =
+        [
+            new("CS0234", "The type or namespace name 'Json' does not exist in the namespace 'System.Text'", "Error", "Workspace", null, null, null, null, null)
+        ];
+
+        var json = await CreateReportAsync(CreateStatus(diagnostics, restoreRequired: true));
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("restore-needed", GetVerdict(doc));
+        StringAssert.Contains(ReadSignals(doc), "restoreRequired=true");
+        Assert.IsFalse(ReadSignals(doc).Contains("buildRequired=true", StringComparison.Ordinal),
+            "a NuGet-restore case without an analyzer warning must not be flagged buildRequired");
+        StringAssert.Contains(ReadWorkflows(doc), "dotnet restore");
     }
 
     [TestMethod]
@@ -115,6 +141,7 @@ public sealed class WorkspaceReadinessReportTests
     private static WorkspaceStatusDto CreateStatus(
         IReadOnlyList<DiagnosticDto>? diagnostics = null,
         bool restoreRequired = false,
+        bool buildRequired = false,
         string workspaceId = "ws-1")
     {
         var workspaceDiagnostics = diagnostics ?? [];
@@ -135,7 +162,8 @@ public sealed class WorkspaceReadinessReportTests
             IsLoaded: true,
             IsStale: false,
             WorkspaceDiagnostics: workspaceDiagnostics,
-            RestoreRequired: restoreRequired);
+            RestoreRequired: restoreRequired,
+            BuildRequired: buildRequired);
     }
 
     private static string GetVerdict(JsonDocument doc) =>


### PR DESCRIPTION
## Summary

`WorkspaceManager` was computing `restoreRequired` as the OR of a package-level NuGet check and `HasRestoreRequiredWorkspaceDiagnostics`, where the latter returned true for a `WORKSPACE_UNRESOLVED_ANALYZER` warning. That warning indicates a missing **build** output (an analyzer dll not yet produced by `dotnet build`), not a missing NuGet package. The conflation routed callers into a no-op `dotnet restore` loop and armed `autoRestore=true` for a pointless restore.

## Change

Split the build-required signal out of `restoreRequired` into a new structured `BuildRequired` field, plumbed from `WorkspaceManager` through both DTOs:

- `WorkspaceManager.cs` — `HasRestoreRequiredWorkspaceDiagnostics` no longer matches `WORKSPACE_UNRESOLVED_ANALYZER`; a new `HasBuildRequiredWorkspaceDiagnostics` detects it separately. `LoadIntoSessionAsync` sets `session.BuildRequired`; the `WorkspaceSession` inner class gains the field; both `BuildStatus` return paths plumb it.
- `WorkspaceStatusDto.cs` — adds `bool BuildRequired = false` after `RestoreRequired`.
- `WorkspaceStatusSummaryDto.cs` — adds `BuildRequired`; `From()` computes it; `BuildRestoreHint` checks `buildRequired` before `restoreRequired` and emits a `dotnet build` hint; `isReady` is gated on `!buildRequired`.

`autoRestore` (`RestoreAndReloadIfRequiredAsync`) stays gated on `RestoreRequired` only, so it no longer fires for a build-only condition. `DetectRestoreRequired(projectStatuses)` is untouched and still independently fires for genuine NuGet-missing cases.

## Tests

- Updated `WorkspaceReadinessReportTests.ReadinessReport_UnresolvedAnalyzerBuildOutput_ReturnsBuildNeededBeforeRestore` to assert the analyzer case yields `restoreRequired=false` / `buildRequired=true`.
- Added `ReadinessReport_NuGetRestoreWithoutAnalyzerWarning_ReturnsRestoreNeededAndNotBuildRequired` proving the genuine-restore path is unaffected and not misclassified.
- `StructuredCallToolFilterResolutionTests` summary-helper updated for the new required positional param (compile-forced).

Validated: `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` clean; targeted `WorkspaceReadinessReportTests` + `WorkspaceStatusSummaryDtoTests` green (14/14), plus the touched `StructuredCallToolFilterResolutionTests` (11/11).

Closes: restore-required-vs-build-conflation

🤖 Generated with [Claude Code](https://claude.com/claude-code)