### PR TITLE
docs(backlog): file legacy-sln-slnx-parity-drift row

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-07-17T13:48:44Z
+**updated_at:** 2026-07-20T04:01:57Z
 
 ## Agent contract
 
@@ -140,6 +140,7 @@
 | `apply-undo-tool-response-contract-docs` | Low | apply-undo-workflow-service-extraction | **Document apply and undo response variants** — enumerate discriminators, exact properties, explicit nulls, and recovery actions for all eight wire shapes. [type: docs] [source: backlog-sweep-20260716-review] | M | items/apply-undo-tool-response-contract-docs.md |
 | `prompt-smoke-tests-concern-split` | Low | prompt-workflows-missing-test-coverage,prompt-shim-parameter-binding-complexity-extraction | **Split prompt smoke-test concerns** — separate builder smoke, prompt-shim binding/error coverage, and shared sample/workspace fixtures. [type: test-refactor] [source: backlog-sweep-20260716-review] | S | items/prompt-smoke-tests-concern-split.md |
 | `client-root-path-validator-remaining-complexity` | Low | client-root-path-validator-complexity-extraction | **Reduce remaining path-validator hotspots** — simplify ValidatePathAgainstRootsAsync and ResolvePath while preserving symlink and filesystem behavior. [type: refactor] [source: backlog-sweep-20260716-review] | S | items/client-root-path-validator-remaining-complexity.md |
+| `legacy-sln-slnx-parity-drift` | Low | — | **Retire the legacy `Roslyn-Backed-MCP.sln`** — delete it (preferred; only live ref is `docs/setup.md:23`) or gate it against `RoslynMcp.slnx`. Already drifted: the `.sln` lists `samples/**` projects the `.slnx` lacks, nothing enforces parity. [type: maintenance] [source: 2026-07-19 slnx session] | S | items/legacy-sln-slnx-parity-drift.md |
 
 ## Defer
 

--- a/ai_docs/items/legacy-sln-slnx-parity-drift.md
+++ b/ai_docs/items/legacy-sln-slnx-parity-drift.md
@@ -1,0 +1,34 @@
+# legacy-sln-slnx-parity-drift — retire the legacy `Roslyn-Backed-MCP.sln` (or gate it against `RoslynMcp.slnx`)
+
+**row:** `legacy-sln-slnx-parity-drift` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `Roslyn-Backed-MCP.sln` — legacy VS solution, 8 project entries, last touched 2026-04-17 (`be2bc4ea`); the file to delete
+- `docs/setup.md:23` — the only live reference to it (labels it "Legacy Visual Studio solution"); the line to drop
+
+Read-only context (not edit targets): `RoslynMcp.slnx` (primary solution, 5 project entries), `eng/verify-release.ps1:20` and `.github/workflows/ci.yml:175` (both build/scan the `.slnx`, never the `.sln`).
+
+## Acceptance
+
+Preferred — delete:
+
+- [ ] `Roslyn-Backed-MCP.sln` is removed from the repo.
+- [ ] `docs/setup.md:23` row is dropped (or rewritten to state `.slnx` is the only solution file).
+- [ ] `dotnet build RoslynMcp.slnx` and the full test suite still pass.
+
+Fallback (only if a live consumer for the `.sln` is identified — record who/what in this file first):
+
+- [ ] A test or `eng/` check asserts the two solution files list the same `src/`, `analyzers/`, and `tests/` project paths, failing when one gains a project the other lacks.
+- [ ] The check is wired into CI on the same path as the other repo-shape gates.
+
+## Evidence
+
+- Session 2026-07-19 (`.slnx` loader-support question): the two solution files have already drifted — the `.sln` carries `samples/**` project entries (`SampleSolution`, `SampleApp`, `SampleLib`) that `RoslynMcp.slnx` does not, and nothing in CI or `eng/` enforces parity. A project added to `.slnx` would be silently missing from the `.sln` indefinitely.
+- No live consumer found: `rg -F "Roslyn-Backed-MCP.sln"` outside `review-inbox/` archives and `ai_docs/plans/` returns only `docs/setup.md:23`.
+
+## Context
+
+Dual-maintenance hazard, not a correctness bug — no runtime or published-artifact impact (the `.sln` is dev-time only and is not part of the `roslyn-mcp` package surface, so removing it is not a breaking change for consumers).
+
+Deletion is the recommended arm: `.slnx` is the dogfooded primary (CI, `verify-release`, all sample fixtures), the repo pins SDK `10.0.100`/`latestFeature`, and VS 17.13+ opens `.slnx` natively — so the "legacy Visual Studio" justification for keeping the `.sln` no longer holds. Low priority; fold into the next docs or repo-shape pass.


### PR DESCRIPTION
## Summary

Files one Low-priority backlog row, `legacy-sln-slnx-parity-drift`, surfaced while verifying that the Roslyn workspace loader handles `.slnx`.

The `.slnx` question itself was a non-issue — `.slnx` is a first-class path (`WorkspaceSessionLoader.cs:63` routes it to `OpenSolutionAsync`, `SolutionDiscoveryHelper.cs:33` *prefers* it over `.sln`, and `RoslynMcp.slnx` is this repo's own dogfooded primary solution). But the check turned up a real drift hazard.

## The finding

Two solution files coexist with nothing enforcing parity:

| File | Project entries | Last touched |
|---|---|---|
| `RoslynMcp.slnx` | 5 (src ×3, analyzers ×1, tests ×1) | live — CI, `verify-release`, all fixtures |
| `Roslyn-Backed-MCP.sln` | 8 (adds `samples/**`) | 2026-04-17 (`be2bc4ea`) |

They have already drifted. A project added to one would be silently missing from the other indefinitely.

The row recommends **deleting** the `.sln` — its only live reference is `docs/setup.md:23`, the repo pins SDK `10.0.100`, and VS 17.13+ opens `.slnx` natively, so the "legacy Visual Studio solution" justification no longer holds. It is dev-time only and not part of the `roslyn-mcp` package surface, so removal is not a breaking change for consumers. A parity gate is documented as a fallback arm if a live consumer turns up.

## Scope

Backlog-only — no production code touched, no changelog fragment warranted. `backlog-lint` reports 0 ERROR and no warns on the new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
