### PR TITLE
fix(validation): make workspace_fork_apply copy/cleanup cancellable, serialize concurrent forks

### DIFF
--- a/changelog.d/workspace-fork-apply-robustness-cancellation.md
+++ b/changelog.d/workspace-fork-apply-robustness-cancellation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `workspace_fork_apply`'s copy/cleanup are now cancellable, concurrent fork-apply against the same source root is serialized, and `test_coverage` no longer misreports genuine caller cancellation as a timeout.

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -96,6 +96,14 @@ public static class TestCoverageTools
                     TryDeleteCoverageDir(coverageDir);
                 }
             }
+            catch (OperationCanceledException) when (c.IsCancellationRequested)
+            {
+                // Genuine caller cancellation (not the gate's internal timeout) must propagate
+                // as OperationCanceledException rather than being misreported as a timeout
+                // envelope — mirrors the split pattern in
+                // ValidationBundleTools.RestoreForkAsync.
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 // OCE-first ordering: if the generic Exception catch is ordered first the

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -47,6 +48,14 @@ public static class ValidationBundleTools
     // The exact wire format CreateForkDirectory stamps as the fork-directory-name prefix.
     // Quoted 'T'/'Z' so the literals are matched (not interpreted) on the parse side.
     private const string ForkTimestampFormat = "yyyyMMdd'T'HHmmssfff'Z'";
+
+    // workspace-fork-apply-robustness-cancellation: serialize concurrent fork-apply
+    // invocations against the same source root. Without this, two concurrent
+    // workspace_fork_apply calls for the same workspace race on CopyDirectory /
+    // DeleteDirectoryIfExists against the same <sourceRoot>/.roslynmcp/forks tree.
+    // Keyed by the normalized (full-path, case-insensitive-on-Windows) source root.
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> ForkApplyLocks =
+        new(StringComparer.OrdinalIgnoreCase);
 
     [McpServerTool(Name = "validate_workspace", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
@@ -164,9 +173,13 @@ public static class ValidationBundleTools
             var retained = false;
             var success = false;
 
+            var sourceRootLock = ForkApplyLocks.GetOrAdd(
+                Path.GetFullPath(sourceRoot),
+                _ => new SemaphoreSlim(1, 1));
+            await sourceRootLock.WaitAsync(c).ConfigureAwait(false);
             try
             {
-                CopyDirectory(sourceRoot, forkPath);
+                CopyDirectory(sourceRoot, forkPath, c);
                 var appliedFiles = await ReplayPreviewIntoForkAsync(
                     entry.Value.OriginalSolution,
                     entry.Value.ModifiedSolution,
@@ -198,7 +211,7 @@ public static class ValidationBundleTools
 
                 if (!retained)
                 {
-                    CleanupFork(workspaceManager, forkWorkspaceId, forkPath, cleanupWarnings);
+                    CleanupFork(workspaceManager, forkWorkspaceId, forkPath, cleanupWarnings, c);
                     forkWorkspaceId = null;
                 }
 
@@ -223,9 +236,16 @@ public static class ValidationBundleTools
             {
                 if (!retained)
                 {
-                    CleanupFork(workspaceManager, forkWorkspaceId, forkPath, cleanupWarnings);
+                    // Best-effort cleanup on the exception path: use CancellationToken.None so
+                    // an already-cancelled `c` does not abort cleanup and mask the original
+                    // exception with an OperationCanceledException from mid-delete.
+                    CleanupFork(workspaceManager, forkWorkspaceId, forkPath, cleanupWarnings, CancellationToken.None);
                 }
                 throw;
+            }
+            finally
+            {
+                sourceRootLock.Release();
             }
         }, ct, applyStalenessPolicy: false);
     }
@@ -397,12 +417,14 @@ public static class ValidationBundleTools
         return slug.Length <= 40 ? slug : slug[..40];
     }
 
-    internal static void CopyDirectory(string sourceDir, string destinationDir)
+    internal static void CopyDirectory(string sourceDir, string destinationDir, CancellationToken ct)
     {
         Directory.CreateDirectory(destinationDir);
 
         foreach (var file in Directory.EnumerateFiles(sourceDir))
         {
+            ct.ThrowIfCancellationRequested();
+
             // workspace-fork-apply-security-hardening: never copy secret-bearing files into a
             // server-writable fork dir. This is a denylist (known secret filename shapes), not an
             // allowlist — see IsSecretBearingFile for the documented limitation.
@@ -417,12 +439,13 @@ public static class ValidationBundleTools
 
         foreach (var directory in Directory.EnumerateDirectories(sourceDir))
         {
+            ct.ThrowIfCancellationRequested();
             if (DirectoryCopyExclusions.Contains(Path.GetFileName(directory)))
             {
                 continue;
             }
 
-            CopyDirectory(directory, Path.Combine(destinationDir, Path.GetFileName(directory)));
+            CopyDirectory(directory, Path.Combine(destinationDir, Path.GetFileName(directory)), ct);
         }
     }
 
@@ -613,7 +636,8 @@ public static class ValidationBundleTools
         IWorkspaceManager workspaceManager,
         string? forkWorkspaceId,
         string forkPath,
-        List<string> cleanupWarnings)
+        List<string> cleanupWarnings,
+        CancellationToken ct)
     {
         try
         {
@@ -629,7 +653,7 @@ public static class ValidationBundleTools
 
         try
         {
-            DeleteDirectoryIfExists(forkPath);
+            DeleteDirectoryIfExists(forkPath, ct);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -637,7 +661,7 @@ public static class ValidationBundleTools
         }
     }
 
-    private static void DeleteDirectoryIfExists(string path)
+    private static void DeleteDirectoryIfExists(string path, CancellationToken ct)
     {
         if (!Directory.Exists(path))
         {
@@ -646,6 +670,7 @@ public static class ValidationBundleTools
 
         foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
         {
+            ct.ThrowIfCancellationRequested();
             var attributes = File.GetAttributes(file);
             if ((attributes & FileAttributes.ReadOnly) != 0)
             {

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -359,7 +359,7 @@ public static class ValidationBundleTools
             {
                 try
                 {
-                    DeleteDirectoryIfExists(dir);
+                    DeleteDirectoryIfExists(dir, CancellationToken.None);
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {

--- a/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
@@ -140,6 +140,36 @@ public sealed class TestCoverageFailureEnvelopeTests
             "TestFailure is retryable once the test is fixed.");
     }
 
+    /// <summary>
+    /// workspace-fork-apply-robustness-cancellation: genuine caller cancellation (the
+    /// passed-in <c>ct</c> is already cancelled) must propagate as
+    /// <see cref="OperationCanceledException"/> rather than being misreported as the
+    /// <c>Timeout</c> envelope built for the gate's internal timeout. This is the
+    /// inverse of the test above — same simulated exception from the runner, but with
+    /// the caller's own token cancelled beforehand.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTestCoverageCore_CallerCancelled_PropagatesWithoutWrapping()
+    {
+        var gate = new PassthroughGate();
+        var workspace = new FakeWorkspaceManager();
+        var runner = new ThrowingDotnetCommandRunner(new OperationCanceledException("simulated caller cancel"));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+            TestCoverageTools.RunTestCoverageCore(
+                gate,
+                workspace,
+                runner,
+                workspaceId: "ws-coverage-caller-cancelled",
+                projectName: null,
+                deprecation: null,
+                progress: null,
+                ct: cts.Token));
+    }
+
     [TestMethod]
     public async Task RunTestCoverageCore_StatusThrows_EmitsUnknownEnvelope()
     {

--- a/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationBundleToolsTests.cs
@@ -172,7 +172,7 @@ public sealed class ValidationBundleToolsTests
             File.WriteAllText(Path.Combine(source, "appsettings.Development.json"), "{}");
             File.WriteAllText(Path.Combine(source, "Program.cs"), "class C {}");
 
-            ValidationBundleTools.CopyDirectory(source, dest);
+            ValidationBundleTools.CopyDirectory(source, dest, CancellationToken.None);
 
             Assert.IsFalse(File.Exists(Path.Combine(dest, ".env")), ".env must be excluded.");
             Assert.IsFalse(File.Exists(Path.Combine(dest, "appsettings.Production.json")),

--- a/tests/RoslynMcp.Tests/WorkspaceForkApplyCancellationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceForkApplyCancellationTests.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for backlog row <c>workspace-fork-apply-robustness-cancellation</c>:
+/// <see cref="ValidationBundleTools"/>'s private <c>CopyDirectory</c> /
+/// <c>DeleteDirectoryIfExists</c> recursive walks were synchronous and non-cancellable —
+/// a cancellation token passed to <c>workspace_fork_apply</c> was silently dropped once
+/// inside the copy/cleanup loops. These tests exercise the two helpers directly via
+/// reflection (an established pattern in this suite — see
+/// <c>DeadLoggerFieldsTests</c>/<c>ToolDiResolutionTests</c>) so the cancellation contract
+/// can be pinned without standing up the full <c>workspace_fork_apply</c> pipeline
+/// (real Roslyn workspace load + <c>dotnet restore</c>), and also pins the per-source-root
+/// <c>SemaphoreSlim</c> keying used to serialize concurrent fork-apply calls.
+/// </summary>
+[TestClass]
+public sealed class WorkspaceForkApplyCancellationTests
+{
+    private static readonly Type ToolsType = typeof(ValidationBundleTools);
+
+    private static readonly MethodInfo CopyDirectoryMethod = ToolsType.GetMethod(
+        "CopyDirectory", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("CopyDirectory method not found via reflection.");
+
+    private static readonly MethodInfo DeleteDirectoryIfExistsMethod = ToolsType.GetMethod(
+        "DeleteDirectoryIfExists", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("DeleteDirectoryIfExists method not found via reflection.");
+
+    private static readonly FieldInfo ForkApplyLocksField = ToolsType.GetField(
+        "ForkApplyLocks", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ForkApplyLocks field not found via reflection.");
+
+    private string _tempRoot = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "roslyn-mcp-forkapply-cancel-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [TestCleanup]
+    public void Teardown()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [TestMethod]
+    public void CopyDirectory_NotCancelled_CopiesAllFilesAndSubdirectoriesUnchanged()
+    {
+        var sourceDir = Path.Combine(_tempRoot, "source");
+        var destDir = Path.Combine(_tempRoot, "dest");
+        Directory.CreateDirectory(sourceDir);
+        File.WriteAllText(Path.Combine(sourceDir, "a.txt"), "a");
+        File.WriteAllText(Path.Combine(sourceDir, "b.txt"), "b");
+        var nested = Path.Combine(sourceDir, "nested");
+        Directory.CreateDirectory(nested);
+        File.WriteAllText(Path.Combine(nested, "c.txt"), "c");
+
+        InvokeCopyDirectory(sourceDir, destDir, CancellationToken.None);
+
+        Assert.AreEqual("a", File.ReadAllText(Path.Combine(destDir, "a.txt")));
+        Assert.AreEqual("b", File.ReadAllText(Path.Combine(destDir, "b.txt")));
+        Assert.AreEqual("c", File.ReadAllText(Path.Combine(destDir, "nested", "c.txt")));
+    }
+
+    [TestMethod]
+    public void CopyDirectory_CancelledBeforeWalk_ThrowsOperationCanceledAndCopiesNothing()
+    {
+        var sourceDir = Path.Combine(_tempRoot, "source");
+        var destDir = Path.Combine(_tempRoot, "dest");
+        Directory.CreateDirectory(sourceDir);
+        File.WriteAllText(Path.Combine(sourceDir, "a.txt"), "a");
+        File.WriteAllText(Path.Combine(sourceDir, "b.txt"), "b");
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var thrown = Assert.ThrowsExactly<TargetInvocationException>(
+            () => InvokeCopyDirectory(sourceDir, destDir, cts.Token));
+        Assert.IsInstanceOfType<OperationCanceledException>(thrown.InnerException,
+            "Cancellation must surface as OperationCanceledException, not be silently swallowed by the copy loop.");
+        Assert.IsFalse(File.Exists(Path.Combine(destDir, "a.txt")),
+            "A cancelled copy must not proceed to copy files — the check is at the top of each loop iteration.");
+    }
+
+    [TestMethod]
+    public void DeleteDirectoryIfExists_NotCancelled_DeletesReadOnlyFilesAndDirectory()
+    {
+        var targetDir = Path.Combine(_tempRoot, "todelete");
+        Directory.CreateDirectory(targetDir);
+        var filePath = Path.Combine(targetDir, "readonly.txt");
+        File.WriteAllText(filePath, "content");
+        File.SetAttributes(filePath, FileAttributes.ReadOnly);
+
+        InvokeDeleteDirectoryIfExists(targetDir, CancellationToken.None);
+
+        Assert.IsFalse(Directory.Exists(targetDir), "Existing behavior: read-only files must still be deletable.");
+    }
+
+    [TestMethod]
+    public void DeleteDirectoryIfExists_CancelledBeforeWalk_ThrowsOperationCanceledAndLeavesDirectoryIntact()
+    {
+        var targetDir = Path.Combine(_tempRoot, "todelete-cancelled");
+        Directory.CreateDirectory(targetDir);
+        File.WriteAllText(Path.Combine(targetDir, "file.txt"), "content");
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var thrown = Assert.ThrowsExactly<TargetInvocationException>(
+            () => InvokeDeleteDirectoryIfExists(targetDir, cts.Token));
+        Assert.IsInstanceOfType<OperationCanceledException>(thrown.InnerException);
+        Assert.IsTrue(Directory.Exists(targetDir),
+            "A cancelled delete must not proceed to delete the directory.");
+    }
+
+    [TestMethod]
+    public void ForkApplyLocks_SameNormalizedSourceRoot_SharesOneSemaphoreAcrossConcurrentCallers()
+    {
+        // Mirrors exactly what WorkspaceForkApply does: ForkApplyLocks.GetOrAdd(Path.GetFullPath(sourceRoot), ...).
+        // Same source root (even with different casing / relative segments that normalize to the
+        // same full path) must resolve to the same SemaphoreSlim instance so concurrent
+        // workspace_fork_apply calls against it are serialized rather than racing.
+        var locks = (System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim>)
+            ForkApplyLocksField.GetValue(null)!;
+
+        var sourceRoot = Path.Combine(_tempRoot, "SourceRoot");
+        Directory.CreateDirectory(sourceRoot);
+        var variantCasing = Path.Combine(_tempRoot, "sourceroot");
+
+        var lock1 = locks.GetOrAdd(Path.GetFullPath(sourceRoot), _ => new SemaphoreSlim(1, 1));
+        var lock2 = locks.GetOrAdd(Path.GetFullPath(sourceRoot), _ => new SemaphoreSlim(1, 1));
+        Assert.AreSame(lock1, lock2, "Identical source root must resolve to the same semaphore instance.");
+
+        var otherRoot = Path.Combine(_tempRoot, "OtherRoot");
+        Directory.CreateDirectory(otherRoot);
+        var lock3 = locks.GetOrAdd(Path.GetFullPath(otherRoot), _ => new SemaphoreSlim(1, 1));
+        Assert.AreNotSame(lock1, lock3, "A distinct source root must not share the same semaphore.");
+
+        // The dictionary itself is case-insensitive (Windows path semantics), matching how
+        // ValidationBundleTools constructs it.
+        Assert.IsTrue(locks.TryGetValue(variantCasing, out var caseInsensitiveHit),
+            "ForkApplyLocks must be keyed case-insensitively so 'SourceRoot' and 'sourceroot' collide on Windows.");
+        Assert.AreSame(lock1, caseInsensitiveHit);
+    }
+
+    private static void InvokeCopyDirectory(string sourceDir, string destinationDir, CancellationToken ct) =>
+        CopyDirectoryMethod.Invoke(null, [sourceDir, destinationDir, ct]);
+
+    private static void InvokeDeleteDirectoryIfExists(string path, CancellationToken ct) =>
+        DeleteDirectoryIfExistsMethod.Invoke(null, [path, ct]);
+}


### PR DESCRIPTION
## Summary
- `ValidationBundleTools`'s `CopyDirectory` / `DeleteDirectoryIfExists` now thread a `CancellationToken` through the recursive walk and check it at the top of each loop iteration, so cancellation is no longer silently dropped mid-copy/mid-cleanup.
- Added a per-normalized-source-root `SemaphoreSlim` (`ForkApplyLocks`) so concurrent `workspace_fork_apply` calls against the same source root are serialized rather than racing; released in a `finally` covering the existing failure-path cleanup.
- `TestCoverageTools.RunTestCoverageCore` no longer conflates genuine caller cancellation with the gate's internal timeout — an ordered `catch (OperationCanceledException) when (ct.IsCancellationRequested)` rethrows before the existing catch that builds the `Timeout` envelope.

Closes: workspace-fork-apply-robustness-cancellation

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~WorkspaceForkApply|FullyQualifiedName~TestCoverageFailureEnvelope|FullyQualifiedName~ValidationBundleTools"` — 16 passed
- [x] `dotnet test --filter "FullyQualifiedName~TestCoverage"` — 12 passed
- [x] `./eng/verify-ai-docs.ps1` — passed
- [x] New `WorkspaceForkApplyCancellationTests`: CopyDirectory/DeleteDirectoryIfExists cancellation + no-op-on-cancel, ForkApplyLocks per-source-root semaphore identity/case-insensitivity
- [x] New `TestCoverageFailureEnvelopeTests.RunTestCoverageCore_CallerCancelled_PropagatesWithoutWrapping`: caller-cancelled ct propagates OperationCanceledException instead of the Timeout envelope
- Not run locally: `./eng/verify-release.ps1` (full `dotnet test`) — per standing session policy, skipped while the self-hosted CI runner may be active; CI will run it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)