### PR TITLE
fix(tools): auto-reload evicted workspace and retry once on compile_check/test_run

### DIFF
--- a/changelog.d/workspace-eviction-no-auto-retry-on-tool-call.md
+++ b/changelog.d/workspace-eviction-no-auto-retry-on-tool-call.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `compile_check` and `test_run` now transparently reload an evicted workspace (via its recorded `LoadedPath`) and retry once instead of surfacing a hard failure — covers both the direct `WorkspaceEvicted` classification and the more common case where the workspace was evicted before the call started.

--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -3,6 +3,7 @@ using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -31,18 +32,25 @@ public static class CompileCheckTools
         [Description("Optional: only return diagnostics whose file path matches any absolute path in this list. Pass as a native JSON array of absolute file paths, not a JSON-encoded string. When combined with file, the union is used.")] string[]? files = null,
         [Description("Number of diagnostics to skip before returning results (default: 0)")] int offset = 0,
         [Description("Maximum number of diagnostics to return (default: 50)")] int limit = 50,
+        IWorkspaceManager? workspaceManager = null,
         CancellationToken ct = default)
     {
         ParameterValidation.ValidateSeverity(severity);
         ParameterValidation.ValidatePagination(offset, limit);
         workspaceId = ToolDispatch.RequireResolvedWorkspaceId(workspaceId);
-        return ToolDispatch.ReadByWorkspaceIdAsync(
+        // workspace-eviction-no-auto-retry-on-tool-call: route through the eviction-tolerant
+        // dispatch helper so a workspace evicted by MaxConcurrentWorkspaces pressure is
+        // rehydrated from its recorded LoadedPath and the check retried once, transparently.
+        // workspaceManager is DI-bound (never surfaced as a tool input); when absent — direct
+        // C# callers in tests — the helper degrades to the plain non-retrying dispatch.
+        return ToolDispatch.ReadByWorkspaceIdWithEvictionRetryAsync(
             gate,
+            workspaceManager,
             workspaceId,
-            async c =>
+            async (wsId, c) =>
             {
                 var result = await compileCheckService.CheckAsync(
-                    workspaceId,
+                    wsId,
                     new CompileCheckOptions(projectName, emitValidation, severity, file, offset, limit, files),
                     c).ConfigureAwait(false);
 

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -208,4 +208,170 @@ internal static class ToolDispatch
             var result = await serviceCall(c).ConfigureAwait(false);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
+
+    /// <summary>
+    /// Eviction-tolerant variant of
+    /// <see cref="ReadByWorkspaceIdAsync{TDto}(IWorkspaceExecutionGate, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>.
+    /// Runs the read once; when the workspace lookup misses because the session was evicted,
+    /// rehydrates it from the evicted session's recorded <c>LoadedPath</c> and retries the read
+    /// exactly once against the fresh <c>workspaceId</c>. Any other failure — and any second
+    /// failure — propagates unchanged so the caller's existing error envelope is preserved.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>workspace-eviction-no-auto-retry-on-tool-call</c>. Two distinct miss shapes reach this
+    /// helper and both must recover:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description><b>Evicted before the call started</b> (the common case) —
+    ///     <c>WorkspaceExecutionGate.RunPerWorkspaceAsync</c> runs a cheap
+    ///     <c>ContainsWorkspace</c> precheck that only consults the live session dictionary and
+    ///     throws a bare <see cref="KeyNotFoundException"/>, never reaching
+    ///     <c>WorkspaceManager.GetRequiredSession</c>'s richer classification. The helper
+    ///     therefore re-probes the manager (<see cref="TryReclassifyAsEvicted"/>) to recover the
+    ///     <see cref="WorkspaceEvictedException"/> the gate short-circuited.</description></item>
+    ///   <item><description><b>Evicted mid-call</b> (the narrow race) — the deeper
+    ///     <c>GetRequiredSession</c> lookup inside the service body throws
+    ///     <see cref="WorkspaceEvictedException"/> directly; it is used as-is.</description></item>
+    /// </list>
+    /// <para>
+    /// <paramref name="workspaceManager"/> is optional so direct (non-DI) callers keep the exact
+    /// pre-existing behaviour: with no manager the helper degrades to
+    /// <see cref="ReadByWorkspaceIdAsync{TDto}(IWorkspaceExecutionGate, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>
+    /// and never retries.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TDto">The DTO type returned by the underlying service call.</typeparam>
+    /// <param name="gate">The workspace execution gate.</param>
+    /// <param name="workspaceManager">
+    /// The workspace manager used to reclassify the miss and rehydrate the evicted session, or
+    /// <see langword="null"/> to disable the retry entirely.
+    /// </param>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="serviceCall">
+    /// A closure that invokes the service method for a given workspace id. Unlike the
+    /// non-retrying helpers this takes the id as a parameter rather than capturing it, because
+    /// the retry leg must run against the post-reload id.
+    /// </param>
+    /// <param name="ct">The caller's cancellation token.</param>
+    /// <returns>The DTO serialized with <see cref="JsonDefaults.Indented"/>.</returns>
+    public static async Task<string> ReadByWorkspaceIdWithEvictionRetryAsync<TDto>(
+        IWorkspaceExecutionGate gate,
+        IWorkspaceManager? workspaceManager,
+        string workspaceId,
+        Func<string, CancellationToken, Task<TDto>> serviceCall,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await ReadByWorkspaceIdAsync(gate, workspaceId, c => serviceCall(workspaceId, c), ct)
+                .ConfigureAwait(false);
+        }
+        catch (KeyNotFoundException ex) when (workspaceManager is not null)
+        {
+            var reloadedId = await TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct)
+                .ConfigureAwait(false);
+            if (reloadedId is null)
+            {
+                // Not an eviction, or not recoverable — rethrow so the original structured
+                // envelope reaches the caller unchanged (no silent retry loop).
+                throw;
+            }
+
+            return await ReadByWorkspaceIdAsync(gate, reloadedId, c => serviceCall(reloadedId, c), ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Re-probes <paramref name="workspaceManager"/> for <paramref name="workspaceId"/> purely to
+    /// recover the eviction classification that a cheap <c>ContainsWorkspace</c> precheck
+    /// discarded. Returns the <see cref="WorkspaceEvictedException"/> when the manager holds an
+    /// eviction record (or a host-recycle signal) for the id, or <see langword="null"/> when the
+    /// miss is a genuine never-loaded/typo'd id — or when the workspace turns out to be live
+    /// again (a concurrent reload won the race), in which case there is nothing to rehydrate.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="IWorkspaceManager.GetCurrentVersion"/> rather than
+    /// <see cref="IWorkspaceManager.GetStatus"/> as the probe: both route through
+    /// <c>GetRequiredSession</c> (the sole source of the eviction classification), but
+    /// <c>GetCurrentVersion</c> returns a single <see langword="int"/> instead of building a full
+    /// status DTO with per-project rollups. The probe only ever runs on an already-failing call,
+    /// never on the hot success path.
+    /// </remarks>
+    internal static WorkspaceEvictedException? TryReclassifyAsEvicted(
+        IWorkspaceManager workspaceManager,
+        string workspaceId)
+    {
+        try
+        {
+            _ = workspaceManager.GetCurrentVersion(workspaceId);
+            return null;
+        }
+        catch (WorkspaceEvictedException evicted)
+        {
+            return evicted;
+        }
+        catch (KeyNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Rehydrates an evicted workspace from its recorded <c>LoadedPath</c> and returns the fresh
+    /// workspace id, or <see langword="null"/> when the failure is not a recoverable eviction (no
+    /// eviction record, no recorded path — e.g. a cross-process recycle — or the reload itself
+    /// failed). Callers rethrow the original failure on <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why <see cref="EvictPolicy.Lru"/> and not <see cref="EvictPolicy.Strict"/>:</b> the
+    /// evidenced failure is LRU eviction under <c>MaxConcurrentWorkspaces</c> pressure — the
+    /// evicted session's slot was freed and immediately consumed by the load that triggered the
+    /// eviction, so the cap is still saturated at retry time. A <see cref="EvictPolicy.Strict"/>
+    /// reload would throw <see cref="InvalidOperationException"/> ("already tracking N
+    /// workspaces") for the primary case this helper exists to fix, recovering nothing and
+    /// replacing the caller's eviction envelope with a confusing cap-reached one.
+    /// <see cref="EvictPolicy.Lru"/> makes room by evicting the current least-recently-used
+    /// session, and <c>WorkspaceManager</c>'s LRU scan already skips sessions holding their load
+    /// lock, so an in-flight workspace is never yanked out from under a concurrent caller. This
+    /// is exactly the recovery a caller would perform by hand
+    /// (<c>workspace_load(path, evictPolicy: "lru")</c>), just without the round trip.
+    /// </para>
+    /// <para>
+    /// A failed reload is deliberately not surfaced: the original eviction exception is richer
+    /// (it carries the id, the recorded path, and a copy-pasteable <c>workspace_load</c> recovery
+    /// hint), and the caller rethrows it, so no diagnostic is lost.
+    /// </para>
+    /// </remarks>
+    internal static async Task<string?> TryReloadEvictedWorkspaceForRetryAsync(
+        IWorkspaceManager workspaceManager,
+        string workspaceId,
+        KeyNotFoundException failure,
+        CancellationToken ct)
+    {
+        var evicted = failure as WorkspaceEvictedException
+            ?? TryReclassifyAsEvicted(workspaceManager, workspaceId);
+
+        if (evicted?.LoadedPath is not { Length: > 0 } loadedPath)
+        {
+            return null;
+        }
+
+        try
+        {
+            var reloaded = await workspaceManager.LoadAsync(loadedPath, EvictPolicy.Lru, ct)
+                .ConfigureAwait(false);
+            return reloaded.WorkspaceId;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -4,6 +4,7 @@ using RoslynMcp.Core.Services;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -196,7 +197,89 @@ public static class ValidationTools
         [Description("Optional: specific test project name or file path")] string? projectName = null,
         [Description("Optional: dotnet test filter expression")] string? filter = null,
         IProgress<ProgressNotificationValue>? progress = null,
+        IWorkspaceManager? workspaceManager = null,
         CancellationToken ct = default)
+        => RunTestsWithEvictionRetryAsync(
+            gate, testRunnerService, workspaceManager, workspaceId, projectName, filter, progress, ct);
+
+    /// <summary>
+    /// <c>workspace-eviction-no-auto-retry-on-tool-call</c> — runs <c>test_run</c> once and, when
+    /// the workspace lookup missed because the session was evicted, rehydrates it from the
+    /// evicted session's recorded <c>LoadedPath</c> and re-runs the suite once against the fresh
+    /// workspace id.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>test_run</c> cannot use
+    /// <see cref="ToolDispatch.ReadByWorkspaceIdWithEvictionRetryAsync{TDto}"/> because it formats
+    /// its own failure envelope inline rather than letting exceptions reach the global
+    /// <c>StructuredCallToolFilter</c>. The retry is therefore hand-rolled here so every
+    /// non-recovering path keeps its existing shape byte-for-byte:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>A miss raised by the gate's <c>ContainsWorkspace</c> precheck (the
+    ///     common "evicted before the call started" case) escapes
+    ///     <see cref="RunTestsOnceAsync"/> today and propagates to the global filter as
+    ///     <c>IsError=true</c>. When it is not recoverable it still does.</description></item>
+    ///   <item><description>A <see cref="WorkspaceEvictedException"/> raised mid-call (the narrow
+    ///     race) is rethrown by <see cref="RunTestsOnceAsync"/> so it can be retried; when it is
+    ///     not recoverable this orchestrator reproduces the original inline
+    ///     <c>ReportStage("done")</c> → <c>ClassifyAndFormat</c> →
+    ///     <c>InjectSchemaHintIfPossible</c> envelope exactly.</description></item>
+    ///   <item><description>Every other exception is still swallowed and formatted inline by
+    ///     <see cref="RunTestsOnceAsync"/> — untouched.</description></item>
+    /// </list>
+    /// </remarks>
+    private static async Task<string> RunTestsWithEvictionRetryAsync(
+        IWorkspaceExecutionGate gate,
+        ITestRunnerService testRunnerService,
+        IWorkspaceManager? workspaceManager,
+        string workspaceId,
+        string? projectName,
+        string? filter,
+        IProgress<ProgressNotificationValue>? progress,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await RunTestsOnceAsync(gate, testRunnerService, workspaceId, projectName, filter, progress, ct)
+                .ConfigureAwait(false);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            var reloadedId = workspaceManager is null
+                ? null
+                : await ToolDispatch.TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct)
+                    .ConfigureAwait(false);
+
+            if (reloadedId is null)
+            {
+                if (ex is WorkspaceEvictedException)
+                {
+                    // Raised inside the gated action, where the pre-existing inline catch would
+                    // have formatted it. Reproduce that envelope rather than changing the shape.
+                    ProgressHelper.ReportStage(progress, 3, 3, "done");
+                    var envelope = ToolErrorHandler.ClassifyAndFormat(ex, "test_run");
+                    return ToolErrorHandler.InjectSchemaHintIfPossible(envelope, "test_run");
+                }
+
+                // Raised by the gate precheck, outside the action — propagates today, still does.
+                throw;
+            }
+
+            return await RunTestsOnceAsync(gate, testRunnerService, reloadedId, projectName, filter, progress, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static Task<string> RunTestsOnceAsync(
+        IWorkspaceExecutionGate gate,
+        ITestRunnerService testRunnerService,
+        string workspaceId,
+        string? projectName,
+        string? filter,
+        IProgress<ProgressNotificationValue>? progress,
+        CancellationToken ct)
     {
         // test-run stage emissions: clients see "discovering-tests → running-tests → done"
         // instead of waiting silently while dotnet-test enumerates assemblies, builds the
@@ -216,6 +299,14 @@ public static class ValidationTools
             }
             catch (OperationCanceledException)
             {
+                throw;
+            }
+            catch (WorkspaceEvictedException)
+            {
+                // Deliberately NOT formatted here: the caller reloads the evicted workspace and
+                // re-runs, and formats this envelope itself when the retry is not available. A
+                // plain KeyNotFoundException from deeper service code is NOT intercepted — it
+                // carries no eviction record, so it stays on the pre-existing inline path below.
                 throw;
             }
             catch (Exception ex)

--- a/tests/RoslynMcp.Tests/WorkspaceEvictionAutoRetryTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceEvictionAutoRetryTests.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn;
+using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for <c>workspace-eviction-no-auto-retry-on-tool-call</c>.
+///
+/// <para>
+/// When a workspace is evicted under <see cref="WorkspaceManagerOptions.MaxConcurrentWorkspaces"/>
+/// pressure, <c>compile_check</c> and <c>test_run</c> must rehydrate it from the evicted session's
+/// recorded <c>LoadedPath</c> and retry once instead of surfacing a hard "workspace not found"
+/// failure. The retry is opt-in by DI availability: without an <see cref="IWorkspaceManager"/> the
+/// original (pre-fix) error shape must be preserved byte-for-byte.
+/// </para>
+///
+/// <para>
+/// The eviction is staged the same way the production failure occurred — a
+/// <see cref="EvictPolicy.Lru"/> load against a saturated cap, which routes through
+/// <c>WorkspaceManager.Close</c> and therefore records the evicted session (id, loadedAt,
+/// loadedPath) that the retry path depends on. With the cap still saturated at retry time, the
+/// rehydration itself must use <see cref="EvictPolicy.Lru"/>; a strict reload would fail with
+/// "already tracking N workspaces" and recover nothing.
+/// </para>
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class WorkspaceEvictionAutoRetryTests
+{
+    private static string s_repositoryRootPath = null!;
+    private static string s_sampleSolutionPath = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        MsBuildInitializer.EnsureInitialized();
+        s_repositoryRootPath = TestFixtureFileSystem.FindRepositoryRoot();
+        s_sampleSolutionPath = TestFixtureFileSystem.FindFixturePath(
+            s_repositoryRootPath,
+            "SampleSolution",
+            "SampleSolution.slnx",
+            "SampleSolution.sln");
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_EvictedWorkspace_TransparentlyReloadsAndRetries()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var compileCheckService = new CompileCheckService(manager, NullLogger<CompileCheckService>.Instance);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            var json = await CompileCheckTools.CompileCheck(
+                gate,
+                compileCheckService,
+                workspaceId: evictedId,
+                workspaceManager: manager,
+                ct: CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsFalse(root.TryGetProperty("error", out _),
+                $"compile_check must transparently recover from an eviction, not return an error envelope. Actual: {json}");
+            Assert.IsTrue(root.TryGetProperty("success", out _),
+                $"Expected a normal compile_check payload after the transparent reload+retry. Actual: {json}");
+
+            Assert.IsFalse(manager.ContainsWorkspace(evictedId),
+                "The retry must run against a NEW workspace id, not resurrect the evicted one.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    [TestMethod]
+    public async Task RunTests_EvictedWorkspace_TransparentlyReloadsAndRetries()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+        var runner = new RecordingTestRunnerService();
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            var json = await ValidationTools.RunTests(
+                gate,
+                runner,
+                workspaceId: evictedId,
+                projectName: null,
+                filter: null,
+                progress: null,
+                workspaceManager: manager,
+                ct: CancellationToken.None);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsFalse(doc.RootElement.TryGetProperty("error", out _),
+                $"test_run must transparently recover from an eviction, not return an error envelope. Actual: {json}");
+
+            // The gate's ContainsWorkspace precheck rejects the evicted id before the service is
+            // ever reached, so the runner sees exactly one invocation — the post-reload retry.
+            Assert.AreEqual(1, runner.ObservedWorkspaceIds.Count,
+                "The test runner must be invoked exactly once — on the post-reload retry leg.");
+            Assert.AreNotEqual(evictedId, runner.ObservedWorkspaceIds[0],
+                "The retry must target the rehydrated workspace id, not the evicted one.");
+            Assert.IsTrue(manager.ContainsWorkspace(runner.ObservedWorkspaceIds[0]),
+                "The id handed to the retry leg must be a live session.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    [TestMethod]
+    public async Task CompileCheck_EvictedWorkspace_NoWorkspaceManagerSupplied_PreservesOriginalNotFoundEnvelope()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var compileCheckService = new CompileCheckService(manager, NullLogger<CompileCheckService>.Instance);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            var json = await ToolExecutionTestHarness.RunAsync(
+                "compile_check",
+                () => CompileCheckTools.CompileCheck(
+                    gate,
+                    compileCheckService,
+                    workspaceId: evictedId,
+                    ct: CancellationToken.None));
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("error", out var errorProp) && errorProp.GetBoolean(),
+                $"Without an IWorkspaceManager the pre-fix error envelope must survive unchanged. Actual: {json}");
+            Assert.AreEqual("NotFound", root.GetProperty("category").GetString(),
+                $"The gate's ContainsWorkspace precheck classifies as NotFound; the retry wiring must not change that when unwired. Actual: {json}");
+            Assert.AreEqual("compile_check", root.GetProperty("tool").GetString());
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    [TestMethod]
+    public async Task RunTests_EvictedWorkspace_NoWorkspaceManagerSupplied_StillPropagatesLookupMiss()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+        var runner = new RecordingTestRunnerService();
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            // Pre-fix behaviour: the gate precheck's KeyNotFoundException escapes test_run's
+            // inline envelope formatting and reaches the global filter as IsError=true. Pinning
+            // it here so the retry wiring cannot silently downgrade a hard failure to content.
+            await Assert.ThrowsExactlyAsync<KeyNotFoundException>(
+                () => ValidationTools.RunTests(
+                    gate,
+                    runner,
+                    workspaceId: evictedId,
+                    projectName: null,
+                    filter: null,
+                    progress: null,
+                    ct: CancellationToken.None));
+
+            Assert.AreEqual(0, runner.ObservedWorkspaceIds.Count,
+                "With no manager wired the service must never be reached.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    /// <summary>
+    /// Loads <paramref name="path1"/> into the (cap-saturated) manager, then LRU-loads
+    /// <paramref name="path2"/> so the first session is evicted with a recoverable eviction
+    /// record. Returns the now-evicted workspace id.
+    /// </summary>
+    private static async Task<string> StageEvictionAsync(WorkspaceManager manager, string path1, string path2)
+    {
+        var status1 = await manager.LoadAsync(path1, EvictPolicy.Strict, CancellationToken.None);
+        await manager.LoadAsync(path2, EvictPolicy.Lru, CancellationToken.None);
+
+        Assert.IsFalse(manager.ContainsWorkspace(status1.WorkspaceId),
+            "Fixture precondition: the first workspace must have been LRU-evicted.");
+
+        return status1.WorkspaceId;
+    }
+
+    private static WorkspaceManager CreateManager(int maxConcurrentWorkspaces)
+    {
+        return new WorkspaceManager(
+            NullLogger<WorkspaceManager>.Instance,
+            new PreviewStore(),
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = maxConcurrentWorkspaces });
+    }
+
+    /// <summary>
+    /// Records the workspace id each invocation was routed to and returns a canned successful
+    /// run, so the test can assert the retry leg targeted the rehydrated session.
+    /// </summary>
+    private sealed class RecordingTestRunnerService : ITestRunnerService
+    {
+        public List<string> ObservedWorkspaceIds { get; } = [];
+
+        public Task<TestRunResultDto> RunTestsAsync(
+            string workspaceId,
+            string? projectName,
+            string? filter,
+            CancellationToken ct)
+        {
+            ObservedWorkspaceIds.Add(workspaceId);
+            return Task.FromResult(new TestRunResultDto(
+                Execution: new CommandExecutionDto(
+                    Command: "dotnet",
+                    Arguments: ["test"],
+                    WorkingDirectory: "C:/fake",
+                    TargetPath: "C:/fake/proj.csproj",
+                    ExitCode: 0,
+                    Succeeded: true,
+                    DurationMs: 1,
+                    StdOut: "Passed!",
+                    StdErr: string.Empty),
+                Total: 1,
+                Passed: 1,
+                Failed: 0,
+                Skipped: 0,
+                Failures: []));
+        }
+    }
+}


### PR DESCRIPTION
Closes: workspace-eviction-no-auto-retry-on-tool-call

## Problem

`compile_check` and `test_run` surfaced a hard "workspace not found" failure when their workspace had been evicted under `MaxConcurrentWorkspaces` pressure — even though `WorkspaceManager` records the evicted session's `LoadedPath` expressly so callers can rehydrate it. Nothing anywhere caught `WorkspaceEvictedException` to retry.

Evidence (2026-08-05 multisession retro): codex session `019fae3e` (`compile_check`, "Workspace ... not found or has been closed" after ~37min idle) and `019fa0a1` (`test_run`, raw `WorkspaceEvictedException` mid-run; an identical rerun 90s later passed clean).

## Two miss shapes, not one

The row's acceptance criteria describe the fix as "catch `WorkspaceEvictedException`". A literal implementation would have been **dead code for the primary evidenced failure**:

- **Evicted before the call started** (common) — `WorkspaceExecutionGate.RunPerWorkspaceAsync` runs a cheap `ContainsWorkspace` precheck that only consults the live session dict and throws a bare `KeyNotFoundException`, never reaching `WorkspaceManager.GetRequiredSession`'s richer classification. This is what session `019fae3e` hit.
- **Evicted mid-call** (narrow race) — the deeper `GetRequiredSession` lookup inside the service body throws `WorkspaceEvictedException` directly. This is what session `019fa0a1` hit.

Both are now handled: the first via a cheap re-probe of the manager to recover the classification the gate short-circuited, the second by using the exception as-is.

## Deliberate deviation from the plan: `EvictPolicy.Lru`, not `Strict`

The plan specified `EvictPolicy.Strict` for the rehydration, reasoning "the evicted workspace's slot was just freed by its own eviction". That reasoning does not hold for the evidenced case: the freed slot was **immediately consumed by the load that triggered the eviction**, so the cap is still saturated at retry time. A strict reload would throw `InvalidOperationException` ("already tracking N workspaces"), recovering nothing for the row's own Acceptance Criterion #3 scenario *and* replacing the caller's eviction envelope with a confusing cap-reached one.

`EvictPolicy.Lru` is used instead. `WorkspaceManager`'s LRU scan already skips sessions holding their load lock, so no in-flight workspace is yanked out from under a concurrent caller. This is exactly the recovery a caller would perform by hand (`workspace_load(path, evictPolicy: "lru")`), minus the round trip.

## Changes

- **`ToolDispatch.cs`** — `ReadByWorkspaceIdWithEvictionRetryAsync`, plus the `TryReclassifyAsEvicted` re-probe (uses `GetCurrentVersion` rather than the plan's `GetStatus`: same `GetRequiredSession` classification, no full status-DTO construction) and `TryReloadEvictedWorkspaceForRetryAsync`. The probe only ever runs on an already-failing call, never the hot success path.
- **`CompileCheckTools.cs`** — routed through the retry helper.
- **`ValidationTools.cs`** — `test_run` split into a retry orchestrator plus the original gated body. It cannot use the shared helper because it formats its own failure envelope inline.

## Behaviour preservation

Every non-recovering path keeps its pre-existing shape byte-for-byte:

| Path | Before | After |
|---|---|---|
| `compile_check`, no manager wired | `NotFound` envelope via global filter | unchanged (pinned by test) |
| `test_run`, gate-precheck miss, not recoverable | propagates → `IsError=true` | unchanged (pinned by test) |
| `test_run`, mid-call eviction, not recoverable | inline `ReportStage("done")` → `ClassifyAndFormat` → `InjectSchemaHintIfPossible` | unchanged (reproduced exactly in the orchestrator) |
| `test_run`, any other exception | swallowed + formatted inline | untouched — the interception is `catch (WorkspaceEvictedException)`, not `catch (KeyNotFoundException)`, so plain lookup misses from deeper service code stay on the original path |

Second failures propagate unchanged — one retry, no loop.

The new `IWorkspaceManager? workspaceManager = null` is appended **last** on both signatures so existing positional call sites (`ValidationToolsIntegrationTests.cs:81-84` passes `workspaceId` as the 3rd positional arg) still bind, and it is DI-resolved rather than surfaced as a tool input (`ToolDiResolutionTests` is the gate).

## Validation

- New `tests/RoslynMcp.Tests/WorkspaceEvictionAutoRetryTests.cs` — 4/4 passing. Stages a real LRU eviction against a cap=1 `WorkspaceManager` + real `WorkspaceExecutionGate`:
  1. `compile_check` transparently reloads and retries (normal payload, no error property).
  2. `test_run` transparently reloads and retries (runner invoked exactly once, against the post-reload id).
  3. `compile_check` with no manager wired preserves the original `NotFound` envelope.
  4. `test_run` with no manager wired still propagates the lookup miss (pins the `IsError=true` shape).
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Regression re-runs, all green: `ToolDiResolutionTests`, `TestRunFailureEnvelopeTests`, `WorkspaceIdOptionalSurfaceTests`, `WorkspaceCapLruEvictionTests`, `SurfaceCatalogTests` (43), `ValidationToolsIntegrationTests` + `Progress/ProgressEmissionTests` (23).
- `eng/verify-ai-docs.ps1` — passed.

Not touched, per the row's explicit Notes: `WorkspaceManager.cs`, `WorkspaceExecutionGate.cs`, the `TouchAccess()` TTL-refresh mechanism, and the sibling tools sharing the same catch shape (`build_workspace`, `test_discover`, `test_related`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
