### PR TITLE
fix(eng): stage retro reports matching the multisession filename shape

### DIFF
--- a/changelog.d/stage-review-inbox-multisession-retro-glob-miss.md
+++ b/changelog.d/stage-review-inbox-multisession-retro-glob-miss.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `eng/stage-review-inbox.ps1`'s retro-report discovery pattern was `*_roslyn-mcp-retro.md`, but every retro report this repo has ever produced is named `*_roslyn-mcp-multisession-retro.md` — none matched, so `/backlog-intake` runs against this repo's own retro output silently found nothing staged. `$filePatterns` and the docstring's recognized-shapes list now include both filename forms.

--- a/eng/stage-review-inbox.ps1
+++ b/eng/stage-review-inbox.ps1
@@ -29,6 +29,7 @@
       *_mcp-server-surface-test.md  Consumer-facing audit from /mcp-server-surface-test
       *_experimental-promotion.md   Experimental tool/prompt promotion audit
       *_roslyn-mcp-retro.md         Session retro on Roslyn-MCP tool quality
+      *_roslyn-mcp-multisession-retro.md  Session multisession-retro on Roslyn-MCP tool quality
       backlog.d/<finding-id>.md     Per-finding fragments emitted by /mcp-server-stress
                                     Phase 19 (canonical schema:
                                     ai_docs/items/backlog-d-fragment-schema.md).
@@ -134,7 +135,8 @@ $filePatterns = @(
     '*_mcp-server-audit.md',
     '*_mcp-server-surface-test.md',
     '*_experimental-promotion.md',
-    '*_roslyn-mcp-retro.md'
+    '*_roslyn-mcp-retro.md',
+    '*_roslyn-mcp-multisession-retro.md'
 )
 
 # Fragment-discovery contract: any .md under <repo-root>/backlog.d/ whose


### PR DESCRIPTION
## Summary

`eng/stage-review-inbox.ps1` discovered retro reports with the literal glob `*_roslyn-mcp-retro.md`, but every retro report this repo has ever produced is named `*_roslyn-mcp-multisession-retro.md`. NTFS `-Filter` semantics require the literal `_roslyn-mcp-retro.md` tail, which the multisession form does not contain — so none of the three existing retros ever matched, and `/backlog-intake` runs against this repo's own retro output silently staged nothing.

## Linked issue

No GitHub Issue mirror exists for this backlog row.

## Changes

- `eng/stage-review-inbox.ps1` — add `'*_roslyn-mcp-multisession-retro.md'` to `$filePatterns`. Additive rather than a replacement: no sibling repo under `C:/Code-Repo/` (19 searched) nor the global `~/.claude/` prompt tree uses the short form, and two explicit literals carry zero over-match surface versus a merged wildcard like `*_roslyn-mcp*retro.md`. NTFS `-Filter` semantics guarantee the two literals cannot double-match the same file.
- `eng/stage-review-inbox.ps1` — sync the docstring's `Recognized shapes:` list with the new pattern.

## Test plan

- [ ] Added or updated unit/integration tests covering the change — N/A: no Pester suite exists for `eng/*.ps1` (`**/*.Tests.ps1` returns zero matches); creating a test project is out of scope for a two-line literal addition.
- [ ] `dotnet build RoslynMcp.slnx` succeeds — N/A: no C# touched. CI covers it.
- [ ] `dotnet test RoslynMcp.slnx` passes — N/A: no C# touched. CI covers it.
- [x] Manually verified the behavior

`pwsh -File eng/stage-review-inbox.ps1 -DryRun` (dry-run only — a bare invocation defaults siblings to `Action=Move`):

- The two previously-unstaged reports now appear with `Action=Copy`:
  - `20260521T043918Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md`
  - `20260608T203050Z_roslyn-backed-mcp_roslyn-mcp-multisession-retro.md`
- The already-archived `20260805T210025Z…` report correctly reports `already processed (review-inbox/archive/)` rather than re-staging.
- No unrelated `.md` under `ai_docs/reports/` or `ai_docs/audit-reports/` newly matched; each file appears exactly once (no double-match between the two retro literals).
- Dry run mutated nothing (`git status` clean apart from the intended edit).

Also verified: `eng/verify-ai-docs.ps1` passes, and the script parses cleanly via `[Parser]::ParseFile` (985 tokens, zero errors).

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (no compiled code touched)
- [x] Public API changes are intentional and documented — none

## Backlog (maintainer-only)

- Closes backlog row: `stage-review-inbox-multisession-retro-glob-miss`

Closes: stage-review-inbox-multisession-retro-glob-miss
