### PR TITLE
fix(apply-with-verify): cancellation-safe revert + project-scoped compile_check

### DIFF
--- a/changelog.d/apply-with-verify-cancellation-and-compile-scope.md
+++ b/changelog.d/apply-with-verify-cancellation-and-compile-scope.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `apply_with_verify` completes a bounded best-effort revert on cancellation between apply and verify/revert; pre/post `compile_check` calls now scope to the preview's affected project when it touches exactly one.

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
@@ -16,6 +17,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ApplyWithVerifyTool
 {
+    /// <summary>
+    /// apply-with-verify-cancellation-and-compile-scope: budget for the best-effort revert
+    /// issued when the caller's <see cref="CancellationToken"/> fires AFTER a successful apply
+    /// but before the normal verify/revert leg completes. The original (already-cancelled)
+    /// token cannot drive the rollback, so a fresh short-lived token is used so the workspace
+    /// is not left mutated with no rollback. Bounded so a wedged revert cannot hang the caller.
+    /// </summary>
+    private static readonly TimeSpan RevertBudget = TimeSpan.FromSeconds(30);
+
     [McpServerTool(Name = "apply_with_verify", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "experimental", false, true,
         "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),
@@ -28,8 +38,10 @@ public static class ApplyWithVerifyTool
         IPreviewStore previewStore,
         [Description("The preview token returned by an *_preview tool")] string previewToken,
         [Description("If true (default) and the apply introduces new compile errors, automatically revert via revert_last_apply.")] bool rollbackOnError = true,
+        ILoggerFactory? loggerFactory = null,
         CancellationToken ct = default)
     {
+        var logger = loggerFactory?.CreateLogger(typeof(ApplyWithVerifyTool).FullName ?? nameof(ApplyWithVerifyTool));
         var workspaceId = previewStore.PeekWorkspaceId(previewToken)
             ?? throw new PreviewTokenStaleException(
                 previewToken,
@@ -37,6 +49,27 @@ public static class ApplyWithVerifyTool
 
         return gate.RunWriteAsync(workspaceId, async c =>
         {
+            // apply-with-verify-cancellation-and-compile-scope: scope both compile_check legs
+            // to the single project the preview actually touches, instead of compiling the FULL
+            // solution twice. Mirrors EditService's ownerProjects/batchProjectFilter pattern:
+            // exactly one changed project → filter to it; zero or many → null (compile
+            // everything, the safe fallback). Retrieve is non-consuming and does not perturb the
+            // token's TTL, so the paired apply below still redeems it. A null entry (stale token)
+            // falls through to the full-solution compile — correctness-preserving, just slower.
+            string? projectFilter = null;
+            if (previewStore.Retrieve(previewToken) is { } previewEntry)
+            {
+                var changedProjects = previewEntry.ModifiedSolution
+                    .GetChanges(previewEntry.OriginalSolution)
+                    .GetProjectChanges()
+                    .Select(pc => pc.NewProject.Name)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                projectFilter = changedProjects.Count == 1 ? changedProjects[0] : null;
+            }
+
+            var checkOptions = new CompileCheckOptions(ProjectFilter: projectFilter);
+
             // apply-with-verify-diff-not-counts: snapshot pre-apply error IDENTITIES (id+file+line)
             // so we can tell NEW errors from pre-existing ones. Identity-diff replaces the prior
             // count-delta + message-fingerprint heuristic that produced ~14% false-positive
@@ -45,7 +78,7 @@ public static class ApplyWithVerifyTool
             // EditService's verify=true path so both verify entry points subtract pre-existing
             // errors uniformly. See DiagnosticIdentitySet for the rationale and format.
             var preBaseline = await compileCheckService.CheckAsync(
-                workspaceId, new CompileCheckOptions(), c).ConfigureAwait(false);
+                workspaceId, checkOptions, c).ConfigureAwait(false);
             var preErrors = DiagnosticIdentitySet.ExtractErrorIdentities(preBaseline);
 
             // Apply
@@ -60,61 +93,102 @@ public static class ApplyWithVerifyTool
                 }, JsonDefaults.Indented);
             }
 
-            // Verify — extract post-apply error identities and subtract the pre-apply set.
-            // The remaining identities are "introduced" errors that did not exist at any
-            // (id+file+line) location before the apply. Pre-existing errors whose severity
-            // flipped, message changed, or column shifted no longer trigger rollback.
-            var postCheck = await compileCheckService.CheckAsync(
-                workspaceId, new CompileCheckOptions(), c).ConfigureAwait(false);
-            var postErrors = DiagnosticIdentitySet.ExtractErrorIdentities(postCheck);
-
-            // Project the introduced identities back to the diagnostic rows so the response
-            // surfaces the actual errors (id, message, location) rather than opaque
-            // identity strings. Use the post-apply diagnostic list as the source of truth
-            // for the introduced rows.
-            var newIdentities = new HashSet<string>(postErrors.Except(preErrors), StringComparer.Ordinal);
-            var newErrors = postCheck.Diagnostics
-                .Where(d => string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase)
-                    && newIdentities.Contains(DiagnosticIdentitySet.FormatIdentity(d)))
-                .ToList();
-
-            if (newErrors.Count == 0)
+            // apply-with-verify-cancellation-and-compile-scope: the workspace is now mutated.
+            // Everything from here to the normal revert leg runs under the caller's token `c`;
+            // if it fires mid-verify (post-check) or mid-revert, an OperationCanceledException
+            // would otherwise unwind straight out of the gate, leaving the apply in place with
+            // NO rollback. Guard the post-apply region so a cancellation triggers a bounded
+            // best-effort revert on a FRESH token before the OCE is rethrown. This catch can
+            // only fire when the apply already succeeded (we are past the !Success early return),
+            // so a pre-apply cancellation on the baseline compile still propagates untouched —
+            // there is nothing applied to revert in that case.
+            try
             {
+                // Verify — extract post-apply error identities and subtract the pre-apply set.
+                // The remaining identities are "introduced" errors that did not exist at any
+                // (id+file+line) location before the apply. Pre-existing errors whose severity
+                // flipped, message changed, or column shifted no longer trigger rollback.
+                var postCheck = await compileCheckService.CheckAsync(
+                    workspaceId, checkOptions, c).ConfigureAwait(false);
+                var postErrors = DiagnosticIdentitySet.ExtractErrorIdentities(postCheck);
+
+                // Project the introduced identities back to the diagnostic rows so the response
+                // surfaces the actual errors (id, message, location) rather than opaque
+                // identity strings. Use the post-apply diagnostic list as the source of truth
+                // for the introduced rows.
+                var newIdentities = new HashSet<string>(postErrors.Except(preErrors), StringComparer.Ordinal);
+                var newErrors = postCheck.Diagnostics
+                    .Where(d => string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase)
+                        && newIdentities.Contains(DiagnosticIdentitySet.FormatIdentity(d)))
+                    .ToList();
+
+                if (newErrors.Count == 0)
+                {
+                    return JsonSerializer.Serialize(new
+                    {
+                        status = "applied",
+                        appliedFiles = applyResult.AppliedFiles,
+                        preErrorCount = preBaseline.ErrorCount,
+                        postErrorCount = postCheck.ErrorCount,
+                    }, JsonDefaults.Indented);
+                }
+
+                // New errors appeared. Either roll back or surface for inspection.
+                if (!rollbackOnError)
+                {
+                    return JsonSerializer.Serialize(new
+                    {
+                        status = "applied_with_errors",
+                        appliedFiles = applyResult.AppliedFiles,
+                        introducedErrors = newErrors,
+                        preErrorCount = preBaseline.ErrorCount,
+                        postErrorCount = postCheck.ErrorCount,
+                        message = "Apply introduced new compile errors; rollbackOnError was false so the broken state is preserved for inspection. Call revert_last_apply to restore.",
+                    }, JsonDefaults.Indented);
+                }
+
+                var reverted = await undoService.RevertAsync(workspaceId, c).ConfigureAwait(false);
                 return JsonSerializer.Serialize(new
                 {
-                    status = "applied",
-                    appliedFiles = applyResult.AppliedFiles,
-                    preErrorCount = preBaseline.ErrorCount,
-                    postErrorCount = postCheck.ErrorCount,
-                }, JsonDefaults.Indented);
-            }
-
-            // New errors appeared. Either roll back or surface for inspection.
-            if (!rollbackOnError)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    status = "applied_with_errors",
+                    status = reverted ? "rolled_back" : "rollback_failed",
                     appliedFiles = applyResult.AppliedFiles,
                     introducedErrors = newErrors,
                     preErrorCount = preBaseline.ErrorCount,
                     postErrorCount = postCheck.ErrorCount,
-                    message = "Apply introduced new compile errors; rollbackOnError was false so the broken state is preserved for inspection. Call revert_last_apply to restore.",
+                    message = reverted
+                    ? "Apply introduced new compile errors and was reverted. The workspace is back to the pre-apply state."
+                    : "Apply introduced new compile errors AND the rollback also failed — the workspace is in an inconsistent state. Inspect manually.",
                 }, JsonDefaults.Indented);
             }
-
-            var reverted = await undoService.RevertAsync(workspaceId, c).ConfigureAwait(false);
-            return JsonSerializer.Serialize(new
+            catch (OperationCanceledException)
             {
-                status = reverted ? "rolled_back" : "rollback_failed",
-                appliedFiles = applyResult.AppliedFiles,
-                introducedErrors = newErrors,
-                preErrorCount = preBaseline.ErrorCount,
-                postErrorCount = postCheck.ErrorCount,
-                message = reverted
-                ? "Apply introduced new compile errors and was reverted. The workspace is back to the pre-apply state."
-                : "Apply introduced new compile errors AND the rollback also failed — the workspace is in an inconsistent state. Inspect manually.",
-            }, JsonDefaults.Indented);
+                // The apply landed but the caller cancelled before the verify/revert leg
+                // finished. Roll the workspace back best-effort on a fresh token (the caller's
+                // token `c` is already cancelled and cannot drive the revert), then rethrow the
+                // original cancellation so the caller still observes it. A second failure in the
+                // revert itself is logged rather than swallowed (Directive #3) and does NOT mask
+                // the cancellation.
+                using var revertCts = new CancellationTokenSource(RevertBudget);
+                try
+                {
+                    var recovered = await undoService.RevertAsync(workspaceId, revertCts.Token).ConfigureAwait(false);
+                    if (!recovered)
+                    {
+                        logger?.LogError(
+                            "apply_with_verify: best-effort revert after cancellation reported failure for workspace {WorkspaceId}; the applied edit may still be present.",
+                            workspaceId);
+                    }
+                }
+                catch (Exception revertEx)
+                {
+                    logger?.LogError(
+                        revertEx,
+                        "apply_with_verify: best-effort revert after cancellation threw for workspace {WorkspaceId}; the applied edit may still be present.",
+                        workspaceId);
+                }
+
+                throw;
+            }
         }, ct);
     }
 }

--- a/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
@@ -1,0 +1,444 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Contracts;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// apply-with-verify-cancellation-and-compile-scope: fake-driven coverage for the two
+/// bug fixes in <see cref="ApplyWithVerifyTool"/>:
+/// <list type="number">
+/// <item><description>
+/// Cancellation that fires AFTER a successful apply but before the verify/revert leg
+/// completes must trigger a best-effort revert on a FRESH (non-cancelled) token, and the
+/// original <see cref="OperationCanceledException"/> must still surface to the caller. A
+/// second failure in the best-effort revert is logged, never swallowed, and never masks
+/// the cancellation.
+/// </description></item>
+/// <item><description>
+/// Both <c>compile_check</c> legs must be scoped to the single project the preview touches
+/// (via <see cref="CompileCheckOptions.ProjectFilter"/>); zero or many touched projects fall
+/// back to a full-solution compile (null filter).
+/// </description></item>
+/// </list>
+/// These use hand-rolled fakes rather than the real workspace harness so the exact token
+/// identity and project-filter arguments are observable.
+/// </summary>
+[TestClass]
+public sealed class ApplyWithVerifyCancellationAndScopeTests
+{
+    // ── Cancellation-safe revert ──
+
+    [TestMethod]
+    public async Task Cancellation_AfterSuccessfulApply_RevertsOnFreshToken_AndRethrows()
+    {
+        var cts = new CancellationTokenSource();
+        var originalCancellation = new OperationCanceledException(cts.Token);
+
+        var compile = new FakeCompileCheck
+        {
+            // Call 0 = pre-apply baseline (succeeds). Call 1 = post-apply verify: model the
+            // caller cancelling mid-verify, after the apply already mutated the workspace.
+            OnCall = i =>
+            {
+                if (i == 1)
+                {
+                    cts.Cancel();
+                    throw originalCancellation;
+                }
+            },
+        };
+        var undo = new FakeUndo();
+        var previewStore = new FakePreviewStore("ws"); // Retrieve returns null → filter skipped
+
+        var thrown = await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+            ApplyWithVerifyTool.ApplyWithVerify(
+                new FakeGate(),
+                new FakeRefactoring(),
+                compile,
+                undo,
+                previewStore,
+                previewToken: "tok",
+                rollbackOnError: true,
+                loggerFactory: null,
+                ct: cts.Token));
+
+        Assert.AreSame(originalCancellation, thrown,
+            "The ORIGINAL cancellation must surface, not a wrapped/replacement exception.");
+        Assert.AreEqual(1, undo.RevertCalls,
+            "A best-effort revert must run exactly once after a post-apply cancellation.");
+        Assert.IsFalse(undo.LastRevertToken.IsCancellationRequested,
+            "The revert must use a FRESH, non-cancelled token — not the caller's cancelled token.");
+        Assert.AreNotEqual(cts.Token, undo.LastRevertToken,
+            "The revert token must not be the caller's (already-cancelled) token.");
+    }
+
+    [TestMethod]
+    public async Task Cancellation_BestEffortRevertThrows_IsLogged_AndOriginalCancellationSurfaces()
+    {
+        var cts = new CancellationTokenSource();
+        var originalCancellation = new OperationCanceledException(cts.Token);
+
+        var compile = new FakeCompileCheck
+        {
+            OnCall = i =>
+            {
+                if (i == 1)
+                {
+                    cts.Cancel();
+                    throw originalCancellation;
+                }
+            },
+        };
+        // The best-effort revert itself blows up — this must be logged, must NOT be swallowed
+        // silently, and must NOT mask the original cancellation.
+        var undo = new FakeUndo { RevertThrows = new InvalidOperationException("revert boom") };
+        var loggerFactory = new CapturingLoggerFactory();
+        var previewStore = new FakePreviewStore("ws");
+
+        var thrown = await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+            ApplyWithVerifyTool.ApplyWithVerify(
+                new FakeGate(),
+                new FakeRefactoring(),
+                compile,
+                undo,
+                previewStore,
+                previewToken: "tok",
+                rollbackOnError: true,
+                loggerFactory: loggerFactory,
+                ct: cts.Token));
+
+        Assert.AreSame(originalCancellation, thrown,
+            "A failing best-effort revert must not mask the original cancellation.");
+        Assert.AreEqual(1, undo.RevertCalls, "The revert must have been attempted.");
+        CollectionAssert.Contains(loggerFactory.Logger.Entries, LogLevel.Error,
+            "A best-effort revert failure must be logged at Error, not swallowed (Directive #3).");
+    }
+
+    [TestMethod]
+    public async Task PreApplyCancellation_DoesNotAttemptRevert()
+    {
+        var cts = new CancellationTokenSource();
+
+        var compile = new FakeCompileCheck
+        {
+            // Call 0 = pre-apply baseline: cancel BEFORE any apply happens. Nothing is applied,
+            // so no revert must be attempted — the cancellation just propagates.
+            OnCall = i =>
+            {
+                if (i == 0)
+                {
+                    cts.Cancel();
+                    throw new OperationCanceledException(cts.Token);
+                }
+            },
+        };
+        var undo = new FakeUndo();
+        var refactoring = new FakeRefactoring();
+        var previewStore = new FakePreviewStore("ws");
+
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+            ApplyWithVerifyTool.ApplyWithVerify(
+                new FakeGate(),
+                refactoring,
+                compile,
+                undo,
+                previewStore,
+                previewToken: "tok",
+                rollbackOnError: true,
+                loggerFactory: null,
+                ct: cts.Token));
+
+        Assert.AreEqual(0, refactoring.ApplyCalls, "Apply must not run when the baseline is cancelled.");
+        Assert.AreEqual(0, undo.RevertCalls,
+            "No revert may be attempted for a cancellation that happens before anything is applied.");
+    }
+
+    // ── Project-scoped compile_check ──
+
+    [TestMethod]
+    public async Task CompileCheck_SingleTouchedProject_ScopesFilterToThatProject()
+    {
+        var (original, modified, _) = BuildSolution(("ProjA", true), ("ProjB", false));
+        var compile = new FakeCompileCheck();
+        var previewStore = new FakePreviewStore("ws", original, modified);
+
+        var json = await ApplyWithVerifyTool.ApplyWithVerify(
+            new FakeGate(),
+            new FakeRefactoring(),
+            compile,
+            new FakeUndo(),
+            previewStore,
+            previewToken: "tok",
+            rollbackOnError: true,
+            loggerFactory: null,
+            ct: CancellationToken.None);
+
+        AssertStatus(json, "applied");
+        Assert.AreEqual(2, compile.RecordedFilters.Count, "Both pre- and post-apply legs must run.");
+        Assert.IsTrue(compile.RecordedFilters.All(f => f == "ProjA"),
+            $"Both legs must scope to the single touched project. Got: [{string.Join(", ", compile.RecordedFilters)}]");
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_MultipleTouchedProjects_UsesNullFilter()
+    {
+        var (original, modified, _) = BuildSolution(("ProjA", true), ("ProjB", true));
+        var compile = new FakeCompileCheck();
+        var previewStore = new FakePreviewStore("ws", original, modified);
+
+        var json = await ApplyWithVerifyTool.ApplyWithVerify(
+            new FakeGate(),
+            new FakeRefactoring(),
+            compile,
+            new FakeUndo(),
+            previewStore,
+            previewToken: "tok",
+            rollbackOnError: true,
+            loggerFactory: null,
+            ct: CancellationToken.None);
+
+        AssertStatus(json, "applied");
+        Assert.AreEqual(2, compile.RecordedFilters.Count);
+        Assert.IsTrue(compile.RecordedFilters.All(f => f is null),
+            $"A multi-project touch must fall back to a full-solution compile (null filter). Got: [{string.Join(", ", compile.RecordedFilters.Select(f => f ?? "null"))}]");
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_ZeroTouchedProjects_UsesNullFilter()
+    {
+        // Original == Modified → GetProjectChanges yields nothing → full-solution fallback.
+        var (original, _, sameAsOriginal) = BuildSolution(("ProjA", false));
+        var compile = new FakeCompileCheck();
+        var previewStore = new FakePreviewStore("ws", original, sameAsOriginal);
+
+        var json = await ApplyWithVerifyTool.ApplyWithVerify(
+            new FakeGate(),
+            new FakeRefactoring(),
+            compile,
+            new FakeUndo(),
+            previewStore,
+            previewToken: "tok",
+            rollbackOnError: true,
+            loggerFactory: null,
+            ct: CancellationToken.None);
+
+        AssertStatus(json, "applied");
+        Assert.AreEqual(2, compile.RecordedFilters.Count);
+        Assert.IsTrue(compile.RecordedFilters.All(f => f is null),
+            "A zero-project diff must fall back to a full-solution compile (null filter).");
+    }
+
+    // ── helpers ──
+
+    private static void AssertStatus(string json, string expected)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var status = doc.RootElement.GetProperty("status").GetString();
+        Assert.AreEqual(expected, status, $"Unexpected status. Full JSON: {json}");
+    }
+
+    /// <summary>
+    /// Builds an in-memory (Adhoc) solution pair. Each tuple names a project and whether the
+    /// "modified" solution changes a document inside it. Returns (original, modified, original)
+    /// — the third element is the unchanged original again, handy for the zero-diff case.
+    /// </summary>
+    private static (Solution Original, Solution Modified, Solution OriginalAgain) BuildSolution(
+        params (string Name, bool Changed)[] projects)
+    {
+        using var ws = new AdhocWorkspace();
+        var solution = ws.CurrentSolution;
+        var docIds = new List<(DocumentId Id, bool Changed)>();
+
+        foreach (var (name, changed) in projects)
+        {
+            var pid = ProjectId.CreateNewId();
+            var did = DocumentId.CreateNewId(pid);
+            solution = solution
+                .AddProject(pid, name, name, LanguageNames.CSharp)
+                .AddDocument(did, $"{name}.cs", $"class {name} {{ }}");
+            docIds.Add((did, changed));
+        }
+
+        var modified = solution;
+        foreach (var (id, changed) in docIds)
+        {
+            if (changed)
+            {
+                modified = modified.WithDocumentText(id, SourceText.From("class Changed { int x; }"));
+            }
+        }
+
+        return (solution, modified, solution);
+    }
+
+    // ── fakes ──
+
+    private sealed class FakeGate : IWorkspaceExecutionGate
+    {
+        public Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct, bool applyStalenessPolicy = true)
+            => action(ct);
+
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => action(ct);
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => action(ct);
+
+        public void RemoveGate(string workspaceId) { }
+    }
+
+    private sealed class FakeCompileCheck : ICompileCheckService
+    {
+        public readonly List<string?> RecordedFilters = new();
+        public Action<int>? OnCall;
+        private int _n;
+
+        public Task<CompileCheckDto> CheckAsync(string workspaceId, CompileCheckOptions options, CancellationToken ct)
+        {
+            RecordedFilters.Add(options.ProjectFilter);
+            OnCall?.Invoke(_n++);
+            return Task.FromResult(new CompileCheckDto(
+                Success: true,
+                ErrorCount: 0,
+                WarningCount: 0,
+                TotalDiagnostics: 0,
+                ReturnedDiagnostics: 0,
+                Offset: 0,
+                Limit: 50,
+                HasMore: false,
+                Diagnostics: Array.Empty<DiagnosticDto>(),
+                ElapsedMs: 0));
+        }
+    }
+
+    private sealed class FakeRefactoring : IRefactoringService
+    {
+        public int ApplyCalls;
+        public ApplyResultDto Result = new(true, new[] { "Changed.cs" }, null);
+
+        public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct)
+        {
+            ApplyCalls++;
+            return Task.FromResult(Result);
+        }
+
+        public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, bool force, CancellationToken ct)
+        {
+            ApplyCalls++;
+            return Task.FromResult(Result);
+        }
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, bool summary, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewOrganizeUsingsAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatDocumentAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatRangeAsync(string workspaceId, string filePath, int startLine, int startColumn, int endLine, int endColumn, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewCodeFixAsync(string workspaceId, string diagnosticId, string filePath, int line, int column, string? fixId, CancellationToken ct)
+            => throw new NotImplementedException();
+    }
+
+    private sealed class FakeUndo : IUndoService
+    {
+        public int RevertCalls;
+        public CancellationToken LastRevertToken;
+        public bool RevertReturns = true;
+        public Exception? RevertThrows;
+
+        public Task<bool> RevertAsync(string workspaceId, CancellationToken cancellationToken = default)
+        {
+            RevertCalls++;
+            LastRevertToken = cancellationToken;
+            if (RevertThrows is not null)
+            {
+                throw RevertThrows;
+            }
+            return Task.FromResult(RevertReturns);
+        }
+
+        public void CaptureBeforeApply(string workspaceId, string description, object? preApplySolution, IReadOnlyList<FileSnapshotDto>? fileSnapshots = null) { }
+
+        public UndoEntry? GetLastOperation(string workspaceId) => null;
+
+        public Task<RevertBySequenceResult> RevertBySequenceAsync(string workspaceId, int sequenceNumber, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public void CommitPendingCapture(string workspaceId, int sequenceNumber, IReadOnlyList<string> affectedFiles) { }
+
+        public void Clear(string workspaceId) { }
+    }
+
+    private sealed class FakePreviewStore : IPreviewStore
+    {
+        private readonly string _workspaceId;
+        private readonly Solution? _original;
+        private readonly Solution? _modified;
+
+        public FakePreviewStore(string workspaceId, Solution? original = null, Solution? modified = null)
+        {
+            _workspaceId = workspaceId;
+            _original = original;
+            _modified = modified;
+        }
+
+        public string? PeekWorkspaceId(string token) => _workspaceId;
+
+        public (string WorkspaceId, Solution OriginalSolution, Solution ModifiedSolution, int WorkspaceVersion, string Description, bool DiffTruncated)? Retrieve(string token)
+            => _original is not null && _modified is not null
+                ? (_workspaceId, _original, _modified, 1, "fake preview", false)
+                : null;
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
+            => throw new NotImplementedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated)
+            => throw new NotImplementedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, IReadOnlyList<FileChangeDto> changes)
+            => throw new NotImplementedException();
+
+        public void Invalidate(string token) { }
+
+        public void InvalidateAll(string? workspaceId = null) { }
+
+        public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion) { }
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        public readonly CapturingLogger Logger = new();
+
+        public ILogger CreateLogger(string categoryName) => Logger;
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public readonly List<LogLevel> Entries = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add(logLevel);
+    }
+}

--- a/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
@@ -153,7 +153,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
 
         var json = await ApplyWithVerifyTool.ApplyWithVerify(
             WorkspaceExecutionGate, RefactoringService, CompileCheckService, UndoService, PreviewStore,
-            preview.PreviewToken, rollbackOnError: true, CancellationToken.None);
+            preview.PreviewToken, rollbackOnError: true, ct: CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         var status = doc.RootElement.GetProperty("status").GetString();
@@ -209,7 +209,7 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         // returns status="applied".
         var json = await ApplyWithVerifyTool.ApplyWithVerify(
             WorkspaceExecutionGate, RefactoringService, CompileCheckService, UndoService, PreviewStore,
-            preview.PreviewToken, rollbackOnError: true, CancellationToken.None);
+            preview.PreviewToken, rollbackOnError: true, ct: CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
         var status = doc.RootElement.GetProperty("status").GetString();


### PR DESCRIPTION
## Summary

Fixes two bugs in `ApplyWithVerifyTool`'s apply -> verify -> revert flow (`src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs`).

**1. Cancellation-safe revert.** A cancellation that fired *after* a successful apply but *before* `RevertAsync` completed unwound straight out of the gate, leaving the workspace mutated with no rollback. The post-apply region is now wrapped in a `try/catch (OperationCanceledException)`: on cancellation it runs a bounded best-effort `RevertAsync` on a **fresh** `CancellationTokenSource(30s)` (the caller's token is already cancelled and cannot drive the revert), then rethrows the original cancellation. A second failure inside the best-effort revert is logged at `Error` (Directive #3) and never masks the cancellation. The catch sits after the `!Success` early-return, so a pre-apply cancellation (nothing applied) still propagates untouched.

**2. Project-scoped `compile_check`.** Both compile legs used an empty `CompileCheckOptions()`, compiling the **full solution twice** even for single-file previews. They now scope to the single project the preview touches — computed from `previewStore.Retrieve(token)`'s `ModifiedSolution.GetChanges(OriginalSolution).GetProjectChanges()` distinct project names, mirroring `EditService`'s `ownerProjects`/`batchProjectFilter` pattern (exactly one changed project -> filter to it; zero or many -> null full-solution fallback). `Retrieve` is non-consuming and does not perturb the token TTL, so the paired apply still redeems it.

## Tests

New `tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs` (6 fake-driven tests):
- cancellation after successful apply reverts on a fresh (non-cancelled) token and rethrows the original OCE
- failing best-effort revert is logged and the original cancellation still surfaces
- pre-apply cancellation attempts no revert
- single / multiple / zero touched projects -> correct `ProjectFilter` (name / null / null)

Two `Top10V2RegressionTests` call sites updated for the new injected `loggerFactory` parameter (named `ct:` argument). Existing `apply_with_verify` integration tests unchanged and green.

## Validation

- `mcp__roslyn__compile_check` (RoslynMcp.Tests, transitively Host.Stdio): 0 errors
- `mcp__roslyn__test_run --filter FullyQualifiedName~ApplyWithVerify`: 8/8 passed (6 new + 2 existing)

Full `verify-release.ps1` deferred to CI per repo policy (self-hosted runner).

Closes: apply-with-verify-cancellation-and-compile-scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)