### PR TITLE
chore(gitignore): ignore /refactorv2 scratch output (.refactor/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -556,3 +556,6 @@ review-inbox/*.md
 
 # Playwright MCP session artifacts (ephemeral page snapshots).
 .playwright-mcp/
+
+# Per-run scratch output from /refactorv2 (matrix + slice-map JSON, working scratch).
+.refactor/


### PR DESCRIPTION
## Summary
- Untracked `/refactorv2` scratch output (`.refactor/` — matrix + slice-map JSON) was blocking the `/release-cut` clean-tree preflight check.
- Adds `.refactor/` to `.gitignore` so future runs don't dirty the tree.

## Test plan
- N/A (gitignore-only change, no code paths affected)