### PR TITLE
perf(advanced-analysis): summary mode for find_duplicated_methods / find_duplicated_code

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -407,7 +407,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicated_methods", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find clusters of near-duplicate method bodies by AST-normalized hash."),
-     Description("Find clusters of method bodies whose AST-normalized structure is identical (or very close) — surfaces internal copy-paste that should be extracted to a shared helper. Normalization strips trivia, renames locals/parameters to ordinal placeholders, and compares the canonical SyntaxKind sequence, so cosmetic differences (formatting, local names, parameter names) don't affect bucketing. Overloads with identical bodies cluster; overloads with different bodies do not (bucketing is by body-shape, not method name). Auto-generated files (.g.cs, .Designer.cs, obj/), abstract declarations, partial methods without bodies, and by default single-delegation [McpServerTool] wrapper shims are excluded. Tune `minLines` up to reduce noise (default 10); narrow `projectFilter` for large solutions. `similarityThreshold` gates exact-structural matches only in the current implementation — near-miss bucketing is reserved for a future iteration, so any value in [0,1] behaves the same as 1.0. Response shape: { count, groups, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. find_duplicated_code).")]
+     Description("Find clusters of method bodies whose AST-normalized structure is identical (or very close) — surfaces internal copy-paste that should be extracted to a shared helper. Normalization strips trivia, renames locals/parameters to ordinal placeholders, and compares the canonical SyntaxKind sequence, so cosmetic differences (formatting, local names, parameter names) don't affect bucketing. Overloads with identical bodies cluster; overloads with different bodies do not (bucketing is by body-shape, not method name). Auto-generated files (.g.cs, .Designer.cs, obj/), abstract declarations, partial methods without bodies, and by default single-delegation [McpServerTool] wrapper shims are excluded. Tune `minLines` up to reduce noise (default 10); narrow `projectFilter` for large solutions. `similarityThreshold` gates exact-structural matches only in the current implementation — near-miss bucketing is reserved for a future iteration, so any value in [0,1] behaves the same as 1.0. Response shape: { count, groups, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. find_duplicated_code). Set `summary=true` for a compact payload that omits each group's per-member `Methods` array (file paths + line spans), keeping only { normalizedHash, memberCount, similarity, lineCount, clusterKind } per cluster — use this on large solutions where the full member lists exceed the MCP output cap.")]
     public static Task<string> FindDuplicatedMethods(
         IWorkspaceExecutionGate gate,
         IDuplicateMethodDetectorService duplicateMethodDetectorService,
@@ -417,9 +417,10 @@ public static class AdvancedAnalysisTools
         [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
         [Description("Maximum number of groups to return (default: 50).")] int limit = 50,
         [Description("When true (default), skip [McpServerTool]-attributed methods whose body is a single delegation, since MCP requires one wrapper shim per tool name.")] bool excludeMcpToolWrappers = true,
+        [Description("When true, omit each group's per-member `Methods` array (file paths + line spans) and return only per-cluster metadata. Smaller payload for large solutions where full member lists exceed the MCP output cap. Default false.")] bool summary = false,
         CancellationToken ct = default)
     {
-        return FindDuplicatedMethodsCore(gate, duplicateMethodDetectorService, workspaceId, minLines, similarityThreshold, projectFilter, limit, excludeMcpToolWrappers, deprecation: null, ct);
+        return FindDuplicatedMethodsCore(gate, duplicateMethodDetectorService, workspaceId, minLines, similarityThreshold, projectFilter, limit, excludeMcpToolWrappers, summary, deprecation: null, ct);
     }
 
     // roslyn-mcp-sister-tool-name-aliases: shared core invoked by both the canonical
@@ -433,6 +434,7 @@ public static class AdvancedAnalysisTools
         string? projectFilter,
         int limit,
         bool excludeMcpToolWrappers,
+        bool summary,
         ToolAliasDeprecation? deprecation,
         CancellationToken ct = default)
     {
@@ -449,6 +451,30 @@ public static class AdvancedAnalysisTools
                     Limit = limit
                 },
                 c);
+
+            // Summary mode: drop the per-member `Methods` array from each group, keeping only
+            // the per-cluster metadata. The full shape embeds one DuplicatedMethodMemberDto
+            // (file path, lines, method/type/project name) per duplicate, which can blow the
+            // MCP output cap on large solutions. Opt-in (default false) so the full shape is
+            // unchanged for existing callers. Mirrors the project_diagnostics summary mode.
+            if (summary)
+            {
+                var compactGroups = results
+                    .Select(group => new
+                    {
+                        group.NormalizedHash,
+                        group.MemberCount,
+                        group.Similarity,
+                        group.LineCount,
+                        group.ClusterKind,
+                    })
+                    .ToList();
+
+                return JsonSerializer.Serialize(
+                    new { count = results.Count, summary = true, deprecation, groups = compactGroups },
+                    JsonDefaults.Indented);
+            }
+
             return JsonSerializer.Serialize(new { count = results.Count, groups = results, deprecation }, JsonDefaults.Indented);
         }, ct);
     }
@@ -462,7 +488,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicated_code", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Alias for find_duplicated_methods (cross-MCP-server name compatibility)."),
-     Description("Alias for `find_duplicated_methods` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical find_duplicated_methods response envelope ({ count, groups, deprecation }) with deprecation.canonicalName populated. Note: the python-refactor server has only one duplicate-detection tool while this server has two — `find_duplicated_methods` (clusters of internal copy-paste, picked here as the broader match) and `find_duplicate_helpers` (private/internal helpers that re-wrap a BCL/NuGet symbol). Call those canonicals directly when you need the targeted shape.")]
+     Description("Alias for `find_duplicated_methods` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical find_duplicated_methods response envelope ({ count, groups, deprecation }) with deprecation.canonicalName populated. Note: the python-refactor server has only one duplicate-detection tool while this server has two — `find_duplicated_methods` (clusters of internal copy-paste, picked here as the broader match) and `find_duplicate_helpers` (private/internal helpers that re-wrap a BCL/NuGet symbol). Call those canonicals directly when you need the targeted shape. Set `summary=true` for a compact payload that omits each group's per-member `Methods` array, keeping only per-cluster metadata — use this on large solutions where the full member lists exceed the MCP output cap.")]
     public static Task<string> FindDuplicatedCode(
         IWorkspaceExecutionGate gate,
         IDuplicateMethodDetectorService duplicateMethodDetectorService,
@@ -472,6 +498,7 @@ public static class AdvancedAnalysisTools
         [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
         [Description("Maximum number of groups to return (default: 50).")] int limit = 50,
         [Description("When true (default), skip [McpServerTool]-attributed methods whose body is a single delegation, since MCP requires one wrapper shim per tool name.")] bool excludeMcpToolWrappers = true,
+        [Description("When true, omit each group's per-member `Methods` array (file paths + line spans) and return only per-cluster metadata. Smaller payload for large solutions where full member lists exceed the MCP output cap. Default false.")] bool summary = false,
         CancellationToken ct = default)
     {
         return FindDuplicatedMethodsCore(
@@ -483,6 +510,7 @@ public static class AdvancedAnalysisTools
             projectFilter,
             limit,
             excludeMcpToolWrappers,
+            summary,
             ToolAliasDeprecation.ForSisterAlias("find_duplicated_methods"),
             ct);
     }

--- a/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DuplicateMethodDetectorTests.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -709,6 +711,214 @@ public sealed class DuplicateMethodDetectorTests
 
         Assert.AreEqual(1, unfiltered.Count,
             "Without a filter, the cross-project duplicate should still cluster.");
+    }
+
+    /// <summary>
+    /// Source with three independent duplicate clusters (six methods, two per cluster). Each
+    /// cluster has a distinct body shape so they bucket separately; the two members within a
+    /// cluster are structurally identical (different names, different locals) so they cluster.
+    /// Used by the summary-mode tests below.
+    /// </summary>
+    private const string ThreeClusterSource = """
+        namespace Sample;
+        public class ThreeClusters
+        {
+            // Cluster 1: arithmetic chain.
+            public int ArithA(int value)
+            {
+                var a1 = value + 1;
+                var a2 = a1 * 2;
+                var a3 = a2 + a2;
+                var a4 = a3 / 2;
+                var a5 = a4 - 1;
+                return a5;
+            }
+            public int ArithB(int input)
+            {
+                var b1 = input + 1;
+                var b2 = b1 * 2;
+                var b3 = b2 + b2;
+                var b4 = b3 / 2;
+                var b5 = b4 - 1;
+                return b5;
+            }
+
+            // Cluster 2: loop-accumulate.
+            public int LoopA(int count)
+            {
+                var total = 0;
+                for (var i = 0; i < count; i++)
+                {
+                    total += i;
+                    total -= 1;
+                }
+                return total;
+            }
+            public int LoopB(int n)
+            {
+                var acc = 0;
+                for (var j = 0; j < n; j++)
+                {
+                    acc += j;
+                    acc -= 1;
+                }
+                return acc;
+            }
+
+            // Cluster 3: string transform.
+            public string StrA(string text)
+            {
+                var s1 = text.Trim();
+                var s2 = s1.ToUpperInvariant();
+                var s3 = s2 + "!";
+                var s4 = s3.Replace("!", "?");
+                var s5 = s4.PadLeft(10);
+                return s5;
+            }
+            public string StrB(string raw)
+            {
+                var t1 = raw.Trim();
+                var t2 = t1.ToUpperInvariant();
+                var t3 = t2 + "!";
+                var t4 = t3.Replace("!", "?");
+                var t5 = t4.PadLeft(10);
+                return t5;
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task FindDuplicatedMethods_SummaryMode_OmitsMethodsArrayButKeepsClusterMetadata()
+    {
+        // Drive the tool wrapper (not the service) so the summary-mode serialization branch in
+        // FindDuplicatedMethodsCore is exercised. The tool runs through the real
+        // WorkspaceExecutionGate against the AdhocWorkspace-backed TestWorkspaceManager.
+        var (service, gate) = BuildServiceAndGate(ThreeClusterSource);
+        using var gateScope = gate;
+
+        var summaryJson = await AdvancedAnalysisTools.FindDuplicatedMethods(
+            gate,
+            service,
+            workspaceId: WorkspaceId,
+            minLines: 6,
+            similarityThreshold: 0.85,
+            projectFilter: null,
+            limit: 50,
+            excludeMcpToolWrappers: true,
+            summary: true,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(summaryJson);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(3, root.GetProperty("count").GetInt32(),
+            "All three clusters must be counted in summary mode.");
+        Assert.IsTrue(root.GetProperty("summary").GetBoolean(),
+            "Summary mode must stamp summary=true.");
+        Assert.IsTrue(root.TryGetProperty("deprecation", out var deprecation));
+        Assert.AreEqual(JsonValueKind.Null, deprecation.ValueKind,
+            "Canonical tool must publish deprecation=null even in summary mode.");
+
+        var groups = root.GetProperty("groups");
+        Assert.AreEqual(3, groups.GetArrayLength(), "Each cluster must still appear as a group.");
+
+        foreach (var group in groups.EnumerateArray())
+        {
+            // (a) The per-member Methods array is omitted — that's the byte budget the summary buys.
+            Assert.IsFalse(group.TryGetProperty("methods", out _),
+                "Summary group must omit the per-member `methods` array.");
+            Assert.IsFalse(group.TryGetProperty("Methods", out _),
+                "Summary group must omit the per-member `Methods` array (any casing).");
+
+            // (b) The cluster metadata is preserved.
+            Assert.IsTrue(group.TryGetProperty("normalizedHash", out var hash));
+            Assert.IsFalse(string.IsNullOrEmpty(hash.GetString()),
+                "normalizedHash must survive into the summary shape.");
+            Assert.IsTrue(group.TryGetProperty("memberCount", out var memberCount));
+            Assert.IsTrue(memberCount.GetInt32() >= 2,
+                "Every emitted cluster has at least two members.");
+            Assert.IsTrue(group.TryGetProperty("lineCount", out var lineCount));
+            Assert.IsTrue(lineCount.GetInt32() > 0, "lineCount must survive into the summary shape.");
+            Assert.IsTrue(group.TryGetProperty("similarity", out _),
+                "similarity must survive into the summary shape.");
+            Assert.IsTrue(group.TryGetProperty("clusterKind", out _),
+                "clusterKind must survive into the summary shape.");
+        }
+    }
+
+    [TestMethod]
+    public async Task FindDuplicatedMethods_FullMode_RetainsMethodsArray()
+    {
+        // The inverse contract: default (summary=false) preserves the per-member Methods array
+        // and does NOT stamp a `summary` field. Pins that summary mode is strictly opt-in.
+        var (service, gate) = BuildServiceAndGate(ThreeClusterSource);
+        using var gateScope = gate;
+
+        var fullJson = await AdvancedAnalysisTools.FindDuplicatedMethods(
+            gate,
+            service,
+            workspaceId: WorkspaceId,
+            minLines: 6,
+            similarityThreshold: 0.85,
+            projectFilter: null,
+            limit: 50,
+            excludeMcpToolWrappers: true,
+            summary: false,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(fullJson);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(3, root.GetProperty("count").GetInt32());
+        Assert.IsFalse(root.TryGetProperty("summary", out _),
+            "Full mode must NOT emit a `summary` field.");
+
+        var groups = root.GetProperty("groups");
+        Assert.AreEqual(3, groups.GetArrayLength());
+        foreach (var group in groups.EnumerateArray())
+        {
+            Assert.IsTrue(group.TryGetProperty("methods", out var methods),
+                "Full mode must retain the per-member `methods` array.");
+            Assert.IsTrue(methods.GetArrayLength() >= 2,
+                "Each full-mode cluster lists all its member locations.");
+        }
+    }
+
+    /// <summary>
+    /// Builds the detector service AND a <see cref="WorkspaceExecutionGate"/> sharing one
+    /// <see cref="TestWorkspaceManager"/> so the tool wrapper (which routes through the gate)
+    /// can be exercised end-to-end. Default <see cref="ExecutionGateOptions"/> are fine: the
+    /// test manager reports <c>IsStale=false</c> and <c>ContainsWorkspace=true</c>, so the
+    /// staleness/reload path never runs and the gate resolves to a plain read.
+    /// </summary>
+    private static (DuplicateMethodDetectorService service, WorkspaceExecutionGate gate) BuildServiceAndGate(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        workspace.AddProject(ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "TestProject",
+            assemblyName: "TestProject",
+            language: LanguageNames.CSharp,
+            filePath: Path.Combine(Path.GetTempPath(), "TestProject.csproj")));
+
+        var docId = DocumentId.CreateNewId(projectId);
+        var fullPath = Path.Combine(Path.GetTempPath(), "Sample.cs");
+        workspace.AddDocument(DocumentInfo.Create(
+            docId,
+            "Sample.cs",
+            filePath: fullPath,
+            loader: TextLoader.From(
+                TextAndVersion.Create(
+                    SourceText.From(source),
+                    VersionStamp.Create(),
+                    fullPath))));
+
+        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
+        var service = new DuplicateMethodDetectorService(wsManager);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), wsManager);
+        return (service, gate);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Adds an opt-in `summary` parameter to `find_duplicated_methods` (and its `find_duplicated_code` alias) so large result sets degrade gracefully instead of exceeding the MCP output cap.

`FindDuplicatedMethodsCore` serialized `{ count, groups, deprecation }` with no byte guard — each `DuplicatedMethodGroupDto` embeds a full per-member `Methods` list (file path, line span, method/type/project name). On large solutions with up to `limit` (default 50) clusters, the payload could blow the output cap. Both the canonical tool and the alias delegate to this shared core, so both were affected equally.

## How

- Added `bool summary = false` to `FindDuplicatedMethodsCore` and threaded it through both callers (`FindDuplicatedMethods`, `FindDuplicatedCode`).
- When `summary=true`, the serialization branch emits a compact shape per group — `{ normalizedHash, memberCount, similarity, lineCount, clusterKind }` — omitting the per-member `Methods` array. Envelope becomes `{ count, summary: true, deprecation, groups }`.
- When `summary=false` (default), the full shape `{ count, groups, deprecation }` is unchanged — strictly opt-in, no breaking change.
- Mirrors the established `project_diagnostics` summary mode in `AnalysisTools.cs`.
- Updated both tools' `[Description]` so `summary` documents in both schemas.

## Tests

Two new tests in `DuplicateMethodDetectorTests` drive the tool wrapper through a real `WorkspaceExecutionGate` over a 3-cluster fixture:
- `FindDuplicatedMethods_SummaryMode_OmitsMethodsArrayButKeepsClusterMetadata` — asserts `summary=true` omits `methods` per group while preserving `count`, `memberCount` (>=2), `lineCount`, `normalizedHash`, `similarity`, `clusterKind`.
- `FindDuplicatedMethods_FullMode_RetainsMethodsArray` — pins that `summary=false` retains the full member list and emits no `summary` field.

Validation in the worktree: `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` (0 warnings, 0 errors); `dotnet test --filter "FullyQualifiedName~DuplicateMethodDetectorTests"` (17/17 pass); `AliasToolsTests` (6/6 pass — alias parity contract intact).

Closes: find-duplicated-methods-no-byte-budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)