### PR TITLE
fix(suppression): log unreadable-file fallbacks

### DIFF
--- a/changelog.d/build-test-services-swallowed-exceptions-no-logging.md
+++ b/changelog.d/build-test-services-swallowed-exceptions-no-logging.md
@@ -3,3 +3,4 @@ category: Fixed
 ---
 
 - **Fixed:** `ScaffoldingService`, `EditorConfigService`, and `MsBuildEvaluationService` now accept an optional `ILogger<T>` and log previously-silent fallback paths (malformed project-file parses defaulting to mstest / allowing non-test projects through; disk-sourced `.editorconfig` overrides; project-not-found resolution) instead of swallowing the underlying exception with no diagnostic trail.
+- **Fixed:** Wired SuppressionService to structured logging and made unreadable-file pragma and line-ending fallbacks observable without changing edit or cancellation behavior.

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -80,7 +80,8 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<IEditorConfigService>(),
             sp.GetRequiredService<IEditService>(),
             sp.GetRequiredService<IWorkspaceManager>(),
-            sp.GetRequiredService<ICompileCheckService>()));
+            sp.GetRequiredService<ICompileCheckService>(),
+            sp.GetRequiredService<ILogger<SuppressionService>>()));
         services.AddSingleton<ICodePatternAnalyzer, CodePatternAnalyzer>();
         services.AddSingleton<EditService>();
         services.AddSingleton<IEditService>(sp => sp.GetRequiredService<EditService>());

--- a/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SuppressionService.cs
@@ -1,6 +1,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
@@ -13,9 +15,12 @@ public sealed class SuppressionService : ISuppressionService
     private readonly IEditService _editService;
     private readonly IWorkspaceManager? _workspace;
     private readonly ICompileCheckService? _compileCheck;
+    private readonly ILogger<SuppressionService> _logger;
     private const string ConfirmationServiceUnavailableReason = "confirmation-service-unavailable";
     private const string WorkspaceNotLoadedReason = "workspace-not-loaded";
     private const string ConfirmationFailedReason = "confirmation-failed";
+    private const string PragmaIdempotencyReadPhase = "pragma-idempotency-read";
+    private const string LineEndingReadPhase = "line-ending-read";
 
     /// <summary>
     /// Constructs a <see cref="SuppressionService"/>. The <paramref name="workspace"/> and
@@ -35,11 +40,22 @@ public sealed class SuppressionService : ISuppressionService
         IEditService editService,
         IWorkspaceManager? workspace = null,
         ICompileCheckService? compileCheck = null)
+        : this(editorConfig, editService, workspace, compileCheck, NullLogger<SuppressionService>.Instance)
+    {
+    }
+
+    internal SuppressionService(
+        IEditorConfigService editorConfig,
+        IEditService editService,
+        IWorkspaceManager? workspace,
+        ICompileCheckService? compileCheck,
+        ILogger<SuppressionService> logger)
     {
         _editorConfig = editorConfig;
         _editService = editService;
         _workspace = workspace;
         _compileCheck = compileCheck;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public Task<EditorConfigWriteResultDto> SetDiagnosticSeverityAsync(
@@ -110,15 +126,17 @@ public sealed class SuppressionService : ISuppressionService
                     Changes: Array.Empty<FileChangeDto>());
             }
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // File unreadable from disk — fall through to the normal insert path; the edit
             // service is the authority on whether the edit can be applied.
-        }
-        catch (UnauthorizedAccessException)
-        {
-            // Same fall-through rationale as IOException: if the file can't be read for the
-            // idempotency pre-check, defer to the edit service to surface any apply failure.
+            _logger.LogWarning(
+                ex,
+                "Failed to read suppression target '{FilePath}' during {Phase} for diagnostic '{DiagnosticId}' at line {Line}; deferring to the edit service.",
+                filePath,
+                PragmaIdempotencyReadPhase,
+                normalizedId,
+                line);
         }
 
         var newline = await DetectLineEndingAsync(filePath, ct).ConfigureAwait(false);
@@ -349,19 +367,20 @@ public sealed class SuppressionService : ISuppressionService
         return line > pair.DisableLine.Value && line < pair.RestoreLine.Value;
     }
 
-    private static async Task<string> DetectLineEndingAsync(string filePath, CancellationToken ct)
+    private async Task<string> DetectLineEndingAsync(string filePath, CancellationToken ct)
     {
         string text;
         try
         {
             text = await ReadSourceTextAsync(filePath, ct).ConfigureAwait(false);
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            return Environment.NewLine;
-        }
-        catch (UnauthorizedAccessException)
-        {
+            _logger.LogWarning(
+                ex,
+                "Failed to read suppression target '{FilePath}' during {Phase}; using the environment line-ending fallback.",
+                filePath,
+                LineEndingReadPhase);
             return Environment.NewLine;
         }
 

--- a/tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs
@@ -36,6 +36,7 @@ public sealed class ServiceCollectionExtensionsTests
         Assert.IsNotNull(sp.GetRequiredService<IClassSplitOrchestrator>());
         Assert.IsNotNull(sp.GetRequiredService<IExtractAndWireOrchestrator>());
         Assert.IsNotNull(sp.GetRequiredService<ICompositeApplyOrchestrator>());
+        Assert.IsNotNull(sp.GetRequiredService<ISuppressionService>());
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SuppressionServiceTests.cs
@@ -1,8 +1,9 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Services;
-using Microsoft.CodeAnalysis;
 
 namespace RoslynMcp.Tests;
 
@@ -193,6 +194,62 @@ public sealed class SuppressionServiceTests
         {
             File.Delete(filePath);
         }
+    }
+
+    [TestMethod]
+    public async Task AddPragmaWarningDisableAsync_WhenFileIsMissing_LogsBothReadFallbacks_AndPreservesEditResult()
+    {
+        var filePath = Path.Combine(
+            Path.GetTempPath(),
+            "suppression-guaranteed-missing-" + Guid.NewGuid().ToString("N") + ".cs");
+        Assert.IsFalse(File.Exists(filePath), "The regression path must be missing before the service reads it.");
+
+        TextEditDto? capturedEdit = null;
+        var expectedResult = new TextEditResultDto(true, filePath, 1, []);
+        var edits = new StubEditService
+        {
+            OnApply = (_, _, editsToApply, _, _, _) =>
+            {
+                capturedEdit = editsToApply.Single();
+                return Task.FromResult(expectedResult);
+            }
+        };
+        var logger = new CaptureLogger<SuppressionService>();
+        var sut = new SuppressionService(
+            new StubEditorConfig(),
+            edits,
+            workspace: null,
+            compileCheck: null,
+            logger: logger);
+
+        var result = await sut.AddPragmaWarningDisableAsync(
+            "ws",
+            filePath,
+            7,
+            "CA1305",
+            CancellationToken.None).ConfigureAwait(false);
+
+        Assert.AreSame(expectedResult, result, "Read fallbacks must not alter the edit service result.");
+        Assert.IsNotNull(capturedEdit);
+        Assert.AreEqual(
+            $"#pragma warning disable CA1305{Environment.NewLine}",
+            capturedEdit.NewText,
+            "The unreadable-file path must retain the environment line-ending fallback.");
+
+        var warnings = logger.Entries.Where(entry => entry.Level == LogLevel.Warning).ToArray();
+        Assert.AreEqual(2, warnings.Length, "The idempotency and line-ending reads must emit distinct warnings.");
+
+        var idempotencyWarning = warnings.Single(entry =>
+            entry.Message.Contains("pragma-idempotency-read", StringComparison.Ordinal));
+        Assert.IsInstanceOfType<FileNotFoundException>(idempotencyWarning.Exception);
+        StringAssert.Contains(idempotencyWarning.Message, filePath);
+        StringAssert.Contains(idempotencyWarning.Message, "CA1305");
+        StringAssert.Contains(idempotencyWarning.Message, "line 7");
+
+        var lineEndingWarning = warnings.Single(entry =>
+            entry.Message.Contains("line-ending-read", StringComparison.Ordinal));
+        Assert.IsInstanceOfType<FileNotFoundException>(lineEndingWarning.Exception);
+        StringAssert.Contains(lineEndingWarning.Message, filePath);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Wire `SuppressionService` to `ILogger<SuppressionService>` in the production DI path.
- Emit structured warnings from the pragma-idempotency and line-ending read fallbacks.
- Preserve the published public constructor through a `NullLogger`-backed compatibility adapter without changing edit or cancellation behavior.

Closes: build-test-services-swallowed-exceptions-no-logging

## Validation
- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --no-build --no-restore --filter "FullyQualifiedName~SuppressionServiceTests|FullyQualifiedName~ServiceCollectionExtensionsTests"` — 19/19 passed.
- `.\eng\verify-ai-docs.ps1` — passed.
- `.\eng\verify-release.ps1 -Configuration Release -NoCoverage -ExcludeNetworkTests` — 1,715/1,715 tests passed; publish and hash verification passed.
- Unfiltered `.\eng\verify-release.ps1 -Configuration Release` — 1,716/1,717 tests passed; the sole stale package-version Network fixture failure was independently reproduced on untouched `main`.
