### PR TITLE
fix(deps): bump System.Security.Cryptography.Xml pin to 10.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,10 @@
     <!-- Transitive pin: System.Security.Cryptography.Xml 8.0.0 (dragged in via
          Microsoft.Build.* / Microsoft.CodeAnalysis.Workspaces.MSBuild) has two
          High-severity DoS advisories (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf,
-         CVE-2026-26171). 10.0.8 is the patched release on the net10.0 line. -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+         CVE-2026-26171). 10.0.9 itself later picked up 5 new High-severity
+         advisories (GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q,
+         GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v). 10.0.10 (2026-07-14) clears all
+         known advisories as of this pin. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-07-20T14:32:12Z
+**updated_at:** 2026-07-22T20:42:54Z
 
 ## Agent contract
 

--- a/ai_docs/items/filewatcher-clearstale-timeout-flake-triage.md
+++ b/ai_docs/items/filewatcher-clearstale-timeout-flake-triage.md
@@ -14,3 +14,9 @@
 ## Evidence
 
 - PR #1034's CI run failed this test with `System.TimeoutException` on a completely unrelated diff (CodeActionTools/FlowAnalysisTools/OperationTools + test changes, zero touches to FileWatcherService); an unmodified rerun of the same commit passed cleanly. Matches the same class of self-hosted-CI-load timing sensitivity already documented for `WorkspaceExecutionGateTests.AutoReload_ResetsTimeoutBudget_ToolActionGetsFullBudget` in `ai_docs/known-flakes.md`, but this test is not yet registered there.
+Second occurrence 2026-07-22: PR #1086 (Directory.Packages.props version-pin-only diff,
+zero touches to FileWatcherService or tests) failed validate with the same
+System.TimeoutException at ExternalEditStalenessTests.cs:405. Confirmed non-deterministic:
+3/3 local reruns passed in ~22ms each (self-hosted runner idle at the time). Matches the
+PR #1034 evidence exactly - timing-sensitive under CI load, not a regression. Strengthens
+the case to register in known-flakes.md per this row's acceptance criteria #2.


### PR DESCRIPTION
## Summary
- The `System.Security.Cryptography.Xml` 10.0.9 security-mitigation pin picked up 5 new High-severity NuGet advisories since it was set. `dotnet restore` runs under NuGetAudit warn-as-error, so this fails restore for every PR touching any project — it's blocking CI for an in-flight backlog-sweep batch (10 initiatives).
- 10.0.10 (published 2026-07-14) clears all known advisories for this package as of this pin (verified via deps.dev).

## Test plan
- [x] `dotnet restore RoslynMcp.slnx` succeeds locally (was failing with NU1903 before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)