### PR TITLE
fix(validation): gate compile-error solely on compile.ErrorCount (validate-workspace-compiler-category-status-mismatch)

### DIFF
--- a/changelog.d/validate-workspace-compiler-category-status-mismatch.md
+++ b/changelog.d/validate-workspace-compiler-category-status-mismatch.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `validate_workspace`'s `overallStatus` no longer reports `compile-error` on an otherwise-clean build when the second, independently-harvested diagnostics pass (`project_diagnostics`) surfaces a Category="Compiler" error that the authoritative `compile_check` pass (`compile.ErrorCount`) does not corroborate — such a diagnostic now surfaces as `analyzer-error` instead of the misleading `compile-error` verdict (previously it could also mask a genuinely clean build behind a phantom compiler failure). `compile.ErrorCount > 0` is now the sole signal gating `compile-error`.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -485,16 +485,29 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     // so a caller exact-matching "clean" doesn't treat a zero-run as success. This is a
     // BREAKING change for callers that exact-match "clean" as the only passing value; the
     // CHANGELOG flags it as such.
+    //
+    // validate-workspace-compiler-category-status-mismatch: the merged `errors` list is built
+    // from TWO independent diagnostic harvests — compile_check (CompileCheckService, which
+    // fetches compilations directly and computes an unbounded ErrorCount) and
+    // project_diagnostics (DiagnosticService, which goes through its own version-keyed
+    // compilation cache). When the two disagree, the second harvest can surface a
+    // Category=="Compiler" row that the authoritative compile pass never saw, producing the
+    // observed "overallStatus: compile-error / Compile errors: 0" contradiction. compile.ErrorCount
+    // is now the SOLE compile-error signal; an uncorroborated Compiler-category row from the
+    // second harvest falls through to "analyzer-error" (branch 2 widened from a
+    // Category!="Compiler" predicate to a plain non-empty check) so it is downgraded, never
+    // silently dropped from the verdict. Note compile.Diagnostics is paged (Limit=200) while
+    // ErrorCount is the true total, so identity-matching against the paged list would be
+    // strictly less reliable than trusting ErrorCount.
     internal static string ComputeOverallStatus(
         CompileCheckDto compile,
         IReadOnlyList<DiagnosticDto> errors,
         TestRunResultDto? testRunResult,
         bool runTests)
     {
-        if (compile.ErrorCount > 0
-            || errors.Any(d => string.Equals(d.Category, "Compiler", StringComparison.Ordinal)))
+        if (compile.ErrorCount > 0)
             return "compile-error";
-        if (errors.Any(d => !string.Equals(d.Category, "Compiler", StringComparison.Ordinal)))
+        if (errors.Count > 0)
             return "analyzer-error";
         if (runTests && testRunResult is not null && testRunResult.Failed > 0)
             return "test-failure";

--- a/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
@@ -95,8 +95,17 @@ public sealed class WorkspaceValidationOverallStatusTests
         Assert.AreEqual("clean", status, "incomplete / vacuous compile_check must not be compile-error with zero errors");
     }
 
+    /// <summary>
+    /// validate-workspace-compiler-category-status-mismatch: a Category=="Compiler" diagnostic
+    /// that appears ONLY in the merged list (i.e. surfaced by the project_diagnostics harvest,
+    /// with its own version-keyed compilation cache) while the authoritative compile_check pass
+    /// reports ErrorCount==0 must NOT yield "compile-error" — that combination produced the
+    /// observed "overallStatus: compile-error / Compile errors: 0" contradiction. It is
+    /// downgraded to "analyzer-error" (surfaced, not silently dropped to "clean").
+    /// This test previously pinned the pre-fix "compile-error" verdict.
+    /// </summary>
     [TestMethod]
-    public void ComputeOverallStatus_CompilerErrorOnlyInMergedErrors_YieldsCompileError()
+    public void ComputeOverallStatus_CompilerErrorOnlyInMergedErrors_YieldsAnalyzerError()
     {
         var compileClean = new CompileCheckDto(
             Success: true,
@@ -122,7 +131,10 @@ public sealed class WorkspaceValidationOverallStatusTests
             null,
             runTests: false);
 
-        Assert.AreEqual("compile-error", status);
+        Assert.AreEqual(
+            "analyzer-error",
+            status,
+            "an uncorroborated Compiler-category row from the second harvest must not override a clean compile.ErrorCount==0 — it degrades to analyzer-error, and must not vanish into 'clean'.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

`validate_workspace` reported `overallStatus: compile-error` on demonstrably clean builds. `ComputeOverallStatus` gated the `compile-error` verdict on `compile.ErrorCount > 0 || errors.Any(d => d.Category == "Compiler")`, where `errors` is a merge of **two independent diagnostic harvests** — `compile_check` (`CompileCheckService`, which fetches compilations directly and computes an unbounded `ErrorCount`) and `project_diagnostics` (`DiagnosticService`, which goes through its own version-keyed compilation cache). When the two disagreed, a `Category=="Compiler"` row surfaced only by the second, less-authoritative harvest overrode a genuinely clean compile pass — producing the `overallStatus: compile-error / Compile errors: 0 / Tests passed: 35/35` contradiction reproduced 5/5 times in the 2026-08-05 multisession retro.

This is the residual half of the already-shipped `validate-workspace-overallstatus-false-positive` fix (v1.28.1), which made `compile.ErrorCount` authoritative for the *first* disjunct of this same line only.

## Linked issue

No GitHub issue mirror — tracked solely as backlog row `validate-workspace-compiler-category-status-mismatch`.

## Changes

- `src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs` — `ComputeOverallStatus`: `compile.ErrorCount > 0` is now the **sole** signal gating `compile-error`. Branch 2 widens from `errors.Any(d => d.Category != "Compiler")` to `errors.Count > 0`, so an uncorroborated Compiler-category row **degrades to `analyzer-error`** rather than vanishing from the verdict entirely (removing the disjunct without widening branch 2 would have been a worse regression than the one being fixed). Added a `// validate-workspace-compiler-category-status-mismatch:` rationale paragraph alongside the two existing ones.
- `tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs` — the existing `ComputeOverallStatus_CompilerErrorOnlyInMergedErrors_YieldsCompileError` **pinned the buggy behavior as intentional**; renamed to `…_YieldsAnalyzerError` and flipped to assert `"analyzer-error"` for the same inputs. This is the regression test for the fix.
- `changelog.d/validate-workspace-compiler-category-status-mismatch.md` — new `Fixed` fragment.

### Design note

Rejected the alternative of identity-matching the merged rows against `compile.Diagnostics`: that list is paged to `Limit=200` while `compile.ErrorCount` is the unbounded true count, so identity-matching would be strictly *less* reliable than trusting `ErrorCount`. The fix is deliberately mechanism-agnostic — it does not require reproducing *why* the second harvest disagreed.

`WorkspaceValidationDto.ErrorCount` (computed off `allErrors.Length`) is intentionally **unchanged**; only the qualitative verdict label moves.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds — plus `dotnet build src/RoslynMcp.Roslyn -c Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors
- [x] `dotnet test RoslynMcp.slnx` passes (scoped): `--filter FullyQualifiedName~WorkspaceValidationOverallStatusTests` → **8/8 passed**; widened to `WorkspaceValidation|ValidateWorkspace|ValidationBundle|ValidateRecentGitChanges` → **77/77 passed**
- [x] Manually verified the behavior (below)

Direct repro against `ComputeOverallStatus`: `compile.ErrorCount == 0` + merged errors = one `Category=="Compiler"` Error-severity `DiagnosticDto` now yields `"analyzer-error"` — not `"compile-error"`, and not silently dropped to `"clean"`. The three surrounding verdict cases are unaffected: `ErrorCount==1` + Compiler row still hits `compile-error`; empty-`errors` cases still yield `clean`; a non-Compiler row still yields `analyzer-error`.

## Checklist

- [x] Followed the existing code style and project layering (see `CONTRIBUTING.md`)
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — `ComputeOverallStatus` is `internal static` with exactly one call site. **Behavior change:** callers that exact-match `overallStatus == "compile-error"` (vs. just `!= "clean"`) see the new `analyzer-error` label for this narrow scenario. Intended correction, mirroring the v1.28.1 precedent; the changelog flags it under `Fixed`.

## Backlog (maintainer-only)

Closes: validate-workspace-compiler-category-status-mismatch

- Closes backlog row: `validate-workspace-compiler-category-status-mismatch`
