### PR TITLE
fix(host-stdio): validate filePath against client roots in extract/move-type tools

### DIFF
--- a/changelog.d/host-refactor-tools-root-boundary-validation.md
+++ b/changelog.d/host-refactor-tools-root-boundary-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_type_preview` and `move_type_to_file_preview` now validate `filePath`/`sourceFilePath` against MCP client-sanctioned roots.

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -21,6 +22,7 @@ public static class TypeExtractionTools
         "Preview extracting selected members from a type into a new type. Adds a private field and constructor parameter for composition. Use get_cohesion_metrics and find_shared_members to plan the extraction."),
      Description("Preview extracting selected members from a type into a new type. The source type gets a private field for the new type and the extracted members are moved. Use this for SRP refactoring.")]
     public static Task<string> PreviewExtractType(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ITypeExtractionService typeExtractionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -30,12 +32,15 @@ public static class TypeExtractionTools
         [Description("Name for the new type")] string newTypeName,
         [Description("Optional: target file path for the new type. If omitted, defaults to {NewTypeName}.cs in the same directory")] string? newFilePath = null,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
-            gate,
-            workspaceId,
-            c => typeExtractionService.PreviewExtractTypeAsync(
-                workspaceId, filePath, typeName, memberNames, newTypeName, newFilePath, c),
-            ct);
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, c).ConfigureAwait(false);
+            var dto = await typeExtractionService.PreviewExtractTypeAsync(
+                workspaceId, filePath, typeName, memberNames, newTypeName, newFilePath, c).ConfigureAwait(false);
+            return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
+        }, ct);
+    }
 
     [McpServerTool(Name = "extract_type_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", false, true,

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -23,6 +24,7 @@ public static class TypeMoveTools
         "Preview moving a type declaration into its own file."),
      Description("Preview moving a type declaration from a multi-type file into its own dedicated file within the same project. Requires the source file to contain at least two top-level types; for single-type rename/move operations use move_file_preview instead.")]
     public static Task<string> PreviewMoveTypeToFile(
+        McpServer server,
         IWorkspaceExecutionGate gate,
         ITypeMoveService typeMoveService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
@@ -30,11 +32,14 @@ public static class TypeMoveTools
         [Description("Name of the type to move")] string typeName,
         [Description("Optional: target file path. If omitted, defaults to {TypeName}.cs in the same directory")] string? targetFilePath = null,
         CancellationToken ct = default)
-        => ToolDispatch.ReadByWorkspaceIdAsync(
-            gate,
-            workspaceId,
-            c => typeMoveService.PreviewMoveTypeToFileAsync(workspaceId, sourceFilePath, typeName, targetFilePath, c),
-            ct);
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, sourceFilePath, c).ConfigureAwait(false);
+            var dto = await typeMoveService.PreviewMoveTypeToFileAsync(workspaceId, sourceFilePath, typeName, targetFilePath, c).ConfigureAwait(false);
+            return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
+        }, ct);
+    }
 
     [McpServerTool(Name = "move_type_to_file_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", false, true,

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -1,3 +1,5 @@
+using RoslynMcp.Host.Stdio.Tools;
+
 namespace RoslynMcp.Tests;
 
 [TestClass]
@@ -8,6 +10,63 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
 
     [ClassCleanup]
     public static void ClassCleanup() => DisposeServices();
+
+    // host-refactor-tools-root-boundary-validation: extract_type_preview now calls
+    // ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, filePath, ct) before
+    // dispatching to the service, mirroring GetSyntaxTree/GetCodeActions. Passing server: null!
+    // exercises the no-MCP-server-context fail-open branch pinned by
+    // ClientRootPathValidatorTests.ValidatePath_NullServer_AllowsAccess — the validator's actual
+    // root-matching logic (accept/reject/traversal/case-insensitivity) is exhaustively unit-tested
+    // there via IsPathUnderAnyRoot. A live root-rejection round trip through the tool would require
+    // standing up the SDK's full transport pipeline to populate McpServer.ClientCapabilities.Roots,
+    // which the existing precedent (ExpandedSurfaceIntegrationTests' AnalyzeDataFlow/
+    // AnalyzeControlFlow/GetOperations coverage) treats as impractical for a unit test.
+    [TestMethod]
+    public async Task PreviewExtractType_Tool_NullServer_AllowsAccess_And_ProducesPreview()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ExtractTypeToolFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExtractTypeToolFixture",
+                "{",
+                "    public int InternalUser() => Compute(42);",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var json = await TypeExtractionTools.PreviewExtractType(
+                null!,
+                WorkspaceExecutionGate,
+                TypeExtractionService,
+                wsId,
+                fixturePath,
+                "ExtractTypeToolFixture",
+                ["Compute"],
+                "ComputeHelper",
+                null,
+                CancellationToken.None);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(json));
+            StringAssert.Contains(json, "previewToken");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
 
     [TestMethod]
     public async Task ExtractType_FromAnimalService_RefusesWhenExternalConsumersExist()

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -1,6 +1,80 @@
+using System.IO.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Stands up a real in-process MCP client/server pair over an in-memory duplex pipe so tests
+/// can exercise <see cref="ClientRootPathValidator.ValidatePathAgainstRootsAsync"/>'s
+/// root-rejection branch through the actual <see cref="McpServer.RequestRootsAsync"/> round
+/// trip. <see cref="McpServer"/> cannot be constructed as a bare test double — its
+/// <c>ClientCapabilities</c> getter and <c>RequestRootsAsync</c> are populated by the real
+/// handshake/session machinery, not settable fields — and the SDK's concrete server
+/// implementation type is internal, so the only public construction path is the same
+/// <c>AddMcpServer().With...Transport()</c> DI composition <c>Program.cs</c> uses, pointed at
+/// an in-memory duplex pipe (<see cref="Pipe"/>) instead of stdio.
+/// </summary>
+internal static class McpRootsTestServerFactory
+{
+    public sealed record Session(McpServer Server, McpClient Client, IHost Host) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await Client.DisposeAsync().ConfigureAwait(false);
+            await Host.StopAsync().ConfigureAwait(false);
+            Host.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Creates a connected client/server pair where the client advertises exactly one
+    /// sanctioned root at <paramref name="sanctionedRootPath"/>.
+    /// </summary>
+    public static async Task<Session> CreateWithSanctionedRootAsync(string sanctionedRootPath, CancellationToken ct)
+    {
+        var clientToServer = new Pipe();
+        var serverToClient = new Pipe();
+
+        var hostBuilder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
+        hostBuilder.Logging.ClearProviders();
+        hostBuilder.Services
+            .AddMcpServer()
+            .WithStreamServerTransport(clientToServer.Reader.AsStream(), serverToClient.Writer.AsStream());
+        var host = hostBuilder.Build();
+        await host.StartAsync(ct).ConfigureAwait(false);
+        var server = host.Services.GetRequiredService<McpServer>();
+
+        var clientTransport = new StreamClientTransport(
+            clientToServer.Writer.AsStream(), serverToClient.Reader.AsStream(), NullLoggerFactory.Instance);
+        var rootUri = new Uri(sanctionedRootPath).AbsoluteUri;
+        var clientOptions = new McpClientOptions
+        {
+            Capabilities = new ClientCapabilities
+            {
+                Roots = new RootsCapability(),
+            },
+            Handlers = new McpClientHandlers
+            {
+                RootsHandler = (_, _) => ValueTask.FromResult(new ListRootsResult
+                {
+                    Roots = [new Root { Uri = rootUri }],
+                }),
+            },
+        };
+
+        var client = await McpClient.CreateAsync(clientTransport, clientOptions, NullLoggerFactory.Instance, ct)
+            .ConfigureAwait(false);
+
+        return new Session(server, client, host);
+    }
+}
 
 [TestClass]
 public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
@@ -65,6 +139,66 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
         {
             WorkspaceManager.Close(wsId);
             TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task PreviewExtractType_Tool_OutOfRootPath_RejectsWithArgumentException()
+    {
+        // Root-boundary regression: when a real MCP client session sanctions a root that
+        // does NOT cover the requested file, extract_type_preview must reject before
+        // dispatching to the service. Uses a real client/server pair (McpRootsTestServerFactory)
+        // rather than server: null! so the actual ValidatePathAgainstRootsAsync root-matching
+        // path (not just the fail-open no-server branch) is exercised end-to-end.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ExtractTypeOutOfRootFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExtractTypeOutOfRootFixture",
+                "{",
+                "    public int InternalUser() => Compute(42);",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        // Sanction a root that is a SIBLING of solutionDir, not an ancestor of fixturePath.
+        var sanctionedRoot = Path.Combine(Path.GetTempPath(), "roots-boundary-sanctioned-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sanctionedRoot);
+
+        await using var session = await McpRootsTestServerFactory.CreateWithSanctionedRootAsync(
+            sanctionedRoot, CancellationToken.None);
+
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                TypeExtractionTools.PreviewExtractType(
+                    session.Server,
+                    WorkspaceExecutionGate,
+                    TypeExtractionService,
+                    wsId,
+                    fixturePath,
+                    "ExtractTypeOutOfRootFixture",
+                    ["Compute"],
+                    "ComputeHelper",
+                    null,
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+            TryDeleteDirectory(sanctionedRoot);
         }
     }
 

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -47,6 +47,52 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task PreviewMoveTypeToFile_Tool_OutOfRootPath_RejectsWithArgumentException()
+    {
+        // Root-boundary regression: mirrors
+        // TypeExtractionTests.PreviewExtractType_Tool_OutOfRootPath_RejectsWithArgumentException.
+        // A real MCP client/server pair (McpRootsTestServerFactory) sanctions a root that does
+        // NOT cover the workspace's source file, so move_type_to_file_preview must reject before
+        // dispatching to the service.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var catFile = workspace.GetPath("SampleLib", "Cat.cs");
+        File.AppendAllText(catFile, "\npublic class RootRejectKitten : IAnimal\n{\n    public string Name => \"RootRejectKitten\";\n    public string Speak() => \"Mew\";\n}\n");
+
+        var wsId = await workspace.LoadAsync(CancellationToken.None);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+        var sanctionedRoot = Path.Combine(Path.GetTempPath(), "roots-boundary-sanctioned-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sanctionedRoot);
+
+        await using var session = await McpRootsTestServerFactory.CreateWithSanctionedRootAsync(
+            sanctionedRoot, CancellationToken.None);
+
+        try
+        {
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                TypeMoveTools.PreviewMoveTypeToFile(
+                    session.Server,
+                    WorkspaceExecutionGate,
+                    TypeMoveService,
+                    wsId,
+                    doc.FilePath!,
+                    "RootRejectKitten",
+                    null,
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "not under any client-sanctioned root");
+        }
+        finally
+        {
+            Directory.Delete(sanctionedRoot, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public async Task MoveType_FromMultiTypeFile_CreatesPreview()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -1,3 +1,5 @@
+using RoslynMcp.Host.Stdio.Tools;
+
 namespace RoslynMcp.Tests;
 
 [TestClass]
@@ -8,6 +10,41 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
 
     [ClassCleanup]
     public static void ClassCleanup() => DisposeServices();
+
+    // host-refactor-tools-root-boundary-validation: move_type_to_file_preview now calls
+    // ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, sourceFilePath, ct) before
+    // dispatching to the service, mirroring GetSyntaxTree/GetCodeActions. Passing server: null!
+    // exercises the no-MCP-server-context fail-open branch pinned by
+    // ClientRootPathValidatorTests.ValidatePath_NullServer_AllowsAccess — see the parallel
+    // comment on TypeExtractionTests.PreviewExtractType_Tool_NullServer_AllowsAccess_And_ProducesPreview
+    // for why a live root-rejection round trip is out of scope for a unit test here.
+    [TestMethod]
+    public async Task PreviewMoveTypeToFile_Tool_NullServer_AllowsAccess_And_ProducesPreview()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+
+        var catFile = workspace.GetPath("SampleLib", "Cat.cs");
+        File.AppendAllText(catFile, "\npublic class ToolPreviewKitten : IAnimal\n{\n    public string Name => \"ToolKitten\";\n    public string Speak() => \"Mew\";\n}\n");
+
+        var wsId = await workspace.LoadAsync(CancellationToken.None);
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
+
+        var json = await TypeMoveTools.PreviewMoveTypeToFile(
+            null!,
+            WorkspaceExecutionGate,
+            TypeMoveService,
+            wsId,
+            doc.FilePath!,
+            "ToolPreviewKitten",
+            null,
+            CancellationToken.None);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(json));
+        StringAssert.Contains(json, "previewToken");
+    }
 
     [TestMethod]
     public async Task MoveType_FromMultiTypeFile_CreatesPreview()


### PR DESCRIPTION
## Summary
- `TypeExtractionTools.PreviewExtractType` and `TypeMoveTools.PreviewMoveTypeToFile` dispatched straight to their services without calling `ClientRootPathValidator.ValidatePathAgainstRootsAsync` first, unlike sibling read tools (`SyntaxTools.GetSyntaxTree`, `MultiFileEditTools.PreviewMultiFileEdit`).
- Added an `McpServer server` parameter to both and converted the pure-dispatch body to a hand-written `gate.RunReadAsync` block that validates `filePath`/`sourceFilePath` against MCP client-sanctioned roots before calling the service, mirroring the established pattern exactly.
- `TypeMoveTools.PreviewChangeTypeNamespace`'s `newFilePath` has the identical gap but is out of scope for this row (not in the Acceptance list) — flagging as a follow-up per the plan's Risks section.

## Test plan
- [x] Added `PreviewExtractType_Tool_NullServer_AllowsAccess_And_ProducesPreview` (TypeExtractionTests.cs) and `PreviewMoveTypeToFile_Tool_NullServer_AllowsAccess_And_ProducesPreview` (TypeMoveTests.cs), calling the tool entry points directly through `WorkspaceExecutionGate` with `server: null!` to exercise the no-MCP-server-context fail-open branch (mirrors precedent in `ExpandedSurfaceIntegrationTests` for `AnalyzeDataFlow`/`AnalyzeControlFlow`/`GetOperations`, and `ClientRootPathValidatorTests.ValidatePath_NullServer_AllowsAccess`). The validator's actual root-matching logic (accept/reject/traversal/case-insensitivity) is already exhaustively unit-tested in `ClientRootPathValidatorTests` via `IsPathUnderAnyRoot` — a live root-rejection round trip through the tool would require standing up the SDK's full transport pipeline to populate `McpServer.ClientCapabilities.Roots`, which existing precedent in this codebase treats as impractical for a unit test.
- [x] `mcp__roslyn__compile_check` clean on both production files and both test files (0 errors).
- [x] `mcp__roslyn__test_run` — `TypeExtractionTests`, `TypeMoveTests`, `ClientRootPathValidatorTests`: 36/36 passed.
- [x] `eng/verify-ai-docs.ps1` passed.
- Full `verify-release.ps1` deferred to CI (self-hosted runner is active on this box — do not duplicate locally per standing policy).

Closes: host-refactor-tools-root-boundary-validation