### PR TITLE
fix(validation): raise VulnerabilityScanTimeout default from 2 to 5 minutes

### DIFF
--- a/changelog.d/nuget-vuln-scan-timeout-bump.md
+++ b/changelog.d/nuget-vuln-scan-timeout-bump.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Raised `ValidationServiceOptions.VulnerabilityScanTimeout`'s default from 2 to 5 minutes. `dotnet list package --vulnerable` fetches full package registration + vulnerability metadata from nuget.org (heavier than a normal restore); under a cold per-account NuGet HTTP cache (e.g. a CI service account with a separate profile from an interactive dev session), 2 minutes proved too tight and caused intermittent `NuGetVulnerabilityScanIntegrationTests` timeouts unrelated to any code change. Still configurable via `ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS`.

--- a/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
@@ -27,7 +27,13 @@ public sealed record ValidationServiceOptions
     /// <summary>
     /// Gets the maximum time allowed for a NuGet vulnerability scan
     /// (<c>dotnet list package --vulnerable</c>) before it is cancelled.
-    /// Defaults to 2 minutes.
+    /// Defaults to 5 minutes. <c>dotnet list package --vulnerable</c> fetches the full package
+    /// registration + vulnerability metadata from nuget.org rather than just the resolved
+    /// versions a normal restore needs, so a cold per-account NuGet HTTP cache (e.g. the
+    /// self-hosted CI runner's service account, which has its own separate profile/cache from
+    /// an interactive dev session) can take noticeably longer than a warm-cache run. 2 minutes
+    /// was observed to be too tight under a cold cache; 5 minutes gives headroom without masking
+    /// a genuinely hung process.
     /// </summary>
-    public TimeSpan VulnerabilityScanTimeout { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan VulnerabilityScanTimeout { get; init; } = TimeSpan.FromMinutes(5);
 }


### PR DESCRIPTION
## Summary
- `ValidationServiceOptions.VulnerabilityScanTimeout` default raised from 2 to 5 minutes.
- `dotnet list package --vulnerable` fetches full package registration + vulnerability metadata from nuget.org — heavier than a normal restore. Under a cold per-account NuGet HTTP cache, 2 minutes proved too tight.
- Observed repeatedly on PR #1055's CI: the self-hosted runner's `LocalSystem` service account has its own separate profile/cache from the interactive `daryl` dev session (which has a ~3GB warm `v3-cache`), so it never benefits from that warm cache. A direct manual repro of the underlying command completed in 2.6s interactively, confirming the issue is cache-locality, not network/connectivity or a code regression.
- Still overridable via `ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS`.

## Test plan
- [x] `dotnet build src/RoslynMcp.Roslyn` — clean, 0 warnings/errors.
- No behavioral test needed (a config default change); CI's own `NuGetVulnerabilityScanIntegrationTests` run against this PR is the live validation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>