### PR TITLE
feat(tools): make compile_check workspaceId optional for single-workspace sessions

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -23,7 +23,7 @@ public static class CompileCheckTools
     public static Task<string> CompileCheck(
         IWorkspaceExecutionGate gate,
         ICompileCheckService compileCheckService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Optional: the workspace session identifier returned by workspace_load. With one workspace loaded you may omit it — the read-path middleware resolves it automatically; pass it explicitly when two or more are loaded.")] string? workspaceId = null,
         [Description("Optional: filter by project name")] string? projectName = null,
         [Description("When true, performs full PE-emit validation (catches more issues like missing references at emit time). Default: false (faster, uses GetDiagnostics only). Requires restored NuGet packages for the perf delta to materialize — see the tool description.")] bool emitValidation = false,
         [Description("Optional: minimum severity filter (Error, Warning, Info, Hidden)")] string? severity = null,
@@ -35,6 +35,7 @@ public static class CompileCheckTools
     {
         ParameterValidation.ValidateSeverity(severity);
         ParameterValidation.ValidatePagination(offset, limit);
+        workspaceId = RequireResolvedWorkspaceId(workspaceId);
         return ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
@@ -56,4 +57,18 @@ public static class CompileCheckTools
             },
             ct);
     }
+
+    // workspace-id-optional-readonly-surface-flip: the read-path middleware
+    // (StructuredCallToolFilter) resolves or auto-loads an omitted workspaceId before this
+    // now-optional tool dispatches. This guard covers the residual case the middleware cannot
+    // resolve — workspaceId omitted, zero workspaces loaded, and no solution discoverable — by
+    // returning a structured InvalidArgument (the filter classifies the throw) that points the
+    // caller at workspace_load. It also narrows workspaceId to non-null for the dispatch below.
+    private static string RequireResolvedWorkspaceId(string? workspaceId) =>
+        string.IsNullOrEmpty(workspaceId)
+            ? throw new ArgumentException(
+                "workspaceId was omitted but no workspace is loaded and none could be discovered. " +
+                "Call workspace_load(path=…) first, or pass workspaceId explicitly.",
+                nameof(workspaceId))
+            : workspaceId;
 }

--- a/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
@@ -11,19 +11,20 @@ namespace RoslynMcp.Tests;
 /// <c>symbol_search</c> — keep it REQUIRED.
 ///
 /// <para>
-/// Pilot scope is 3 tools (<c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>)
-/// whose <c>workspaceId</c> is followed only by optional parameters, so the flip is a pure in-place
-/// default with no parameter reordering and no caller churn. <c>symbol_search</c> is intentionally
-/// EXCLUDED from this pilot: a required <c>query</c> parameter follows its <c>workspaceId</c>, so
-/// making it optional would force a reorder that breaks ~16 positional call sites — it is folded
-/// into the deferred full read-only sweep follow-on alongside the remaining ~45 methods.
+/// The pilot flipped 3 tools (<c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>);
+/// the bounded full-sweep sub-batch adds <c>compile_check</c> — each has a <c>workspaceId</c> followed
+/// only by optional parameters, so the flip is a pure in-place default with no parameter reordering
+/// and no caller churn. <c>symbol_search</c> is intentionally EXCLUDED: a required <c>query</c>
+/// parameter follows its <c>workspaceId</c>, so making it optional would force a reorder that breaks
+/// ~16 positional call sites — it is folded into the deferred full read-only sweep follow-on
+/// alongside the remaining unflipped read-only methods.
 /// </para>
 /// </summary>
 [TestClass]
 public sealed class WorkspaceIdOptionalSurfaceTests
 {
     private static readonly string[] FlippedPilotTools =
-        ["go_to_definition", "find_references", "document_symbols"];
+        ["go_to_definition", "find_references", "document_symbols", "compile_check"];
 
     // Deferred to the follow-on (required query param forces a reorder) + a sample of tools that
     // must KEEP workspaceId required: writers, destructive, and not-yet-swept read-only tools.
@@ -53,6 +54,21 @@ public sealed class WorkspaceIdOptionalSurfaceTests
         // runs before any service is touched, so null DI args are safe here.
         var ex = Assert.ThrowsException<ArgumentException>(() =>
             SymbolTools.GetDocumentSymbols(server: null!, gate: null!, symbolSearchService: null!, workspaceId: null));
+
+        Assert.AreEqual("workspaceId", ex.ParamName);
+        StringAssert.Contains(ex.Message, "workspace_load",
+            "The guard must steer the caller to workspace_load rather than fail opaquely.");
+    }
+
+    [TestMethod]
+    public void CompileCheck_WithNullWorkspaceId_ThrowsGuidedInvalidArgument()
+    {
+        // compile_check's body guard mirrors the symbol-tool guard above. The pre-gate severity +
+        // pagination validations pass for the defaults (severity=null, offset=0, limit=50), so the
+        // null-workspaceId case reaches RequireResolvedWorkspaceId before any service or gate is
+        // touched — null DI args are safe here.
+        var ex = Assert.ThrowsException<ArgumentException>(() =>
+            CompileCheckTools.CompileCheck(gate: null!, compileCheckService: null!, workspaceId: null));
 
         Assert.AreEqual("workspaceId", ex.ParamName);
         StringAssert.Contains(ex.Message, "workspace_load",


### PR DESCRIPTION
## Summary

Bounded sub-batch of the `workspace-id-optional-readonly-surface-full-sweep` initiative, scoped to **`CompileCheckTools.cs` only**.

Flips `compile_check`'s `workspaceId` from `string` (Required) to `string? = null` (Optional), so the read-path middleware (`StructuredCallToolFilter`) auto-resolves it when a single workspace is loaded — matching the pilot-flipped `go_to_definition` / `find_references` / `document_symbols`. `compile_check` already passes the read-path auto-resolution gate (`ReadOnly:true, Destructive:false`); only the missing C# default blocked omission.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs`:
  - `workspaceId` → `string? workspaceId = null` with an updated optional-semantics description.
  - Added `RequireResolvedWorkspaceId(string?)` guard (mirrors `SymbolTools`) covering the residual case the middleware cannot resolve (omitted id + zero workspaces + nothing discoverable) — throws a structured `ArgumentException` steering the caller to `workspace_load`.
  - Narrows `workspaceId` to non-null **before** the positional `ToolDispatch.ReadByWorkspaceIdAsync` dispatch.
- `tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs` (extend):
  - `compile_check` added to the flipped-tools assertion (`Required == false`).
  - New `CompileCheck_WithNullWorkspaceId_ThrowsGuidedInvalidArgument` guard-throw test.

No catalog regen (`ToolParameterIndex` is reflection-derived). No CS1737 hazard — every parameter following `workspaceId` already had a default.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → 0 errors (ServerSurfaceCatalogAnalyzer clean).
- `dotnet test --filter "FullyQualifiedName~WorkspaceIdOptionalSurfaceTests"` → 4/4 passed.

## Backlog correlation

Closes: workspace-id-optional-readonly-surface-full-sweep (PARTIAL sub-batch — `CompileCheckTools.cs` only; does NOT close the parent row; ~44 read-only tools remain. Orchestrator owns row lifecycle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)