### PR TITLE
refactor(server): extract GetServerInfo builders to cut complexity (server-info-complexity-extraction)

### DIFF
--- a/changelog.d/server-info-complexity-extraction.md
+++ b/changelog.d/server-info-complexity-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** extracted focused version, workspace-hint, surface-count, and update-block builders out of `ServerTools.GetServerInfo`, reducing its cyclomatic complexity from 11 to ≤ 8 with no change to the `server_info` response shape.

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -100,26 +100,12 @@ public static class ServerTools
         IWorkspaceManager workspace,
         ILatestVersionProvider versionChecker)
     {
-        var assembly = typeof(ServerTools).Assembly;
-        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                      ?? assembly.GetName().Version?.ToString() ?? "unknown";
+        var (version, currentSemver) = ResolveVersionInfo(typeof(ServerTools).Assembly);
 
         var catalogSummary = ServerSurfaceCatalog.GetSummary();
         var wsCount = workspace.ListWorkspaces().Count;
-
-        // Best-effort: returns cached latest version or null if pending/failed.
-        // Sanity guard: never report "update available" when the reported latest is
-        // older than the running version (can happen with stale NuGet CDN cache).
-        var latestVersion = versionChecker.GetLatestVersion();
-        var checkStatus = versionChecker.LastCheckStatus;
-        var lastCheckedAt = versionChecker.LastCheckedAt;
-        var currentSemver = version.Split('+')[0]; // strip git hash suffix
-        var updateAvailable = latestVersion is not null
-                              && Version.TryParse(currentSemver, out var currentParsed)
-                              && Version.TryParse(latestVersion, out var latestParsed)
-                              && latestParsed > currentParsed;
-
         var registeredSnapshot = SurfaceRegistrationSnapshot.Value;
+
         var info = new ServerInfoDto(
             Server: "roslyn-mcp",
             Version: version,
@@ -128,31 +114,14 @@ public static class ServerTools
             Os: System.Runtime.InteropServices.RuntimeInformation.OSDescription,
             RoslynVersion: typeof(Microsoft.CodeAnalysis.SyntaxNode).Assembly.GetName().Version?.ToString() ?? "unknown",
             WorkspaceCount: wsCount,
-            WorkspaceCountHint: wsCount == 0
-                ? "If you just called workspace_load, workspaceCount may still be 0 briefly; call workspace_list for authoritative session ids."
-                : null,
+            WorkspaceCountHint: BuildWorkspaceCountHint(wsCount),
             // mcp-connection-session-resilience: explicit connection readiness so consumers
             // can distinguish transport-up from workspace-loaded without guessing via
             // workspaceCount. Same shape as `server_heartbeat` but carried inline on
             // server_info so existing pollers get it without a second round-trip.
             Connection: BuildConnection(workspace),
             CatalogVersion: ServerSurfaceCatalog.CatalogVersion,
-            Surface: new ServerSurfaceCountsDto(
-                Tools: new SurfaceTierCountsDto(catalogSummary.StableTools, catalogSummary.ExperimentalTools),
-                Resources: new SurfaceTierCountsDto(catalogSummary.StableResources, catalogSummary.ExperimentalResources),
-                Prompts: new SurfaceTierCountsDto(catalogSummary.StablePrompts, catalogSummary.ExperimentalPrompts),
-                // concurrent-mcp-instances-no-tools: runtime-observed counts captured at
-                // host.Build() from McpServer.ServerOptions.{Tool,Resource,Prompt}Collection.
-                // A client that sees `surface.tools.registered == 0` here has reached a
-                // process where WithToolsFromAssembly() found no attributed methods —
-                // an unambiguous server-side failure distinct from catalog drift. Null
-                // when the snapshot was not populated (unit-test paths that construct
-                // ServerTools directly without booting the host).
-                Registered: registeredSnapshot is null ? null : new SurfaceRegisteredCountsDto(
-                    Tools: registeredSnapshot.ToolsRegistered,
-                    Resources: registeredSnapshot.ResourcesRegistered,
-                    Prompts: registeredSnapshot.PromptsRegistered,
-                    ParityOk: registeredSnapshot.AllParityOk)),
+            Surface: BuildSurfaceCounts(catalogSummary, registeredSnapshot),
             ResourceServerNames: new ResourceServerNameHintsDto(
                 Canonical: "roslyn",
                 Aliases:
@@ -170,25 +139,93 @@ public static class ServerTools
                 "Remote HTTP/SSE hosting is not part of the current stable release contract."
             ],
             Capabilities: new ServerCapabilitiesDto(Tools: true, Resources: true, Prompts: true, Logging: true, Progress: true),
-            // latest-version-status-surface: always emit the update block so operators can
-            // distinguish "still checking" from "check failed/timed out" and "succeeded,
-            // no newer version" even though all three keep `latest=null`.
-            //
-            // server-info-update-latest-inverted: only emit `latest` when the registry
-            // reports a STRICTLY GREATER version than the running build. Pre-fix the
-            // field surfaced any cached registry value (Jellyfin 2026-04-16: latest=1.16.0
-            // while current=1.18.2 — the cached value was older). The new contract: if
-            // `latest` is present, it is genuinely newer than `current`. updateAvailable
-            // remains for callers that prefer the boolean.
-            Update: new ServerUpdateInfoDto(
-                Current: currentSemver,
-                Latest: updateAvailable ? latestVersion : null,
-                UpdateAvailable: updateAvailable,
-                Command: updateAvailable ? "dotnet tool update -g Darylmcd.RoslynMcp" : null,
-                CheckStatus: FormatVersionCheckStatus(checkStatus),
-                LastCheckedAt: lastCheckedAt?.ToString("O")));
+            Update: BuildUpdateInfo(currentSemver, versionChecker));
 
         return Task.FromResult(JsonSerializer.Serialize(info, JsonDefaults.Indented));
+    }
+
+    /// <summary>
+    /// Resolves the running assembly's informational version and its semver-only form
+    /// (git-hash suffix stripped). Both flow into the <see cref="ServerInfoDto"/>: the
+    /// full <paramref name="assembly"/> version as <c>Version</c>, the stripped form as
+    /// the update block's <c>Current</c>.
+    /// </summary>
+    private static (string Version, string CurrentSemver) ResolveVersionInfo(Assembly assembly)
+    {
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                      ?? assembly.GetName().Version?.ToString() ?? "unknown";
+        var currentSemver = version.Split('+')[0]; // strip git hash suffix
+        return (version, currentSemver);
+    }
+
+    /// <summary>
+    /// Builds the <c>workspaceCount</c> disclaimer surfaced only while no session is loaded
+    /// (null once a workspace exists), so callers know a just-issued <c>workspace_load</c>
+    /// may briefly still read as zero.
+    /// </summary>
+    private static string? BuildWorkspaceCountHint(int wsCount)
+        => wsCount == 0
+            ? "If you just called workspace_load, workspaceCount may still be 0 briefly; call workspace_list for authoritative session ids."
+            : null;
+
+    /// <summary>
+    /// Projects the catalog summary and the (optional) runtime registration snapshot into the
+    /// <see cref="ServerSurfaceCountsDto"/> emitted under <c>surface</c>.
+    /// </summary>
+    private static ServerSurfaceCountsDto BuildSurfaceCounts(
+        SurfaceSummary catalogSummary,
+        StartupDiagnostics.SurfaceRegistrationReport? registeredSnapshot)
+        => new(
+            Tools: new SurfaceTierCountsDto(catalogSummary.StableTools, catalogSummary.ExperimentalTools),
+            Resources: new SurfaceTierCountsDto(catalogSummary.StableResources, catalogSummary.ExperimentalResources),
+            Prompts: new SurfaceTierCountsDto(catalogSummary.StablePrompts, catalogSummary.ExperimentalPrompts),
+            // concurrent-mcp-instances-no-tools: runtime-observed counts captured at
+            // host.Build() from McpServer.ServerOptions.{Tool,Resource,Prompt}Collection.
+            // A client that sees `surface.tools.registered == 0` here has reached a
+            // process where WithToolsFromAssembly() found no attributed methods —
+            // an unambiguous server-side failure distinct from catalog drift. Null
+            // when the snapshot was not populated (unit-test paths that construct
+            // ServerTools directly without booting the host).
+            Registered: registeredSnapshot is null ? null : new SurfaceRegisteredCountsDto(
+                Tools: registeredSnapshot.ToolsRegistered,
+                Resources: registeredSnapshot.ResourcesRegistered,
+                Prompts: registeredSnapshot.PromptsRegistered,
+                ParityOk: registeredSnapshot.AllParityOk));
+
+    /// <summary>
+    /// Computes the <see cref="ServerUpdateInfoDto"/> update block: reads the cached latest
+    /// version + check status once, then applies the inverted-latest sanity guard.
+    /// </summary>
+    private static ServerUpdateInfoDto BuildUpdateInfo(string currentSemver, ILatestVersionProvider versionChecker)
+    {
+        // Best-effort: returns cached latest version or null if pending/failed.
+        // Sanity guard: never report "update available" when the reported latest is
+        // older than the running version (can happen with stale NuGet CDN cache).
+        var latestVersion = versionChecker.GetLatestVersion();
+        var checkStatus = versionChecker.LastCheckStatus;
+        var lastCheckedAt = versionChecker.LastCheckedAt;
+        var updateAvailable = latestVersion is not null
+                              && Version.TryParse(currentSemver, out var currentParsed)
+                              && Version.TryParse(latestVersion, out var latestParsed)
+                              && latestParsed > currentParsed;
+
+        // latest-version-status-surface: always emit the update block so operators can
+        // distinguish "still checking" from "check failed/timed out" and "succeeded,
+        // no newer version" even though all three keep `latest=null`.
+        //
+        // server-info-update-latest-inverted: only emit `latest` when the registry
+        // reports a STRICTLY GREATER version than the running build. Pre-fix the
+        // field surfaced any cached registry value (Jellyfin 2026-04-16: latest=1.16.0
+        // while current=1.18.2 — the cached value was older). The new contract: if
+        // `latest` is present, it is genuinely newer than `current`. updateAvailable
+        // remains for callers that prefer the boolean.
+        return new ServerUpdateInfoDto(
+            Current: currentSemver,
+            Latest: updateAvailable ? latestVersion : null,
+            UpdateAvailable: updateAvailable,
+            Command: updateAvailable ? "dotnet tool update -g Darylmcd.RoslynMcp" : null,
+            CheckStatus: FormatVersionCheckStatus(checkStatus),
+            LastCheckedAt: lastCheckedAt?.ToString("O"));
     }
 
     private static string FormatVersionCheckStatus(VersionCheckStatus status)


### PR DESCRIPTION
## Summary

Extracts four focused private `static` helpers out of `ServerTools.GetServerInfo`, dropping its cyclomatic complexity from **11 to 2** (all new helpers ≤ 6) with **no change** to the `server_info` response shape, DTOs, or JSON field order.

- `ResolveVersionInfo(Assembly)` — informational version + git-hash-stripped semver.
- `BuildWorkspaceCountHint(int)` — the zero-session disclaimer string.
- `BuildSurfaceCounts(SurfaceSummary, SurfaceRegistrationReport?)` — the `surface` counts DTO.
- `BuildUpdateInfo(string, ILatestVersionProvider)` — the update block, with the inverted-latest sanity guard moved **verbatim**.

`GetServerInfo` becomes a linear sequence of helper calls feeding the unchanged `ServerInfoDto` constructor. `BuildConnection` is untouched (no second call introduced); the two independent `ListWorkspaces().Count` reads stay separate; `checkStatus`/`lastCheckedAt` now live inside `BuildUpdateInfo` (their only consumer).

## Validation

- `get_complexity_metrics`: `GetServerInfo` CC 2 · `ResolveVersionInfo` 3 · `BuildWorkspaceCountHint` 2 · `BuildSurfaceCounts` 2 · `BuildUpdateInfo` 6 — all ≤ 8 (acceptance criterion).
- Clean `dotnet build` of `RoslynMcp.Host.Stdio` (0 warnings / 0 errors).
- Regression suites pass unmodified (53 tests, 0 failures): `ServerInfoUpdateLatestTests`, `ServerHeartbeatTests`, `HostProcessMetadataTests`, `StartupDiagnosticsTests`, `SurfaceCatalogTests`.

Closes: server-info-complexity-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)