### PR TITLE
fix(fork-apply): exclude secrets, expire kept forks, clean coverage temp dir

### DIFF
--- a/changelog.d/workspace-fork-apply-security-hardening.md
+++ b/changelog.d/workspace-fork-apply-security-hardening.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_fork_apply` no longer copies secret-bearing files (`.env`, `appsettings.*.json` except base/Development, `*.pubxml`, `secrets.json`, `*.pfx`, `*.key`) into forks; `retention=keep` forks now expire via a configurable TTL (`ROSLYNMCP_FORK_TTL_HOURS`, default 24h); the fork restore path and timeout are configurable via `ROSLYNMCP_FORK_DOTNET_PATH` / `ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES`; and `test_coverage` now deletes its temp coverage directory after aggregation.

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -59,29 +59,42 @@ public static class TestCoverageTools
 
                 var coverageDir = Path.Combine(Path.GetTempPath(), "roslyn-mcp-coverage", Guid.NewGuid().ToString("N"));
 
-                var partition = TestCoverageCoordinator.PartitionTestProjectsByCoverlet(status, projectName);
-                if (partition.WithCoverlet.Count == 0 && partition.WithoutCoverlet.Count > 0)
+                // test-coverage-temp-dir-leak (workspace-fork-apply-security-hardening): the temp
+                // coverage results dir is allocated per run and was previously never deleted, leaking a
+                // directory into %TEMP% on every invocation. Wrap the whole coverage lifecycle so the
+                // dir is removed after aggregation regardless of which return path (coverlet-missing,
+                // no-coverage-file, aggregated) fires. Best-effort delete — a lock on a coverage file
+                // must not turn a successful coverage run into an error.
+                try
                 {
+                    var partition = TestCoverageCoordinator.PartitionTestProjectsByCoverlet(status, projectName);
+                    if (partition.WithCoverlet.Count == 0 && partition.WithoutCoverlet.Count > 0)
+                    {
+                        ProgressHelper.Report(progress, 1, 1);
+                        return SerializeWithDeprecation(
+                            TestCoverageCoordinator.BuildCoverletMissingResult(partition.WithoutCoverlet),
+                            deprecation);
+                    }
+
+                    var (execution, coverageFiles, coverageGaps) = await RunCoveragePassAsync(
+                        commandRunner, status, partition, loadedPath, projectName, coverageDir, progress, c).ConfigureAwait(false);
+
+                    if (coverageFiles.Length == 0)
+                    {
+                        ProgressHelper.Report(progress, 1, 1);
+                        return SerializeWithDeprecation(
+                            TestCoverageCoordinator.BuildNoCoverageFileResult(execution.Succeeded, execution.ExitCode, coverageGaps),
+                            deprecation);
+                    }
+
+                    var result = TestCoverageCoordinator.ParseAndAggregateCoberturaXml(coverageFiles, coverageGaps);
                     ProgressHelper.Report(progress, 1, 1);
-                    return SerializeWithDeprecation(
-                        TestCoverageCoordinator.BuildCoverletMissingResult(partition.WithoutCoverlet),
-                        deprecation);
+                    return SerializeWithDeprecation(result, deprecation);
                 }
-
-                var (execution, coverageFiles, coverageGaps) = await RunCoveragePassAsync(
-                    commandRunner, status, partition, loadedPath, projectName, coverageDir, progress, c).ConfigureAwait(false);
-
-                if (coverageFiles.Length == 0)
+                finally
                 {
-                    ProgressHelper.Report(progress, 1, 1);
-                    return SerializeWithDeprecation(
-                        TestCoverageCoordinator.BuildNoCoverageFileResult(execution.Succeeded, execution.ExitCode, coverageGaps),
-                        deprecation);
+                    TryDeleteCoverageDir(coverageDir);
                 }
-
-                var result = TestCoverageCoordinator.ParseAndAggregateCoberturaXml(coverageFiles, coverageGaps);
-                ProgressHelper.Report(progress, 1, 1);
-                return SerializeWithDeprecation(result, deprecation);
             }
             catch (OperationCanceledException)
             {
@@ -233,5 +246,23 @@ public static class TestCoverageTools
             coverageGaps = result.CoverageGaps,
             deprecation,
         }, JsonDefaults.Indented);
+    }
+
+    // test-coverage-temp-dir-leak (workspace-fork-apply-security-hardening): best-effort deletion
+    // of the per-run temp coverage results dir. Internal for direct assertion in tests. Swallows
+    // IO/access failures — the dir is under %TEMP% and a leftover on a locked file is non-fatal.
+    internal static void TryDeleteCoverageDir(string coverageDir)
+    {
+        try
+        {
+            if (Directory.Exists(coverageDir))
+            {
+                Directory.Delete(coverageDir, recursive: true);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort — a locked coverage file must not fail an otherwise-successful run.
+        }
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
@@ -33,6 +34,19 @@ public static class ValidationBundleTools
         "obj",
         "TestResults",
     };
+
+    // workspace-fork-apply-security-hardening: default TTL (hours) for retained forks when
+    // ROSLYNMCP_FORK_TTL_HOURS is unset/invalid. Kept forks older than this are swept on the
+    // next fork-apply write path (bounded O(fork-count)).
+    private const double DefaultForkTtlHours = 24;
+
+    // Default dotnet restore timeout (minutes) when ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES
+    // is unset/invalid.
+    private const double DefaultForkRestoreTimeoutMinutes = 2;
+
+    // The exact wire format CreateForkDirectory stamps as the fork-directory-name prefix.
+    // Quoted 'T'/'Z' so the literals are matched (not interpreted) on the parse side.
+    private const string ForkTimestampFormat = "yyyyMMdd'T'HHmmssfff'Z'";
 
     [McpServerTool(Name = "validate_workspace", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
@@ -274,11 +288,94 @@ public static class ValidationBundleTools
         var forkRoot = Path.Combine(sourceRoot, ".roslynmcp", "forks");
         Directory.CreateDirectory(forkRoot);
 
+        // workspace-fork-apply-security-hardening: lazily expire stale retained forks before
+        // minting a new one so retention=keep no longer accumulates forks indefinitely.
+        SweepExpiredForks(forkRoot);
+
         var slug = SanitizeForkName(forkName);
-        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmssfffZ");
+        var timestamp = DateTimeOffset.UtcNow.ToString(ForkTimestampFormat, CultureInfo.InvariantCulture);
         var forkPath = Path.Combine(forkRoot, $"{timestamp}-{slug}");
         Directory.CreateDirectory(forkPath);
         return forkPath;
+    }
+
+    /// <summary>
+    /// workspace-fork-apply-security-hardening: TTL sweep for retained forks. Reads
+    /// <c>ROSLYNMCP_FORK_TTL_HOURS</c> (default 24h) and deletes fork dirs whose
+    /// <see cref="ForkTimestampFormat"/> name-prefix is older than the cutoff. Fork dirs with an
+    /// unparseable prefix are kept (fail-safe: never delete something we cannot date). A
+    /// non-positive TTL disables the sweep. Best-effort — a delete failure is swallowed so a
+    /// locked stale fork never blocks a fresh fork-apply.
+    /// </summary>
+    internal static void SweepExpiredForks(string forkRoot)
+        => SweepExpiredForks(forkRoot, ResolveForkTtlHours(), DateTimeOffset.UtcNow);
+
+    internal static void SweepExpiredForks(string forkRoot, double ttlHours, DateTimeOffset now)
+    {
+        if (ttlHours <= 0 || !Directory.Exists(forkRoot))
+        {
+            return;
+        }
+
+        var cutoff = now - TimeSpan.FromHours(ttlHours);
+        foreach (var dir in Directory.EnumerateDirectories(forkRoot))
+        {
+            var name = Path.GetFileName(dir);
+            var dashIndex = name.IndexOf('-');
+            var timestampPart = dashIndex > 0 ? name[..dashIndex] : name;
+
+            if (!DateTimeOffset.TryParseExact(
+                    timestampPart,
+                    ForkTimestampFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var created))
+            {
+                // Unparseable prefix — keep it. We only expire forks we can positively date.
+                continue;
+            }
+
+            if (created < cutoff)
+            {
+                try
+                {
+                    DeleteDirectoryIfExists(dir);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // Best-effort — a locked stale fork must not block minting a new one.
+                }
+            }
+        }
+    }
+
+    internal static double ResolveForkTtlHours()
+        => ReadPositiveEnvDouble("ROSLYNMCP_FORK_TTL_HOURS", DefaultForkTtlHours, allowZero: true);
+
+    internal static double ResolveForkRestoreTimeoutMinutes()
+        => ReadPositiveEnvDouble("ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES", DefaultForkRestoreTimeoutMinutes, allowZero: false);
+
+    internal static string ResolveForkDotnetPath()
+    {
+        var configured = Environment.GetEnvironmentVariable("ROSLYNMCP_FORK_DOTNET_PATH");
+        return string.IsNullOrWhiteSpace(configured) ? "dotnet" : configured.Trim();
+    }
+
+    private static double ReadPositiveEnvDouble(string variable, double fallback, bool allowZero)
+    {
+        var raw = Environment.GetEnvironmentVariable(variable);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return fallback;
+        }
+
+        if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            && (parsed > 0 || (allowZero && parsed == 0)))
+        {
+            return parsed;
+        }
+
+        return fallback;
     }
 
     private static string SanitizeForkName(string? forkName)
@@ -300,12 +397,20 @@ public static class ValidationBundleTools
         return slug.Length <= 40 ? slug : slug[..40];
     }
 
-    private static void CopyDirectory(string sourceDir, string destinationDir)
+    internal static void CopyDirectory(string sourceDir, string destinationDir)
     {
         Directory.CreateDirectory(destinationDir);
 
         foreach (var file in Directory.EnumerateFiles(sourceDir))
         {
+            // workspace-fork-apply-security-hardening: never copy secret-bearing files into a
+            // server-writable fork dir. This is a denylist (known secret filename shapes), not an
+            // allowlist — see IsSecretBearingFile for the documented limitation.
+            if (IsSecretBearingFile(Path.GetFileName(file)))
+            {
+                continue;
+            }
+
             var destination = Path.Combine(destinationDir, Path.GetFileName(file));
             File.Copy(file, destination, overwrite: true);
         }
@@ -321,16 +426,68 @@ public static class ValidationBundleTools
         }
     }
 
+    /// <summary>
+    /// workspace-fork-apply-security-hardening: true when <paramref name="fileName"/> matches a
+    /// known secret-bearing filename shape that must not be copied into a server-writable fork
+    /// dir. All comparisons are case-insensitive (<see cref="StringComparison.OrdinalIgnoreCase"/>).
+    /// <para>
+    /// KNOWN LIMITATION: this is a denylist of common secret-file shapes, not an allowlist. A
+    /// project that stashes secrets in a non-matching filename (e.g. <c>config.local.yaml</c>,
+    /// <c>credentials.txt</c>) will still have that file copied into the fork. The fork dir lives
+    /// under the source root and is deleted by retention policy / TTL sweep, so exposure is
+    /// bounded, but this predicate should be extended as new secret conventions surface.
+    /// </para>
+    /// Excluded shapes: <c>.env</c>, <c>.env.*</c>, <c>secrets.json</c>, <c>*.pubxml</c>,
+    /// <c>*.pubxml.user</c>, <c>*.pfx</c>, <c>*.key</c>, and <c>appsettings.*.json</c> EXCEPT the
+    /// non-secret base <c>appsettings.json</c> and <c>appsettings.Development.json</c>.
+    /// </summary>
+    internal static bool IsSecretBearingFile(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return false;
+        }
+
+        if (fileName.Equals(".env", StringComparison.OrdinalIgnoreCase)
+            || fileName.StartsWith(".env.", StringComparison.OrdinalIgnoreCase)
+            || fileName.Equals("secrets.json", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".pubxml", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".pubxml.user", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".pfx", StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith(".key", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // appsettings.*.json — environment-specific settings often carry connection strings /
+        // secrets. The base appsettings.json and the conventionally-non-secret
+        // appsettings.Development.json are retained.
+        if (fileName.StartsWith("appsettings.", StringComparison.OrdinalIgnoreCase)
+            && fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return !fileName.Equals("appsettings.json", StringComparison.OrdinalIgnoreCase)
+                && !fileName.Equals("appsettings.Development.json", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
     private static async Task RestoreForkAsync(string forkLoadedPath, CancellationToken ct)
     {
         var workingDirectory = Path.GetDirectoryName(forkLoadedPath)
             ?? throw new InvalidOperationException($"Could not resolve working directory for fork '{forkLoadedPath}'.");
+
+        // workspace-fork-apply-security-hardening: dotnet path + restore timeout are env-configurable
+        // (ROSLYNMCP_FORK_DOTNET_PATH / ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES) so pinned-SDK and
+        // slow-network environments are not stuck with a hardcoded "dotnet" on PATH and a fixed 2-min cap.
+        var dotnetPath = ResolveForkDotnetPath();
+        var timeoutMinutes = ResolveForkRestoreTimeoutMinutes();
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeout.CancelAfter(TimeSpan.FromMinutes(2));
+        timeout.CancelAfter(TimeSpan.FromMinutes(timeoutMinutes));
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = "dotnet",
+            FileName = dotnetPath,
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -356,7 +513,8 @@ public static class ValidationBundleTools
             // process already exited, or a race on the process handle) is not actionable here —
             // we are already throwing TimeoutException — so the swallow is deliberate.
             try { process.Kill(entireProcessTree: true); } catch { /* see comment above — non-actionable on the timeout path */ }
-            throw new TimeoutException("dotnet restore for workspace fork exceeded the 2 minute timeout.");
+            throw new TimeoutException(
+                $"dotnet restore for workspace fork exceeded the {timeoutMinutes.ToString(CultureInfo.InvariantCulture)} minute timeout.");
         }
 
         var stdout = await stdoutTask.ConfigureAwait(false);

--- a/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
@@ -177,7 +177,72 @@ public sealed class TestCoverageFailureEnvelopeTests
         StringAssert.Contains(envelope.GetProperty("summary").GetString() ?? string.Empty, "workspace status unavailable");
     }
 
+    /// <summary>
+    /// (5) test-coverage-temp-dir-leak (workspace-fork-apply-security-hardening): even when the
+    /// runner throws mid-run, the per-run temp coverage dir must be deleted by the finally block.
+    /// The runner creates the <c>--results-directory</c> on disk (as <c>dotnet test</c> would) then
+    /// throws; after the classified failure envelope is returned, the dir must be gone.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_RunnerThrowsAfterCreatingDir_StillDeletesTempCoverageDir()
+    {
+        var gate = new PassthroughGate();
+        var workspace = new FakeWorkspaceManager();
+        var runner = new DirCreatingThrowingDotnetCommandRunner(new InvalidOperationException("boom"));
+
+        var json = await TestCoverageTools.RunTestCoverageCore(
+            gate,
+            workspace,
+            runner,
+            workspaceId: "ws-coverage-cleanup-throw",
+            projectName: null,
+            deprecation: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(doc.RootElement.GetProperty("success").GetBoolean(),
+            "The thrown runner must surface a failure envelope.");
+
+        Assert.IsNotNull(runner.CreatedResultsDirectory,
+            "Runner should have created and captured the --results-directory.");
+        Assert.IsFalse(Directory.Exists(runner.CreatedResultsDirectory!),
+            "The temp coverage dir must be deleted by the finally block even on the exception path.");
+    }
+
     // ── Test doubles ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runner that creates the <c>--results-directory</c> on disk (mirroring <c>dotnet test</c>)
+    /// and then throws, exercising the finally-block cleanup on the exception path.
+    /// </summary>
+    private sealed class DirCreatingThrowingDotnetCommandRunner : IDotnetCommandRunner
+    {
+        private readonly Exception _toThrow;
+
+        public DirCreatingThrowingDotnetCommandRunner(Exception toThrow) => _toThrow = toThrow;
+
+        public string? CreatedResultsDirectory { get; private set; }
+
+        public Task<CommandExecutionDto> RunAsync(
+            string workingDirectory,
+            string targetPath,
+            IReadOnlyList<string> arguments,
+            CancellationToken ct)
+        {
+            for (var i = 0; i < arguments.Count - 1; i++)
+            {
+                if (string.Equals(arguments[i], "--results-directory", StringComparison.Ordinal))
+                {
+                    CreatedResultsDirectory = arguments[i + 1];
+                    Directory.CreateDirectory(CreatedResultsDirectory);
+                    break;
+                }
+            }
+
+            throw _toThrow;
+        }
+    }
 
     /// <summary>
     /// Minimal stand-in for <see cref="IWorkspaceExecutionGate"/> that invokes the lambda

--- a/tests/RoslynMcp.Tests/TestCoveragePartialCoverletTests.cs
+++ b/tests/RoslynMcp.Tests/TestCoveragePartialCoverletTests.cs
@@ -178,6 +178,41 @@ public sealed class TestCoveragePartialCoverletTests
             "All-projects-have-coverlet must NOT populate coverageGaps — that field is partial-only.");
     }
 
+    /// <summary>
+    /// (4) test-coverage-temp-dir-leak (workspace-fork-apply-security-hardening): the per-run temp
+    /// coverage results dir must be deleted after aggregation. Pre-fix it leaked into %TEMP% on
+    /// every invocation. The runner captures the <c>--results-directory</c> it was handed; after a
+    /// successful run that directory must no longer exist on disk.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_SuccessPath_DeletesTempCoverageDir()
+    {
+        using var fixture = new CoverletProjectFixture();
+        var pathA = fixture.WriteCsproj("WithCoverletA", includesCoverletCollector: true);
+
+        var gate = new PassthroughGate();
+        var workspace = new MixedCoverletWorkspaceManager(
+            withCoverletProjectPath: null,
+            withoutCoverletProjectPath: null,
+            extraProjects: [("WithCoverletA", pathA, true)]);
+        var runner = new CoberturaWritingDotnetCommandRunner();
+
+        await TestCoverageTools.RunTestCoverageCore(
+            gate,
+            workspace,
+            runner,
+            workspaceId: "ws-coverage-cleanup",
+            projectName: null,
+            deprecation: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        Assert.IsNotNull(runner.LastResultsDirectory,
+            "Runner should have received a --results-directory argument.");
+        Assert.IsFalse(Directory.Exists(runner.LastResultsDirectory!),
+            "The temp coverage dir must be deleted after a successful coverage run — it previously leaked.");
+    }
+
     // ── Test doubles ────────────────────────────────────────────────────────
 
     /// <summary>
@@ -291,6 +326,13 @@ public sealed class TestCoveragePartialCoverletTests
     {
         private int _invocationCount;
 
+        /// <summary>
+        /// The <c>--results-directory</c> (per-run temp coverage dir) captured on the last
+        /// invocation. Used to assert the tool deletes the dir after aggregation
+        /// (test-coverage-temp-dir-leak).
+        /// </summary>
+        public string? LastResultsDirectory { get; private set; }
+
         public Task<CommandExecutionDto> RunAsync(
             string workingDirectory,
             string targetPath,
@@ -308,6 +350,8 @@ public sealed class TestCoveragePartialCoverletTests
                     break;
                 }
             }
+
+            LastResultsDirectory = resultsDir;
 
             if (resultsDir is not null)
             {

--- a/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
@@ -119,6 +119,227 @@ public sealed class ValidationBundleToolsTests
                 gate, service, workspaceId: "ws-1", runTests: false, summary: false, ct: default));
     }
 
+    // ── workspace-fork-apply-security-hardening ─────────────────────────────
+    // Secret-file exclusion, retained-fork TTL sweep, and env-configurable restore path/timeout.
+
+    [TestMethod]
+    [DataRow(".env")]
+    [DataRow(".ENV")]
+    [DataRow(".env.local")]
+    [DataRow(".env.Production")]
+    [DataRow("secrets.json")]
+    [DataRow("Secrets.JSON")]
+    [DataRow("app.pubxml")]
+    [DataRow("app.pubxml.user")]
+    [DataRow("cert.pfx")]
+    [DataRow("private.key")]
+    [DataRow("appsettings.Production.json")]
+    [DataRow("appsettings.Staging.json")]
+    [DataRow("APPSETTINGS.PRODUCTION.JSON")]
+    public void IsSecretBearingFile_SecretShapes_ReturnsTrue(string fileName)
+        => Assert.IsTrue(ValidationBundleTools.IsSecretBearingFile(fileName),
+            $"'{fileName}' is a secret-bearing shape and must be excluded from forks.");
+
+    [TestMethod]
+    [DataRow("appsettings.json")]
+    [DataRow("APPSETTINGS.JSON")]
+    [DataRow("appsettings.Development.json")]
+    [DataRow("appsettings.development.json")]
+    [DataRow("Program.cs")]
+    [DataRow("README.md")]
+    [DataRow("keychain.txt")]
+    [DataRow("envelope.cs")]
+    [DataRow("")]
+    public void IsSecretBearingFile_SafeShapes_ReturnsFalse(string fileName)
+        => Assert.IsFalse(ValidationBundleTools.IsSecretBearingFile(fileName),
+            $"'{fileName}' is not a secret-bearing shape and must be copied into forks.");
+
+    [TestMethod]
+    public void CopyDirectory_ExcludesSecretFiles_KeepsSafeFiles()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "roslyn-mcp-fork-copy-tests", Guid.NewGuid().ToString("N"));
+        var source = Path.Combine(root, "src");
+        var dest = Path.Combine(root, "fork");
+        try
+        {
+            Directory.CreateDirectory(source);
+            // Secret-bearing — must NOT land in the fork.
+            File.WriteAllText(Path.Combine(source, ".env"), "SECRET=1");
+            File.WriteAllText(Path.Combine(source, "appsettings.Production.json"), "{}");
+            File.WriteAllText(Path.Combine(source, "cert.pfx"), "binary");
+            // Safe — must land in the fork.
+            File.WriteAllText(Path.Combine(source, "appsettings.json"), "{}");
+            File.WriteAllText(Path.Combine(source, "appsettings.Development.json"), "{}");
+            File.WriteAllText(Path.Combine(source, "Program.cs"), "class C {}");
+
+            ValidationBundleTools.CopyDirectory(source, dest);
+
+            Assert.IsFalse(File.Exists(Path.Combine(dest, ".env")), ".env must be excluded.");
+            Assert.IsFalse(File.Exists(Path.Combine(dest, "appsettings.Production.json")),
+                "appsettings.Production.json must be excluded.");
+            Assert.IsFalse(File.Exists(Path.Combine(dest, "cert.pfx")), "*.pfx must be excluded.");
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "appsettings.json")),
+                "base appsettings.json must be copied.");
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "appsettings.Development.json")),
+                "appsettings.Development.json must be copied.");
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "Program.cs")), "Program.cs must be copied.");
+        }
+        finally
+        {
+            TryDeleteTree(root);
+        }
+    }
+
+    [TestMethod]
+    public void SweepExpiredForks_DeletesExpired_KeepsFreshAndUnparseable()
+    {
+        var forkRoot = Path.Combine(Path.GetTempPath(), "roslyn-mcp-fork-ttl-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(forkRoot);
+            var now = DateTimeOffset.UtcNow;
+
+            // Expired: stamped 48h ago (TTL below is 24h).
+            var expired = MakeForkDir(forkRoot, now.AddHours(-48), "old");
+            // Fresh: stamped 1h ago.
+            var fresh = MakeForkDir(forkRoot, now.AddHours(-1), "new");
+            // Unparseable prefix — must be kept (fail-safe).
+            var unparseable = Path.Combine(forkRoot, "not-a-timestamp-abc");
+            Directory.CreateDirectory(unparseable);
+
+            ValidationBundleTools.SweepExpiredForks(forkRoot, ttlHours: 24, now: now);
+
+            Assert.IsFalse(Directory.Exists(expired), "Fork older than the TTL must be swept.");
+            Assert.IsTrue(Directory.Exists(fresh), "Fork newer than the TTL must be kept.");
+            Assert.IsTrue(Directory.Exists(unparseable),
+                "Fork with an unparseable timestamp prefix must be kept (fail-safe).");
+        }
+        finally
+        {
+            TryDeleteTree(forkRoot);
+        }
+    }
+
+    [TestMethod]
+    public void SweepExpiredForks_NonPositiveTtl_DisablesSweep()
+    {
+        var forkRoot = Path.Combine(Path.GetTempPath(), "roslyn-mcp-fork-ttl-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(forkRoot);
+            var now = DateTimeOffset.UtcNow;
+            var ancient = MakeForkDir(forkRoot, now.AddHours(-1000), "ancient");
+
+            ValidationBundleTools.SweepExpiredForks(forkRoot, ttlHours: 0, now: now);
+
+            Assert.IsTrue(Directory.Exists(ancient), "A non-positive TTL must disable the sweep entirely.");
+        }
+        finally
+        {
+            TryDeleteTree(forkRoot);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveForkTtlHours_HonorsEnvOverrideAndFallsBack()
+    {
+        const string var = "ROSLYNMCP_FORK_TTL_HOURS";
+        var previous = Environment.GetEnvironmentVariable(var);
+        try
+        {
+            Environment.SetEnvironmentVariable(var, null);
+            Assert.AreEqual(24, ValidationBundleTools.ResolveForkTtlHours(), "Unset must fall back to 24h.");
+
+            Environment.SetEnvironmentVariable(var, "6");
+            Assert.AreEqual(6, ValidationBundleTools.ResolveForkTtlHours(), "Override must be honored.");
+
+            Environment.SetEnvironmentVariable(var, "0");
+            Assert.AreEqual(0, ValidationBundleTools.ResolveForkTtlHours(), "Zero is a valid disable value for TTL.");
+
+            Environment.SetEnvironmentVariable(var, "not-a-number");
+            Assert.AreEqual(24, ValidationBundleTools.ResolveForkTtlHours(), "Invalid must fall back to the default.");
+
+            Environment.SetEnvironmentVariable(var, "-5");
+            Assert.AreEqual(24, ValidationBundleTools.ResolveForkTtlHours(), "Negative must fall back to the default.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(var, previous);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveForkRestoreTimeoutMinutes_HonorsEnvOverrideAndFallsBack()
+    {
+        const string var = "ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES";
+        var previous = Environment.GetEnvironmentVariable(var);
+        try
+        {
+            Environment.SetEnvironmentVariable(var, null);
+            Assert.AreEqual(2, ValidationBundleTools.ResolveForkRestoreTimeoutMinutes(), "Unset must fall back to 2 min.");
+
+            Environment.SetEnvironmentVariable(var, "10");
+            Assert.AreEqual(10, ValidationBundleTools.ResolveForkRestoreTimeoutMinutes(), "Override must be honored.");
+
+            Environment.SetEnvironmentVariable(var, "0");
+            Assert.AreEqual(2, ValidationBundleTools.ResolveForkRestoreTimeoutMinutes(),
+                "Zero is not a usable timeout — must fall back to the default.");
+
+            Environment.SetEnvironmentVariable(var, "garbage");
+            Assert.AreEqual(2, ValidationBundleTools.ResolveForkRestoreTimeoutMinutes(), "Invalid must fall back.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(var, previous);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveForkDotnetPath_HonorsEnvOverrideAndFallsBack()
+    {
+        const string var = "ROSLYNMCP_FORK_DOTNET_PATH";
+        var previous = Environment.GetEnvironmentVariable(var);
+        try
+        {
+            Environment.SetEnvironmentVariable(var, null);
+            Assert.AreEqual("dotnet", ValidationBundleTools.ResolveForkDotnetPath(), "Unset must fall back to 'dotnet'.");
+
+            Environment.SetEnvironmentVariable(var, "  ");
+            Assert.AreEqual("dotnet", ValidationBundleTools.ResolveForkDotnetPath(), "Whitespace must fall back to 'dotnet'.");
+
+            Environment.SetEnvironmentVariable(var, @"C:\sdk\dotnet.exe");
+            Assert.AreEqual(@"C:\sdk\dotnet.exe", ValidationBundleTools.ResolveForkDotnetPath(),
+                "A configured dotnet path must be honored.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(var, previous);
+        }
+    }
+
+    private static string MakeForkDir(string forkRoot, DateTimeOffset stamp, string slug)
+    {
+        var name = $"{stamp.UtcDateTime.ToString("yyyyMMdd'T'HHmmssfff'Z'", System.Globalization.CultureInfo.InvariantCulture)}-{slug}";
+        var path = Path.Combine(forkRoot, name);
+        Directory.CreateDirectory(path);
+        // Drop a file so we prove recursive deletion, not just empty-dir removal.
+        File.WriteAllText(Path.Combine(path, "marker.txt"), "x");
+        return path;
+    }
+
+    private static void TryDeleteTree(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
     private static void AssertStructuredEnvelope(string result, string expectedTool)
     {
         Assert.IsFalse(string.IsNullOrWhiteSpace(result), "Handler must always return a non-empty JSON string.");


### PR DESCRIPTION
## Summary

Closes three security/robustness gaps identified in `ValidationBundleTools.cs` and `TestCoverageTools.cs` (initiative `workspace-fork-apply-security-hardening`, refactor-matrix-pass1).

1. **Secret exposure in forks** — `workspace_fork_apply`'s `CopyDirectory` copied every file into a server-writable fork dir. Now `IsSecretBearingFile` (case-insensitive denylist) skips `.env`, `.env.*`, `appsettings.*.json` (except base `appsettings.json` and `appsettings.Development.json`), `*.pubxml`, `*.pubxml.user`, `secrets.json`, `*.pfx`, `*.key`. Documented as a denylist (known limitation), not an allowlist.
2. **Unbounded `retention=keep` forks** — kept forks accumulated indefinitely. A lazy TTL sweep now runs in `CreateForkDirectory` before minting a new fork, reading `ROSLYNMCP_FORK_TTL_HOURS` (default 24h) from the fork dir's timestamp prefix. Unparseable prefixes are kept (fail-safe); a non-positive TTL disables the sweep.
3. **Hardcoded restore path/timeout** — `RestoreForkAsync`'s `FileName="dotnet"` and fixed 2-min timeout are now env-configurable via `ROSLYNMCP_FORK_DOTNET_PATH` / `ROSLYNMCP_FORK_RESTORE_TIMEOUT_MINUTES`.
4. **Coverage temp-dir leak** — `test_coverage` allocated a per-run temp coverage dir that was never deleted. Now wrapped in try/finally with a best-effort delete regardless of return path.

Peer initiative `workspace-fork-apply-robustness-cancellation`'s cancellation/OCE sites were left untouched — only `FileName`/timeout values changed here.

## Validation

- `mcp__roslyn__compile_check` clean on all 5 changed files.
- `mcp__roslyn__test_run` — 41/41 pass across `ValidationBundleToolsTests`, `TestCoveragePartialCoverletTests`, `TestCoverageFailureEnvelopeTests`.
- New tests: secret-shape exclusion (incl. base appsettings.json kept, appsettings.Production.json excluded, case-insensitivity), CopyDirectory wiring, TTL sweep (expired/fresh/unparseable/disabled), env-override resolution for TTL/timeout/dotnet-path, and coverage-dir cleanup on both success and exception paths.

New helpers promoted to `internal static` (InternalsVisibleTo RoslynMcp.Tests) for direct testing.

Closes: workspace-fork-apply-security-hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)