### PR TITLE
feat(workflow-recommendation): add semantic_grep routing branch

### DIFF
--- a/changelog.d/recommend-workflow-missing-semantic-grep-route.md
+++ b/changelog.d/recommend-workflow-missing-semantic-grep-route.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Added a `semantic_grep` routing branch to `recommend_workflow` so pattern/text-search-shaped tasks (regex sweeps, code-idiom searches) route to token-aware semantic search instead of falling through to `discover_capabilities`.

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs
@@ -86,6 +86,16 @@ public static class WorkflowRecommendationTools
                 RequiredWorkspaceState: "workspace_loaded");
         }
 
+        if (ContainsAny(text, "find occurrences of pattern", "search the codebase for", "pattern search", "sensitive api", "sync-over-async", "text pattern", "code idiom"))
+        {
+            return new(
+                PrimaryTools: ["semantic_grep"],
+                FollowUpTools: ["find_references", "symbol_search"],
+                Avoid: ["rg", "grep", "manual file scan"],
+                Why: "semantic_grep is token-aware regex search over syntax — it excludes false positives inside string literals/comments that plain text grep would match, and covers multi-candidate pattern sweeps find_references cannot (which requires a resolved symbol identity).",
+                RequiredWorkspaceState: "workspace_loaded");
+        }
+
         return new(
             PrimaryTools: ["discover_capabilities"],
             FollowUpTools: ["server_info", "roslyn://server/catalog"],

--- a/tests/RoslynMcp.Tests/WorkflowRecommendationToolsTests.cs
+++ b/tests/RoslynMcp.Tests/WorkflowRecommendationToolsTests.cs
@@ -12,6 +12,7 @@ public sealed class WorkflowRecommendationToolsTests
     [DataRow("quick compile sanity after an edit", "compile_check", "dotnet build")]
     [DataRow("run related tests for this changed file", "test_related_files", "full dotnet test")]
     [DataRow("rename this symbol safely", "rename_preview", "search-and-replace")]
+    [DataRow("search the codebase for all call sites of the GetAwaiter().GetResult() sync-over-async pattern", "semantic_grep", "grep")]
     public async Task RecommendWorkflow_CommonTasks_ReturnsFocusedFirstHop(
         string task,
         string expectedPrimaryTool,


### PR DESCRIPTION
## Summary
- `recommend_workflow`'s 5 existing `ContainsAny` branches never routed pattern/text-search-shaped tasks to `semantic_grep`, so they fell through to `discover_capabilities`.
- Adds a 6th branch (after the existing rename branch, before the fallback) mapping pattern-search-shaped tasks to `semantic_grep` with `find_references`/`symbol_search` as follow-ups.
- Fixed a keyword-collision defect surfaced while implementing the plan's own suggested needle/test wording: the needle `"find usages of pattern"` and the plan's suggested test string both contain the substring `"usages"`, which the pre-existing branch-1 needle (`"usages"`) also matches — since branches are first-match-wins, that text never reached the new branch. Replaced the colliding needle with `"find occurrences of pattern"` and reworded the added test case to avoid the `"usages"` substring.
- Adds a `[DataRow]` case to the existing parameterized test confirming the new route.

## Test plan
- [x] `mcp__roslyn__compile_check` — 0 errors on both changed files.
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~WorkflowRecommendationToolsTests"` — 7/7 passed (all 5 pre-existing DataRow cases + the new one + the compile-sanity test).
- [x] `./eng/verify-ai-docs.ps1` — passed.
- Full `./eng/verify-release.ps1` skipped locally per standing policy (self-hosted CI runner covers it) — relying on CI for that pass.

Closes: `recommend-workflow-missing-semantic-grep-route`