### PR TITLE
refactor(tools)!: canonicalize 5 experimental project-scope params to projectName

### DIFF
--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -328,7 +328,7 @@ public static class AdvancedAnalysisTools
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectName = null,
         [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
         CancellationToken ct = default)
     {
@@ -338,7 +338,7 @@ public static class AdvancedAnalysisTools
                 workspaceId,
                 new DeadLocalsAnalysisOptions
                 {
-                    ProjectFilter = projectFilter,
+                    ProjectFilter = projectName,
                     Limit = limit
                 },
                 c);
@@ -354,7 +354,7 @@ public static class AdvancedAnalysisTools
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectName = null,
         [Description("Include public/protected fields in the scan (default: false).")] bool includePublic = false,
         [Description("Optional: restrict results to one usage kind: `never-read`, `never-written`, or `never-either`. Default: all kinds.")] string? usageKind = null,
         [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
@@ -366,7 +366,7 @@ public static class AdvancedAnalysisTools
                 workspaceId,
                 new DeadFieldsAnalysisOptions
                 {
-                    ProjectFilter = projectFilter,
+                    ProjectFilter = projectName,
                     IncludePublic = includePublic,
                     UsageKindFilter = usageKind,
                     Limit = limit
@@ -384,7 +384,7 @@ public static class AdvancedAnalysisTools
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectFilter = null,
+        [Description("Optional: filter by project name to scope the scan on large solutions.")] string? projectName = null,
         [Description("Maximum number of hits to return (default: 50).")] int limit = 50,
         [Description("When true (default), omit delegations into common hosting, service-registration, and HTTP extension APIs as framework glue (minimal APIs, DI/CORS setup, logging host hooks, HTTP client helpers, and resilience handlers).")] bool excludeFrameworkWrappers = true,
         CancellationToken ct = default)
@@ -395,7 +395,7 @@ public static class AdvancedAnalysisTools
                 workspaceId,
                 new DuplicateHelperAnalysisOptions
                 {
-                    ProjectFilter = projectFilter,
+                    ProjectFilter = projectName,
                     Limit = limit,
                     ExcludeFrameworkWrappers = excludeFrameworkWrappers
                 },

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -435,7 +435,7 @@ public static class AnalysisTools
         "Tokenization rule for `identifiers` scope: the regex is applied to one C#-lexer identifier token at a time. Dotted member-access expressions are MULTIPLE tokens (e.g. `Task.Run` is `Task` / `.` / `Run`), so a pattern like `Task\\.Run` will match 0 results under `scope=\"identifiers\"`. " +
         "Recoverable patterns: (a) issue two separate calls — `pattern=\"^Task$\"` and `pattern=\"^Run$\"`, both `scope=\"identifiers\"` — and intersect the hits client-side by (filePath, line); (b) use `scope=\"all\"` with a prose-fragment pattern when the dotted text also appears in a comment or string literal (trade-off: `all` also matches inside comments/strings, so it may surface non-code references). " +
         "Per-document regex evaluation is hard-capped at 2 seconds; tokens that trigger a timeout are silently skipped rather than failing the call — use simpler patterns if results seem incomplete on large files. " +
-        "Optional `projectFilter` restricts the walk by Project.Name. Hard-capped at 500 hits per call to bound response size — narrow `pattern` or `projectFilter` if hits are truncated. " +
+        "Optional `projectName` restricts the walk by Project.Name. Hard-capped at 500 hits per call to bound response size — narrow `pattern` or `projectName` if hits are truncated. " +
         "Paginated via offset/limit — callers should iterate until hasMore=false. totalCount counts all hits up to the 500-hit hard cap (collection ceiling, decoupled from the user-facing page limit); the paged items slice contains only the [offset, offset+limit) window. " +
         "Response shape: { count, totalCount, hasMore, offset, limit, items: [{ filePath, line, column, tokenKind, snippet }] } sorted by ascending file/line/column.")]
     [McpToolMetadata("analysis", "experimental", true, false,
@@ -446,8 +446,8 @@ public static class AnalysisTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description(".NET regex pattern to match against token text.")] string pattern,
         [Description("Token-kind scope: 'identifiers' | 'strings' | 'comments' | 'all'.")] string scope = "identifiers",
-        [Description("Optional: case-sensitive Project.Name filter to scope the walk.")] string? projectFilter = null,
-        [Description("Page size — maximum hits to return per call (default 500). Hits beyond the 500-hit collection ceiling are dropped; narrow pattern or projectFilter if hasMore stays true at offset=500.")] int limit = 500,
+        [Description("Optional: case-sensitive Project.Name filter to scope the walk.")] string? projectName = null,
+        [Description("Page size — maximum hits to return per call (default 500). Hits beyond the 500-hit collection ceiling are dropped; narrow pattern or projectName if hasMore stays true at offset=500.")] int limit = 500,
         [Description("Number of hits to skip before returning results (default: 0).")] int offset = 0,
         CancellationToken ct = default)
     {
@@ -458,7 +458,7 @@ public static class AnalysisTools
             // The user-facing `limit` is the page size, not the collection ceiling — see
             // SemanticGrepHardCap comment. Mirrors find_type_usages / find_reflection_usages
             // which collect-all then Skip/Take client-side.
-            var results = await semanticGrepService.SearchAsync(workspaceId, pattern, scope, projectFilter, SemanticGrepHardCap, c);
+            var results = await semanticGrepService.SearchAsync(workspaceId, pattern, scope, projectName, SemanticGrepHardCap, c);
             var paged = results.Skip(offset).Take(limit).ToList();
             var hasMore = offset + paged.Count < results.Count;
             return JsonSerializer.Serialize(new

--- a/src/RoslynMcp.Host.Stdio/Tools/ExceptionFlowTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExceptionFlowTools.cs
@@ -25,13 +25,13 @@ public static class ExceptionFlowTools
         IExceptionFlowService exceptionFlowService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Fully qualified metadata name of the exception type to trace, e.g. 'System.Text.Json.JsonException' or 'System.ArgumentException'")] string exceptionTypeMetadataName,
-        [Description("Optional: restrict the walk to a specific project name")] string? scopeProjectFilter = null,
+        [Description("Optional: restrict the walk to a specific project name")] string? projectName = null,
         [Description("Optional: cap the returned catch-site list. Defaults to 200; absolute upper bound is 2000 to keep the payload bounded.")] int? maxResults = null,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
             c => exceptionFlowService.TraceExceptionFlowAsync(
-                workspaceId, exceptionTypeMetadataName, scopeProjectFilter, maxResults, c),
+                workspaceId, exceptionTypeMetadataName, projectName, maxResults, c),
             ct);
 }

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -99,7 +99,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
             WorkspaceExecutionGate,
             UnusedCodeAnalyzer,
             WorkspaceId,
-            projectFilter: "SampleLib",
+            projectName: "SampleLib",
             includePublic: false,
             usageKind: "never-read",
             limit: 20,

--- a/tests/RoslynMcp.Tests/ExperimentalSurfaceParameterNamingTests.cs
+++ b/tests/RoslynMcp.Tests/ExperimentalSurfaceParameterNamingTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// parameter-naming-canonicalization-migration: lock the canonical wire-parameter name for
+/// the project-scope filter across the experimental tool surface to <c>projectName</c>.
+///
+/// Five experimental tools historically exposed non-canonical wire keys —
+/// <c>find_dead_locals</c>, <c>find_dead_fields</c>, <c>find_duplicate_helpers</c>, and
+/// <c>semantic_grep</c> used <c>projectFilter</c>; <c>trace_exception_flow</c> used
+/// <c>scopeProjectFilter</c>. Every other tool that scopes by project already uses
+/// <c>projectName</c>, so these were the outliers a consumer had to special-case.
+///
+/// The reflection sweep below is the regression guard: it walks every <c>[McpServerTool]</c>
+/// method annotated <c>experimental</c> via <see cref="McpToolMetadataAttribute"/> and asserts
+/// none of them exposes a <c>projectFilter</c> or <c>scopeProjectFilter</c> wire parameter. A
+/// missed rename — or a future experimental tool that reintroduces the old name — fails here.
+///
+/// NOTE — negative space: STABLE-tier tools that still legitimately expose <c>projectFilter</c>
+/// (e.g. <c>find_duplicated_methods</c> / <c>find_duplicated_code</c> in AdvancedAnalysisTools,
+/// <c>find_type_consumers</c> in ConsumerAnalysisTools) are intentionally out of scope of this
+/// migration and are NOT asserted on — the SupportTier filter excludes them.
+/// </summary>
+[TestClass]
+public sealed class ExperimentalSurfaceParameterNamingTests
+{
+    // The wire parameter names this migration eliminated from the experimental surface.
+    private static readonly string[] BannedExperimentalParameterNames = ["projectFilter", "scopeProjectFilter"];
+
+    // The five experimental tools whose project-scope wire parameter was renamed to projectName.
+    // Pinned by name so the positive assertion below survives a tool being renamed or retired
+    // (a stale entry surfaces as a discovery failure rather than silently passing).
+    private static readonly string[] RenamedExperimentalTools =
+    [
+        "find_dead_locals",
+        "find_dead_fields",
+        "find_duplicate_helpers",
+        "semantic_grep",
+        "trace_exception_flow",
+    ];
+
+    [TestMethod]
+    public void NoExperimentalTool_ExposesNonCanonicalProjectScopeParameter()
+    {
+        var failures = new List<string>();
+        foreach (var (toolName, method) in EnumerateExperimentalToolMethods())
+        {
+            foreach (var param in method.GetParameters())
+            {
+                if (BannedExperimentalParameterNames.Contains(param.Name, StringComparer.Ordinal))
+                {
+                    failures.Add(
+                        $"{toolName} ({method.DeclaringType!.Name}.{method.Name}): exposes wire parameter " +
+                        $"'{param.Name}'. Experimental tools must use the canonical 'projectName' for the " +
+                        "project-scope filter (parameter-naming-canonicalization-migration).");
+                }
+            }
+        }
+
+        Assert.AreEqual(0, failures.Count,
+            "Experimental tools expose non-canonical project-scope parameter names:\n\n" +
+            string.Join("\n", failures));
+    }
+
+    [TestMethod]
+    public void RenamedExperimentalTools_ExposeProjectNameWireParameter()
+    {
+        var methodsByToolName = EnumerateExperimentalToolMethods()
+            .ToDictionary(pair => pair.ToolName, pair => pair.Method, StringComparer.Ordinal);
+
+        foreach (var toolName in RenamedExperimentalTools)
+        {
+            Assert.IsTrue(methodsByToolName.TryGetValue(toolName, out var method),
+                $"Experimental tool '{toolName}' was not discovered — it was renamed, retired, or its " +
+                "experimental tier flipped. Update RenamedExperimentalTools accordingly.");
+
+            var hasProjectName = method!.GetParameters()
+                .Any(p => string.Equals(p.Name, "projectName", StringComparison.Ordinal));
+
+            Assert.IsTrue(hasProjectName,
+                $"Tool '{toolName}' ({method.DeclaringType!.Name}.{method.Name}) must expose a 'projectName' " +
+                "wire parameter after the canonicalization migration.");
+        }
+    }
+
+    private static IEnumerable<(string ToolName, MethodInfo Method)> EnumerateExperimentalToolMethods()
+    {
+        var toolAssembly = typeof(ServerTools).Assembly;
+        var experimentalMethods = toolAssembly.GetTypes()
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .Where(m => string.Equals(
+                m.GetCustomAttribute<McpToolMetadataAttribute>()?.SupportTier,
+                "experimental",
+                StringComparison.Ordinal))
+            .Select(m => (ToolName: m.GetCustomAttribute<McpServerToolAttribute>()!.Name!, Method: m))
+            .ToList();
+
+        Assert.IsTrue(experimentalMethods.Count > 0,
+            "No experimental [McpServerTool] methods were discovered — test fixture broken.");
+
+        return experimentalMethods;
+    }
+}

--- a/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
@@ -148,7 +148,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
             workspaceId: WorkspaceId,
             pattern: ".",
             scope: "identifiers",
-            projectFilter: null,
+            projectName: null,
             limit: Limit,
             offset: 0,
             ct: CancellationToken.None);
@@ -192,7 +192,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
             workspaceId: WorkspaceId,
             pattern: ".",
             scope: "identifiers",
-            projectFilter: null,
+            projectName: null,
             limit: Limit,
             offset: 0,
             ct: CancellationToken.None);
@@ -203,7 +203,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
             workspaceId: WorkspaceId,
             pattern: ".",
             scope: "identifiers",
-            projectFilter: null,
+            projectName: null,
             limit: Limit,
             offset: Limit,
             ct: CancellationToken.None);


### PR DESCRIPTION
## Summary

Renames the wire-facing project-scope filter parameter on 5 **experimental** MCP tools to the canonical `projectName`. Every other project-scoped tool on the server already uses `projectName`; these 5 were the outliers a consumer had to special-case.

| Tool | Before | After |
|------|--------|-------|
| `find_dead_locals` | `projectFilter` | `projectName` |
| `find_dead_fields` | `projectFilter` | `projectName` |
| `find_duplicate_helpers` | `projectFilter` | `projectName` |
| `semantic_grep` | `projectFilter` | `projectName` |
| `trace_exception_flow` | `scopeProjectFilter` | `projectName` |

## Scope / negative space

- Rename is strictly the `[McpServerTool]` **wire** parameter declarations + their in-method references + `[Description]` wire-key mentions.
- Internal service-layer params keep their names (`IExceptionFlowService.TraceExceptionFlowAsync`'s `scopeProjectFilter`, the `*AnalysisOptions.ProjectFilter` option-object properties); the wrappers pass the renamed value **positionally**.
- **STABLE-tier `projectFilter` params are intentionally untouched**: `find_duplicated_methods` / `find_duplicated_code` (same file, shared `FindDuplicatedMethodsCore`) and `find_type_consumers` (`ConsumerAnalysisTools.cs`, not opened).

## Tests

- New `ExperimentalSurfaceParameterNamingTests` — reflection sweep over every `experimental`-tier `[McpServerTool]` asserting none exposes `projectFilter`/`scopeProjectFilter`, plus a positive pin that the 5 renamed tools expose `projectName`. A missed rename (or a future experimental tool reintroducing the old name) fails here.
- Updated the 4 wrapper-call sites in `ExpandedSurfaceIntegrationTests` + `SemanticGrepServiceTests` to the new named argument (compile fixes from the rename, not shims).
- `SurfaceCatalogTests` needed **no** change: the catalog stores `parameters: null` for all tools (only prompts carry `parameters`), so the wire rename does not alter the v2.3.1→current version-diff (verified passing).

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors)
- Targeted tests (`ExperimentalSurfaceParameterNamingTests` + `ExceptionFlow*` + `SemanticGrep*` + `SurfaceCatalogTests`) — 39/39 pass

## Breaking change

The project-scope wire parameter on the 5 experimental tools above is renamed to `projectName`. Experimental tier; callers using the old keys must update.

Closes: parameter-naming-canonicalization-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)