### PR TITLE
fix(undo): capture byte-exact snapshots on direct-mutation paths (direct-mutation-undo-byte-fidelity)

### DIFF
--- a/changelog.d/direct-mutation-undo-byte-fidelity.md
+++ b/changelog.d/direct-mutation-undo-byte-fidelity.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `apply_text_edit`, `apply_multi_file_edit`, `set_editorconfig_option`, and `apply_project_mutation` now capture byte-exact pre-mutation snapshots via `FileSnapshotDto.FromExistingBytes` before mutating disk, so `revert_last_apply` restores UTF-8-BOM and UTF-16 fixtures byte-for-byte on all four direct-mutation paths (previously only the refactoring file-set snapshot path had this fix).

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -77,9 +77,14 @@ public sealed class EditService : IEditService
         // pass BOTH the solution (for the legacy path) AND an explicit file snapshot
         // (for the authoritative file-based restore path — see FLAG-9A in UndoService).
         // Syntax check runs before capture so a rejected edit does not leave a no-op undo entry.
+        var normalizedFilePath = Path.GetFullPath(filePath);
         var fileSnapshots = new[]
         {
-            new FileSnapshotDto(Path.GetFullPath(filePath), sourceText.ToString()),
+            File.Exists(normalizedFilePath)
+                ? FileSnapshotDto.FromExistingBytes(
+                    normalizedFilePath,
+                    await File.ReadAllBytesAsync(normalizedFilePath, ct).ConfigureAwait(false))
+                : new FileSnapshotDto(normalizedFilePath, sourceText.ToString()),
         };
         _undoService?.CaptureBeforeApply(
             workspaceId,
@@ -134,9 +139,15 @@ public sealed class EditService : IEditService
 
         // Single snapshot at the top so revert_last_apply rolls back the ENTIRE batch atomically
         // (from an undo perspective; individual disk writes still happen sequentially).
-        var fileSnapshots = perFileSnapshots
-            .Select(t => new FileSnapshotDto(t.NormalizedPath, t.SourceText.ToString()))
-            .ToList();
+        var fileSnapshots = new List<FileSnapshotDto>(perFileSnapshots.Count);
+        foreach (var t in perFileSnapshots)
+        {
+            fileSnapshots.Add(File.Exists(t.NormalizedPath)
+                ? FileSnapshotDto.FromExistingBytes(
+                    t.NormalizedPath,
+                    await File.ReadAllBytesAsync(t.NormalizedPath, ct).ConfigureAwait(false))
+                : new FileSnapshotDto(t.NormalizedPath, t.SourceText.ToString()));
+        }
         _undoService?.CaptureBeforeApply(
             workspaceId,
             $"Apply edits to {fileEdits.Count} file(s)",

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -342,7 +342,7 @@ public sealed class EditorConfigService : IEditorConfigService
             ?? Path.Combine(Path.GetDirectoryName(normalizedSource) ?? throw new InvalidOperationException("Invalid source path."), ".editorconfig");
 
         var created = !File.Exists(editorconfigPath);
-        var existingText = created ? null : File.ReadAllText(editorconfigPath);
+        var existingBytes = created ? null : File.ReadAllBytes(editorconfigPath);
         var lines = created ? new List<string>() : File.ReadAllLines(editorconfigPath).ToList();
 
         // set-editorconfig-option-not-undoable: capture the pre-apply content so
@@ -352,7 +352,9 @@ public sealed class EditorConfigService : IEditorConfigService
         {
             var snapshot = new[]
             {
-                new FileSnapshotDto(editorconfigPath, existingText),
+                existingBytes is not null
+                    ? FileSnapshotDto.FromExistingBytes(editorconfigPath, existingBytes)
+                    : new FileSnapshotDto(editorconfigPath, OriginalText: null),
             };
             _undoService.CaptureBeforeApply(
                 workspaceId,

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -550,14 +550,17 @@ public sealed class ProjectMutationService : IProjectMutationService
             // may have changed since the preview was generated (last-apply-wins semantics).
             // `null` OriginalText is impossible here because Retrieve above succeeded and
             // the preview-store entry was created from File.ReadAllTextAsync.
-            var preApplyContent = File.Exists(projectFilePath)
-                ? await File.ReadAllTextAsync(projectFilePath, ct).ConfigureAwait(false)
-                : null;
+            var normalizedProjectFilePath = Path.GetFullPath(projectFilePath);
+            var preApplySnapshot = File.Exists(projectFilePath)
+                ? FileSnapshotDto.FromExistingBytes(
+                    normalizedProjectFilePath,
+                    await File.ReadAllBytesAsync(projectFilePath, ct).ConfigureAwait(false))
+                : new FileSnapshotDto(normalizedProjectFilePath, OriginalText: null);
             _undoService?.CaptureBeforeApply(
                 workspaceId,
                 $"Project mutation: {Path.GetFileName(projectFilePath)}",
                 preApplySolution: null,
-                fileSnapshots: new[] { new FileSnapshotDto(Path.GetFullPath(projectFilePath), preApplyContent) });
+                fileSnapshots: new[] { preApplySnapshot });
 
             await AtomicFileWriter.WriteAllTextAsync(projectFilePath, updatedContent, ct).ConfigureAwait(false);
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);

--- a/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Tests;
@@ -52,6 +53,50 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
             "After revert, Dog.cs must match the original byte-for-byte.");
     }
 
+    /// <summary>
+    /// Regression guard for direct-mutation-undo-byte-fidelity: <c>apply_text_edit</c>
+    /// must capture a byte-exact pre-apply snapshot (via <c>FileSnapshotDto.FromExistingBytes</c>)
+    /// so revert restores the original BOM/encoding exactly, not a re-encoded-as-default-UTF8
+    /// approximation. Mirrors <see cref="UndoFileOperationsTests.DeleteFile_Then_Revert_Restores_Original_Bytes"/>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task ApplyTextEdit_ThenRevert_RestoresOriginalBytes(bool useUtf16)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        Encoding encoding = useUtf16
+            ? new UnicodeEncoding(bigEndian: false, byteOrderMark: true)
+            : new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var originalBytes = encoding.GetPreamble()
+            .Concat(encoding.GetBytes(originalText))
+            .ToArray();
+        await File.WriteAllBytesAsync(dogFilePath, originalBytes, CancellationToken.None);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var lines = originalText.Split('\n');
+        var lastLine = lines.Length;
+        var lastColumn = lines[^1].Length + 1;
+        var edit = new TextEditDto(lastLine, lastColumn, lastLine, lastColumn, "\n// inserted by test");
+
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(result.Success, "ApplyTextEditsAsync should report success.");
+
+        var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(reverted, "Revert should succeed.");
+
+        CollectionAssert.AreEqual(
+            originalBytes,
+            await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None),
+            "Restored file must exactly match the pre-apply byte sequence, including its BOM and encoding.");
+    }
+
     [TestMethod]
     public async Task ApplyMultiFileEdit_ThenRevert_RestoresAllFiles()
     {
@@ -94,6 +139,59 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         var revertedCat = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
         Assert.AreEqual(originalDog, revertedDog, "Dog.cs must match the original after revert.");
         Assert.AreEqual(originalCat, revertedCat, "Cat.cs must match the original after revert.");
+    }
+
+    /// <summary>
+    /// Regression guard for direct-mutation-undo-byte-fidelity: <c>apply_multi_file_edit</c>'s
+    /// batch snapshot must be byte-exact per file so revert restores each file's original
+    /// BOM/encoding exactly.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task ApplyMultiFileEdit_ThenRevert_RestoresOriginalBytes(bool useUtf16)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+
+        var originalDogText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        var originalCatText = await File.ReadAllTextAsync(catFilePath, CancellationToken.None);
+
+        Encoding encoding = useUtf16
+            ? new UnicodeEncoding(bigEndian: false, byteOrderMark: true)
+            : new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var originalDogBytes = encoding.GetPreamble().Concat(encoding.GetBytes(originalDogText)).ToArray();
+        var originalCatBytes = encoding.GetPreamble().Concat(encoding.GetBytes(originalCatText)).ToArray();
+        await File.WriteAllBytesAsync(dogFilePath, originalDogBytes, CancellationToken.None);
+        await File.WriteAllBytesAsync(catFilePath, originalCatBytes, CancellationToken.None);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var dogEdit = AppendCommentEdit(originalDogText, "// dog test");
+        var catEdit = AppendCommentEdit(originalCatText, "// cat test");
+
+        var fileEdits = new[]
+        {
+            new FileEditsDto(dogFilePath, new[] { dogEdit }),
+            new FileEditsDto(catFilePath, new[] { catEdit }),
+        };
+
+        var dto = await EditService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, "apply_multi_file_edit", CancellationToken.None);
+        Assert.IsTrue(dto.Success);
+
+        var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(reverted, "Multi-file revert should succeed.");
+
+        CollectionAssert.AreEqual(
+            originalDogBytes,
+            await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None),
+            "Dog.cs must be restored byte-exact, including BOM/encoding.");
+        CollectionAssert.AreEqual(
+            originalCatBytes,
+            await File.ReadAllBytesAsync(catFilePath, CancellationToken.None),
+            "Cat.cs must be restored byte-exact, including BOM/encoding.");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Roslyn.Services;
 
@@ -46,6 +47,49 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
             $"Get must surface '{unloadedKey}' after Set writes it, even when no loaded analyzer reports the id. " +
             $"Returned keys: {string.Join(", ", options.Options.Select(o => o.Key))}");
         Assert.AreEqual(value, entry!.Value);
+    }
+
+    /// <summary>
+    /// Regression guard for direct-mutation-undo-byte-fidelity: <c>set_editorconfig_option</c>
+    /// must capture a byte-exact pre-apply snapshot (via <c>FileSnapshotDto.FromExistingBytes</c>)
+    /// of a pre-existing <c>.editorconfig</c> so <c>revert_last_apply</c> restores its original
+    /// BOM/encoding exactly, not a re-encoded-as-default-UTF8 approximation.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task SetOptionAsync_ThenRevert_RestoresOriginalBytes(bool useUtf16)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var editorconfigPath = Path.Combine(workspace.RootPath, ".editorconfig");
+        const string key = "dotnet_diagnostic.CA9877.severity";
+        const string originalContent = "[*.{cs,csx,cake}]\ndotnet_diagnostic.CA9877.severity = warning\n";
+
+        Encoding encoding = useUtf16
+            ? new UnicodeEncoding(bigEndian: false, byteOrderMark: true)
+            : new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var originalBytes = encoding.GetPreamble()
+            .Concat(encoding.GetBytes(originalContent))
+            .ToArray();
+        await File.WriteAllBytesAsync(editorconfigPath, originalBytes, CancellationToken.None);
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, "error", "set_editorconfig_option", CancellationToken.None);
+        Assert.IsFalse(setResult.CreatedNewFile, "File already existed; CreatedNewFile must be false.");
+
+        var afterSet = await File.ReadAllTextAsync(editorconfigPath, CancellationToken.None);
+        StringAssert.Contains(afterSet, "error", "Sanity check: the option must have been updated.");
+
+        var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(reverted, "Revert should succeed.");
+
+        CollectionAssert.AreEqual(
+            originalBytes,
+            await File.ReadAllBytesAsync(editorconfigPath, CancellationToken.None),
+            "Restored .editorconfig must exactly match the pre-apply byte sequence, including its BOM and encoding.");
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Xml.Linq;
 using RoslynMcp.Core.Models;
 
@@ -552,6 +553,49 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
 
         var revertedBytes = await File.ReadAllTextAsync(projectFilePath, CancellationToken.None);
         Assert.AreEqual(preApplyBytes, revertedBytes, "Revert must restore the .csproj byte-exact.");
+    }
+
+    /// <summary>
+    /// Regression guard for direct-mutation-undo-byte-fidelity: <c>apply_project_mutation</c>
+    /// must capture a byte-exact pre-apply snapshot (via <c>FileSnapshotDto.FromExistingBytes</c>)
+    /// so revert restores the original BOM/encoding exactly, not a re-encoded-as-default-UTF8
+    /// approximation. The sibling test above only asserts on decoded text, which passes even
+    /// with the pre-fix text-only snapshot; this test asserts on raw bytes to close that gap.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task Apply_Project_Mutation_Then_Revert_Restores_Original_Bytes(bool useUtf16)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var projectFilePath = workspace.GetPath("SampleLib", "SampleLib.csproj");
+
+        var originalContent = await File.ReadAllTextAsync(projectFilePath, CancellationToken.None);
+        Encoding encoding = useUtf16
+            ? new UnicodeEncoding(bigEndian: false, byteOrderMark: true)
+            : new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var originalBytes = encoding.GetPreamble()
+            .Concat(encoding.GetBytes(originalContent))
+            .ToArray();
+        await File.WriteAllBytesAsync(projectFilePath, originalBytes, CancellationToken.None);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preview = await ProjectMutationService.PreviewAddPackageReferenceAsync(
+            workspaceId,
+            new AddPackageReferenceDto("SampleLib", "Humanizer.Core", "2.14.1"),
+            CancellationToken.None);
+
+        var applyResult = await ProjectMutationService.ApplyProjectMutationAsync(preview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+        var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
+        Assert.IsTrue(reverted, "revert_last_apply must succeed.");
+
+        CollectionAssert.AreEqual(
+            originalBytes,
+            await File.ReadAllBytesAsync(projectFilePath, CancellationToken.None),
+            "Restored .csproj must exactly match the pre-apply byte sequence, including its BOM and encoding.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- `apply_text_edit` (single + multi-file), `set_editorconfig_option`, and `apply_project_mutation` now capture byte-exact pre-apply undo snapshots via `FileSnapshotDto.FromExistingBytes` (reading raw bytes off disk) instead of the text-only `FileSnapshotDto` constructor.
- Mirrors the pattern already used by `RefactoringService.AddFileSnapshotAsync`. The new-file case (e.g. a freshly-created `.editorconfig`) still uses `OriginalText: null` so `UndoService.RevertAsync`'s delete-on-revert branch is unaffected.
- `revert_last_apply` now restores UTF-8-BOM and UTF-16 fixtures byte-for-byte on all four direct-mutation paths (previously only the refactoring file-set snapshot path had this fix).

## Test plan

- [x] `mcp__roslyn__compile_check` clean on all 3 production files and all 3 extended test files.
- [x] Extended `EditUndoIntegrationTests`, `EditorConfigServiceTests`, `ProjectMutationIntegrationTests` with `[DataRow(false)]`/`[DataRow(true)]` UTF-8-BOM/UTF-16 byte round-trip regression tests, mirroring `UndoFileOperationsTests.DeleteFile_Then_Revert_Restores_Original_Bytes`.
- [x] `dotnet test --filter "FullyQualifiedName~EditUndoIntegrationTests|FullyQualifiedName~EditorConfigServiceTests|FullyQualifiedName~ProjectMutationIntegrationTests"` — 46/46 passed.
- [x] `./eng/verify-ai-docs.ps1` passed.
- Full `./eng/verify-release.ps1` was intentionally skipped locally (self-hosted CI runner contention per standing session policy) — CI will run it on this PR.

Closes: `direct-mutation-undo-byte-fidelity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)