### PR TITLE
fix(services): log composite-apply temp-cleanup failures

### DIFF
--- a/changelog.d/compositeapply-temp-cleanup-failure-observability.md
+++ b/changelog.d/compositeapply-temp-cleanup-failure-observability.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `CompositeApplyOrchestrator`'s temp-file cleanup failures (a stray `.tmp` sibling that fails to delete after a failed write) are now logged as a warning with the path and exception instead of being silently discarded; the primary apply failure/result is unaffected.

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -77,7 +77,7 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
                     Directory.CreateDirectory(directory);
                 }
 
-                await AtomicFileWriter.WriteAllTextAsync(mutation.FilePath, mutation.UpdatedContent ?? string.Empty, ct).ConfigureAwait(false);
+                await AtomicFileWriter.WriteAllTextAsync(mutation.FilePath, mutation.UpdatedContent ?? string.Empty, ct, _logger).ConfigureAwait(false);
                 appliedFiles.Add(mutation.FilePath);
             }
 
@@ -123,11 +123,14 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
 /// so it lives on the same directory/volume as the target — a precondition for <c>File.Move</c>
 /// being atomic (a cross-volume move degrades to a non-atomic copy+delete). On any failure the
 /// orphaned <c>.tmp</c> is best-effort deleted so a failed write leaves no artifact, then the
-/// original exception is re-thrown for the caller's catch filter.
+/// original exception is re-thrown for the caller's catch filter. If an optional
+/// <paramref name="logger"/> is supplied, a failure to delete the orphaned <c>.tmp</c> is logged
+/// at Warning level (the primary write failure is still re-thrown either way) so a stray artifact
+/// left on disk leaves an observability trail instead of being silently discarded.
 /// </summary>
 internal static class AtomicFileWriter
 {
-    public static async Task WriteAllTextAsync(string path, string content, CancellationToken ct)
+    public static async Task WriteAllTextAsync(string path, string content, CancellationToken ct, ILogger? logger = null)
     {
         var tmp = path + ".tmp";
         try
@@ -137,12 +140,12 @@ internal static class AtomicFileWriter
         }
         catch
         {
-            TryDeleteTemp(tmp);
+            TryDeleteTemp(tmp, path, logger);
             throw;
         }
     }
 
-    private static void TryDeleteTemp(string tmp)
+    private static void TryDeleteTemp(string tmp, string path, ILogger? logger)
     {
         try
         {
@@ -154,6 +157,13 @@ internal static class AtomicFileWriter
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort cleanup — a stray .tmp is non-fatal and must not mask the original failure.
+            // The primary write exception is still re-thrown by the caller; this only records that the
+            // orphaned temp artifact could not be removed so it is not left on disk silently.
+            logger?.LogWarning(
+                ex,
+                "AtomicFileWriter: failed to delete orphaned temp file {TempPath} after a failed write to {TargetPath}; a stray .tmp artifact may remain on disk.",
+                tmp,
+                path);
         }
     }
 }

--- a/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
+++ b/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
@@ -71,6 +71,41 @@ public sealed class CompositeApplyOrchestratorTests
     }
 
     [TestMethod]
+    public async Task AtomicFileWriter_Logs_Warning_When_Temp_Cleanup_Fails_After_Write_Failure()
+    {
+        // Windows-only: an exclusive FileShare.None lock on the pre-created .tmp forces BOTH the
+        // initial write (File.WriteAllTextAsync to the locked .tmp) AND the subsequent cleanup
+        // delete to fail — so we exercise the swallowed-cleanup catch with a genuine failure, not a
+        // no-op. On non-Windows, a held handle does not block delete the same way, so we skip.
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("Deterministic temp-lock only reproduces on Windows (FileShare.None semantics).");
+            return;
+        }
+
+        var path = Path.Combine(_tempDir, "target.cs");
+        var tmp = path + ".tmp";
+
+        // Pre-create and hold the .tmp with an exclusive lock so the write to it throws IOException
+        // and the cleanup delete also throws (still locked) — the path the fix must observe.
+        using var hold = new FileStream(tmp, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+
+        var logger = new RecordingLogger<CompositeApplyOrchestrator>();
+
+        // (a) The original write failure must still propagate — primary failure is not masked.
+        await Assert.ThrowsExceptionAsync<IOException>(
+            () => AtomicFileWriter.WriteAllTextAsync(path, "// content", CancellationToken.None, logger));
+
+        // (b) Exactly one Warning naming the .tmp path is recorded.
+        var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.AreEqual(1, warnings.Count, "Exactly one Warning should be logged for the failed temp cleanup.");
+        StringAssert.Contains(warnings[0].Message, tmp, "The warning must name the orphaned .tmp path.");
+
+        // (c) The .tmp still exists — cleanup genuinely failed (it is still locked open), not a no-op.
+        Assert.IsTrue(File.Exists(tmp), "The locked .tmp must remain on disk because its cleanup delete failed.");
+    }
+
+    [TestMethod]
     public async Task ApplyComposite_MidLoop_Failure_Applies_Prior_Writes_Marks_Partial_And_Logs()
     {
         // Arrange: a first valid write, then a second mutation whose parent path is an existing


### PR DESCRIPTION
## Summary

`AtomicFileWriter.TryDeleteTemp` (in `CompositeApplyOrchestrator.cs`) swallowed `IOException`/`UnauthorizedAccessException` on the orphaned `.tmp` delete with a comment-only discard — a stray `.tmp` sibling that fails to clean up after a failed write left zero observability trail.

This threads an optional `ILogger` through `AtomicFileWriter.WriteAllTextAsync` -> `TryDeleteTemp` and logs the cleanup failure at **Warning** level (naming the `.tmp` path + exception), mirroring the existing `LogWarning` precedent in `ApplyCompositeAsync`'s own partial-apply catch. The primary write failure is still re-thrown unchanged, and the `ApplyResultDto` outcome is untouched — the log is a pure side effect inside the already-swallowing catch.

Signature change is source-compatible (optional 4th param, default `null`): only the `CompositeApplyOrchestrator` call site passes `_logger`; the other 4 `AtomicFileWriter` callers (`EditService`, `ProjectMutationService`, `UndoService` x2) compile unchanged and stay at `logger: null` — out of this row's scope.

## Testing

- New regression test `AtomicFileWriter_Logs_Warning_When_Temp_Cleanup_Fails_After_Write_Failure`: pre-creates and holds the `.tmp` with an exclusive `FileShare.None` lock so both the initial write AND the cleanup delete fail, then asserts (a) the original `IOException` still propagates, (b) exactly one `Warning` naming the `.tmp` path is recorded, (c) the `.tmp` survives (cleanup genuinely failed). Windows-guarded with `Assert.Inconclusive` on non-Windows (precedent: `WorkspaceLoadDedupTests.cs`).
- All 5 `CompositeApplyOrchestratorTests` pass (4 existing regression-guard tests + the new one); `dotnet build` clean.

Closes: compositeapply-temp-cleanup-failure-observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)