### PR TITLE
fix(tests): serialize TypeExtractionTests/TypeMoveTests to match WorkspaceManager convention

### DIFF
--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -76,6 +76,7 @@ internal static class McpRootsTestServerFactory
     }
 }
 
+[DoNotParallelize]
 [TestClass]
 public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
 {

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -2,6 +2,7 @@ using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
 {


### PR DESCRIPTION
## Summary
- `TypeExtractionTests`/`TypeMoveTests` derive from `IsolatedWorkspaceTestBase`, which drives the shared process-wide static `WorkspaceManager`. Every other test class touching it concurrently opts out of MSTest class-level parallelization via `[DoNotParallelize]`; these two never got it, causing an intermittent race under parallel scheduling.
- Reproduced pre-fix (2 unrelated test failures: "Document not found" / "Sequence contains no matching element"), confirmed fixed post-fix (2 clean runs).

Found during cold code review of the `20260709T033118Z` backlog-sweep batch, which extended both test classes with new coverage that surfaced the latent gap.

## Test plan
- [x] `dotnet build` clean
- [x] Targeted filter run clean x2 post-fix (pre-fix reproduced the race on both cited commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)