### PR TITLE
refactor(host-stdio): decompose StructuredCallToolFilter god-class (structuredcalltoolfilter-god-class-decompose)

### DIFF
--- a/changelog.d/structuredcalltoolfilter-god-class-decompose.md
+++ b/changelog.d/structuredcalltoolfilter-god-class-decompose.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Split `StructuredCallToolFilter`'s elicitation-allowlist policy (`IsElicitationAllowedFor`/`IsWorkspaceIdRecoveryAllowedFor`/`IsWorkspaceIdAutoResolveAllowedFor`/`HasElicitation`/`IsSensitiveFieldName`) into a new `ElicitationAllowlistPolicy` class, and its ambient-metrics recording (`RecordAutoResolution`/`RecordAutoLoadElapsed`/`RecordElapsed`) into a new `CallMetricsRecorder` class, reducing the god-class's LOC. `StructuredCallToolFilter`'s public static API is unchanged (thin delegates preserve every existing call site); adds `ElicitationAllowlistPolicyTests` covering the extracted policy directly.

--- a/src/RoslynMcp.Host.Stdio/Middleware/CallMetricsRecorder.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/CallMetricsRecorder.cs
@@ -1,0 +1,40 @@
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// Ambient-metrics recording helpers extracted from <see cref="StructuredCallToolFilter"/>.
+/// Each method writes one field on the current <see cref="AmbientGateMetrics"/> request scope
+/// (a no-op when no scope is active), keeping the filter's dispatch body free of the
+/// null-check ceremony. Purely a write-through to <see cref="AmbientGateMetrics.Current"/>;
+/// holds no state of its own.
+/// </summary>
+internal static class CallMetricsRecorder
+{
+    /// <summary>Records the workspaceId auto-resolution outcome (<c>explicit</c>, <c>single-workspace</c>, <c>fast-fail</c>, <c>auto-loaded</c>).</summary>
+    public static void RecordAutoResolution(string value)
+    {
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.AutoResolution = value;
+        }
+    }
+
+    /// <summary>Records the elapsed time spent auto-loading a workspace on demand.</summary>
+    public static void RecordAutoLoadElapsed(long elapsedMs)
+    {
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.AutoLoadElapsedMs = elapsedMs;
+        }
+    }
+
+    /// <summary>Records the end-to-end wall-clock elapsed time for the tool call.</summary>
+    public static void RecordElapsed(long elapsedMs)
+    {
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.ElapsedMs = elapsedMs;
+        }
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
@@ -1,0 +1,175 @@
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Host.Stdio.Catalog;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// The elicitation-allowlist policy layer extracted from <see cref="StructuredCallToolFilter"/>.
+/// Owns every decision about <em>whether</em> a missing parameter may be elicited from the user
+/// via MCP <c>elicitation/create</c> — the strict per-arg allowlist, the sensitive-field refusal,
+/// and the read-only <c>workspaceId</c> recovery/auto-resolve gates. Holds no dispatch or metrics
+/// concerns; those stay in the filter and <see cref="CallMetricsRecorder"/> respectively.
+///
+/// <para>
+/// <see cref="StructuredCallToolFilter"/> keeps thin public delegates that forward to these
+/// members, so its historical static call surface (consumed by <c>SymbolTools</c> and the existing
+/// filter test suites) is preserved byte-for-byte.
+/// </para>
+/// </summary>
+internal static class ElicitationAllowlistPolicy
+{
+    private const string WorkspaceLoadToolName = "workspace_load";
+    private const string WorkspaceIdParameterName = "workspaceId";
+    private const string PathParameterName = "path";
+
+    /// <summary>
+    /// Strict allowlist of <c>(toolName, paramName)</c> pairs that may be elicited from the
+    /// user via <c>elicitation/create</c>. Anything not on this list is rejected at the
+    /// elicitation entry point regardless of any other heuristic — defense layer 1 (per-arg
+    /// allowlist) and defense layer 2 (<see cref="IsSensitiveFieldName"/>) are both checked
+    /// before any elicit request is built.
+    ///
+    /// <para>
+    /// Adding to this list requires explicit policy review: the parameter must be
+    /// non-sensitive, naturally bounded (a path, an id, a select-from-N), and the recovery
+    /// shape (one-shot retry with the elicited value patched in) must be safe for the tool's
+    /// idempotency semantics. <c>workspaceId</c> parameters (Required or optional) for read-only,
+    /// non-destructive tools are handled by
+    /// <see cref="IsWorkspaceIdRecoveryAllowedFor"/> because the concrete elicited field is
+    /// <c>workspace_load.path</c>; <c>workspaceId</c> itself is a path-derived session token,
+    /// not a credential, and is pinned non-sensitive by tests.
+    /// </para>
+    /// </summary>
+    private static readonly HashSet<(string Tool, string Param)> AllowedElicitationParameters =
+        new()
+        {
+            (WorkspaceLoadToolName, PathParameterName),
+        };
+
+    /// <summary>
+    /// Capability-check helper: returns <see langword="true"/> when the connected client
+    /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
+    /// Public so initiative #9 (<c>elicit-disambiguation-on-multi-symbol-resolve</c>) can
+    /// reuse the same predicate without copy-pasting the null-coalescing dance.
+    /// </summary>
+    /// <param name="capabilities">
+    /// The <see cref="McpServer.ClientCapabilities"/> snapshot, typically obtained as
+    /// <c>context.Server.ClientCapabilities</c> inside a request filter or tool method.
+    /// May be <see langword="null"/> on the server's pre-initialize path.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when both <paramref name="capabilities"/> and
+    /// <c>capabilities.Elicitation</c> are non-null. Zero-allocation and side-effect-free.
+    /// </returns>
+    public static bool HasElicitation(ClientCapabilities? capabilities) =>
+        capabilities?.Elicitation is not null;
+
+    /// <summary>
+    /// Defense-in-depth predicate: returns <see langword="true"/> when the parameter name
+    /// suggests credential / secret / token / password / API-key / authorization material.
+    /// The primary defense is the strict <see cref="AllowedElicitationParameters"/>
+    /// allowlist; this helper exists so tests can pin the policy and so any future allowlist
+    /// addition is double-checked before being merged. Per MCP spec § Elicitation security,
+    /// "Servers MUST NOT request sensitive information" via <c>elicitation/create</c>.
+    /// </summary>
+    /// <param name="paramName">Parameter name (case-insensitive comparison).</param>
+    /// <returns>
+    /// <see langword="true"/> when the name matches a sensitive-data pattern. Empty/null
+    /// names return <see langword="false"/> — the allowlist owns the positive permission
+    /// decision; this helper only owns the "do not even consider" decision.
+    /// </returns>
+    public static bool IsSensitiveFieldName(string? paramName)
+    {
+        if (string.IsNullOrEmpty(paramName)) return false;
+        // Use Contains-based matching so common variants ("apiKey", "api_key", "ApiKey",
+        // "authToken", "passwordHash", etc.) all classify as sensitive without
+        // enumerating every casing.
+        return paramName.Contains("password", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("secret", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("credential", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("token", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("apikey", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("api_key", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("api-key", StringComparison.OrdinalIgnoreCase)
+            || paramName.Equals("auth", StringComparison.OrdinalIgnoreCase)
+            || paramName.Equals("authorization", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("private_key", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("privatekey", StringComparison.OrdinalIgnoreCase)
+            || paramName.Contains("private-key", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="toolName"/> + <paramref name="paramName"/>
+    /// is on the strict elicitation allowlist AND the parameter name is not flagged sensitive.
+    /// Both checks must pass — an entry that ends up sensitive (because someone added
+    /// <c>workspace_load.token</c> to the allowlist by mistake, say) still gets refused.
+    /// Public so tests can pin the allowlist policy.
+    /// </summary>
+    public static bool IsElicitationAllowedFor(string? toolName, string? paramName)
+    {
+        if (string.IsNullOrEmpty(toolName) || string.IsNullOrEmpty(paramName)) return false;
+        if (IsSensitiveFieldName(paramName)) return false;
+        return AllowedElicitationParameters.Contains((toolName, paramName))
+               || IsWorkspaceIdRecoveryAllowedFor(toolName, paramName);
+    }
+
+    /// <summary>
+    /// workspace-id-omitted-residual-recovery-coherence: returns <see langword="true"/> when
+    /// <paramref name="toolName"/> is a read-only, non-destructive tool and <paramref name="paramName"/>
+    /// is the non-sensitive string <c>workspaceId</c> parameter, making it eligible for the
+    /// exception-path elicitation recovery. <b>Independent of the Required flag</b> (mirrors
+    /// <see cref="IsWorkspaceIdAutoResolveAllowedFor"/>): the recovery only fires from the
+    /// exception-catch block, and the binder never throws for a missing <em>optional</em> arg, so a
+    /// relaxed gate cannot fire spuriously — but keeping it Required-independent ensures recovery
+    /// stays live for read-only tools that flip <c>workspaceId</c> to optional
+    /// (e.g. <c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>).
+    /// </summary>
+    public static bool IsWorkspaceIdRecoveryAllowedFor(string toolName, string paramName)
+    {
+        if (!string.Equals(paramName, WorkspaceIdParameterName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (IsSensitiveFieldName(paramName))
+        {
+            return false;
+        }
+
+        var schema = ToolParameterIndex.GetParameter(toolName, paramName);
+        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
+            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
+
+        return schema is { Type: "string" }
+               && tool is { ReadOnly: true, Destructive: false };
+    }
+
+    /// <summary>
+    /// workspace-id-omitted-single-resolve: returns <see langword="true"/> when
+    /// <paramref name="toolName"/> is a read-only, non-destructive tool that declares a string
+    /// <c>workspaceId</c> parameter, making it eligible for pre-dispatch auto-resolution.
+    /// Distinct from <see cref="IsWorkspaceIdRecoveryAllowedFor"/>: that predicate gates the
+    /// exception-path elicitation recovery (it fires when a tool-call surfaces a missing
+    /// <c>workspaceId</c>); both predicates are now <b>independent of the Required flag</b> so
+    /// they keep working after a read-only tool flips <c>workspaceId</c> to optional. This one
+    /// gates pre-dispatch auto-resolution rather than the exception-path recovery. Public so
+    /// tests can pin the policy.
+    /// </summary>
+    public static bool IsWorkspaceIdAutoResolveAllowedFor(string? toolName)
+    {
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return false;
+        }
+
+        var schema = ToolParameterIndex.GetParameter(toolName, WorkspaceIdParameterName);
+        if (schema is not { Type: "string" })
+        {
+            return false;
+        }
+
+        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
+            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
+        return tool is { ReadOnly: true, Destructive: false };
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -66,8 +66,8 @@ namespace RoslynMcp.Host.Stdio.Middleware;
 /// preserved exactly. Sensitive parameters (credentials, tokens, secrets, passwords,
 /// API keys, auth headers) are explicitly NOT on the allowlist — per MCP spec §
 /// Elicitation security, "Servers MUST NOT request sensitive information" via
-/// <c>elicitation/create</c>. See <see cref="IsSensitiveFieldName"/> and
-/// <see cref="AllowedElicitationParameters"/> for the defense layers.
+/// <c>elicitation/create</c>. See <see cref="ElicitationAllowlistPolicy.IsSensitiveFieldName"/>
+/// and <see cref="ElicitationAllowlistPolicy"/> for the defense layers.
 /// </para>
 ///
 /// <para>
@@ -76,33 +76,12 @@ namespace RoslynMcp.Host.Stdio.Middleware;
 /// </summary>
 internal static class StructuredCallToolFilter
 {
+    // Shared with ElicitationAllowlistPolicy (which duplicates these consts — a private const
+    // does not cross the class boundary). Retained here because the filter's dispatch/recovery
+    // body still references all three (workspace_load dispatch, workspaceId patching, path elicit).
     private const string WorkspaceLoadToolName = "workspace_load";
     private const string WorkspaceIdParameterName = "workspaceId";
     private const string PathParameterName = "path";
-
-    /// <summary>
-    /// Strict allowlist of <c>(toolName, paramName)</c> pairs that may be elicited from the
-    /// user via <c>elicitation/create</c>. Anything not on this list is rejected at the
-    /// elicitation entry point regardless of any other heuristic — defense layer 1 (per-arg
-    /// allowlist) and defense layer 2 (<see cref="IsSensitiveFieldName"/>) are both checked
-    /// before any elicit request is built.
-    ///
-    /// <para>
-    /// Adding to this list requires explicit policy review: the parameter must be
-    /// non-sensitive, naturally bounded (a path, an id, a select-from-N), and the recovery
-    /// shape (one-shot retry with the elicited value patched in) must be safe for the tool's
-    /// idempotency semantics. <c>workspaceId</c> parameters (Required or optional) for read-only,
-    /// non-destructive tools are handled by
-    /// <see cref="IsWorkspaceIdRecoveryAllowedFor"/> because the concrete elicited field is
-    /// <c>workspace_load.path</c>; <c>workspaceId</c> itself is a path-derived session token,
-    /// not a credential, and is pinned non-sensitive by tests.
-    /// </para>
-    /// </summary>
-    private static readonly HashSet<(string Tool, string Param)> AllowedElicitationParameters =
-        new()
-        {
-            (WorkspaceLoadToolName, PathParameterName),
-        };
 
     /// <summary>
     /// Decorator factory matching the SDK's <c>McpRequestFilter&lt;TParams, TResult&gt;</c>
@@ -143,7 +122,7 @@ internal static class StructuredCallToolFilter
                     {
                         // Explicit id supplied — record it and skip the loaded-workspace
                         // enumeration entirely (the common path; avoids per-call DTO projection).
-                        RecordAutoResolution("explicit");
+                        CallMetricsRecorder.RecordAutoResolution("explicit");
                     }
                     else
                     {
@@ -161,16 +140,16 @@ internal static class StructuredCallToolFilter
                             case WorkspaceIdAutoResolution.SingleWorkspace:
                                 context.Params!.Arguments =
                                     WithWorkspaceId(context.Params.Arguments, resolvedWorkspaceId!);
-                                RecordAutoResolution("single-workspace");
+                                CallMetricsRecorder.RecordAutoResolution("single-workspace");
                                 logger?.LogInformation(
                                     "Tool {ToolName} called without workspaceId; resolved to the single " +
                                     "loaded workspace {WorkspaceId}.", toolName, resolvedWorkspaceId);
                                 break;
 
                             case WorkspaceIdAutoResolution.FastFail:
-                                RecordAutoResolution("fast-fail");
+                                CallMetricsRecorder.RecordAutoResolution("fast-fail");
                                 stopwatch.Stop();
-                                RecordElapsed(stopwatch.ElapsedMilliseconds);
+                                CallMetricsRecorder.RecordElapsed(stopwatch.ElapsedMilliseconds);
                                 logger?.LogWarning(
                                     "Tool {ToolName} called without workspaceId while {Count} workspaces " +
                                     "are loaded; returning a structured fast-fail.",
@@ -191,7 +170,7 @@ internal static class StructuredCallToolFilter
                                 if (autoLoadFastFail is not null)
                                 {
                                     stopwatch.Stop();
-                                    RecordElapsed(stopwatch.ElapsedMilliseconds);
+                                    CallMetricsRecorder.RecordElapsed(stopwatch.ElapsedMilliseconds);
                                     return autoLoadFastFail;
                                 }
 
@@ -208,7 +187,7 @@ internal static class StructuredCallToolFilter
 
                 var result = await next(context, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
-                RecordElapsed(stopwatch.ElapsedMilliseconds);
+                CallMetricsRecorder.RecordElapsed(stopwatch.ElapsedMilliseconds);
                 logger?.LogInformation("Tool {ToolName} completed successfully", toolName);
                 return InjectMetaIntoContent(result, toolName);
             }
@@ -230,14 +209,14 @@ internal static class StructuredCallToolFilter
                 if (elicitResult is not null)
                 {
                     stopwatch.Stop();
-                    RecordElapsed(stopwatch.ElapsedMilliseconds);
+                    CallMetricsRecorder.RecordElapsed(stopwatch.ElapsedMilliseconds);
                     logger?.LogInformation(
                         "Tool {ToolName} succeeded on retry after elicitation", toolName);
                     return InjectMetaIntoContent(elicitResult, toolName);
                 }
 
                 stopwatch.Stop();
-                RecordElapsed(stopwatch.ElapsedMilliseconds);
+                CallMetricsRecorder.RecordElapsed(stopwatch.ElapsedMilliseconds);
 
                 var level = IsInternalError(ex) ? LogLevel.Error : LogLevel.Warning;
                 logger?.Log(level, ex, "Tool {ToolName} failed", toolName);
@@ -248,71 +227,26 @@ internal static class StructuredCallToolFilter
     }
 
     /// <summary>
-    /// Capability-check helper: returns <see langword="true"/> when the connected client
-    /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
-    /// Public so initiative #9 (<c>elicit-disambiguation-on-multi-symbol-resolve</c>) can
-    /// reuse the same predicate without copy-pasting the null-coalescing dance.
+    /// Thin delegate preserving the historical static call surface. The policy lives in
+    /// <see cref="ElicitationAllowlistPolicy.HasElicitation"/>; kept here so existing callers
+    /// (<c>SymbolTools</c>, the filter test suites) compile unchanged.
     /// </summary>
-    /// <param name="capabilities">
-    /// The <see cref="McpServer.ClientCapabilities"/> snapshot, typically obtained as
-    /// <c>context.Server.ClientCapabilities</c> inside a request filter or tool method.
-    /// May be <see langword="null"/> on the server's pre-initialize path.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> when both <paramref name="capabilities"/> and
-    /// <c>capabilities.Elicitation</c> are non-null. Zero-allocation and side-effect-free.
-    /// </returns>
     public static bool HasElicitation(ClientCapabilities? capabilities) =>
-        capabilities?.Elicitation is not null;
+        ElicitationAllowlistPolicy.HasElicitation(capabilities);
 
     /// <summary>
-    /// Defense-in-depth predicate: returns <see langword="true"/> when the parameter name
-    /// suggests credential / secret / token / password / API-key / authorization material.
-    /// The primary defense is the strict <see cref="AllowedElicitationParameters"/>
-    /// allowlist; this helper exists so tests can pin the policy and so any future allowlist
-    /// addition is double-checked before being merged. Per MCP spec § Elicitation security,
-    /// "Servers MUST NOT request sensitive information" via <c>elicitation/create</c>.
+    /// Thin delegate preserving the historical static call surface. See
+    /// <see cref="ElicitationAllowlistPolicy.IsSensitiveFieldName"/>.
     /// </summary>
-    /// <param name="paramName">Parameter name (case-insensitive comparison).</param>
-    /// <returns>
-    /// <see langword="true"/> when the name matches a sensitive-data pattern. Empty/null
-    /// names return <see langword="false"/> — the allowlist owns the positive permission
-    /// decision; this helper only owns the "do not even consider" decision.
-    /// </returns>
-    public static bool IsSensitiveFieldName(string? paramName)
-    {
-        if (string.IsNullOrEmpty(paramName)) return false;
-        // Use Contains-based matching so common variants ("apiKey", "api_key", "ApiKey",
-        // "authToken", "passwordHash", etc.) all classify as sensitive without
-        // enumerating every casing.
-        return paramName.Contains("password", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("secret", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("credential", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("token", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("apikey", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("api_key", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("api-key", StringComparison.OrdinalIgnoreCase)
-            || paramName.Equals("auth", StringComparison.OrdinalIgnoreCase)
-            || paramName.Equals("authorization", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("private_key", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("privatekey", StringComparison.OrdinalIgnoreCase)
-            || paramName.Contains("private-key", StringComparison.OrdinalIgnoreCase);
-    }
+    public static bool IsSensitiveFieldName(string? paramName) =>
+        ElicitationAllowlistPolicy.IsSensitiveFieldName(paramName);
 
     /// <summary>
-    /// Returns <see langword="true"/> when <paramref name="toolName"/> + <paramref name="paramName"/>
-    /// is on the strict elicitation allowlist AND the parameter name is not flagged sensitive.
-    /// Both checks must pass — an entry that ends up sensitive (because someone added
-    /// <c>workspace_load.token</c> to the allowlist by mistake, say) still gets refused.
-    /// Public so tests can pin the allowlist policy.
+    /// Thin delegate preserving the historical static call surface. See
+    /// <see cref="ElicitationAllowlistPolicy.IsElicitationAllowedFor"/>.
     /// </summary>
-    public static bool IsElicitationAllowedFor(string? toolName, string? paramName)
-    {
-        if (string.IsNullOrEmpty(toolName) || string.IsNullOrEmpty(paramName)) return false;
-        if (IsSensitiveFieldName(paramName)) return false;
-        return AllowedElicitationParameters.Contains((toolName, paramName))
-               || IsWorkspaceIdRecoveryAllowedFor(toolName, paramName);
-    }
+    public static bool IsElicitationAllowedFor(string? toolName, string? paramName) =>
+        ElicitationAllowlistPolicy.IsElicitationAllowedFor(toolName, paramName);
 
     /// <summary>
     /// Core of the elicitation-fallback path: when <paramref name="ex"/> is an
@@ -440,64 +374,18 @@ internal static class StructuredCallToolFilter
     }
 
     /// <summary>
-    /// workspace-id-omitted-residual-recovery-coherence: returns <see langword="true"/> when
-    /// <paramref name="toolName"/> is a read-only, non-destructive tool and <paramref name="paramName"/>
-    /// is the non-sensitive string <c>workspaceId</c> parameter, making it eligible for the
-    /// exception-path elicitation recovery. <b>Independent of the Required flag</b> (mirrors
-    /// <see cref="IsWorkspaceIdAutoResolveAllowedFor"/>): the recovery only fires from the
-    /// exception-catch block, and the binder never throws for a missing <em>optional</em> arg, so a
-    /// relaxed gate cannot fire spuriously — but keeping it Required-independent ensures recovery
-    /// stays live for read-only tools that flip <c>workspaceId</c> to optional
-    /// (e.g. <c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>).
+    /// Thin delegate preserving the historical static call surface. See
+    /// <see cref="ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor"/>.
     /// </summary>
-    internal static bool IsWorkspaceIdRecoveryAllowedFor(string toolName, string paramName)
-    {
-        if (!string.Equals(paramName, WorkspaceIdParameterName, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (IsSensitiveFieldName(paramName))
-        {
-            return false;
-        }
-
-        var schema = ToolParameterIndex.GetParameter(toolName, paramName);
-        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
-            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
-
-        return schema is { Type: "string" }
-               && tool is { ReadOnly: true, Destructive: false };
-    }
+    internal static bool IsWorkspaceIdRecoveryAllowedFor(string toolName, string paramName) =>
+        ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor(toolName, paramName);
 
     /// <summary>
-    /// workspace-id-omitted-single-resolve: returns <see langword="true"/> when
-    /// <paramref name="toolName"/> is a read-only, non-destructive tool that declares a string
-    /// <c>workspaceId</c> parameter, making it eligible for pre-dispatch auto-resolution.
-    /// Distinct from <see cref="IsWorkspaceIdRecoveryAllowedFor"/>: that predicate gates the
-    /// exception-path elicitation recovery (it fires when a tool-call surfaces a missing
-    /// <c>workspaceId</c>); both predicates are now <b>independent of the Required flag</b> so
-    /// they keep working after a read-only tool flips <c>workspaceId</c> to optional. This one
-    /// gates pre-dispatch auto-resolution rather than the exception-path recovery. Public so
-    /// tests can pin the policy.
+    /// Thin delegate preserving the historical static call surface. See
+    /// <see cref="ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor"/>.
     /// </summary>
-    public static bool IsWorkspaceIdAutoResolveAllowedFor(string? toolName)
-    {
-        if (string.IsNullOrEmpty(toolName))
-        {
-            return false;
-        }
-
-        var schema = ToolParameterIndex.GetParameter(toolName, WorkspaceIdParameterName);
-        if (schema is not { Type: "string" })
-        {
-            return false;
-        }
-
-        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
-            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
-        return tool is { ReadOnly: true, Destructive: false };
-    }
+    public static bool IsWorkspaceIdAutoResolveAllowedFor(string? toolName) =>
+        ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor(toolName);
 
     /// <summary>
     /// The outcome of pre-dispatch <c>workspaceId</c> resolution for an auto-resolve-eligible
@@ -586,22 +474,6 @@ internal static class StructuredCallToolFilter
         return newArgs;
     }
 
-    private static void RecordAutoResolution(string value)
-    {
-        if (AmbientGateMetrics.Current is { } metrics)
-        {
-            metrics.AutoResolution = value;
-        }
-    }
-
-    private static void RecordAutoLoadElapsed(long elapsedMs)
-    {
-        if (AmbientGateMetrics.Current is { } metrics)
-        {
-            metrics.AutoLoadElapsedMs = elapsedMs;
-        }
-    }
-
     /// <summary>
     /// workspace-auto-load-on-demand: invoked from the pre-dispatch path when an auto-resolve
     /// eligible tool is called with <c>workspaceId</c> omitted and ZERO workspaces loaded.
@@ -656,8 +528,8 @@ internal static class StructuredCallToolFilter
                 }
 
                 context.Params!.Arguments = WithWorkspaceId(context.Params.Arguments, workspaceId);
-                RecordAutoResolution("auto-loaded");
-                RecordAutoLoadElapsed(stopwatch.ElapsedMilliseconds);
+                CallMetricsRecorder.RecordAutoResolution("auto-loaded");
+                CallMetricsRecorder.RecordAutoLoadElapsed(stopwatch.ElapsedMilliseconds);
                 logger?.LogInformation(
                     "Tool {ToolName} called without workspaceId and none loaded; auto-loaded {Path} " +
                     "as {WorkspaceId} in {ElapsedMs}ms.",
@@ -667,7 +539,7 @@ internal static class StructuredCallToolFilter
 
             case SolutionDiscoveryHelper.DiscoveryStatus.Ambiguous:
             {
-                RecordAutoResolution("fast-fail");
+                CallMetricsRecorder.RecordAutoResolution("fast-fail");
                 var candidates = string.Join(", ", discovery.Candidates);
                 logger?.LogWarning(
                     "Tool {ToolName} called without workspaceId and none loaded; {Count} candidate " +
@@ -1072,14 +944,6 @@ internal static class StructuredCallToolFilter
             // otherwise emit the schema-mirrored body when the tool has opted in.
             StructuredContent = result.StructuredContent ?? structuredFromBody,
         };
-    }
-
-    private static void RecordElapsed(long elapsedMs)
-    {
-        if (AmbientGateMetrics.Current is { } metrics)
-        {
-            metrics.ElapsedMs = elapsedMs;
-        }
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ElicitationAllowlistPolicyTests.cs
+++ b/tests/RoslynMcp.Tests/ElicitationAllowlistPolicyTests.cs
@@ -1,0 +1,201 @@
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for <see cref="ElicitationAllowlistPolicy"/> — the elicitation-allowlist policy layer
+/// extracted from <see cref="StructuredCallToolFilter"/> in the
+/// <c>structuredcalltoolfilter-god-class-decompose</c> initiative. These assertions exercise the
+/// policy members <b>directly</b> (not through the filter's thin delegates), pinning the
+/// decomposed unit on its own so the policy contract is guarded even if the filter's forwarding
+/// surface changes. The pre-existing <c>StructuredCallToolFilterElicitationTests</c> continue to
+/// assert the same guarantees through the filter delegates, proving the delegates are
+/// behavior-preserving.
+/// </summary>
+[TestClass]
+public sealed class ElicitationAllowlistPolicyTests
+{
+    // ── HasElicitation ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void HasElicitation_WhenCapabilityNonNull_ReturnsTrue()
+    {
+        var capabilities = new ClientCapabilities
+        {
+            Elicitation = new ElicitationCapability(),
+        };
+
+        Assert.IsTrue(ElicitationAllowlistPolicy.HasElicitation(capabilities),
+            "An ElicitationCapability instance present on ClientCapabilities means the client " +
+            "supports elicitation/create — the elicit recovery path is permitted.");
+    }
+
+    [TestMethod]
+    public void HasElicitation_WhenCapabilitiesNull_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.HasElicitation(null),
+            "Null ClientCapabilities means no handshake-established capability set; refuse to elicit.");
+    }
+
+    [TestMethod]
+    public void HasElicitation_WhenElicitationOmitted_ReturnsFalse()
+    {
+        var capabilities = new ClientCapabilities();
+
+        Assert.IsFalse(ElicitationAllowlistPolicy.HasElicitation(capabilities),
+            "Client must explicitly advertise the elicitation capability; absence means refuse.");
+    }
+
+    // ── IsSensitiveFieldName ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsSensitiveFieldName_FlagsCommonCredentialPatterns()
+    {
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("password"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("Password"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("passwordHash"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("secret"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("clientSecret"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("credential"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("credentials"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("token"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("authToken"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("apiKey"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("api_key"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("api-key"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("ApiKey"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("auth"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("Authorization"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("private_key"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("privateKey"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsSensitiveFieldName("private-key"));
+    }
+
+    [TestMethod]
+    public void IsSensitiveFieldName_DoesNotFlagBenignNames()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("path"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("workspaceId"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("filePath"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("query"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("verbose"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName(""),
+            "Empty string is not a sensitive name — it just isn't a name at all.");
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName(null),
+            "Null is not a sensitive name — it just isn't a name at all.");
+    }
+
+    // ── IsElicitationAllowedFor ───────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_WorkspaceLoadPath_ReturnsTrue()
+    {
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "path"),
+            "workspace_load.path must stay on the strict elicitation allowlist.");
+    }
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_RequiredWorkspaceId_ReturnsTrue()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsSensitiveFieldName("workspaceId"),
+            "Security review: workspaceId is a non-secret session token derived from the loaded path.");
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_status", "workspaceId"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsElicitationAllowedFor("compile_check", "workspaceId"));
+    }
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_WriteOrDestructiveWorkspaceId_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("apply_text_edit", "workspaceId"),
+            "Missing workspaceId recovery must not auto-load-and-retry direct edit tools.");
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("revert_last_apply", "workspaceId"),
+            "Missing workspaceId recovery must not auto-load-and-retry destructive undo tools.");
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_close", "workspaceId"),
+            "Missing workspaceId recovery must not auto-load-and-retry destructive workspace lifecycle tools.");
+    }
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_RandomToolOrParam_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "verbose"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("symbol_search", "query"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("unknown_tool", "workspaceId"));
+    }
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_RefusesSensitiveFields()
+    {
+        // Even if a sensitive name were on the allowlist, IsElicitationAllowedFor MUST refuse it.
+        // MCP spec § Elicitation security: "Servers MUST NOT request sensitive information".
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "password"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "token"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "apiKey"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "secret"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "credential"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", "Authorization"));
+    }
+
+    [TestMethod]
+    public void IsElicitationAllowedFor_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor(null, "path"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", null));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("", "path"));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor("workspace_load", ""));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsElicitationAllowedFor(null, null));
+    }
+
+    // ── IsWorkspaceIdRecoveryAllowedFor ───────────────────────────────────────
+
+    [TestMethod]
+    public void IsWorkspaceIdRecoveryAllowedFor_OptionalWorkspaceIdReadOnlyTool_ReturnsTrue()
+    {
+        // The recovery gate is decoupled from the Required flag, so read-only tools that flipped
+        // workspaceId to Required:false keep a live exception-path elicitation recovery.
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("go_to_definition", "workspaceId"),
+            "Recovery must stay eligible for go_to_definition after workspaceId flipped to optional.");
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("find_references", "workspaceId"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("document_symbols", "workspaceId"));
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdRecoveryAllowedFor_NonWorkspaceIdParam_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("go_to_definition", "path"),
+            "Only the workspaceId parameter is eligible for the workspaceId recovery gate.");
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("find_references", "query"));
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdRecoveryAllowedFor_DestructiveTool_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor("apply_text_edit", "workspaceId"),
+            "Recovery must not auto-load-and-retry a destructive tool.");
+    }
+
+    // ── IsWorkspaceIdAutoResolveAllowedFor ────────────────────────────────────
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_ReadOnlyWorkspaceScopedTool_ReturnsTrue()
+    {
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor("go_to_definition"),
+            "Read-only, non-destructive tools declaring a string workspaceId are auto-resolve eligible.");
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor("find_references"));
+        Assert.IsTrue(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor("document_symbols"));
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_DestructiveTool_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor("apply_text_edit"),
+            "Destructive edit tools must not have workspaceId auto-resolved pre-dispatch.");
+    }
+
+    [TestMethod]
+    public void IsWorkspaceIdAutoResolveAllowedFor_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor(null));
+        Assert.IsFalse(ElicitationAllowlistPolicy.IsWorkspaceIdAutoResolveAllowedFor(""));
+    }
+}


### PR DESCRIPTION
## Summary

Decomposes the 1099-line `StructuredCallToolFilter` static god-class by extracting two of its unrelated concerns into dedicated same-namespace classes, without changing the filter's public static call surface.

- **`ElicitationAllowlistPolicy`** (new) — houses the elicitation-allowlist policy: `HasElicitation`, `IsSensitiveFieldName`, `IsElicitationAllowedFor`, `IsWorkspaceIdRecoveryAllowedFor`, `IsWorkspaceIdAutoResolveAllowedFor`, and the private `AllowedElicitationParameters` allowlist. The three shared consts (`WorkspaceLoadToolName`/`WorkspaceIdParameterName`/`PathParameterName`) are duplicated here since a private const does not cross the class boundary; they remain in the filter too (still used by its dispatch/recovery body).
- **`CallMetricsRecorder`** (new) — houses the ambient-metrics recorders `RecordAutoResolution`/`RecordAutoLoadElapsed`/`RecordElapsed`, each a write-through to `AmbientGateMetrics.Current`. All 11 internal call sites updated to `CallMetricsRecorder.RecordX(...)`.
- **`StructuredCallToolFilter`** — the six policy methods become one-line pass-through delegates to `ElicitationAllowlistPolicy`, preserving identical signatures/visibility. Consumers (`SymbolTools.cs` and the six existing filter test suites) compile and pass unchanged. Filter drops **1099 → 963 lines**.

## Scope note (partial acceptance)

Per the plan stanza, this initiative extracts only the allowlist + metrics helpers (the backlog row's named next-deliverable). The four hotspot methods `Create`/`TryElicitAndRetryAsync`/`TryElicitChoiceAsync`/`InjectMetaIntoContent` are intentionally NOT restructured here; a follow-up row is recommended if further complexity reduction on those is wanted.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.
- Targeted tests (new `ElicitationAllowlistPolicyTests` + the 6 pre-existing filter suites): **69 passed, 0 failed**.

Closes: structuredcalltoolfilter-god-class-decompose

🤖 Generated with [Claude Code](https://claude.com/claude-code)