### PR TITLE
fix(host-stdio): validate filePath against client roots in analysis tools

### DIFF
--- a/changelog.d/host-analysis-tools-missing-clientroot-path-validation.md
+++ b/changelog.d/host-analysis-tools-missing-clientroot-path-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `get_code_actions`, `preview_code_action`, `analyze_data_flow`, `analyze_control_flow`, and `get_operations` now validate `filePath` against client-sanctioned roots via `ClientRootPathValidator`.

--- a/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CodeActionTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 using RoslynMcp.Host.Stdio.Catalog;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -27,6 +28,7 @@ public static class CodeActionTools
     [McpToolMetadata("code-actions", "stable", true, false,
         "List Roslyn code fixes and refactorings at a location or selection range. Selection-range refactorings include introduce parameter and inline temporary variable. Pass endLine/endColumn for selection-range actions.")]
     public static Task<string> GetCodeActions(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ICodeActionService codeActionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -39,13 +41,18 @@ public static class CodeActionTools
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => codeActionService.GetCodeActionsAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, c),
+            async c =>
+            {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+                return await codeActionService.GetCodeActionsAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, c).ConfigureAwait(false);
+            },
             ct);
 
     [McpServerTool(Name = "preview_code_action", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview the changes that a specific code action would make. Use get_code_actions first to get the available actions and their indices.")]
     [McpToolMetadata("code-actions", "stable", true, false,
         "Preview a Roslyn code action before applying it.")]
     public static Task<string> PreviewCodeAction(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ICodeActionService codeActionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -59,7 +66,11 @@ public static class CodeActionTools
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => codeActionService.PreviewCodeActionAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, actionIndex, c),
+            async c =>
+            {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+                return await codeActionService.PreviewCodeActionAsync(workspaceId, filePath, startLine, startColumn, endLine, endColumn, actionIndex, c).ConfigureAwait(false);
+            },
             ct);
 
     [McpServerTool(Name = "apply_code_action", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false), Description("Apply a previously previewed code action using its preview token")]

--- a/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 using RoslynMcp.Host.Stdio.Catalog;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -19,6 +20,7 @@ public static class FlowAnalysisTools
         "Analyze variable flow through a code region: reads, writes, captures, always-assigned."),
      Description("Analyze how variables flow through a code region: which are read, written, captured by lambdas, always assigned, etc. Use to understand data dependencies before refactoring.")]
     public static Task<string> AnalyzeDataFlow(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IFlowAnalysisService flowAnalysisService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -29,7 +31,11 @@ public static class FlowAnalysisTools
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => flowAnalysisService.AnalyzeDataFlowAsync(workspaceId, filePath, startLine, endLine, c),
+            async c =>
+            {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+                return await flowAnalysisService.AnalyzeDataFlowAsync(workspaceId, filePath, startLine, endLine, c).ConfigureAwait(false);
+            },
             ct);
 
     [McpServerTool(Name = "analyze_control_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
@@ -37,6 +43,7 @@ public static class FlowAnalysisTools
         "Analyze control flow: entry/exit points, reachability, return statements."),
      Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. EndPointIsReachable follows Roslyn semantics (whether execution can fall through the end of the region without return/throw), not whether the method can complete; see Warning when returns exist but EndPointIsReachable is false.")]
     public static Task<string> AnalyzeControlFlow(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IFlowAnalysisService flowAnalysisService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -47,6 +54,10 @@ public static class FlowAnalysisTools
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
             workspaceId,
-            c => flowAnalysisService.AnalyzeControlFlowAsync(workspaceId, filePath, startLine, endLine, c),
+            async c =>
+            {
+                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+                return await flowAnalysisService.AnalyzeControlFlowAsync(workspaceId, filePath, startLine, endLine, c).ConfigureAwait(false);
+            },
             ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
+using McpServer = ModelContextProtocol.Server.McpServer;
 using RoslynMcp.Host.Stdio.Catalog;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -14,6 +15,7 @@ public static class OperationTools
         "Get the IOperation tree for behavioral analysis at a source position."),
      Description("Get the IOperation tree (language-agnostic behavioral representation) for a syntax node. Returns operation kinds like Invocation, Assignment, Loop, etc. Use for behavioral pattern matching at a higher abstraction than syntax trees. IMPORTANT (UX-003): the column must point at the syntax token whose operation you want — calling on a token returns that token's operation, NOT the enclosing expression. To inspect a method call, place the column on the method-name identifier, not on '(' or whitespace; to inspect a binary expression, place it on the operator. If you only have an approximate cursor, walk outward by re-querying with adjacent columns until the desired operation kind appears.")]
     public static Task<string> GetOperations(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         IOperationService operationService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -25,6 +27,7 @@ public static class OperationTools
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
             var result = await operationService.GetOperationsAsync(workspaceId, filePath, line, column, maxDepth, c);
             if (result is null)
                 return JsonSerializer.Serialize(new { message = "No IOperation found at the specified position." }, JsonDefaults.Indented);

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.ToolContract.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.ToolContract.cs
@@ -79,6 +79,7 @@ public sealed class ExpandedSurfaceIntegrationTests_ToolContract : SharedWorkspa
     public async Task PreviewCodeAction_Serializes_Service_Response()
     {
         var previewJson = await CodeActionTools.PreviewCodeAction(
+            null!,
             WorkspaceExecutionGate,
             new FakeCodeActionService(),
             WorkspaceId,

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -392,6 +392,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var actionsJson = await CodeActionTools.GetCodeActions(
+            null!,
             WorkspaceExecutionGate,
             CodeActionService,
             WorkspaceId,
@@ -405,6 +406,72 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         using var actionsDoc = JsonDocument.Parse(actionsJson);
         Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("count", out _));
         Assert.IsTrue(actionsDoc.RootElement.TryGetProperty("actions", out _));
+    }
+
+    // host-analysis-tools-missing-clientroot-path-validation: AnalyzeDataFlow, AnalyzeControlFlow,
+    // and GetOperations gained a leading McpServer parameter so they can call
+    // ClientRootPathValidator.ValidatePathAgainstRootsAsync before dispatching to their service,
+    // mirroring the pattern already covered for GetSyntaxTree/GetCodeActions above. Passing null!
+    // for server exercises the same no-capability fail-open branch pinned by
+    // ClientRootPathValidatorTests.ValidatePath_NullServer_AllowsAccess — the validator's actual
+    // root-matching logic (accept/reject/traversal/case-insensitivity) is exhaustively unit-tested
+    // there via IsPathUnderAnyRoot; a live root-rejection round trip through these tools would
+    // require standing up the SDK's full transport pipeline, which the codebase's existing
+    // precedent (see StructuredCallToolFilterElicitationTests remarks) treats as impractical for a
+    // unit test.
+    [TestMethod]
+    public async Task AnalyzeDataFlow_Returns_Structured_Results()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var json = await FlowAnalysisTools.AnalyzeDataFlow(
+            null!,
+            WorkspaceExecutionGate,
+            FlowAnalysisService,
+            WorkspaceId,
+            filePath,
+            startLine: 32,
+            endLine: 37,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.ValueKind == JsonValueKind.Object);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeControlFlow_Returns_Structured_Results()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var json = await FlowAnalysisTools.AnalyzeControlFlow(
+            null!,
+            WorkspaceExecutionGate,
+            FlowAnalysisService,
+            WorkspaceId,
+            filePath,
+            startLine: 32,
+            endLine: 37,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.ValueKind == JsonValueKind.Object);
+    }
+
+    [TestMethod]
+    public async Task GetOperations_Returns_Structured_Results()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var json = await OperationTools.GetOperations(
+            null!,
+            WorkspaceExecutionGate,
+            OperationService,
+            WorkspaceId,
+            filePath,
+            line: 27,
+            column: 16,
+            maxDepth: 3,
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.ValueKind == JsonValueKind.Object);
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -1,4 +1,9 @@
+using System.IO.Pipelines;
 using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Host.Stdio.Tools;
 
@@ -415,10 +420,15 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     // for server exercises the same no-capability fail-open branch pinned by
     // ClientRootPathValidatorTests.ValidatePath_NullServer_AllowsAccess — the validator's actual
     // root-matching logic (accept/reject/traversal/case-insensitivity) is exhaustively unit-tested
-    // there via IsPathUnderAnyRoot; a live root-rejection round trip through these tools would
-    // require standing up the SDK's full transport pipeline, which the codebase's existing
-    // precedent (see StructuredCallToolFilterElicitationTests remarks) treats as impractical for a
-    // unit test.
+    // there via IsPathUnderAnyRoot. A live root-rejection round trip through these tools additionally
+    // needs a real McpServer whose ClientCapabilities.Roots is populated — see
+    // CreateServerWithSanctionedRootAsync below, which wires a real McpServer/McpClient pair over an
+    // in-memory duplex pipe (ModelContextProtocol.Server.StreamServerTransport +
+    // ModelContextProtocol.Client.StreamClientTransport) and answers "roots/list" from the client
+    // side, exactly like a real MCP client would. This closes the round-trip gap the
+    // StructuredCallToolFilterElicitationTests remarks call out as impractical for ElicitAsync (which
+    // needs full duplex request/response mid-call); RequestRootsAsync only needs one round trip at
+    // handshake time, which this harness provides cheaply.
     [TestMethod]
     public async Task AnalyzeDataFlow_Returns_Structured_Results()
     {
@@ -472,6 +482,193 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
 
         using var doc = JsonDocument.Parse(json);
         Assert.IsTrue(doc.RootElement.ValueKind == JsonValueKind.Object);
+    }
+
+    // ── Root-rejection regression coverage ───────────────────────────────────
+    // The tests above only exercise the null-server (fail-open, no-capability) branch.
+    // These pin the other half of the contract: when the client DOES advertise roots and
+    // the requested filePath falls outside every sanctioned root, ValidatePathAgainstRootsAsync
+    // must reject it — for all 5 endpoints this initiative touched.
+
+    [TestMethod]
+    public async Task GetCodeActions_Rejects_FilePath_Outside_SanctionedRoot()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
+        await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => CodeActionTools.GetCodeActions(
+            harness.Server,
+            WorkspaceExecutionGate,
+            CodeActionService,
+            WorkspaceId,
+            filePath,
+            startLine: 1,
+            startColumn: 1,
+            endLine: null,
+            endColumn: null,
+            CancellationToken.None));
+        StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+    }
+
+    [TestMethod]
+    public async Task PreviewCodeAction_Rejects_FilePath_Outside_SanctionedRoot()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
+        await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => CodeActionTools.PreviewCodeAction(
+            harness.Server,
+            WorkspaceExecutionGate,
+            CodeActionService,
+            WorkspaceId,
+            filePath,
+            startLine: 1,
+            startColumn: 1,
+            actionIndex: 0,
+            endLine: null,
+            endColumn: null,
+            CancellationToken.None));
+        StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeDataFlow_Rejects_FilePath_Outside_SanctionedRoot()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
+        await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeDataFlow(
+            harness.Server,
+            WorkspaceExecutionGate,
+            FlowAnalysisService,
+            WorkspaceId,
+            filePath,
+            startLine: 32,
+            endLine: 37,
+            CancellationToken.None));
+        StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeControlFlow_Rejects_FilePath_Outside_SanctionedRoot()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
+        await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeControlFlow(
+            harness.Server,
+            WorkspaceExecutionGate,
+            FlowAnalysisService,
+            WorkspaceId,
+            filePath,
+            startLine: 32,
+            endLine: 37,
+            CancellationToken.None));
+        StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+    }
+
+    [TestMethod]
+    public async Task GetOperations_Rejects_FilePath_Outside_SanctionedRoot()
+    {
+        var filePath = FindDocumentPath("AnimalService.cs");
+        var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
+        await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
+
+        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => OperationTools.GetOperations(
+            harness.Server,
+            WorkspaceExecutionGate,
+            OperationService,
+            WorkspaceId,
+            filePath,
+            line: 27,
+            column: 16,
+            maxDepth: 3,
+            CancellationToken.None));
+        StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+    }
+
+    /// <summary>
+    /// Returns a fresh temp directory guaranteed to NOT be an ancestor of the shared sample
+    /// workspace's files (which live under the repository's fixture tree), so any document
+    /// path resolved via <see cref="FindDocumentPath(string)"/> falls outside it.
+    /// </summary>
+    private static string CreateUnrelatedSanctionedRootDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "rmcp-sanctioned-root-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// Wires a real <see cref="McpServer"/> to a real <see cref="McpClient"/> over an in-memory
+    /// duplex pipe so <c>server.ClientCapabilities.Roots</c> is genuinely populated (via the MCP
+    /// initialize handshake) and <c>server.RequestRootsAsync</c> genuinely round-trips to a client
+    /// that advertises <paramref name="sanctionedRoot"/> as its only root — a live analogue of what
+    /// <see cref="ClientRootPathValidator.ValidatePathAgainstRootsAsync"/> talks to in production,
+    /// rather than a hand-rolled fake. Dispose the returned harness to tear down the client and stop
+    /// the server's receive loop.
+    /// </summary>
+    private static async Task<ServerWithSanctionedRootHarness> CreateServerWithSanctionedRootAsync(
+        string sanctionedRoot, CancellationToken ct)
+    {
+        var clientToServer = new Pipe();
+        var serverToClient = new Pipe();
+
+        var serverTransport = new StreamServerTransport(
+            clientToServer.Reader.AsStream(), serverToClient.Writer.AsStream(), "test-server", NullLoggerFactory.Instance);
+        var server = McpServer.Create(serverTransport, new McpServerOptions(), NullLoggerFactory.Instance, null);
+        var cts = new CancellationTokenSource();
+        var serverRunTask = server.RunAsync(cts.Token);
+
+        var clientTransport = new StreamClientTransport(
+            clientToServer.Writer.AsStream(), serverToClient.Reader.AsStream(), NullLoggerFactory.Instance);
+        var rootUri = new Uri(sanctionedRoot).AbsoluteUri;
+
+        var client = await McpClient.CreateAsync(
+            clientTransport,
+            new McpClientOptions
+            {
+                Capabilities = new ClientCapabilities { Roots = new RootsCapability() },
+                Handlers = new McpClientHandlers
+                {
+                    RootsHandler = (_, _) => ValueTask.FromResult(new ListRootsResult
+                    {
+                        Roots = [new Root { Uri = rootUri }],
+                    }),
+                },
+            },
+            NullLoggerFactory.Instance,
+            ct).ConfigureAwait(false);
+
+        return new ServerWithSanctionedRootHarness(server, client, cts, serverRunTask);
+    }
+
+    private sealed class ServerWithSanctionedRootHarness(
+        McpServer server, McpClient client, CancellationTokenSource cts, Task serverRunTask) : IAsyncDisposable
+    {
+        public McpServer Server { get; } = server;
+
+        public async ValueTask DisposeAsync()
+        {
+            await client.DisposeAsync().ConfigureAwait(false);
+            cts.Cancel();
+            try
+            {
+                await serverRunTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected — cancelling the server's receive loop surfaces as this.
+            }
+            finally
+            {
+                cts.Dispose();
+            }
+        }
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Five `filePath`-accepting MCP tool endpoints dispatched straight to their service without calling `ClientRootPathValidator.ValidatePathAgainstRootsAsync` first, unlike sibling validated tools:

- `CodeActionTools.cs`: `GetCodeActions`, `PreviewCodeAction`
- `FlowAnalysisTools.cs`: `AnalyzeDataFlow`, `AnalyzeControlFlow`
- `OperationTools.cs`: `GetOperations`

`PreviewCodeAction`'s output feeds `ApplyCodeAction` (`Destructive = true`), so an unvalidated `filePath` here was the entry point for a destructive apply on an out-of-root file.

Each of the five methods now takes a leading `McpServer server` parameter and validates `filePath` before calling into its service, mirroring the established pattern already used in `SymbolTools.cs`, `SyntaxTools.cs`, `EditTools.cs`, `FileOperationTools.cs`, `MultiFileEditTools.cs`, and `WorkspaceTools.cs`.

## Test plan

- [x] `mcp__roslyn__compile_check` clean (0 errors/warnings) on all 5 touched files
- [x] Existing `CodeActionTools_Return_Structured_Results` / `PreviewCodeAction_Serializes_Service_Response` call sites updated for the new leading param
- [x] Added `AnalyzeDataFlow_Returns_Structured_Results`, `AnalyzeControlFlow_Returns_Structured_Results`, `GetOperations_Returns_Structured_Results` — these two tool files previously had zero tool-level test coverage
- [x] `ClientRootPathValidatorTests` (19 tests) still pass — validator's root-matching logic is unchanged
- [x] `ToolDiResolutionTests` + `StartupDiagnosticsTests` (9 tests) pass — DI resolution unaffected by the new `McpServer` param
- [x] `eng/verify-ai-docs.ps1` passes
- [x] `eng/verify-changelog-fragments.ps1` passes

Note: a live round-trip test asserting actual *rejection* of an out-of-root path would require standing up the SDK's full transport pipeline to populate `McpServer.ClientCapabilities`/`RequestRootsAsync` — the codebase's existing precedent (see `StructuredCallToolFilterElicitationTests` remarks) treats that as impractical for a unit test, and no other validated call site in this repo does it either. The root-matching logic itself (accept/reject/traversal/case-insensitivity) is exhaustively unit-tested in `ClientRootPathValidatorTests`; what changed here is purely wiring the 5 endpoints to call it.

Closes: host-analysis-tools-missing-clientroot-path-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)