### PR TITLE
perf(dispatch): cache root scans, depth-cap walk-up, O(1) tool lookup (solutiondiscoveryhelper-hotpath-perf)

### DIFF
--- a/changelog.d/solutiondiscoveryhelper-hotpath-perf.md
+++ b/changelog.d/solutiondiscoveryhelper-hotpath-perf.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Reduced hot-path cost in the read-only tool auto-discovery/auto-resolve dispatch path (`SolutionDiscoveryHelper`, `StructuredCallToolFilter`) — root-directory solution scans are now memoized with a short (~10s) TTL, the file-anchored ancestor walk-up is depth-capped (8 hops) and off-loaded off the async continuation thread, and `workspaceId` eligibility checks against `ServerSurfaceCatalog.Tools` are now O(1) via a name-keyed index instead of an O(n) linear scan per call. Closes `solutiondiscoveryhelper-hotpath-perf`.

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -29,7 +30,32 @@ public static partial class ServerSurfaceCatalog
     private static readonly Lazy<IReadOnlyList<SurfaceEntry>> s_allTools = new(
         static () => [.. WorkspaceTools!, .. SymbolTools!, .. AnalysisTools!, .. RefactoringTools!, .. EditingTools!, .. OrchestrationTools!]);
 
+    // solutiondiscoveryhelper-hotpath-perf: name-keyed index over the same Tools list, built once
+    // (Tools is a build-once immutable Lazy, never mutated), so hot-path eligibility checks in the
+    // dispatch filter (IsWorkspaceIdRecoveryAllowedFor / IsWorkspaceIdAutoResolveAllowedFor) are
+    // O(1) instead of an O(n) linear FirstOrDefault scan of the full catalog per read-only call.
+    // Built from Tools itself — never from the six partial arrays — to avoid drift.
+    private static readonly Lazy<IReadOnlyDictionary<string, SurfaceEntry>> s_toolsByName = new(
+        static () => Tools.ToDictionary(entry => entry.Name, StringComparer.Ordinal));
+
     public static IReadOnlyList<SurfaceEntry> Tools => s_allTools.Value;
+
+    /// <summary>
+    /// solutiondiscoveryhelper-hotpath-perf: O(1) name lookup into <see cref="Tools"/>. Returns
+    /// <see langword="false"/> for a null/unknown tool name (leaving <paramref name="entry"/>
+    /// <see langword="null"/>), matching the prior <c>FirstOrDefault(...) is null</c> semantics.
+    /// </summary>
+    internal static bool TryGetTool(string? name, [NotNullWhen(true)] out SurfaceEntry? entry)
+    {
+        if (name is not null && s_toolsByName.Value.TryGetValue(name, out var found))
+        {
+            entry = found;
+            return true;
+        }
+
+        entry = null;
+        return false;
+    }
 
     public static string CurrentReleaseVersion => s_currentReleaseVersion.Value;
 

--- a/src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -31,6 +32,22 @@ internal static class SolutionDiscoveryHelper
     // Solution files preferred over projects; .slnx before .sln when both somehow coexist.
     private static readonly string[] SolutionExtensions = [".slnx", ".sln"];
     private static readonly string[] ProjectExtensions = [".csproj"];
+
+    // solutiondiscoveryhelper-hotpath-perf: the file-anchored walk-up is bounded to this many
+    // ancestor hops from the anchor file's directory so a pathological deep-nested filePath cannot
+    // trigger a full walk to the filesystem root on the read-only dispatch hot path. Mirrors the
+    // bounded (one-level-down) shape already used by ScanDirectoriesForSolutions.
+    private const int MaxAncestorLevels = 8;
+
+    // solutiondiscoveryhelper-hotpath-perf: short-TTL memoization of the query-anchored root scan.
+    // A burst of workspaceId-omitted read-only dispatches (no workspace loaded) would otherwise
+    // re-walk every declared client root's top level + one level down on every call. Keyed by the
+    // sorted, ordinal-case-insensitive root-directory set; scoped to the cold no-workspace path
+    // only, where a short staleness window (a solution created inside the TTL is not seen until
+    // expiry) is low-stakes because the caller falls back to binder/elicitation regardless.
+    private static readonly TimeSpan RootScanCacheTtl = TimeSpan.FromSeconds(10);
+    private static readonly ConcurrentDictionary<string, (DiscoveryResult Result, DateTime ExpiresUtc)> s_rootScanCache =
+        new(StringComparer.Ordinal);
 
     internal enum DiscoveryStatus
     {
@@ -70,7 +87,13 @@ internal static class SolutionDiscoveryHelper
         McpServer? server,
         CancellationToken cancellationToken)
     {
-        var fileAnchored = TryDiscoverFromFilePath(arguments);
+        // solutiondiscoveryhelper-hotpath-perf: off-load the synchronous ancestor-walk directory I/O
+        // to the thread pool so it does not block the calling async continuation's thread. .NET has
+        // no true async Directory API, so Task.Run off-loading plus the walk's own depth cap is the
+        // correct "off the hot synchronous path" fix. The method's own behavior/signature is
+        // unchanged — only how its single caller invokes it.
+        var fileAnchored = await Task.Run(() => TryDiscoverFromFilePath(arguments), cancellationToken)
+            .ConfigureAwait(false);
         if (fileAnchored.Status != DiscoveryStatus.None)
         {
             return fileAnchored;
@@ -101,6 +124,7 @@ internal static class SolutionDiscoveryHelper
             return DiscoveryResult.None;
         }
 
+        var levelsWalked = 0;
         while (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
         {
             var solutions = EnumerateByExtensions(directory, SolutionExtensions);
@@ -117,6 +141,13 @@ internal static class SolutionDiscoveryHelper
 
             var parent = Path.GetDirectoryName(directory);
             if (string.IsNullOrEmpty(parent) || string.Equals(parent, directory, StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            // solutiondiscoveryhelper-hotpath-perf: bound the ancestor walk-up so a deeply-nested
+            // anchor file cannot trigger a walk all the way to the filesystem root.
+            if (++levelsWalked >= MaxAncestorLevels)
             {
                 break;
             }
@@ -158,7 +189,36 @@ internal static class SolutionDiscoveryHelper
             return DiscoveryResult.None;
         }
 
-        return ScanDirectoriesForSolutions(rootDirectories, cancellationToken);
+        return ScanDirectoriesForSolutionsCached(rootDirectories, cancellationToken);
+    }
+
+    /// <summary>
+    /// solutiondiscoveryhelper-hotpath-perf: short-TTL memoized wrapper around
+    /// <see cref="ScanDirectoriesForSolutions"/>. A burst of workspaceId-omitted read-only
+    /// dispatches within <see cref="RootScanCacheTtl"/> reuses the last scan for the same declared
+    /// root set instead of re-walking every root's tree. <see cref="DiscoveryStatus.None"/> results
+    /// are cached too (that is the burst case). Internal for direct coverage of the cache-hit /
+    /// staleness-window behavior.
+    /// </summary>
+    internal static DiscoveryResult ScanDirectoriesForSolutionsCached(
+        IReadOnlyList<string> rootDirectories, CancellationToken cancellationToken)
+    {
+        if (rootDirectories.Count == 0)
+        {
+            return DiscoveryResult.None;
+        }
+
+        var cacheKey = string.Join('\0', rootDirectories.OrderBy(d => d, StringComparer.OrdinalIgnoreCase));
+        var nowUtc = DateTime.UtcNow;
+
+        if (s_rootScanCache.TryGetValue(cacheKey, out var cached) && cached.ExpiresUtc > nowUtc)
+        {
+            return cached.Result;
+        }
+
+        var result = ScanDirectoriesForSolutions(rootDirectories, cancellationToken);
+        s_rootScanCache[cacheKey] = (result, nowUtc.Add(RootScanCacheTtl));
+        return result;
     }
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -463,10 +463,9 @@ internal static class StructuredCallToolFilter
         }
 
         var schema = ToolParameterIndex.GetParameter(toolName, paramName);
-        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
-            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
 
         return schema is { Type: "string" }
+               && ServerSurfaceCatalog.TryGetTool(toolName, out var tool)
                && tool is { ReadOnly: true, Destructive: false };
     }
 
@@ -494,9 +493,8 @@ internal static class StructuredCallToolFilter
             return false;
         }
 
-        var tool = ServerSurfaceCatalog.Tools.FirstOrDefault(entry =>
-            string.Equals(entry.Name, toolName, StringComparison.Ordinal));
-        return tool is { ReadOnly: true, Destructive: false };
+        return ServerSurfaceCatalog.TryGetTool(toolName, out var tool)
+               && tool is { ReadOnly: true, Destructive: false };
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/SolutionDiscoveryHelperTests.cs
+++ b/tests/RoslynMcp.Tests/SolutionDiscoveryHelperTests.cs
@@ -128,6 +128,30 @@ public sealed class SolutionDiscoveryHelperTests
         Assert.AreEqual(sln, SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("file", source))).UniquePath);
     }
 
+    [TestMethod]
+    public void TryDiscoverFromFilePath_SolutionBeyondDepthCap_IsNone()
+    {
+        // solutiondiscoveryhelper-hotpath-perf: the ancestor walk-up is capped at 8 hops. Nest the
+        // source file 9 directory levels below the root and place the only solution at the root, so
+        // reaching it would require a 9th hop. The cap must stop the walk first → None (an uncapped
+        // walk would find the solution and return Unique).
+        var deep = _root;
+        for (var i = 1; i <= 9; i++)
+        {
+            deep = Path.Combine(deep, "l" + i);
+        }
+
+        Directory.CreateDirectory(deep);
+        File.WriteAllText(Path.Combine(_root, "Sample.slnx"), "<Solution />");
+        var source = Path.Combine(deep, "Class1.cs");
+        File.WriteAllText(source, "// source");
+
+        var result = SolutionDiscoveryHelper.TryDiscoverFromFilePath(Args(("filePath", source)));
+
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None, result.Status,
+            "A solution more than 8 ancestor hops above the anchor file must not be discovered.");
+    }
+
     // ── scan seam (query-anchored core) ─────────────────────────────────────
 
     [TestMethod]
@@ -170,6 +194,39 @@ public sealed class SolutionDiscoveryHelperTests
         Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
             SolutionDiscoveryHelper.ScanDirectoriesForSolutions(
                 new[] { Path.Combine(_root, "does-not-exist") }, CancellationToken.None).Status);
+    }
+
+    // ── TTL cache around the root scan ──────────────────────────────────────
+
+    [TestMethod]
+    public void ScanDirectoriesForSolutionsCached_WithinTtl_ReturnsStaleResult()
+    {
+        // solutiondiscoveryhelper-hotpath-perf: the cached wrapper memoizes the root scan for a
+        // short TTL keyed by the root set. Prime the cache with a single-solution result, then add
+        // a second solution to the same root: a fresh scan would now be Ambiguous, but a cache hit
+        // within the TTL must return the original (stale) Unique result — proving the second call
+        // did not re-walk the tree.
+        File.WriteAllText(Path.Combine(_root, "First.slnx"), "<Solution />");
+        var roots = new[] { _root };
+
+        var first = SolutionDiscoveryHelper.ScanDirectoriesForSolutionsCached(roots, CancellationToken.None);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, first.Status);
+
+        File.WriteAllText(Path.Combine(_root, "Second.slnx"), "<Solution />");
+
+        var second = SolutionDiscoveryHelper.ScanDirectoriesForSolutionsCached(roots, CancellationToken.None);
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.Unique, second.Status,
+            "A cache hit within the TTL must reuse the prior scan; the newly-added second solution " +
+            "must not turn the cached Unique result into Ambiguous until the TTL expires.");
+        Assert.AreEqual(first.UniquePath, second.UniquePath);
+    }
+
+    [TestMethod]
+    public void ScanDirectoriesForSolutionsCached_EmptyRoots_IsNone()
+    {
+        Assert.AreEqual(SolutionDiscoveryHelper.DiscoveryStatus.None,
+            SolutionDiscoveryHelper.ScanDirectoriesForSolutionsCached(
+                Array.Empty<string>(), CancellationToken.None).Status);
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs
@@ -81,6 +81,17 @@ public sealed class StructuredCallToolFilterResolutionTests
         Assert.IsFalse(StructuredCallToolFilter.IsWorkspaceIdAutoResolveAllowedFor(null));
     }
 
+    [TestMethod]
+    public void IsWorkspaceIdRecoveryAllowedFor_UnknownTool_ReturnsFalse()
+    {
+        // solutiondiscoveryhelper-hotpath-perf: the recovery predicate now resolves the tool via the
+        // O(1) ServerSurfaceCatalog.TryGetTool index instead of a linear FirstOrDefault scan. An
+        // unknown tool name must still short-circuit to false (TryGetTool miss ⇒ no eligible tool),
+        // preserving the pre-switch behavior.
+        Assert.IsFalse(
+            StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor("not_a_real_tool", "workspaceId"));
+    }
+
     // ── classification ──────────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Three hot-path perf fixes on the read-only tool auto-discovery/auto-resolve dispatch chain (initiative `solutiondiscoveryhelper-hotpath-perf`, plan `20260713T021417Z_backlog-sweep`).

1. **`SolutionDiscoveryHelper` — TTL-memoize the root scan.** The query-anchored `roots/list` scan (top level + one level down over every declared client root) is now cached with a short (~10s) TTL keyed by the sorted root-directory set, wrapped around the caller (`TryDiscoverFromRootsAsync`) — not the pure, test-covered `ScanDirectoriesForSolutions`. A burst of `workspaceId`-omitted dispatches with no workspace loaded no longer re-walks every root's tree on every call. Scoped to the cold no-workspace path where a short staleness window is low-stakes (caller falls back to binder/elicitation regardless).
2. **`SolutionDiscoveryHelper` — depth-cap + off-load the file-anchored walk-up.** `TryDiscoverFromFilePath`'s ancestor `while` loop is capped at 8 hops so a deeply-nested `filePath` cannot trigger a walk to the filesystem root; the call at `TryDiscoverAsync` is wrapped in `Task.Run` so the synchronous directory I/O runs off the async continuation thread (.NET has no async `Directory` API). The method's own signature/behavior is unchanged.
3. **`ServerSurfaceCatalog` — O(1) tool lookup.** Adds a name-keyed `Lazy<IReadOnlyDictionary>` index (`TryGetTool`) built once from the immutable `Tools` list (never from the six partial arrays, to avoid drift). `StructuredCallToolFilter.IsWorkspaceIdRecoveryAllowedFor` / `IsWorkspaceIdAutoResolveAllowedFor` switch from an O(n) `FirstOrDefault` catalog scan to O(1) lookup per read-only call, preserving identical `{ ReadOnly: true, Destructive: false }` semantics. The other 43 `Tools` readers are untouched.

## Scope

Production (3, within Rule 3's 4-file cap):
- `src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs`
- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs`
- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs`

Tests (2, extended not created):
- `tests/RoslynMcp.Tests/SolutionDiscoveryHelperTests.cs` — depth-cap-beyond-8 → None; cache-hit-within-TTL returns stale result; empty-roots → None.
- `tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs` — unknown-tool recovery predicate → false (exercises the `TryGetTool` miss path).

## Validation

- `dotnet build tests/RoslynMcp.Tests` (Debug) — 0 warnings, 0 errors.
- Targeted `dotnet test`: `SolutionDiscoveryHelperTests`, `StructuredCallToolFilterResolutionTests`, `StructuredCallToolFilterAutoLoadTests`, `StructuredCallToolFilterElicitationTests` — 45/45 pass.
- Catalog surface guard suites (`SurfaceCatalogTests`, `ReadmeSurfaceCountTests`, `CatalogDestructiveWarningTests`, `ServerSurfaceCatalogAnalyzerTests`) — 30/30 pass (the additive index does not change the tool surface).
- Full `./eng/verify-release.ps1 -Configuration Release` runs on the self-hosted CI runner on push.

## Backlog sync

Closes: solutiondiscoveryhelper-hotpath-perf

🤖 Generated with [Claude Code](https://claude.com/claude-code)