### PR TITLE
refactor(roslyn): dedupe CSharp.Features assembly-load helper

### DIFF
--- a/changelog.d/dedupe-csharp-features-assembly-load-helper.md
+++ b/changelog.d/dedupe-csharp-features-assembly-load-helper.md
@@ -1,0 +1,4 @@
+---
+category: Maintenance
+---
+Extracted the duplicated `Microsoft.CodeAnalysis.CSharp.Features` assembly-load-with-swallowed-exception logic from `CodeActionService` and `FixAllService` into a shared `CSharpFeaturesAssemblyLoader` helper (`src/RoslynMcp.Roslyn/Helpers/`), removing byte-for-byte-identical duplicate methods. No behavior change.

--- a/src/RoslynMcp.Roslyn/Helpers/CSharpFeaturesAssemblyLoader.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/CSharpFeaturesAssemblyLoader.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+
+namespace RoslynMcp.Roslyn.Helpers;
+
+/// <summary>
+/// Loads the <c>Microsoft.CodeAnalysis.CSharp.Features</c> assembly used to discover built-in
+/// Roslyn code fix providers, code refactoring providers, and diagnostic analyzers.
+/// </summary>
+/// <remarks>
+/// <c>dedupe-csharp-features-assembly-load-helper</c> — prior to this helper,
+/// <c>CodeActionService.LoadCSharpFeaturesAssembly()</c> and
+/// <c>FixAllService.LoadFeaturesAssembly()</c> each carried a byte-for-byte-identical private
+/// method that loaded this assembly and swallowed any non-cancellation exception into a
+/// <see langword="null"/> return. This helper centralizes that logic so both services share one
+/// implementation.
+/// </remarks>
+internal static class CSharpFeaturesAssemblyLoader
+{
+    /// <summary>
+    /// Attempts to load the <c>Microsoft.CodeAnalysis.CSharp.Features</c> assembly.
+    /// </summary>
+    /// <returns>
+    /// The loaded <see cref="Assembly"/>, or <see langword="null"/> if the load failed for any
+    /// reason other than cancellation.
+    /// </returns>
+    internal static Assembly? TryLoad()
+    {
+        try
+        {
+            return Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CodeActionService.cs
@@ -260,23 +260,11 @@ public sealed class CodeActionService : ICodeActionService
         return TextSpan.FromBounds(startPosition, Math.Max(startPosition, lineEnd));
     }
 
-    private static Assembly? LoadCSharpFeaturesAssembly()
-    {
-        try
-        {
-            return Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features");
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            return null;
-        }
-    }
-
     private ImmutableArray<CodeFixProvider> LoadCodeFixProviders()
     {
         try
         {
-            var featuresAssembly = LoadCSharpFeaturesAssembly();
+            var featuresAssembly = CSharpFeaturesAssemblyLoader.TryLoad();
             if (featuresAssembly is null)
             {
                 _logger.LogWarning("Could not load Microsoft.CodeAnalysis.CSharp.Features assembly for code fix providers");
@@ -308,7 +296,7 @@ public sealed class CodeActionService : ICodeActionService
     {
         try
         {
-            var featuresAssembly = LoadCSharpFeaturesAssembly();
+            var featuresAssembly = CSharpFeaturesAssemblyLoader.TryLoad();
             if (featuresAssembly is null)
             {
                 _logger.LogWarning("Could not load Microsoft.CodeAnalysis.CSharp.Features assembly for code refactoring providers");

--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -419,23 +419,11 @@ public sealed class FixAllService : IFixAllService
         return [..set];
     }
 
-    private static Assembly? LoadFeaturesAssembly()
-    {
-        try
-        {
-            return Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features");
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            return null;
-        }
-    }
-
     private ImmutableArray<CodeFixProvider> LoadCodeFixProviders()
     {
         try
         {
-            var featuresAssembly = LoadFeaturesAssembly();
+            var featuresAssembly = CSharpFeaturesAssemblyLoader.TryLoad();
             if (featuresAssembly is null)
             {
                 _logger.LogWarning("Could not load Microsoft.CodeAnalysis.CSharp.Features assembly");
@@ -473,7 +461,7 @@ public sealed class FixAllService : IFixAllService
     {
         try
         {
-            var featuresAssembly = LoadFeaturesAssembly();
+            var featuresAssembly = CSharpFeaturesAssemblyLoader.TryLoad();
             if (featuresAssembly is null) return [];
 
             var analyzers = featuresAssembly.GetTypes()


### PR DESCRIPTION
## Summary

- Extracted the byte-for-byte-identical `Assembly.Load("Microsoft.CodeAnalysis.CSharp.Features")` try/catch helper duplicated in `CodeActionService.LoadCSharpFeaturesAssembly()` and `FixAllService.LoadFeaturesAssembly()` into a shared `internal static class CSharpFeaturesAssemblyLoader` (`src/RoslynMcp.Roslyn/Helpers/`), following this repo's existing small-static-helper convention.
- Updated all 4 call sites (2 in `CodeActionService`, 2 in `FixAllService`) to `CSharpFeaturesAssemblyLoader.TryLoad()`. No behavior change — same catch clause (`ex is not OperationCanceledException` swallow-to-null) preserved verbatim.

## Validation

- `mcp__roslyn__compile_check` on all 3 touched files — 0 errors.
- `mcp__roslyn__symbol_search` confirms `CSharpFeaturesAssemblyLoader.TryLoad()` resolves; `mcp__roslyn__find_references` confirms exactly 4 call sites (2 per service), matching pre-existing call-site count.
- `mcp__roslyn__test_run --filter "FullyQualifiedName~CodeActionServiceTests|FullyQualifiedName~FixAllServiceTests"` — 16/16 passed.

Closes: dedupe-csharp-features-assembly-load-helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)