### PR TITLE
refactor(compcache): route 3 group-a tail services' live-solution compilation fetches through ICompilationCache

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 
 namespace RoslynMcp.Roslyn.Services;
@@ -23,12 +24,14 @@ public sealed class ImpactSweepService : IImpactSweepService
     private readonly IWorkspaceManager _workspace;
     private readonly IReferenceService _references;
     private readonly IDiagnosticService _diagnostics;
+    private readonly ICompilationCache _compilationCache;
 
-    public ImpactSweepService(IWorkspaceManager workspace, IReferenceService references, IDiagnosticService diagnostics)
+    public ImpactSweepService(IWorkspaceManager workspace, IReferenceService references, IDiagnosticService diagnostics, ICompilationCache compilationCache)
     {
         _workspace = workspace;
         _references = references;
         _diagnostics = diagnostics;
+        _compilationCache = compilationCache;
     }
 
     public async Task<SymbolImpactSweepDto> SweepAsync(
@@ -132,7 +135,7 @@ public sealed class ImpactSweepService : IImpactSweepService
         var dtoSiblings = new List<(INamedTypeSymbol DtoType, IPropertySymbol DtoProperty)>();
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
             foreach (var dto in compilation.GlobalNamespace.GetAllTypes(allowedKinds: TypeKind.Class))
             {
@@ -155,7 +158,7 @@ public sealed class ImpactSweepService : IImpactSweepService
         // the property in serialize (To*) and/or deserialize (From*) directions.
         foreach (var (dtoType, dtoProperty) in dtoSiblings)
         {
-            var mappers = await FindMapperTypesAsync(solution, property.ContainingType, dtoType, ct).ConfigureAwait(false);
+            var mappers = await FindMapperTypesAsync(workspaceId, _compilationCache, solution, property.ContainingType, dtoType, ct).ConfigureAwait(false);
             if (mappers.Count == 0) continue;
 
             var directionsPresent = new List<string>();
@@ -219,12 +222,12 @@ public sealed class ImpactSweepService : IImpactSweepService
     }
 
     private static async Task<IReadOnlyList<INamedTypeSymbol>> FindMapperTypesAsync(
-        Solution solution, INamedTypeSymbol domainType, INamedTypeSymbol dtoType, CancellationToken ct)
+        string workspaceId, ICompilationCache compilationCache, Solution solution, INamedTypeSymbol domainType, INamedTypeSymbol dtoType, CancellationToken ct)
     {
         var matches = new List<INamedTypeSymbol>();
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
             foreach (var type in compilation.GlobalNamespace.GetAllTypes(allowedKinds: TypeKind.Class))
             {

--- a/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MutationAnalysisService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,10 +13,12 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class MutationAnalysisService : IMutationAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly ICompilationCache _compilationCache;
 
-    public MutationAnalysisService(IWorkspaceManager workspace)
+    public MutationAnalysisService(IWorkspaceManager workspace, ICompilationCache compilationCache)
     {
         _workspace = workspace;
+        _compilationCache = compilationCache;
     }
 
     public async Task<ImpactAnalysisDto?> AnalyzeImpactAsync(
@@ -326,7 +329,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         var symbol = await SymbolResolver.ResolveAsync(solution, locator, ct).ConfigureAwait(false);
         if (symbol is not INamedTypeSymbol namedType) return null;
 
-        var compilation = await ResolveContainingCompilationAsync(solution, namedType, ct).ConfigureAwait(false);
+        var compilation = await ResolveContainingCompilationAsync(workspaceId, solution, namedType, ct).ConfigureAwait(false);
         var candidates = GetMutationCandidates(namedType, compilation);
 
         if (candidates.Length == 0)
@@ -339,6 +342,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
     }
 
     private async Task<Compilation?> ResolveContainingCompilationAsync(
+        string workspaceId,
         Solution solution,
         INamedTypeSymbol namedType,
         CancellationToken ct)
@@ -347,7 +351,7 @@ public sealed class MutationAnalysisService : IMutationAnalysisService
         // semantic models against the same compilation as the symbol.
         foreach (var project in solution.Projects)
         {
-            var projectCompilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var projectCompilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (projectCompilation is null)
             {
                 continue;

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -13,12 +14,14 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IReferenceService _referenceService;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<SymbolRelationshipService> _logger;
 
-    public SymbolRelationshipService(IWorkspaceManager workspace, IReferenceService referenceService, ILogger<SymbolRelationshipService> logger)
+    public SymbolRelationshipService(IWorkspaceManager workspace, IReferenceService referenceService, ICompilationCache compilationCache, ILogger<SymbolRelationshipService> logger)
     {
         _workspace = workspace;
         _referenceService = referenceService;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -236,7 +239,7 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         // list, retries the resolve, and picks the matching overload.
         if (symbol is null && locator.HasMetadataName)
         {
-            symbol = await TryResolveByQualifiedSignatureAsync(solution, locator.MetadataName!, ct).ConfigureAwait(false);
+            symbol = await TryResolveByQualifiedSignatureAsync(workspaceId, _compilationCache, solution, locator.MetadataName!, ct).ConfigureAwait(false);
         }
 
         if (symbol is null)
@@ -277,7 +280,7 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         // unbalanced/inside-parens dots that defeat that path entirely.
         if (symbol is null && locator.HasMetadataName)
         {
-            symbol = await TryResolveByQualifiedSignatureAsync(solution, locator.MetadataName!, ct).ConfigureAwait(false);
+            symbol = await TryResolveByQualifiedSignatureAsync(workspaceId, _compilationCache, solution, locator.MetadataName!, ct).ConfigureAwait(false);
         }
 
         if (symbol is null) return null;
@@ -400,7 +403,7 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
     /// locator (symbolHandle or source position) if that picks the wrong overload.
     /// </remarks>
     internal static async Task<ISymbol?> TryResolveByQualifiedSignatureAsync(
-        Solution solution, string metadataName, CancellationToken ct)
+        string workspaceId, ICompilationCache compilationCache, Solution solution, string metadataName, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(metadataName)) return null;
 
@@ -424,7 +427,7 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             var containingType = compilation.GetTypeByMetadataName(containingTypeName);

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -186,6 +186,76 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
     }
 
+    [TestMethod]
+    public async Task ImpactSweepService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new ImpactSweepService(
+            WorkspaceManager,
+            new ReferenceService(WorkspaceManager, cache, NullLogger<ReferenceService>.Instance),
+            new DiagnosticService(WorkspaceManager, cache, new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance)),
+            cache);
+
+        // CollectPersistenceLayerFindingsAsync (and its FindMapperTypesAsync helper) are the two
+        // converted sites. They only fetch compilations when the swept symbol is a property — anchor
+        // on SampleLib.Dog.Name (a property) so the per-project compilation loop runs through the cache.
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var dogFile = solution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "Dog.cs");
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.SweepAsync(
+                workspace.WorkspaceId,
+                SymbolLocator.BySource(dogFile.FilePath!, 5, 19),
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task MutationAnalysisService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new MutationAnalysisService(WorkspaceManager, cache);
+
+        // FindTypeMutationsAsync -> ResolveContainingCompilationAsync is the converted site. It runs
+        // only for a named-type target — anchor on SampleLib.Dog so the project loop that locates the
+        // defining compilation fetches through the cache.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.FindTypeMutationsAsync(
+                workspace.WorkspaceId,
+                SymbolLocator.ByMetadataName("SampleLib.Dog"),
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task SymbolRelationshipService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new SymbolRelationshipService(
+            WorkspaceManager,
+            new ReferenceService(WorkspaceManager, cache, NullLogger<ReferenceService>.Instance),
+            cache,
+            NullLogger<SymbolRelationshipService>.Instance);
+
+        // TryResolveByQualifiedSignatureAsync is the converted site. It only runs when the standard
+        // metadata-name resolve returns null — a fully-qualified signature whose last dot lands inside
+        // the parenthesized parameter list (`SampleLib.Dog.Fetch(System.String)`) defeats the last-dot
+        // split, so the fallback's per-project compilation loop runs through the cache.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.GetSignatureHelpAsync(
+                workspace.WorkspaceId,
+                SymbolLocator.ByMetadataName("SampleLib.Dog.Fetch(System.String)"),
+                preferDeclaringMember: false,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
     /// <summary>
     /// Runs the service once (proving it touched the cache), snapshots the compilations the cache
     /// handed out, then runs it a second time at the unchanged workspace version so the caller can

--- a/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolImpactSweepBudgetTests.cs
@@ -25,7 +25,8 @@ public sealed class SymbolImpactSweepBudgetTests : SharedWorkspaceTestBase
         _impactSweepService = new RoslynMcp.Roslyn.Services.ImpactSweepService(
             WorkspaceManager,
             ReferenceService,
-            DiagnosticService);
+            DiagnosticService,
+            new RoslynMcp.Roslyn.Services.CompilationCache(WorkspaceManager));
     }
 
     [ClassCleanup]

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -90,7 +90,7 @@ internal sealed class TestServiceContainer
             workspaceManager,
             compilationCache,
             NullLogger<ReferenceService>.Instance);
-        var mutationAnalysisService = new MutationAnalysisService(workspaceManager);
+        var mutationAnalysisService = new MutationAnalysisService(workspaceManager, compilationCache);
         var codeFixRegistry = new CodeFixProviderRegistry(NullLogger<CodeFixProviderRegistry>.Instance);
         var diagnosticService = new DiagnosticService(
             workspaceManager,
@@ -155,6 +155,7 @@ internal sealed class TestServiceContainer
             SymbolRelationshipService = new SymbolRelationshipService(
                 workspaceManager,
                 referenceService,
+                compilationCache,
                 NullLogger<SymbolRelationshipService>.Instance),
             DiagnosticService = diagnosticService,
             UndoService = undoService,


### PR DESCRIPTION
## Summary

Group-a **tail** batch of `compilation-cache-adoption-read-side`. Converts four raw `project.GetCompilationAsync` sites in three group-a tail services to route through the shared `ICompilationCache` — all confirmed live-solution reads (no forked-solution sites). Mirrors batch-a core (#1005).

| Service | Site | Threading |
|---|---|---|
| `ImpactSweepService` | `CollectPersistenceLayerFindingsAsync` (:135) | ctor field `_compilationCache` |
| `ImpactSweepService` | `FindMapperTypesAsync` (static, :227) | threads `(workspaceId, compilationCache)` params |
| `MutationAnalysisService` | `ResolveContainingCompilationAsync` (:350) | ctor field + threads `workspaceId` |
| `SymbolRelationshipService` | `TryResolveByQualifiedSignatureAsync` (internal static, :427) | threads `(workspaceId, compilationCache)`; call sites :239/:280 updated |

DI auto-resolves the new ctor `ICompilationCache` param from the registered singleton (`ServiceCollectionExtensions.cs:23`) — no registration change.

## Tests

- 3 new `[TestMethod]`s in `CompilationCacheAdoptionTests` (one per converted service) mirror the existing `AssertRoutedThroughCacheAndShared` helper: each asserts `cache.GetCompilationCallCount > 0` AND reference-equal warm compilations at an unchanged workspace version.
- `TestServiceContainer` + `SymbolImpactSweepBudgetTests` ctor call sites updated for the new param (no backwards-compat overloads).
- Validation: `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` clean (0 warnings); filtered tests pass (16/16: 9 `CompilationCacheAdoptionTests` + 7 `SymbolImpactSweepBudgetTests`).

## Scope

Production (3): `ImpactSweepService.cs`, `MutationAnalysisService.cs`, `SymbolRelationshipService.cs`. Test (3): `CompilationCacheAdoptionTests.cs`, `TestServiceContainer.cs`, `SymbolImpactSweepBudgetTests.cs`. Within Rule 3 (3≤4) / Rule 4 (3≤3). No shims added.

**Partial batch — does NOT close the parent row** (group-b/c remainder + re-scope still open).

Closes: compilation-cache-adoption-read-side (partial — does NOT close; group-b/c remainder remains)