### PR TITLE
refactor(undo): extract ApplyUndoWorkflowService from Host tool wrappers

### DIFF
--- a/changelog.d/apply-undo-workflow-service-extraction.md
+++ b/changelog.d/apply-undo-workflow-service-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** extracted the apply/undo workflow decisions (project-scoped compile-check diffing, apply/rollback outcome selection, cancellation-safe best-effort revert, and sequence-revert outcome mapping) into a new `IApplyUndoWorkflowService` in the Roslyn layer. The `apply_with_verify` and `revert_apply_by_sequence` Host wrappers now only resolve the workspace, open the write gate, and map domain outcomes onto their existing JSON shapes — no wire-format change and no tool-surface change.

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -1,80 +1,36 @@
 using System.ComponentModel;
 using System.Text.Json;
-using Microsoft.Extensions.Logging;
-using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
-using RoslynMcp.Roslyn.Helpers;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
 /// <summary>
 /// apply-with-verify-and-rollback: atomic apply → compile_check → revert primitive. Wraps
 /// the existing <see cref="IRefactoringService.ApplyRefactoringAsync"/> + <c>compile_check</c>
-/// + <c>revert_last_apply</c> chain so callers get one tool call instead of three.
+/// + <c>revert_last_apply</c> chain so callers get one tool call instead of three. The apply →
+/// verify → diff → rollback decision logic lives in <see cref="IApplyUndoWorkflowService"/>
+/// (Roslyn layer); this wrapper only resolves the workspace, opens the write gate, and maps the
+/// returned <see cref="ApplyVerifyOutcome"/> onto the tool's JSON wire shape.
 /// </summary>
 [McpServerToolType]
 public static class ApplyWithVerifyTool
 {
-    /// <summary>
-    /// apply-with-verify-cancellation-and-compile-scope: budget for the best-effort revert
-    /// issued when the caller's <see cref="CancellationToken"/> fires AFTER a successful apply
-    /// but before the normal verify/revert leg completes. The original (already-cancelled)
-    /// token cannot drive the rollback, so a fresh short-lived token is used so the workspace
-    /// is not left mutated with no rollback. Bounded so a wedged revert cannot hang the caller.
-    /// </summary>
-    private static readonly TimeSpan RevertBudget = TimeSpan.FromSeconds(30);
-
-    /// <summary>
-    /// apply-with-verify-cancelled-result-compensation: best-effort revert issued when a
-    /// cancellation is observed after a successful apply, on a FRESH <see cref="RevertBudget"/>-scoped
-    /// token (the caller's own token is already cancelled and cannot drive the rollback). A
-    /// revert failure — either a <see langword="false"/> result or a thrown exception — is
-    /// logged at Error and never swallowed (Directive #3), and never masks the caller's
-    /// cancellation, which the caller rethrows after this returns. Shared by both the
-    /// thrown-OperationCanceledException catch path and the returned-Cancelled=true DTO checks
-    /// below so all three cancellation-observation points revert identically.
-    /// </summary>
-    private static async Task BestEffortRevertAfterCancellationAsync(
-        IUndoService undoService, string workspaceId, ILogger? logger)
-    {
-        using var revertCts = new CancellationTokenSource(RevertBudget);
-        try
-        {
-            var recovered = await undoService.RevertAsync(workspaceId, revertCts.Token).ConfigureAwait(false);
-            if (!recovered)
-            {
-                logger?.LogError(
-                    "apply_with_verify: best-effort revert after cancellation reported failure for workspace {WorkspaceId}; the applied edit may still be present.",
-                    workspaceId);
-            }
-        }
-        catch (Exception revertEx)
-        {
-            logger?.LogError(
-                revertEx,
-                "apply_with_verify: best-effort revert after cancellation threw for workspace {WorkspaceId}; the applied edit may still be present.",
-                workspaceId);
-        }
-    }
-
     [McpServerTool(Name = "apply_with_verify", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "experimental", false, true,
         "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),
      Description("Apply a previously previewed refactoring AND immediately verify the workspace still compiles. When new compile errors appear (relative to the pre-apply baseline), automatically revert via revert_last_apply and return status=\"rolled_back\" with the introduced errors. Otherwise return status=\"applied\". Pass rollbackOnError=false to keep broken state for inspection (returns status=\"applied_with_errors\").")]
     public static Task<string> ApplyWithVerify(
         IWorkspaceExecutionGate gate,
-        IRefactoringService refactoringService,
-        ICompileCheckService compileCheckService,
-        IUndoService undoService,
+        IApplyUndoWorkflowService workflowService,
         IPreviewStore previewStore,
         [Description("The preview token returned by an *_preview tool")] string previewToken,
         [Description("If true (default) and the apply introduces new compile errors, automatically revert via revert_last_apply.")] bool rollbackOnError = true,
-        ILoggerFactory? loggerFactory = null,
         CancellationToken ct = default)
     {
-        var logger = loggerFactory?.CreateLogger(typeof(ApplyWithVerifyTool).FullName ?? nameof(ApplyWithVerifyTool));
         var workspaceId = previewStore.PeekWorkspaceId(previewToken)
             ?? throw new PreviewTokenStaleException(
                 previewToken,
@@ -82,175 +38,49 @@ public static class ApplyWithVerifyTool
 
         return gate.RunWriteAsync(workspaceId, async c =>
         {
-            // apply-with-verify-cancellation-and-compile-scope: scope both compile_check legs
-            // to the single project the preview actually touches, instead of compiling the FULL
-            // solution twice. Mirrors EditService's ownerProjects/batchProjectFilter pattern:
-            // exactly one changed project → filter to it; zero or many → null (compile
-            // everything, the safe fallback). Retrieve is non-consuming and does not perturb the
-            // token's TTL, so the paired apply below still redeems it. A null entry (stale token)
-            // falls through to the full-solution compile — correctness-preserving, just slower.
-            string? projectFilter = null;
-            if (previewStore.Retrieve(previewToken) is { } previewEntry)
+            var outcome = await workflowService.ApplyWithVerifyAsync(previewToken, rollbackOnError, c).ConfigureAwait(false);
+
+            return outcome switch
             {
-                var changedProjects = previewEntry.ModifiedSolution
-                    .GetChanges(previewEntry.OriginalSolution)
-                    .GetProjectChanges()
-                    .Select(pc => pc.NewProject.Name)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-                projectFilter = changedProjects.Count == 1 ? changedProjects[0] : null;
-            }
-
-            var checkOptions = new CompileCheckOptions(ProjectFilter: projectFilter);
-
-            // apply-with-verify-diff-not-counts: snapshot pre-apply error IDENTITIES (id+file+line)
-            // so we can tell NEW errors from pre-existing ones. Identity-diff replaces the prior
-            // count-delta + message-fingerprint heuristic that produced ~14% false-positive
-            // rollbacks (5/36 over 14 days) when a pre-existing diagnostic flipped severity class
-            // or had its message text shift on the post-apply build path. Shared with
-            // EditService's verify=true path so both verify entry points subtract pre-existing
-            // errors uniformly. See DiagnosticIdentitySet for the rationale and format.
-            var preBaseline = await compileCheckService.CheckAsync(
-                workspaceId, checkOptions, c).ConfigureAwait(false);
-
-            // apply-with-verify-cancelled-result-compensation: CompileCheckService.CheckAsync
-            // catches OperationCanceledException internally and returns a normal (non-throwing)
-            // DTO with Cancelled=true instead of propagating the exception — so a caller-token
-            // cancellation that landed inside the pre-apply baseline check is otherwise invisible
-            // here. Nothing has been applied yet, so surface the cancellation directly with zero
-            // apply/revert calls, mirroring PreApplyCancellation_DoesNotAttemptRevert's
-            // thrown-exception shape.
-            if (preBaseline.Cancelled)
-            {
-                c.ThrowIfCancellationRequested();
-                throw new OperationCanceledException(c);
-            }
-
-            var preErrors = DiagnosticIdentitySet.ExtractErrorIdentities(preBaseline);
-
-            // Apply
-            var applyResult = await refactoringService.ApplyRefactoringAsync(previewToken, "apply_with_verify", c).ConfigureAwait(false);
-            if (!applyResult.Success)
-            {
-                return JsonSerializer.Serialize(new
+                ApplyVerifyOutcome.ApplyFailed applyFailed => JsonSerializer.Serialize(new
                 {
                     status = "apply_failed",
-                    error = applyResult.Error,
+                    error = applyFailed.Error,
                     appliedFiles = Array.Empty<string>(),
-                }, JsonDefaults.Indented);
-            }
+                }, JsonDefaults.Indented),
 
-            // apply-with-verify-cancellation-and-compile-scope: the workspace is now mutated.
-            // Everything from here to the normal revert leg runs under the caller's token `c`;
-            // if it fires mid-verify (post-check) or mid-revert, an OperationCanceledException
-            // would otherwise unwind straight out of the gate, leaving the apply in place with
-            // NO rollback. Guard the post-apply region so a cancellation triggers a bounded
-            // best-effort revert on a FRESH token before the OCE is rethrown. This catch can
-            // only fire when the apply already succeeded (we are past the !Success early return),
-            // so a pre-apply cancellation on the baseline compile still propagates untouched —
-            // there is nothing applied to revert in that case.
-            //
-            // apply-with-verify-cancelled-result-compensation: `revertedForCancelledDto` guards
-            // against a DOUBLE revert. The postCheck.Cancelled branch below performs its own
-            // best-effort revert and then throws OperationCanceledException from INSIDE this same
-            // try block, which the catch immediately below would otherwise also revert for —
-            // exactly one best-effort revert is required per cancellation, matching the existing
-            // thrown-OCE tests. The flag is false on every path where compileCheckService threw
-            // directly (the catch's original, unchanged responsibility) and true only when this
-            // method already reverted before throwing.
-            var revertedForCancelledDto = false;
-            try
-            {
-                // Verify — extract post-apply error identities and subtract the pre-apply set.
-                // The remaining identities are "introduced" errors that did not exist at any
-                // (id+file+line) location before the apply. Pre-existing errors whose severity
-                // flipped, message changed, or column shifted no longer trigger rollback.
-                var postCheck = await compileCheckService.CheckAsync(
-                    workspaceId, checkOptions, c).ConfigureAwait(false);
-
-                // apply-with-verify-cancelled-result-compensation: as above, a caller-token
-                // cancellation that landed inside the post-apply verify check returns a
-                // Cancelled=true DTO rather than throwing. The apply already succeeded and
-                // mutated the workspace, so — unlike the pre-apply check above — this must
-                // attempt exactly one best-effort revert (same fresh-token helper the thrown-OCE
-                // catch block below uses) before surfacing the cancellation. `newErrors` would
-                // otherwise be computed from a partial/incomplete diagnostic list.
-                if (postCheck.Cancelled)
+                ApplyVerifyOutcome.Applied applied => JsonSerializer.Serialize(new
                 {
-                    await BestEffortRevertAfterCancellationAsync(undoService, workspaceId, logger).ConfigureAwait(false);
-                    revertedForCancelledDto = true;
-                    c.ThrowIfCancellationRequested();
-                    throw new OperationCanceledException(c);
-                }
+                    status = "applied",
+                    appliedFiles = applied.AppliedFiles,
+                    preErrorCount = applied.PreErrorCount,
+                    postErrorCount = applied.PostErrorCount,
+                }, JsonDefaults.Indented),
 
-                var postErrors = DiagnosticIdentitySet.ExtractErrorIdentities(postCheck);
-
-                // Project the introduced identities back to the diagnostic rows so the response
-                // surfaces the actual errors (id, message, location) rather than opaque
-                // identity strings. Use the post-apply diagnostic list as the source of truth
-                // for the introduced rows.
-                var newIdentities = new HashSet<string>(postErrors.Except(preErrors), StringComparer.Ordinal);
-                var newErrors = postCheck.Diagnostics
-                    .Where(d => string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase)
-                        && newIdentities.Contains(DiagnosticIdentitySet.FormatIdentity(d)))
-                    .ToList();
-
-                if (newErrors.Count == 0)
+                ApplyVerifyOutcome.AppliedWithErrors appliedWithErrors => JsonSerializer.Serialize(new
                 {
-                    return JsonSerializer.Serialize(new
-                    {
-                        status = "applied",
-                        appliedFiles = applyResult.AppliedFiles,
-                        preErrorCount = preBaseline.ErrorCount,
-                        postErrorCount = postCheck.ErrorCount,
-                    }, JsonDefaults.Indented);
-                }
+                    status = "applied_with_errors",
+                    appliedFiles = appliedWithErrors.AppliedFiles,
+                    introducedErrors = appliedWithErrors.IntroducedErrors,
+                    preErrorCount = appliedWithErrors.PreErrorCount,
+                    postErrorCount = appliedWithErrors.PostErrorCount,
+                    message = "Apply introduced new compile errors; rollbackOnError was false so the broken state is preserved for inspection. Call revert_last_apply to restore.",
+                }, JsonDefaults.Indented),
 
-                // New errors appeared. Either roll back or surface for inspection.
-                if (!rollbackOnError)
+                ApplyVerifyOutcome.RolledBack rolledBack => JsonSerializer.Serialize(new
                 {
-                    return JsonSerializer.Serialize(new
-                    {
-                        status = "applied_with_errors",
-                        appliedFiles = applyResult.AppliedFiles,
-                        introducedErrors = newErrors,
-                        preErrorCount = preBaseline.ErrorCount,
-                        postErrorCount = postCheck.ErrorCount,
-                        message = "Apply introduced new compile errors; rollbackOnError was false so the broken state is preserved for inspection. Call revert_last_apply to restore.",
-                    }, JsonDefaults.Indented);
-                }
-
-                var reverted = await undoService.RevertAsync(workspaceId, c).ConfigureAwait(false);
-                return JsonSerializer.Serialize(new
-                {
-                    status = reverted ? "rolled_back" : "rollback_failed",
-                    appliedFiles = applyResult.AppliedFiles,
-                    introducedErrors = newErrors,
-                    preErrorCount = preBaseline.ErrorCount,
-                    postErrorCount = postCheck.ErrorCount,
-                    message = reverted
+                    status = rolledBack.Reverted ? "rolled_back" : "rollback_failed",
+                    appliedFiles = rolledBack.AppliedFiles,
+                    introducedErrors = rolledBack.IntroducedErrors,
+                    preErrorCount = rolledBack.PreErrorCount,
+                    postErrorCount = rolledBack.PostErrorCount,
+                    message = rolledBack.Reverted
                     ? "Apply introduced new compile errors and was reverted. The workspace is back to the pre-apply state."
                     : "Apply introduced new compile errors AND the rollback also failed — the workspace is in an inconsistent state. Inspect manually.",
-                }, JsonDefaults.Indented);
-            }
-            catch (OperationCanceledException)
-            {
-                // The apply landed but the caller cancelled before the verify/revert leg
-                // finished. Roll the workspace back best-effort on a fresh token (the caller's
-                // token `c` is already cancelled and cannot drive the revert), then rethrow the
-                // original cancellation so the caller still observes it. A second failure in the
-                // revert itself is logged rather than swallowed (Directive #3) and does NOT mask
-                // the cancellation. Skip the revert here if the postCheck.Cancelled branch above
-                // already performed it (revertedForCancelledDto) — otherwise this genuinely is
-                // the first (and only) observation of the cancellation, e.g. a thrown OCE from
-                // compileCheckService itself or from the RevertAsync call in the new-errors branch.
-                if (!revertedForCancelledDto)
-                {
-                    await BestEffortRevertAfterCancellationAsync(undoService, workspaceId, logger).ConfigureAwait(false);
-                }
+                }, JsonDefaults.Indented),
 
-                throw;
-            }
+                _ => throw new InvalidOperationException($"Unhandled apply-verify outcome: {outcome.GetType().Name}"),
+            };
         }, ct);
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -65,7 +66,7 @@ public static class UndoTools
      Description("Revert a specific earlier apply by its sequence number — the value reported by workspace_changes. Complements revert_last_apply: instead of LIFO, this revert targets any historical apply still in this session's revert history. Conservative dependency check: if a later apply touched any file that the target apply also touched, the revert is blocked and the offending later sequence numbers are returned in `blockingSequences` so the caller can revert them first. workspaceId is required. sequenceNumber must match a value returned by workspace_changes for this workspace. Returns `{reverted, revertedOperation, affectedFiles, reason?, blockingSequences?}` — `reason` is `unknown-sequence` when the sequence has no recorded snapshot, `dependency-blocked` when a later apply overlaps in files, and `revert-failed` when the snapshot exists but disk/workspace mechanics rejected the revert.")]
     public static Task<string> RevertApplyBySequence(
         IWorkspaceExecutionGate gate,
-        IUndoService undoService,
+        IApplyUndoWorkflowService workflowService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("The sequence number reported by workspace_changes for the apply you want to revert")] int sequenceNumber,
         CancellationToken ct = default)
@@ -80,7 +81,7 @@ public static class UndoTools
         }
         return gate.RunWriteAsync(workspaceId, async c =>
         {
-            var result = await undoService.RevertBySequenceAsync(workspaceId, sequenceNumber, c).ConfigureAwait(false);
+            var result = await workflowService.RevertBySequenceAsync(workspaceId, sequenceNumber, c).ConfigureAwait(false);
 
             // Shape the response: include `reason`/`blockingSequences` only when present so success
             // payloads stay clean. Failure payloads always carry `reason`.

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -107,6 +107,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBulkRefactoringService, BulkRefactoringService>();
         services.AddSingleton<ITypeExtractionService, TypeExtractionService>();
         services.AddSingleton<IUndoService, UndoService>();
+        services.AddSingleton<IApplyUndoWorkflowService, ApplyUndoWorkflowService>();
         services.AddSingleton<IFlowAnalysisService, FlowAnalysisService>();
         services.AddSingleton<ICompileCheckService, CompileCheckService>();
         services.AddSingleton<IAnalyzerInfoService, AnalyzerInfoService>();

--- a/src/RoslynMcp.Roslyn/Services/ApplyUndoWorkflowService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ApplyUndoWorkflowService.cs
@@ -1,0 +1,316 @@
+using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// apply-undo-workflow-service-extraction: owns the domain decisions of the
+/// <c>apply_with_verify</c> and <c>revert_apply_by_sequence</c> tools so the Host-layer
+/// wrappers only map the returned outcomes onto their JSON wire shapes. Extracted from
+/// <c>ApplyWithVerifyTool</c>/<c>UndoTools</c> so other Roslyn-layer consumers (e.g. the
+/// dependent apply/verify workflow consolidation) can reuse the same apply → compile_check →
+/// diff → rollback decision path without going through the MCP tool surface.
+/// </summary>
+public interface IApplyUndoWorkflowService
+{
+    /// <summary>
+    /// Applies a previously previewed refactoring, verifies the workspace still compiles by
+    /// comparing pre/post error IDENTITIES (id+file+line), and — when new errors appear and
+    /// <paramref name="rollbackOnError"/> is <see langword="true"/> — reverts the apply. Returns
+    /// one of the four <see cref="ApplyVerifyOutcome"/> shapes describing what happened. A caller
+    /// cancellation observed after a successful apply triggers a bounded best-effort revert on a
+    /// fresh token before the <see cref="OperationCanceledException"/> is surfaced.
+    /// </summary>
+    Task<ApplyVerifyOutcome> ApplyWithVerifyAsync(string previewToken, bool rollbackOnError, CancellationToken ct);
+
+    /// <summary>
+    /// Reverts the apply identified by <paramref name="sequenceNumber"/>, surfacing the underlying
+    /// <see cref="IUndoService.RevertBySequenceAsync"/> result as a documented
+    /// <see cref="SequenceRevertOutcome"/> instead of a raw <c>Reason</c>/<c>BlockingSequences</c>
+    /// tuple.
+    /// </summary>
+    Task<SequenceRevertOutcome> RevertBySequenceAsync(string workspaceId, int sequenceNumber, CancellationToken ct);
+}
+
+/// <summary>
+/// Outcome of <see cref="IApplyUndoWorkflowService.ApplyWithVerifyAsync"/>. The four variants map
+/// 1:1 onto the four distinct JSON shapes the <c>apply_with_verify</c> tool historically produced
+/// (<c>apply_failed</c>, <c>applied</c>, <c>applied_with_errors</c>, and the
+/// <c>rolled_back</c>/<c>rollback_failed</c> pair collapsed into <see cref="RolledBack"/>).
+/// </summary>
+public abstract record ApplyVerifyOutcome
+{
+    private ApplyVerifyOutcome() { }
+
+    /// <summary>The apply itself failed; nothing was mutated (<c>status="apply_failed"</c>).</summary>
+    public sealed record ApplyFailed(string? Error) : ApplyVerifyOutcome;
+
+    /// <summary>The apply succeeded and introduced no new compile errors (<c>status="applied"</c>).</summary>
+    public sealed record Applied(
+        IReadOnlyList<string> AppliedFiles,
+        int PreErrorCount,
+        int PostErrorCount) : ApplyVerifyOutcome;
+
+    /// <summary>
+    /// The apply introduced new errors but <c>rollbackOnError</c> was <see langword="false"/>, so the
+    /// broken state is preserved for inspection (<c>status="applied_with_errors"</c>).
+    /// </summary>
+    public sealed record AppliedWithErrors(
+        IReadOnlyList<string> AppliedFiles,
+        IReadOnlyList<DiagnosticDto> IntroducedErrors,
+        int PreErrorCount,
+        int PostErrorCount) : ApplyVerifyOutcome;
+
+    /// <summary>
+    /// The apply introduced new errors and a rollback was attempted. <see cref="Reverted"/> is
+    /// <see langword="true"/> for <c>status="rolled_back"</c> and <see langword="false"/> for
+    /// <c>status="rollback_failed"</c> (the revert itself also failed).
+    /// </summary>
+    public sealed record RolledBack(
+        bool Reverted,
+        IReadOnlyList<string> AppliedFiles,
+        IReadOnlyList<DiagnosticDto> IntroducedErrors,
+        int PreErrorCount,
+        int PostErrorCount) : ApplyVerifyOutcome;
+}
+
+/// <summary>
+/// Outcome of <see cref="IApplyUndoWorkflowService.RevertBySequenceAsync"/> — a documented Roslyn-layer
+/// projection of <see cref="RevertBySequenceResult"/> (1:1 fields) so Host wrappers and other consumers
+/// read named properties instead of inspecting <c>Reason</c>/<c>BlockingSequences</c> strings from the
+/// undo service directly.
+/// </summary>
+/// <param name="Reverted">Whether the target apply was successfully reverted.</param>
+/// <param name="RevertedOperation">Human-readable description of the reverted operation, or <see langword="null"/> on failure.</param>
+/// <param name="AffectedFiles">The file set the target apply touched; empty when the revert failed before locating the target.</param>
+/// <param name="Reason">Machine-readable failure code (<c>unknown-sequence</c>/<c>dependency-blocked</c>/<c>revert-failed</c>) or <see langword="null"/> on success.</param>
+/// <param name="BlockingSequences">Later overlapping sequence numbers when <see cref="Reason"/> is <c>dependency-blocked</c>; otherwise <see langword="null"/>.</param>
+public sealed record SequenceRevertOutcome(
+    bool Reverted,
+    string? RevertedOperation,
+    IReadOnlyList<string> AffectedFiles,
+    string? Reason,
+    IReadOnlyList<int>? BlockingSequences);
+
+/// <inheritdoc cref="IApplyUndoWorkflowService"/>
+public sealed class ApplyUndoWorkflowService : IApplyUndoWorkflowService
+{
+    /// <summary>
+    /// apply-with-verify-cancellation-and-compile-scope: budget for the best-effort revert issued
+    /// when the caller's <see cref="CancellationToken"/> fires AFTER a successful apply but before
+    /// the normal verify/revert leg completes. The original (already-cancelled) token cannot drive
+    /// the rollback, so a fresh short-lived token is used so the workspace is not left mutated with
+    /// no rollback. Bounded so a wedged revert cannot hang the caller.
+    /// </summary>
+    private static readonly TimeSpan RevertBudget = TimeSpan.FromSeconds(30);
+
+    private readonly IRefactoringService _refactoringService;
+    private readonly ICompileCheckService _compileCheckService;
+    private readonly IUndoService _undoService;
+    private readonly IPreviewStore _previewStore;
+    private readonly ILogger? _logger;
+
+    public ApplyUndoWorkflowService(
+        IRefactoringService refactoringService,
+        ICompileCheckService compileCheckService,
+        IUndoService undoService,
+        IPreviewStore previewStore,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _refactoringService = refactoringService;
+        _compileCheckService = compileCheckService;
+        _undoService = undoService;
+        _previewStore = previewStore;
+        _logger = loggerFactory?.CreateLogger(typeof(ApplyUndoWorkflowService).FullName ?? nameof(ApplyUndoWorkflowService));
+    }
+
+    /// <summary>
+    /// apply-with-verify-cancelled-result-compensation: best-effort revert issued when a
+    /// cancellation is observed after a successful apply, on a FRESH <see cref="RevertBudget"/>-scoped
+    /// token (the caller's own token is already cancelled and cannot drive the rollback). A revert
+    /// failure — either a <see langword="false"/> result or a thrown exception — is logged at Error
+    /// and never swallowed (Directive #3), and never masks the caller's cancellation, which the
+    /// caller rethrows after this returns. Shared by both the thrown-OperationCanceledException catch
+    /// path and the returned-Cancelled=true DTO check below so both cancellation-observation points
+    /// revert identically.
+    /// </summary>
+    private async Task BestEffortRevertAfterCancellationAsync(string workspaceId)
+    {
+        using var revertCts = new CancellationTokenSource(RevertBudget);
+        try
+        {
+            var recovered = await _undoService.RevertAsync(workspaceId, revertCts.Token).ConfigureAwait(false);
+            if (!recovered)
+            {
+                _logger?.LogError(
+                    "apply_with_verify: best-effort revert after cancellation reported failure for workspace {WorkspaceId}; the applied edit may still be present.",
+                    workspaceId);
+            }
+        }
+        catch (Exception revertEx)
+        {
+            _logger?.LogError(
+                revertEx,
+                "apply_with_verify: best-effort revert after cancellation threw for workspace {WorkspaceId}; the applied edit may still be present.",
+                workspaceId);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ApplyVerifyOutcome> ApplyWithVerifyAsync(string previewToken, bool rollbackOnError, CancellationToken ct)
+    {
+        var workspaceId = _previewStore.PeekWorkspaceId(previewToken)
+            ?? throw new PreviewTokenStaleException(
+                previewToken,
+                $"Preview token '{previewToken}' has expired or was invalidated: the workspace was reloaded after the preview was created, dropping the stored solution snapshot. Re-issue the paired *_preview call against the current workspace.");
+
+        // apply-with-verify-cancellation-and-compile-scope: scope both compile_check legs to the
+        // single project the preview actually touches, instead of compiling the FULL solution twice.
+        // Mirrors EditService's ownerProjects/batchProjectFilter pattern: exactly one changed
+        // project → filter to it; zero or many → null (compile everything, the safe fallback).
+        // Retrieve is non-consuming and does not perturb the token's TTL, so the paired apply below
+        // still redeems it. A null entry (stale token) falls through to the full-solution compile —
+        // correctness-preserving, just slower.
+        string? projectFilter = null;
+        if (_previewStore.Retrieve(previewToken) is { } previewEntry)
+        {
+            var changedProjects = previewEntry.ModifiedSolution
+                .GetChanges(previewEntry.OriginalSolution)
+                .GetProjectChanges()
+                .Select(pc => pc.NewProject.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            projectFilter = changedProjects.Count == 1 ? changedProjects[0] : null;
+        }
+
+        var checkOptions = new CompileCheckOptions(ProjectFilter: projectFilter);
+
+        // apply-with-verify-diff-not-counts: snapshot pre-apply error IDENTITIES (id+file+line) so we
+        // can tell NEW errors from pre-existing ones. Identity-diff replaces the prior count-delta +
+        // message-fingerprint heuristic that produced false-positive rollbacks when a pre-existing
+        // diagnostic flipped severity class or had its message text shift on the post-apply build
+        // path. Shared with EditService's verify=true path so both verify entry points subtract
+        // pre-existing errors uniformly. See DiagnosticIdentitySet for the rationale and format.
+        var preBaseline = await _compileCheckService.CheckAsync(
+            workspaceId, checkOptions, ct).ConfigureAwait(false);
+
+        // apply-with-verify-cancelled-result-compensation: CompileCheckService.CheckAsync catches
+        // OperationCanceledException internally and returns a normal (non-throwing) DTO with
+        // Cancelled=true instead of propagating the exception — so a caller-token cancellation that
+        // landed inside the pre-apply baseline check is otherwise invisible here. Nothing has been
+        // applied yet, so surface the cancellation directly with zero apply/revert calls.
+        if (preBaseline.Cancelled)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new OperationCanceledException(ct);
+        }
+
+        var preErrors = DiagnosticIdentitySet.ExtractErrorIdentities(preBaseline);
+
+        // Apply
+        var applyResult = await _refactoringService.ApplyRefactoringAsync(previewToken, "apply_with_verify", ct).ConfigureAwait(false);
+        if (!applyResult.Success)
+        {
+            return new ApplyVerifyOutcome.ApplyFailed(applyResult.Error);
+        }
+
+        // apply-with-verify-cancellation-and-compile-scope: the workspace is now mutated. Everything
+        // from here to the normal revert leg runs under the caller's token `ct`; if it fires
+        // mid-verify (post-check) or mid-revert, an OperationCanceledException would otherwise unwind
+        // with the apply left in place and NO rollback. Guard the post-apply region so a cancellation
+        // triggers a bounded best-effort revert on a FRESH token before the OCE is rethrown. This
+        // catch can only fire when the apply already succeeded (we are past the !Success early
+        // return), so a pre-apply cancellation on the baseline compile still propagates untouched.
+        //
+        // apply-with-verify-cancelled-result-compensation: `revertedForCancelledDto` guards against a
+        // DOUBLE revert. The postCheck.Cancelled branch below performs its own best-effort revert and
+        // then throws OperationCanceledException from INSIDE this same try block, which the catch
+        // immediately below would otherwise also revert for — exactly one best-effort revert is
+        // required per cancellation. The flag is false on every path where compileCheckService threw
+        // directly (the catch's original responsibility) and true only when this method already
+        // reverted before throwing.
+        var revertedForCancelledDto = false;
+        try
+        {
+            // Verify — extract post-apply error identities and subtract the pre-apply set. The
+            // remaining identities are "introduced" errors that did not exist at any (id+file+line)
+            // location before the apply. Pre-existing errors whose severity flipped, message changed,
+            // or column shifted no longer trigger rollback.
+            var postCheck = await _compileCheckService.CheckAsync(
+                workspaceId, checkOptions, ct).ConfigureAwait(false);
+
+            // apply-with-verify-cancelled-result-compensation: as above, a caller-token cancellation
+            // that landed inside the post-apply verify check returns a Cancelled=true DTO rather than
+            // throwing. The apply already succeeded and mutated the workspace, so — unlike the
+            // pre-apply check above — this must attempt exactly one best-effort revert (same
+            // fresh-token helper the thrown-OCE catch block below uses) before surfacing the
+            // cancellation. `newErrors` would otherwise be computed from a partial diagnostic list.
+            if (postCheck.Cancelled)
+            {
+                await BestEffortRevertAfterCancellationAsync(workspaceId).ConfigureAwait(false);
+                revertedForCancelledDto = true;
+                ct.ThrowIfCancellationRequested();
+                throw new OperationCanceledException(ct);
+            }
+
+            var postErrors = DiagnosticIdentitySet.ExtractErrorIdentities(postCheck);
+
+            // Project the introduced identities back to the diagnostic rows so the outcome surfaces
+            // the actual errors (id, message, location) rather than opaque identity strings. Use the
+            // post-apply diagnostic list as the source of truth for the introduced rows.
+            var newIdentities = new HashSet<string>(postErrors.Except(preErrors), StringComparer.Ordinal);
+            var newErrors = postCheck.Diagnostics
+                .Where(d => string.Equals(d.Severity, "Error", StringComparison.OrdinalIgnoreCase)
+                    && newIdentities.Contains(DiagnosticIdentitySet.FormatIdentity(d)))
+                .ToList();
+
+            if (newErrors.Count == 0)
+            {
+                return new ApplyVerifyOutcome.Applied(
+                    applyResult.AppliedFiles, preBaseline.ErrorCount, postCheck.ErrorCount);
+            }
+
+            // New errors appeared. Either roll back or surface for inspection.
+            if (!rollbackOnError)
+            {
+                return new ApplyVerifyOutcome.AppliedWithErrors(
+                    applyResult.AppliedFiles, newErrors, preBaseline.ErrorCount, postCheck.ErrorCount);
+            }
+
+            var reverted = await _undoService.RevertAsync(workspaceId, ct).ConfigureAwait(false);
+            return new ApplyVerifyOutcome.RolledBack(
+                reverted, applyResult.AppliedFiles, newErrors, preBaseline.ErrorCount, postCheck.ErrorCount);
+        }
+        catch (OperationCanceledException)
+        {
+            // The apply landed but the caller cancelled before the verify/revert leg finished. Roll
+            // the workspace back best-effort on a fresh token (the caller's token `ct` is already
+            // cancelled and cannot drive the revert), then rethrow the original cancellation so the
+            // caller still observes it. A second failure in the revert itself is logged rather than
+            // swallowed (Directive #3) and does NOT mask the cancellation. Skip the revert here if
+            // the postCheck.Cancelled branch above already performed it (revertedForCancelledDto) —
+            // otherwise this genuinely is the first (and only) observation of the cancellation.
+            if (!revertedForCancelledDto)
+            {
+                await BestEffortRevertAfterCancellationAsync(workspaceId).ConfigureAwait(false);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SequenceRevertOutcome> RevertBySequenceAsync(string workspaceId, int sequenceNumber, CancellationToken ct)
+    {
+        var result = await _undoService.RevertBySequenceAsync(workspaceId, sequenceNumber, ct).ConfigureAwait(false);
+        return new SequenceRevertOutcome(
+            result.Reverted,
+            result.RevertedOperation,
+            result.AffectedFiles,
+            result.Reason,
+            result.BlockingSequences);
+    }
+}

--- a/tests/RoslynMcp.Tests/ApplyUndoWorkflowServiceTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyUndoWorkflowServiceTests.cs
@@ -1,0 +1,315 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// apply-undo-workflow-service-extraction: direct, fake-driven coverage of the outcome-selection
+/// logic that <see cref="ApplyUndoWorkflowService"/> now owns (moved out of the Host
+/// <c>ApplyWithVerifyTool</c>/<c>UndoTools</c> JSON wrappers). Verifies that each of the four
+/// <see cref="ApplyVerifyOutcome"/> variants is selected for the right condition, and that
+/// <see cref="ApplyUndoWorkflowService.RevertBySequenceAsync"/> maps the underlying
+/// <see cref="RevertBySequenceResult"/> 1:1 onto a <see cref="SequenceRevertOutcome"/>. The
+/// cancellation / fresh-token / project-scope behavior is covered separately by
+/// <see cref="ApplyWithVerifyCancellationAndScopeTests"/>.
+/// </summary>
+[TestClass]
+public sealed class ApplyUndoWorkflowServiceTests
+{
+    private static CompileCheckDto CleanCheck() => new(
+        Success: true,
+        ErrorCount: 0,
+        WarningCount: 0,
+        TotalDiagnostics: 0,
+        ReturnedDiagnostics: 0,
+        Offset: 0,
+        Limit: 50,
+        HasMore: false,
+        Diagnostics: Array.Empty<DiagnosticDto>(),
+        ElapsedMs: 0);
+
+    private static CompileCheckDto CheckWithError(DiagnosticDto error) => new(
+        Success: false,
+        ErrorCount: 1,
+        WarningCount: 0,
+        TotalDiagnostics: 1,
+        ReturnedDiagnostics: 1,
+        Offset: 0,
+        Limit: 50,
+        HasMore: false,
+        Diagnostics: new[] { error },
+        ElapsedMs: 0);
+
+    private static DiagnosticDto NewError() =>
+        new("CS0103", "The name 'Nope' does not exist", "Error", "Compiler", "File.cs", 7, 5, 7, 9);
+
+    private static ApplyUndoWorkflowService Create(
+        FakeCompileCheck compile,
+        FakeUndo undo,
+        FakeRefactoring? refactoring = null)
+        => new(refactoring ?? new FakeRefactoring(), compile, undo, new FakePreviewStore("ws"));
+
+    [TestMethod]
+    public async Task ApplyFailed_ShortCircuits_BeforeVerifyOrRevert()
+    {
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(false, Array.Empty<string>(), "apply blew up") };
+        var compile = new FakeCompileCheck(CleanCheck(), CleanCheck());
+        var undo = new FakeUndo();
+        var service = Create(compile, undo, refactoring);
+
+        var outcome = await service.ApplyWithVerifyAsync("tok", rollbackOnError: true, CancellationToken.None);
+
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.ApplyFailed>(outcome);
+        var failed = (ApplyVerifyOutcome.ApplyFailed)outcome;
+        Assert.AreEqual("apply blew up", failed.Error);
+        Assert.AreEqual(1, compile.Calls, "Only the pre-apply baseline check runs; there is no post-apply verify after an apply failure.");
+        Assert.AreEqual(0, undo.RevertCalls, "A failed apply mutated nothing, so no revert is attempted.");
+    }
+
+    [TestMethod]
+    public async Task NoNewErrors_ReturnsApplied()
+    {
+        var compile = new FakeCompileCheck(CleanCheck(), CleanCheck());
+        var undo = new FakeUndo();
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(true, new[] { "A.cs", "B.cs" }, null) };
+        var service = Create(compile, undo, refactoring);
+
+        var outcome = await service.ApplyWithVerifyAsync("tok", rollbackOnError: true, CancellationToken.None);
+
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.Applied>(outcome);
+        var applied = (ApplyVerifyOutcome.Applied)outcome;
+        CollectionAssert.AreEqual(new[] { "A.cs", "B.cs" }, applied.AppliedFiles.ToList());
+        Assert.AreEqual(0, applied.PreErrorCount);
+        Assert.AreEqual(0, applied.PostErrorCount);
+        Assert.AreEqual(0, undo.RevertCalls, "A clean apply is not reverted.");
+    }
+
+    [TestMethod]
+    public async Task NewError_RollbackOnErrorFalse_ReturnsAppliedWithErrors_NoRevert()
+    {
+        var error = NewError();
+        var compile = new FakeCompileCheck(CleanCheck(), CheckWithError(error));
+        var undo = new FakeUndo();
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(true, new[] { "A.cs" }, null) };
+        var service = Create(compile, undo, refactoring);
+
+        var outcome = await service.ApplyWithVerifyAsync("tok", rollbackOnError: false, CancellationToken.None);
+
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.AppliedWithErrors>(outcome);
+        var withErrors = (ApplyVerifyOutcome.AppliedWithErrors)outcome;
+        Assert.AreEqual(1, withErrors.IntroducedErrors.Count);
+        Assert.AreEqual("CS0103", withErrors.IntroducedErrors[0].Id);
+        Assert.AreEqual(0, withErrors.PreErrorCount);
+        Assert.AreEqual(1, withErrors.PostErrorCount);
+        Assert.AreEqual(0, undo.RevertCalls, "rollbackOnError=false must preserve the broken state, not revert it.");
+    }
+
+    [TestMethod]
+    public async Task NewError_RollbackSucceeds_ReturnsRolledBackReverted()
+    {
+        var error = NewError();
+        var compile = new FakeCompileCheck(CleanCheck(), CheckWithError(error));
+        var undo = new FakeUndo { RevertReturns = true };
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(true, new[] { "A.cs" }, null) };
+        var service = Create(compile, undo, refactoring);
+
+        var outcome = await service.ApplyWithVerifyAsync("tok", rollbackOnError: true, CancellationToken.None);
+
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.RolledBack>(outcome);
+        var rolledBack = (ApplyVerifyOutcome.RolledBack)outcome;
+        Assert.IsTrue(rolledBack.Reverted, "A successful revert maps to Reverted=true (status=\"rolled_back\").");
+        Assert.AreEqual(1, rolledBack.IntroducedErrors.Count);
+        Assert.AreEqual(1, undo.RevertCalls, "Exactly one revert must be issued when new errors appear.");
+    }
+
+    [TestMethod]
+    public async Task NewError_RollbackFails_ReturnsRolledBackNotReverted()
+    {
+        var error = NewError();
+        var compile = new FakeCompileCheck(CleanCheck(), CheckWithError(error));
+        var undo = new FakeUndo { RevertReturns = false };
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(true, new[] { "A.cs" }, null) };
+        var service = Create(compile, undo, refactoring);
+
+        var outcome = await service.ApplyWithVerifyAsync("tok", rollbackOnError: true, CancellationToken.None);
+
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.RolledBack>(outcome);
+        var rolledBack = (ApplyVerifyOutcome.RolledBack)outcome;
+        Assert.IsFalse(rolledBack.Reverted, "A failed revert maps to Reverted=false (status=\"rollback_failed\").");
+        Assert.AreEqual(1, undo.RevertCalls);
+    }
+
+    // ── RevertBySequenceAsync 1:1 mapping ──
+
+    [TestMethod]
+    public async Task RevertBySequence_Success_MapsAllFields()
+    {
+        var undo = new FakeUndo
+        {
+            SequenceResult = new RevertBySequenceResult(
+                Reverted: true,
+                RevertedOperation: "organize usings",
+                AffectedFiles: new[] { "A.cs" },
+                Reason: null,
+                BlockingSequences: null),
+        };
+        var service = new ApplyUndoWorkflowService(new FakeRefactoring(), new FakeCompileCheck(CleanCheck(), CleanCheck()), undo, new FakePreviewStore("ws"));
+
+        var outcome = await service.RevertBySequenceAsync("ws", 3, CancellationToken.None);
+
+        Assert.IsTrue(outcome.Reverted);
+        Assert.AreEqual("organize usings", outcome.RevertedOperation);
+        CollectionAssert.AreEqual(new[] { "A.cs" }, outcome.AffectedFiles.ToList());
+        Assert.IsNull(outcome.Reason);
+        Assert.IsNull(outcome.BlockingSequences);
+    }
+
+    [TestMethod]
+    public async Task RevertBySequence_DependencyBlocked_MapsReasonAndBlockingSequences()
+    {
+        var undo = new FakeUndo
+        {
+            SequenceResult = new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: null,
+                AffectedFiles: new[] { "A.cs" },
+                Reason: "dependency-blocked",
+                BlockingSequences: new[] { 5, 6 }),
+        };
+        var service = new ApplyUndoWorkflowService(new FakeRefactoring(), new FakeCompileCheck(CleanCheck(), CleanCheck()), undo, new FakePreviewStore("ws"));
+
+        var outcome = await service.RevertBySequenceAsync("ws", 3, CancellationToken.None);
+
+        Assert.IsFalse(outcome.Reverted);
+        Assert.AreEqual("dependency-blocked", outcome.Reason);
+        CollectionAssert.AreEqual(new[] { 5, 6 }, outcome.BlockingSequences!.ToList());
+    }
+
+    [TestMethod]
+    public async Task RevertBySequence_UnknownSequence_MapsReason()
+    {
+        var undo = new FakeUndo
+        {
+            SequenceResult = new RevertBySequenceResult(
+                Reverted: false,
+                RevertedOperation: null,
+                AffectedFiles: Array.Empty<string>(),
+                Reason: "unknown-sequence",
+                BlockingSequences: null),
+        };
+        var service = new ApplyUndoWorkflowService(new FakeRefactoring(), new FakeCompileCheck(CleanCheck(), CleanCheck()), undo, new FakePreviewStore("ws"));
+
+        var outcome = await service.RevertBySequenceAsync("ws", 99, CancellationToken.None);
+
+        Assert.IsFalse(outcome.Reverted);
+        Assert.AreEqual("unknown-sequence", outcome.Reason);
+        Assert.IsNull(outcome.BlockingSequences);
+        Assert.AreEqual(0, outcome.AffectedFiles.Count);
+    }
+
+    // ── fakes ──
+
+    private sealed class FakeCompileCheck : ICompileCheckService
+    {
+        private readonly CompileCheckDto _pre;
+        private readonly CompileCheckDto _post;
+        public int Calls { get; private set; }
+
+        public FakeCompileCheck(CompileCheckDto pre, CompileCheckDto post)
+        {
+            _pre = pre;
+            _post = post;
+        }
+
+        public Task<CompileCheckDto> CheckAsync(string workspaceId, CompileCheckOptions options, CancellationToken ct)
+        {
+            var call = Calls++;
+            return Task.FromResult(call == 0 ? _pre : _post);
+        }
+    }
+
+    private sealed class FakeRefactoring : IRefactoringService
+    {
+        public ApplyResultDto Result = new(true, new[] { "A.cs" }, null);
+
+        public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct)
+            => Task.FromResult(Result);
+
+        public Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, bool force, CancellationToken ct)
+            => Task.FromResult(Result);
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, bool summary, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewOrganizeUsingsAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatDocumentAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatRangeAsync(string workspaceId, string filePath, int startLine, int startColumn, int endLine, int endColumn, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<RefactoringPreviewDto> PreviewCodeFixAsync(string workspaceId, string diagnosticId, string filePath, int line, int column, string? fixId, CancellationToken ct)
+            => throw new NotImplementedException();
+    }
+
+    private sealed class FakeUndo : IUndoService
+    {
+        public int RevertCalls;
+        public bool RevertReturns = true;
+        public RevertBySequenceResult SequenceResult =
+            new(false, null, Array.Empty<string>(), "unknown-sequence", null);
+
+        public Task<bool> RevertAsync(string workspaceId, CancellationToken cancellationToken = default)
+        {
+            RevertCalls++;
+            return Task.FromResult(RevertReturns);
+        }
+
+        public void CaptureBeforeApply(string workspaceId, string description, object? preApplySolution, IReadOnlyList<FileSnapshotDto>? fileSnapshots = null) { }
+
+        public UndoEntry? GetLastOperation(string workspaceId) => null;
+
+        public Task<RevertBySequenceResult> RevertBySequenceAsync(string workspaceId, int sequenceNumber, CancellationToken cancellationToken = default)
+            => Task.FromResult(SequenceResult);
+
+        public void CommitPendingCapture(string workspaceId, int sequenceNumber, IReadOnlyList<string> affectedFiles) { }
+
+        public void Clear(string workspaceId) { }
+    }
+
+    private sealed class FakePreviewStore : IPreviewStore
+    {
+        private readonly string _workspaceId;
+
+        public FakePreviewStore(string workspaceId) => _workspaceId = workspaceId;
+
+        public string? PeekWorkspaceId(string token) => _workspaceId;
+
+        // Retrieve returns null → project-filter derivation is skipped (full-solution compile).
+        public (string WorkspaceId, Solution OriginalSolution, Solution ModifiedSolution, int WorkspaceVersion, string Description, bool DiffTruncated)? Retrieve(string token)
+            => null;
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
+            => throw new NotImplementedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated)
+            => throw new NotImplementedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, IReadOnlyList<FileChangeDto> changes)
+            => throw new NotImplementedException();
+
+        public void Invalidate(string token) { }
+
+        public void InvalidateAll(string? workspaceId = null) { }
+
+        public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion) { }
+    }
+}

--- a/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyWithVerifyCancellationAndScopeTests.cs
@@ -1,17 +1,17 @@
-using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
-using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
 /// <summary>
-/// apply-with-verify-cancellation-and-compile-scope: fake-driven coverage for the two
-/// bug fixes in <see cref="ApplyWithVerifyTool"/>:
+/// apply-with-verify-cancellation-and-compile-scope: fake-driven coverage for the two behaviors
+/// that now live in <see cref="ApplyUndoWorkflowService"/> (extracted from <c>ApplyWithVerifyTool</c>
+/// by apply-undo-workflow-service-extraction):
 /// <list type="number">
 /// <item><description>
 /// Cancellation that fires AFTER a successful apply but before the verify/revert leg
@@ -27,19 +27,28 @@ namespace RoslynMcp.Tests;
 /// </description></item>
 /// </list>
 /// These use hand-rolled fakes rather than the real workspace harness so the exact token
-/// identity and project-filter arguments are observable.
+/// identity and project-filter arguments are observable, and call
+/// <see cref="ApplyUndoWorkflowService.ApplyWithVerifyAsync"/> directly (no gate / no Host JSON
+/// wrapper) since the cancellation, fresh-token, and compile-scope logic all live in the service.
 ///
 /// apply-with-verify-cancelled-result-compensation: the real <c>CompileCheckService.CheckAsync</c>
 /// never lets an <see cref="OperationCanceledException"/> escape — it catches it internally and
 /// returns a normal (non-throwing) <c>CompileCheckDto</c> with <c>Cancelled=true</c>. The three
-/// tests above simulate cancellation by having <c>FakeCompileCheck</c> throw directly, a shape
-/// the real service never produces, so they do not exercise that production failure mode. The
-/// two <c>*_CancelledDto_</c> tests below close that gap by returning a <c>Cancelled=true</c> DTO
-/// instead of throwing.
+/// tests that simulate cancellation by having <c>FakeCompileCheck</c> throw directly use a shape
+/// the real service never produces; the two <c>*_CancelledDto_</c> tests close that gap by
+/// returning a <c>Cancelled=true</c> DTO instead of throwing.
 /// </summary>
 [TestClass]
 public sealed class ApplyWithVerifyCancellationAndScopeTests
 {
+    private static ApplyUndoWorkflowService CreateService(
+        ICompileCheckService compile,
+        IUndoService undo,
+        IPreviewStore previewStore,
+        IRefactoringService? refactoring = null,
+        ILoggerFactory? loggerFactory = null)
+        => new(refactoring ?? new FakeRefactoring(), compile, undo, previewStore, loggerFactory);
+
     // ── Cancellation-safe revert ──
 
     [TestMethod]
@@ -63,18 +72,10 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         };
         var undo = new FakeUndo();
         var previewStore = new FakePreviewStore("ws"); // Retrieve returns null → filter skipped
+        var service = CreateService(compile, undo, previewStore);
 
         var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
-            ApplyWithVerifyTool.ApplyWithVerify(
-                new FakeGate(),
-                new FakeRefactoring(),
-                compile,
-                undo,
-                previewStore,
-                previewToken: "tok",
-                rollbackOnError: true,
-                loggerFactory: null,
-                ct: cts.Token));
+            service.ApplyWithVerifyAsync(previewToken: "tok", rollbackOnError: true, ct: cts.Token));
 
         Assert.AreSame(originalCancellation, thrown,
             "The ORIGINAL cancellation must surface, not a wrapped/replacement exception.");
@@ -108,18 +109,10 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var undo = new FakeUndo { RevertThrows = new InvalidOperationException("revert boom") };
         var loggerFactory = new CapturingLoggerFactory();
         var previewStore = new FakePreviewStore("ws");
+        var service = CreateService(compile, undo, previewStore, loggerFactory: loggerFactory);
 
         var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
-            ApplyWithVerifyTool.ApplyWithVerify(
-                new FakeGate(),
-                new FakeRefactoring(),
-                compile,
-                undo,
-                previewStore,
-                previewToken: "tok",
-                rollbackOnError: true,
-                loggerFactory: loggerFactory,
-                ct: cts.Token));
+            service.ApplyWithVerifyAsync(previewToken: "tok", rollbackOnError: true, ct: cts.Token));
 
         Assert.AreSame(originalCancellation, thrown,
             "A failing best-effort revert must not mask the original cancellation.");
@@ -149,18 +142,10 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var undo = new FakeUndo();
         var refactoring = new FakeRefactoring();
         var previewStore = new FakePreviewStore("ws");
+        var service = CreateService(compile, undo, previewStore, refactoring);
 
         await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
-            ApplyWithVerifyTool.ApplyWithVerify(
-                new FakeGate(),
-                refactoring,
-                compile,
-                undo,
-                previewStore,
-                previewToken: "tok",
-                rollbackOnError: true,
-                loggerFactory: null,
-                ct: cts.Token));
+            service.ApplyWithVerifyAsync(previewToken: "tok", rollbackOnError: true, ct: cts.Token));
 
         Assert.AreEqual(0, refactoring.ApplyCalls, "Apply must not run when the baseline is cancelled.");
         Assert.AreEqual(0, undo.RevertCalls,
@@ -189,18 +174,10 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var undo = new FakeUndo();
         var refactoring = new FakeRefactoring();
         var previewStore = new FakePreviewStore("ws");
+        var service = CreateService(compile, undo, previewStore, refactoring);
 
         var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
-            ApplyWithVerifyTool.ApplyWithVerify(
-                new FakeGate(),
-                refactoring,
-                compile,
-                undo,
-                previewStore,
-                previewToken: "tok",
-                rollbackOnError: true,
-                loggerFactory: null,
-                ct: cts.Token));
+            service.ApplyWithVerifyAsync(previewToken: "tok", rollbackOnError: true, ct: cts.Token));
 
         Assert.AreEqual(cts.Token, thrown.CancellationToken,
             "The thrown exception must carry the caller's own token.");
@@ -234,18 +211,10 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         };
         var undo = new FakeUndo();
         var previewStore = new FakePreviewStore("ws");
+        var service = CreateService(compile, undo, previewStore);
 
         var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
-            ApplyWithVerifyTool.ApplyWithVerify(
-                new FakeGate(),
-                new FakeRefactoring(),
-                compile,
-                undo,
-                previewStore,
-                previewToken: "tok",
-                rollbackOnError: true,
-                loggerFactory: null,
-                ct: cts.Token));
+            service.ApplyWithVerifyAsync(previewToken: "tok", rollbackOnError: true, ct: cts.Token));
 
         Assert.AreEqual(cts.Token, thrown.CancellationToken,
             "The thrown exception must carry the caller's own token.");
@@ -265,19 +234,12 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var (original, modified, _) = BuildSolution(("ProjA", true), ("ProjB", false));
         var compile = new FakeCompileCheck();
         var previewStore = new FakePreviewStore("ws", original, modified);
+        var service = CreateService(compile, new FakeUndo(), previewStore);
 
-        var json = await ApplyWithVerifyTool.ApplyWithVerify(
-            new FakeGate(),
-            new FakeRefactoring(),
-            compile,
-            new FakeUndo(),
-            previewStore,
-            previewToken: "tok",
-            rollbackOnError: true,
-            loggerFactory: null,
-            ct: CancellationToken.None);
+        var outcome = await service.ApplyWithVerifyAsync(
+            previewToken: "tok", rollbackOnError: true, ct: CancellationToken.None);
 
-        AssertStatus(json, "applied");
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.Applied>(outcome);
         Assert.AreEqual(2, compile.RecordedFilters.Count, "Both pre- and post-apply legs must run.");
         Assert.IsTrue(compile.RecordedFilters.All(f => f == "ProjA"),
             $"Both legs must scope to the single touched project. Got: [{string.Join(", ", compile.RecordedFilters)}]");
@@ -289,19 +251,12 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var (original, modified, _) = BuildSolution(("ProjA", true), ("ProjB", true));
         var compile = new FakeCompileCheck();
         var previewStore = new FakePreviewStore("ws", original, modified);
+        var service = CreateService(compile, new FakeUndo(), previewStore);
 
-        var json = await ApplyWithVerifyTool.ApplyWithVerify(
-            new FakeGate(),
-            new FakeRefactoring(),
-            compile,
-            new FakeUndo(),
-            previewStore,
-            previewToken: "tok",
-            rollbackOnError: true,
-            loggerFactory: null,
-            ct: CancellationToken.None);
+        var outcome = await service.ApplyWithVerifyAsync(
+            previewToken: "tok", rollbackOnError: true, ct: CancellationToken.None);
 
-        AssertStatus(json, "applied");
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.Applied>(outcome);
         Assert.AreEqual(2, compile.RecordedFilters.Count);
         Assert.IsTrue(compile.RecordedFilters.All(f => f is null),
             $"A multi-project touch must fall back to a full-solution compile (null filter). Got: [{string.Join(", ", compile.RecordedFilters.Select(f => f ?? "null"))}]");
@@ -314,32 +269,18 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
         var (original, _, sameAsOriginal) = BuildSolution(("ProjA", false));
         var compile = new FakeCompileCheck();
         var previewStore = new FakePreviewStore("ws", original, sameAsOriginal);
+        var service = CreateService(compile, new FakeUndo(), previewStore);
 
-        var json = await ApplyWithVerifyTool.ApplyWithVerify(
-            new FakeGate(),
-            new FakeRefactoring(),
-            compile,
-            new FakeUndo(),
-            previewStore,
-            previewToken: "tok",
-            rollbackOnError: true,
-            loggerFactory: null,
-            ct: CancellationToken.None);
+        var outcome = await service.ApplyWithVerifyAsync(
+            previewToken: "tok", rollbackOnError: true, ct: CancellationToken.None);
 
-        AssertStatus(json, "applied");
+        Assert.IsInstanceOfType<ApplyVerifyOutcome.Applied>(outcome);
         Assert.AreEqual(2, compile.RecordedFilters.Count);
         Assert.IsTrue(compile.RecordedFilters.All(f => f is null),
             "A zero-project diff must fall back to a full-solution compile (null filter).");
     }
 
     // ── helpers ──
-
-    private static void AssertStatus(string json, string expected)
-    {
-        using var doc = JsonDocument.Parse(json);
-        var status = doc.RootElement.GetProperty("status").GetString();
-        Assert.AreEqual(expected, status, $"Unexpected status. Full JSON: {json}");
-    }
 
     /// <summary>
     /// Builds an in-memory (Adhoc) solution pair. Each tuple names a project and whether the
@@ -376,20 +317,6 @@ public sealed class ApplyWithVerifyCancellationAndScopeTests
     }
 
     // ── fakes ──
-
-    private sealed class FakeGate : IWorkspaceExecutionGate
-    {
-        public Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct, bool applyStalenessPolicy = true)
-            => action(ct);
-
-        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
-            => action(ct);
-
-        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
-            => action(ct);
-
-        public void RemoveGate(string workspaceId) { }
-    }
 
     private sealed class FakeCompileCheck : ICompileCheckService
     {

--- a/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Host.Stdio.Resources;
 using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -151,8 +152,10 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         var preview = await RefactoringService.PreviewOrganizeUsingsAsync(
             workspace.WorkspaceId, animalServicePath, CancellationToken.None);
 
+        var workflowService = new ApplyUndoWorkflowService(
+            RefactoringService, CompileCheckService, UndoService, PreviewStore);
         var json = await ApplyWithVerifyTool.ApplyWithVerify(
-            WorkspaceExecutionGate, RefactoringService, CompileCheckService, UndoService, PreviewStore,
+            WorkspaceExecutionGate, workflowService, PreviewStore,
             preview.PreviewToken, rollbackOnError: true, ct: CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);
@@ -207,8 +210,10 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         // pair. Post-fix (id+file+line identity), the pre-existing error has the SAME
         // identity in pre and post sets — so it is filtered out and the innocent apply
         // returns status="applied".
+        var workflowService = new ApplyUndoWorkflowService(
+            RefactoringService, CompileCheckService, UndoService, PreviewStore);
         var json = await ApplyWithVerifyTool.ApplyWithVerify(
-            WorkspaceExecutionGate, RefactoringService, CompileCheckService, UndoService, PreviewStore,
+            WorkspaceExecutionGate, workflowService, PreviewStore,
             preview.PreviewToken, rollbackOnError: true, ct: CancellationToken.None);
 
         using var doc = JsonDocument.Parse(json);


### PR DESCRIPTION
Move the apply/undo workflow domain decisions out of the Host-layer `ApplyWithVerifyTool`/`UndoTools` static methods into a new Roslyn-layer `IApplyUndoWorkflowService`:

- Project-scoped compile-check diffing, the four apply/rollback outcomes (`apply_failed` / `applied` / `applied_with_errors` / `rolled_back`|`rollback_failed`), the cancellation-safe best-effort revert on a fresh token, and the sequence-revert outcome mapping now live in `ApplyUndoWorkflowService`.
- `ApplyVerifyOutcome` (4 variants) and `SequenceRevertOutcome` give the Host documented domain results; the Host wrappers only resolve the workspace, open the write gate, and map outcomes onto the **exact existing JSON shapes** (byte-identical wire format, no tool-surface change).
- Registered as a singleton beside `IUndoService` in `AddRoslynServices`.
- Preserves the merged `apply-with-verify-cancelled-result-compensation` fix (returned `Cancelled=true` DTO handling) inside the extracted service.

Tests: new `ApplyUndoWorkflowServiceTests` (outcome selection + sequence-revert mapping via fakes); `ApplyWithVerifyCancellationAndScopeTests` retargeted to the service directly; `Top10V2RegressionTests` construct the service inline and keep driving the Host JSON wrapper for byte-shape coverage. Build clean (Release, TreatWarningsAsErrors); 26 targeted tests pass.

```
 .../apply-undo-workflow-service-extraction.md      |   5 +
 .../Tools/ApplyWithVerifyTool.cs                   | 244 +++-------------
 src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs        |   5 +-
 .../ServiceCollectionExtensions.cs                 |   1 +
 .../Services/ApplyUndoWorkflowService.cs           | 316 +++++++++++++++++++++
 .../ApplyUndoWorkflowServiceTests.cs               | 315 ++++++++++++++++++++
 .../ApplyWithVerifyCancellationAndScopeTests.cs    | 159 +++--------
 tests/RoslynMcp.Tests/Top10V2RegressionTests.cs    |   9 +-
 8 files changed, 727 insertions(+), 327 deletions(-)
```

Closes: apply-undo-workflow-service-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)