### PR TITLE
chore(backlog): file stale-precedence-comment row (cold-review finding)

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-06-21T21:49:58Z
+**updated_at:** 2026-06-21T22:09:05Z
 
 ## Agent contract
 
@@ -83,6 +83,7 @@
 | dup-method-detector-test-setup-dedup | Low | — | **De-dup DuplicateMethodDetectorTests workspace setup** — `BuildServiceAndGate` copy-pastes ~22 lines from `BuildServiceWithSourcesCore` (delta: the added gate); reuse the existing builder. [type: test] [source: 2026-06-21 sweep #1011 cq] | S | items/dup-method-detector-test-setup-dedup.md |
 | exception-flow-throwsite-test-and-arm-dedup | Low | — | **trace_exception_flow throw-site exclusion test + arm dedup** — add a test that an unrelated thrown type is excluded from ThrowSites; dedupe the bounded-add across the throw-node switch arms. [type: test] [source: 2026-06-21 sweep #1015 cq] | S | items/exception-flow-throwsite-test-and-arm-dedup.md |
 | aggregate-scorecard-test-runner-dedup | Low | — | **Dedup AggregatePromotionScorecards test runner helpers** — collapse `RunAggregatorWithIncludeSelf` (a ~30-line near-copy of `RunAggregator`) into one parameterized helper backing all call sites. [type: refactor] [source: 2026-06-21 top-n cq] | S | items/aggregate-scorecard-test-runner-dedup.md |
+| filewatcher-markstaleifrelevant-stale-precedence-comment | Low | — | **MarkStaleIfRelevant comment claims external-edit precedence the code lacks** — `FileWatcherService.cs:154-155` says external edits take precedence / no-downgrade, but `MarkStaleWithReason` (:247) is unconditional last-writer-wins; fix or delete the stale comment. [type: docs] [source: 2026-06-21 top-n cold-review] | S | items/filewatcher-markstaleifrelevant-stale-precedence-comment.md |
 
 ## Defer
 

--- a/ai_docs/items/filewatcher-markstaleifrelevant-stale-precedence-comment.md
+++ b/ai_docs/items/filewatcher-markstaleifrelevant-stale-precedence-comment.md
@@ -1,0 +1,19 @@
+# filewatcher-markstaleifrelevant-stale-precedence-comment — comment claims external-edit precedence the code doesn't implement
+
+**row:** `filewatcher-markstaleifrelevant-stale-precedence-comment` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Roslyn/Services/FileWatcherService.cs:151-156` — the `MarkStaleIfRelevant` inline comment ("External edits take precedence: once set, a subsequent explicit MarkStale(\"apply\") does not downgrade.")
+
+## Acceptance
+
+- [ ] The stale claim is fixed or deleted so no comment asserts external-edit precedence / no-downgrade. The actual behavior is unconditional **last-writer-wins** — `MarkStaleWithReason` (`FileWatcherService.cs:247`) does `_staleReason = reason` with no precedence guard, and its own `<summary>` + the class `<remarks>` both state last-writer-wins.
+
+## Evidence
+
+- Cold-review of the 2026-06-21 top-n-remediation run flagged the contradiction: `MarkStaleIfRelevant` (lines 151-156) claims "External edits take precedence: once set, a subsequent explicit MarkStale(\"apply\") does not downgrade", but `MarkStaleWithReason` is unconditional last-writer-wins (`:243-253`, `_staleReason = reason`). Predates this run (`git blame` → #267, April 2026); now also contradicts the corrected class `<remarks>` and the `filewatcher-class-xmldoc-truncated` clause completed in the same run.
+
+## Context
+
+Pure doc-accuracy fix, 1 file, 1 comment. The inline comment was authored before the last-writer-wins semantics were settled and never updated. Low priority; the runtime behavior is correct — only the comment lies.


### PR DESCRIPTION
Files one Low/S backlog row surfaced by the cold-review self-reflection pass of the 2026-06-21 `/top-n-remediation` run (Directive #3).

## Finding (pre-existing, not introduced this run)
`FileWatcherService.MarkStaleIfRelevant` (`:151-156`) carries a stale comment: *"External edits take precedence: once set, a subsequent explicit MarkStale(\"apply\") does not downgrade."* The actual behavior is unconditional **last-writer-wins** — `MarkStaleWithReason` (`:247`) does `_staleReason = reason` with no precedence guard, and its own `<summary>` + the class `<remarks>` both say last-writer-wins. The contradiction became sharper after this run completed the class XML-doc clause (`filewatcher-class-xmldoc-truncated`, #1022).

Tracked as `filewatcher-markstaleifrelevant-stale-precedence-comment` for a future run; the runtime behavior is correct — only the comment lies.

## Validation
Docs-only change (`ai_docs/backlog.md` + new `items/<id>.md`) — `backlog-lint` 0 ERROR. CI runs the docs-only path (verify-ai-docs + skills-generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)