### PR TITLE
fix(analysis): enforce pagination/batch bounds on analysis tools

### DIFF
--- a/changelog.d/analysis-tools-pagination-clamp-rollout.md
+++ b/changelog.d/analysis-tools-pagination-clamp-rollout.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_references_bulk` now enforces its documented 50-symbol batch cap (`ArgumentException` on overflow instead of silently accepting unbounded arrays); `get_complexity_metrics` now validates its `limit` parameter via `ParameterValidation.ValidatePagination`; `find_consumers` gained `limit`/`offset` parameters (default `limit=100`) with `hasMore`/`totals` reporting, matching the pagination contract already used by `find_type_usages`, `callers_callees`, and `symbol_relationships`.

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -185,6 +185,7 @@ public static class AdvancedAnalysisTools
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            ParameterValidation.ValidatePagination(0, limit);
             var results = await codeMetricsService.GetComplexityMetricsAsync(workspaceId, filePath, filePaths, projectName, minComplexity, limit, c);
             return JsonSerializer.Serialize(new { count = results.Count, metrics = results }, JsonDefaults.Indented);
         }, ct);

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -24,15 +24,32 @@ public static class ConsumerAnalysisTools
         [Description("Optional: stable symbol handle returned by other semantic tools")] string? symbolHandle = null,
         [Description("Optional: fully qualified metadata name, e.g. Namespace.IMyInterface")] string? metadataName = null,
         [Description("Optional: case-sensitive Project.Name filter to scope the consumer walk; comma-separated for multiple projects (e.g. 'Foo.Core,Foo.Tests'). Null/empty preserves the unfiltered solution-wide walk.")] string? projectFilter = null,
+        [Description("Number of consumers to skip before returning results (default: 0).")] int offset = 0,
+        [Description("Maximum number of consumers to return (default: 100). Consumers are ordered by ascending type name; the `totals` block and `hasMore` flag let callers page high-fan-out types.")] int limit = 100,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
+            ParameterValidation.ValidatePagination(offset, limit);
             var locator = SymbolLocatorFactory.Create(filePath, line, column, symbolHandle, metadataName);
             var filterSet = SymbolTools.ParseProjectFilter(projectFilter);
             var result = await consumerAnalysisService.FindConsumersAsync(workspaceId, locator, c, filterSet);
             if (result is null) throw new KeyNotFoundException(SymbolLocatorFactory.FormatSymbolNotFoundMessage(locator));
-            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+
+            var totalConsumers = result.Consumers.Count;
+            var pagedConsumers = result.Consumers.Skip(offset).Take(limit).ToList();
+            var hasMore = offset + pagedConsumers.Count < totalConsumers;
+
+            return JsonSerializer.Serialize(new
+            {
+                targetSymbol = result.TargetSymbol,
+                consumers = pagedConsumers,
+                summary = result.Summary,
+                offset,
+                limit,
+                hasMore,
+                totals = new { consumers = totalConsumers }
+            }, JsonDefaults.Indented);
         }, ct);
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterValidation.cs
@@ -65,4 +65,16 @@ internal static class ParameterValidation
         if (limit > MaxLimit)
             throw new ArgumentException($"Invalid limit '{limit}'. Limit must not exceed {MaxLimit}.");
     }
+
+    /// <summary>
+    /// Validates a batch/array-size bound. Unlike <see cref="ValidatePagination"/> (an offset/limit
+    /// pair), this guards the length of a caller-supplied collection against a per-tool maximum so a
+    /// documented batch cap (e.g. "max 50") is actually enforced instead of silently accepted.
+    /// </summary>
+    public static void ValidateBulkSize(int count, int maxCount, string paramName)
+    {
+        if (count > maxCount)
+            throw new ArgumentException(
+                $"Too many items ({count}) for '{paramName}'. Must not exceed {maxCount}.", paramName);
+    }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -653,6 +653,8 @@ public static class SymbolTools
             if (maxItemsPerSymbol < 1)
                 throw new ArgumentException("maxItemsPerSymbol must be >= 1.", nameof(maxItemsPerSymbol));
 
+            ParameterValidation.ValidateBulkSize(symbols.Length, 50, nameof(symbols));
+
             var results = await referenceService.FindReferencesBulkAsync(workspaceId, symbols, includeDefinition, c);
 
             // Apply the per-symbol cap + summary stripping BEFORE assembling the outer envelope.

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.cs
@@ -351,6 +351,94 @@ public sealed class ExpandedSurfaceIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task FindReferencesBulk_MoreThan50Symbols_Throws()
+    {
+        var symbols = Enumerable.Range(0, 51)
+            .Select(_ => new BulkSymbolLocator(SymbolHandle: null, MetadataName: "SampleLib.IAnimal",
+                FilePath: null, Line: null, Column: null))
+            .ToArray();
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => SymbolTools.FindReferencesBulk(
+            WorkspaceExecutionGate,
+            ReferenceService,
+            WorkspaceId,
+            symbols,
+            includeDefinition: false,
+            summary: false,
+            maxItemsPerSymbol: 100,
+            ct: CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task GetComplexityMetrics_NegativeLimit_Throws()
+    {
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => AdvancedAnalysisTools.GetComplexityMetrics(
+            WorkspaceExecutionGate,
+            CodeMetricsService,
+            WorkspaceId,
+            filePath: null,
+            filePaths: null,
+            projectName: "SampleLib",
+            minComplexity: 1,
+            limit: -5,
+            ct: CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_Limit_Caps_And_Reports_HasMore()
+    {
+        var pagedJson = await ConsumerAnalysisTools.FindConsumers(
+            WorkspaceExecutionGate,
+            ConsumerAnalysisService,
+            WorkspaceId,
+            metadataName: "SampleLib.IAnimal",
+            offset: 0,
+            limit: 1,
+            ct: CancellationToken.None);
+
+        using var pagedDoc = JsonDocument.Parse(pagedJson);
+        var root = pagedDoc.RootElement;
+        Assert.AreEqual(1, root.GetProperty("consumers").GetArrayLength(),
+            "limit=1 must cap the returned consumers array to a single entry.");
+        Assert.AreEqual(1, root.GetProperty("limit").GetInt32());
+        Assert.AreEqual(0, root.GetProperty("offset").GetInt32());
+        var total = root.GetProperty("totals").GetProperty("consumers").GetInt32();
+        Assert.IsTrue(total >= 3, $"IAnimal should report >=3 total consumers, got {total}.");
+        Assert.IsTrue(root.GetProperty("hasMore").GetBoolean(),
+            "With >1 total consumers and limit=1, hasMore must be true.");
+    }
+
+    [TestMethod]
+    public async Task FindConsumers_Offset_Skips_Correctly()
+    {
+        var firstPage = await ConsumerAnalysisTools.FindConsumers(
+            WorkspaceExecutionGate,
+            ConsumerAnalysisService,
+            WorkspaceId,
+            metadataName: "SampleLib.IAnimal",
+            offset: 0,
+            limit: 1,
+            ct: CancellationToken.None);
+
+        var secondPage = await ConsumerAnalysisTools.FindConsumers(
+            WorkspaceExecutionGate,
+            ConsumerAnalysisService,
+            WorkspaceId,
+            metadataName: "SampleLib.IAnimal",
+            offset: 1,
+            limit: 1,
+            ct: CancellationToken.None);
+
+        using var firstDoc = JsonDocument.Parse(firstPage);
+        using var secondDoc = JsonDocument.Parse(secondPage);
+
+        var firstName = firstDoc.RootElement.GetProperty("consumers")[0].GetProperty("typeName").GetString();
+        var secondName = secondDoc.RootElement.GetProperty("consumers")[0].GetProperty("typeName").GetString();
+        Assert.AreNotEqual(firstName, secondName,
+            "offset=1 must skip the first consumer returned at offset=0.");
+    }
+
+    [TestMethod]
     public async Task Relationship_And_Cohesion_Tools_Expose_New_Limit_And_Interface_Flags()
     {
         var iAnimalPath = FindDocumentPath("IAnimal.cs");

--- a/tests/RoslynMcp.Tests/ParameterValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterValidationTests.cs
@@ -90,4 +90,19 @@ public class ParameterValidationTests
     public void ValidatePagination_Limit_Above_Max_Throws()
         => Assert.ThrowsExactly<ArgumentException>(
             () => ParameterValidation.ValidatePagination(0, 1001));
+
+    // ── ValidateBulkSize ──
+
+    [TestMethod]
+    public void ValidateBulkSize_Below_Max_Does_Not_Throw()
+        => ParameterValidation.ValidateBulkSize(10, 50, "symbols");
+
+    [TestMethod]
+    public void ValidateBulkSize_At_Max_Does_Not_Throw()
+        => ParameterValidation.ValidateBulkSize(50, 50, "symbols");
+
+    [TestMethod]
+    public void ValidateBulkSize_Above_Max_Throws()
+        => Assert.ThrowsExactly<ArgumentException>(
+            () => ParameterValidation.ValidateBulkSize(51, 50, "symbols"));
 }


### PR DESCRIPTION
Wires bound-enforcement into three unbounded/inconsistent-clamp analysis-tool call sites, matching the pagination contract already used by `find_type_usages`, `callers_callees`, and `symbol_relationships`.

## Changes
- **`ParameterValidation.ValidateBulkSize(count, maxCount, paramName)`** — new array-length guard (throws `ArgumentException` on overflow), distinct from the offset/limit `ValidatePagination`.
- **`find_references_bulk`** — now enforces its documented "max 50" symbol batch cap via `ValidateBulkSize(symbols.Length, 50, ...)` before the service call; previously the claim was advertised in the tool Description but never checked.
- **`get_complexity_metrics`** — now calls `ValidatePagination(0, limit)`, mirroring `symbol_relationships`; a negative or `int.MaxValue` limit previously passed through uncaught.
- **`find_consumers`** — gained `offset`/`limit` params (default `limit=100`) with tool-layer `.Skip(offset).Take(limit)` slicing plus `hasMore`/`totals` reporting. No `IConsumerAnalysisService`/DTO signature change — slicing is tool-layer only.

## Behavior note
`find_consumers` response shape changes (adds `hasMore`/`totals`, pages the `consumers` array when >limit). Internal MCP tool, no backward-compat contract per repo defaults; logged as Fixed in the changelog.

## Validation
- `dotnet build tests/RoslynMcp.Tests` — clean (0 warnings, 0 errors).
- Targeted `ParameterValidationTests` + `ExpandedSurfaceIntegrationTests` — 60/60 pass. New cases: `ValidateBulkSize` at/above max, `FindReferencesBulk_MoreThan50Symbols_Throws`, `GetComplexityMetrics_NegativeLimit_Throws`, `FindConsumers_Limit_Caps_And_Reports_HasMore`, `FindConsumers_Offset_Skips_Correctly`.

Closes: analysis-tools-pagination-clamp-rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)