### PR TITLE
refactor(host-stdio): extract complexity from ClientRootPathValidator.IsPathUnderAnyRoot

### DIFF
--- a/changelog.d/client-root-path-validator-complexity-extraction.md
+++ b/changelog.d/client-root-path-validator-complexity-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extracted lazy allowed-root enumeration, one-level parent widening, and separator-bounded root matching out of `ClientRootPathValidator.IsPathUnderAnyRoot` into three focused private helpers, reducing its cyclomatic complexity from 11 to 4 with no behavior change.

--- a/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ClientRootPathValidator.cs
@@ -123,43 +123,80 @@ internal static class ClientRootPathValidator
             return false;
         }
 
-        var allowedRoots = new List<string>(rootPaths.Count * (expandSanctionedRoots ? 2 : 1));
-        foreach (var rootPath in rootPaths)
+        foreach (var rootPath in EnumerateAllowedRoots(rootPaths, expandSanctionedRoots))
         {
-            allowedRoots.Add(rootPath);
-
-            if (expandSanctionedRoots)
-            {
-                // Widen by exactly one level — the parent directory of each sanctioned
-                // root. This permits sibling worktrees (e.g. parent/main is sanctioned and
-                // the worktree is at parent/.worktrees/foo) without exposing arbitrary
-                // grandparent or unrelated filesystem locations. Drive-root parents are
-                // skipped to avoid widening to the entire drive.
-                var parent = Path.GetDirectoryName(rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-                if (!string.IsNullOrEmpty(parent) && Path.GetPathRoot(parent) != parent)
-                {
-                    allowedRoots.Add(parent);
-                }
-            }
-        }
-
-        foreach (var rootPath in allowedRoots)
-        {
-            if (string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            var normalizedRoot = rootPath.EndsWith(Path.DirectorySeparatorChar)
-                ? rootPath
-                : rootPath + Path.DirectorySeparatorChar;
-            if (fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            if (IsPathUnderRoot(fullPath, rootPath))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Lazily yields each sanctioned root, and — when <paramref name="expandSanctionedRoots"/>
+    /// is <c>true</c> — the one-level-widened parent of each root (drive roots excluded).
+    /// Extracted from <see cref="IsPathUnderAnyRoot"/> so root-set construction is a pure
+    /// iterator rather than an eagerly materialized list.
+    /// </summary>
+    /// <remarks>
+    /// Must be enumerated exactly once per call (the single <c>foreach</c> in
+    /// <see cref="IsPathUnderAnyRoot"/> satisfies this) — a caller that enumerates it twice
+    /// would silently re-run <see cref="Path.GetDirectoryName(string?)"/> /
+    /// <see cref="Path.GetPathRoot(string?)"/> per pass.
+    /// </remarks>
+    private static IEnumerable<string> EnumerateAllowedRoots(IReadOnlyList<string> rootPaths, bool expandSanctionedRoots)
+    {
+        foreach (var rootPath in rootPaths)
+        {
+            yield return rootPath;
+
+            if (expandSanctionedRoots)
+            {
+                var parent = GetWidenedParent(rootPath);
+                if (parent is not null)
+                {
+                    yield return parent;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Widens by exactly one level — the parent directory of <paramref name="rootPath"/>.
+    /// This permits sibling worktrees (e.g. parent/main is sanctioned and the worktree is at
+    /// parent/.worktrees/foo) without exposing arbitrary grandparent or unrelated filesystem
+    /// locations. Returns <c>null</c> when there is no parent, or when the parent is a drive
+    /// root (to avoid widening to the entire drive).
+    /// </summary>
+    private static string? GetWidenedParent(string rootPath)
+    {
+        var parent = Path.GetDirectoryName(rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (!string.IsNullOrEmpty(parent) && Path.GetPathRoot(parent) != parent)
+        {
+            return parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Tests whether <paramref name="fullPath"/> equals <paramref name="rootPath"/> exactly,
+    /// or falls under it as a separator-bounded child. Both checks are
+    /// <see cref="StringComparison.OrdinalIgnoreCase"/> to match Windows path semantics.
+    /// </summary>
+    private static bool IsPathUnderRoot(string fullPath, string rootPath)
+    {
+        if (string.Equals(fullPath, rootPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var normalizedRoot = rootPath.EndsWith(Path.DirectorySeparatorChar)
+            ? rootPath
+            : rootPath + Path.DirectorySeparatorChar;
+        return fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Extracts three private static helpers (`EnumerateAllowedRoots`, `GetWidenedParent`, `IsPathUnderRoot`) out of `ClientRootPathValidator.IsPathUnderAnyRoot`, reducing its cyclomatic complexity from 11 to 4.
- Root-set construction is now a lazy `IEnumerable<string>` iterator (`EnumerateAllowedRoots`) instead of an eagerly materialized `List<string>` — no root-list materialization is added.
- Public signature of `IsPathUnderAnyRoot(string, IReadOnlyList<string>, bool)` is unchanged; behavior is preserved exactly (drive-root exclusion, trailing-separator normalization, case-insensitive comparison all carried over verbatim).

## Test plan
- [x] `mcp__roslyn__compile_check` on `ClientRootPathValidator.cs` — clean, 0 diagnostics.
- [x] `mcp__roslyn__test_run --filter ClientRootPathValidatorTests` — 21/21 passed.
- [x] `mcp__roslyn__get_complexity_metrics` re-measured post-refactor: `IsPathUnderAnyRoot` CC 11→4; `EnumerateAllowedRoots` CC 4; `GetWidenedParent` CC 3; `IsPathUnderRoot` CC 3 — all comfortably under the ≤8 acceptance target.

Closes: client-root-path-validator-complexity-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)