### PR TITLE
chore(plan): sync deferred namespace-cycle metadata (no-op closure + size cache)

### DIFF
--- a/ai_docs/items/hoststdio-middleware-tools-namespace-cycle.md
+++ b/ai_docs/items/hoststdio-middleware-tools-namespace-cycle.md
@@ -1,6 +1,6 @@
 # hoststdio-middleware-tools-namespace-cycle — break the Middleware ↔ Tools namespace cycle
 
-**row:** `hoststdio-middleware-tools-namespace-cycle` · **pri:** `Low` · **size:** `M` <!-- cache — the backlog row is canonical for pri/size; refresh on open if they disagree -->
+**row:** `hoststdio-middleware-tools-namespace-cycle` · **pri:** `Low` · **size:** `L` <!-- cache — the backlog row is canonical for pri/size; refresh on open if they disagree -->
 
 ## Anchors
 

--- a/ai_docs/plans/20260620T233102Z_backlog-sweep/plan.md
+++ b/ai_docs/plans/20260620T233102Z_backlog-sweep/plan.md
@@ -19,7 +19,7 @@
 | 7 | trace-exception-flow-no-throwsite | merged | [#1015](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/1015) | trace-exception-flow-no-throwsite |
 | 8 | compilation-cache-adoption-read-side | merged | [#1010](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/1010) | — |
 | 9 | workspace-id-optional-readonly-surface-full-sweep | merged | [#1012](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/1012) | — |
-| 10 | hoststdio-middleware-tools-namespace-cycle | deferred | — | hoststdio-middleware-tools-namespace-cycle |
+| 10 | hoststdio-middleware-tools-namespace-cycle | deferred | — | — |
 <!-- BSWEEP:STATUS-TABLE END -->
 
 ## Initiatives (in order)

--- a/ai_docs/plans/20260620T233102Z_backlog-sweep/state.json
+++ b/ai_docs/plans/20260620T233102Z_backlog-sweep/state.json
@@ -358,9 +358,7 @@
       "id": "hoststdio-middleware-tools-namespace-cycle",
       "order": 10,
       "status": "deferred",
-      "backlogRowsClosed": [
-        "hoststdio-middleware-tools-namespace-cycle"
-      ],
+      "backlogRowsClosed": [],
       "productionFilesTouched": 3,
       "productionFiles": [
         "src/RoslynMcp.Host.Stdio/Catalog/WorkspaceResolutionHelper.cs",
@@ -368,7 +366,7 @@
         "src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs"
       ],
       "testFilesAdded": 1,
-      "rowsClosedCount": 1,
+      "rowsClosedCount": 0,
       "estimatedContextTokens": 30000,
       "toolPolicy": "edit-only",
       "scheduleHint": null,
@@ -384,7 +382,7 @@
       "worktreePath": null,
       "prUrl": null,
       "mergedAt": null,
-      "notes": "Touches WorkspaceTools.cs (also touched by #5 worktree-teardown) -> conflict-graph edge; must not parallel-wave with #5.",
+      "notes": "Touches WorkspaceTools.cs (also touched by #5 worktree-teardown) -> conflict-graph edge; must not parallel-wave with #5. Deferred — closes no row (premise false; see items re-plan note).",
       "fileSetHash": "5404b1fd4487eeb2e65c7a7229472ce143a54838ea9c9f7b0b8ba138286dabbe",
       "stanzaHash": "4bb9d6692fece561b693c0496d2cc20a90ee6aed146e24b0e749b82b68214c32",
       "reviewedStanzaHash": "4bb9d6692fece561b693c0496d2cc20a90ee6aed146e24b0e749b82b68214c32"


### PR DESCRIPTION
Post-reconcile cleanup from the `20260620T233102Z` sweep's self-review cold pass. Plan-metadata only.

- `state.json`: deferred initiative `hoststdio-middleware-tools-namespace-cycle` had a leftover `backlogRowsClosed`/`rowsClosedCount: 1` from its pre-deferral plan text — a deferred initiative closes nothing. Nulled both (+ note) and regenerated the plan.md status table so it no longer claims a closure that didn't happen (and won't trip a future `reconcile-plans`).
- `items/hoststdio-middleware-tools-namespace-cycle.md`: size cache header `M` → `L` to match the canonical backlog row (bumped at reconcile when the ToolErrorHandler blast radius was discovered).

No code, no backlog rows changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)