### PR TITLE
refactor(services): dedupe copy-pasted helper methods across refactor services

### DIFF
--- a/changelog.d/refactor-services-duplicate-code-sweep.md
+++ b/changelog.d/refactor-services-duplicate-code-sweep.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** consolidated duplicated helper methods across RecordFieldAdditionService, RestructureService, StringLiteralReplaceService, and SymbolRefactorService (no behavior change).

--- a/src/RoslynMcp.Roslyn/Services/RecordFieldAdditionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RecordFieldAdditionService.cs
@@ -251,11 +251,11 @@ public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
                 break;
             case DeclarationExpressionSyntax decl when decl.Designation is ParenthesizedVariableDesignationSyntax pvd
                                                         && InferredDeconstructionTargetMatches(decl, semanticModel, typeSymbol, ct):
-                AddUniqueDeconstructionFromDesignation(decl, pvd, doc, existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
+                AddUniqueDeconstructionFromDesignation(pvd, BuildLocationDto(decl, doc), existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
                 break;
             case AssignmentExpressionSyntax asn when asn.Left is TupleExpressionSyntax tuple
                                                       && AssignmentTargetMatches(asn, semanticModel, typeSymbol, ct):
-                AddUniqueDeconstructionFromTuple(asn, tuple, doc, existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
+                AddUniqueDeconstructionFromTuple(tuple, BuildLocationDto(asn, doc), existingPositionalParameters, newField, deconstructionSites, dedupeSpans);
                 break;
             case RecursivePatternSyntax rp when PatternMatchesTarget(rp, semanticModel, typeSymbol, ct):
                 AddUniqueRecursivePattern(rp, doc, existingPositionalParameters, newField, deconstructionSites, propertyPatternSites, dedupeSpans);
@@ -428,7 +428,7 @@ public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
     {
         if (decl.Designation is not ParenthesizedVariableDesignationSyntax pvd) return false;
         if (!InferredDeconstructionTargetMatches(decl, ctx.SemanticModel, ctx.TargetType, ct)) return false;
-        AddUniqueDeconstructionFromDesignation(decl, pvd, baseDto, ctx.ExistingParameters, ctx.NewField, ctx.DeconstructionSites, ctx.DedupeSpans);
+        AddUniqueDeconstructionFromDesignation(pvd, UpdateDtoSpan(baseDto, decl), ctx.ExistingParameters, ctx.NewField, ctx.DeconstructionSites, ctx.DedupeSpans);
         return true;
     }
 
@@ -440,7 +440,7 @@ public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
     {
         if (asn.Left is not TupleExpressionSyntax tuple) return false;
         if (!AssignmentTargetMatches(asn, ctx.SemanticModel, ctx.TargetType, ct)) return false;
-        AddUniqueDeconstructionFromTuple(asn, tuple, baseDto, ctx.ExistingParameters, ctx.NewField, ctx.DeconstructionSites, ctx.DedupeSpans);
+        AddUniqueDeconstructionFromTuple(tuple, UpdateDtoSpan(baseDto, asn), ctx.ExistingParameters, ctx.NewField, ctx.DeconstructionSites, ctx.DedupeSpans);
         return true;
     }
 
@@ -475,36 +475,19 @@ public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
         }
     }
 
+    // Deconstruction-site recorders shared by both discovery passes. The pass-A reference walker
+    // resolves `loc` via UpdateDtoSpan(baseDto, node); the pass-B document walker resolves it via
+    // BuildLocationDto(node, document). Both callers pass the already-resolved LocationDto so this
+    // method is span-source-agnostic.
     private static void AddUniqueDeconstructionFromDesignation(
-        DeclarationExpressionSyntax decl,
         ParenthesizedVariableDesignationSyntax pvd,
-        LocationDto baseDto,
+        LocationDto loc,
         IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
         NewRecordFieldDto newField,
         List<RecordDeconstructionSiteDto> deconstructionSites,
         HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
     {
         if (existingParameters.Count == 0 || pvd.Variables.Count != existingParameters.Count) return;
-        var loc = UpdateDtoSpan(baseDto, decl);
-        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Designation:" + nameof(DeclarationExpressionSyntax))))
-        {
-            var original = pvd.ToString();
-            var suggested = BuildSuggestedDesignationPattern(pvd, newField);
-            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
-        }
-    }
-
-    private static void AddUniqueDeconstructionFromDesignation(
-        DeclarationExpressionSyntax decl,
-        ParenthesizedVariableDesignationSyntax pvd,
-        Document document,
-        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
-        NewRecordFieldDto newField,
-        List<RecordDeconstructionSiteDto> deconstructionSites,
-        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
-    {
-        if (existingParameters.Count == 0 || pvd.Variables.Count != existingParameters.Count) return;
-        var loc = BuildLocationDto(decl, document);
         if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Designation:" + nameof(DeclarationExpressionSyntax))))
         {
             var original = pvd.ToString();
@@ -514,35 +497,14 @@ public sealed class RecordFieldAdditionService : IRecordFieldAdditionService
     }
 
     private static void AddUniqueDeconstructionFromTuple(
-        AssignmentExpressionSyntax asn,
         TupleExpressionSyntax tuple,
-        LocationDto baseDto,
+        LocationDto loc,
         IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
         NewRecordFieldDto newField,
         List<RecordDeconstructionSiteDto> deconstructionSites,
         HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
     {
         if (existingParameters.Count == 0 || tuple.Arguments.Count != existingParameters.Count) return;
-        var loc = UpdateDtoSpan(baseDto, asn);
-        if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Tuple:" + nameof(AssignmentExpressionSyntax))))
-        {
-            var original = tuple.ToString();
-            var suggested = BuildSuggestedTuplePattern(tuple, newField);
-            deconstructionSites.Add(new RecordDeconstructionSiteDto(loc, original, suggested));
-        }
-    }
-
-    private static void AddUniqueDeconstructionFromTuple(
-        AssignmentExpressionSyntax asn,
-        TupleExpressionSyntax tuple,
-        Document document,
-        IReadOnlyList<ExistingPositionalParameterDto> existingParameters,
-        NewRecordFieldDto newField,
-        List<RecordDeconstructionSiteDto> deconstructionSites,
-        HashSet<(string Path, int Line, int Col, string Kind)> dedupeSpans)
-    {
-        if (existingParameters.Count == 0 || tuple.Arguments.Count != existingParameters.Count) return;
-        var loc = BuildLocationDto(asn, document);
         if (dedupeSpans.Add((loc.FilePath, loc.StartLine, loc.StartColumn, "Tuple:" + nameof(AssignmentExpressionSyntax))))
         {
             var original = tuple.ToString();

--- a/src/RoslynMcp.Roslyn/Services/RestructureService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RestructureService.cs
@@ -77,9 +77,9 @@ public sealed class RestructureService : IRestructureService
         var changes = new List<FileChangeDto>();
         var totalMatches = 0;
 
-        foreach (var project in EnumerateProjects(solution, scope))
+        foreach (var project in SolutionScopeHelper.EnumerateProjects(solution, scope))
         {
-            foreach (var document in EnumerateDocuments(project, scope))
+            foreach (var document in SolutionScopeHelper.EnumerateDocuments(project, scope))
             {
                 ct.ThrowIfCancellationRequested();
                 var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
@@ -157,9 +157,9 @@ public sealed class RestructureService : IRestructureService
         var changes = new List<FileChangeDto>();
         var totalMatches = 0;
 
-        foreach (var project in EnumerateProjects(inputSolution, scope))
+        foreach (var project in SolutionScopeHelper.EnumerateProjects(inputSolution, scope))
         {
-            foreach (var document in EnumerateDocuments(project, scope))
+            foreach (var document in SolutionScopeHelper.EnumerateDocuments(project, scope))
             {
                 ct.ThrowIfCancellationRequested();
                 var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
@@ -240,34 +240,6 @@ public sealed class RestructureService : IRestructureService
 
         name = string.Empty;
         return false;
-    }
-
-    private static IEnumerable<Project> EnumerateProjects(Solution solution, RestructureScope scope)
-    {
-        if (!string.IsNullOrWhiteSpace(scope.ProjectName))
-        {
-            var match = solution.Projects.FirstOrDefault(p =>
-                string.Equals(p.Name, scope.ProjectName, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.FilePath, scope.ProjectName, StringComparison.OrdinalIgnoreCase));
-            if (match is null)
-                throw new InvalidOperationException($"Project '{scope.ProjectName}' not found in workspace.");
-            return [match];
-        }
-        return solution.Projects;
-    }
-
-    private static IEnumerable<Document> EnumerateDocuments(Project project, RestructureScope scope)
-    {
-        if (!string.IsNullOrWhiteSpace(scope.FilePath))
-        {
-            var fullPath = Path.GetFullPath(scope.FilePath);
-            var doc = project.Documents.FirstOrDefault(d =>
-                string.Equals(d.FilePath, fullPath, StringComparison.OrdinalIgnoreCase));
-            return doc is null ? [] : [doc];
-        }
-        return project.Documents.Where(d =>
-            !string.IsNullOrEmpty(d.FilePath) &&
-            string.Equals(Path.GetExtension(d.FilePath), ".cs", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -442,5 +414,43 @@ public sealed class RestructureService : IRestructureService
                 return base.VisitIdentifierName(node);
             }
         }
+    }
+}
+
+/// <summary>
+/// Resolves the project/document set a <see cref="RestructureScope"/> selects. Shared by
+/// <see cref="RestructureService"/> and <see cref="StringLiteralReplaceService"/>, which both
+/// scope solution-wide sweeps the same way. Kept in this file (rather than a dedicated one) to
+/// stay within the sweep's production-file budget; promote to its own file if a third consumer
+/// appears.
+/// </summary>
+internal static class SolutionScopeHelper
+{
+    public static IEnumerable<Project> EnumerateProjects(Solution solution, RestructureScope scope)
+    {
+        if (!string.IsNullOrWhiteSpace(scope.ProjectName))
+        {
+            var match = solution.Projects.FirstOrDefault(p =>
+                string.Equals(p.Name, scope.ProjectName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.FilePath, scope.ProjectName, StringComparison.OrdinalIgnoreCase));
+            if (match is null)
+                throw new InvalidOperationException($"Project '{scope.ProjectName}' not found in workspace.");
+            return [match];
+        }
+        return solution.Projects;
+    }
+
+    public static IEnumerable<Document> EnumerateDocuments(Project project, RestructureScope scope)
+    {
+        if (!string.IsNullOrWhiteSpace(scope.FilePath))
+        {
+            var fullPath = Path.GetFullPath(scope.FilePath);
+            var doc = project.Documents.FirstOrDefault(d =>
+                string.Equals(d.FilePath, fullPath, StringComparison.OrdinalIgnoreCase));
+            return doc is null ? [] : [doc];
+        }
+        return project.Documents.Where(d =>
+            !string.IsNullOrEmpty(d.FilePath) &&
+            string.Equals(Path.GetExtension(d.FilePath), ".cs", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/StringLiteralReplaceService.cs
+++ b/src/RoslynMcp.Roslyn/Services/StringLiteralReplaceService.cs
@@ -57,9 +57,9 @@ public sealed class StringLiteralReplaceService : IStringLiteralReplaceService
         var changes = new List<FileChangeDto>();
         var totalHits = 0;
 
-        foreach (var project in EnumerateProjects(solution, scope))
+        foreach (var project in SolutionScopeHelper.EnumerateProjects(solution, scope))
         {
-            foreach (var document in EnumerateDocuments(project, scope))
+            foreach (var document in SolutionScopeHelper.EnumerateDocuments(project, scope))
             {
                 ct.ThrowIfCancellationRequested();
                 var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
@@ -119,34 +119,6 @@ public sealed class StringLiteralReplaceService : IStringLiteralReplaceService
                 return true;
         }
         return false;
-    }
-
-    private static IEnumerable<Project> EnumerateProjects(Solution solution, RestructureScope scope)
-    {
-        if (!string.IsNullOrWhiteSpace(scope.ProjectName))
-        {
-            var match = solution.Projects.FirstOrDefault(p =>
-                string.Equals(p.Name, scope.ProjectName, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.FilePath, scope.ProjectName, StringComparison.OrdinalIgnoreCase));
-            if (match is null)
-                throw new InvalidOperationException($"Project '{scope.ProjectName}' not found in workspace.");
-            return [match];
-        }
-        return solution.Projects;
-    }
-
-    private static IEnumerable<Document> EnumerateDocuments(Project project, RestructureScope scope)
-    {
-        if (!string.IsNullOrWhiteSpace(scope.FilePath))
-        {
-            var fullPath = Path.GetFullPath(scope.FilePath);
-            var doc = project.Documents.FirstOrDefault(d =>
-                string.Equals(d.FilePath, fullPath, StringComparison.OrdinalIgnoreCase));
-            return doc is null ? [] : [doc];
-        }
-        return project.Documents.Where(d =>
-            !string.IsNullOrEmpty(d.FilePath) &&
-            string.Equals(Path.GetExtension(d.FilePath), ".cs", StringComparison.OrdinalIgnoreCase));
     }
 
     private sealed class LiteralRewriter : CSharpSyntaxRewriter

--- a/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs
@@ -379,7 +379,7 @@ public sealed partial class SymbolRefactorService : ISymbolRefactorService
                 .ToArray();
 
             var partitionMethods = rawPartitionMethods
-                .Select(method => NormalizeMemberForPartition(method))
+                .Select(method => NormalizeForPartition(method))
                 .ToArray();
 
             var referencedFields = ResolveFieldsReferencedByMethods(context.FieldDeclarations, rawPartitionMethods);
@@ -667,13 +667,21 @@ public sealed partial class SymbolRefactorService : ISymbolRefactorService
         return builder.ToString();
     }
 
-    private static MethodDeclarationSyntax NormalizeMemberForPartition(MethodDeclarationSyntax method)
+    /// <summary>
+    /// Strips attribute lists and resets leading/trailing trivia so a migrated member (method or
+    /// field) sits cleanly in the generated partition file. Attributes on the source declaration
+    /// are kept on the facade's forwarding stub if the user needs them; the authoritative
+    /// implementation on the partition gets a neutral decoration. Field initializers are preserved
+    /// verbatim — they may carry trailing trivia we don't want to disturb
+    /// (e.g. <c>= new(); // configured at construction</c>).
+    /// </summary>
+    private static T NormalizeForPartition<T>(T member) where T : MemberDeclarationSyntax
     {
-        // Strip attribute lists and normalize leading trivia so the moved method sits cleanly
-        // inside the generated partition file. Attributes on the source declaration are kept on
-        // the facade's forwarding stub if the user needs them; the authoritative implementation
-        // on the partition gets a neutral decoration.
-        return method
+        // WithAttributeLists on the MemberDeclarationSyntax base returns the base type; the
+        // WithLeading/TrailingTrivia extensions are generic over the node type. Roslyn's Update
+        // preserves the concrete runtime node type through the whole chain, so the cast back to T
+        // is safe.
+        return (T)member
             .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
             .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed))
             .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
@@ -693,7 +701,7 @@ public sealed partial class SymbolRefactorService : ISymbolRefactorService
         // assigned in the synthesized ctor body. When no uninitialized fields remain the ctor
         // is omitted entirely so we don't conflict with the implicit default constructor.
         var partitionMembers = new List<MemberDeclarationSyntax>();
-        partitionMembers.AddRange(referencedFields.Select(NormalizeFieldForPartition));
+        partitionMembers.AddRange(referencedFields.Select(field => NormalizeForPartition(field)));
 
         var ctorEligibleFields = referencedFields
             .Where(field => !FieldHasInitializer(field))
@@ -712,17 +720,6 @@ public sealed partial class SymbolRefactorService : ISymbolRefactorService
         var compilationUnit = SyntaxFactory.CompilationUnit().WithUsings(usings);
         compilationUnit = WrapInNamespace(compilationUnit, namespaceName, classDecl);
         return compilationUnit.NormalizeWhitespace().ToFullString() + Environment.NewLine;
-    }
-
-    private static FieldDeclarationSyntax NormalizeFieldForPartition(FieldDeclarationSyntax field)
-    {
-        // Strip attributes and reset trivia so the migrated field sits cleanly at the top of the
-        // partition. Field initializers are preserved verbatim — they may carry trailing trivia
-        // we don't want to disturb (e.g. `= new(); // configured at construction`).
-        return field
-            .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
-            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed))
-            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
     }
 
     private static bool FieldHasInitializer(FieldDeclarationSyntax field)


### PR DESCRIPTION
## Summary

Consolidates three verified duplication clusters across four refactor services. **No behavior change** — pure de-dup refactor (`refactor-services-duplicate-code-sweep`).

1. **RecordFieldAdditionService** — the `LocationDto`-variant / `Document`-variant overload pairs of `AddUniqueDeconstructionFromDesignation` and `AddUniqueDeconstructionFromTuple` were byte-identical apart from how `loc` was obtained. Collapsed each pair into a single method that takes the already-resolved `LocationDto`; the pass-A reference walker forwards `UpdateDtoSpan(baseDto, node)` and the pass-B document walker forwards `BuildLocationDto(node, doc)` at the call site — exactly the span source each overload used before, so dedupe keys and emitted DTO shapes are identical.
2. **RestructureService / StringLiteralReplaceService** — the copy-pasted `EnumerateProjects` / `EnumerateDocuments` pair (identical in both files) is extracted into an `internal static class SolutionScopeHelper`. Both services now call the shared helper.
3. **SymbolRefactorService** — `NormalizeMemberForPartition(MethodDeclarationSyntax)` and `NormalizeFieldForPartition(FieldDeclarationSyntax)` differed only in node type. Unified into `NormalizeForPartition<T>(T member) where T : MemberDeclarationSyntax` (the `With*` chain returns the base type; a cast back to `T` is safe because Roslyn's `Update` preserves the concrete runtime node type).

## Reviewer note

`SolutionScopeHelper` is intentionally embedded in `RestructureService.cs` rather than given its own file — a deliberate Rule-3 (≤4 production files) trade-off. A doc-comment on the class flags it for promotion to a dedicated file if a third consumer appears.

## Validation

- `mcp__roslyn__compile_check` clean (0 errors, 0 warnings) on all four files.
- Targeted tests: 21 passed / 0 failed across `RestructureServiceTests`, `StringLiteralReplaceServiceTests`, `RecordFieldAddSatelliteTests`, `RecordFieldAdditionImpactTests`, `SymbolRefactorPreviewTests`, `CompositeSplitServiceDiPreviewTests`.
- `verify-ai-docs.ps1` and `verify-changelog-fragments.ps1` pass. Full `verify-release.ps1` deferred to the self-hosted CI runner.

Closes: refactor-services-duplicate-code-sweep