### PR TITLE
chore(tests): migrate to Assert.ThrowsExactly family + TestMethod, fix MSTEST0032 tautologies

### DIFF
--- a/changelog.d/mstest-throwsexactly-migration.md
+++ b/changelog.d/mstest-throwsexactly-migration.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Migrated the test suite off MSTest APIs that newer MSTest analyzers promote to build errors under warnings-as-errors: `Assert.ThrowsExceptionAsync` → `Assert.ThrowsExactlyAsync` (129 sites), `Assert.ThrowsException<T>` → `Assert.ThrowsExactly<T>` (28 sites), `[DataTestMethod]` → `[TestMethod]` (4 sites), and strengthened three tautological assertions flagged by MSTEST0032 (value-tuple/`JsonElement` `IsNotNull` checks that were always true now assert the real found/shape condition). Identical exact-type-match semantics at the current MSTest 3.8.3 pin; unblocks every open dependabot MSTest bump (MSTEST0039/MSTEST0044/MSTEST0032/CS0117 failures).

--- a/tests/RoslynMcp.Tests/AnalysisToolsTests.cs
+++ b/tests/RoslynMcp.Tests/AnalysisToolsTests.cs
@@ -109,7 +109,7 @@ public sealed class AnalysisToolsTests : SharedWorkspaceTestBase
     {
         var animalServicePath = FindDocumentPath("AnimalService.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
         {
             await AnalysisTools.GetDiagnosticDetails(
                 server: null!,
@@ -131,7 +131,7 @@ public sealed class AnalysisToolsTests : SharedWorkspaceTestBase
     {
         var animalServicePath = FindDocumentPath("AnimalService.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
         {
             await AnalysisTools.GetDiagnosticDetails(
                 server: null!,
@@ -309,7 +309,7 @@ public sealed class AnalysisToolsTests : SharedWorkspaceTestBase
     {
         var animalPath = FindDocumentPath("IAnimal.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
         {
             await AnalysisTools.AnalyzeImpact(
                 gate: WorkspaceExecutionGate,
@@ -326,7 +326,7 @@ public sealed class AnalysisToolsTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task FindTypeMutations_UnresolvedSymbolHandle_UsesCanonicalMessage()
     {
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
             AnalysisTools.FindTypeMutations(
                 gate: WorkspaceExecutionGate,
                 mutationAnalysisService: new NullMutationAnalysisService(),

--- a/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
@@ -56,7 +56,7 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var undo = new FakeUndo();
         var previewStore = new FakePreviewStore("ws"); // Retrieve returns null → filter skipped
 
-        var thrown = await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+        var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
             ApplyWithVerifyTool.ApplyWithVerify(
                 new FakeGate(),
                 new FakeRefactoring(),
@@ -101,7 +101,7 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var loggerFactory = new CapturingLoggerFactory();
         var previewStore = new FakePreviewStore("ws");
 
-        var thrown = await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+        var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
             ApplyWithVerifyTool.ApplyWithVerify(
                 new FakeGate(),
                 new FakeRefactoring(),
@@ -142,7 +142,7 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var refactoring = new FakeRefactoring();
         var previewStore = new FakePreviewStore("ws");
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
             ApplyWithVerifyTool.ApplyWithVerify(
                 new FakeGate(),
                 refactoring,

--- a/tests/RoslynMcp.Tests/BacklogFixTests.cs
+++ b/tests/RoslynMcp.Tests/BacklogFixTests.cs
@@ -101,7 +101,7 @@ public sealed class BacklogFixTests : SharedWorkspaceTestBase
     [TestMethod]
     public void GatedCommandExecutor_ResolveProject_ThrowsForUnknown()
     {
-        Assert.ThrowsException<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
         {
             var workspaceId = WorkspaceManager.ListWorkspaces().First().WorkspaceId;
             GatedCommandExecutor.ResolveProject(workspaceId, "NonExistentProject");
@@ -129,7 +129,7 @@ public sealed class BacklogFixTests : SharedWorkspaceTestBase
     [TestMethod]
     public void WorkspaceManager_SessionNotFound_ErrorIncludesActiveCount()
     {
-        var ex = Assert.ThrowsException<KeyNotFoundException>(() =>
+        var ex = Assert.ThrowsExactly<KeyNotFoundException>(() =>
             WorkspaceManager.GetCurrentSolution("nonexistent-workspace-id"));
 
         Assert.IsTrue(ex.Message.Contains("active session(s)"));

--- a/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
+++ b/tests/RoslynMcp.Tests/BulkRefactoringTests.cs
@@ -31,7 +31,7 @@ public sealed class BulkRefactoringTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task BulkReplaceType_NonExistentType_ThrowsInvalidOperation()
     {
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             BulkRefactoringService.PreviewBulkReplaceTypeAsync(
                 WorkspaceId, "NonExistentType123", "Shape", null, CancellationToken.None));
     }
@@ -39,7 +39,7 @@ public sealed class BulkRefactoringTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task BulkReplaceType_InvalidScope_ThrowsArgument()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             BulkRefactoringService.PreviewBulkReplaceTypeAsync(
                 WorkspaceId, "IAnimal", "Shape", "invalid_scope", CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewMetadataNameShapeTests.cs
@@ -63,7 +63,7 @@ public sealed class ChangeSignaturePreviewMetadataNameShapeTests : IsolatedWorks
             NewName: null,
             DefaultValue: null);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, request, CancellationToken.None));
 

--- a/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ChangeSignaturePreviewTests.cs
@@ -604,7 +604,7 @@ public sealed class ChangeSignaturePreviewTests : IsolatedWorkspaceTestBase
             NewName: null,
             DefaultValue: "default");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, request, CancellationToken.None));
 
@@ -763,35 +763,35 @@ public sealed class ChangeSignaturePreviewTests : IsolatedWorkspaceTestBase
         var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
 
         // Missing NewOrder.
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, new ChangeSignatureRequest(Op: "reorder"), CancellationToken.None));
         StringAssert.Contains(ex.Message, "NewOrder",
             $"missing-NewOrder error must cite 'NewOrder'; got: {ex.Message}");
 
         // Wrong arity (2 tokens for 3-param method).
-        ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b"), CancellationToken.None));
         StringAssert.Contains(ex.Message, "exactly once",
             $"wrong-arity error must explain that every parameter must appear exactly once; got: {ex.Message}");
 
         // Unknown name token.
-        ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b,zz"), CancellationToken.None));
         StringAssert.Contains(ex.Message, "zz",
             $"unknown-token error must cite the offending token; got: {ex.Message}");
 
         // Duplicate token.
-        ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,a,b"), CancellationToken.None));
         StringAssert.Contains(ex.Message, "more than once",
             $"duplicate-token error must explain the parameter is listed twice; got: {ex.Message}");
 
         // Identity permutation (no-op).
-        ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, new ChangeSignatureRequest(Op: "reorder", NewOrder: "a,b,c"), CancellationToken.None));
         StringAssert.Contains(ex.Message, "identity",
@@ -834,7 +834,7 @@ public sealed class ChangeSignaturePreviewTests : IsolatedWorkspaceTestBase
         var locator = SymbolLocator.BySource(fixturePath, line: 5, column: 16);
         var request = new ChangeSignatureRequest(Op: "reorder", NewOrder: "c,a,b");
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await _changeSignatureService.PreviewChangeSignatureAsync(
                 workspace.WorkspaceId, locator, request, CancellationToken.None));
         StringAssert.Contains(ex.Message, "mixes positional and named",

--- a/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
+++ b/tests/RoslynMcp.Tests/ConsumerAnalysisTests.cs
@@ -42,7 +42,7 @@ public sealed class ConsumerAnalysisTests : SharedWorkspaceTestBase
         // structured NotFound envelope (instead of the old null/empty result that callers
         // could not distinguish from a legitimate "valid symbol, zero consumers" outcome).
         var locator = SymbolLocator.ByMetadataName("SampleLib.NonExistentType");
-        await Assert.ThrowsExceptionAsync<SymbolNotFoundException>(
+        await Assert.ThrowsExactlyAsync<SymbolNotFoundException>(
             () => ConsumerAnalysisService.FindConsumersAsync(WorkspaceId, locator, CancellationToken.None));
     }
 

--- a/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/CrossProjectRefactoringIntegrationTests.cs
@@ -599,7 +599,7 @@ public sealed class CrossProjectRefactoringIntegrationTests : IsolatedWorkspaceT
         var sourceFilePath = workspace.GetPath("SampleLib", "Dog.cs");
         await workspace.LoadAsync(CancellationToken.None);
 
-        var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await CrossProjectRefactoringService.PreviewMoveTypeToProjectAsync(
                 workspace.WorkspaceId,
                 sourceFilePath,

--- a/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
+++ b/tests/RoslynMcp.Tests/DeadFieldDetectorTests.cs
@@ -276,7 +276,7 @@ public sealed class DeadFieldDetectorTests
     // `never-written`. `Interlocked.*` callsites that take the field by `ref` are
     // covered by the existing `RefKeyword` arm; adding the member-access case
     // here ensures `Interlocked.Increment(ref acc.field)` works for qualified refs.
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("_count++;", DisplayName = "PostfixIncrement")]
     [DataRow("_count--;", DisplayName = "PostfixDecrement")]
     [DataRow("++_count;", DisplayName = "PrefixIncrement")]

--- a/tests/RoslynMcp.Tests/DiagnosticIdentitySetTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticIdentitySetTests.cs
@@ -107,7 +107,7 @@ public sealed class DiagnosticIdentitySetTests
     [TestMethod]
     public void FormatIdentity_NullDiagnostic_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => DiagnosticIdentitySet.FormatIdentity(null!));
     }
 

--- a/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
@@ -38,7 +38,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         // record so we construct it via `default` + expression to bypass nullable analysis.
         var edit = new TextEditDto(1, 1, 1, 1, null!);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "null NewText");
     }
@@ -52,7 +52,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         // Start (5,10) → End (5,5): end precedes start on the same line.
         var edit = new TextEditDto(5, 10, 5, 5, "x");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "reversed range");
     }
@@ -66,7 +66,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         // Line 9999 is far beyond the file length.
         var edit = new TextEditDto(9999, 1, 9999, 1, "oops");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "9999");
     }
@@ -80,7 +80,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         // Column 0 is invalid — line/column are 1-based.
         var edit = new TextEditDto(1, 0, 1, 1, "oops");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "1-based");
     }
@@ -118,7 +118,7 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
         var e1 = new TextEditDto(5, 5, 5, 12, "x");
         var e2 = new TextEditDto(5, 6, 5, 20, "y");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { e1, e2 }, "apply_text_edit", CancellationToken.None));
         StringAssert.Contains(ex.Message, "overlapping");
     }

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -339,7 +339,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
                 FilePath: null, Line: null, Column: null),
         };
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() => SymbolTools.FindReferencesBulk(
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => SymbolTools.FindReferencesBulk(
             WorkspaceExecutionGate,
             ReferenceService,
             WorkspaceId,
@@ -497,7 +497,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
         await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => CodeActionTools.GetCodeActions(
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() => CodeActionTools.GetCodeActions(
             harness.Server,
             WorkspaceExecutionGate,
             CodeActionService,
@@ -518,7 +518,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
         await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => CodeActionTools.PreviewCodeAction(
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() => CodeActionTools.PreviewCodeAction(
             harness.Server,
             WorkspaceExecutionGate,
             CodeActionService,
@@ -540,7 +540,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
         await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeDataFlow(
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeDataFlow(
             harness.Server,
             WorkspaceExecutionGate,
             FlowAnalysisService,
@@ -559,7 +559,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
         await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeControlFlow(
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() => FlowAnalysisTools.AnalyzeControlFlow(
             harness.Server,
             WorkspaceExecutionGate,
             FlowAnalysisService,
@@ -578,7 +578,7 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
         var sanctionedRoot = CreateUnrelatedSanctionedRootDirectory();
         await using var harness = await CreateServerWithSanctionedRootAsync(sanctionedRoot, CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => OperationTools.GetOperations(
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() => OperationTools.GetOperations(
             harness.Server,
             WorkspaceExecutionGate,
             OperationService,

--- a/tests/RoslynMcp.Tests/ExternalEditStalenessTests.cs
+++ b/tests/RoslynMcp.Tests/ExternalEditStalenessTests.cs
@@ -119,7 +119,7 @@ public sealed class ExternalEditStalenessTests : IsolatedWorkspaceTestBase
                 WorkspaceManager.GetStaleReason(workspace.WorkspaceId),
                 "Precondition: watcher attributed the write as external-edit.");
 
-            var ex = Assert.ThrowsException<InvalidOperationException>(
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
                 () => WorkspaceManager.EnsureFreshForWritePreview(workspace.WorkspaceId),
                 "Write-preview gate must throw when staleReason is external-edit.");
 

--- a/tests/RoslynMcp.Tests/ExtractMethodTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractMethodTests.cs
@@ -111,7 +111,7 @@ public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
         // Select lines 13-16 including "return doubled;"
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ExtractMethodService.PreviewExtractMethodAsync(
                 workspace.WorkspaceId,
                 filePath,
@@ -132,7 +132,7 @@ public sealed class ExtractMethodTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             ExtractMethodService.PreviewExtractMethodAsync(
                 workspace.WorkspaceId,
                 filePath,

--- a/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractSharedExpressionTests.cs
@@ -74,7 +74,7 @@ public sealed class ExtractSharedExpressionTests : IsolatedWorkspaceTestBase
         // RefactoringProbe has only one `Math.PI * radius * radius` expression.
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
                 workspace.WorkspaceId,
                 filePath,
@@ -98,7 +98,7 @@ public sealed class ExtractSharedExpressionTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
                 workspace.WorkspaceId,
                 filePath,
@@ -119,7 +119,7 @@ public sealed class ExtractSharedExpressionTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "SharedExpressionProbe.cs");
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             ExtractMethodService.PreviewExtractSharedExpressionToHelperAsync(
                 workspace.WorkspaceId,
                 filePath,

--- a/tests/RoslynMcp.Tests/FindReflectionUsagesPaginationTests.cs
+++ b/tests/RoslynMcp.Tests/FindReflectionUsagesPaginationTests.cs
@@ -330,7 +330,7 @@ public static class ReflectionUsageFixture
     {
         var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
 
-        var negativeOffsetEx = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var negativeOffsetEx = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             AdvancedAnalysisTools.FindReflectionUsages(
                 gate: WorkspaceExecutionGate,
                 codePatternAnalyzer: CodePatternAnalyzer,
@@ -342,7 +342,7 @@ public static class ReflectionUsageFixture
                 ct: CancellationToken.None));
         StringAssert.Contains(negativeOffsetEx.Message, "offset");
 
-        var zeroLimitEx = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var zeroLimitEx = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             AdvancedAnalysisTools.FindReflectionUsages(
                 gate: WorkspaceExecutionGate,
                 codePatternAnalyzer: CodePatternAnalyzer,

--- a/tests/RoslynMcp.Tests/FlowAnalysisServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FlowAnalysisServiceTests.cs
@@ -176,7 +176,7 @@ public class ExpressionBodiedSamples
         // analyze-data-flow-inverted-range: pre-fix, inverted ranges fell through to the
         // misleading "No statements found in the line range 200-100" InvalidOperation. Post-fix,
         // the service rejects the input upfront with a structured ArgumentException.
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             FlowAnalysisService.AnalyzeDataFlowAsync(
                 WorkspaceId, TargetFilePath, startLine: 200, endLine: 100, CancellationToken.None));
         StringAssert.Contains(ex.Message, "<=");
@@ -185,7 +185,7 @@ public class ExpressionBodiedSamples
     [TestMethod]
     public async Task AnalyzeControlFlow_InvertedRange_ThrowsArgumentException()
     {
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             FlowAnalysisService.AnalyzeControlFlowAsync(
                 WorkspaceId, TargetFilePath, startLine: 200, endLine: 100, CancellationToken.None));
         StringAssert.Contains(ex.Message, "<=");
@@ -194,7 +194,7 @@ public class ExpressionBodiedSamples
     [TestMethod]
     public async Task AnalyzeDataFlow_NegativeLine_ThrowsArgumentException()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             FlowAnalysisService.AnalyzeDataFlowAsync(
                 WorkspaceId, TargetFilePath, startLine: 0, endLine: 5, CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
+++ b/tests/RoslynMcp.Tests/FormatRangeServiceTests.cs
@@ -38,7 +38,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             RefactoringService.PreviewFormatRangeAsync(
                 workspace.WorkspaceId, filePath,
                 startLine: 17, startColumn: 1,
@@ -53,7 +53,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             RefactoringService.PreviewFormatRangeAsync(
                 workspace.WorkspaceId, filePath,
                 startLine: 11, startColumn: 0,
@@ -68,7 +68,7 @@ public sealed class FormatRangeServiceTests : IsolatedWorkspaceTestBase
         await using var workspace = await CreateIsolatedWorkspaceAsync();
         var filePath = workspace.GetPath("SampleLib", "RefactoringProbe.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             RefactoringService.PreviewFormatRangeAsync(
                 workspace.WorkspaceId, filePath,
                 startLine: 99999, startColumn: 1,

--- a/tests/RoslynMcp.Tests/GoToTypeDefinitionTests.cs
+++ b/tests/RoslynMcp.Tests/GoToTypeDefinitionTests.cs
@@ -53,7 +53,7 @@ public sealed class GoToTypeDefinitionTests : SharedWorkspaceTestBase
         // Cursor on `sound` (line 20 col 13 declared as `var sound = animal.Speak();` returning string).
         var locator = SymbolLocator.BySource(_animalServicePath, line: 20, column: 17);
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
             SymbolNavigationService.GoToTypeDefinitionAsync(
                 _workspaceId, locator, CancellationToken.None));
 

--- a/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -23,7 +23,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
         var beforeCount = WorkspaceManager.ListWorkspaces().Count;
         var missingPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.slnx");
 
-        await Assert.ThrowsExceptionAsync<FileNotFoundException>(() =>
+        await Assert.ThrowsExactlyAsync<FileNotFoundException>(() =>
             WorkspaceManager.LoadAsync(missingPath, CancellationToken.None));
 
         Assert.AreEqual(beforeCount, WorkspaceManager.ListWorkspaces().Count);
@@ -45,7 +45,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
         {
             await manager.LoadAsync(firstPath, CancellationToken.None);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
                 manager.LoadAsync(secondPath, CancellationToken.None));
         }
         finally
@@ -63,7 +63,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
             .Select(index => Path.Combine(Path.GetTempPath(), $"File{index}.cs"))
             .ToArray();
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             TestDiscoveryService.FindRelatedTestsForFilesAsync(workspaceId, excessivePaths, 100, CancellationToken.None));
     }
 
@@ -86,7 +86,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
                 MaxRelatedFiles = 25
             });
 
-        await Assert.ThrowsExceptionAsync<TimeoutException>(() =>
+        await Assert.ThrowsExactlyAsync<TimeoutException>(() =>
             service.BuildWorkspaceAsync("workspace-1", CancellationToken.None));
     }
 
@@ -101,7 +101,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
             runner.RunAsync(
                 Environment.CurrentDirectory,
                 targetPath: "dotnet-info",
@@ -113,7 +113,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
             candidate.Message.Contains("Failed to kill dotnet process tree", StringComparison.Ordinal) &&
             candidate.Exception is InvalidOperationException);
 
-        Assert.IsNotNull(entry, "Cancellation kill failures should be observable without changing cancellation semantics.");
+        Assert.AreNotEqual(default, entry, "Cancellation kill failures should be observable without changing cancellation semantics.");
     }
 
     private sealed class HangingDotnetCommandRunner : IDotnetCommandRunner

--- a/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/HighValueCoverageIntegrationTests.cs
@@ -81,7 +81,7 @@ public sealed class HighValueCoverageIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             CodeActionService.PreviewCodeActionAsync(
                 SampleWorkspaceId,
                 filePath,
@@ -144,7 +144,7 @@ public sealed class HighValueCoverageIntegrationTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task DeadCode_PreviewRemoveDeadCode_Empty_Throws()
     {
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             DeadCodeService.PreviewRemoveDeadCodeAsync(
                 SampleWorkspaceId,
                 new DeadCodeRemovalDto([]),

--- a/tests/RoslynMcp.Tests/IdentifierValidationTests.cs
+++ b/tests/RoslynMcp.Tests/IdentifierValidationTests.cs
@@ -27,28 +27,28 @@ public class IdentifierValidationTests
 
     [TestMethod]
     public void Empty_String_Throws()
-        => Assert.ThrowsException<InvalidOperationException>(
+        => Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier(""));
 
     [TestMethod]
     public void Null_Throws()
-        => Assert.ThrowsException<InvalidOperationException>(
+        => Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier(null!));
 
     [TestMethod]
     public void At_Sign_Alone_Throws()
-        => Assert.ThrowsException<InvalidOperationException>(
+        => Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier("@"));
 
     [TestMethod]
     public void Numeric_Prefix_Throws()
-        => Assert.ThrowsException<InvalidOperationException>(
+        => Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier("2InvalidName"));
 
     [TestMethod]
     public void Reserved_Keyword_Throws()
     {
-        var ex = Assert.ThrowsException<InvalidOperationException>(
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier("class"));
         StringAssert.Contains(ex.Message, "reserved");
     }
@@ -56,7 +56,7 @@ public class IdentifierValidationTests
     [TestMethod]
     public void Contextual_Keyword_Throws()
     {
-        var ex = Assert.ThrowsException<InvalidOperationException>(
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier("var"));
         StringAssert.Contains(ex.Message, "contextual");
     }
@@ -64,7 +64,7 @@ public class IdentifierValidationTests
     [TestMethod]
     public void Custom_Parameter_Label_Appears_In_Error()
     {
-        var ex = Assert.ThrowsException<InvalidOperationException>(
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
             () => IdentifierValidation.ThrowIfInvalidIdentifier("", "type name"));
         StringAssert.Contains(ex.Message, "type name");
     }

--- a/tests/RoslynMcp.Tests/IntegrationTests.WorkspaceCore.cs
+++ b/tests/RoslynMcp.Tests/IntegrationTests.WorkspaceCore.cs
@@ -53,7 +53,7 @@ public class IntegrationTests_WorkspaceCore : SharedWorkspaceTestBase
     [TestMethod]
     public async Task Workspace_Reload_Rejects_Unknown_Id()
     {
-        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(() =>
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
             WorkspaceManager.ReloadAsync("missing-workspace", CancellationToken.None));
     }
 

--- a/tests/RoslynMcp.Tests/MsBuildEvaluationServiceTests.cs
+++ b/tests/RoslynMcp.Tests/MsBuildEvaluationServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class MsBuildEvaluationServiceTests : IsolatedWorkspaceTestBase
 
         const string missingProject = "ZZZ_DoesNotExistProject";
 
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             service.EvaluatePropertyAsync(workspaceId, missingProject, "TargetFramework", CancellationToken.None));
 
         var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);

--- a/tests/RoslynMcp.Tests/NamespaceRelocationTests.cs
+++ b/tests/RoslynMcp.Tests/NamespaceRelocationTests.cs
@@ -193,7 +193,7 @@ public sealed class NamespaceRelocationTests : IsolatedWorkspaceTestBase
         var wsId = await workspace.LoadAsync(CancellationToken.None);
 
         var service = CreateService();
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             service.PreviewChangeTypeNamespaceAsync(
                 wsId,
                 typeName: "Dog",
@@ -210,7 +210,7 @@ public sealed class NamespaceRelocationTests : IsolatedWorkspaceTestBase
         var wsId = await workspace.LoadAsync(CancellationToken.None);
 
         var service = CreateService();
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             service.PreviewChangeTypeNamespaceAsync(
                 wsId,
                 typeName: "Dog",
@@ -238,7 +238,7 @@ public sealed class NamespaceRelocationTests : IsolatedWorkspaceTestBase
 
         // An absolute path outside the project directory must be rejected.
         var outsidePath = Path.Combine(Path.GetTempPath(), "Widget.cs");
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             service.PreviewChangeTypeNamespaceAsync(
                 wsId,
                 typeName: "Widget",

--- a/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
+++ b/tests/RoslynMcp.Tests/NegativeEdgeCaseTests.cs
@@ -21,7 +21,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
     [TestMethod]
     public void InvalidWorkspaceId_ThrowsKeyNotFoundException()
     {
-        Assert.ThrowsException<KeyNotFoundException>(() =>
+        Assert.ThrowsExactly<KeyNotFoundException>(() =>
             WorkspaceManager.GetStatus("nonexistent-workspace-id"));
     }
 
@@ -29,7 +29,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
     public async Task MalformedSymbolHandle_InvalidBase64_ThrowsArgumentException()
     {
         var locator = SymbolLocator.ByHandle("not-valid-base64!!!");
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
         StringAssert.Contains(ex.Message, "base64", StringComparison.OrdinalIgnoreCase);
     }
@@ -39,7 +39,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
     {
         var handle = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("this is not json"));
         var locator = SymbolLocator.ByHandle(handle);
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
         StringAssert.Contains(ex.Message, "JSON", StringComparison.OrdinalIgnoreCase);
     }
@@ -48,7 +48,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
     public void SymbolLocator_NoFields_ThrowsArgumentException()
     {
         var locator = new SymbolLocator(null, null, null, null, null);
-        Assert.ThrowsException<ArgumentException>(() => locator.Validate());
+        Assert.ThrowsExactly<ArgumentException>(() => locator.Validate());
     }
 
     [TestMethod]
@@ -70,7 +70,7 @@ public sealed class NegativeEdgeCaseTests : SharedWorkspaceTestBase
             .Documents.First(d => d.FilePath?.EndsWith(".cs") == true);
 
         var locator = SymbolLocator.BySource(doc.FilePath!, -1, -1);
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             SymbolNavigationService.GoToDefinitionAsync(WorkspaceId, locator, CancellationToken.None));
         StringAssert.Contains(ex.Message, "out of range");
     }

--- a/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/OrchestrationIntegrationTests.cs
@@ -129,7 +129,7 @@ public sealed class OrchestrationIntegrationTests : IsolatedWorkspaceTestBase
         // `<PackageVersion Include="Legacy.NotPresent">` entry exists either.
         await workspace.LoadAsync(CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             PackageMigrationOrchestrator.PreviewMigratePackageAsync(
                 workspace.WorkspaceId,
                 "Legacy.NotPresent",
@@ -492,7 +492,7 @@ public sealed class OrchestrationIntegrationTests : IsolatedWorkspaceTestBase
         await workspace.LoadAsync(CancellationToken.None);
 
         // Attempting to extract IAnimalService again must produce a structured rejection.
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ExtractAndWireOrchestrator.PreviewExtractAndWireInterfaceAsync(
                 workspace.WorkspaceId,
                 sourceFilePath,

--- a/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
+++ b/tests/RoslynMcp.Tests/P4BehavioralBundleTests.cs
@@ -190,7 +190,7 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
     public async Task EvaluateMsBuildProperty_UnknownProject_ErrorListsLoadedProjects()
     {
         // Unknown project name must surface a loaded-projects list in the error.
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await MsBuildEvaluationService.EvaluatePropertyAsync(
                 WorkspaceId,
                 projectName: "DoesNotExist.Xyz",
@@ -205,7 +205,7 @@ public sealed class P4BehavioralBundleTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task EvaluateMsBuildProperty_EmptyProject_ThrowsArgumentExceptionWithExample()
     {
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await MsBuildEvaluationService.EvaluatePropertyAsync(
                 WorkspaceId,
                 projectName: "",

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -113,7 +113,7 @@ public sealed class ParameterObjectPreviewTests : TestBase
 
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
                 ParameterObjectService.PreviewParameterObjectAsync(
                     workspaceId,
                     SymbolLocator.BySource(fixturePath, line: 5, column: 16),
@@ -145,7 +145,7 @@ public sealed class ParameterObjectPreviewTests : TestBase
 
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 ParameterObjectService.PreviewParameterObjectAsync(
                     workspaceId,
                     SymbolLocator.BySource(fixturePath, line: 5, column: 17),
@@ -243,7 +243,7 @@ public sealed class ParameterObjectPreviewTests : TestBase
         var workspaceId = loadResult.WorkspaceId;
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 ParameterObjectService.PreviewParameterObjectAsync(
                     workspaceId,
                     SymbolLocator.BySource(libFile, line: 5, column: 16),

--- a/tests/RoslynMcp.Tests/ParameterValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterValidationTests.cs
@@ -21,7 +21,7 @@ public class ParameterValidationTests
 
     [TestMethod]
     public void ValidateSeverity_Invalid_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidateSeverity("Critical"));
 
     [TestMethod]
@@ -40,7 +40,7 @@ public class ParameterValidationTests
 
     [TestMethod]
     public void ValidateTypeKind_Invalid_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidateTypeKind("struct"));
 
     // ── ValidateBulkReplaceScope ──
@@ -58,7 +58,7 @@ public class ParameterValidationTests
 
     [TestMethod]
     public void ValidateBulkReplaceScope_Invalid_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidateBulkReplaceScope("none"));
 
     // ── ValidatePagination ──
@@ -69,17 +69,17 @@ public class ParameterValidationTests
 
     [TestMethod]
     public void ValidatePagination_Negative_Offset_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidatePagination(-1, 50));
 
     [TestMethod]
     public void ValidatePagination_Zero_Limit_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidatePagination(0, 0));
 
     [TestMethod]
     public void ValidatePagination_Negative_Limit_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidatePagination(0, -5));
 
     [TestMethod]
@@ -88,6 +88,6 @@ public class ParameterValidationTests
 
     [TestMethod]
     public void ValidatePagination_Limit_Above_Max_Throws()
-        => Assert.ThrowsException<ArgumentException>(
+        => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidatePagination(0, 1001));
 }

--- a/tests/RoslynMcp.Tests/PositionProbeTests.cs
+++ b/tests/RoslynMcp.Tests/PositionProbeTests.cs
@@ -170,7 +170,7 @@ public sealed class PositionProbeTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task ProbePosition_LineOutOfRange_Throws()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             SymbolNavigationService.ProbePositionAsync(
                 _workspaceId, _animalServicePath, line: 99_999, column: 1, CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/PragmaScopeManipulationTests.cs
+++ b/tests/RoslynMcp.Tests/PragmaScopeManipulationTests.cs
@@ -394,11 +394,11 @@ public sealed class PragmaScopeManipulationTests : IsolatedWorkspaceTestBase
     public async Task VerifyPragmaSuppresses_Throws_OnBadArgs()
     {
         var sut = CreateService();
-        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() =>
             sut.VerifyPragmaSuppressesAsync("ws", "/tmp/a.cs", 0, "CS0219", CancellationToken.None));
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.VerifyPragmaSuppressesAsync("ws", "/tmp/a.cs", 1, " ", CancellationToken.None));
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.VerifyPragmaSuppressesAsync("ws", " ", 1, "CS0219", CancellationToken.None));
     }
 
@@ -406,11 +406,11 @@ public sealed class PragmaScopeManipulationTests : IsolatedWorkspaceTestBase
     public async Task PragmaScopeWiden_Throws_OnBadArgs()
     {
         var sut = CreateService();
-        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() =>
             sut.WidenPragmaScopeAsync("ws", "/tmp/a.cs", 0, "CS0219", CancellationToken.None));
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.WidenPragmaScopeAsync("ws", "/tmp/a.cs", 1, " ", CancellationToken.None));
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.WidenPragmaScopeAsync("ws", " ", 1, "CS0219", CancellationToken.None));
     }
 }

--- a/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
@@ -44,7 +44,7 @@ public sealed class PreviewMultiFileEditSyntaxRegressionTests : IsolatedWorkspac
                 new[] { new TextEditDto(1, colAfterLine1, 1, colAfterLine1, "\n// F17\n{\n") }),
         };
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
         {
             await edit.PreviewMultiFileTextEditsAsync(
                 workspaceId, fileEdits, CancellationToken.None, skipSyntaxCheck: false);

--- a/tests/RoslynMcp.Tests/PreviewStoreTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewStoreTests.cs
@@ -210,7 +210,7 @@ public class PreviewStoreTests
         var solution = workspace.CurrentSolution;
         _store.Store("workspace-1", solution, 1, "test");
 
-        Assert.ThrowsException<ArgumentNullException>(() => _store.InvalidateOnVersionBump(null!, 1));
-        Assert.ThrowsException<ArgumentException>(() => _store.InvalidateOnVersionBump(string.Empty, 1));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _store.InvalidateOnVersionBump(null!, 1));
+        Assert.ThrowsExactly<ArgumentException>(() => _store.InvalidateOnVersionBump(string.Empty, 1));
     }
 }

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -89,7 +89,7 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
 
-        var selfReference = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var selfReference = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ProjectMutationService.PreviewAddProjectReferenceAsync(
                 workspace.WorkspaceId,
                 new AddProjectReferenceDto("SampleLib", "SampleLib"),
@@ -99,7 +99,7 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
 
         // SampleApp already references SampleLib in the fixture. Adding the reverse edge
         // SampleLib -> SampleApp would create a two-project cycle.
-        var cycle = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var cycle = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ProjectMutationService.PreviewAddProjectReferenceAsync(
                 workspace.WorkspaceId,
                 new AddProjectReferenceDto("SampleLib", "SampleApp"),
@@ -504,7 +504,7 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
         // as a PackageReference for every project, so it acts as the "transitive-present" repro.
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ProjectMutationService.PreviewAddPackageReferenceAsync(
                 workspace.WorkspaceId,
                 new AddPackageReferenceDto("SampleLib", "Microsoft.CodeAnalysis.NetAnalyzers", "10.0.100"),
@@ -562,7 +562,7 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
         // Pass a condition that omits MSBuild-style single-quoting (the common first-time caller mistake).
         const string invalidCondition = "$(Configuration) == Release";
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ProjectMutationService.PreviewSetConditionalPropertyAsync(
                 workspace.WorkspaceId,
                 new SetConditionalPropertyDto("SampleLib", "LangVersion", "preview", invalidCondition),

--- a/tests/RoslynMcp.Tests/PromptSmokeTests.cs
+++ b/tests/RoslynMcp.Tests/PromptSmokeTests.cs
@@ -55,7 +55,7 @@ public sealed class PromptSmokeTests : SharedWorkspaceTestBase
         StringAssert.Contains(text, "server");
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("navigation")]
     [DataRow("refactoring")]
     [DataRow("testing")]

--- a/tests/RoslynMcp.Tests/RecordFieldAdditionImpactTests.cs
+++ b/tests/RoslynMcp.Tests/RecordFieldAdditionImpactTests.cs
@@ -221,7 +221,7 @@ public static class NonPositionalRecordConsumer
         // should know they invoked the wrong tool.
         var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
             await RecordFieldAdditionService.PreviewAdditionAsync(
                 workspaceId,
                 recordMetadataName: "SampleLib.Dog",
@@ -239,7 +239,7 @@ public static class NonPositionalRecordConsumer
         // typos.
         var workspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
 
-        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await RecordFieldAdditionService.PreviewAdditionAsync(
                 workspaceId,
                 recordMetadataName: "SampleLib.NoSuchRecordType",

--- a/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringToolsIntegrationTests.cs
@@ -71,7 +71,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var locator = SymbolLocator.BySource(filePath, 7, 26);
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             RefactoringService.PreviewRenameAsync(WorkspaceId, locator, "2foo", CancellationToken.None));
         StringAssert.Contains(ex.Message, "is not a valid C# identifier");
     }
@@ -81,7 +81,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var locator = SymbolLocator.BySource(filePath, 7, 26);
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             RefactoringService.PreviewRenameAsync(WorkspaceId, locator, "class", CancellationToken.None));
         StringAssert.Contains(ex.Message, "reserved C# keyword");
     }
@@ -91,7 +91,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var locator = SymbolLocator.BySource(filePath, 7, 26);
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             RefactoringService.PreviewRenameAsync(WorkspaceId, locator, "var", CancellationToken.None));
         StringAssert.Contains(ex.Message, "contextual C# keyword");
     }
@@ -112,7 +112,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
     {
         var filePath = FindDocumentPath("AnimalService.cs");
         var locator = SymbolLocator.BySource(filePath, 7, 26);
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             RefactoringService.PreviewRenameAsync(WorkspaceId, locator, string.Empty, CancellationToken.None));
         StringAssert.Contains(ex.Message, "is required");
     }
@@ -133,7 +133,7 @@ public sealed class RefactoringToolsIntegrationTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task RenamePreview_BareMemberMetadataName_Returns_Targeting_Guidance()
     {
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             RefactoringService.PreviewRenameAsync(
                 WorkspaceId,
                 SymbolLocator.ByMetadataName("GetAllAnimals"),

--- a/tests/RoslynMcp.Tests/ReplaceInvocationTests.cs
+++ b/tests/RoslynMcp.Tests/ReplaceInvocationTests.cs
@@ -142,7 +142,7 @@ public sealed class ReplaceInvocationTests : SharedWorkspaceTestBase
 
         try
         {
-            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 BulkRefactoringService.PreviewReplaceInvocationAsync(
                     loadResult.WorkspaceId,
                     oldMethod: "SampleLib.ReplaceInvocationHelper.Build",
@@ -190,7 +190,7 @@ public sealed class ReplaceInvocationTests : SharedWorkspaceTestBase
 
         try
         {
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
                 BulkRefactoringService.PreviewReplaceInvocationAsync(
                     loadResult.WorkspaceId,
                     oldMethod: "SampleLib.ReplaceInvocationMismatch.OldFn(int, int)",
@@ -218,7 +218,7 @@ public sealed class ReplaceInvocationTests : SharedWorkspaceTestBase
 
         try
         {
-            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 BulkRefactoringService.PreviewReplaceInvocationAsync(
                     loadResult.WorkspaceId,
                     oldMethod: "SampleLib.ReplaceInvocationHelper.Build(int, string, bool)",

--- a/tests/RoslynMcp.Tests/RestructureServiceTests.cs
+++ b/tests/RoslynMcp.Tests/RestructureServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class RestructureServiceTests : SharedWorkspaceTestBase
         // Pattern captures __items__; goal references a second placeholder __count__ that was
         // never captured. Pre-fix this produced output containing literal `__count__` text;
         // now the service rejects the preview before touching the solution.
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             Service.PreviewRestructureAsync(
                 WorkspaceId,
                 pattern: "return __items__;",
@@ -52,7 +52,7 @@ public sealed class RestructureServiceTests : SharedWorkspaceTestBase
         // Canonical R17A shape: pattern has NO placeholders, goal has one. Pre-fix
         // `_placeholderNames.Count == 0` short-circuited Substitute and the goal's literal
         // `__x__` text was emitted verbatim. Now the mismatch is rejected at validation.
-        var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             Service.PreviewRestructureAsync(
                 WorkspaceId,
                 pattern: "42",
@@ -71,7 +71,7 @@ public sealed class RestructureServiceTests : SharedWorkspaceTestBase
         // validation must not break this case. The scope filter points at a file that does
         // not contain the pattern so we expect the "no matches" exception, NOT the orphaned
         // placeholder one — proves the validation path accepted the pattern/goal.
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             Service.PreviewRestructureAsync(
                 WorkspaceId,
                 pattern: "42",

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -90,7 +90,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(File.Exists(destinationPath),
             $"Test precondition violated: '{destinationPath}' must exist for this scenario.");
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
                 workspace.WorkspaceId,
                 new ScaffoldFirstTestFileDto("SampleLib.AnimalService", "SampleLib.Tests"),
@@ -141,7 +141,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
         // namespace.
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
                 workspace.WorkspaceId,
                 new ScaffoldFirstTestFileDto("SampleLib.NoSuchService", "SampleLib.Tests"),
@@ -232,7 +232,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
             await RestoreWorkspaceAsync(workspace, CancellationToken.None);
             await workspace.LoadAsync(CancellationToken.None);
 
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
                 ScaffoldingService.PreviewScaffoldFirstTestFileAsync(
                     workspace.WorkspaceId,
                     new ScaffoldFirstTestFileDto(

--- a/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
+++ b/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
@@ -287,7 +287,7 @@ public sealed class ScriptingServiceTests
         cts.CancelAfter(TimeSpan.FromMilliseconds(500));
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () =>
             await service.EvaluateAsync("while(true){}", null, cts.Token, null, 30).ConfigureAwait(false))
             .ConfigureAwait(false);
         sw.Stop();

--- a/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
@@ -102,7 +102,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task SemanticGrep_InvalidScope_Throws()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
             () => SemanticGrepService.SearchAsync(
                 WorkspaceId, @"x", "definitely-not-a-scope", projectFilter: null, limit: 10, CancellationToken.None));
     }
@@ -110,7 +110,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task SemanticGrep_EmptyPattern_Throws()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
             () => SemanticGrepService.SearchAsync(
                 WorkspaceId, "", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
     }
@@ -118,7 +118,7 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task SemanticGrep_InvalidRegex_Throws()
     {
-        await Assert.ThrowsExceptionAsync<ArgumentException>(
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
             () => SemanticGrepService.SearchAsync(
                 WorkspaceId, "(unclosed", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/NavigationToolsNotFoundMessageTests.cs
@@ -41,7 +41,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await AnalysisTools.GetCallersCallees(
                 WorkspaceExecutionGate,
                 SymbolRelationshipService,
@@ -68,7 +68,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<SymbolNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<SymbolNotFoundException>(async () =>
             await AnalysisTools.AnalyzeImpact(
                 WorkspaceExecutionGate,
                 MutationAnalysisService,
@@ -98,7 +98,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<SymbolNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<SymbolNotFoundException>(async () =>
             await ConsumerAnalysisTools.FindConsumers(
                 WorkspaceExecutionGate,
                 ConsumerAnalysisService,
@@ -126,7 +126,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         var bogusFile = Path.Combine(Path.GetTempPath(), "definitely_not_in_workspace.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await SymbolTools.GetSymbolRelationships(
                 WorkspaceExecutionGate,
                 SymbolRelationshipService,
@@ -161,7 +161,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await SymbolTools.GetMemberHierarchy(
                 WorkspaceExecutionGate,
                 SymbolRelationshipService,
@@ -188,7 +188,7 @@ public sealed class NavigationToolsNotFoundMessageTests : SharedWorkspaceTestBas
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await SymbolTools.GetSignatureHelp(
                 WorkspaceExecutionGate,
                 SymbolRelationshipService,

--- a/tests/RoslynMcp.Tests/Services/SymbolInfoNotFoundMessageTests.cs
+++ b/tests/RoslynMcp.Tests/Services/SymbolInfoNotFoundMessageTests.cs
@@ -39,7 +39,7 @@ public sealed class SymbolInfoNotFoundMessageTests : SharedWorkspaceTestBase
     {
         const string bogusName = "SampleLib.DefinitelyDoesNotExist__Bogus";
 
-        var ex = await Assert.ThrowsExceptionAsync<SymbolNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<SymbolNotFoundException>(async () =>
             await SymbolTools.GetSymbolInfo(
                 WorkspaceExecutionGate,
                 SymbolSearchService,
@@ -70,7 +70,7 @@ public sealed class SymbolInfoNotFoundMessageTests : SharedWorkspaceTestBase
         // value is deterministic across machines.
         var bogusFile = Path.Combine(Path.GetTempPath(), "definitely_not_in_workspace.cs");
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await SymbolTools.GetSymbolInfo(
                 WorkspaceExecutionGate,
                 SymbolSearchService,
@@ -109,7 +109,7 @@ public sealed class SymbolInfoNotFoundMessageTests : SharedWorkspaceTestBase
         // reaches the SymbolTools.cs throw site we're testing.
         var validButMissingHandle = EncodeHandle("SampleLib.DefinitelyMissingType_Bogus");
 
-        var ex = await Assert.ThrowsExceptionAsync<KeyNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
             await SymbolTools.GetSymbolInfo(
                 WorkspaceExecutionGate,
                 SymbolSearchService,
@@ -152,7 +152,7 @@ public sealed class SymbolInfoNotFoundMessageTests : SharedWorkspaceTestBase
         // input but MUST contain a leading prefix and the truncation marker.
         var hugeName = "SampleLib.Bogus_" + new string('X', 2000);
 
-        var ex = await Assert.ThrowsExceptionAsync<SymbolNotFoundException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<SymbolNotFoundException>(async () =>
             await SymbolTools.GetSymbolInfo(
                 WorkspaceExecutionGate,
                 SymbolSearchService,

--- a/tests/RoslynMcp.Tests/StringLiteralReplaceServiceTests.cs
+++ b/tests/RoslynMcp.Tests/StringLiteralReplaceServiceTests.cs
@@ -61,7 +61,7 @@ public sealed class StringLiteralReplaceServiceTests : SharedWorkspaceTestBase
         // Guard that the zero-match relaxation didn't weaken input validation. A caller
         // passing an empty replacements array is a programming error, distinct from a
         // well-formed replacement that simply doesn't match anything in scope.
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             Service.PreviewReplaceAsync(
                 WorkspaceId,
                 replacements: Array.Empty<StringLiteralReplacementDto>(),

--- a/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
@@ -13,7 +13,7 @@ public sealed class SuppressionServiceTests
     public async Task SetDiagnosticSeverityAsync_Throws_WhenDiagnosticId_Missing()
     {
         var sut = new SuppressionService(new StubEditorConfig(), new StubEditService());
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.SetDiagnosticSeverityAsync("ws", " ", "warning", "/tmp/a.cs", CancellationToken.None));
     }
 
@@ -21,7 +21,7 @@ public sealed class SuppressionServiceTests
     public async Task AddPragmaWarningDisableAsync_Throws_WhenLine_NotPositive()
     {
         var sut = new SuppressionService(new StubEditorConfig(), new StubEditService());
-        await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() =>
             sut.AddPragmaWarningDisableAsync("ws", "/tmp/a.cs", 0, "CS0168", CancellationToken.None));
     }
 
@@ -29,7 +29,7 @@ public sealed class SuppressionServiceTests
     public async Task AddPragmaWarningDisableAsync_Throws_WhenDiagnosticId_Missing()
     {
         var sut = new SuppressionService(new StubEditorConfig(), new StubEditService());
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             sut.AddPragmaWarningDisableAsync("ws", "/tmp/a.cs", 1, " ", CancellationToken.None));
     }
 

--- a/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestCoverageFailureEnvelopeTests.cs
@@ -158,7 +158,7 @@ public sealed class TestCoverageFailureEnvelopeTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
             TestCoverageTools.RunTestCoverageCore(
                 gate,
                 workspace,

--- a/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
+++ b/tests/RoslynMcp.Tests/TestReferenceMapServiceTests.cs
@@ -129,7 +129,7 @@ public sealed class TestReferenceMapServiceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task BuildAsync_ProjectName_UnknownName_Throws()
     {
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             Service.BuildAsync(
                 WorkspaceId, projectName: "DefinitelyNotARealProject", offset: 0, limit: 10,
                 maxMockDriftWarnings: DefaultMaxMockDriftWarnings, CancellationToken.None));

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -66,7 +66,7 @@ public sealed class ToolDispatchTests
         var gate = new FakeGate();
         var store = new FakePreviewStore(token: "real-token", workspaceId: "ws-x");
 
-        var ex = await Assert.ThrowsExceptionAsync<PreviewTokenStaleException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<PreviewTokenStaleException>(() =>
             ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
                 gate,
                 store,

--- a/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V3RegressionTests.cs
@@ -48,7 +48,7 @@ public sealed class Top10V3RegressionTests : IsolatedWorkspaceTestBase
 
     // ── symbol-search-empty-query-overflow: guard empty/whitespace queries ──
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("")]
     [DataRow(" ")]
     [DataRow("\t")]

--- a/tests/RoslynMcp.Tests/TypeConsumersServiceTests.cs
+++ b/tests/RoslynMcp.Tests/TypeConsumersServiceTests.cs
@@ -77,7 +77,7 @@ public sealed class TypeConsumersServiceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task FindTypeConsumers_NonExistentType_ThrowsKeyNotFound()
     {
-        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(
             () => TypeConsumersService.FindTypeConsumersAsync(
                 WorkspaceId, "SampleLib.DefinitelyNotAType", limit: 100, CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -180,7 +180,7 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
 
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 TypeExtractionTools.PreviewExtractType(
                     session.Server,
                     WorkspaceExecutionGate,
@@ -245,7 +245,7 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
 
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
                 TypeExtractionService.PreviewExtractTypeAsync(
                     wsId, sourcePath, "ExternalConsumerFixture", ["Compute"], "ComputeHelper", null, CancellationToken.None));
 
@@ -311,7 +311,7 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
 
-        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             TypeExtractionService.PreviewExtractTypeAsync(
                 wsId, doc.FilePath!, "AnimalService", [], "NewType", null, CancellationToken.None));
     }
@@ -326,7 +326,7 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
 
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeExtractionService.PreviewExtractTypeAsync(
                 wsId, doc.FilePath!, "NonExistentType", ["Foo"], "NewType", null, CancellationToken.None));
     }

--- a/tests/RoslynMcp.Tests/TypeMoveTests.cs
+++ b/tests/RoslynMcp.Tests/TypeMoveTests.cs
@@ -74,7 +74,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
 
         try
         {
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
                 TypeMoveTools.PreviewMoveTypeToFile(
                     session.Server,
                     WorkspaceExecutionGate,
@@ -125,7 +125,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("Dog.cs") == true);
 
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeMoveService.PreviewMoveTypeToFileAsync(
                 wsId, doc.FilePath!, "Dog", null, CancellationToken.None));
     }
@@ -143,7 +143,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("Dog.cs") == true);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeMoveService.PreviewMoveTypeToFileAsync(
                 wsId, doc.FilePath!, "Dog", null, CancellationToken.None));
 
@@ -163,7 +163,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
 
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeMoveService.PreviewMoveTypeToFileAsync(
                 wsId, doc.FilePath!, "NonExistentType", null, CancellationToken.None));
     }
@@ -184,7 +184,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeMoveService.PreviewMoveTypeToFileAsync(
                 wsId, doc.FilePath!, "IngestionTerminalStatus", null, CancellationToken.None));
 
@@ -209,7 +209,7 @@ public sealed class TypeMoveTests : IsolatedWorkspaceTestBase
             .Projects.SelectMany(p => p.Documents)
             .First(d => d.FilePath?.EndsWith("Cat.cs") == true);
 
-        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
             TypeMoveService.PreviewMoveTypeToFileAsync(
                 wsId, doc.FilePath!, "NotificationHandler", null, CancellationToken.None));
 

--- a/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
@@ -338,7 +338,7 @@ public sealed class ValidateRecentGitChangesTests : IsolatedWorkspaceTestBase
             candidate.Message.Contains(process.Id.ToString(), StringComparison.Ordinal) &&
             ReferenceEquals(candidate.Exception, killException));
 
-        Assert.IsNotNull(entry,
+        Assert.AreNotEqual(default, entry,
             "A git kill failure must be observable at Warning level with the process id; "
             + $"got [{string.Join("; ", logger.Entries.Select(e => $"{e.Level}:{e.Message}"))}].");
     }

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -141,7 +141,7 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
             symbolHandle: null,
             ct: CancellationToken.None);
         using var doc = JsonDocument.Parse(json);
-        Assert.IsNotNull(doc.RootElement);
+        Assert.AreEqual(JsonValueKind.Object, doc.RootElement.ValueKind);
     }
 
     // test-related-empty-for-valid-symbol: an interface MEMBER whose implementations are

--- a/tests/RoslynMcp.Tests/WorkflowRecommendationToolsTests.cs
+++ b/tests/RoslynMcp.Tests/WorkflowRecommendationToolsTests.cs
@@ -6,7 +6,7 @@ namespace RoslynMcp.Tests;
 [TestClass]
 public sealed class WorkflowRecommendationToolsTests
 {
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("find callers of AnimalService.CountAnimals", "find_references", "rg")]
     [DataRow("show a file outline", "document_symbols", "reading the entire file")]
     [DataRow("quick compile sanity after an edit", "compile_check", "dotnet build")]

--- a/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
@@ -102,7 +102,7 @@ public sealed class WorkspaceCapLruEvictionTests
                 "First workspace must be tracked (sanity).");
 
             // Strict load: must throw because the cap is full.
-            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
                 () => manager.LoadAsync(path2, EvictPolicy.Strict, CancellationToken.None));
 
             // Message must carry activeWorkspaces JSON and lruCandidate for self-recovery.

--- a/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
@@ -52,7 +52,7 @@ public sealed class WorkspaceIdOptionalSurfaceTests
         // must throw a structured ArgumentException (the filter classifies it to InvalidArgument)
         // pointing the caller at workspace_load — not NRE on the downstream gate call. The guard
         // runs before any service is touched, so null DI args are safe here.
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
             SymbolTools.GetDocumentSymbols(server: null!, gate: null!, symbolSearchService: null!, workspaceId: null));
 
         Assert.AreEqual("workspaceId", ex.ParamName);
@@ -67,7 +67,7 @@ public sealed class WorkspaceIdOptionalSurfaceTests
         // pagination validations pass for the defaults (severity=null, offset=0, limit=50), so the
         // null-workspaceId case reaches RequireResolvedWorkspaceId before any service or gate is
         // touched — null DI args are safe here.
-        var ex = Assert.ThrowsException<ArgumentException>(() =>
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
             CompileCheckTools.CompileCheck(gate: null!, compileCheckService: null!, workspaceId: null));
 
         Assert.AreEqual("workspaceId", ex.ParamName);

--- a/tests/RoslynMcp.Tests/WorkspaceManagerEvictionTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceManagerEvictionTests.cs
@@ -110,7 +110,7 @@ public sealed class WorkspaceManagerEvictionTests
             // Direct exception assertion — manager throws WorkspaceEvictedException, the
             // most-specific shape consumers can branch on without going through the
             // ToolErrorHandler dictionary.
-            var ex = Assert.ThrowsException<WorkspaceEvictedException>(() =>
+            var ex = Assert.ThrowsExactly<WorkspaceEvictedException>(() =>
                 manager.GetStatus(status.WorkspaceId));
 
             Assert.AreEqual(status.WorkspaceId, ex.WorkspaceId,
@@ -239,7 +239,7 @@ public sealed class WorkspaceManagerEvictionTests
         // recycled, so this is unambiguously a recycle eviction (the prior process
         // owned the now-missing id).
         const string priorWorkspaceId = "abc123def456ghi789";
-        var ex = Assert.ThrowsException<WorkspaceEvictedException>(() =>
+        var ex = Assert.ThrowsExactly<WorkspaceEvictedException>(() =>
             manager.GetStatus(priorWorkspaceId));
 
         Assert.AreEqual(priorWorkspaceId, ex.WorkspaceId);
@@ -265,7 +265,7 @@ public sealed class WorkspaceManagerEvictionTests
         using var manager = CreateManager();
 
         const string typoedWorkspaceId = "this-id-was-never-issued";
-        var ex = Assert.ThrowsException<KeyNotFoundException>(() =>
+        var ex = Assert.ThrowsExactly<KeyNotFoundException>(() =>
             manager.GetStatus(typoedWorkspaceId));
 
         Assert.IsFalse(ex is WorkspaceEvictedException,
@@ -300,7 +300,7 @@ public sealed class WorkspaceManagerEvictionTests
                 "LoadAsync must return a non-empty id (sanity).");
 
             const string typoedId = "still-a-typo-because-there-is-a-live-session";
-            var ex = Assert.ThrowsException<KeyNotFoundException>(() =>
+            var ex = Assert.ThrowsExactly<KeyNotFoundException>(() =>
                 manager.GetStatus(typoedId));
             Assert.IsFalse(ex is WorkspaceEvictedException,
                 "When a live session exists in the current process, a miss is a typo " +

--- a/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
@@ -145,7 +145,7 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetSourceFile_Resource_Rejects_Relative_Path()
     {
-        var ex = await Assert.ThrowsExceptionAsync<McpToolException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<McpToolException>(() =>
             WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, "AnimalService.cs", CancellationToken.None));
         StringAssert.Contains(ex.Message, "Invalid operation");
         StringAssert.Contains(ex.Message, "absolute path");

--- a/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
@@ -305,7 +305,7 @@ public sealed class WorkspaceToolsIntegrationTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task WorkspaceExecutionGate_Rejects_Unknown_Workspace_Id()
     {
-        await Assert.ThrowsExceptionAsync<KeyNotFoundException>(() =>
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
             WorkspaceExecutionGate.RunReadAsync(
                 "ffffffffffffffffffffffffffffffff",
                 _ => Task.FromResult("x"),

--- a/tests/RoslynMcp.Tests/WorkspaceValidationTimeoutTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationTimeoutTests.cs
@@ -132,7 +132,7 @@ public sealed class WorkspaceValidationTimeoutTests : IsolatedWorkspaceTestBase
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
-        // ThrowsExceptionAsync<OperationCanceledException> is strict-typed and rejects the
+        // ThrowsExactlyAsync<OperationCanceledException> is strict-typed and rejects the
         // TaskCanceledException subclass that Task.Delay actually throws. Catch the base
         // class manually so subclass-vs-base differences don't fail the assertion.
         OperationCanceledException? caught = null;


### PR DESCRIPTION
Unblocks every open dependabot MSTest PR (#1062, #1061, #1058, #1000): newer MSTest analyzers turn MSTEST0039/0044/0032 into build errors under warnings-as-errors, and MSTest 4.x removes `Assert.ThrowsExceptionAsync` (CS0117).

- `Assert.ThrowsExceptionAsync` → `Assert.ThrowsExactlyAsync` — 129 sites / 53 files
- `Assert.ThrowsException<T>` → `Assert.ThrowsExactly<T>` — 28 sites / 9 files
- `[DataTestMethod]` → `[TestMethod]` — 4 sites
- 3 MSTEST0032 tautologies strengthened (value-tuple `IsNotNull` → `AreNotEqual(default, …)`, `JsonElement` `IsNotNull` → `ValueKind == Object`)

`ThrowsExactly`/`ThrowsExactlyAsync` exist at the current 3.8.3 pin with identical exact-type-match semantics (verified against the 3.8.3 XML docs; 7 files already used them), so this is safe to land before any version bump. `TestDiscoveryService.cs:1027`'s legacy-attribute recognition list intentionally untouched — it must keep recognizing `DataTestMethod` in analyzed user code.

Verified: full test-project compile (the exact gate dependabot fails) + 47 tests across the manually-fixed and sampled renamed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)