### PR TITLE
perf(msbuild): cache ProjectCollection evaluation in MsBuildEvaluationService

### DIFF
--- a/changelog.d/msbuild-evaluation-uncached-perf.md
+++ b/changelog.d/msbuild-evaluation-uncached-perf.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Cache MSBuild `ProjectCollection` evaluation in `MsBuildEvaluationService`, keyed by workspace version + project path, so `evaluate_msbuild_properties`/`evaluate_msbuild_items` (and their `get_nuget_dependencies`/`get_security_status` consumers) stop re-parsing unchanged project XML on every call; invalidated on workspace reload/close.

--- a/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/MsBuildEvaluationService.cs
@@ -1,18 +1,40 @@
+using System.Collections.Concurrent;
 using Microsoft.Build.Evaluation;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using RoslynProject = Microsoft.CodeAnalysis.Project;
+using MsBuildProject = Microsoft.Build.Evaluation.Project;
 
 namespace RoslynMcp.Roslyn.Services;
 
 public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
 {
     private readonly IWorkspaceManager _workspace;
+
+    /// <summary>
+    /// msbuild-evaluation-uncached-perf: caches the loaded MSBuild <see cref="MsBuildProject"/>
+    /// (and its owning <see cref="ProjectCollection"/>) keyed by workspace id → (workspace version,
+    /// project file path). Without this, every <c>EvaluatePropertyAsync</c>/<c>EvaluateItemsAsync</c>/
+    /// <c>GetEvaluatedPropertiesAsync</c> call re-parsed the full MSBuild import graph (SDK targets,
+    /// Directory.Build.props, …) from disk even when the project was unchanged — and
+    /// <c>get_nuget_dependencies</c> + <c>get_security_status</c> each loop over every project and
+    /// duplicated that work. Mirrors the version-keyed, per-workspace invalidation pattern of
+    /// <see cref="NuGetDependencyService"/>'s <c>_vulnCache</c>. Invalidated wholesale on
+    /// <see cref="IWorkspaceManager.WorkspaceReloaded"/>/<see cref="IWorkspaceManager.WorkspaceClosed"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<(int Version, string FilePath), Lazy<CachedMsBuildProject>>> _cache
+        = new(StringComparer.Ordinal);
+
     public MsBuildEvaluationService(IWorkspaceManager workspace)
     {
         _workspace = workspace;
+        // Drop the cached ProjectCollection(s) for a workspace as soon as it reloads (version bump,
+        // typically after an on-disk change / restore) or closes, so a subsequent evaluation re-parses
+        // the fresh project XML. Mirrors NuGetDependencyService.cs:57-60.
+        _workspace.WorkspaceReloaded += InvalidateWorkspace;
+        _workspace.WorkspaceClosed += InvalidateWorkspace;
     }
 
     public Task<MsBuildPropertyEvaluationDto> EvaluatePropertyAsync(
@@ -20,22 +42,16 @@ public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
     {
         MsBuildInitializer.EnsureInitialized();
         var roslynProj = ResolveRoslynProject(workspaceId, projectName);
-        using var collection = new ProjectCollection();
-        try
-        {
-            ct.ThrowIfCancellationRequested();
-            var msbuildProj = collection.LoadProject(roslynProj.FilePath!);
-            var value = msbuildProj.GetPropertyValue(propertyName);
-            return Task.FromResult(new MsBuildPropertyEvaluationDto(
-                roslynProj.Name,
-                roslynProj.FilePath!,
-                propertyName,
-                string.IsNullOrEmpty(value) ? null : value));
-        }
-        finally
-        {
-            collection.UnloadAllProjects();
-        }
+        // Keep the cancellation observation OUTSIDE GetOrLoadProject so a cancel on one caller cannot
+        // fault/poison the shared Lazy<CachedMsBuildProject> that other concurrent callers await.
+        ct.ThrowIfCancellationRequested();
+        var msbuildProj = GetOrLoadProject(workspaceId, roslynProj);
+        var value = msbuildProj.GetPropertyValue(propertyName);
+        return Task.FromResult(new MsBuildPropertyEvaluationDto(
+            roslynProj.Name,
+            roslynProj.FilePath!,
+            propertyName,
+            string.IsNullOrEmpty(value) ? null : value));
     }
 
     public Task<MsBuildItemEvaluationDto> EvaluateItemsAsync(
@@ -43,28 +59,21 @@ public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
     {
         MsBuildInitializer.EnsureInitialized();
         var roslynProj = ResolveRoslynProject(workspaceId, projectName);
-        using var collection = new ProjectCollection();
-        try
+        ct.ThrowIfCancellationRequested();
+        var msbuildProj = GetOrLoadProject(workspaceId, roslynProj);
+        var items = new List<MsBuildItemInstanceDto>();
+        foreach (var item in msbuildProj.GetItems(itemType))
         {
-            var msbuildProj = collection.LoadProject(roslynProj.FilePath!);
-            var items = new List<MsBuildItemInstanceDto>();
-            foreach (var item in msbuildProj.GetItems(itemType))
-            {
-                ct.ThrowIfCancellationRequested();
-                var meta = item.Metadata.ToDictionary(m => m.Name, m => m.EvaluatedValue, StringComparer.OrdinalIgnoreCase);
-                items.Add(new MsBuildItemInstanceDto(item.EvaluatedInclude, meta));
-            }
+            ct.ThrowIfCancellationRequested();
+            var meta = item.Metadata.ToDictionary(m => m.Name, m => m.EvaluatedValue, StringComparer.OrdinalIgnoreCase);
+            items.Add(new MsBuildItemInstanceDto(item.EvaluatedInclude, meta));
+        }
 
-            return Task.FromResult(new MsBuildItemEvaluationDto(
-                roslynProj.Name,
-                roslynProj.FilePath!,
-                itemType,
-                items));
-        }
-        finally
-        {
-            collection.UnloadAllProjects();
-        }
+        return Task.FromResult(new MsBuildItemEvaluationDto(
+            roslynProj.Name,
+            roslynProj.FilePath!,
+            itemType,
+            items));
     }
 
     public Task<MsBuildPropertiesDumpDto> GetEvaluatedPropertiesAsync(
@@ -76,58 +85,113 @@ public sealed class MsBuildEvaluationService : IMsBuildEvaluationService
     {
         MsBuildInitializer.EnsureInitialized();
         var roslynProj = ResolveRoslynProject(workspaceId, projectName);
-        using var collection = new ProjectCollection();
-        try
+        ct.ThrowIfCancellationRequested();
+        var msbuildProj = GetOrLoadProject(workspaceId, roslynProj);
+
+        // Filter at evaluation time so we never serialize 60KB+ of internal MSBuild
+        // properties when the caller only needs a handful. The explicit allowlist takes
+        // precedence; falling back to a substring filter mirrors get_diagnostics behavior.
+        HashSet<string>? allowlist = null;
+        if (includedNames is not null && includedNames.Count > 0)
         {
-            var msbuildProj = collection.LoadProject(roslynProj.FilePath!);
-
-            // Filter at evaluation time so we never serialize 60KB+ of internal MSBuild
-            // properties when the caller only needs a handful. The explicit allowlist takes
-            // precedence; falling back to a substring filter mirrors get_diagnostics behavior.
-            HashSet<string>? allowlist = null;
-            if (includedNames is not null && includedNames.Count > 0)
-            {
-                allowlist = new HashSet<string>(includedNames, StringComparer.OrdinalIgnoreCase);
-            }
-
-            var hasSubstringFilter = !string.IsNullOrWhiteSpace(propertyNameFilter);
-            var totalCount = 0;
-            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var prop in msbuildProj.Properties)
-            {
-                ct.ThrowIfCancellationRequested();
-                totalCount++;
-
-                if (allowlist is not null)
-                {
-                    if (!allowlist.Contains(prop.Name)) continue;
-                }
-                else if (hasSubstringFilter &&
-                         !prop.Name.Contains(propertyNameFilter!, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                dict[prop.Name] = prop.EvaluatedValue;
-            }
-
-            var appliedFilter = allowlist is not null
-                ? $"includedNames=[{string.Join(",", allowlist.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))}]"
-                : hasSubstringFilter
-                    ? $"propertyNameFilter='{propertyNameFilter}'"
-                    : null;
-
-            return Task.FromResult(new MsBuildPropertiesDumpDto(
-                roslynProj.Name,
-                roslynProj.FilePath!,
-                dict,
-                TotalCount: totalCount,
-                ReturnedCount: dict.Count,
-                AppliedFilter: appliedFilter));
+            allowlist = new HashSet<string>(includedNames, StringComparer.OrdinalIgnoreCase);
         }
-        finally
+
+        var hasSubstringFilter = !string.IsNullOrWhiteSpace(propertyNameFilter);
+        var totalCount = 0;
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var prop in msbuildProj.Properties)
+        {
+            ct.ThrowIfCancellationRequested();
+            totalCount++;
+
+            if (allowlist is not null)
+            {
+                if (!allowlist.Contains(prop.Name)) continue;
+            }
+            else if (hasSubstringFilter &&
+                     !prop.Name.Contains(propertyNameFilter!, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            dict[prop.Name] = prop.EvaluatedValue;
+        }
+
+        var appliedFilter = allowlist is not null
+            ? $"includedNames=[{string.Join(",", allowlist.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))}]"
+            : hasSubstringFilter
+                ? $"propertyNameFilter='{propertyNameFilter}'"
+                : null;
+
+        return Task.FromResult(new MsBuildPropertiesDumpDto(
+            roslynProj.Name,
+            roslynProj.FilePath!,
+            dict,
+            TotalCount: totalCount,
+            ReturnedCount: dict.Count,
+            AppliedFilter: appliedFilter));
+    }
+
+    /// <summary>
+    /// Returns a loaded MSBuild <see cref="MsBuildProject"/> for the given project, reusing a cached
+    /// instance when the workspace version and project file path are unchanged. The
+    /// <see cref="Lazy{T}"/> with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/> guarantees
+    /// <c>LoadProject</c> runs exactly once per key even under concurrent callers. Ownership of the
+    /// created <see cref="ProjectCollection"/> transfers to the cache; callers must NOT unload it.
+    /// </summary>
+    private MsBuildProject GetOrLoadProject(string workspaceId, RoslynProject roslynProj)
+    {
+        var version = _workspace.GetCurrentVersion(workspaceId);
+        var bucket = _cache.GetOrAdd(
+            workspaceId,
+            static _ => new ConcurrentDictionary<(int Version, string FilePath), Lazy<CachedMsBuildProject>>());
+
+        var filePath = roslynProj.FilePath!;
+        var entry = bucket.GetOrAdd(
+            (version, filePath),
+            static key => new Lazy<CachedMsBuildProject>(
+                () =>
+                {
+                    var collection = new ProjectCollection();
+                    return new CachedMsBuildProject(collection, collection.LoadProject(key.FilePath));
+                },
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return entry.Value.Project;
+    }
+
+    private void InvalidateWorkspace(string workspaceId)
+    {
+        if (!_cache.TryRemove(workspaceId, out var bucket))
+        {
+            return;
+        }
+
+        foreach (var lazy in bucket.Values)
+        {
+            // Only dispose entries whose factory actually ran — touching an uncreated Lazy would
+            // force a needless LoadProject just to dispose it.
+            if (lazy.IsValueCreated)
+            {
+                lazy.Value.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Holds a loaded MSBuild <see cref="MsBuildProject"/> together with its owning
+    /// <see cref="ProjectCollection"/>. Disposal unloads and disposes the collection so the cached
+    /// import graph is released on workspace reload/close.
+    /// </summary>
+    private sealed class CachedMsBuildProject(ProjectCollection collection, MsBuildProject project) : IDisposable
+    {
+        public MsBuildProject Project { get; } = project;
+
+        public void Dispose()
         {
             collection.UnloadAllProjects();
+            collection.Dispose();
         }
     }
 

--- a/tests/RoslynMcp.Tests/MsBuildEvaluationCacheTests.cs
+++ b/tests/RoslynMcp.Tests/MsBuildEvaluationCacheTests.cs
@@ -1,0 +1,178 @@
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// msbuild-evaluation-uncached-perf regression guard. <see cref="RoslynMcp.Roslyn.Services.MsBuildEvaluationService"/>
+/// previously constructed a fresh <see cref="Microsoft.Build.Evaluation.ProjectCollection"/> and re-ran
+/// <c>LoadProject</c> — re-parsing the full MSBuild import graph from disk — on every
+/// <c>EvaluatePropertyAsync</c>/<c>EvaluateItemsAsync</c>/<c>GetEvaluatedPropertiesAsync</c> call. The
+/// service now caches the loaded project keyed by (workspace version, project file path) and invalidates
+/// the whole cache on <c>WorkspaceReloaded</c>/<c>WorkspaceClosed</c>. These tests assert the cache is
+/// (a) actually caching — an on-disk mutation without a reload is NOT observed — and (b) correctly
+/// invalidated — a reload (version bump) surfaces the new value.
+/// </summary>
+[TestClass]
+public sealed class MsBuildEvaluationCacheTests : TestBase
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        // Registers MSBuild + builds the shared service graph (MsBuildEvaluationService, WorkspaceManager).
+        InitializeServices();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        DisposeServices();
+    }
+
+    private const string ProbePropertyName = "CacheProbeProperty";
+
+    private static string ProjectXml(string probeValue) =>
+        $"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <{ProbePropertyName}>{probeValue}</{ProbePropertyName}>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    [TestMethod]
+    public async Task EvaluateProperty_MutatedOnDiskWithoutReload_ReturnsCachedValue()
+    {
+        using var fixture = CreateProjectFixture("CacheProbe.csproj", ProjectXml("before"));
+
+        var loadStatus = await WorkspaceManager.LoadAsync(fixture.ProjectPath, CancellationToken.None);
+        try
+        {
+            var projectName = (await WorkspaceManager.GetStatusAsync(loadStatus.WorkspaceId, CancellationToken.None))
+                .Projects[0].Name;
+
+            var first = await MsBuildEvaluationService.EvaluatePropertyAsync(
+                loadStatus.WorkspaceId, projectName, ProbePropertyName, CancellationToken.None);
+            Assert.AreEqual("before", first.EvaluatedValue,
+                "First evaluation must read the property value present on disk at load time.");
+
+            // Mutate the .csproj on disk WITHOUT reloading the workspace. The workspace version is
+            // unchanged, so the cached MSBuild project must still surface the original value — proving
+            // the evaluation is served from cache rather than a fresh LoadProject re-parse.
+            File.WriteAllText(fixture.ProjectPath, ProjectXml("after"));
+
+            var second = await MsBuildEvaluationService.EvaluatePropertyAsync(
+                loadStatus.WorkspaceId, projectName, ProbePropertyName, CancellationToken.None);
+            Assert.AreEqual("before", second.EvaluatedValue,
+                "Without a workspace reload (no version bump), the cached project must be reused — the on-disk mutation must NOT be observed.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(loadStatus.WorkspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task EvaluateProperty_AfterReload_InvalidatesCacheAndReturnsNewValue()
+    {
+        using var fixture = CreateProjectFixture("CacheProbeReload.csproj", ProjectXml("before"));
+
+        var loadStatus = await WorkspaceManager.LoadAsync(fixture.ProjectPath, CancellationToken.None);
+        try
+        {
+            var projectName = (await WorkspaceManager.GetStatusAsync(loadStatus.WorkspaceId, CancellationToken.None))
+                .Projects[0].Name;
+
+            var first = await MsBuildEvaluationService.EvaluatePropertyAsync(
+                loadStatus.WorkspaceId, projectName, ProbePropertyName, CancellationToken.None);
+            Assert.AreEqual("before", first.EvaluatedValue, "Baseline evaluation must read the on-disk value.");
+
+            // Mutate on disk, then reload (bumps the workspace version and raises WorkspaceReloaded,
+            // which the service subscribes to to drop the workspace's cached ProjectCollection(s)).
+            File.WriteAllText(fixture.ProjectPath, ProjectXml("after"));
+            await WorkspaceManager.ReloadAsync(loadStatus.WorkspaceId, CancellationToken.None);
+
+            var afterReload = await MsBuildEvaluationService.EvaluatePropertyAsync(
+                loadStatus.WorkspaceId, projectName, ProbePropertyName, CancellationToken.None);
+            Assert.AreEqual("after", afterReload.EvaluatedValue,
+                "A workspace reload must invalidate the cache (WorkspaceReloaded → InvalidateWorkspace); the next evaluation must re-parse and surface the new on-disk value.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(loadStatus.WorkspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task EvaluateItems_RepeatedUnchangedCalls_ReturnIdenticalResults()
+    {
+        using var fixture = CreateProjectFixture(
+            "CacheProbeItems.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var loadStatus = await WorkspaceManager.LoadAsync(fixture.ProjectPath, CancellationToken.None);
+        try
+        {
+            var projectName = (await WorkspaceManager.GetStatusAsync(loadStatus.WorkspaceId, CancellationToken.None))
+                .Projects[0].Name;
+
+            var first = await MsBuildEvaluationService.EvaluateItemsAsync(
+                loadStatus.WorkspaceId, projectName, "PackageReference", CancellationToken.None);
+            var second = await MsBuildEvaluationService.EvaluateItemsAsync(
+                loadStatus.WorkspaceId, projectName, "PackageReference", CancellationToken.None);
+
+            // Functional idempotence: caching the underlying project must not change the observed items.
+            CollectionAssert.AreEqual(
+                first.Items.Select(i => i.Include).ToList(),
+                second.Items.Select(i => i.Include).ToList(),
+                "Repeated EvaluateItemsAsync calls for an unchanged project must return identical item includes.");
+            Assert.IsTrue(
+                first.Items.Any(i => string.Equals(i.Include, "Newtonsoft.Json", StringComparison.OrdinalIgnoreCase)),
+                "The declared PackageReference must be surfaced by evaluation.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(loadStatus.WorkspaceId);
+        }
+    }
+
+    private static ProjectFixture CreateProjectFixture(string fileName, string content)
+    {
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "RoslynMcpTests",
+            "MsBuildEvaluationCacheTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        var projectPath = Path.Combine(tempRoot, fileName);
+        File.WriteAllText(projectPath, content);
+        return new ProjectFixture(tempRoot, projectPath);
+    }
+
+    private sealed class ProjectFixture(string rootPath, string projectPath) : IDisposable
+    {
+        public string ProjectPath { get; } = projectPath;
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; a locked temp dir is reclaimed by the OS sweep.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MsBuildEvaluationService.EvaluatePropertyAsync`, `EvaluateItemsAsync`, and `GetEvaluatedPropertiesAsync` each constructed a fresh `Microsoft.Build.Evaluation.ProjectCollection` and called `LoadProject` on **every** invocation — unconditionally re-parsing the full MSBuild XML import graph (SDK targets, `Directory.Build.props`, …) even for an unchanged project. `get_nuget_dependencies` and `get_security_status` each loop over every project in the solution and duplicated that evaluation work with zero sharing.

This caches the loaded MSBuild `Project` (plus its owning `ProjectCollection`) keyed by `workspaceId → (workspace version, project file path)`, mirroring `NuGetDependencyService._vulnCache`'s version-keyed per-workspace invalidation pattern. Result: one parse per `(workspace, version, project)` until the next reload/close.

## Design notes

- **`Lazy<CachedMsBuildProject>` with `ExecutionAndPublication`** guarantees `LoadProject` runs exactly once per key even under concurrent callers.
- **CancellationToken observed outside the `Lazy` factory** so a cancel on one concurrent caller cannot fault/poison the shared entry other callers are awaiting (Risk 3 in the plan).
- **`CachedMsBuildProject : IDisposable`** unloads + disposes the owning `ProjectCollection` on eviction.
- **Invalidated wholesale** on `WorkspaceReloaded`/`WorkspaceClosed` (wired in the ctor, same as `_vulnCache`).
- **No consumer edits** — `NuGetDependencyService`/`SecurityDiagnosticService` share the one `AddSingleton<IMsBuildEvaluationService>` instance and inherit the cache for free. `IMsBuildEvaluationService` is unchanged.

## Validation

- `dotnet build` of `RoslynMcp.Roslyn` + `RoslynMcp.Tests`: 0 warnings, 0 errors.
- New `MsBuildEvaluationCacheTests` (3 tests) — caching (on-disk mutation without reload is NOT observed), invalidation (reload surfaces new value), item idempotence: all pass.
- Regression suites `ProjectOutputTypeTests` + `NuGetVulnerabilityScanIntegrationTests` + `SecurityDiagnosticIntegrationTests` (32 tests): all pass.

Closes: msbuild-evaluation-uncached-perf

🤖 Generated with [Claude Code](https://claude.com/claude-code)