### PR TITLE
refactor(prompt-shim): decompose no-op async parameter binder

### DIFF
--- a/changelog.d/prompt-shim-parameter-binding-complexity-extraction.md
+++ b/changelog.d/prompt-shim-parameter-binding-complexity-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Refactored `PromptShimTools`'s parameter binder: replaced the no-op `async` `BuildParameterValuesAsync` (CC 11) with a synchronous `BuildParameterValues` plus focused `ParseParametersDocument`, `EnsureRequiredParametersPresent`, `ResolveParameterValue`, and `DeserializeParameterValue` helpers, each ≤8 cyclomatic complexity. No behavior change to `get_prompt_text` — precedence, error wording, and `JsonDocument` disposal are preserved.

--- a/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
@@ -41,7 +41,7 @@ public static class PromptShimTools
                 nameof(promptName));
         }
 
-        var parameterValues = await BuildParameterValuesAsync(method, services, parametersJson, ct).ConfigureAwait(false);
+        var parameterValues = BuildParameterValues(method, services, parametersJson, ct);
 
         object? result;
         try
@@ -109,17 +109,32 @@ public static class PromptShimTools
         return names;
     }
 
-    private static async Task<object?[]> BuildParameterValuesAsync(
+    private static object?[] BuildParameterValues(
         MethodInfo method, IServiceProvider services, string parametersJson, CancellationToken ct)
     {
-        await Task.CompletedTask.ConfigureAwait(false);
+        using var doc = ParseParametersDocument(parametersJson);
+        var rootObj = doc.RootElement;
 
-        // dr-9-7-bug-json-parse-surfaces-stack-trace: a raw JsonException bubbling out of this
-        // method lands in ToolErrorHandler.ClassifyError without the InvocationWrapper guard,
-        // so it falls through to "InternalError" and the client sees a stack trace. Wrap the
-        // top-level parse + each per-parameter deserialize and re-throw as ArgumentException —
-        // that maps to "InvalidArgument" via the exact-type handler dictionary and the message
-        // tells the agent exactly which parameter broke.
+        var parameters = method.GetParameters();
+        EnsureRequiredParametersPresent(method.Name, parameters, rootObj);
+
+        var values = new object?[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            values[i] = ResolveParameterValue(parameters[i], services, rootObj, ct);
+        }
+        return values;
+    }
+
+    // dr-9-7-bug-json-parse-surfaces-stack-trace: a raw JsonException bubbling out of the binder
+    // lands in ToolErrorHandler.ClassifyError without the InvocationWrapper guard, so it falls
+    // through to "InternalError" and the client sees a stack trace. Wrap the top-level parse (and
+    // each per-parameter deserialize, in DeserializeParameterValue) and re-throw as
+    // ArgumentException — that maps to "InvalidArgument" via the exact-type handler dictionary and
+    // the message tells the agent exactly which parameter broke. Callers own disposal of the
+    // returned JsonDocument on the success path; the non-object branch disposes before throwing.
+    private static JsonDocument ParseParametersDocument(string parametersJson)
+    {
         JsonDocument doc;
         try
         {
@@ -129,71 +144,66 @@ public static class PromptShimTools
         {
             throw new ArgumentException(
                 $"parametersJson is not valid JSON: {ex.Message}. Supply a JSON object (e.g. {{\"workspaceId\":\"…\"}}); use \"{{}}\" to omit all parameters.",
-                nameof(parametersJson),
+                "parametersJson",
                 ex);
         }
 
-        using (doc)
+        if (doc.RootElement.ValueKind != JsonValueKind.Object)
         {
-            var rootObj = doc.RootElement;
-            if (rootObj.ValueKind != JsonValueKind.Object)
-                throw new ArgumentException("parametersJson must be a JSON object.", nameof(parametersJson));
+            doc.Dispose();
+            throw new ArgumentException("parametersJson must be a JSON object.", "parametersJson");
+        }
 
-            var parameters = method.GetParameters();
-            var missingRequired = parameters
-                .Where(p => p.ParameterType != typeof(CancellationToken))
-                .Where(p => !IsServiceType(p.ParameterType))
-                .Where(p => !p.HasDefaultValue)
-                .Where(p => !rootObj.TryGetProperty(p.Name!, out _))
-                .Select(p => p.Name!)
-                .ToArray();
-            if (missingRequired.Length > 0)
-            {
-                throw new ArgumentException(
-                    $"Prompt '{method.Name}' is missing required parameters in parametersJson: {string.Join(", ", missingRequired)}.",
-                    nameof(parametersJson));
-            }
+        return doc;
+    }
 
-            var values = new object?[parameters.Length];
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                var p = parameters[i];
-                if (p.ParameterType == typeof(CancellationToken))
-                {
-                    values[i] = ct;
-                    continue;
-                }
-                if (IsServiceType(p.ParameterType))
-                {
-                    values[i] = services.GetRequiredService(p.ParameterType);
-                    continue;
-                }
-                if (rootObj.TryGetProperty(p.Name!, out var element))
-                {
-                    try
-                    {
-                        values[i] = JsonSerializer.Deserialize(element.GetRawText(), p.ParameterType);
-                    }
-                    catch (JsonException ex)
-                    {
-                        throw new ArgumentException(
-                            $"parametersJson property '{p.Name}' could not be deserialized into {p.ParameterType.Name}: {ex.Message}.",
-                            nameof(parametersJson),
-                            ex);
-                    }
-                }
-                else if (p.HasDefaultValue)
-                {
-                    values[i] = p.DefaultValue;
-                }
-                else
-                {
-                    throw new ArgumentException(
-                        $"Prompt parameter '{p.Name}' (type {p.ParameterType.Name}) is required but missing from parametersJson.",
-                        nameof(parametersJson));
-                }
-            }
-            return values;
+    private static void EnsureRequiredParametersPresent(
+        string methodName, ParameterInfo[] parameters, JsonElement rootObj)
+    {
+        var missingRequired = parameters
+            .Where(p => p.ParameterType != typeof(CancellationToken))
+            .Where(p => !IsServiceType(p.ParameterType))
+            .Where(p => !p.HasDefaultValue)
+            .Where(p => !rootObj.TryGetProperty(p.Name!, out _))
+            .Select(p => p.Name!)
+            .ToArray();
+        if (missingRequired.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Prompt '{methodName}' is missing required parameters in parametersJson: {string.Join(", ", missingRequired)}.",
+                "parametersJson");
+        }
+    }
+
+    private static object? ResolveParameterValue(
+        ParameterInfo p, IServiceProvider services, JsonElement rootObj, CancellationToken ct)
+    {
+        if (p.ParameterType == typeof(CancellationToken))
+            return ct;
+        if (IsServiceType(p.ParameterType))
+            return services.GetRequiredService(p.ParameterType);
+        if (rootObj.TryGetProperty(p.Name!, out var element))
+            return DeserializeParameterValue(p, element);
+        if (p.HasDefaultValue)
+            return p.DefaultValue;
+
+        throw new ArgumentException(
+            $"Prompt parameter '{p.Name}' (type {p.ParameterType.Name}) is required but missing from parametersJson.",
+            "parametersJson");
+    }
+
+    private static object? DeserializeParameterValue(ParameterInfo p, JsonElement element)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize(element.GetRawText(), p.ParameterType);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException(
+                $"parametersJson property '{p.Name}' could not be deserialized into {p.ParameterType.Name}: {ex.Message}.",
+                "parametersJson",
+                ex);
         }
     }
 

--- a/tests/RoslynMcp.Tests/PromptShimToolsTests.cs
+++ b/tests/RoslynMcp.Tests/PromptShimToolsTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+// prompt-shim-parameter-binding-complexity-extraction: the parameter binder
+// (BuildParameterValues + its ParseParametersDocument / EnsureRequiredParametersPresent /
+// ResolveParameterValue / DeserializeParameterValue helpers) was previously only exercised
+// on its error paths by the four GetPromptText_* tests in PromptSmokeTests.cs. This file adds
+// the missing success-path regression: it drives dead_code_audit end-to-end through
+// GetPromptText/BuildParameterValues with the real shared workspace fixture, a live
+// CancellationToken, a DI-resolved service parameter (IUnusedCodeAnalyzer), a JSON-supplied
+// value (workspaceId), and an omitted parameter falling through to its default (projectName),
+// asserting the rendered message text. This pins the CT → DI service → supplied-JSON → default
+// precedence chain that the error-path tests do not cover.
+[DoNotParallelize]
+[TestClass]
+public sealed class PromptShimToolsTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task GetPromptText_DeadCodeAudit_BindsServiceJsonAndDefault_RendersText()
+    {
+        // dead_code_audit's first parameter is the DI service IUnusedCodeAnalyzer, so the
+        // ServiceProvider must register it — an empty ServiceCollection would throw at
+        // GetRequiredService before the assertion runs.
+        using var services = new ServiceCollection()
+            .AddSingleton<IUnusedCodeAnalyzer>(UnusedCodeAnalyzer)
+            .BuildServiceProvider();
+
+        // workspaceId is supplied via JSON; projectName is omitted so the binder falls through
+        // to the parameter's default (null); the CancellationToken and the service are resolved
+        // by the binder, not by parametersJson.
+        var json = await PromptShimTools.GetPromptText(
+            services,
+            promptName: "dead_code_audit",
+            parametersJson: $"{{\"workspaceId\":\"{WorkspaceId}\"}}",
+            CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual("dead_code_audit", root.GetProperty("promptName").GetString());
+        Assert.AreEqual(2, root.GetProperty("parameterCount").GetInt32(),
+            "dead_code_audit exposes exactly two user-facing parameters (workspaceId, projectName); "
+            + "the service and CancellationToken must not be surfaced in the published schema.");
+
+        var messages = root.GetProperty("messages");
+        Assert.AreEqual(1, messages.GetArrayLength(),
+            "dead_code_audit renders a single prompt message.");
+
+        var text = messages[0].GetProperty("text").GetString() ?? string.Empty;
+        StringAssert.Contains(text, "dead code audit",
+            "Rendered dead_code_audit message must contain the audit body text.");
+        StringAssert.Contains(text, "(entire workspace)",
+            "Omitting projectName must fall through to the null default, which the template renders "
+            + "as '(entire workspace)' — this pins the default-value binder branch.");
+    }
+}


### PR DESCRIPTION
## Summary

Refactors `PromptShimTools`'s parameter binder to eliminate a no-op `async` method and reduce cyclomatic complexity. The original `BuildParameterValuesAsync` (CC 11) was declared `async Task<object?[]>` but its only await was `Task.CompletedTask.ConfigureAwait(false)` — a no-op that made the whole binder needlessly async while packing JSON parsing, object-kind validation, a required-parameter scan, and per-parameter resolution into one method.

## Changes

- Convert `BuildParameterValuesAsync` → synchronous `BuildParameterValues` (drops the `async`/`await`/`ConfigureAwait` plumbing); sole caller `GetPromptText` updated to a plain call.
- Extract four focused helpers:
  - `ParseParametersDocument` — JSON parse + non-object `ValueKind` guard (disposes the doc before throwing on the non-object path).
  - `EnsureRequiredParametersPresent` — the missing-required-parameter scan.
  - `ResolveParameterValue` — per-parameter precedence: CancellationToken → DI service → supplied JSON → default → required-but-missing throw.
  - `DeserializeParameterValue` — the per-parameter `JsonSerializer.Deserialize` + `JsonException` wrap.
- Each of the 5 methods measures CC ≤5 (Roslyn metrics), down from the single-method CC 11.

## Behavior preservation

No behavior change to `get_prompt_text`: parameter precedence, every `ArgumentException` message, the `"parametersJson"` `paramName`, and `JsonDocument` disposal on all throw paths are preserved.

## Tests

- New `tests/RoslynMcp.Tests/PromptShimToolsTests.cs`: success-path regression driving `dead_code_audit` end-to-end through `GetPromptText`/`BuildParameterValues` with the real shared workspace fixture, a live `CancellationToken`, a DI-resolved service parameter, a JSON-supplied value, and an omitted-→-default parameter. This pins the CT → DI service → supplied-JSON → default precedence chain that the existing error-path tests do not cover.
- The 4 existing `GetPromptText_*` error-path tests in `PromptSmokeTests.cs` are unmodified and continue to pass (free regression net over the public surface).
- Validation: `compile_check` clean; targeted `PromptShimToolsTests`+`PromptSmokeTests` filter — 21 passed / 0 failed; per-method CC re-measured ≤5.

Closes: prompt-shim-parameter-binding-complexity-extraction