### PR TITLE
fix(analysis): share complete lazy type-enumeration helper

### DIFF
--- a/changelog.d/analysis-type-traversal-enumeration-helper.md
+++ b/changelog.d/analysis-type-traversal-enumeration-helper.md
@@ -1,0 +1,4 @@
+---
+category: Fixed
+---
+Impact sweep, coupling analysis, and symbol search now share one correct lazy type-enumeration helper (`RoslynSymbolTraversal`) that walks namespace/type trees to arbitrary nesting depth without pruning matching descendants beneath non-matching parents. Previously `ImpactSweepService` silently dropped matching nested types beneath a non-matching parent, and both `ImpactSweepService` and `SymbolSearchService` missed types nested more than one level deep.

--- a/src/RoslynMcp.Roslyn/Helpers/RoslynSymbolTraversal.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/RoslynSymbolTraversal.cs
@@ -1,0 +1,69 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Roslyn.Helpers;
+
+/// <summary>
+/// Shared lazy walker for named-type trees. Consolidates three independently-maintained local
+/// enumeration walks (<c>ImpactSweepService</c>, <c>CouplingAnalysisService</c>,
+/// <c>SymbolSearchService</c>), two of which carried distinct pruning / depth-cap defects.
+/// </summary>
+internal static class RoslynSymbolTraversal
+{
+    /// <summary>
+    /// Yields every <see cref="INamedTypeSymbol"/> reachable from <paramref name="root"/> —
+    /// descending through child namespaces and into nested types to ARBITRARY depth — in
+    /// pre-order depth-first order matching <see cref="INamespaceOrTypeSymbol.GetMembers"/> /
+    /// <see cref="INamedTypeSymbol.GetTypeMembers"/> declaration order (each container's subtree is
+    /// fully exhausted before control returns to a shallower container).
+    /// </summary>
+    /// <param name="root">The namespace to walk (typically a global namespace).</param>
+    /// <param name="allowedKinds">
+    /// When supplied, only types whose <see cref="INamedTypeSymbol.TypeKind"/> equals this value are
+    /// yielded. The walk still descends into EVERY named type regardless of whether it matched the
+    /// filter, so a matching type nested beneath a non-matching parent (e.g. a class nested inside a
+    /// struct) is never pruned.
+    /// </param>
+    /// <remarks>
+    /// Implemented with an explicit <see cref="Stack{T}"/> of enumerator frames — one frame per open
+    /// ancestor container — so auxiliary storage is O(tree depth) and enumeration stays lazy.
+    /// </remarks>
+    public static IEnumerable<INamedTypeSymbol> EnumerateNamedTypes(INamespaceSymbol root, TypeKind? allowedKinds = null)
+    {
+        var frames = new Stack<IEnumerator<ISymbol>>();
+        frames.Push(((IEnumerable<ISymbol>)root.GetMembers()).GetEnumerator());
+        try
+        {
+            while (frames.Count > 0)
+            {
+                var frame = frames.Peek();
+                if (!frame.MoveNext())
+                {
+                    frames.Pop().Dispose();
+                    continue;
+                }
+
+                switch (frame.Current)
+                {
+                    case INamespaceSymbol childNamespace:
+                        frames.Push(((IEnumerable<ISymbol>)childNamespace.GetMembers()).GetEnumerator());
+                        break;
+
+                    case INamedTypeSymbol type:
+                        if (allowedKinds is null || type.TypeKind == allowedKinds.Value)
+                            yield return type;
+
+                        // Descend UNCONDITIONALLY — matching descendants must not be pruned when the
+                        // parent type fails the kind filter, and nested types are walked to arbitrary
+                        // depth (not capped at one level).
+                        frames.Push(type.GetTypeMembers().Cast<ISymbol>().GetEnumerator());
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            while (frames.Count > 0)
+                frames.Pop().Dispose();
+        }
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/CouplingAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CouplingAnalysisService.cs
@@ -55,7 +55,7 @@ public sealed class CouplingAnalysisService : ICouplingAnalysisService
             var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
-            foreach (var symbol in EnumerateDeclaredTypes(compilation.Assembly.GlobalNamespace))
+            foreach (var symbol in RoslynSymbolTraversal.EnumerateNamedTypes(compilation.Assembly.GlobalNamespace))
             {
                 if (ct.IsCancellationRequested) break;
                 if (!ShouldAnalyze(symbol, includeInterfaces)) continue;
@@ -116,35 +116,6 @@ public sealed class CouplingAnalysisService : ICouplingAnalysisService
             .ThenBy(r => r.FullyQualifiedName, StringComparer.Ordinal)
             .Take(limit)
             .ToList();
-    }
-
-    private static IEnumerable<INamedTypeSymbol> EnumerateDeclaredTypes(INamespaceSymbol ns)
-    {
-        foreach (var member in ns.GetMembers())
-        {
-            if (member is INamespaceSymbol child)
-            {
-                foreach (var t in EnumerateDeclaredTypes(child))
-                    yield return t;
-            }
-            else if (member is INamedTypeSymbol type)
-            {
-                yield return type;
-                // Nested types count too — they own their own afferent/efferent graph.
-                foreach (var nested in EnumerateNestedTypes(type))
-                    yield return nested;
-            }
-        }
-    }
-
-    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
-    {
-        foreach (var nested in type.GetTypeMembers())
-        {
-            yield return nested;
-            foreach (var deeper in EnumerateNestedTypes(nested))
-                yield return deeper;
-        }
     }
 
     private static bool ShouldAnalyze(INamedTypeSymbol type, bool includeInterfaces)

--- a/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ImpactSweepService.cs
@@ -137,7 +137,7 @@ public sealed class ImpactSweepService : IImpactSweepService
         {
             var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
-            foreach (var dto in compilation.GlobalNamespace.GetAllTypes(allowedKinds: TypeKind.Class))
+            foreach (var dto in RoslynSymbolTraversal.EnumerateNamedTypes(compilation.GlobalNamespace, TypeKind.Class))
             {
                 if (SymbolEqualityComparer.Default.Equals(dto, property.ContainingType)) continue;
                 if (!IsLikelyDtoType(dto)) continue;
@@ -253,7 +253,7 @@ public sealed class ImpactSweepService : IImpactSweepService
         {
             var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
-            foreach (var type in compilation.GlobalNamespace.GetAllTypes(allowedKinds: TypeKind.Class))
+            foreach (var type in RoslynSymbolTraversal.EnumerateNamedTypes(compilation.GlobalNamespace, TypeKind.Class))
             {
                 var name = type.Name;
                 if (!(name.EndsWith("Mapper", StringComparison.Ordinal) ||
@@ -391,33 +391,5 @@ public sealed class ImpactSweepService : IImpactSweepService
             }
         }
         return tasks;
-    }
-}
-
-internal static class NamespaceTypeEnumeration
-{
-    /// <summary>Recursive walker that yields every named type in a global namespace tree, optionally filtered by kind.</summary>
-    public static IEnumerable<INamedTypeSymbol> GetAllTypes(this INamespaceSymbol root, TypeKind? allowedKinds = null)
-    {
-        var stack = new Stack<INamespaceSymbol>();
-        stack.Push(root);
-        while (stack.Count > 0)
-        {
-            var ns = stack.Pop();
-            foreach (var member in ns.GetMembers())
-            {
-                if (member is INamespaceSymbol child) stack.Push(child);
-                else if (member is INamedTypeSymbol type)
-                {
-                    if (allowedKinds.HasValue && type.TypeKind != allowedKinds.Value) continue;
-                    yield return type;
-                    foreach (var nested in type.GetTypeMembers())
-                    {
-                        if (allowedKinds.HasValue && nested.TypeKind != allowedKinds.Value) continue;
-                        yield return nested;
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolSearchService.cs
@@ -141,7 +141,7 @@ public sealed class SymbolSearchService : ISymbolSearchService
         HashSet<string> seenKeys,
         CancellationToken ct)
     {
-        foreach (var typeSymbol in EnumerateNamedTypes(compilation.GlobalNamespace))
+        foreach (var typeSymbol in RoslynSymbolTraversal.EnumerateNamedTypes(compilation.GlobalNamespace))
         {
             if (ct.IsCancellationRequested) return false;
             if (results.Count >= limit) return false;
@@ -206,24 +206,6 @@ public sealed class SymbolSearchService : ISymbolSearchService
 
         results.Add(SymbolMapper.ToDto(symbol, solution));
         return true;
-    }
-
-    private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypes(INamespaceSymbol ns)
-    {
-        foreach (var member in ns.GetMembers())
-        {
-            if (member is INamespaceSymbol child)
-            {
-                foreach (var nested in EnumerateNamedTypes(child))
-                    yield return nested;
-            }
-            else if (member is INamedTypeSymbol type)
-            {
-                yield return type;
-                foreach (var nested in type.GetTypeMembers())
-                    yield return nested;
-            }
-        }
     }
 
     public async Task<SymbolDto?> GetSymbolInfoAsync(string workspaceId, SymbolLocator locator, CancellationToken ct, bool allowAdjacent = false)

--- a/tests/RoslynMcp.Tests/SymbolTraversalTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolTraversalTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the four acceptance bullets for <see cref="RoslynSymbolTraversal.EnumerateNamedTypes"/>:
+/// (a) a class buried beneath non-class parents is yielded under a Class filter (no pruning),
+/// (b) sibling declaration order is preserved, (c) an unfiltered walk yields every named type at
+/// every depth including grandchildren, and (d) a kind filter drops non-matching types without
+/// pruning matching descendants beneath them.
+/// </summary>
+[TestClass]
+public class SymbolTraversalTests
+{
+    // Named types by kind in this fixture:
+    //   classes:    Alpha, Beta, Gamma, Buried, Parent, Child, Grandchild, MatchingLeaf
+    //   structs:    S1, S2, S3, Wrapper
+    //   interfaces: INested
+    private const string Source = @"
+namespace Sample
+{
+    public class Alpha { }
+    public class Beta { }
+    public class Gamma { }
+
+    // Three struct wrappers bury a class three levels deep beneath non-class parents.
+    public struct S1
+    {
+        public struct S2
+        {
+            public struct S3
+            {
+                public class Buried { }
+            }
+        }
+    }
+
+    // Arbitrary-depth class nesting for the grandchildren case.
+    public class Parent
+    {
+        public class Child
+        {
+            public class Grandchild { }
+        }
+    }
+
+    // Mixed-kind nesting under a non-class parent for the filter case.
+    public struct Wrapper
+    {
+        public interface INested { }
+        public class MatchingLeaf { }
+    }
+}
+";
+
+    [TestMethod]
+    public async Task Filtered_Yields_Class_Buried_Beneath_NonClass_Parents()
+    {
+        var compilation = await CompileAsync(Source);
+
+        var classes = RoslynSymbolTraversal
+            .EnumerateNamedTypes(SampleNamespace(compilation), TypeKind.Class)
+            .Select(t => t.Name)
+            .ToList();
+
+        // `Buried` is a class nested three levels under struct wrappers S1/S2/S3. The buggy
+        // predecessors pruned its walk the moment a parent failed the Class filter — the fix
+        // descends unconditionally, so it must surface.
+        CollectionAssert.Contains(classes, "Buried",
+            "A class buried beneath non-class (struct) parents must not be pruned by the Class filter.");
+        // MatchingLeaf sits beneath the `Wrapper` struct — same non-matching-parent shape.
+        CollectionAssert.Contains(classes, "MatchingLeaf");
+    }
+
+    [TestMethod]
+    public async Task Preserves_Sibling_Declaration_Order()
+    {
+        var compilation = await CompileAsync(Source);
+
+        var names = RoslynSymbolTraversal
+            .EnumerateNamedTypes(SampleNamespace(compilation))
+            .Select(t => t.Name)
+            .ToList();
+
+        var alpha = names.IndexOf("Alpha");
+        var beta = names.IndexOf("Beta");
+        var gamma = names.IndexOf("Gamma");
+
+        Assert.IsTrue(alpha >= 0 && beta >= 0 && gamma >= 0, "All three top-level siblings must be yielded.");
+        Assert.IsTrue(alpha < beta && beta < gamma,
+            $"Sibling declaration order must be preserved (Alpha<Beta<Gamma); got {alpha},{beta},{gamma}.");
+    }
+
+    [TestMethod]
+    public async Task Unfiltered_Yields_Every_Named_Type_At_Every_Depth()
+    {
+        var compilation = await CompileAsync(Source);
+
+        var names = RoslynSymbolTraversal
+            .EnumerateNamedTypes(SampleNamespace(compilation))
+            .Select(t => t.Name)
+            .ToList();
+
+        // Rooted at the `Sample` namespace, the walk must yield EXACTLY every declared named type
+        // at every depth — grandchildren (Grandchild) and types buried beneath non-class parents
+        // (Buried) included — and nothing more, nothing twice.
+        string[] expected =
+        {
+            "Alpha", "Beta", "Gamma",
+            "S1", "S2", "S3", "Buried",
+            "Parent", "Child", "Grandchild",
+            "Wrapper", "INested", "MatchingLeaf",
+        };
+        CollectionAssert.AreEquivalent(expected, names,
+            $"Unfiltered walk must yield every declared type exactly once. Got: [{string.Join(", ", names)}]");
+    }
+
+    [TestMethod]
+    public async Task Filter_Drops_NonMatching_Without_Pruning_Matching_Descendants()
+    {
+        var compilation = await CompileAsync(Source);
+
+        var classes = RoslynSymbolTraversal
+            .EnumerateNamedTypes(SampleNamespace(compilation), TypeKind.Class)
+            .Select(t => t.Name)
+            .ToHashSet();
+
+        // Non-matching kinds must be excluded from the yielded set...
+        foreach (var excluded in new[] { "S1", "S2", "S3", "Wrapper", "INested" })
+            Assert.IsFalse(classes.Contains(excluded), $"'{excluded}' is not a class and must be filtered out.");
+
+        // ...yet every class, at every depth, must still be present.
+        foreach (var included in new[] { "Alpha", "Beta", "Gamma", "Parent", "Child", "Grandchild", "Buried", "MatchingLeaf" })
+            Assert.IsTrue(classes.Contains(included), $"Class '{included}' must survive the filter.");
+    }
+
+    // Root the walk at the source `Sample` namespace rather than the merged global namespace —
+    // `compilation.GlobalNamespace` also carries every referenced BCL type, which would drown the
+    // fixture assertions. The walker accepts any namespace root, so this exercises the same code.
+    private static INamespaceSymbol SampleNamespace(Compilation compilation) =>
+        compilation.GlobalNamespace.GetNamespaceMembers().Single(n => n.Name == "Sample");
+
+    private static Task<Compilation> CompileAsync(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "TestAsm",
+            new[] { tree },
+            new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Threading.Tasks.Task).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Collections.Generic.List<>).Assembly.Location),
+            });
+        return Task.FromResult<Compilation>(compilation);
+    }
+}


### PR DESCRIPTION
## Summary

Consolidate three independently-maintained local type-enumeration walks — in `ImpactSweepService`, `CouplingAnalysisService`, and `SymbolSearchService` — into one correct shared lazy helper, `RoslynSymbolTraversal.EnumerateNamedTypes`, fixing two distinct pruning/depth defects.

## Linked issue

No GitHub issue — tracked by backlog row.

Closes: analysis-type-traversal-enumeration-helper

## Changes

- **New** `src/RoslynMcp.Roslyn/Helpers/RoslynSymbolTraversal.cs` — `internal static EnumerateNamedTypes(INamespaceSymbol root, TypeKind? allowedKinds = null)`. Walks namespace/type trees with an explicit `Stack<IEnumerator<ISymbol>>` (one frame per open ancestor → O(tree depth) aux storage), yielding pre-order depth-first in declaration order. Descends into **every** named type regardless of whether it matched the kind filter, so matching descendants beneath a non-matching parent are never pruned, and nesting is followed to arbitrary depth.
- `ImpactSweepService.cs` — both call sites (`:140` DTO-sibling scan, `:256` mapper-candidate scan) migrated to the shared helper; deleted the local `NamespaceTypeEnumeration` extension class, which pruned a non-matching parent's nested-type walk entirely and only descended one level.
- `CouplingAnalysisService.cs` — migrated the unfiltered enumeration to the shared helper; deleted the duplicated `EnumerateDeclaredTypes`/`EnumerateNestedTypes` recursion. Downstream `ShouldAnalyze` (incl. the `includeInterfaces` toggle) is unchanged.
- `SymbolSearchService.cs` — migrated the FQN-substring fallback to the shared helper; deleted the local `EnumerateNamedTypes` that only descended one level into nested types.
- **New** `tests/RoslynMcp.Tests/SymbolTraversalTests.cs` — four MSTest cases: (a) a class buried three levels beneath struct parents is yielded under a Class filter (no pruning), (b) sibling declaration order preserved, (c) an unfiltered walk yields every named type at every depth including grandchildren, (d) a kind filter drops non-matching types without pruning matching descendants.
- `changelog.d/analysis-type-traversal-enumeration-helper.md` — Fixed fragment.

## Test plan

- [x] Added unit tests covering the change (`SymbolTraversalTests`, 4 cases)
- [x] `dotnet build tests/RoslynMcp.Tests -c Release -p:TreatWarningsAsErrors=true` succeeds (0 warnings)
- [x] Ran `dotnet test --filter "SymbolTraversalTests|SymbolImpactSweepBudgetTests|CouplingAnalysisTests|SymbolSearchPaginationTests"` — 25 passed, 0 failed
- [x] Verified the three call sites' return sets are unchanged for flat trees and now more complete (never fewer) for deeply-nested trees

## Notes

The behavior change is the acceptance-mandated bug fix: impact-sweep and symbol-search now surface types that the prior pruning/one-level-cap bugs silently dropped — the result set only grows, never shrinks, for any existing fixture. `SymbolResolver.EnumerateNamedTypesAndMembers` is a fourth, correct (arbitrary-depth) walk that yields a different shape (types + members) and was left untouched as out of scope.
