### PR TITLE
fix(undo): preserve snapshot until revert restore confirms success

### DIFF
--- a/changelog.d/undo-revert-preserve-snapshot-on-failure-or-cancellation.md
+++ b/changelog.d/undo-revert-preserve-snapshot-on-failure-or-cancellation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `UndoService.RevertAsync` and `RevertBySequenceAsync` no longer discard the undo snapshot/history entry before the restore completes — a cancelled or failed revert now leaves the same snapshot retryable instead of silently losing it, and `RevertBySequenceAsync` preserves dependency ordering across a failed-then-retried sequence revert.

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -96,10 +96,33 @@ public sealed class UndoService : IUndoService, IDisposable
 
     public async Task<bool> RevertAsync(string workspaceId, CancellationToken cancellationToken = default)
     {
-        if (!_snapshots.TryRemove(workspaceId, out var snapshot))
+        // Peek — do NOT consume the snapshot until the restore confirms success. A failed
+        // (disk I/O) or cancelled restore must leave the snapshot and its history entry in
+        // place so the SAME call is retryable once the obstruction clears; consuming up front
+        // permanently destroys the retry target that the compensating callers depend on
+        // (ApplyWithVerifyTool's rollback and cancellation-recovery legs).
+        if (!_snapshots.TryGetValue(workspaceId, out var snapshot))
             return false;
 
         var workspace = _workspaceManager;
+
+        // Fast path: the caller provided an explicit file-snapshot list. Restore those
+        // files directly — authoritative, independent of the workspace solution state.
+        // Legacy (else) path: solution-based restore with a snapshot-wide walk so
+        // empty-GetChanges no longer silently wins. A thrown OperationCanceledException
+        // propagates out of here without reaching the consume block below, so cancellation
+        // also leaves _snapshots/_history untouched (retryable) by construction.
+        bool reverted = snapshot.FileSnapshots is { Count: > 0 }
+            ? await RevertFromFileSnapshotsAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false)
+            : await RevertFromSolutionSnapshotAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
+
+        if (!reverted)
+            return false;
+
+        // Restore succeeded — consume the snapshot exactly once. Use the atomic
+        // compare-and-remove overload so a newer CaptureBeforeApply that landed while the
+        // restore was in flight is not clobbered (only the exact snapshot we restored is removed).
+        _snapshots.TryRemove(new KeyValuePair<string, UndoSnapshot>(workspaceId, snapshot));
 
         // Also drop the matching history entry so the LIFO and by-sequence pathways agree
         // on what's been reverted. The pending snapshot is identified by sequence number
@@ -122,16 +145,7 @@ public sealed class UndoService : IUndoService, IDisposable
             }
         }
 
-        // Fast path: the caller provided an explicit file-snapshot list. Restore those
-        // files directly — authoritative, independent of the workspace solution state.
-        if (snapshot.FileSnapshots is { Count: > 0 })
-        {
-            return await RevertFromFileSnapshotsAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
-        }
-
-        // Legacy path: solution-based restore with a snapshot-wide walk so empty-GetChanges
-        // no longer silently wins.
-        return await RevertFromSolutionSnapshotAsync(workspaceId, workspace, snapshot, cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     public async Task<RevertBySequenceResult> RevertBySequenceAsync(
@@ -199,31 +213,56 @@ public sealed class UndoService : IUndoService, IDisposable
                 BlockingSequences: blocking);
         }
 
-        // Apply the revert. Drop the history entry first so concurrent callers can't double-revert.
+        // Claim the revert BEFORE running it so concurrent callers can't double-revert: remove
+        // the target history entry (recording its ordinal position so a failed/cancelled restore
+        // can reinsert it at the same spot) and, if it is also the pending LIFO snapshot, remove
+        // that too. Unlike the previous unconditional drop-first, a failed restore now UNDOES this
+        // claim (below) instead of permanently destroying the retry target and its dependency ordering.
+        int claimedIndex;
         lock (historyList)
         {
-            historyList.RemoveAll(s => s.SequenceNumber == sequenceNumber);
+            claimedIndex = historyList.FindIndex(s => s.SequenceNumber == sequenceNumber);
+            if (claimedIndex >= 0)
+            {
+                historyList.RemoveAt(claimedIndex);
+            }
         }
 
         // If this is also the pending LIFO snapshot, drop it from _snapshots too — keeps
-        // GetLastOperation / RevertAsync consistent.
+        // GetLastOperation / RevertAsync consistent. Use the compare-and-remove overload so a
+        // newer capture that raced in is not clobbered.
         if (_snapshots.TryGetValue(workspaceId, out var pending) && pending.SequenceNumber == sequenceNumber)
         {
-            _snapshots.TryRemove(workspaceId, out _);
+            _snapshots.TryRemove(new KeyValuePair<string, UndoSnapshot>(workspaceId, pending));
         }
 
         bool reverted;
-        if (target.FileSnapshots is { Count: > 0 })
+        try
         {
-            reverted = await RevertFromFileSnapshotsAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+            if (target.FileSnapshots is { Count: > 0 })
+            {
+                reverted = await RevertFromFileSnapshotsAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                reverted = await RevertFromSolutionSnapshotAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+            }
         }
-        else
+        catch (OperationCanceledException)
         {
-            reverted = await RevertFromSolutionSnapshotAsync(workspaceId, _workspaceManager, target, cancellationToken).ConfigureAwait(false);
+            // A cancelled restore must not destroy the retry target: undo the claim so the same
+            // sequence stays retryable with its ordering preserved, then rethrow so cancellation
+            // still surfaces to the caller.
+            RestoreSequenceClaim(workspaceId, historyList, claimedIndex, target);
+            throw;
         }
 
         if (!reverted)
         {
+            // Restore failed (disk I/O). Undo the claim so the target sequence remains retryable
+            // and keeps its ordinal position in the dependency-ordered history for future overlap
+            // checks, then surface the failure.
+            RestoreSequenceClaim(workspaceId, historyList, claimedIndex, target);
             return new RevertBySequenceResult(
                 Reverted: false,
                 RevertedOperation: target.Description,
@@ -238,6 +277,34 @@ public sealed class UndoService : IUndoService, IDisposable
             AffectedFiles: target.AffectedFiles,
             Reason: null,
             BlockingSequences: null);
+    }
+
+    /// <summary>
+    /// Undoes a claimed-but-failed (or cancelled) sequence revert: reinserts the target history
+    /// entry at (or as close as bounds allow to) its original ordinal position so the
+    /// dependency-ordered overlap check stays correct, and best-effort restores it as the pending
+    /// LIFO snapshot (<see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/> won't overwrite a
+    /// newer capture that raced in during the restore). No-op when nothing was claimed
+    /// (<paramref name="claimedIndex"/> &lt; 0, e.g. a concurrent caller already claimed the entry).
+    /// </summary>
+    private void RestoreSequenceClaim(
+        string workspaceId,
+        List<UndoSnapshot> historyList,
+        int claimedIndex,
+        UndoSnapshot target)
+    {
+        if (claimedIndex < 0)
+            return;
+
+        lock (historyList)
+        {
+            // Re-derive the insert position with a bounds check — concurrent CommitPendingCapture
+            // calls may have grown the list while the restore was in flight.
+            var insertIndex = Math.Min(claimedIndex, historyList.Count);
+            historyList.Insert(insertIndex, target);
+        }
+
+        _snapshots.TryAdd(workspaceId, target);
     }
 
     public void CommitPendingCapture(string workspaceId, int sequenceNumber, IReadOnlyList<string> affectedFiles)

--- a/tests/RoslynMcp.Tests/UndoServiceTests.cs
+++ b/tests/RoslynMcp.Tests/UndoServiceTests.cs
@@ -146,4 +146,197 @@ public sealed class UndoServiceTests : IsolatedWorkspaceTestBase
         Assert.AreEqual("unknown-sequence", revertResult.Reason);
         Assert.IsNull(revertResult.BlockingSequences);
     }
+
+    [TestMethod]
+    public async Task RevertAsync_RestoreFails_SnapshotSurvivesAndRetrySucceeds()
+    {
+        // A failed disk restore must NOT consume the pending snapshot — the compensating
+        // caller (ApplyWithVerifyTool's rollback leg) needs the same snapshot to retry.
+        // Force the file-snapshot restore to fail by marking the target file read-only,
+        // then clear the obstruction and revert again for the SAME workspace.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var dogOriginal = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        var edit = new TextEditDto(1, 1, 1, 1, "// apply\n");
+        var applyResult = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, "Apply should succeed.");
+        Assert.IsNotNull(UndoService.GetLastOperation(workspaceId), "Undo entry must exist after apply.");
+
+        try
+        {
+            File.SetAttributes(dogFilePath, FileAttributes.ReadOnly);
+
+            var firstRevert = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+            Assert.IsFalse(firstRevert, "Revert must report failure when the disk restore cannot write.");
+
+            // The snapshot must have survived the failed restore.
+            Assert.IsNotNull(UndoService.GetLastOperation(workspaceId),
+                "A failed revert must leave the pending snapshot in place so it can be retried.");
+        }
+        finally
+        {
+            File.SetAttributes(dogFilePath, FileAttributes.Normal);
+        }
+
+        // Retry now that the file is writable again — the surviving snapshot must restore the original.
+        var secondRevert = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(secondRevert, "Retry after clearing the obstruction must succeed.");
+
+        var dogAfterRetry = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(dogOriginal, dogAfterRetry,
+            "Retried revert must restore Dog.cs to its pre-apply content — proving the snapshot survived the first failure.");
+        Assert.IsNull(UndoService.GetLastOperation(workspaceId),
+            "The successful retry must finally consume the snapshot.");
+    }
+
+    [TestMethod]
+    public async Task RevertAsync_Cancelled_SnapshotSurvivesAndRetrySucceeds()
+    {
+        // An already-cancelled token must not consume the snapshot: cancellation surfaces
+        // (OperationCanceledException), but a follow-up revert with a live token still works.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var dogOriginal = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        var edit = new TextEditDto(1, 1, 1, 1, "// apply\n");
+        var applyResult = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, "Apply should succeed.");
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var threw = false;
+        try
+        {
+            await UndoService.RevertAsync(workspaceId, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            threw = true;
+        }
+
+        Assert.IsTrue(threw, "A revert driven by an already-cancelled token must surface cancellation.");
+        Assert.IsNotNull(UndoService.GetLastOperation(workspaceId),
+            "A cancelled revert must leave the pending snapshot in place so it can be retried.");
+
+        var retry = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(retry, "Retry with a live token must succeed after the cancelled attempt.");
+
+        var dogAfterRetry = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(dogOriginal, dogAfterRetry,
+            "Retried revert must restore Dog.cs — proving the cancelled attempt did not consume the snapshot.");
+    }
+
+    [TestMethod]
+    public async Task RevertAsync_HappyPath_ConsumesSnapshotExactlyOnce()
+    {
+        // A successful revert consumes the snapshot exactly once: the second call finds
+        // nothing to revert and GetLastOperation returns null.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var dogOriginal = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        var edit = new TextEditDto(1, 1, 1, 1, "// apply\n");
+        var applyResult = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, "Apply should succeed.");
+
+        var firstRevert = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(firstRevert, "First revert should succeed.");
+
+        var dogAfterRevert = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(dogOriginal, dogAfterRevert, "Revert must restore the original content.");
+
+        var secondRevert = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsFalse(secondRevert, "The snapshot must be consumed exactly once — a second revert finds nothing.");
+        Assert.IsNull(UndoService.GetLastOperation(workspaceId),
+            "GetLastOperation must return null after the snapshot has been consumed.");
+    }
+
+    [TestMethod]
+    public async Task RevertBySequence_RestoreFails_SequenceRemainsRetryable()
+    {
+        // Apply A (Dog.cs) then Apply B (Cat.cs) — non-overlapping. Force the revert of A
+        // to fail by marking Dog.cs read-only. The failed revert must NOT destroy A's history
+        // entry: a follow-up RevertBySequenceAsync for the SAME sequence must succeed once the
+        // obstruction clears, and B's edit must be untouched throughout (ordering preserved).
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+        var dogOriginal = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var catOriginal = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+
+        var dogEdit = new TextEditDto(1, 1, 1, 1, "// apply A\n");
+        var resultA = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { dogEdit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultA.Success, "Apply A should succeed.");
+
+        var catEdit = new TextEditDto(1, 1, 1, 1, "// apply B\n");
+        var resultB = await EditService.ApplyTextEditsAsync(
+            workspaceId, catFilePath, new[] { catEdit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(resultB.Success, "Apply B should succeed.");
+
+        var changes = ChangeTracker.GetChanges(workspaceId);
+        Assert.AreEqual(2, changes.Count, "Expected 2 recorded changes.");
+        var sequenceA = changes[0].SequenceNumber;
+
+        try
+        {
+            File.SetAttributes(dogFilePath, FileAttributes.ReadOnly);
+
+            var failedRevert = await UndoService.RevertBySequenceAsync(
+                workspaceId, sequenceA, CancellationToken.None);
+            Assert.IsFalse(failedRevert.Reverted, "Revert must report failure when the disk restore cannot write.");
+            Assert.AreEqual("revert-failed", failedRevert.Reason);
+
+            // B's edit must be untouched by the failed revert of A.
+            var catAfterFailure = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+            StringAssert.Contains(catAfterFailure, "// apply B",
+                "A failed revert of A must not touch B's file.");
+        }
+        finally
+        {
+            File.SetAttributes(dogFilePath, FileAttributes.Normal);
+        }
+
+        // The target sequence must still be retryable — its history entry survived the failure.
+        var retryRevert = await UndoService.RevertBySequenceAsync(
+            workspaceId, sequenceA, CancellationToken.None);
+        Assert.IsTrue(retryRevert.Reverted,
+            $"The target sequence must remain retryable after a failed restore; got reason={retryRevert.Reason}.");
+        Assert.IsNull(retryRevert.Reason);
+
+        var dogAfterRetry = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(dogOriginal, dogAfterRetry,
+            "Retried revert-by-sequence must restore Dog.cs to its pre-apply-A content.");
+
+        // B was never reverted — Cat.cs keeps apply B's edit; ordering was preserved across the failure.
+        var catAfterRetry = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+        StringAssert.Contains(catAfterRetry, "// apply B",
+            "Cat.cs should retain apply B's edit — only apply A was reverted.");
+        Assert.AreNotEqual(catOriginal, catAfterRetry, "Cat.cs should still be at its post-apply-B state.");
+    }
 }


### PR DESCRIPTION
## Summary

`UndoService.RevertAsync` and `RevertBySequenceAsync` consumed the undo snapshot/history entry **before** the cancellable restore work confirmed success, so a failed or cancelled restore permanently destroyed the retry target the compensating callers (`ApplyWithVerifyTool` rollback / cancellation-recovery legs) depend on.

- **`RevertAsync`** — now peeks the snapshot, runs the restore, and consumes it (via the atomic compare-and-remove overload) only after the restore returns `true`. A `false` return or a thrown `OperationCanceledException` leaves `_snapshots`/`_history` untouched so the same call is retryable.
- **`RevertBySequenceAsync`** — records the claimed history-list index, runs the restore, and on failure or cancellation reinserts the entry at its ordinal position (bounds-checked against concurrent growth) and best-effort restores the LIFO snapshot (`TryAdd` won't clobber a newer capture), preserving dependency ordering for future overlap checks.

Interface-free ordering fix — `IUndoService` signatures unchanged, no caller updates in `ApplyWithVerifyTool.cs`, `UndoTools.cs`, or `EditService.cs`.

## Tests

Adds four `UndoServiceTests`: `RevertAsync` restore-failure retry, cancelled retry, happy-path exactly-once consumption, and `RevertBySequenceAsync` restore-failure retryability with ordering preserved. The 3 existing sequence-revert tests remain green.

Validated: scoped Release build (`TreatWarningsAsErrors=true`, 0 warnings) + `UndoServiceTests` / `EditUndoIntegrationTests` / `ChangeTrackerTests` / `ApplyWithVerify*` (32 passed).

Closes: undo-revert-preserve-snapshot-on-failure-or-cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
