### PR TITLE
fix(security)!: default PathValidationFailOpen to fail-closed

### DIFF
--- a/changelog.d/security-options-fail-open-default.md
+++ b/changelog.d/security-options-fail-open-default.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed (BREAKING):** `SecurityOptions.PathValidationFailOpen` now defaults to `false` (fail-closed). Previously, an MCP client roots-lookup failure silently allowed file writes/edits through; it now rejects them unless `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN=true` is explicitly set. This closes a fail-open trust-boundary gap on path validation.

--- a/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
@@ -14,8 +14,9 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// If the client does not advertise roots capability, or if the roots list is empty,
 /// the path is allowed unconditionally. If the roots request itself fails (e.g. the
 /// client advertises the capability but doesn't fully support it), behavior depends on
-/// <see cref="SecurityOptions.PathValidationFailOpen"/>: when true (default) the path is
-/// allowed; when false the request is rejected.
+/// <see cref="SecurityOptions.PathValidationFailOpen"/>: when false (default) the request
+/// is rejected (fail-closed); when true the path is allowed (fail-open). When no
+/// <see cref="SecurityOptions"/> is supplied, the fail-closed default applies.
 /// Symlinks and junctions are resolved before comparison to prevent traversal attacks.
 /// </remarks>
 internal static class ClientRootPathValidator
@@ -47,7 +48,7 @@ internal static class ClientRootPathValidator
         SecurityOptions? securityOptions = null,
         bool expandSanctionedRoots = false)
     {
-        var failOpen = securityOptions?.PathValidationFailOpen ?? true;
+        var failOpen = securityOptions?.PathValidationFailOpen ?? false;
 
         try
         {

--- a/src/RoslynMcp.Roslyn/Services/SecurityOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/SecurityOptions.cs
@@ -6,10 +6,10 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class SecurityOptions
 {
     /// <summary>
-    /// When <c>true</c> (default), if the MCP client roots lookup fails the path is allowed
-    /// unconditionally. When <c>false</c>, a roots lookup failure causes path validation to reject
-    /// the request (fail-closed).
+    /// When <c>false</c> (default), a roots lookup failure causes path validation to reject the
+    /// request (fail-closed). When <c>true</c>, if the MCP client roots lookup fails the path is
+    /// allowed unconditionally (fail-open).
     /// Set via <c>ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN</c> (true/false).
     /// </summary>
-    public bool PathValidationFailOpen { get; init; } = true;
+    public bool PathValidationFailOpen { get; init; }
 }

--- a/tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs
+++ b/tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -96,6 +97,29 @@ public class ClientRootPathValidatorTests
         await ClientRootPathValidator.ValidatePathAgainstRootsAsync(
             null!, "C:\\any\\path", CancellationToken.None);
         // No exception = pass
+    }
+
+    // ───────── SecurityOptions fail-open/fail-closed default tests ─────────
+
+    [TestMethod]
+    public void SecurityOptions_Default_Is_FailClosed()
+    {
+        // The trust-boundary default: a fresh SecurityOptions (what BindSecurityOptions supplies
+        // when ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN is unset/unparseable) must fail CLOSED. A
+        // roots-lookup failure then rejects the write/edit rather than silently allowing it.
+        Assert.IsFalse(new SecurityOptions().PathValidationFailOpen,
+            "PathValidationFailOpen must default to false (fail-closed) on a security-relevant path check.");
+    }
+
+    [TestMethod]
+    public void SecurityOptions_FailOpen_Is_Opt_In()
+    {
+        // The escape hatch is explicit-only: fail-open is reachable solely by setting the value
+        // to true (mirrors ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN=true). The null-coalescing fallback
+        // in ValidatePathAgainstRootsAsync (`securityOptions?.PathValidationFailOpen ?? false`)
+        // therefore resolves to fail-closed whenever no options object is supplied.
+        Assert.IsTrue(new SecurityOptions { PathValidationFailOpen = true }.PathValidationFailOpen,
+            "Fail-open must remain reachable via explicit opt-in.");
     }
 
     // ───────── IsPathUnderAnyRoot tests (sanctioned-root + expandSanctionedRoots widening) ─────────


### PR DESCRIPTION
## Summary

Flips `SecurityOptions.PathValidationFailOpen` from a fail-open default to **fail-closed** — closing a fail-open trust-boundary gap on a security-relevant path check.

- `SecurityOptions.PathValidationFailOpen` default flipped `true` → `false` (XML doc updated to match).
- `ClientRootPathValidator.ValidatePathAgainstRootsAsync` null-coalescing fallback flipped `?? true` → `?? false`, so callers passing `securityOptions: null` also fail closed. `<remarks>` doc updated.
- `Program.cs BindSecurityOptions` needs no change — it already falls back to `new SecurityOptions()` on unset/unparseable env var, which now carries the corrected default.
- `ai_docs/runtime.md` already documented the default as `false`; code and doc are now in agreement (no doc edit needed).

## Behavior change (BREAKING)

When an MCP client's roots lookup throws inside `ValidatePathAgainstRootsAsync`, the request is now **rejected** (fail-closed) instead of being silently allowed. Deployments that relied on the implicit fail-open behavior must set `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN=true` to restore it. Private repo, internal default, no external consumer (Directive #4).

## Tests

`tests/RoslynMcp.Tests/ClientRootPathValidatorTests.cs` extended with:
- `SecurityOptions_Default_Is_FailClosed` — `new SecurityOptions().PathValidationFailOpen` is `false`.
- `SecurityOptions_FailOpen_Is_Opt_In` — fail-open reachable only via explicit `= true`, documenting that the `?? false` fallback resolves fail-closed when no options object is supplied.

Targeted run green: `dotnet test --filter FullyQualifiedName~ClientRootPathValidatorTests` → 21/21 passed.

**Note on acceptance scope:** a true end-to-end exception-path test (forcing `RequestRootsAsync` to throw inside the try/catch) would need new `McpServer` test-double infrastructure that does not exist in the suite (no `FakeMcpServer`/`MockMcpServer`). Scope here is the achievable, observable subset: the default-value and fallback-semantics assertions. The server-null test short-circuits before the `failOpen` branch, so it remains unaffected.

Closes: security-options-fail-open-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)