### PR TITLE
fix(services): add ILogger + log swallowed exceptions in build/test config services

### DIFF
--- a/changelog.d/build-test-services-swallowed-exceptions-no-logging.md
+++ b/changelog.d/build-test-services-swallowed-exceptions-no-logging.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `ScaffoldingService`, `EditorConfigService`, and `MsBuildEvaluationService` now accept an optional `ILogger<T>` and log previously-silent fallback paths (malformed project-file parses defaulting to mstest / allowing non-test projects through; disk-sourced `.editorconfig` overrides; project-not-found resolution) instead of swallowing the underlying exception with no diagnostic trail.

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -3,6 +3,7 @@ using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -11,15 +12,18 @@ public sealed class EditorConfigService : IEditorConfigService
     private readonly IWorkspaceManager _workspace;
     private readonly IUndoService? _undoService;
     private readonly IChangeTracker? _changeTracker;
+    private readonly ILogger<EditorConfigService>? _logger;
 
     public EditorConfigService(
         IWorkspaceManager workspace,
         IUndoService? undoService = null,
-        IChangeTracker? changeTracker = null)
+        IChangeTracker? changeTracker = null,
+        ILogger<EditorConfigService>? logger = null)
     {
         _workspace = workspace;
         _undoService = undoService;
         _changeTracker = changeTracker;
+        _logger = logger;
     }
 
     public async Task<EditorConfigOptionsDto> GetOptionsAsync(
@@ -64,25 +68,36 @@ public sealed class EditorConfigService : IEditorConfigService
         if (editorconfigPath is not null && File.Exists(editorconfigPath))
         {
             var existingKeys = new HashSet<string>(options.Select(o => o.Key), StringComparer.OrdinalIgnoreCase);
+            var diskSupplementedCount = 0;
             foreach (var (key, value) in ParseEditorconfigCsKeys(editorconfigPath))
             {
                 if (!existingKeys.Contains(key))
                 {
                     options.Add(new EditorConfigEntryDto(key, value, "disk"));
                     existingKeys.Add(key);
+                    diskSupplementedCount++;
                 }
             }
 
             // Second pass: override cached values for keys that the disk file has also
             // enumerated. Roslyn's snapshot may lag behind a recent set_editorconfig_option
             // write, so the on-disk value wins whenever the file exists.
+            var diskOverriddenCount = 0;
             foreach (var (key, diskValue) in ParseEditorconfigCsKeys(editorconfigPath))
             {
                 var idx = options.FindIndex(o => string.Equals(o.Key, key, StringComparison.OrdinalIgnoreCase));
                 if (idx >= 0 && options[idx].Source != "disk")
                 {
                     options[idx] = new EditorConfigEntryDto(key, diskValue, "disk");
+                    diskOverriddenCount++;
                 }
+            }
+
+            if (diskSupplementedCount > 0 || diskOverriddenCount > 0)
+            {
+                _logger?.LogDebug(
+                    "Applied disk-sourced .editorconfig values from '{EditorConfigPath}' over the Roslyn snapshot: {SupplementedCount} key(s) supplemented, {OverriddenCount} key(s) overridden.",
+                    editorconfigPath, diskSupplementedCount, diskOverriddenCount);
             }
         }
 

--- a/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
@@ -3,6 +3,7 @@ using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using RoslynProject = Microsoft.CodeAnalysis.Project;
 
 namespace RoslynMcp.Roslyn.Services;
@@ -10,9 +11,11 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
 {
     private readonly IWorkspaceManager _workspace;
-    public MsBuildEvaluationService(IWorkspaceManager workspace)
+    private readonly ILogger<MsBuildEvaluationService>? _logger;
+    public MsBuildEvaluationService(IWorkspaceManager workspace, ILogger<MsBuildEvaluationService>? logger = null)
     {
         _workspace = workspace;
+        _logger = logger;
     }
 
     public Task<MsBuildPropertyEvaluationDto> EvaluatePropertyAsync(
@@ -155,6 +158,10 @@ public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
             var loadedList = loadedProjects.Count > 0
                 ? string.Join(", ", loadedProjects)
                 : "(none — the workspace has no projects loaded)";
+
+            _logger?.LogWarning(
+                "MSBuild evaluation could not resolve project '{ProjectName}' in workspace '{WorkspaceId}'; {LoadedCount} project(s) loaded: {LoadedProjects}.",
+                projectName, workspaceId, loadedProjects.Count, loadedList);
 
             throw new InvalidOperationException(
                 $"Project '{projectName}' not found in workspace '{workspaceId}'. " +

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
@@ -24,15 +25,18 @@ public sealed partial class ScaffoldingService : IScaffoldingService
     private readonly IWorkspaceManager _workspace;
     private readonly IFileOperationService _fileOperationService;
     private readonly Contracts.IPreviewStore _previewStore;
+    private readonly ILogger<ScaffoldingService>? _logger;
 
     public ScaffoldingService(
         IWorkspaceManager workspace,
         IFileOperationService fileOperationService,
-        Contracts.IPreviewStore previewStore)
+        Contracts.IPreviewStore previewStore,
+        ILogger<ScaffoldingService>? logger = null)
     {
         _workspace = workspace;
         _fileOperationService = fileOperationService;
         _previewStore = previewStore;
+        _logger = logger;
     }
 
     /// <summary>
@@ -95,7 +99,7 @@ public sealed partial class ScaffoldingService : IScaffoldingService
         public static ResolvedTargetTypeInfo NotFound { get; } = new(string.Empty, string.Empty, null, null, null);
     }
 
-    private static string ResolveTestFramework(string? requested, string? projectFilePath)
+    private string ResolveTestFramework(string? requested, string? projectFilePath)
     {
         if (string.IsNullOrWhiteSpace(requested) ||
             string.Equals(requested, "auto", StringComparison.OrdinalIgnoreCase))
@@ -111,7 +115,7 @@ public sealed partial class ScaffoldingService : IScaffoldingService
             $"Unsupported testFramework '{requested}'. Use mstest, xunit, nunit, or auto.");
     }
 
-    private static string DetectTestFrameworkFromProjectFile(string? projectFilePath)
+    private string DetectTestFrameworkFromProjectFile(string? projectFilePath)
     {
         if (string.IsNullOrWhiteSpace(projectFilePath) || !File.Exists(projectFilePath))
             return "mstest";
@@ -130,9 +134,9 @@ public sealed partial class ScaffoldingService : IScaffoldingService
             if (includes.Any(i => i.Contains("nunit", StringComparison.Ordinal)))
                 return "nunit";
         }
-        catch
+        catch (Exception ex)
         {
-            // Fall through to default
+            _logger?.LogWarning(ex, "Failed to parse project file '{ProjectFilePath}' while detecting test framework; defaulting to mstest.", projectFilePath);
         }
 
         return "mstest";
@@ -482,7 +486,7 @@ public sealed partial class ScaffoldingService : IScaffoldingService
                ?? throw new InvalidOperationException($"Project not found: {projectName}");
     }
 
-    private static void ValidateIsTestProject(ProjectStatusDto project)
+    private void ValidateIsTestProject(ProjectStatusDto project)
     {
         if (string.IsNullOrWhiteSpace(project.FilePath) || !File.Exists(project.FilePath))
             return; // Can't validate — allow and let framework detection handle it
@@ -515,9 +519,10 @@ public sealed partial class ScaffoldingService : IScaffoldingService
                 "Please specify a test project instead.");
         }
         catch (InvalidOperationException) { throw; }
-        catch
+        catch (Exception ex)
         {
-            // If we can't parse the project file, allow and let downstream handle it
+            // If we can't parse the project file, allow and let downstream handle it.
+            _logger?.LogWarning(ex, "Failed to parse project file '{ProjectFilePath}' while validating test project; allowing operation to proceed.", project.FilePath);
         }
     }
 

--- a/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
+++ b/tests/RoslynMcp.Tests/DeadLoggerFieldsTests.cs
@@ -28,7 +28,6 @@ public sealed class DeadLoggerFieldsTests
         typeof(CompletionService),
         typeof(ConsumerAnalysisService),
         typeof(DiagnosticService),
-        typeof(EditorConfigService),
         typeof(FlowAnalysisService),
         typeof(MutationAnalysisService),
         typeof(NamespaceDependencyService),

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -315,5 +316,40 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
         Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("[*.json]"));
         Assert.IsFalse(EditorConfigService.SectionMatchesCSharp(""));
         Assert.IsFalse(EditorConfigService.SectionMatchesCSharp("not-a-section"));
+    }
+
+    /// <summary>
+    /// Coverage for <c>build-test-services-swallowed-exceptions-no-logging</c>:
+    /// <see cref="IEditorConfigService.GetOptionsAsync"/> now emits a <see cref="LogLevel.Debug"/>
+    /// entry (previously no logger existed at all) when it applies disk-sourced .editorconfig
+    /// values over the Roslyn snapshot, naming the .editorconfig path and the supplement/override
+    /// counts so a stale-snapshot merge leaves a diagnostic trail.
+    /// </summary>
+    [TestMethod]
+    public async Task GetOptions_DiskSourcedOverrides_LogsDebug()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Write an unloaded analyzer key so the on-disk supplement path (source "disk") fires
+        // on the next read — guaranteeing diskSupplementedCount > 0 and thus the Debug log.
+        const string unloadedKey = "dotnet_diagnostic.CA9998.severity";
+        await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, unloadedKey, "none", "set_editorconfig_option", CancellationToken.None);
+
+        var logger = new CaptureLogger<EditorConfigService>();
+        var service = new EditorConfigService(WorkspaceManager, logger: logger);
+
+        var options = await service.GetOptionsAsync(workspaceId, dogFilePath, CancellationToken.None);
+        Assert.IsTrue(
+            options.Options.Any(o => string.Equals(o.Key, unloadedKey, StringComparison.OrdinalIgnoreCase)),
+            "Precondition: the disk-supplemented key must be present in the returned options.");
+
+        var debug = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Debug);
+        Assert.IsNotNull(debug,
+            "Applying disk-sourced .editorconfig values must emit a Debug log. " +
+            $"Captured entries: {string.Join("; ", logger.Entries.Select(e => $"{e.Level}:{e.Message}"))}");
+        StringAssert.Contains(debug!.Message, options.ApplicableEditorConfigPath!);
     }
 }

--- a/tests/RoslynMcp.Tests/MsBuildEvaluationServiceTests.cs
+++ b/tests/RoslynMcp.Tests/MsBuildEvaluationServiceTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for <c>build-test-services-swallowed-exceptions-no-logging</c>:
+/// <see cref="MsBuildEvaluationService"/> previously had no <see cref="ILogger{T}"/> and
+/// surfaced a project-not-found only through the thrown <see cref="InvalidOperationException"/>
+/// message. It now emits a <see cref="LogLevel.Warning"/> naming the missing project, the
+/// workspace, and the loaded-project list before throwing, so operators get a diagnostic
+/// trail even when the exception message is not routed to logs.
+/// </summary>
+[TestClass]
+public sealed class MsBuildEvaluationServiceTests : IsolatedWorkspaceTestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task EvaluateProperty_ProjectNotFound_LogsWarning_AndThrows()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        var logger = new CaptureLogger<MsBuildEvaluationService>();
+        var service = new MsBuildEvaluationService(WorkspaceManager, logger);
+
+        const string missingProject = "ZZZ_DoesNotExistProject";
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            service.EvaluatePropertyAsync(workspaceId, missingProject, "TargetFramework", CancellationToken.None));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
+        Assert.IsNotNull(warning,
+            "MSBuild project-not-found must emit a Warning log (previously silent). " +
+            $"Captured entries: {string.Join("; ", logger.Entries.Select(e => $"{e.Level}:{e.Message}"))}");
+        StringAssert.Contains(warning!.Message, missingProject);
+        StringAssert.Contains(warning.Message, workspaceId);
+    }
+}
+
+/// <summary>
+/// Minimal in-memory <see cref="ILogger{T}"/> double that records every emitted log entry.
+/// The test project has no capturing logger and every fixture builds services with
+/// <c>NullLogger&lt;T&gt;.Instance</c>, so observability assertions must supply their own.
+/// Shared by the swallowed-exception logging tests (Scaffolding / EditorConfig / MsBuild).
+/// </summary>
+internal sealed class CaptureLogger<T> : ILogger<T>
+{
+    public sealed record Entry(LogLevel Level, string Message, Exception? Exception);
+
+    public ConcurrentQueue<Entry> Entries { get; } = new();
+
+    IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Enqueue(new Entry(logLevel, formatter(state, exception), exception));
+    }
+}

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Roslyn.Services;
 
@@ -391,5 +393,87 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(
             execution.Succeeded,
             $"dotnet restore failed for test fixture. ExitCode={execution.ExitCode} StdOut={execution.StdOut} StdErr={execution.StdErr}");
+    }
+
+    // ── build-test-services-swallowed-exceptions-no-logging ──
+    // These two cases exercise the previously-silent bare-catch fallbacks in
+    // ScaffoldingService (test-framework detection and test-project validation). The
+    // helpers are private instance methods with no instance-field dependency other than
+    // _logger, so they are constructed with null collaborators and driven directly via
+    // reflection against a hand-rolled capturing ILogger — the test project has no
+    // capturing logger and the shared static ScaffoldingService is built with a NullLogger.
+
+    [TestMethod]
+    public void DetectTestFramework_MalformedProjectFile_LogsWarning_AndDefaultsToMsTest()
+    {
+        var malformedPath = WriteMalformedProjectFile();
+        try
+        {
+            var logger = new CaptureLogger<ScaffoldingService>();
+            var service = new ScaffoldingService(null!, null!, null!, logger);
+
+            var method = typeof(ScaffoldingService).GetMethod(
+                "DetectTestFrameworkFromProjectFile",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var result = (string)method.Invoke(service, [malformedPath])!;
+
+            Assert.AreEqual("mstest", result,
+                "A malformed project file must still default to mstest (behavior unchanged).");
+            var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
+            Assert.IsNotNull(warning,
+                "A malformed project file must now emit a Warning log instead of being silently swallowed.");
+            StringAssert.Contains(warning!.Message, malformedPath);
+            Assert.IsNotNull(warning.Exception, "The underlying parse exception must be attached to the log entry.");
+        }
+        finally
+        {
+            File.Delete(malformedPath);
+        }
+    }
+
+    [TestMethod]
+    public void ValidateIsTestProject_MalformedProjectFile_LogsWarning_AndAllowsThrough()
+    {
+        var malformedPath = WriteMalformedProjectFile();
+        try
+        {
+            var logger = new CaptureLogger<ScaffoldingService>();
+            var service = new ScaffoldingService(null!, null!, null!, logger);
+
+            var project = new ProjectStatusDto(
+                Name: "Malformed",
+                FilePath: malformedPath,
+                DocumentCount: 0,
+                ProjectReferences: [],
+                TargetFrameworks: [],
+                IsTestProject: false,
+                AssemblyName: "Malformed",
+                OutputType: "Library");
+
+            var method = typeof(ScaffoldingService).GetMethod(
+                "ValidateIsTestProject",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            // Must NOT throw — a parse failure allows the operation through (behavior unchanged).
+            method.Invoke(service, [project]);
+
+            var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
+            Assert.IsNotNull(warning,
+                "A malformed project file must now emit a Warning log instead of being silently swallowed.");
+            StringAssert.Contains(warning!.Message, malformedPath);
+            Assert.IsNotNull(warning.Exception, "The underlying parse exception must be attached to the log entry.");
+        }
+        finally
+        {
+            File.Delete(malformedPath);
+        }
+    }
+
+    private static string WriteMalformedProjectFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"malformed-{Guid.NewGuid():N}.csproj");
+        // Unclosed element — XDocument.Load throws XmlException mid-parse.
+        File.WriteAllText(path, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0");
+        return path;
     }
 }


### PR DESCRIPTION
## Summary

Injects an optional `ILogger<T>` into three build/test config services and logs previously-silent fallback paths instead of swallowing exceptions with no diagnostic trail. Mirrors the established `ChangeTracker` optional-logger pattern; shorthand `AddSingleton<I,X>()` DI auto-resolves `ILogger<T>`, so no registration change is needed.

- **ScaffoldingService** — the two bare `catch {}` blocks around `XDocument.Load` (`DetectTestFrameworkFromProjectFile`, `ValidateIsTestProject`) now `catch (Exception ex)` and `LogWarning`. Behavior unchanged (mstest fallback / allow-through). Three helpers de-staticed to reach the instance `_logger`; all call sites were already instance methods.
- **EditorConfigService** — `GetOptionsAsync` logs a `Debug` line (with the `.editorconfig` path + supplement/override counts) when disk-sourced values are applied over the Roslyn snapshot.
- **MsBuildEvaluationService** — `ResolveRoslynProject` logs a `Warning` (project name, workspace, loaded-project list) before the not-found `InvalidOperationException` throw.

## Scope note — 3 of 4 named services

`SuppressionService` (the 4th service named in the backlog row) is **deliberately deferred**: it is registered via an explicit factory delegate in `ServiceCollectionExtensions.cs`, so wiring a functional (non-null) logger there requires editing both `SuppressionService.cs` and the registration line — a 5th production file that breaches Rule 3's 4-file cap. Recommend a follow-on P3 row (`build-test-services-suppression-logger-wiring`, 2 files) before the parent backlog row is closed. **Do not close the parent row on this PR alone.**

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.
- Targeted tests (`ScaffoldingFirstTestFileTests`, `EditorConfigServiceTests`, `MsBuildEvaluationServiceTests`) → 18 passed, 0 failed. 4 new tests: 2 Scaffolding warning-log, 1 EditorConfig debug-log, 1 MsBuild warning-log (each asserts behavior is unchanged and the diagnostic now fires).

## Backlog

Closes: build-test-services-swallowed-exceptions-no-logging (partial — 3 of 4 services; see scope note; parent row should stay open pending the SuppressionService follow-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)