### PR TITLE
fix(services): prune per-workspace command gates + harden preview-store TOCTOU

### DIFF
--- a/changelog.d/workspace-infra-resource-cleanup-hygiene.md
+++ b/changelog.d/workspace-infra-resource-cleanup-hygiene.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `GatedCommandExecutor` now prunes its per-workspace command-execution semaphore on `workspace_close` (including LRU eviction), preventing unbounded growth of its internal gate dictionary across repeated load/close cycles. `PersistentCompositeStorage.TryRead` no longer throws uncaught when a preview-token subdirectory is deleted concurrently by another process; the cross-process race is now treated as a cache miss.

--- a/src/RoslynMcp.Roslyn/Services/GatedCommandExecutor.cs
+++ b/src/RoslynMcp.Roslyn/Services/GatedCommandExecutor.cs
@@ -34,7 +34,25 @@ public sealed class GatedCommandExecutor : IGatedCommandExecutor
         _logger = logger;
         var globalLimit = Math.Clamp(Environment.ProcessorCount / 4, 1, 4);
         _globalCommandGate = new SemaphoreSlim(globalLimit, globalLimit);
+        _workspaceManager.WorkspaceClosed += RemoveWorkspaceGate;
     }
+
+    /// <summary>
+    /// Prunes the per-workspace command gate when a workspace is closed or LRU-evicted, so the
+    /// <see cref="_workspaceCommandGates"/> dictionary stays bounded across repeated
+    /// load/close cycles instead of accumulating one <see cref="SemaphoreSlim"/> per distinct
+    /// workspaceId for the process lifetime.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT call <see cref="SemaphoreSlim.Dispose"/> on the removed semaphore:
+    /// <see cref="ExecuteAsync(string, string, IReadOnlyList{string}, TimeSpan, IReadOnlyList{EarlyKillPattern}?, CancellationToken)"/>
+    /// can be mid-flight against this gate for the closing workspace (the command-execution gate
+    /// and the workspace-lifecycle gate are independent locking systems), and disposing a
+    /// <see cref="SemaphoreSlim"/> concurrently with an in-flight <c>WaitAsync</c>/<c>Release</c>
+    /// is documented as unsafe. Removing the dictionary entry alone satisfies bounded growth; the
+    /// orphaned semaphore is GC'd once the in-flight caller's local reference goes out of scope.
+    /// </remarks>
+    private void RemoveWorkspaceGate(string workspaceId) => _workspaceCommandGates.TryRemove(workspaceId, out _);
 
     public Task<CommandExecutionDto> ExecuteAsync(
         string workspaceId,
@@ -117,6 +135,7 @@ public sealed class GatedCommandExecutor : IGatedCommandExecutor
 
     public void Dispose()
     {
+        _workspaceManager.WorkspaceClosed -= RemoveWorkspaceGate;
         _globalCommandGate.Dispose();
         foreach (var kvp in _workspaceCommandGates)
         {

--- a/src/RoslynMcp.Roslyn/Services/PersistentCompositeStorage.cs
+++ b/src/RoslynMcp.Roslyn/Services/PersistentCompositeStorage.cs
@@ -61,38 +61,57 @@ public sealed class PersistentCompositeStorage
         // Search across workspaceVersion subdirectories — caller doesn't know the version
         // when redeeming a token from a separate process.
         if (!Directory.Exists(_rootDirectory)) return null;
-        foreach (var subdir in Directory.EnumerateDirectories(_rootDirectory))
+
+        // The enumeration and the TTL stat below race a sibling process's concurrent Delete /
+        // directory cleanup (this store's whole purpose is cross-process token redemption).
+        // Directory.EnumerateDirectories is lazy, so a mid-walk directory removal throws during
+        // the foreach's MoveNext, and File.GetLastWriteTimeUtc can throw between the File.Exists
+        // check and the stat. Wrap the whole loop so a caught race is treated as a cache miss
+        // (the in-memory CompositePreviewStore is the source of truth) rather than surfacing an
+        // uncaught DirectoryNotFoundException/IOException. DirectoryNotFoundException and
+        // FileNotFoundException both derive from IOException; UnauthorizedAccessException does
+        // not and is intentionally left to propagate (a genuine permissions problem, not a race).
+        try
         {
-            var path = Path.Combine(subdir, token + ".json");
-            if (!File.Exists(path)) continue;
+            foreach (var subdir in Directory.EnumerateDirectories(_rootDirectory))
+            {
+                var path = Path.Combine(subdir, token + ".json");
+                if (!File.Exists(path)) continue;
 
-            // TTL check based on file write time so cross-process readers honor expiry.
-            var age = DateTime.UtcNow - File.GetLastWriteTimeUtc(path);
-            if (age > _ttl)
-            {
-                TryDelete(path);
-                return null;
-            }
+                // TTL check based on file write time so cross-process readers honor expiry.
+                var age = DateTime.UtcNow - File.GetLastWriteTimeUtc(path);
+                if (age > _ttl)
+                {
+                    TryDelete(path);
+                    return null;
+                }
 
-            try
-            {
-                var json = File.ReadAllText(path);
-                var dto = JsonSerializer.Deserialize<PersistedEntry>(json, JsonOpts);
-                if (dto is null) return null;
-                return new CompositePreviewStore.Entry(
-                    dto.WorkspaceId,
-                    dto.WorkspaceVersion,
-                    dto.Description,
-                    dto.Mutations.Select(m => new CompositeFileMutation(m.FilePath, m.UpdatedContent, m.DeleteFile)).ToArray(),
-                    dto.CreatedAt);
+                try
+                {
+                    var json = File.ReadAllText(path);
+                    var dto = JsonSerializer.Deserialize<PersistedEntry>(json, JsonOpts);
+                    if (dto is null) return null;
+                    return new CompositePreviewStore.Entry(
+                        dto.WorkspaceId,
+                        dto.WorkspaceVersion,
+                        dto.Description,
+                        dto.Mutations.Select(m => new CompositeFileMutation(m.FilePath, m.UpdatedContent, m.DeleteFile)).ToArray(),
+                        dto.CreatedAt);
+                }
+                catch (Exception ex)
+                {
+                    // Corrupt entry — drop it and return null so the in-memory miss path takes over.
+                    _logger?.LogDebug(ex, "PersistentCompositeStorage: dropping unreadable entry at {Path}.", path);
+                    TryDelete(path);
+                    return null;
+                }
             }
-            catch (Exception ex)
-            {
-                // Corrupt entry — drop it and return null so the in-memory miss path takes over.
-                _logger?.LogDebug(ex, "PersistentCompositeStorage: dropping unreadable entry at {Path}.", path);
-                TryDelete(path);
-                return null;
-            }
+        }
+        catch (IOException ex)
+        {
+            // Directory/file removed by another process mid-enumeration — treat as a miss.
+            _logger?.LogDebug(ex, "PersistentCompositeStorage: directory/file race while reading token; treating as miss.");
+            return null;
         }
         return null;
     }

--- a/tests/RoslynMcp.Tests/Services/GatedCommandExecutorTests.cs
+++ b/tests/RoslynMcp.Tests/Services/GatedCommandExecutorTests.cs
@@ -1,0 +1,153 @@
+using System.Collections;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests.Services;
+
+/// <summary>
+/// Direct unit tests for <see cref="GatedCommandExecutor"/>'s per-workspace gate lifecycle
+/// (<c>workspace-infra-resource-cleanup-hygiene</c>). The executor is an <c>AddSingleton</c>, so
+/// without pruning its <c>_workspaceCommandGates</c> dictionary would accumulate one
+/// <see cref="SemaphoreSlim"/> per distinct workspaceId for the process lifetime. These tests
+/// prove the gate is removed when the workspace's <see cref="IWorkspaceManager.WorkspaceClosed"/>
+/// event fires (explicit close AND LRU eviction both raise it), keeping the dictionary bounded.
+/// </summary>
+[TestClass]
+public sealed class GatedCommandExecutorTests
+{
+    [TestMethod]
+    public async Task WorkspaceClosed_PrunesGate_AcrossRepeatedLoadCloseCycles()
+    {
+        var ws = new FakeWorkspaceManager();
+        var runner = new StubCommandRunner();
+        using var executor = new GatedCommandExecutor(ws, runner, NullLogger<GatedCommandExecutor>.Instance);
+
+        // Drive 5 distinct load→execute→close cycles. Without the WorkspaceClosed subscription
+        // the dictionary would grow to 5; with it, each close prunes its entry back to 0.
+        for (var i = 0; i < 5; i++)
+        {
+            var workspaceId = $"ws-{i}";
+            await executor.ExecuteAsync(
+                workspaceId, @"C:\tmp\Sample.sln", new[] { "build" }, TimeSpan.FromMinutes(1), default);
+
+            Assert.AreEqual(1, GetGateCount(executor),
+                "A gate is created lazily on ExecuteAsync for the active workspace.");
+
+            ws.RaiseWorkspaceClosed(workspaceId);
+
+            Assert.AreEqual(0, GetGateCount(executor),
+                "Closing the workspace must prune its command gate so the dictionary stays bounded.");
+        }
+    }
+
+    [TestMethod]
+    public async Task WorkspaceClosed_RemovesOnlyClosedWorkspaceGate()
+    {
+        var ws = new FakeWorkspaceManager();
+        var runner = new StubCommandRunner();
+        using var executor = new GatedCommandExecutor(ws, runner, NullLogger<GatedCommandExecutor>.Instance);
+
+        await executor.ExecuteAsync("ws-a", @"C:\tmp\A.sln", new[] { "build" }, TimeSpan.FromMinutes(1), default);
+        await executor.ExecuteAsync("ws-b", @"C:\tmp\B.sln", new[] { "build" }, TimeSpan.FromMinutes(1), default);
+        Assert.AreEqual(2, GetGateCount(executor));
+
+        ws.RaiseWorkspaceClosed("ws-a");
+
+        Assert.AreEqual(1, GetGateCount(executor), "Only the closed workspace's gate is removed.");
+        Assert.IsTrue(GateContains(executor, "ws-b"), "The still-open workspace's gate is retained.");
+        Assert.IsFalse(GateContains(executor, "ws-a"), "The closed workspace's gate is gone.");
+    }
+
+    [TestMethod]
+    public void WorkspaceClosed_ForUnknownWorkspace_IsNoOp()
+    {
+        var ws = new FakeWorkspaceManager();
+        var runner = new StubCommandRunner();
+        using var executor = new GatedCommandExecutor(ws, runner, NullLogger<GatedCommandExecutor>.Instance);
+
+        // No gate was ever created; a close for an unseen id must not throw.
+        ws.RaiseWorkspaceClosed("never-seen");
+        Assert.AreEqual(0, GetGateCount(executor));
+    }
+
+    [TestMethod]
+    public async Task Dispose_UnsubscribesFromWorkspaceClosed()
+    {
+        var ws = new FakeWorkspaceManager();
+        var runner = new StubCommandRunner();
+        var executor = new GatedCommandExecutor(ws, runner, NullLogger<GatedCommandExecutor>.Instance);
+
+        await executor.ExecuteAsync("ws-x", @"C:\tmp\X.sln", new[] { "build" }, TimeSpan.FromMinutes(1), default);
+        executor.Dispose();
+
+        // After disposal the handler is detached, so a late close must not touch the (cleared)
+        // dictionary or throw ObjectDisposedException from the handler.
+        ws.RaiseWorkspaceClosed("ws-x");
+        Assert.AreEqual(0, GetGateCount(executor));
+    }
+
+    private static int GetGateCount(GatedCommandExecutor executor)
+        => ((ICollection)GetGateDictionary(executor)).Count;
+
+    private static bool GateContains(GatedCommandExecutor executor, string workspaceId)
+        => ((IDictionary)GetGateDictionary(executor)).Contains(workspaceId);
+
+    private static object GetGateDictionary(GatedCommandExecutor executor)
+    {
+        // _workspaceCommandGates is private (InternalsVisibleTo does not reach it), so read it via
+        // reflection rather than widening the field's accessibility just for the test.
+        var field = typeof(GatedCommandExecutor).GetField(
+            "_workspaceCommandGates", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field, "Expected private field _workspaceCommandGates to exist.");
+        return field!.GetValue(executor)!;
+    }
+
+    /// <summary>
+    /// Stub runner — <see cref="GatedCommandExecutor.ExecuteAsync(string, string, IReadOnlyList{string}, TimeSpan, CancellationToken)"/>
+    /// calls it once per invocation; returns a trivial success result without spawning a process.
+    /// </summary>
+    private sealed class StubCommandRunner : IDotnetCommandRunner
+    {
+        public Task<CommandExecutionDto> RunAsync(
+            string workingDirectory, string targetPath, IReadOnlyList<string> arguments, CancellationToken ct)
+            => Task.FromResult(new CommandExecutionDto(
+                "dotnet", arguments, workingDirectory, targetPath, 0, true, 1, string.Empty, string.Empty));
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IWorkspaceManager"/> stand-in exposing <see cref="RaiseWorkspaceClosed"/>
+    /// so the test can drive the close/eviction signal. Unused members throw to surface accidental
+    /// coupling immediately.
+    /// </summary>
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public event Action<string>? WorkspaceClosed;
+        public event Action<string>? WorkspaceReloaded;
+
+        public void RaiseWorkspaceClosed(string workspaceId) => WorkspaceClosed?.Invoke(workspaceId);
+        public void RaiseWorkspaceReloaded(string workspaceId) => WorkspaceReloaded?.Invoke(workspaceId);
+
+        // ----- Unused by GatedCommandExecutor's gate lifecycle; throw to surface coupling -----
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => throw new NotSupportedException();
+        public bool IsStale(string workspaceId) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/Services/PersistentCompositeStorageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/PersistentCompositeStorageTests.cs
@@ -1,0 +1,123 @@
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests.Services;
+
+/// <summary>
+/// Direct unit tests for <see cref="PersistentCompositeStorage"/> covering the cross-process
+/// TOCTOU hardening in <c>TryRead</c> (<c>workspace-infra-resource-cleanup-hygiene</c>). The
+/// store's whole purpose is cross-process token redemption, so a sibling process deleting a
+/// version subdirectory (or the root) while <c>TryRead</c> is enumerating is a real scenario;
+/// the enumeration must be treated as a cache miss rather than surfacing an uncaught
+/// <see cref="DirectoryNotFoundException"/>/<see cref="IOException"/>.
+/// </summary>
+/// <remarks>
+/// Each test uses an isolated cache root under <see cref="Path.GetTempPath"/> so concurrent test
+/// runs don't poison each other.
+/// </remarks>
+[TestClass]
+public sealed class PersistentCompositeStorageTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(
+            Path.GetTempPath(), "RoslynMcpTests", "PersistentCompositeStorage", Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Teardown()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; a leaked temp dir under GetTempPath is harmless.
+        }
+    }
+
+    [TestMethod]
+    public void Write_ThenTryRead_RoundTripsEntry()
+    {
+        var store = new PersistentCompositeStorage(_root, TimeSpan.FromMinutes(5));
+        var entry = new CompositePreviewStore.Entry(
+            "ws-1", 3, "sample composite",
+            new[] { new CompositeFileMutation(@"C:\proj\File.cs", "// updated", false) },
+            DateTime.UtcNow);
+
+        store.Write("token-abc", entry);
+        var read = store.TryRead("token-abc");
+
+        Assert.IsNotNull(read, "A freshly-written, unexpired entry must round-trip through TryRead.");
+        Assert.AreEqual("ws-1", read!.WorkspaceId);
+        Assert.AreEqual(3, read.WorkspaceVersion);
+        Assert.AreEqual("sample composite", read.Description);
+        Assert.AreEqual(1, read.Mutations.Count);
+        Assert.AreEqual(@"C:\proj\File.cs", read.Mutations[0].FilePath);
+        Assert.AreEqual("// updated", read.Mutations[0].UpdatedContent);
+    }
+
+    [TestMethod]
+    public void TryRead_MissingToken_ReturnsNull()
+    {
+        var store = new PersistentCompositeStorage(_root, TimeSpan.FromMinutes(5));
+        Assert.IsNull(store.TryRead("no-such-token"));
+    }
+
+    [TestMethod]
+    public async Task TryRead_ConcurrentDirectoryDeletion_ReturnsNull_DoesNotThrow()
+    {
+        var store = new PersistentCompositeStorage(_root, TimeSpan.FromMinutes(5));
+
+        // Repeatedly race TryRead's lazy Directory.EnumerateDirectories walk against a concurrent
+        // recursive deletion of the whole root. Before the fix this threw an uncaught
+        // DirectoryNotFoundException/IOException from the enumerator's MoveNext (or from the
+        // File.GetLastWriteTimeUtc TTL stat). The assertion is timing-independent: every iteration
+        // must return null without throwing, whichever way the race resolves.
+        for (var iteration = 0; iteration < 200; iteration++)
+        {
+            Directory.CreateDirectory(_root);
+            for (var version = 0; version < 40; version++)
+            {
+                var versionDir = Path.Combine(_root, version.ToString());
+                Directory.CreateDirectory(versionDir);
+                // A decoy file so the enumeration + per-subdir File.Exists probes take real time,
+                // widening the window in which the background delete lands mid-walk.
+                File.WriteAllText(Path.Combine(versionDir, "decoy.json"), "{}");
+            }
+
+            var deleter = Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(_root, recursive: true);
+                }
+                catch
+                {
+                    // The delete itself may race the reader (sharing violation); irrelevant to
+                    // what we're asserting, which is that the READER never throws.
+                }
+            });
+
+            CompositePreviewStore.Entry? result = null;
+            try
+            {
+                result = store.TryRead("token-under-race");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"TryRead threw during a concurrent directory deletion race: {ex}");
+            }
+
+            Assert.IsNull(result, "A token that was never written must read as a miss, even mid-race.");
+            await deleter;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes two resource-cleanup / hygiene gaps from the refactor-matrix pass (`workspace-infra-resource-cleanup-hygiene`).

**1. `GatedCommandExecutor` — unbounded per-workspace gate growth.**
The executor is registered `AddSingleton`, and its `_workspaceCommandGates` (`ConcurrentDictionary<string, SemaphoreSlim>`) was populated via `GetOrAdd` in `ExecuteAsync` but only cleared in `Dispose()` — so every distinct `workspaceId` ever seen leaked a permanent `SemaphoreSlim` for the process lifetime (sweep worktree churn, LRU eviction). It now subscribes to `IWorkspaceManager.WorkspaceClosed` (raised on both explicit `Close()` and internal LRU eviction) and prunes the closing workspace's gate, mirroring the established pattern in `ChangeTracker`/`CompilationCache`/etc. The removed semaphore is **deliberately not disposed** — an in-flight `WaitAsync`/`Release` against it is possible (the command-execution gate and the workspace-lifecycle gate are independent locking systems) and concurrent `SemaphoreSlim.Dispose()` is documented-unsafe; the orphan is GC'd once the in-flight caller's local reference drops. The handler is unsubscribed in `Dispose()`.

**2. `PersistentCompositeStorage.TryRead` — cross-process TOCTOU.**
The class exists for cross-process token redemption, so a sibling process's concurrent `Delete`/directory cleanup racing `TryRead`'s lazy `Directory.EnumerateDirectories` walk (or the `File.GetLastWriteTimeUtc` TTL stat) is a real scenario. Both sat outside the existing per-file try/catch. The whole loop is now wrapped in `try/catch(IOException)` (the shared base of `DirectoryNotFoundException`/`FileNotFoundException`), treating a caught race as a cache miss — consistent with the file's best-effort-persistence philosophy (the in-memory store is source of truth). `UnauthorizedAccessException` is intentionally left to propagate (a permissions problem, not a race).

## Tests

- `GatedCommandExecutorTests` (new): repeated load→execute→close cycles keep the gate dictionary bounded; only the closed workspace's gate is removed; unknown-id close is a no-op; `Dispose` unsubscribes. Asserts the private `_workspaceCommandGates` count via reflection (InternalsVisibleTo does not reach a private field).
- `PersistentCompositeStorageTests` (new): write→read round-trip; missing-token miss; 200-iteration stress race of `TryRead` against concurrent recursive root deletion asserting it returns null and never throws.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors).
- Targeted: 7/7 new tests pass.
- `eng/verify-ai-docs.ps1` — passed. Full `verify-release.ps1` runs on the self-hosted CI runner on PR push.

shims-added: 0

Closes: workspace-infra-resource-cleanup-hygiene