### PR TITLE
fix(ci): repair weekly ubuntu ai-docs validation dead since 2026-05-18

### DIFF
--- a/.claude/skills/reconcile-backlog-vs-issues/SKILL.md
+++ b/.claude/skills/reconcile-backlog-vs-issues/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[--stale-days N] (default 60) — threshold for the reserved-sta
 You audit `ai_docs/backlog.md` against live GitHub Issue state. The backlog references Issues two ways:
 
 1. **Reserved rows** — `**Reserved — [gh #NNN](https://github.com/<owner>/<repo>/issues/NNN) (good first issue); skip in sweeps until contributor pickup.**` — these rows are parked for outside contributors; sweeps must skip them.
-2. **Tracked-only rows** — `[gh #NNN](...)` somewhere in the `do` cell with no Reserved marker — the backlog row is the canonical work item, the Issue is just a public mirror.
+2. **Tracked-only rows** — `[gh #NNN]({issue-url})` somewhere in the `do` cell with no Reserved marker — the backlog row is the canonical work item, the Issue is just a public mirror.
 
 When PRs merge, Issues close, contributors abandon, or labels drift, the two sides desynchronize. This skill walks every `[gh #NNN]` reference, queries `gh issue view N`, classifies the result, and emits a triage report. **It does not mutate `backlog.md` or any Issue** — the maintainer applies recommendations manually (or via `/close-backlog-rows` for the easy cases).
 

--- a/changelog.d/ai-docs-linux-link-validation.md
+++ b/changelog.d/ai-docs-linux-link-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** The weekly hosted-ubuntu CI lane (coverage + artifact freshness) had been failing silently since 2026-05-18 at `verify-ai-docs.ps1`: a literal `](...)` ellipsis link in a skill doc resolves under Windows path normalization (so self-hosted PR runs passed) but is a plain missing filename on Linux. The doc now uses the `{braces}` placeholder convention, and the verifier flags all-dot link targets on every platform so PR CI catches this class before the weekly run does.

--- a/eng/verify-ai-docs.ps1
+++ b/eng/verify-ai-docs.ps1
@@ -69,6 +69,16 @@ foreach ($file in $markdownFiles) {
             continue
         }
 
+        # All-dot targets like `(...)` are ellipsis placeholders, never real paths. Windows
+        # path normalization makes Test-Path resolve them (so the self-hosted PR runs passed)
+        # while Linux treats them as a plain missing filename (so every hosted-ubuntu run
+        # failed) — flag them on every platform so PR CI catches what the weekly run would.
+        # Intentional placeholder links must use the {braces} convention skipped above.
+        if ($pathPart -match '^\.{3,}[/\\]?$') {
+            $issues.Add("Broken relative link (all-dot placeholder; use {braces} instead): $($file.FullName) -> $target")
+            continue
+        }
+
         if ($pathPart -match '^[a-zA-Z]:\\') {
             if (-not (Test-Path -LiteralPath $pathPart)) {
                 $issues.Add("Broken absolute link: $($file.FullName) -> $target")


### PR DESCRIPTION
Every weekly hosted-ubuntu schedule run since 2026-05-18 (nine runs) failed in ~20s at `Validate AI docs`, killing the coverage/artifact lane — silently, because nothing watches the weekly run.

Root cause: `.claude/skills/reconcile-backlog-vs-issues/SKILL.md` documents a backlog row pattern with a literal `[gh #NNN](...)` link. `Test-Path '...'` resolves under Windows path normalization (so the self-hosted PR runs that gate merges all passed) but `...` is a plain missing filename on Linux.

- Doc now uses the verifier's `{braces}` placeholder convention: `[gh #NNN]({issue-url})`.
- `verify-ai-docs.ps1` now flags all-dot link targets on **every** platform, so the Windows PR gate catches this class instead of leaving it to the weekly Linux run.

Verified locally: hardened script reproduces the exact ubuntu failure on Windows against the unfixed doc, passes after the doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)