### PR TITLE
fix(services): atomic temp+rename writes + partial-apply signalling (refactor-services-non-atomic-write-rollback)

### DIFF
--- a/changelog.d/refactor-services-non-atomic-write-rollback.md
+++ b/changelog.d/refactor-services-non-atomic-write-rollback.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** multi-file `apply_composite_preview` writes (and the underlying source-file writes in `EditService`, `UndoService`, and `ProjectMutationService`) now go through a shared atomic temp+rename helper instead of a direct `File.WriteAllTextAsync`, preventing a truncated/corrupt file on a mid-write crash or disk-full condition. A failure partway through a composite apply now logs a warning naming applied-vs-total plus the failing file and clearly marks the returned result as a partial apply instead of silently swallowing the exception. Closes `refactor-services-non-atomic-write-rollback`.

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 
@@ -8,15 +9,18 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
     private readonly IWorkspaceManager _workspace;
     private readonly ICompositePreviewStore _compositePreviewStore;
     private readonly IChangeTracker? _changeTracker;
+    private readonly ILogger<CompositeApplyOrchestrator>? _logger;
 
     public CompositeApplyOrchestrator(
         IWorkspaceManager workspace,
         ICompositePreviewStore compositePreviewStore,
-        IChangeTracker? changeTracker = null)
+        IChangeTracker? changeTracker = null,
+        ILogger<CompositeApplyOrchestrator>? logger = null)
     {
         _workspace = workspace;
         _compositePreviewStore = compositePreviewStore;
         _changeTracker = changeTracker;
+        _logger = logger;
     }
 
     public async Task<ApplyResultDto> ApplyCompositeAsync(string previewToken, CancellationToken ct)
@@ -73,7 +77,7 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
                     Directory.CreateDirectory(directory);
                 }
 
-                await File.WriteAllTextAsync(mutation.FilePath, mutation.UpdatedContent ?? string.Empty, ct).ConfigureAwait(false);
+                await AtomicFileWriter.WriteAllTextAsync(mutation.FilePath, mutation.UpdatedContent ?? string.Empty, ct).ConfigureAwait(false);
                 appliedFiles.Add(mutation.FilePath);
             }
 
@@ -85,7 +89,71 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
-            return new ApplyResultDto(false, appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList(), ex.Message);
+            // A mutation failed mid-loop. Prior mutations already hit disk — this orchestrator does
+            // not roll them back (see plan Risk 3: true rollback would duplicate UndoService's
+            // pre-image capture). Instead we log a warning naming applied-vs-total plus the failing
+            // file, and clearly mark the returned result as a partial apply so a caller can tell a
+            // genuine partial state apart from a clean no-op failure. Each completed mutation adds
+            // exactly one entry to appliedFiles, so appliedFiles.Count is the index of the failing
+            // mutation. The preview token is intentionally left valid (Invalidate is not called).
+            var applied = appliedFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            var failingFile = appliedFiles.Count < mutations.Count
+                ? mutations[appliedFiles.Count].FilePath
+                : "(unknown)";
+            _logger?.LogWarning(
+                ex,
+                "Composite apply failed after {AppliedCount} of {TotalCount} mutation(s); failing file: {FailingFile}. Prior writes are left in place (no rollback).",
+                appliedFiles.Count,
+                mutations.Count,
+                failingFile);
+            var message = appliedFiles.Count > 0
+                ? $"Partial composite apply: {applied.Count} file(s) were written before the failure at {failingFile}. {ex.Message}"
+                : ex.Message;
+            return new ApplyResultDto(false, applied, message);
+        }
+    }
+}
+
+/// <summary>
+/// Shared atomic file-write primitive: writes <paramref name="content"/> to a same-directory
+/// <c>.tmp</c> sibling of <paramref name="path"/>, then <see cref="File.Move(string, string, bool)"/>
+/// over the target. This mirrors the proven pattern in <c>WorkspaceCacheStore</c> and
+/// <c>PersistentCompositeStorage</c> and prevents a truncated/corrupt target file if the process
+/// crashes or the disk fills mid-write. The temp file is always <paramref name="path"/> + ".tmp",
+/// so it lives on the same directory/volume as the target — a precondition for <c>File.Move</c>
+/// being atomic (a cross-volume move degrades to a non-atomic copy+delete). On any failure the
+/// orphaned <c>.tmp</c> is best-effort deleted so a failed write leaves no artifact, then the
+/// original exception is re-thrown for the caller's catch filter.
+/// </summary>
+internal static class AtomicFileWriter
+{
+    public static async Task WriteAllTextAsync(string path, string content, CancellationToken ct)
+    {
+        var tmp = path + ".tmp";
+        try
+        {
+            await File.WriteAllTextAsync(tmp, content, ct).ConfigureAwait(false);
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteTemp(tmp);
+            throw;
+        }
+    }
+
+    private static void TryDeleteTemp(string tmp)
+    {
+        try
+        {
+            if (File.Exists(tmp))
+            {
+                File.Delete(tmp);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort cleanup — a stray .tmp is non-fatal and must not mask the original failure.
         }
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -661,7 +661,7 @@ public sealed class EditService : IEditService
         try
         {
             var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
-            await File.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
+            await AtomicFileWriter.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -559,7 +559,7 @@ public sealed class ProjectMutationService : IProjectMutationService
                 preApplySolution: null,
                 fileSnapshots: new[] { new FileSnapshotDto(Path.GetFullPath(projectFilePath), preApplyContent) });
 
-            await File.WriteAllTextAsync(projectFilePath, updatedContent, ct).ConfigureAwait(false);
+            await AtomicFileWriter.WriteAllTextAsync(projectFilePath, updatedContent, ct).ConfigureAwait(false);
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
             _previewStore.Invalidate(previewToken);
             _changeTracker?.RecordChange(workspaceId, $"Project mutation: {Path.GetFileName(projectFilePath)}", [projectFilePath], "apply_project_mutation");

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -293,7 +293,7 @@ public sealed class UndoService : IUndoService, IDisposable
                     {
                         Directory.CreateDirectory(directory);
                     }
-                    await File.WriteAllTextAsync(file.FilePath, file.OriginalText, cancellationToken).ConfigureAwait(false);
+                    await AtomicFileWriter.WriteAllTextAsync(file.FilePath, file.OriginalText, cancellationToken).ConfigureAwait(false);
                     restoredAny = true;
                 }
             }
@@ -488,7 +488,7 @@ public sealed class UndoService : IUndoService, IDisposable
         {
             try
             {
-                await File.WriteAllTextAsync(filePath, text, cancellationToken).ConfigureAwait(false);
+                await AtomicFileWriter.WriteAllTextAsync(filePath, text, cancellationToken).ConfigureAwait(false);
                 anyDiskWrite = true;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
+++ b/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="CompositeApplyOrchestrator"/> and the shared
+/// <c>AtomicFileWriter</c> primitive it (and the other source-mutation services) now route
+/// disk writes through. Focused on the atomic-write round-trip and the mid-loop partial-apply
+/// failure contract — see plan initiative refactor-services-non-atomic-write-rollback.
+/// These tests operate purely on a temp directory + hand-rolled fakes, so they need no loaded
+/// MSBuild workspace and are safe to run in parallel with the workspace-bound suites.
+/// </summary>
+[TestClass]
+public sealed class CompositeApplyOrchestratorTests
+{
+    private string _tempDir = string.Empty;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "roslynmcp-atomicwrite-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort temp cleanup.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort temp cleanup.
+        }
+    }
+
+    [TestMethod]
+    public async Task AtomicFileWriter_RoundTrips_Content_And_Leaves_No_Temp_Artifact()
+    {
+        var path = Path.Combine(_tempDir, "target.cs");
+        const string content = "// hello atomic world\nclass C {}\n";
+
+        await AtomicFileWriter.WriteAllTextAsync(path, content, CancellationToken.None);
+
+        Assert.AreEqual(content, await File.ReadAllTextAsync(path));
+        Assert.IsFalse(File.Exists(path + ".tmp"), "The .tmp sibling must not survive a successful write.");
+    }
+
+    [TestMethod]
+    public async Task AtomicFileWriter_Overwrites_Existing_File_Atomically()
+    {
+        var path = Path.Combine(_tempDir, "target.cs");
+        await File.WriteAllTextAsync(path, "original");
+
+        await AtomicFileWriter.WriteAllTextAsync(path, "replacement", CancellationToken.None);
+
+        Assert.AreEqual("replacement", await File.ReadAllTextAsync(path));
+        Assert.IsFalse(File.Exists(path + ".tmp"));
+    }
+
+    [TestMethod]
+    public async Task ApplyComposite_MidLoop_Failure_Applies_Prior_Writes_Marks_Partial_And_Logs()
+    {
+        // Arrange: a first valid write, then a second mutation whose parent path is an existing
+        // FILE — so Directory.CreateDirectory throws IOException mid-loop, after the first write
+        // already hit disk. This exercises the "partial composite apply" branch deterministically
+        // and cross-platform.
+        var blocker = Path.Combine(_tempDir, "blocker");
+        await File.WriteAllTextAsync(blocker, "i am a file, not a directory");
+
+        var goodPath = Path.Combine(_tempDir, "good.cs");
+        var doomedPath = Path.Combine(blocker, "nested.cs"); // parent 'blocker' is a file
+
+        var mutations = new List<CompositeFileMutation>
+        {
+            new(goodPath, "// good content", DeleteFile: false),
+            new(doomedPath, "// never written", DeleteFile: false),
+        };
+
+        var store = new CompositePreviewStore();
+        var token = store.Store("ws-1", 1, "test composite", mutations);
+
+        var workspace = new RecordingWorkspaceManager();
+        var logger = new RecordingLogger<CompositeApplyOrchestrator>();
+        var orchestrator = new CompositeApplyOrchestrator(workspace, store, changeTracker: null, logger: logger);
+
+        // Act
+        var result = await orchestrator.ApplyCompositeAsync(token, CancellationToken.None);
+
+        // Assert: failed, but the first write landed and is marked as a partial apply.
+        Assert.IsFalse(result.Success, "A mid-loop failure must report success:false.");
+        CollectionAssert.AreEqual(new[] { goodPath }, result.AppliedFiles.ToArray(), "Only the pre-failure write should be reported as applied.");
+        Assert.IsNotNull(result.Error);
+        StringAssert.StartsWith(result.Error, "Partial composite apply: ", "The message must carry the partial-apply marker.");
+        Assert.AreEqual("// good content", await File.ReadAllTextAsync(goodPath), "The successful write must remain on disk.");
+        Assert.IsFalse(File.Exists(goodPath + ".tmp"), "No .tmp artifact should remain from the successful write.");
+        Assert.IsFalse(File.Exists(doomedPath), "The failing mutation must not have produced a file.");
+
+        // A warning was logged for the partial failure.
+        Assert.IsTrue(
+            logger.Entries.Any(e => e.Level == LogLevel.Warning),
+            "A warning must be logged when a composite apply fails partway through.");
+
+        // The workspace must NOT be reloaded on a failed apply.
+        Assert.IsFalse(workspace.ReloadCalled, "ReloadAsync must not run when the apply failed.");
+
+        // Regression guard: the preview token is intentionally left valid (not invalidated) on failure.
+        Assert.IsNotNull(store.Retrieve(token), "The preview token must remain valid after a partial failure.");
+    }
+
+    [TestMethod]
+    public async Task ApplyComposite_FirstMutation_Failure_Is_Not_Marked_Partial()
+    {
+        // When nothing was written before the failure it is a clean failure, not a partial apply.
+        var blocker = Path.Combine(_tempDir, "blocker");
+        await File.WriteAllTextAsync(blocker, "i am a file");
+        var doomedPath = Path.Combine(blocker, "nested.cs");
+
+        var mutations = new List<CompositeFileMutation> { new(doomedPath, "// never written", DeleteFile: false) };
+        var store = new CompositePreviewStore();
+        var token = store.Store("ws-1", 1, "test composite", mutations);
+        var orchestrator = new CompositeApplyOrchestrator(new RecordingWorkspaceManager(), store);
+
+        var result = await orchestrator.ApplyCompositeAsync(token, CancellationToken.None);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(0, result.AppliedFiles.Count);
+        Assert.IsNotNull(result.Error);
+        Assert.IsFalse(result.Error!.StartsWith("Partial composite apply: ", StringComparison.Ordinal),
+            "A failure with zero prior writes is a clean failure, not a partial apply.");
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private sealed class RecordingWorkspaceManager : IWorkspaceManager
+    {
+        public bool ReloadCalled { get; private set; }
+
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+        public event Action<string>? WorkspaceReloaded { add { } remove { } }
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
+
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct)
+        {
+            ReloadCalled = true;
+            return Task.FromResult(GetStatus(workspaceId));
+        }
+
+        public bool ContainsWorkspace(string workspaceId) => !string.IsNullOrWhiteSpace(workspaceId);
+        public bool IsStale(string workspaceId) => false;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+        public WorkspaceStatusDto GetStatus(string workspaceId) =>
+            new(
+                WorkspaceId: workspaceId,
+                LoadedPath: "C:\\repo\\Sample.slnx",
+                WorkspaceVersion: 1,
+                SnapshotToken: "snapshot",
+                LoadedAtUtc: DateTimeOffset.UtcNow,
+                ProjectCount: 0,
+                DocumentCount: 0,
+                Projects: [],
+                IsLoaded: true,
+                IsStale: false,
+                WorkspaceDiagnostics: []);
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(GetStatus(workspaceId));
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Routes all five non-atomic `File.WriteAllTextAsync` source-file mutation sites through a new shared `AtomicFileWriter` (temp-file write + `File.Move(overwrite: true)`), mirroring the proven pattern already in `WorkspaceCacheStore`/`PersistentCompositeStorage`. This prevents a truncated/corrupt target file if the process crashes or the disk fills mid-write.

Also fixes the silent swallow in `CompositeApplyOrchestrator`: a mid-loop apply failure now logs a warning (applied-vs-total + failing file) and marks the returned result `"Partial composite apply: ..."` instead of returning a bare exception message with zero operator-visible signal.

### Changed sites
- `CompositeApplyOrchestrator.cs` — new `internal static AtomicFileWriter`; write routed through it; optional `ILogger<CompositeApplyOrchestrator>` injected; catch block logs + marks partial apply.
- `EditService.cs` — `PersistDocumentTextToDiskAsync` write.
- `UndoService.cs` — both file-snapshot restore (`:296`) and `PersistRevertChangesAsync` disk-restore (`:491`).
- `ProjectMutationService.cs` — `.csproj` write.

### Design notes
- Per Rule 3's 4-production-file cap, `AtomicFileWriter` is colocated as a second top-level type in `CompositeApplyOrchestrator.cs` (same `RoslynMcp.Roslyn.Services` namespace) rather than a new `Helpers/` file (flagged `judgmentHeavy` in the plan).
- `File.Move` is only atomic within one volume — the `.tmp` is always `path + ".tmp"` (same directory/volume by construction); documented in the helper's XML doc.
- Not full rollback-of-prior-writes: true rollback would duplicate `UndoService`'s pre-image capture (plan Risk 3). The smaller correct fix — a clearly-marked partial-apply result with logging — is taken per "match change size to task value".
- `ServiceCollectionExtensions.cs` needs no edit — the logger resolves via the container's built-in generic `ILogger<T>` support.

## Testing
- New `tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs` (4 tests): atomic round-trip + no `.tmp` artifact, atomic overwrite, mid-loop partial-apply (only prior writes reported, partial marker, warning logged, workspace not reloaded, preview token still valid), and first-mutation failure is *not* marked partial.
- Full solution build: 0 warnings, 0 errors.
- Regression suites green: `UndoServiceTests`, `UndoFileOperationsTests`, `ProjectMutationIntegrationTests`, `OrchestrationIntegrationTests` (40), plus `ApplyTextEditVerifyTests`/`EditUndo*`/`ExternalEditStalenessTests` (30). 74 targeted tests total pass.
- `verify-changelog-fragments.ps1` and `verify-ai-docs.ps1` pass. Full `verify-release.ps1` deferred to push CI on the self-hosted runner.

## Follow-up (out of scope — fast-follow row recommended)
6 additional non-atomic `File.WriteAllTextAsync` sites remain outside this item's file cap: `RefactoringService.cs` (5 sites), `CsprojSemanticEquality.cs:276`, `ValidationBundleTools.cs:620`.

Closes: refactor-services-non-atomic-write-rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)