### PR TITLE
feat(extract-type): surface structured blockingDependencies on extract_type_preview refusals

### DIFF
--- a/changelog.d/extract-type-preview-refusal-missing-blocking-deps.md
+++ b/changelog.d/extract-type-preview-refusal-missing-blocking-deps.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `extract_type_preview` refusals (dangling-reference and member-not-found) now carry a structured `blockingDependencies: [{member, reason}]` field alongside the existing prose message, so callers can programmatically retry with a corrected `memberNames` set instead of abandoning the tool.

--- a/src/RoslynMcp.Core/Models/BlockingDependencyDto.cs
+++ b/src/RoslynMcp.Core/Models/BlockingDependencyDto.cs
@@ -1,0 +1,13 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// A single structured reason why a refactoring refused to proceed, naming the member that
+/// blocks the operation and why. Emitted alongside the prose error message so callers can
+/// programmatically adjust their request (e.g. widen an <c>extract_type_preview</c>
+/// <c>memberNames</c> set) instead of string-matching the message.
+/// </summary>
+/// <param name="Member">The member name the refusal is attributed to.</param>
+/// <param name="Reason">Human-readable explanation of why this member blocks the operation.</param>
+public sealed record BlockingDependencyDto(
+    string Member,
+    string Reason);

--- a/src/RoslynMcp.Core/Services/ExtractTypeBlockingDependencyException.cs
+++ b/src/RoslynMcp.Core/Services/ExtractTypeBlockingDependencyException.cs
@@ -1,0 +1,26 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Core.Services;
+
+/// <summary>
+/// Refusal error for <c>extract_type_preview</c> that carries the structured blocking-member
+/// data the refusal was computed from, on top of the existing prose message.
+/// </summary>
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> — mirroring
+/// <see cref="SymbolNotFoundException"/>'s relationship to <see cref="KeyNotFoundException"/> —
+/// so every existing <c>catch (InvalidOperationException)</c> and the <c>ToolErrorHandler</c>
+/// classification table keep matching unchanged: the error <c>category</c> stays
+/// <c>InvalidOperation</c> and the prose <c>message</c> is untouched. Only the JSON envelope
+/// gains an extra <c>blockingDependencies</c> field.
+/// </remarks>
+public sealed class ExtractTypeBlockingDependencyException : InvalidOperationException
+{
+    public ExtractTypeBlockingDependencyException(string message, IReadOnlyList<BlockingDependencyDto> blockingDependencies)
+        : base(message)
+    {
+        BlockingDependencies = blockingDependencies;
+    }
+
+    public IReadOnlyList<BlockingDependencyDto> BlockingDependencies { get; }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -538,6 +538,24 @@ internal static class ToolErrorHandler
                 return JsonSerializer.Serialize(error, JsonDefaults.Indented);
             }
 
+            // extract-type-preview-refusal-missing-blocking-deps: mirror the closestMatches
+            // treatment above for extract_type_preview's refusals — the prose message and the
+            // InvalidOperation category are unchanged; the envelope just gains the structured
+            // per-member blocking data the refusal was computed from.
+            if (ex is ExtractTypeBlockingDependencyException { BlockingDependencies.Count: > 0 } blockedExtraction)
+            {
+                var error = new
+                {
+                    error = true,
+                    category = info.Category,
+                    tool = toolName,
+                    message = info.Message,
+                    exceptionType = ex.GetType().Name,
+                    blockingDependencies = blockedExtraction.BlockingDependencies,
+                };
+                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
+            }
+
             // inv-arg-envelope-schema-hint: attach a one-line schema hint for InvalidArgument
             // envelopes so cold-context callers can re-call without round-tripping through
             // server_info. Hint is omitted (rather than emitted as null) when the failing

--- a/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
@@ -55,12 +55,16 @@ public sealed class TypeExtractionService : ITypeExtractionService
         // the split before attempting it.
         if (warnings.Count > 0)
         {
-            var summary = string.Join("; ", warnings);
-            throw new InvalidOperationException(
+            var summary = string.Join("; ", warnings.Select(w => w.Reason));
+            // extract-type-preview-refusal-missing-blocking-deps: the prose message is unchanged;
+            // the structured per-member blocking data that produced it now rides along on the
+            // exception so callers can retry with a corrected memberNames set programmatically.
+            throw new ExtractTypeBlockingDependencyException(
                 $"Refusing to extract type '{newTypeName}' from '{sourceTypeName}': the selected members reference state " +
                 $"that would remain on the source type, so the generated code would not compile. " +
                 $"Either include the referenced members in the extraction or perform a manual redesign first. " +
-                $"Details: {summary}");
+                $"Details: {summary}",
+                warnings);
         }
 
         // dr-9-1-does-not-update-external-consumer-call-sites (SampleSolution audit §9.1):
@@ -117,7 +121,9 @@ public sealed class TypeExtractionService : ITypeExtractionService
         var description = $"Extract {membersToExtract.Count} member(s) from '{sourceTypeName}' into new type '{newTypeName}'";
         var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
 
-        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
+        return new RefactoringPreviewDto(
+            token, description, changes,
+            warnings.Count > 0 ? warnings.Select(w => w.Reason).ToList() : null);
     }
 
     private static (List<MemberDeclarationSyntax> ToExtract, List<MemberDeclarationSyntax> ToKeep) PartitionMembers(
@@ -142,8 +148,19 @@ public sealed class TypeExtractionService : ITypeExtractionService
         }
 
         if (memberNameSet.Count > 0)
-            throw new InvalidOperationException(
-                $"Members not found in type '{sourceTypeName}': {string.Join(", ", memberNameSet)}");
+        {
+            // extract-type-preview-refusal-missing-blocking-deps: prose message unchanged; the
+            // unmatched names are also projected into structured blocking dependencies so the
+            // caller can correct `memberNames` without parsing the sentence.
+            var unmatched = memberNameSet
+                .Select(name => new BlockingDependencyDto(
+                    name,
+                    $"Member '{name}' not found in type '{sourceTypeName}'."))
+                .ToList();
+            throw new ExtractTypeBlockingDependencyException(
+                $"Members not found in type '{sourceTypeName}': {string.Join(", ", memberNameSet)}",
+                unmatched);
+        }
 
         if (toExtract.Count == 0)
             throw new InvalidOperationException("No members matched for extraction.");
@@ -354,7 +371,15 @@ public sealed class TypeExtractionService : ITypeExtractionService
         return warnings;
     }
 
-    private static List<string> CollectExtractTypeDanglingReferenceWarnings(
+    /// <summary>
+    /// Collects one entry per (extracted member, referenced symbol that stays behind) pair.
+    /// extract-type-preview-refusal-missing-blocking-deps: returns structured
+    /// <see cref="BlockingDependencyDto"/> values rather than flat prose so the refusal at the
+    /// call site can carry them through to the caller. Dedup is keyed on the reason text alone
+    /// (unchanged from the pre-structured behavior), so a symbol referenced from several
+    /// extracted members is reported once, attributed to the first member that referenced it.
+    /// </summary>
+    private static List<BlockingDependencyDto> CollectExtractTypeDanglingReferenceWarnings(
         SemanticModel semanticModel,
         INamedTypeSymbol typeSymbol,
         IReadOnlyList<MemberDeclarationSyntax> membersToExtract,
@@ -369,10 +394,15 @@ public sealed class TypeExtractionService : ITypeExtractionService
         }
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        var warnings = new List<string>();
+        var warnings = new List<BlockingDependencyDto>();
 
         foreach (var member in membersToExtract)
         {
+            // GetMemberName returns null for shapes it does not name (operators, indexers,
+            // destructors); fall back to the syntax kind so the structured entry always
+            // carries a non-null attribution.
+            var memberName = GetMemberName(member) ?? member.Kind().ToString();
+
             foreach (var node in member.DescendantNodesAndSelf())
             {
                 ct.ThrowIfCancellationRequested();
@@ -396,7 +426,7 @@ public sealed class TypeExtractionService : ITypeExtractionService
                     $"Extracted member may reference '{sym.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}' " +
                     $"which remains on the original type '{typeSymbol.Name}' and is not available in the new type.";
                 if (seen.Add(msg))
-                    warnings.Add(msg);
+                    warnings.Add(new BlockingDependencyDto(memberName, msg));
             }
         }
 

--- a/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
+++ b/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
@@ -94,6 +94,43 @@ public sealed class ErrorResponseObservabilityTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task ExtractTypePreview_WithUnknownMemberName_ReturnsBlockingDependencies()
+    {
+        // extract-type-preview-refusal-missing-blocking-deps: mirrors the closestMatches contract
+        // above — an extract_type_preview refusal keeps its InvalidOperation category and prose
+        // message, and additionally carries the structured member/reason pairs that produced it.
+        // server: null! exercises the validator's documented no-MCP-context fail-open branch
+        // (same technique as TypeExtractionTests).
+        var animalServicePath = _scope.GetPath("SampleLib", "AnimalService.cs");
+
+        var json = await ToolExecutionTestHarness.RunAsync(
+            "extract_type_preview",
+            () => TypeExtractionTools.PreviewExtractType(
+                server: null!,
+                WorkspaceExecutionGate,
+                TypeExtractionService,
+                WorkspaceId,
+                animalServicePath,
+                typeName: "AnimalService",
+                memberNames: ["NoSuchMemberOnAnimalService"],
+                newTypeName: "AnimalHelper",
+                newFilePath: null,
+                ct: CancellationToken.None));
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(doc.RootElement.GetProperty("error").GetBoolean(),
+            $"Expected structured error envelope. Actual: {json}");
+        Assert.AreEqual("InvalidOperation", doc.RootElement.GetProperty("category").GetString(),
+            "category must be unchanged by the structured-field addition.");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("blockingDependencies", out var blocking),
+            $"extract_type_preview refusals must carry blockingDependencies. Envelope: {json}");
+        var first = blocking.EnumerateArray().First();
+        Assert.AreEqual("NoSuchMemberOnAnimalService", first.GetProperty("member").GetString(),
+            $"blockingDependencies entries must carry a camelCase 'member' key. Envelope: {json}");
+        StringAssert.Contains(first.GetProperty("reason").GetString(), "not found in type 'AnimalService'");
+    }
+
+    [TestMethod]
     public async Task Resource_GetWorkspaceStatus_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
     {
         // Pre-fix: a resource exception bubbled to the framework which labelled it

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -314,6 +315,82 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
         await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
             TypeExtractionService.PreviewExtractTypeAsync(
                 wsId, doc.FilePath!, "AnimalService", [], "NewType", null, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ExtractType_DanglingReference_ThrowsWithStructuredBlockingDependencies()
+    {
+        // extract-type-preview-refusal-missing-blocking-deps: the compile-safety refusal already
+        // computed per-(member, referenced-symbol) detail but flattened it into prose. It must now
+        // also carry the structured list so a caller can widen `memberNames` programmatically.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ExtractTypeDanglingFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExtractTypeDanglingFixture",
+                "{",
+                "    private int _seed = 7;",
+                "    public int Compute(int x) => x * _seed;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            // Extracting Compute leaves _seed behind on the source type, so the generated code
+            // would not compile — the refusal fires before the external-consumer check.
+            var ex = await Assert.ThrowsExactlyAsync<ExtractTypeBlockingDependencyException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, fixturePath, "ExtractTypeDanglingFixture", ["Compute"], "ComputeHelper", null,
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "would not compile",
+                "prose message must be unchanged so existing callers keep working");
+            Assert.IsTrue(ex.BlockingDependencies.Count > 0,
+                "refusal must carry at least one structured blocking dependency");
+            Assert.IsTrue(ex.BlockingDependencies.Any(d =>
+                    string.Equals(d.Member, "Compute", StringComparison.Ordinal)),
+                "the blocking dependency must be attributed to the extracted member that references the leftover state");
+            Assert.IsTrue(ex.BlockingDependencies.Any(d => d.Reason.Contains("_seed", StringComparison.Ordinal)),
+                $"the reason must name the symbol that remains behind. Actual: {string.Join(" | ", ex.BlockingDependencies.Select(d => d.Reason))}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_MemberNotFound_ThrowsWithStructuredBlockingDependencies()
+    {
+        // extract-type-preview-refusal-missing-blocking-deps: the member-not-found refusal held the
+        // unmatched names in a HashSet but only emitted them as a comma-joined sentence.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var wsId = workspace.WorkspaceId;
+
+        var doc = WorkspaceManager.GetCurrentSolution(wsId)
+            .Projects.SelectMany(p => p.Documents)
+            .First(d => d.FilePath?.EndsWith("AnimalService.cs") == true);
+
+        var ex = await Assert.ThrowsExactlyAsync<ExtractTypeBlockingDependencyException>(() =>
+            TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, doc.FilePath!, "AnimalService", ["NoSuchMemberOnAnimalService"], "NewType", null,
+                CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "NoSuchMemberOnAnimalService");
+        Assert.AreEqual(1, ex.BlockingDependencies.Count,
+            "exactly one member name was unmatched, so exactly one structured entry is expected");
+        Assert.AreEqual("NoSuchMemberOnAnimalService", ex.BlockingDependencies[0].Member);
+        StringAssert.Contains(ex.BlockingDependencies[0].Reason, "not found in type 'AnimalService'");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

`extract_type_preview` refuses in two places after computing exact, structured blocking-member data — and then throws that structure away, flattening it into a prose sentence. Callers had nothing to act on but a string-match.

1. **Compile-safety refusal** (`TypeExtractionService.cs`): `CollectExtractTypeDanglingReferenceWarnings` already built a per-(member, referenced-symbol) list; the caller only saw `string.Join("; ", warnings)`.
2. **Member-not-found refusal** (`PartitionMembers`): `memberNameSet` held exactly the unmatched names; the throw emitted only a comma-joined sentence.

This mirrors the existing `SymbolNotFoundException` → `closestMatches` precedent one-for-one.

## Changes

- **New** `src/RoslynMcp.Core/Models/BlockingDependencyDto.cs` — `record BlockingDependencyDto(string Member, string Reason)`, shaped like `SymbolClosestMatchDto`.
- **New** `src/RoslynMcp.Core/Services/ExtractTypeBlockingDependencyException.cs` — derives from `InvalidOperationException` (mirroring `SymbolNotFoundException : KeyNotFoundException`), so the `ToolErrorHandler` `IsAssignableFrom` walk still resolves `category=InvalidOperation` and every existing `catch (InvalidOperationException)` keeps matching.
- `TypeExtractionService.cs` — `CollectExtractTypeDanglingReferenceWarnings` returns `List<BlockingDependencyDto>` (dedup key unchanged: the reason text, so parallel lists cannot desync); both refusals now throw the new carrier with **byte-identical prose messages**. The success-path `RefactoringPreviewDto.Warnings` projection is preserved (`.Select(w => w.Reason)`).
- `ToolErrorHandler.cs` — one new `else if` branch beside the `closestMatches` branch, emitting `blockingDependencies` on top of the standard envelope. No change to `_errorHandlers` or `ClassifyError`.

## Validation

- `dotnet build RoslynMcp.slnx -c Debug -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `./eng/verify-ai-docs.ps1` — passed.
- 3 new tests, all passing:
  - `ExtractType_DanglingReference_ThrowsWithStructuredBlockingDependencies`
  - `ExtractType_MemberNotFound_ThrowsWithStructuredBlockingDependencies`
  - `ExtractTypePreview_WithUnknownMemberName_ReturnsBlockingDependencies` (envelope-level, asserts camelCase `member`/`reason` keys)
- Regression sweep: `TypeExtractionTests` + `ErrorResponseObservabilityTests` (22 passed), plus `ToolErrorHandler*` / `StructuredCallToolFilter*` / `ToolDispatchTests` / `NavigationToolsNotFoundMessage` / `AuditFixesTests` / `Top10V2RegressionTests` (91 passed).

## Follow-ons (out of scope, worth backlog rows)

- The **external-consumer refusal** (`TypeExtractionService.cs:73-84`) flattens its own structured per-file warning list the same way — extending `blockingDependencies` to it is the natural next step now that this pattern exists.
- `TypeExtractionService.PreviewExtractTypeAsync`'s success-path `warnings.Count > 0 ? … : null` is **dead code**: the method already threw earlier if `warnings` were non-empty, so `RefactoringPreviewDto.Warnings` is always `null` on the success path. Left intact deliberately (separate row).

Closes: extract-type-preview-refusal-missing-blocking-deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
