### PR TITLE
fix(paramvalidation): clamp pagination limit to a defined maximum

### DIFF
--- a/changelog.d/paramvalidation-pagination-upper-bound-clamp.md
+++ b/changelog.d/paramvalidation-pagination-upper-bound-clamp.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `ParameterValidation.ValidatePagination` now rejects `limit` values above a defined maximum (1000), preventing unbounded materialization when a caller supplies an excessively large page size.

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
@@ -11,6 +11,13 @@ internal static class ParameterValidation
     private static readonly string[] BulkReplaceScopeValues = ["parameters", "fields", "all"];
     private static readonly string[] ReplaceInvocationScopeValues = ["all"];
 
+    /// <summary>
+    /// Upper bound for pagination page size. Guards against unbounded materialization
+    /// when a caller supplies an excessively large limit (e.g. int.MaxValue). Chosen with
+    /// headroom above every current tool default/clamp (highest observed is 500).
+    /// </summary>
+    private const int MaxLimit = 1000;
+
     /// <summary>Validates severity filter if provided.</summary>
     public static void ValidateSeverity(string? severity)
     {
@@ -54,5 +61,8 @@ internal static class ParameterValidation
 
         if (limit <= 0)
             throw new ArgumentException($"Invalid limit '{limit}'. Limit must be greater than 0.");
+
+        if (limit > MaxLimit)
+            throw new ArgumentException($"Invalid limit '{limit}'. Limit must not exceed {MaxLimit}.");
     }
 }

--- a/tests/RoslynMcp.Tests/ParameterValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterValidationTests.cs
@@ -81,4 +81,13 @@ public class ParameterValidationTests
     public void ValidatePagination_Negative_Limit_Throws()
         => Assert.ThrowsException<ArgumentException>(
             () => ParameterValidation.ValidatePagination(0, -5));
+
+    [TestMethod]
+    public void ValidatePagination_Limit_At_Max_Does_Not_Throw()
+        => ParameterValidation.ValidatePagination(0, 1000);
+
+    [TestMethod]
+    public void ValidatePagination_Limit_Above_Max_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => ParameterValidation.ValidatePagination(0, 1001));
 }


### PR DESCRIPTION
## Summary

Adds an enforced upper bound to `ParameterValidation.ValidatePagination`. It previously only rejected `offset < 0` and `limit <= 0` — a caller could pass `limit: int.MaxValue` and force unbounded materialization downstream. Now rejects `limit > 1000` with an `ArgumentException` naming the max.

- New `private const int MaxLimit = 1000` (headroom above every current tool default/clamp — highest observed is 500).
- No signature change — all 15 call sites across `AdvancedAnalysisTools`, `AnalyzerInfoTools`, `AnalysisTools`, `CompileCheckTools`, and `SymbolTools` route through this single shared validator unchanged.

## Validation

- Scoped `dotnet build` of `RoslynMcp.Host.Stdio` — 0 warnings, 0 errors.
- `dotnet test --filter ParameterValidationTests` — 28/28 pass, including two new cases: `ValidatePagination_Limit_At_Max_Does_Not_Throw` (limit=1000) and `ValidatePagination_Limit_Above_Max_Throws` (limit=1001).

Closes: paramvalidation-pagination-upper-bound-clamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)