### PR TITLE
refactor(roslyn): route four preview services' compilation reads through ICompilationCache (compilation-cache-adoption-read-side)

### DIFF
--- a/changelog.d/compilation-cache-adoption-read-side.md
+++ b/changelog.d/compilation-cache-adoption-read-side.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Routed `BuildService`, `FixAllService`, `BulkRefactoringService`, and `CrossProjectRefactoringService`'s live-solution compilation reads through the shared `ICompilationCache`, closing the next bounded slice of the read-side compilation-cache adoption sweep (group-b core).

--- a/src/RoslynMcp.Roslyn/Services/BuildService.cs
+++ b/src/RoslynMcp.Roslyn/Services/BuildService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -10,17 +11,20 @@ public sealed class BuildService : IBuildService
 {
     private readonly IWorkspaceManager _workspaceManager;
     private readonly IGatedCommandExecutor _executor;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<BuildService> _logger;
     private readonly ValidationServiceOptions _options;
 
     public BuildService(
         IWorkspaceManager workspaceManager,
         IGatedCommandExecutor executor,
+        ICompilationCache compilationCache,
         ILogger<BuildService> logger,
         ValidationServiceOptions? options = null)
     {
         _workspaceManager = workspaceManager;
         _executor = executor;
+        _compilationCache = compilationCache;
         _logger = logger;
         _options = options ?? new ValidationServiceOptions();
     }
@@ -97,7 +101,8 @@ public sealed class BuildService : IBuildService
         try
         {
             var solution = _workspaceManager.GetCurrentSolution(workspaceId);
-            spans = await CollectRoslynDiagnosticSpansAsync(solution, candidates, ct).ConfigureAwait(false);
+            spans = await CollectRoslynDiagnosticSpansAsync(
+                workspaceId, _compilationCache, solution, candidates, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -126,6 +131,8 @@ public sealed class BuildService : IBuildService
     }
 
     private static async Task<Dictionary<string, (int EndLine, int EndColumn)>> CollectRoslynDiagnosticSpansAsync(
+        string workspaceId,
+        ICompilationCache compilationCache,
         Microsoft.CodeAnalysis.Solution solution,
         IReadOnlyList<DiagnosticDto> candidates,
         CancellationToken ct)
@@ -146,7 +153,9 @@ public sealed class BuildService : IBuildService
                     continue;
                 }
 
-                var compilation = await document.Project.GetCompilationAsync(ct).ConfigureAwait(false);
+                var compilation = await compilationCache
+                    .GetCompilationAsync(workspaceId, document.Project, ct)
+                    .ConfigureAwait(false);
                 if (compilation is null)
                 {
                     continue;

--- a/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/BulkRefactoringService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,11 +13,16 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly ICompilationCache _compilationCache;
 
-    public BulkRefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore)
+    public BulkRefactoringService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        ICompilationCache compilationCache)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _compilationCache = compilationCache;
     }
 
     public async Task<RefactoringPreviewDto> PreviewBulkReplaceTypeAsync(
@@ -25,11 +31,11 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
         // Resolve old type
-        var oldTypeSymbol = await ResolveTypeByNameAsync(solution, oldTypeName, ct).ConfigureAwait(false)
+        var oldTypeSymbol = await ResolveTypeByNameAsync(workspaceId, _compilationCache, solution, oldTypeName, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Type '{oldTypeName}' not found in the solution.");
 
         // Resolve new type (must exist)
-        var newTypeSymbol = await ResolveTypeByNameAsync(solution, newTypeName, ct).ConfigureAwait(false)
+        var newTypeSymbol = await ResolveTypeByNameAsync(workspaceId, _compilationCache, solution, newTypeName, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Replacement type '{newTypeName}' not found in the solution.");
 
         var normalizedScope = (scope ?? "all").ToLowerInvariant();
@@ -158,12 +164,13 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
         return lastDot >= 0 ? typeName[(lastDot + 1)..] : typeName;
     }
 
-    private static async Task<INamedTypeSymbol?> ResolveTypeByNameAsync(Solution solution, string typeName, CancellationToken ct)
+    private static async Task<INamedTypeSymbol?> ResolveTypeByNameAsync(
+        string workspaceId, ICompilationCache compilationCache, Solution solution, string typeName, CancellationToken ct)
     {
         // Try fully qualified name first
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             var symbol = compilation.GetTypeByMetadataName(typeName);
@@ -209,11 +216,11 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
 
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
-        var oldMethodSymbol = await ResolveMethodBySignatureAsync(solution, oldSig, ct).ConfigureAwait(false)
+        var oldMethodSymbol = await ResolveMethodBySignatureAsync(workspaceId, _compilationCache, solution, oldSig, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException(
                 $"Could not resolve oldMethod '{oldMethod}'. Ensure the fully-qualified type name and parameter-type list match an existing method overload.");
 
-        var newMethodSymbol = await ResolveMethodBySignatureAsync(solution, newSig, ct).ConfigureAwait(false)
+        var newMethodSymbol = await ResolveMethodBySignatureAsync(workspaceId, _compilationCache, solution, newSig, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException(
                 $"Could not resolve newMethod '{newMethod}'. Ensure the fully-qualified type name and parameter-type list match an existing method overload.");
 
@@ -535,14 +542,14 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
     }
 
     private static async Task<IMethodSymbol?> ResolveMethodBySignatureAsync(
-        Solution solution, MethodSignature sig, CancellationToken ct)
+        string workspaceId, ICompilationCache compilationCache, Solution solution, MethodSignature sig, CancellationToken ct)
     {
         // Split FQ name into containing-type + method-name at the last dot.
         var lastDot = sig.FullyQualifiedName.LastIndexOf('.');
         if (lastDot <= 0 || lastDot == sig.FullyQualifiedName.Length - 1)
         {
             // No namespace/type qualifier — fall back to solution-wide simple-name search.
-            return await ResolveMethodByBareNameAsync(solution, sig, ct).ConfigureAwait(false);
+            return await ResolveMethodByBareNameAsync(workspaceId, compilationCache, solution, sig, ct).ConfigureAwait(false);
         }
 
         var containingTypeName = sig.FullyQualifiedName[..lastDot];
@@ -551,7 +558,7 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             var containingType = compilation.GetTypeByMetadataName(containingTypeName);
@@ -566,12 +573,12 @@ public sealed class BulkRefactoringService : IBulkRefactoringService
     }
 
     private static async Task<IMethodSymbol?> ResolveMethodByBareNameAsync(
-        Solution solution, MethodSignature sig, CancellationToken ct)
+        string workspaceId, ICompilationCache compilationCache, Solution solution, MethodSignature sig, CancellationToken ct)
     {
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             var candidates = new List<IMethodSymbol>();

--- a/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CrossProjectRefactoringService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -14,11 +15,16 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly ICompilationCache _compilationCache;
 
-    public CrossProjectRefactoringService(IWorkspaceManager workspace, IPreviewStore previewStore)
+    public CrossProjectRefactoringService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        ICompilationCache compilationCache)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _compilationCache = compilationCache;
     }
 
     public async Task<RefactoringPreviewDto> PreviewMoveTypeToProjectAsync(
@@ -152,7 +158,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
             ? DeriveTargetNamespaceForPath(targetProject, targetProjectDirectory, interfaceDirectory)
             : GetContainingNamespace(typeSymbol);
 
-        await DetectExistingTypeConflictAsync(solution, namespaceName, resolvedInterfaceName, ct).ConfigureAwait(false);
+        await DetectExistingTypeConflictAsync(
+            workspaceId, _compilationCache, solution, namespaceName, resolvedInterfaceName, ct).ConfigureAwait(false);
 
         // gh #765 — walk the source type's public-instance member symbols semantically and
         // collect every referenced type's containing namespace. The generated interface file's
@@ -215,6 +222,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         var resolvedInterfaceName = string.IsNullOrWhiteSpace(interfaceName) ? $"I{typeName}" : interfaceName;
         var updatedSolution = await CreateInterfaceExtractionSolutionAsync(
+            workspaceId,
+            _compilationCache,
             solution,
             sourceDocument,
             sourceRoot,
@@ -379,6 +388,7 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
     }
 
     private static async Task DetectExistingTypeConflictAsync(
+        string workspaceId, ICompilationCache compilationCache,
         Solution solution, string namespaceName, string typeName, CancellationToken ct)
     {
         var fullyQualifiedName = string.IsNullOrWhiteSpace(namespaceName)
@@ -387,7 +397,7 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
 
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
             if (compilation?.GetTypeByMetadataName(fullyQualifiedName) is not null)
             {
                 throw new InvalidOperationException(
@@ -759,6 +769,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
     }
 
     private static async Task<Solution> CreateInterfaceExtractionSolutionAsync(
+        string workspaceId,
+        ICompilationCache compilationCache,
         Solution solution,
         Document sourceDocument,
         CompilationUnitSyntax sourceRoot,
@@ -776,7 +788,8 @@ public sealed class CrossProjectRefactoringService : ICrossProjectRefactoringSer
             ? DeriveTargetNamespace(targetProject)
             : GetContainingNamespace(typeSymbol);
 
-        await DetectExistingTypeConflictAsync(solution, namespaceName, interfaceName, ct).ConfigureAwait(false);
+        await DetectExistingTypeConflictAsync(
+            workspaceId, compilationCache, solution, namespaceName, interfaceName, ct).ConfigureAwait(false);
 
         // gh #765 — collect required namespaces semantically (see PreviewExtractInterfaceAsync
         // for the same call). The DI-inversion path routes through here too, so missing this

--- a/src/RoslynMcp.Roslyn/Services/FixAllService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FixAllService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -16,14 +17,20 @@ public sealed class FixAllService : IFixAllService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<FixAllService> _logger;
     private readonly Lazy<ImmutableArray<CodeFixProvider>> _codeFixProviders;
     private readonly Lazy<ImmutableArray<DiagnosticAnalyzer>> _analyzers;
 
-    public FixAllService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<FixAllService> logger)
+    public FixAllService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        ICompilationCache compilationCache,
+        ILogger<FixAllService> logger)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _compilationCache = compilationCache;
         _logger = logger;
         _codeFixProviders = new Lazy<ImmutableArray<CodeFixProvider>>(LoadCodeFixProviders);
         _analyzers = new Lazy<ImmutableArray<DiagnosticAnalyzer>>(LoadAnalyzers);
@@ -110,7 +117,7 @@ public sealed class FixAllService : IFixAllService
             diagnosticId, _analyzers.Value, projectAnalyzers);
 
         var diagnosticsMap = await CollectDiagnosticsAsync(
-            solution, diagnosticId, fixAllScope, targetDocument, targetProject,
+            workspaceId, _compilationCache, solution, diagnosticId, fixAllScope, targetDocument, targetProject,
             analyzersForCollection, ct).ConfigureAwait(false);
 
         var totalDiagCount = diagnosticsMap.Values.Sum(d => d.Length);
@@ -290,6 +297,7 @@ public sealed class FixAllService : IFixAllService
     }
 
     private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> CollectDiagnosticsAsync(
+        string workspaceId, ICompilationCache compilationCache,
         Solution solution, string diagnosticId, FixAllScope scope,
         Document targetDocument, Project targetProject,
         ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken ct)
@@ -303,7 +311,9 @@ public sealed class FixAllService : IFixAllService
         foreach (var project in projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await compilationCache
+                .GetCompilationAsync(workspaceId, project, ct)
+                .ConfigureAwait(false);
             if (compilation is null) continue;
 
             IEnumerable<Diagnostic> allDiagnostics;

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Services;
 
@@ -16,7 +17,11 @@ namespace RoslynMcp.Tests;
 /// <see cref="CouplingAnalysisService"/>, <see cref="ExceptionFlowService"/>, and
 /// <see cref="AnalyzerInfoService"/>; batch 2 adds <see cref="TypeConsumersService"/>,
 /// <see cref="CodePatternAnalyzer"/>, and <see cref="SymbolSearchService"/>; group-a core adds
-/// <see cref="TestReferenceMapService"/> and <see cref="ReferenceService"/>.
+/// <see cref="TestReferenceMapService"/>, <see cref="ReferenceService"/>,
+/// <see cref="ImpactSweepService"/>, <see cref="MutationAnalysisService"/>, and
+/// <see cref="SymbolRelationshipService"/>; group-b core adds <see cref="BuildService"/>,
+/// <see cref="FixAllService"/>, <see cref="BulkRefactoringService"/>, and
+/// <see cref="CrossProjectRefactoringService"/>.
 /// <para>
 /// A reference-equality check alone cannot prove adoption — Roslyn memoizes a
 /// <see cref="Compilation"/> on its owning <see cref="Project"/>, so two direct calls would also
@@ -371,6 +376,129 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
     }
 
+    [TestMethod]
+    public async Task BuildService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+
+        // EnrichDiagnosticSpansAsync -> CollectRoslynDiagnosticSpansAsync is the converted site. Its
+        // candidate gate only admits a parsed build diagnostic that HAS a start position but NO end
+        // position, so the command executor is stubbed with a canned MSBuild warning line anchored on
+        // a real sample document. Shelling out to a real `dotnet build` would emit no diagnostics at
+        // all against the clean sample, skip the helper entirely, and produce a false-green
+        // zero-call assertion.
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var dogFile = solution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "Dog.cs");
+        using var executor = new CannedBuildOutputExecutor(
+            $"{dogFile.FilePath}(5,19): warning CS0219: The variable 'unused' is assigned but its value is never used");
+        var service = new BuildService(
+            WorkspaceManager,
+            executor,
+            cache,
+            NullLogger<BuildService>.Instance);
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.BuildWorkspaceAsync(workspace.WorkspaceId, CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task FixAllService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new FixAllService(
+            WorkspaceManager,
+            new PreviewStore(),
+            cache,
+            NullLogger<FixAllService>.Instance);
+
+        // CollectDiagnosticsAsync is the converted site. PreviewFixAllAsync early-returns BEFORE it
+        // unless a CodeFixProvider *and* a FixAllProvider both resolve for the id, so anchor on
+        // IDE0161 (ConvertNamespaceCodeFixProvider) — the same id FixAllServiceGuidanceTests relies
+        // on for reaching the active-provider path. Solution scope makes the collection walk every
+        // project, so a correctly-routed implementation drives one cache fetch per project.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.PreviewFixAllAsync(
+                workspace.WorkspaceId,
+                diagnosticId: "IDE0161",
+                scope: "solution",
+                filePath: null,
+                projectName: null,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task BulkRefactoringService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new BulkRefactoringService(WorkspaceManager, new PreviewStore(), cache);
+
+        // All THREE converted resolve-helpers must share the one injected cache instance, so the
+        // reference-equality assertion below holds across the whole service rather than one path.
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, async () =>
+        {
+            // ResolveTypeByNameAsync — the fully-qualified-metadata sweep runs over every project
+            // before the simple-name fallback resolves 'IAnimal'.
+            await service.PreviewBulkReplaceTypeAsync(
+                workspace.WorkspaceId, "IAnimal", "Shape", scope: null, CancellationToken.None);
+
+            // ResolveMethodBySignatureAsync — a qualified-but-unresolvable signature drives the full
+            // per-project compilation loop; the public method then throws because nothing matched.
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                service.PreviewReplaceInvocationAsync(
+                    workspace.WorkspaceId,
+                    oldMethod: "SampleLib.NoSuchHelper.Build(int, string)",
+                    newMethod: "SampleLib.NoSuchHelper.Generate(string, int)",
+                    scope: null,
+                    CancellationToken.None));
+
+            // ResolveMethodByBareNameAsync — an unqualified name defeats the last-dot split, so the
+            // bare-name fallback runs its own per-project compilation loop.
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                service.PreviewReplaceInvocationAsync(
+                    workspace.WorkspaceId,
+                    oldMethod: "NoSuchBareBuild(int, string)",
+                    newMethod: "NoSuchBareGenerate(string, int)",
+                    scope: null,
+                    CancellationToken.None));
+        });
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task CrossProjectRefactoringService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new CrossProjectRefactoringService(WorkspaceManager, new PreviewStore(), cache);
+
+        // DetectExistingTypeConflictAsync is the converted site — reached from BOTH
+        // PreviewExtractInterfaceAsync and (via CreateInterfaceExtractionSolutionAsync)
+        // PreviewDependencyInversionAsync, always against the LIVE solution. It throws on a
+        // collision, so the interface name is deliberately one the sample cannot already declare.
+        // Explicitly NOT covered here: the SymbolResolver.ResolveByMetadataNameAsync call in
+        // PreviewDependencyInversionAsync, which reads a FORKED solution and stays uncached.
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.PreviewExtractInterfaceAsync(
+                workspace.WorkspaceId,
+                sourceFilePath,
+                "AnimalService",
+                interfaceName: "IAnimalServiceCompilationCacheProbe",
+                targetProjectName: null,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
     /// <summary>
     /// Runs the service once (proving it touched the cache), snapshots the compilations the cache
     /// handed out, then runs it a second time at the unchanged workspace version so the caller can
@@ -470,6 +598,39 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
         var dto = compilation.GetTypeByMetadataName("HoistFixture.Gadget")!;
         var otherDto = compilation.GetTypeByMetadataName("HoistFixture.Trinket")!;
         return (solution, 2, domain, dto, otherDto);
+    }
+
+    /// <summary>
+    /// Stub <see cref="IGatedCommandExecutor"/> that returns a fixed <c>dotnet build</c> stdout
+    /// instead of spawning the real CLI. The canned line carries a start position and no end
+    /// position, which is exactly the diagnostic shape <see cref="BuildService"/> routes into its
+    /// Roslyn span-enrichment path — the converted compilation-cache site.
+    /// </summary>
+    private sealed class CannedBuildOutputExecutor(string stdOut) : IGatedCommandExecutor
+    {
+        public Task<CommandExecutionDto> ExecuteAsync(
+            string workspaceId,
+            string targetPath,
+            IReadOnlyList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken ct) =>
+            Task.FromResult(new CommandExecutionDto(
+                Command: "dotnet",
+                Arguments: arguments,
+                WorkingDirectory: Path.GetDirectoryName(targetPath) ?? ".",
+                TargetPath: targetPath,
+                ExitCode: 0,
+                Succeeded: true,
+                DurationMs: 1,
+                StdOut: stdOut,
+                StdErr: string.Empty));
+
+        public ProjectStatusDto ResolveProject(string workspaceId, string projectName) =>
+            throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/HardeningBehaviorTests.cs
@@ -78,6 +78,7 @@ public sealed class HardeningBehaviorTests : SharedWorkspaceTestBase
         var service = new BuildService(
             fakeWorkspaceManager,
             executor,
+            new CompilationCache(fakeWorkspaceManager),
             NullLogger<BuildService>.Instance,
             new ValidationServiceOptions
             {

--- a/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
+++ b/tests/RoslynMcp.Tests/PerformanceBehaviorTests.cs
@@ -119,6 +119,7 @@ public class PerformanceBehaviorTests : SharedWorkspaceTestBase
         var buildService = new BuildService(
             workspaceManager,
             executor,
+            new CompilationCache(workspaceManager),
             NullLogger<BuildService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -118,7 +118,8 @@ internal sealed class TestServiceContainer
             NullLogger<FileOperationService>.Instance);
         var crossProjectRefactoringService = new CrossProjectRefactoringService(
             workspaceManager,
-            previewStore);
+            previewStore,
+            compilationCache);
         var compositePreviewStore = new CompositePreviewStore();
 
         // semantic-edit-with-compile-check-wrapper: hoist CompileCheckService construction
@@ -170,6 +171,7 @@ internal sealed class TestServiceContainer
             BuildService = new BuildService(
                 workspaceManager,
                 gatedCommandExecutor,
+                compilationCache,
                 NullLogger<BuildService>.Instance,
                 validationOptions),
             TestRunnerService = new TestRunnerService(
@@ -233,7 +235,8 @@ internal sealed class TestServiceContainer
             SyntaxService = new SyntaxService(workspaceManager),
             BulkRefactoringService = new BulkRefactoringService(
                 workspaceManager,
-                previewStore),
+                previewStore,
+                compilationCache),
             CohesionAnalysisService = new CohesionAnalysisService(
                 workspaceManager,
                 NullLogger<CohesionAnalysisService>.Instance),
@@ -262,6 +265,7 @@ internal sealed class TestServiceContainer
             FixAllService = new FixAllService(
                 workspaceManager,
                 previewStore,
+                compilationCache,
                 NullLogger<FixAllService>.Instance),
             OperationService = new OperationService(workspaceManager),
             SnippetAnalysisService = new SnippetAnalysisService(


### PR DESCRIPTION
## Summary

Group-b core slice of the read-side compilation-cache adoption sweep. Four services held `Solution`-parameterized private helpers with **no `workspaceId`**, which foreclosed the version-keyed `ICompilationCache` lookup — every preview pass re-derived compilations a sibling service had already warmed.

Each helper now takes `workspaceId` + `ICompilationCache` alongside the existing `Solution`, mirroring the batch-1/2/a pattern (`SymbolRelationshipService.cs:405-430`, `MutationAnalysisService.cs:344-354`). `ICompilationCache` is already DI-registered as a singleton — no registration change needed.

| Service | Converted helper(s) |
|---|---|
| `BuildService` | `CollectRoslynDiagnosticSpansAsync` |
| `FixAllService` | `CollectDiagnosticsAsync` |
| `BulkRefactoringService` | `ResolveTypeByNameAsync`, `ResolveMethodBySignatureAsync`, `ResolveMethodByBareNameAsync` |
| `CrossProjectRefactoringService` | `DetectExistingTypeConflictAsync` (threaded through `CreateInterfaceExtractionSolutionAsync` for the DI-inversion caller) |

All six call sites are fed by `_workspace.GetCurrentSolution(workspaceId)`, so the cache key matches the live snapshot.

## Negative space — deliberately NOT converted

`CrossProjectRefactoringService`'s `SymbolResolver.ResolveByMetadataNameAsync(updatedSolution, …)` call reads a **forked** solution and stays raw. Caching a forked-solution read against the live workspace version would be a correctness bug. That is the group-c HAZARD batch, which needs a `solution == GetCurrentSolution(workspaceId)` gate inside `SymbolResolver` — a separate initiative.

## Constructor fanout

Adding the `ICompilationCache` ctor parameter breaks six construction sites, all updated in this commit: `TestServiceContainer.cs` (×4, reusing the `compilationCache` local already present), `HardeningBehaviorTests.cs`, `PerformanceBehaviorTests.cs`. No shims, no optional-parameter escape hatches.

## Tests

Four new `[TestMethod]`s in `CompilationCacheAdoptionTests.cs` following the existing `RecordingCompilationCache` + `RunTwiceAndCaptureAsync` + `AssertRoutedThroughCacheAndShared` pattern. Each asserts (a) the cache was actually consulted and (b) the warm compilation is reference-equal across two reads at an unchanged workspace version.

Two of the four sites sit behind early-return gates that would otherwise yield false-green zero-call assertions:

- `BuildService` — the span-enrichment helper only runs for a diagnostic with a start position and no end position, so the command executor is stubbed (`CannedBuildOutputExecutor`) with a canned MSBuild warning line anchored on a real sample document. A real `dotnet build` against the clean sample emits nothing and would skip the helper entirely.
- `FixAllService` — `PreviewFixAllAsync` returns before the collection unless both a `CodeFixProvider` and a `FixAllProvider` resolve, so the test anchors on `IDE0161` (the id `FixAllServiceGuidanceTests` already relies on for the active-provider path).

**Non-vacuousness verified:** reverting the four routing lines to raw `project.GetCompilationAsync(ct)` fails all four new tests; restoring them passes.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- `./eng/verify-release.ps1 -Configuration Release` — **1851 passed, 0 failed**
- `./eng/verify-ai-docs.ps1` — passed
- `./eng/verify-changelog-fragments.ps1` — 13 fragments valid

## Backlog

Closes: (partial slice — leaves the row open)

This is one bounded child batch of the size-`L` row `compilation-cache-adoption-read-side`, not a full close. Remaining follow-on batches: the ScaffoldingService trio, `InterfaceExtractionService`'s live site, the untracked `CompileCheckService` / `CodeActionService` / `NamespaceRelocationService` / `WorkspaceWarmService` sites, and the group-c HAZARD gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
