### PR TITLE
refactor(roslyn): dedupe RefactoringService ItemGroup helper + index rebase scan

### DIFF
--- a/changelog.d/refactoringservice-god-class-decomposition.md
+++ b/changelog.d/refactoringservice-god-class-decomposition.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** `RefactoringService` no longer duplicates `OrchestrationMsBuildXml.GetOrCreateItemGroup` (fixes a latent formatting gap where a freshly-created `<ItemGroup>` was appended without indent/line-ending trivia) and its solution-rebase path now uses a precomputed file-path index instead of a per-changed-document linear scan.

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -744,6 +744,25 @@ public sealed class RefactoringService : IRefactoringService
         var previewChanges = modifiedSolution.GetChanges(originalSolution);
         var rebased = currentSolution;
 
+        // Precompute a FilePath -> DocumentId index over the current solution once, so the
+        // cross-lineage changed-document fallback below is an O(1) dictionary lookup instead of
+        // an O(total-docs) SelectMany scan per changed document (previously O(changed-docs ×
+        // total-docs) on this apply-path hot function). Keyed OrdinalIgnoreCase to match the
+        // prior scan's comparison; first occurrence wins to mirror FirstOrDefault when the same
+        // FilePath is linked into multiple projects.
+        var currentDocumentsByPath = new Dictionary<string, DocumentId>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in currentSolution.Projects)
+        {
+            foreach (var currentDocument in project.Documents)
+            {
+                if (!string.IsNullOrWhiteSpace(currentDocument.FilePath)
+                    && !currentDocumentsByPath.ContainsKey(currentDocument.FilePath))
+                {
+                    currentDocumentsByPath[currentDocument.FilePath] = currentDocument.Id;
+                }
+            }
+        }
+
         foreach (var projectChange in previewChanges.GetProjectChanges())
         {
             foreach (var docId in projectChange.GetChangedDocuments())
@@ -758,11 +777,10 @@ public sealed class RefactoringService : IRefactoringService
                 // current workspace still has the same DocumentId, apply the text directly;
                 // otherwise match on FilePath (the canonical cross-lineage key).
                 var currentDoc = rebased.GetDocument(docId);
-                if (currentDoc is null && !string.IsNullOrWhiteSpace(doc.FilePath))
+                if (currentDoc is null && !string.IsNullOrWhiteSpace(doc.FilePath)
+                    && currentDocumentsByPath.TryGetValue(doc.FilePath, out var matchedDocId))
                 {
-                    currentDoc = rebased.Projects
-                        .SelectMany(project => project.Documents)
-                        .FirstOrDefault(candidate => string.Equals(candidate.FilePath, doc.FilePath, StringComparison.OrdinalIgnoreCase));
+                    currentDoc = rebased.GetDocument(matchedDocId);
                 }
 
                 if (currentDoc is null)
@@ -1287,7 +1305,7 @@ public sealed class RefactoringService : IRefactoringService
                 continue;
             }
 
-            GetOrCreateItemGroup(document, "ProjectReference")
+            OrchestrationMsBuildXml.GetOrCreateItemGroup(document, "ProjectReference")
                 .Add(new XElement("ProjectReference", new XAttribute("Include", relativePath)));
             changed = true;
         }
@@ -1324,20 +1342,6 @@ public sealed class RefactoringService : IRefactoringService
 
         await File.WriteAllTextAsync(modifiedProject.FilePath, document.ToString(SaveOptions.DisableFormatting), ct).ConfigureAwait(false);
         appliedFiles.Add(modifiedProject.FilePath);
-    }
-
-    private static XElement GetOrCreateItemGroup(XDocument document, string itemName)
-    {
-        var existingGroup = document.Root?.Elements("ItemGroup")
-            .FirstOrDefault(group => group.Elements(itemName).Any());
-        if (existingGroup is not null)
-        {
-            return existingGroup;
-        }
-
-        var itemGroup = new XElement("ItemGroup");
-        document.Root?.Add(itemGroup);
-        return itemGroup;
     }
 
     private static string NormalizeInclude(string? include)

--- a/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
@@ -48,6 +48,56 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
     }
 
     [TestMethod]
+    public async Task Extract_Interface_Apply_Writes_Properly_Indented_ItemGroup_For_New_Project_Reference()
+    {
+        // Regression for refactoringservice-god-class-decomposition (item 1): RefactoringService
+        // previously carried a private GetOrCreateItemGroup that appended a fresh <ItemGroup> via
+        // `document.Root?.Add(itemGroup)` with NO trivia, producing collapsed on-disk XML —
+        // `...</PropertyGroup>\n<ItemGroup>...</ItemGroup></Project>` with the ItemGroup at column 0
+        // and `</Project>` glued onto `</ItemGroup>`. The consolidated
+        // OrchestrationMsBuildXml.GetOrCreateItemGroup splices the new element with matching
+        // indent + line-ending trivia (AppendRootChildWithFormatting). SampleLib.csproj ships with
+        // NO existing ProjectReference ItemGroup, so this apply exercises the new-ItemGroup path.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        AddProjectToCopiedSolution(workspace.RootPath, "Contracts", "net10.0");
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+        var sourceProjectFilePath = workspace.GetPath("SampleLib", "SampleLib.csproj");
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var preview = await CrossProjectRefactoringService.PreviewExtractInterfaceAsync(
+            workspace.WorkspaceId,
+            sourceFilePath,
+            "AnimalService",
+            "IAnimalService",
+            "Contracts",
+            CancellationToken.None);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+        var rawProjectXml = await File.ReadAllTextAsync(sourceProjectFilePath, CancellationToken.None);
+        var normalized = rawProjectXml.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        // (1) The freshly-created ItemGroup must be on its own indented line, not appended at
+        //     column 0 as the private-dup helper did.
+        StringAssert.Contains(
+            normalized,
+            "\n  <ItemGroup>",
+            $"New ProjectReference ItemGroup must be spliced on its own indented line.\nFile contents:\n{rawProjectXml}");
+
+        // (2) The closing </ItemGroup> must not be glued directly onto </Project> — the latent
+        //     formatting bug the private dup lacked a fix for.
+        Assert.IsFalse(
+            normalized.Contains("</ItemGroup></Project>", StringComparison.Ordinal),
+            $"Closing </ItemGroup> must not be glued onto </Project>.\nFile contents:\n{rawProjectXml}");
+
+        // (3) The reference itself must be present and target the new project.
+        var projectXml = XDocument.Parse(rawProjectXml);
+        Assert.IsTrue(projectXml.Descendants("ProjectReference").Any(element =>
+            string.Equals(Path.GetFileName((string?)element.Attribute("Include")), "Contracts.csproj", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
     public async Task Move_Type_To_Project_Preview_And_Apply_Moves_File_And_Adds_Project_Reference()
     {
         await using var workspace = CreateIsolatedWorkspaceCopy();


### PR DESCRIPTION
## Summary

Scoped to items 1+2 of `refactoringservice-god-class-decomposition` (S-sized; per Directive #6, item 3 document-set-persistence extraction is materially larger and filed as a follow-up row).

**Item 1 — dedupe `GetOrCreateItemGroup`.** `RefactoringService` carried a private `GetOrCreateItemGroup` that duplicated the shared `OrchestrationMsBuildXml.GetOrCreateItemGroup`. The private copy appended a fresh `<ItemGroup>` via `document.Root?.Add(itemGroup)` with no trivia, producing collapsed on-disk XML (`</PropertyGroup>\n<ItemGroup>...</ItemGroup></Project>` — ItemGroup at column 0, `</Project>` glued onto `</ItemGroup>`). The shared helper splices the element with matching indent + line-ending trivia (`AppendRootChildWithFormatting`), fixing that latent formatting gap. Deleted the private method; routed its sole call site through the shared helper (same namespace, no new using).

**Item 2 — index the rebase scan.** `RebaseModifiedSolutionOntoCurrentAsync` did a per-changed-document `SelectMany(...).FirstOrDefault(...)` linear scan for the cross-lineage FilePath fallback — O(changed-docs × total-docs) on an apply-path hot function. Precomputed a `Dictionary<string, DocumentId>` keyed by FilePath (`OrdinalIgnoreCase`, first-occurrence-wins to mirror the prior `FirstOrDefault`) once before the loop → O(total-docs + changed-docs). The AddedDocuments / RemovedDocuments branches are untouched.

## Tests

- New formatting-sensitive regression test `Extract_Interface_Apply_Writes_Properly_Indented_ItemGroup_For_New_Project_Reference` asserts the on-disk csproj gets a properly-indented multi-line `<ItemGroup>` (not collapsed inline, `</ItemGroup>` not glued to `</Project>`). SampleLib.csproj ships with no existing ProjectReference ItemGroup, so the apply exercises the new-ItemGroup path.
- `CrossProjectRefactoringIntegrationTests` + `RefactoringToolsIntegrationTests`: 23 passed / 0 failed.
- `compile_check` clean on `RoslynMcp.Roslyn` and `RoslynMcp.Tests`; `verify-ai-docs.ps1` passed.

## Follow-up

Recommend filing `refactoringservice-persistence-extraction` (size M/L) for the document-set-persistence extraction (item 3), explicitly out of this S-sized fix's scope.

Closes: refactoringservice-god-class-decomposition