### PR TITLE
refactor(middleware): finish StructuredCallToolFilter hotspot decomposition

### DIFF
--- a/changelog.d/structuredcalltoolfilter-hotspot-decomposition-followup.md
+++ b/changelog.d/structuredcalltoolfilter-hotspot-decomposition-followup.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** extracted `StructuredCallElicitationCoordinator` and `StructuredCallContentProjector` from `StructuredCallToolFilter`, completing the hotspot-decomposition follow-up — elicitation/retry orchestration and structured-content/`_meta` projection now live in focused, directly-tested collaborators, and `StructuredCallToolFilter.Create` is orchestration-only (filter file 963 → 544 lines). The historical static call surface is preserved via thin forwarding delegates, so existing callers and test suites are unchanged. Closes `structuredcalltoolfilter-hotspot-decomposition-followup`.

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallContentProjector.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallContentProjector.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// The structured-content / <c>_meta</c> projection layer extracted from
+/// <see cref="StructuredCallToolFilter"/>. Owns injection of the gate-metrics snapshot as a
+/// top-level <c>_meta</c> property on the response's first text block and the dual-channel
+/// <see cref="CallToolResult.StructuredContent"/> mirror for tools with a registered output schema.
+/// Holds no error-classification, dispatch, or allowlist concerns; those stay in the filter,
+/// <see cref="StructuredCallElicitationCoordinator"/>, and <see cref="ElicitationAllowlistPolicy"/>.
+///
+/// <para>
+/// <see cref="StructuredCallToolFilter"/> keeps thin delegates that forward to these overloads, so
+/// its historical static call surface (consumed by the existing filter/content test suites) is
+/// preserved byte-for-byte.
+/// </para>
+/// </summary>
+internal static class StructuredCallContentProjector
+{
+    /// <summary>
+    /// Injects the gate-metrics snapshot as a top-level <c>_meta</c> property on the first
+    /// text content block when the tool's JSON response is object-rooted. Arrays,
+    /// primitives, and non-text content are returned unchanged — preserving the
+    /// historical contract that e.g. <c>source_generated_documents</c>'s bare-array
+    /// response shape remains stable across the filter migration. Exposed <c>internal</c>
+    /// so tests can assert meta-injection behavior directly.
+    ///
+    /// <para><b>tool-output-schema-infrastructure (MCP 2025-06-18 § Tools / Structured Content):</b></para>
+    /// <para>
+    /// When the tool has a registered <c>outputSchema</c> via
+    /// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/>, this method ALSO populates
+    /// <see cref="CallToolResult.StructuredContent"/> with the same payload (sans <c>_meta</c>) so
+    /// the structured-content channel is non-empty. Per spec, when <c>structuredContent</c> is
+    /// emitted the server MUST also emit a serialized JSON copy in the <c>content[].text</c>
+    /// channel — both channels coexist; <c>_meta</c> lives only in the text channel so clients
+    /// never see two observability blobs (defense against the dedupe risk noted in the
+    /// initiative plan).
+    /// </para>
+    /// </summary>
+    internal static CallToolResult InjectMetaIntoContent(CallToolResult result, string toolName) =>
+        InjectMetaIntoContent(result, toolName, ToolOutputSchemaIndex.GetSchema);
+
+    /// <summary>
+    /// Test seam: same as <see cref="InjectMetaIntoContent(CallToolResult, string)"/> but lets
+    /// the caller supply a custom schema resolver so dual-channel behavior can be exercised
+    /// without needing a live <c>[McpToolMetadata(outputSchemaTypeRef:)]</c> opt-in. The
+    /// production path always uses the static <see cref="ToolOutputSchemaIndex"/>.
+    /// </summary>
+    internal static CallToolResult InjectMetaIntoContent(
+        CallToolResult result, string toolName, Func<string, JsonNode?> schemaResolver)
+    {
+        if (result.Content is null || result.Content.Count == 0)
+        {
+            return result;
+        }
+
+        if (result.Content[0] is not TextContentBlock text || string.IsNullOrEmpty(text.Text))
+        {
+            return result;
+        }
+
+        // Parse once so both the meta-injection path and the structuredContent path can share
+        // a single JsonNode tree. Non-JSON / array-rooted responses bail out early as before.
+        JsonNode? parsedRoot = null;
+        try
+        {
+            parsedRoot = JsonNode.Parse(text.Text);
+        }
+        catch (JsonException)
+        {
+            // Fall through to the original best-effort path; non-JSON responses pass through.
+        }
+
+        var schema = schemaResolver(toolName);
+        // structuredContent is only emitted when (a) the tool opted in via OutputSchemaTypeRef
+        // and (b) the response is an object-rooted JSON document we can mirror. Arrays, scalars,
+        // and non-JSON responses leave structuredContent absent — matching the spec's "MAY"
+        // semantics rather than fabricating a structured shape that doesn't match the schema.
+        // CallToolResult.StructuredContent is a JsonElement? — convert from JsonNode via the
+        // round-trip text. The body is small (already serialized once for the text channel)
+        // so the extra parse is bounded; deep-clone to detach from the parsed tree.
+        JsonElement? structuredFromBody = null;
+        if (schema is not null && parsedRoot is JsonObject bodyObj)
+        {
+            structuredFromBody = JsonDocument.Parse(bodyObj.ToJsonString()).RootElement.Clone();
+        }
+
+        var injected = ToolErrorHandler.InjectMetaIfPossible(text.Text, toolName);
+        var textChanged = !(ReferenceEquals(injected, text.Text) || injected == text.Text);
+
+        if (!textChanged && structuredFromBody is null)
+        {
+            // Nothing to change — skip the allocation so array-rooted and non-JSON
+            // responses pass through byte-for-byte identical.
+            return result;
+        }
+
+        var newContent = new List<ContentBlock>(result.Content.Count)
+        {
+            new TextContentBlock { Text = textChanged ? injected : text.Text }
+        };
+        for (var i = 1; i < result.Content.Count; i++)
+        {
+            newContent.Add(result.Content[i]);
+        }
+
+        return new CallToolResult
+        {
+            IsError = result.IsError,
+            Content = newContent,
+            // Preserve any pre-existing StructuredContent (a tool may have set it directly);
+            // otherwise emit the schema-mirrored body when the tool has opted in.
+            StructuredContent = result.StructuredContent ?? structuredFromBody,
+        };
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
@@ -1,0 +1,454 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// The elicitation/retry orchestration layer extracted from <see cref="StructuredCallToolFilter"/>.
+/// Owns the <em>how</em> of asking the user for a missing value via MCP <c>elicitation/create</c>
+/// and re-dispatching the original call — the exception-path recovery
+/// (<see cref="TryElicitAndRetryAsync"/>), the workspaceId-specific recover-load-retry loop
+/// (<see cref="TryRecoverMissingWorkspaceIdAsync"/>), and the shared select-from-N picker
+/// (<see cref="TryElicitChoiceAsync"/>). Whether a parameter <em>may</em> be elicited stays in
+/// <see cref="ElicitationAllowlistPolicy"/>; metrics stay in <see cref="CallMetricsRecorder"/>;
+/// the pre-dispatch auto-resolve/auto-load flow and error-envelope construction stay in the filter.
+///
+/// <para>
+/// <see cref="StructuredCallToolFilter"/> keeps thin delegates that forward to these members, so
+/// its historical static call surface (consumed by <c>SymbolTools</c> and the existing filter test
+/// suites) is preserved byte-for-byte. <see cref="DispatchWithTemporaryArgumentsAsync"/> and
+/// <see cref="TryExtractWorkspaceId"/> are <c>internal</c> (not <c>private</c>) so the filter's
+/// retained <c>TryAutoLoadWorkspaceAsync</c> can keep calling them directly.
+/// </para>
+/// </summary>
+internal static class StructuredCallElicitationCoordinator
+{
+    // Duplicated from ElicitationAllowlistPolicy / StructuredCallToolFilter (a private const does
+    // not cross the class boundary). Retained here because the recover/load/retry body references
+    // all three (workspace_load dispatch, workspaceId patching, path elicit).
+    private const string WorkspaceLoadToolName = "workspace_load";
+    private const string WorkspaceIdParameterName = "workspaceId";
+    private const string PathParameterName = "path";
+
+    /// <summary>
+    /// Core of the elicitation-fallback path: when <paramref name="ex"/> is an
+    /// <c>InvalidArgument</c> for a missing required parameter on a tool whose
+    /// (toolName, paramName) pair is on the elicitation allowlist AND the client supports
+    /// elicitation, this method asks the user for the missing value via
+    /// <see cref="McpServer.ElicitAsync(ElicitRequestParams, CancellationToken)"/>, patches
+    /// the elicited value into the request's <c>Arguments</c> dictionary, and re-invokes
+    /// <paramref name="next"/>. Returns <see langword="null"/> when the recovery does not
+    /// apply (any layer of the gate fails) — the caller falls through to
+    /// <see cref="StructuredCallToolFilter.BuildErrorResult"/> with the existing schema-hint envelope.
+    /// </summary>
+    /// <remarks>
+    /// We do NOT hold any workspace lock or other resource during the elicit wait — that
+    /// wait is unbounded (user-paced) and would otherwise starve concurrent tool calls.
+    /// The original failure already released anything <c>next</c> had taken; the retry
+    /// re-acquires from a clean state.
+    /// </remarks>
+    internal static async Task<CallToolResult?> TryElicitAndRetryAsync(
+        RequestContext<CallToolRequestParams> context,
+        Exception ex,
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        // Layer 0: only InvalidArgument-like exceptions with a known param name qualify.
+        if (!TryGetMissingParam(ex, out var missingParam) || string.IsNullOrEmpty(missingParam))
+        {
+            return null;
+        }
+
+        var toolName = context.Params?.Name;
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return null;
+        }
+
+        // Layer 1 + 2: allowlist + sensitive-name refusal in one call. Either failure
+        // means "do not elicit" — the legacy schemaHint envelope is the right fallback.
+        if (!ElicitationAllowlistPolicy.IsElicitationAllowedFor(toolName, missingParam))
+        {
+            // Defense-in-depth log: explicit "refused to elicit sensitive field" branch
+            // so a future audit can grep for it. Not an error — we refuse silently and
+            // fall through to the normal envelope.
+            if (ElicitationAllowlistPolicy.IsSensitiveFieldName(missingParam))
+            {
+                logger?.LogWarning(
+                    "Refusing to elicit sensitive parameter '{Param}' on tool '{Tool}'. " +
+                    "MCP spec § Elicitation security: 'Servers MUST NOT request sensitive information'.",
+                    missingParam, toolName);
+            }
+            return null;
+        }
+
+        // Layer 3: client must support elicitation. server.ClientCapabilities.Elicitation
+        // is established at initialize-handshake time; this is a property read, not an RPC.
+        if (!ElicitationAllowlistPolicy.HasElicitation(context.Server?.ClientCapabilities))
+        {
+            return null;
+        }
+
+        if (ElicitationAllowlistPolicy.IsWorkspaceIdRecoveryAllowedFor(toolName, missingParam))
+        {
+            return await TryRecoverMissingWorkspaceIdAsync(
+                toolName,
+                CopyArguments(context.Params!.Arguments),
+                request => context.Server!.ElicitAsync(request, cancellationToken),
+                (dispatchToolName, arguments) =>
+                    DispatchWithTemporaryArgumentsAsync(context, next, dispatchToolName, arguments, cancellationToken),
+                logger,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Build the strict elicit request. Single string field ('path'), required, with a
+        // descriptive prompt — the user sees a one-field form (in form mode) or navigates
+        // to the URL (in url mode); the client picks based on its declared sub-capability.
+        var elicitRequest = BuildWorkspacePathElicitationRequest(toolName, missingParam);
+
+        ElicitResult elicitResult;
+        try
+        {
+            elicitResult = await context.Server!.ElicitAsync(elicitRequest, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception elicitEx)
+        {
+            // ElicitAsync can throw InvalidOperationException (client doesn't support
+            // elicitation despite the capability check, transport went away, etc.) or
+            // McpException (client returned an error). Either way we fall through to the
+            // existing envelope rather than masking the original error.
+            logger?.LogWarning(elicitEx,
+                "Elicitation request failed for {Tool}.{Param}; falling back to schemaHint envelope.",
+                toolName, missingParam);
+            return null;
+        }
+
+        // User declined or cancelled — surface the original error. Don't retry with empty
+        // input; that would just re-trigger the same InvalidArgument.
+        if (!elicitResult.IsAccepted || elicitResult.Content is null
+            || !elicitResult.Content.TryGetValue(missingParam, out var elicitedValue))
+        {
+            logger?.LogInformation(
+                "User declined or cancelled elicitation for {Tool}.{Param}", toolName, missingParam);
+            return null;
+        }
+
+        // Patch the missing parameter into the arguments dictionary and retry.
+        // CallToolRequestParams.Arguments is IReadOnlyDictionary<string, JsonElement>?;
+        // we materialize a new mutable copy, set the elicited value, and assign it back.
+        var existingArgs = context.Params!.Arguments;
+        var newArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        if (existingArgs is not null)
+        {
+            foreach (var kvp in existingArgs)
+            {
+                newArgs[kvp.Key] = kvp.Value;
+            }
+        }
+        newArgs[missingParam] = elicitedValue;
+        context.Params.Arguments = newArgs;
+
+        // Re-dispatch. If this throws too, the exception bubbles back to the outer catch
+        // — we don't loop indefinitely.
+        return await next(context, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// workspaceId-specific recover-load-retry loop: elicits a workspace path, calls
+    /// <c>workspace_load</c> via <paramref name="dispatchAsync"/>, extracts the returned
+    /// <c>workspaceId</c>, and retries the original tool with that id patched into
+    /// <paramref name="originalArguments"/>. Every failure mode (elicit throws, user declines,
+    /// non-string path, load dispatch throws, load returns no id, retry throws) falls through to
+    /// <see langword="null"/> so the caller can surface the existing schema-hint envelope.
+    /// </summary>
+    internal static async Task<CallToolResult?> TryRecoverMissingWorkspaceIdAsync(
+        string toolName,
+        IReadOnlyDictionary<string, JsonElement>? originalArguments,
+        Func<ElicitRequestParams, ValueTask<ElicitResult>> elicitAsync,
+        Func<string, IReadOnlyDictionary<string, JsonElement>, Task<CallToolResult>> dispatchAsync,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        var elicitRequest = BuildWorkspacePathElicitationRequest(toolName, WorkspaceIdParameterName);
+        ElicitResult elicitResult;
+        try
+        {
+            elicitResult = await elicitAsync(elicitRequest).ConfigureAwait(false);
+        }
+        catch (Exception elicitEx)
+        {
+            logger?.LogWarning(elicitEx,
+                "WorkspaceId recovery elicitation failed for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
+
+        if (!elicitResult.IsAccepted || elicitResult.Content is null
+            || !elicitResult.Content.TryGetValue(PathParameterName, out var pathValue))
+        {
+            logger?.LogInformation(
+                "User declined or cancelled workspaceId recovery elicitation for {Tool}", toolName);
+            return null;
+        }
+
+        if (pathValue.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(pathValue.GetString()))
+        {
+            return null;
+        }
+
+        var loadArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            [PathParameterName] = pathValue,
+        };
+        CallToolResult loadResult;
+        try
+        {
+            loadResult = await dispatchAsync(WorkspaceLoadToolName, loadArgs).ConfigureAwait(false);
+        }
+        catch (Exception loadEx)
+        {
+            logger?.LogWarning(loadEx,
+                "workspace_load dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
+
+        var workspaceId = TryExtractWorkspaceId(loadResult);
+        if (string.IsNullOrWhiteSpace(workspaceId))
+        {
+            logger?.LogWarning(
+                "workspace_load did not return a workspaceId during recovery for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
+
+        var retryArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        if (originalArguments is not null)
+        {
+            foreach (var kvp in originalArguments)
+            {
+                retryArgs[kvp.Key] = kvp.Value;
+            }
+        }
+
+        retryArgs[WorkspaceIdParameterName] = JsonSerializer.SerializeToElement(workspaceId, JsonDefaults.Indented);
+        try
+        {
+            return await dispatchAsync(toolName, retryArgs).ConfigureAwait(false);
+        }
+        catch (Exception retryEx)
+        {
+            logger?.LogWarning(retryEx,
+                "Retried tool dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
+                toolName);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
+    /// helper. Builds an enum-shaped <c>elicitation/create</c> request whose options carry
+    /// short candidate labels and stable string keys, calls the SDK, and returns the chosen
+    /// key (or <see langword="null"/> when the user declined / the client lacks elicitation /
+    /// the request itself failed). The caller uses the returned key to map back to the
+    /// original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call against that
+    /// chosen candidate.
+    /// </summary>
+    /// <param name="server">The connected <see cref="McpServer"/>; <see langword="null"/> short-circuits to null.</param>
+    /// <param name="paramName">
+    /// Name of the schema field carrying the picked option — also the dictionary key the
+    /// SDK populates in <see cref="ElicitResult.Content"/>. Conventionally <c>"choice"</c>.
+    /// </param>
+    /// <param name="title">Short title shown above the option list.</param>
+    /// <param name="description">Longer description (one or two sentences) explaining why the user is being asked.</param>
+    /// <param name="options">
+    /// The select-from-N options. <c>Key</c> is the stable identifier returned to the caller,
+    /// <c>Label</c> is the human-readable text shown in the picker.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
+    /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
+    public static async Task<string?> TryElicitChoiceAsync(
+        McpServer? server,
+        string paramName,
+        string title,
+        string description,
+        IReadOnlyList<(string Key, string Label)> options,
+        CancellationToken cancellationToken)
+    {
+        if (server is null) return null;
+        if (!ElicitationAllowlistPolicy.HasElicitation(server.ClientCapabilities)) return null;
+        if (string.IsNullOrEmpty(paramName) || options is null || options.Count == 0) return null;
+
+        var oneOf = new List<ElicitRequestParams.EnumSchemaOption>(options.Count);
+        for (var i = 0; i < options.Count; i++)
+        {
+            var (key, label) = options[i];
+            if (string.IsNullOrEmpty(key)) continue;
+            oneOf.Add(new ElicitRequestParams.EnumSchemaOption
+            {
+                Const = key,
+                Title = string.IsNullOrEmpty(label) ? key : label,
+            });
+        }
+        if (oneOf.Count == 0) return null;
+
+        var request = new ElicitRequestParams
+        {
+            Message = description,
+            RequestedSchema = new ElicitRequestParams.RequestSchema
+            {
+                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
+                {
+                    [paramName] = new ElicitRequestParams.TitledSingleSelectEnumSchema
+                    {
+                        Title = title,
+                        Description = description,
+                        OneOf = oneOf,
+                    },
+                },
+                Required = [paramName],
+            },
+        };
+
+        ElicitResult result;
+        try
+        {
+            result = await server.ElicitAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // ElicitAsync can throw InvalidOperationException (transport gone, capability
+            // mismatch) or McpException (client-side error). Either way, the disambiguation
+            // path falls through to the additive list response — never masks a real failure.
+            return null;
+        }
+
+        if (!result.IsAccepted || result.Content is null) return null;
+        if (!result.Content.TryGetValue(paramName, out var chosen)) return null;
+        var chosenKey = chosen.ValueKind == JsonValueKind.String ? chosen.GetString() : null;
+        return string.IsNullOrEmpty(chosenKey) ? null : chosenKey;
+    }
+
+    /// <summary>
+    /// Inspects <paramref name="ex"/> for the InvalidArgument-shaped binding-failure
+    /// exceptions the SDK delivers when a required parameter is missing. Returns
+    /// <see langword="true"/> with the parameter name on success, otherwise
+    /// <see langword="false"/> (caller skips the elicit path).
+    /// </summary>
+    private static bool TryGetMissingParam(Exception ex, out string? paramName)
+    {
+        // The SDK delivers two shapes (see ToolErrorHandler.ClassifyError comments):
+        //   1. Direct ArgumentException / ArgumentNullException carrying ParamName.
+        //   2. Wrapped in TargetInvocationException or InvalidOperationException whose
+        //      InnerException is the real ArgumentException.
+        if (ex is ArgumentException directArg && !string.IsNullOrEmpty(directArg.ParamName))
+        {
+            paramName = directArg.ParamName;
+            return true;
+        }
+        if (ex.InnerException is ArgumentException innerArg && !string.IsNullOrEmpty(innerArg.ParamName))
+        {
+            paramName = innerArg.ParamName;
+            return true;
+        }
+        paramName = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the strict path-only elicit request for the
+    /// <c>elicit-workspace-path-on-missing-required-arg</c> initiative. Single string field,
+    /// required, descriptive prompt naming the tool so the user knows what they're being
+    /// asked for. Form mode is the canonical shape; clients that only support url mode can
+    /// still complete via out-of-band navigation.
+    /// </summary>
+    private static ElicitRequestParams BuildWorkspacePathElicitationRequest(string toolName, string missingParamName)
+    {
+        var message = string.Equals(missingParamName, WorkspaceIdParameterName, StringComparison.Ordinal)
+            ? $"The {toolName} tool was called without a 'workspaceId' argument. " +
+              "Provide an absolute path to a .sln, .slnx, or .csproj file; the server will call workspace_load and retry with the recovered workspaceId."
+            : $"The {toolName} tool was called without a '{missingParamName}' argument. " +
+              "Provide an absolute path to a .sln, .slnx, or .csproj file to continue.";
+
+        return new ElicitRequestParams
+        {
+            Message = message,
+            RequestedSchema = new ElicitRequestParams.RequestSchema
+            {
+                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
+                {
+                    [PathParameterName] = new ElicitRequestParams.StringSchema
+                    {
+                        Title = "Workspace path",
+                        Description =
+                            "Absolute path to a .sln, .slnx, or .csproj file on the local filesystem.",
+                    },
+                },
+                Required = [PathParameterName],
+            },
+        };
+    }
+
+    /// <summary>
+    /// Temporarily swaps <paramref name="context"/>'s tool name and arguments, dispatches through
+    /// <paramref name="next"/>, then restores the originals in a <c>finally</c>. Used to run
+    /// <c>workspace_load</c> (or a patched retry) on the same request context without leaking the
+    /// mutation to the caller. <c>internal</c> so the filter's retained auto-load path can reuse it.
+    /// </summary>
+    internal static async Task<CallToolResult> DispatchWithTemporaryArgumentsAsync(
+        RequestContext<CallToolRequestParams> context,
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next,
+        string toolName,
+        IReadOnlyDictionary<string, JsonElement> arguments,
+        CancellationToken cancellationToken)
+    {
+        var originalToolName = context.Params!.Name;
+        var originalArgs = context.Params.Arguments;
+        try
+        {
+            context.Params.Name = toolName;
+            context.Params.Arguments = new Dictionary<string, JsonElement>(arguments, StringComparer.Ordinal);
+            return await next(context, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.Params.Name = originalToolName;
+            context.Params.Arguments = originalArgs;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, JsonElement>? CopyArguments(
+        IDictionary<string, JsonElement>? arguments)
+    {
+        if (arguments is null) return null;
+        return new Dictionary<string, JsonElement>(arguments, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Extracts the <c>workspaceId</c> string from a <c>workspace_load</c> result's JSON body,
+    /// or <see langword="null"/> when the content is empty, non-text, non-JSON, or lacks the
+    /// property. <c>internal</c> so the filter's retained auto-load path can reuse it.
+    /// </summary>
+    internal static string? TryExtractWorkspaceId(CallToolResult result)
+    {
+        if (result.Content is null || result.Content.Count == 0) return null;
+        if (result.Content[0] is not TextContentBlock text || string.IsNullOrWhiteSpace(text.Text)) return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text.Text);
+            return doc.RootElement.TryGetProperty(WorkspaceIdParameterName, out var id)
+                   && id.ValueKind == JsonValueKind.String
+                ? id.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -249,129 +249,17 @@ internal static class StructuredCallToolFilter
         ElicitationAllowlistPolicy.IsElicitationAllowedFor(toolName, paramName);
 
     /// <summary>
-    /// Core of the elicitation-fallback path: when <paramref name="ex"/> is an
-    /// <c>InvalidArgument</c> for a missing required parameter on a tool whose
-    /// (toolName, paramName) pair is on the elicitation allowlist AND the client supports
-    /// elicitation, this method asks the user for the missing value via
-    /// <see cref="McpServer.ElicitAsync(ElicitRequestParams, CancellationToken)"/>, patches
-    /// the elicited value into the request's <c>Arguments</c> dictionary, and re-invokes
-    /// <paramref name="next"/>. Returns <see langword="null"/> when the recovery does not
-    /// apply (any layer of the gate fails) — the caller falls through to
-    /// <see cref="BuildErrorResult"/> with the existing schema-hint envelope.
+    /// Thin delegate preserving the historical static call surface. The elicitation/retry
+    /// orchestration lives in <see cref="StructuredCallElicitationCoordinator.TryElicitAndRetryAsync"/>;
+    /// kept here so <see cref="Create"/> and the existing filter test suites compile unchanged.
     /// </summary>
-    /// <remarks>
-    /// We do NOT hold any workspace lock or other resource during the elicit wait — that
-    /// wait is unbounded (user-paced) and would otherwise starve concurrent tool calls.
-    /// The original failure already released anything <c>next</c> had taken; the retry
-    /// re-acquires from a clean state.
-    /// </remarks>
-    internal static async Task<CallToolResult?> TryElicitAndRetryAsync(
+    internal static Task<CallToolResult?> TryElicitAndRetryAsync(
         RequestContext<CallToolRequestParams> context,
         Exception ex,
         McpRequestHandler<CallToolRequestParams, CallToolResult> next,
         ILogger? logger,
-        CancellationToken cancellationToken)
-    {
-        // Layer 0: only InvalidArgument-like exceptions with a known param name qualify.
-        if (!TryGetMissingParam(ex, out var missingParam) || string.IsNullOrEmpty(missingParam))
-        {
-            return null;
-        }
-
-        var toolName = context.Params?.Name;
-        if (string.IsNullOrEmpty(toolName))
-        {
-            return null;
-        }
-
-        // Layer 1 + 2: allowlist + sensitive-name refusal in one call. Either failure
-        // means "do not elicit" — the legacy schemaHint envelope is the right fallback.
-        if (!IsElicitationAllowedFor(toolName, missingParam))
-        {
-            // Defense-in-depth log: explicit "refused to elicit sensitive field" branch
-            // so a future audit can grep for it. Not an error — we refuse silently and
-            // fall through to the normal envelope.
-            if (IsSensitiveFieldName(missingParam))
-            {
-                logger?.LogWarning(
-                    "Refusing to elicit sensitive parameter '{Param}' on tool '{Tool}'. " +
-                    "MCP spec § Elicitation security: 'Servers MUST NOT request sensitive information'.",
-                    missingParam, toolName);
-            }
-            return null;
-        }
-
-        // Layer 3: client must support elicitation. server.ClientCapabilities.Elicitation
-        // is established at initialize-handshake time; this is a property read, not an RPC.
-        if (!HasElicitation(context.Server?.ClientCapabilities))
-        {
-            return null;
-        }
-
-        if (IsWorkspaceIdRecoveryAllowedFor(toolName, missingParam))
-        {
-            return await TryRecoverMissingWorkspaceIdAsync(
-                toolName,
-                CopyArguments(context.Params!.Arguments),
-                request => context.Server!.ElicitAsync(request, cancellationToken),
-                (dispatchToolName, arguments) =>
-                    DispatchWithTemporaryArgumentsAsync(context, next, dispatchToolName, arguments, cancellationToken),
-                logger,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        // Build the strict elicit request. Single string field ('path'), required, with a
-        // descriptive prompt — the user sees a one-field form (in form mode) or navigates
-        // to the URL (in url mode); the client picks based on its declared sub-capability.
-        var elicitRequest = BuildWorkspacePathElicitationRequest(toolName, missingParam);
-
-        ElicitResult elicitResult;
-        try
-        {
-            elicitResult = await context.Server!.ElicitAsync(elicitRequest, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (Exception elicitEx)
-        {
-            // ElicitAsync can throw InvalidOperationException (client doesn't support
-            // elicitation despite the capability check, transport went away, etc.) or
-            // McpException (client returned an error). Either way we fall through to the
-            // existing envelope rather than masking the original error.
-            logger?.LogWarning(elicitEx,
-                "Elicitation request failed for {Tool}.{Param}; falling back to schemaHint envelope.",
-                toolName, missingParam);
-            return null;
-        }
-
-        // User declined or cancelled — surface the original error. Don't retry with empty
-        // input; that would just re-trigger the same InvalidArgument.
-        if (!elicitResult.IsAccepted || elicitResult.Content is null
-            || !elicitResult.Content.TryGetValue(missingParam, out var elicitedValue))
-        {
-            logger?.LogInformation(
-                "User declined or cancelled elicitation for {Tool}.{Param}", toolName, missingParam);
-            return null;
-        }
-
-        // Patch the missing parameter into the arguments dictionary and retry.
-        // CallToolRequestParams.Arguments is IReadOnlyDictionary<string, JsonElement>?;
-        // we materialize a new mutable copy, set the elicited value, and assign it back.
-        var existingArgs = context.Params!.Arguments;
-        var newArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
-        if (existingArgs is not null)
-        {
-            foreach (var kvp in existingArgs)
-            {
-                newArgs[kvp.Key] = kvp.Value;
-            }
-        }
-        newArgs[missingParam] = elicitedValue;
-        context.Params.Arguments = newArgs;
-
-        // Re-dispatch. If this throws too, the exception bubbles back to the outer catch
-        // — we don't loop indefinitely.
-        return await next(context, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken) =>
+        StructuredCallElicitationCoordinator.TryElicitAndRetryAsync(context, ex, next, logger, cancellationToken);
 
     /// <summary>
     /// Thin delegate preserving the historical static call surface. See
@@ -514,9 +402,9 @@ internal static class StructuredCallToolFilter
                 {
                     [PathParameterName] = JsonSerializer.SerializeToElement(discovery.UniquePath!),
                 };
-                var loadResult = await DispatchWithTemporaryArgumentsAsync(
+                var loadResult = await StructuredCallElicitationCoordinator.DispatchWithTemporaryArgumentsAsync(
                     context, next, WorkspaceLoadToolName, loadArguments, cancellationToken).ConfigureAwait(false);
-                var workspaceId = TryExtractWorkspaceId(loadResult);
+                var workspaceId = StructuredCallElicitationCoordinator.TryExtractWorkspaceId(loadResult);
                 stopwatch.Stop();
 
                 if (string.IsNullOrWhiteSpace(workspaceId))
@@ -557,197 +445,21 @@ internal static class StructuredCallToolFilter
         }
     }
 
-    internal static async Task<CallToolResult?> TryRecoverMissingWorkspaceIdAsync(
+    /// <summary>
+    /// Thin delegate preserving the historical static call surface. The recover-load-retry
+    /// loop lives in
+    /// <see cref="StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync"/>;
+    /// kept here so the existing filter test suites compile unchanged.
+    /// </summary>
+    internal static Task<CallToolResult?> TryRecoverMissingWorkspaceIdAsync(
         string toolName,
         IReadOnlyDictionary<string, JsonElement>? originalArguments,
         Func<ElicitRequestParams, ValueTask<ElicitResult>> elicitAsync,
         Func<string, IReadOnlyDictionary<string, JsonElement>, Task<CallToolResult>> dispatchAsync,
         ILogger? logger,
-        CancellationToken cancellationToken)
-    {
-        var elicitRequest = BuildWorkspacePathElicitationRequest(toolName, WorkspaceIdParameterName);
-        ElicitResult elicitResult;
-        try
-        {
-            elicitResult = await elicitAsync(elicitRequest).ConfigureAwait(false);
-        }
-        catch (Exception elicitEx)
-        {
-            logger?.LogWarning(elicitEx,
-                "WorkspaceId recovery elicitation failed for {Tool}; falling back to schemaHint envelope.",
-                toolName);
-            return null;
-        }
-
-        if (!elicitResult.IsAccepted || elicitResult.Content is null
-            || !elicitResult.Content.TryGetValue(PathParameterName, out var pathValue))
-        {
-            logger?.LogInformation(
-                "User declined or cancelled workspaceId recovery elicitation for {Tool}", toolName);
-            return null;
-        }
-
-        if (pathValue.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(pathValue.GetString()))
-        {
-            return null;
-        }
-
-        var loadArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
-        {
-            [PathParameterName] = pathValue,
-        };
-        CallToolResult loadResult;
-        try
-        {
-            loadResult = await dispatchAsync(WorkspaceLoadToolName, loadArgs).ConfigureAwait(false);
-        }
-        catch (Exception loadEx)
-        {
-            logger?.LogWarning(loadEx,
-                "workspace_load dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
-                toolName);
-            return null;
-        }
-
-        var workspaceId = TryExtractWorkspaceId(loadResult);
-        if (string.IsNullOrWhiteSpace(workspaceId))
-        {
-            logger?.LogWarning(
-                "workspace_load did not return a workspaceId during recovery for {Tool}; falling back to schemaHint envelope.",
-                toolName);
-            return null;
-        }
-
-        var retryArgs = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
-        if (originalArguments is not null)
-        {
-            foreach (var kvp in originalArguments)
-            {
-                retryArgs[kvp.Key] = kvp.Value;
-            }
-        }
-
-        retryArgs[WorkspaceIdParameterName] = JsonSerializer.SerializeToElement(workspaceId, JsonDefaults.Indented);
-        try
-        {
-            return await dispatchAsync(toolName, retryArgs).ConfigureAwait(false);
-        }
-        catch (Exception retryEx)
-        {
-            logger?.LogWarning(retryEx,
-                "Retried tool dispatch threw during workspaceId recovery for {Tool}; falling back to schemaHint envelope.",
-                toolName);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Inspects <paramref name="ex"/> for the InvalidArgument-shaped binding-failure
-    /// exceptions the SDK delivers when a required parameter is missing. Returns
-    /// <see langword="true"/> with the parameter name on success, otherwise
-    /// <see langword="false"/> (caller skips the elicit path).
-    /// </summary>
-    private static bool TryGetMissingParam(Exception ex, out string? paramName)
-    {
-        // The SDK delivers two shapes (see ToolErrorHandler.ClassifyError comments):
-        //   1. Direct ArgumentException / ArgumentNullException carrying ParamName.
-        //   2. Wrapped in TargetInvocationException or InvalidOperationException whose
-        //      InnerException is the real ArgumentException.
-        if (ex is ArgumentException directArg && !string.IsNullOrEmpty(directArg.ParamName))
-        {
-            paramName = directArg.ParamName;
-            return true;
-        }
-        if (ex.InnerException is ArgumentException innerArg && !string.IsNullOrEmpty(innerArg.ParamName))
-        {
-            paramName = innerArg.ParamName;
-            return true;
-        }
-        paramName = null;
-        return false;
-    }
-
-    /// <summary>
-    /// Builds the strict path-only elicit request for the
-    /// <c>elicit-workspace-path-on-missing-required-arg</c> initiative. Single string field,
-    /// required, descriptive prompt naming the tool so the user knows what they're being
-    /// asked for. Form mode is the canonical shape; clients that only support url mode can
-    /// still complete via out-of-band navigation.
-    /// </summary>
-    private static ElicitRequestParams BuildWorkspacePathElicitationRequest(string toolName, string missingParamName)
-    {
-        var message = string.Equals(missingParamName, WorkspaceIdParameterName, StringComparison.Ordinal)
-            ? $"The {toolName} tool was called without a 'workspaceId' argument. " +
-              "Provide an absolute path to a .sln, .slnx, or .csproj file; the server will call workspace_load and retry with the recovered workspaceId."
-            : $"The {toolName} tool was called without a '{missingParamName}' argument. " +
-              "Provide an absolute path to a .sln, .slnx, or .csproj file to continue.";
-
-        return new ElicitRequestParams
-        {
-            Message = message,
-            RequestedSchema = new ElicitRequestParams.RequestSchema
-            {
-                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
-                {
-                    [PathParameterName] = new ElicitRequestParams.StringSchema
-                    {
-                        Title = "Workspace path",
-                        Description =
-                            "Absolute path to a .sln, .slnx, or .csproj file on the local filesystem.",
-                    },
-                },
-                Required = [PathParameterName],
-            },
-        };
-    }
-
-    private static async Task<CallToolResult> DispatchWithTemporaryArgumentsAsync(
-        RequestContext<CallToolRequestParams> context,
-        McpRequestHandler<CallToolRequestParams, CallToolResult> next,
-        string toolName,
-        IReadOnlyDictionary<string, JsonElement> arguments,
-        CancellationToken cancellationToken)
-    {
-        var originalToolName = context.Params!.Name;
-        var originalArgs = context.Params.Arguments;
-        try
-        {
-            context.Params.Name = toolName;
-            context.Params.Arguments = new Dictionary<string, JsonElement>(arguments, StringComparer.Ordinal);
-            return await next(context, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            context.Params.Name = originalToolName;
-            context.Params.Arguments = originalArgs;
-        }
-    }
-
-    private static IReadOnlyDictionary<string, JsonElement>? CopyArguments(
-        IDictionary<string, JsonElement>? arguments)
-    {
-        if (arguments is null) return null;
-        return new Dictionary<string, JsonElement>(arguments, StringComparer.Ordinal);
-    }
-
-    private static string? TryExtractWorkspaceId(CallToolResult result)
-    {
-        if (result.Content is null || result.Content.Count == 0) return null;
-        if (result.Content[0] is not TextContentBlock text || string.IsNullOrWhiteSpace(text.Text)) return null;
-
-        try
-        {
-            using var doc = JsonDocument.Parse(text.Text);
-            return doc.RootElement.TryGetProperty(WorkspaceIdParameterName, out var id)
-                   && id.ValueKind == JsonValueKind.String
-                ? id.GetString()
-                : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
+        CancellationToken cancellationToken) =>
+        StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync(
+            toolName, originalArguments, elicitAsync, dispatchAsync, logger, cancellationToken);
 
     /// <summary>
     /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
@@ -771,67 +483,15 @@ internal static class StructuredCallToolFilter
     /// </param>
     /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
     /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
-    public static async Task<string?> TryElicitChoiceAsync(
+    public static Task<string?> TryElicitChoiceAsync(
         McpServer? server,
         string paramName,
         string title,
         string description,
         IReadOnlyList<(string Key, string Label)> options,
-        CancellationToken cancellationToken)
-    {
-        if (server is null) return null;
-        if (!HasElicitation(server.ClientCapabilities)) return null;
-        if (string.IsNullOrEmpty(paramName) || options is null || options.Count == 0) return null;
-
-        var oneOf = new List<ElicitRequestParams.EnumSchemaOption>(options.Count);
-        for (var i = 0; i < options.Count; i++)
-        {
-            var (key, label) = options[i];
-            if (string.IsNullOrEmpty(key)) continue;
-            oneOf.Add(new ElicitRequestParams.EnumSchemaOption
-            {
-                Const = key,
-                Title = string.IsNullOrEmpty(label) ? key : label,
-            });
-        }
-        if (oneOf.Count == 0) return null;
-
-        var request = new ElicitRequestParams
-        {
-            Message = description,
-            RequestedSchema = new ElicitRequestParams.RequestSchema
-            {
-                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
-                {
-                    [paramName] = new ElicitRequestParams.TitledSingleSelectEnumSchema
-                    {
-                        Title = title,
-                        Description = description,
-                        OneOf = oneOf,
-                    },
-                },
-                Required = [paramName],
-            },
-        };
-
-        ElicitResult result;
-        try
-        {
-            result = await server.ElicitAsync(request, cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // ElicitAsync can throw InvalidOperationException (transport gone, capability
-            // mismatch) or McpException (client-side error). Either way, the disambiguation
-            // path falls through to the additive list response — never masks a real failure.
-            return null;
-        }
-
-        if (!result.IsAccepted || result.Content is null) return null;
-        if (!result.Content.TryGetValue(paramName, out var chosen)) return null;
-        var chosenKey = chosen.ValueKind == JsonValueKind.String ? chosen.GetString() : null;
-        return string.IsNullOrEmpty(chosenKey) ? null : chosenKey;
-    }
+        CancellationToken cancellationToken) =>
+        StructuredCallElicitationCoordinator.TryElicitChoiceAsync(
+            server, paramName, title, description, options, cancellationToken);
 
     /// <summary>
     /// Produces the <see cref="CallToolResult"/> envelope the filter emits when a tool call
@@ -850,101 +510,22 @@ internal static class StructuredCallToolFilter
     }
 
     /// <summary>
-    /// Injects the gate-metrics snapshot as a top-level <c>_meta</c> property on the first
-    /// text content block when the tool's JSON response is object-rooted. Arrays,
-    /// primitives, and non-text content are returned unchanged — preserving the
-    /// historical contract that e.g. <c>source_generated_documents</c>'s bare-array
-    /// response shape remains stable across the filter migration. Exposed <c>internal</c>
-    /// so tests can assert meta-injection behavior directly.
-    ///
-    /// <para><b>tool-output-schema-infrastructure (MCP 2025-06-18 § Tools / Structured Content):</b></para>
-    /// <para>
-    /// When the tool has a registered <c>outputSchema</c> via
-    /// <see cref="McpToolMetadataAttribute.OutputSchemaTypeRef"/>, this method ALSO populates
-    /// <see cref="CallToolResult.StructuredContent"/> with the same payload (sans <c>_meta</c>) so
-    /// the structured-content channel is non-empty. Per spec, when <c>structuredContent</c> is
-    /// emitted the server MUST also emit a serialized JSON copy in the <c>content[].text</c>
-    /// channel — both channels coexist; <c>_meta</c> lives only in the text channel so clients
-    /// never see two observability blobs (defense against the dedupe risk noted in the
-    /// initiative plan).
-    /// </para>
+    /// Thin delegate preserving the historical static call surface. The structured-content /
+    /// <c>_meta</c> projection lives in
+    /// <see cref="StructuredCallContentProjector.InjectMetaIntoContent(CallToolResult, string)"/>;
+    /// kept here so <see cref="Create"/> and the existing filter/content test suites compile unchanged.
     /// </summary>
     internal static CallToolResult InjectMetaIntoContent(CallToolResult result, string toolName) =>
-        InjectMetaIntoContent(result, toolName, ToolOutputSchemaIndex.GetSchema);
+        StructuredCallContentProjector.InjectMetaIntoContent(result, toolName);
 
     /// <summary>
-    /// Test seam: same as <see cref="InjectMetaIntoContent(CallToolResult, string)"/> but lets
-    /// the caller supply a custom schema resolver so dual-channel behavior can be exercised
-    /// without needing a live <c>[McpToolMetadata(outputSchemaTypeRef:)]</c> opt-in. The
-    /// production path always uses the static <see cref="ToolOutputSchemaIndex"/>.
+    /// Thin delegate preserving the historical static call surface (test seam with a custom
+    /// schema resolver). See
+    /// <see cref="StructuredCallContentProjector.InjectMetaIntoContent(CallToolResult, string, Func{string, JsonNode})"/>.
     /// </summary>
     internal static CallToolResult InjectMetaIntoContent(
-        CallToolResult result, string toolName, Func<string, JsonNode?> schemaResolver)
-    {
-        if (result.Content is null || result.Content.Count == 0)
-        {
-            return result;
-        }
-
-        if (result.Content[0] is not TextContentBlock text || string.IsNullOrEmpty(text.Text))
-        {
-            return result;
-        }
-
-        // Parse once so both the meta-injection path and the structuredContent path can share
-        // a single JsonNode tree. Non-JSON / array-rooted responses bail out early as before.
-        JsonNode? parsedRoot = null;
-        try
-        {
-            parsedRoot = JsonNode.Parse(text.Text);
-        }
-        catch (JsonException)
-        {
-            // Fall through to the original best-effort path; non-JSON responses pass through.
-        }
-
-        var schema = schemaResolver(toolName);
-        // structuredContent is only emitted when (a) the tool opted in via OutputSchemaTypeRef
-        // and (b) the response is an object-rooted JSON document we can mirror. Arrays, scalars,
-        // and non-JSON responses leave structuredContent absent — matching the spec's "MAY"
-        // semantics rather than fabricating a structured shape that doesn't match the schema.
-        // CallToolResult.StructuredContent is a JsonElement? — convert from JsonNode via the
-        // round-trip text. The body is small (already serialized once for the text channel)
-        // so the extra parse is bounded; deep-clone to detach from the parsed tree.
-        JsonElement? structuredFromBody = null;
-        if (schema is not null && parsedRoot is JsonObject bodyObj)
-        {
-            structuredFromBody = JsonDocument.Parse(bodyObj.ToJsonString()).RootElement.Clone();
-        }
-
-        var injected = ToolErrorHandler.InjectMetaIfPossible(text.Text, toolName);
-        var textChanged = !(ReferenceEquals(injected, text.Text) || injected == text.Text);
-
-        if (!textChanged && structuredFromBody is null)
-        {
-            // Nothing to change — skip the allocation so array-rooted and non-JSON
-            // responses pass through byte-for-byte identical.
-            return result;
-        }
-
-        var newContent = new List<ContentBlock>(result.Content.Count)
-        {
-            new TextContentBlock { Text = textChanged ? injected : text.Text }
-        };
-        for (var i = 1; i < result.Content.Count; i++)
-        {
-            newContent.Add(result.Content[i]);
-        }
-
-        return new CallToolResult
-        {
-            IsError = result.IsError,
-            Content = newContent,
-            // Preserve any pre-existing StructuredContent (a tool may have set it directly);
-            // otherwise emit the schema-mirrored body when the tool has opted in.
-            StructuredContent = result.StructuredContent ?? structuredFromBody,
-        };
-    }
+        CallToolResult result, string toolName, Func<string, JsonNode?> schemaResolver) =>
+        StructuredCallContentProjector.InjectMetaIntoContent(result, toolName, schemaResolver);
 
     /// <summary>
     /// Predicate for logger severity: anything that <see cref="ToolErrorHandler"/>

--- a/tests/RoslynMcp.Tests/StructuredCallContentProjectorTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallContentProjectorTests.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct coverage for <see cref="StructuredCallContentProjector"/>, the structured-content /
+/// <c>_meta</c> projection layer extracted from <see cref="StructuredCallToolFilter"/> by the
+/// <c>structuredcalltoolfilter-hotspot-decomposition-followup</c> initiative. These tests call the
+/// projector directly (not through the filter's thin delegate) so the extracted collaborator is
+/// exercised on its own surface. The delegate-forwarded behavior stays pinned by
+/// <see cref="StructuredCallToolFilterTests"/> and <see cref="StructuredContentRoundTripTests"/>.
+/// </summary>
+[TestClass]
+public sealed class StructuredCallContentProjectorTests
+{
+    // ── _meta injection on the success path (mirrors StructuredCallToolFilterTests) ──
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ObjectRootedJson_InjectsMetaField()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = """{"result":"ok"}""" }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(input, "test_tool");
+
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var payload = JsonDocument.Parse(text).RootElement;
+        Assert.IsTrue(payload.TryGetProperty("_meta", out var meta),
+            "Object-rooted success responses must carry a _meta block for observability.");
+        Assert.IsTrue(meta.TryGetProperty("queuedMs", out _));
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ArrayRootedJson_ReturnsResultUnchanged()
+    {
+        // Backward-compat contract: tools like source_generated_documents return bare
+        // arrays. The projector must NOT wrap them in {data, _meta} — array-rooted JSON
+        // passes through byte-for-byte identical (same instance).
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = "[1,2,3]" }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(input, "test_tool");
+
+        Assert.AreSame(input, result, "Array-rooted responses should return the exact same CallToolResult instance.");
+        Assert.AreEqual("[1,2,3]", ((TextContentBlock)result.Content![0]).Text);
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_EmptyContent_ReturnsResultUnchanged()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(input, "test_tool");
+
+        Assert.AreSame(input, result);
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_NonJsonText_ReturnsResultUnchanged()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = "not valid json at all" }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(input, "test_tool");
+
+        Assert.AreSame(input, result);
+    }
+
+    // ── dual-channel structuredContent via the schema-resolver seam ──
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ToolWithSchema_EmitsBothChannelsWithSingleMeta()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var bodyJson = JsonSerializer.Serialize(
+            new { name = "ws-1", count = 42, loaded = true }, JsonDefaults.Indented);
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(
+            input, "sample_tool", _ => JsonNode.Parse("""{"type":"object"}"""));
+
+        // Channel 1: text carries body + _meta.
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var textPayload = JsonDocument.Parse(text).RootElement;
+        Assert.IsTrue(textPayload.TryGetProperty("name", out _),
+            "Text channel must still carry the response body for legacy clients.");
+        Assert.IsTrue(textPayload.TryGetProperty("_meta", out _),
+            "Text channel must carry _meta for observability.");
+
+        // Channel 2: structuredContent carries body MINUS _meta.
+        Assert.IsNotNull(result.StructuredContent,
+            "Tools with a registered output schema MUST populate structuredContent.");
+        var structured = result.StructuredContent!.Value;
+        Assert.IsTrue(structured.TryGetProperty("name", out var nameProp));
+        Assert.AreEqual("ws-1", nameProp.GetString());
+        Assert.IsFalse(structured.TryGetProperty("_meta", out _),
+            "_meta MUST live ONLY in the text channel — never duplicated into structuredContent.");
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ToolWithoutSchema_TextOnlyContractPreserved()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var bodyJson = JsonSerializer.Serialize(new { name = "ws-1", count = 42 }, JsonDefaults.Indented);
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(
+            input, "no_schema_tool", _ => null);
+
+        var text = ((TextContentBlock)result.Content![0]).Text;
+        var payload = JsonDocument.Parse(text).RootElement;
+        Assert.IsTrue(payload.TryGetProperty("_meta", out _),
+            "Tools without a schema still get _meta on the text channel — the legacy contract.");
+        Assert.IsNull(result.StructuredContent,
+            "Tools without a registered output schema MUST NOT populate structuredContent.");
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_ArrayRootedJson_StaysTextOnlyEvenWithSchema()
+    {
+        // Even when a schema resolves, an array-rooted body cannot be mirrored into the
+        // object-shaped structuredContent channel — it stays text-only and unchanged.
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = "[1,2,3]" }],
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(
+            input, "sample_tool", _ => JsonNode.Parse("""{"type":"object"}"""));
+
+        Assert.AreSame(input, result);
+        Assert.IsNull(result.StructuredContent);
+    }
+
+    [TestMethod]
+    public void InjectMetaIntoContent_PreExistingStructuredContent_NotOverwritten()
+    {
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var preExisting = JsonDocument.Parse("""{"pre":"existing"}""").RootElement.Clone();
+        var bodyJson = JsonSerializer.Serialize(new { name = "ws-1" }, JsonDefaults.Indented);
+        var input = new CallToolResult
+        {
+            IsError = false,
+            Content = [new TextContentBlock { Text = bodyJson }],
+            StructuredContent = preExisting,
+        };
+
+        var result = StructuredCallContentProjector.InjectMetaIntoContent(
+            input, "sample_tool", _ => JsonNode.Parse("""{"type":"object"}"""));
+
+        Assert.IsNotNull(result.StructuredContent);
+        Assert.IsTrue(result.StructuredContent!.Value.TryGetProperty("pre", out var pre),
+            "A tool that set StructuredContent directly must have it preserved, not overwritten by the body mirror.");
+        Assert.AreEqual("existing", pre.GetString());
+    }
+}

--- a/tests/RoslynMcp.Tests/StructuredCallElicitationCoordinatorTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallElicitationCoordinatorTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Middleware;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct coverage for <see cref="StructuredCallElicitationCoordinator"/>, the elicitation/retry
+/// orchestration layer extracted from <see cref="StructuredCallToolFilter"/> by the
+/// <c>structuredcalltoolfilter-hotspot-decomposition-followup</c> initiative. These tests call the
+/// coordinator directly (not through the filter's thin delegate) so the extracted collaborator is
+/// exercised on its own surface. The delegate-forwarded behavior stays pinned by
+/// <see cref="StructuredCallToolFilterElicitationTests"/>.
+///
+/// <para>
+/// The recover-load-retry loop takes its elicit + dispatch collaborators as delegates, so it is
+/// fully unit-testable without standing up a live MCP transport. <see cref="McpServer"/>-bound
+/// entry points (<c>TryElicitAndRetryAsync</c>, the transport-driven arms of
+/// <c>TryElicitChoiceAsync</c>) still require a real server; their gate logic is covered via the
+/// null-short-circuit and the allowlist tests in <see cref="StructuredCallToolFilterElicitationTests"/>.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class StructuredCallElicitationCoordinatorTests
+{
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_ElicitsPathLoadsWorkspaceAndRetriesOriginalTool()
+    {
+        const string solutionPath = "C:/repo/SampleSolution.slnx";
+        const string recoveredWorkspaceId = "ws-recovered";
+        var elicitationCount = 0;
+        var dispatches = new List<(string ToolName, IReadOnlyDictionary<string, JsonElement> Arguments)>();
+
+        var result = await StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: request =>
+            {
+                elicitationCount++;
+                Assert.IsTrue(request.RequestedSchema!.Properties.ContainsKey("path"),
+                    "Missing workspaceId recovery must elicit workspace_load.path, not ask the user to invent a session id.");
+                Assert.IsTrue(request.Message.Contains("workspaceId", StringComparison.Ordinal));
+
+                var pathElement = JsonSerializer.SerializeToElement(solutionPath, JsonDefaults.Indented);
+                return ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement> { ["path"] = pathElement },
+                });
+            },
+            dispatchAsync: (toolName, arguments) =>
+            {
+                dispatches.Add((toolName, new Dictionary<string, JsonElement>(arguments, StringComparer.Ordinal)));
+
+                if (toolName == "workspace_load")
+                {
+                    Assert.AreEqual(solutionPath, arguments["path"].GetString());
+                    return Task.FromResult(new CallToolResult
+                    {
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text = JsonSerializer.Serialize(
+                                    new { WorkspaceId = recoveredWorkspaceId }, JsonDefaults.Indented),
+                            },
+                        ],
+                    });
+                }
+
+                Assert.AreEqual("workspace_status", toolName);
+                Assert.AreEqual(recoveredWorkspaceId, arguments["workspaceId"].GetString());
+                return Task.FromResult(new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = """{"state":"ready"}""" }],
+                });
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNotNull(result, "A supporting client path elicitation should recover and retry.");
+        Assert.AreEqual(1, elicitationCount, "The recovery path should ask the user exactly once.");
+        CollectionAssert.AreEqual(
+            new[] { "workspace_load", "workspace_status" },
+            dispatches.Select(dispatch => dispatch.ToolName).ToArray(),
+            "Recovery must load the workspace before retrying the original workspace-scoped tool.");
+        Assert.AreEqual("""{"state":"ready"}""", ((TextContentBlock)result.Content![0]).Text);
+    }
+
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_UserDeclines_ReturnsNull()
+    {
+        var result = await StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: _ => ValueTask.FromResult(new ElicitResult { Action = "decline" }),
+            dispatchAsync: (_, _) =>
+            {
+                Assert.Fail("Dispatch must not run when the user declines the recovery elicitation.");
+                return Task.FromResult(new CallToolResult());
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result, "A declined elicitation must fall through to the existing envelope (null).");
+    }
+
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_WorkspaceLoadDispatchThrows_ReturnsNullWithoutEscaping()
+    {
+        const string solutionPath = "C:/repo/SampleSolution.slnx";
+
+        var result = await StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: _ =>
+            {
+                var pathElement = JsonSerializer.SerializeToElement(solutionPath, JsonDefaults.Indented);
+                return ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement> { ["path"] = pathElement },
+                });
+            },
+            dispatchAsync: (toolName, _) =>
+            {
+                Assert.AreEqual("workspace_load", toolName,
+                    "A throw from the workspace_load dispatch must stop recovery before retrying the original tool.");
+                throw new InvalidOperationException("workspace_load blew up");
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result,
+            "A throwing workspace_load dispatch must be caught and surface as a null fall-through, not escape.");
+    }
+
+    [TestMethod]
+    public async Task TryRecoverMissingWorkspaceIdAsync_RetriedToolDispatchThrows_ReturnsNullWithoutEscaping()
+    {
+        const string solutionPath = "C:/repo/SampleSolution.slnx";
+        const string recoveredWorkspaceId = "ws-recovered";
+
+        var result = await StructuredCallElicitationCoordinator.TryRecoverMissingWorkspaceIdAsync(
+            "workspace_status",
+            originalArguments: null,
+            elicitAsync: _ =>
+            {
+                var pathElement = JsonSerializer.SerializeToElement(solutionPath, JsonDefaults.Indented);
+                return ValueTask.FromResult(new ElicitResult
+                {
+                    Action = "accept",
+                    Content = new Dictionary<string, JsonElement> { ["path"] = pathElement },
+                });
+            },
+            dispatchAsync: (toolName, _) =>
+            {
+                if (toolName == "workspace_load")
+                {
+                    return Task.FromResult(new CallToolResult
+                    {
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text = JsonSerializer.Serialize(
+                                    new { WorkspaceId = recoveredWorkspaceId }, JsonDefaults.Indented),
+                            },
+                        ],
+                    });
+                }
+
+                Assert.AreEqual("workspace_status", toolName);
+                throw new InvalidOperationException("retried tool blew up");
+            },
+            logger: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result,
+            "A throwing retried-tool dispatch must be caught and surface as a null fall-through, not escape.");
+    }
+
+    [TestMethod]
+    public async Task TryElicitChoiceAsync_NullServer_ReturnsNull()
+    {
+        // The disambiguation picker short-circuits to null when there is no connected server,
+        // so a caller with no elicitation-capable client falls through to its additive list.
+        var result = await StructuredCallElicitationCoordinator.TryElicitChoiceAsync(
+            server: null,
+            paramName: "choice",
+            title: "Pick a symbol",
+            description: "Multiple symbols matched.",
+            options: [("k1", "Label 1"), ("k2", "Label 2")],
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsNull(result, "A null server must short-circuit the picker to null.");
+    }
+}


### PR DESCRIPTION
Finish the `StructuredCallToolFilter` hotspot decomposition (backlog row `structuredcalltoolfilter-hotspot-decomposition-followup`). PR #1049 had already extracted the allowlist and metrics concerns; this completes the row's remaining acceptance bullet by extracting the elicitation/retry orchestration and the structured-content/`_meta` projection into focused, directly-tested collaborators.

## Changes

- **New `StructuredCallElicitationCoordinator`** (internal static) — holds `TryElicitAndRetryAsync`, `TryRecoverMissingWorkspaceIdAsync`, `TryElicitChoiceAsync`, and the supporting private helpers (`TryGetMissingParam`, `BuildWorkspacePathElicitationRequest`, `DispatchWithTemporaryArgumentsAsync`, `CopyArguments`, `TryExtractWorkspaceId`). `DispatchWithTemporaryArgumentsAsync` and `TryExtractWorkspaceId` land `internal` so the retained `TryAutoLoadWorkspaceAsync` keeps calling them. Policy predicates re-qualify to `ElicitationAllowlistPolicy` (byte-identical behavior).
- **New `StructuredCallContentProjector`** (internal static) — holds both `InjectMetaIntoContent` overloads, including the `ToolOutputSchemaIndex.GetSchema` default-resolver wiring.
- **`StructuredCallToolFilter`** keeps thin forwarding delegates for `TryElicitAndRetryAsync`, `TryRecoverMissingWorkspaceIdAsync`, `TryElicitChoiceAsync`, and both `InjectMetaIntoContent` overloads, so the historical static call surface (`SymbolTools`, existing filter/content test suites) stays byte-identical. `Create` is now orchestration-only. File shrinks 963 → 544 lines.
- **Direct tests** for both new collaborators (`StructuredCallElicitationCoordinatorTests`, `StructuredCallContentProjectorTests`), called on the collaborators directly rather than through the filter delegates.
- `ElicitationAllowlistPolicy` and `CallMetricsRecorder` untouched (per the row's Notes).

## Validation

- `dotnet build tests/RoslynMcp.Tests -c Release -p:TreatWarningsAsErrors=true` → 0 warnings / 0 errors (includes the RMCP001/RMCP002 catalog analyzers).
- `dotnet test --filter "FullyQualifiedName~StructuredCall"` → 56 passed / 0 failed (all existing filter/content/autoload/resolution classes + the 2 new direct-test classes).

Closes: structuredcalltoolfilter-hotspot-decomposition-followup
