### PR TITLE
fix(core): restore FileEditsDto value equality and close aliased-array mutation (core-dto-fileeditsdto-array-to-readonlylist)

### DIFF
--- a/changelog.d/core-dto-fileeditsdto-array-to-readonlylist.md
+++ b/changelog.d/core-dto-fileeditsdto-array-to-readonlylist.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `FileEditsDto` so two instances holding equal edit sequences now compare equal via record `Equals`/`GetHashCode` (previously always reference-unequal because the `Edits` property was a raw array); `Edits` is now `IReadOnlyList<TextEditDto>`, closing the aliased-mutation surface where a caller could mutate a shared edit array through one `FileEditsDto` reference and silently affect another.

--- a/src/RoslynMcp.Core/Models/FileEditsDto.cs
+++ b/src/RoslynMcp.Core/Models/FileEditsDto.cs
@@ -3,6 +3,64 @@ namespace RoslynMcp.Core.Models;
 /// <summary>
 /// Groups a set of text edits to be applied to a single file.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Edits"/> is deliberately typed as <see cref="IReadOnlyList{T}"/> rather than
+/// <c>TextEditDto[]</c>: an array-typed record property hands every holder of the DTO a live
+/// mutable reference, so one caller doing <c>dto.Edits[0] = …</c> silently corrupts the edit
+/// sequence observed by every other holder of the same instance.
+/// </para>
+/// <para>
+/// The interface swap alone does NOT restore record value equality — the compiler-synthesized
+/// <c>Equals</c>/<c>GetHashCode</c> route collection properties through
+/// <c>EqualityComparer&lt;T&gt;.Default</c>, which for any of the concrete collection types that
+/// back this interface (arrays, <c>List&lt;T&gt;</c>) falls back to reference equality. The
+/// explicit <see cref="Equals(FileEditsDto)"/> / <see cref="GetHashCode"/> overrides below do the
+/// structural element-wise comparison instead, so two instances holding equal edit sequences
+/// compare equal regardless of which concrete collection carries them. The record-generated
+/// <c>==</c>/<c>!=</c> operators call through to these overrides automatically.
+/// </para>
+/// </remarks>
 /// <param name="FilePath">The absolute path to the file being edited.</param>
 /// <param name="Edits">The text edits to apply, in any order.</param>
-public sealed record FileEditsDto(string FilePath, TextEditDto[] Edits);
+public sealed record FileEditsDto(string FilePath, IReadOnlyList<TextEditDto> Edits)
+{
+    /// <summary>
+    /// Structural equality: <see cref="FilePath"/> compared ordinally (matching the
+    /// synthesized behaviour it replaces) and <see cref="Edits"/> compared element-wise in
+    /// order. <see cref="TextEditDto"/> is an all-primitive record, so its own synthesized
+    /// value equality makes the element comparison correct.
+    /// </summary>
+    public bool Equals(FileEditsDto? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(FilePath, other.FilePath, StringComparison.Ordinal)
+            && Edits.SequenceEqual(other.Edits);
+    }
+
+    /// <summary>
+    /// Order-sensitive element-wise hash over <see cref="Edits"/> combined with
+    /// <see cref="FilePath"/>, so any two instances that are <see cref="Equals(FileEditsDto)"/>
+    /// -true necessarily produce the same hash code.
+    /// </summary>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(FilePath, StringComparer.Ordinal);
+        foreach (var edit in Edits)
+        {
+            hash.Add(edit);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/tests/RoslynMcp.Tests/FileEditsDtoTests.cs
+++ b/tests/RoslynMcp.Tests/FileEditsDtoTests.cs
@@ -1,0 +1,108 @@
+using RoslynMcp.Core.Models;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for `core-dto-fileeditsdto-array-to-readonlylist` (P4): `FileEditsDto.Edits` was
+/// declared as `TextEditDto[]`, so the compiler-synthesized record `Equals`/`GetHashCode` routed
+/// the property through `EqualityComparer&lt;TextEditDto[]&gt;.Default` — `Array` never overrides
+/// `object.Equals`, so two instances holding distinct-but-content-equal edit sequences always
+/// compared unequal, defeating the point of the record. The property is now
+/// `IReadOnlyList&lt;TextEditDto&gt;` (closing the aliased-array mutation surface) with explicit
+/// structural `Equals`/`GetHashCode` overrides (restoring value equality).
+/// </summary>
+[TestClass]
+public sealed class FileEditsDtoTests
+{
+    private const string SamplePath = "/work/Sample.cs";
+
+    private static TextEditDto Edit(int startLine, string newText) =>
+        new(startLine, 1, startLine, 5, newText);
+
+    [TestMethod]
+    public void Equals_SeparatelyAllocatedEqualArrays_AreEqualAndHashEqual()
+    {
+        var left = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+        var right = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+
+        Assert.AreNotSame(left.Edits, right.Edits, "the two DTOs must hold distinct backing sequences for this to prove anything");
+        Assert.AreEqual(left, right);
+        Assert.IsTrue(left == right, "record-generated == must route through the structural Equals override");
+        Assert.IsFalse(left != right);
+        Assert.AreEqual(left.GetHashCode(), right.GetHashCode(), "Equals-true instances must hash equal");
+    }
+
+    [TestMethod]
+    public void Equals_ListAndArrayWithSameContent_AreEqualAndHashEqual()
+    {
+        var fromArray = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+        var fromList = new FileEditsDto(SamplePath, new List<TextEditDto> { Edit(1, "a"), Edit(2, "b") });
+
+        Assert.AreEqual(fromArray, fromList, "equality must be structural, not dependent on the concrete collection type");
+        Assert.AreEqual(fromArray.GetHashCode(), fromList.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Equals_CollectionExpressionCallsite_StillCompilesAndBehavesIdentically()
+    {
+        // Both the `new[] { … }` and collection-expression construction forms used across the
+        // existing edit-regression suites must keep working after the array -> IReadOnlyList swap.
+        var fromCollectionExpression = new FileEditsDto(SamplePath, [Edit(1, "a")]);
+        var fromArrayLiteral = new FileEditsDto(SamplePath, new[] { Edit(1, "a") });
+
+        Assert.AreEqual(1, fromCollectionExpression.Edits.Count);
+        Assert.AreEqual(fromArrayLiteral, fromCollectionExpression);
+    }
+
+    [TestMethod]
+    public void Equals_DifferentFilePath_AreNotEqual()
+    {
+        var left = new FileEditsDto(SamplePath, new[] { Edit(1, "a") });
+        var right = new FileEditsDto("/work/Other.cs", new[] { Edit(1, "a") });
+
+        Assert.AreNotEqual(left, right, "FilePath must still participate in equality");
+    }
+
+    [TestMethod]
+    public void Equals_SameLengthDifferentContent_AreNotEqual()
+    {
+        var left = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+        var right = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "DIFFERENT") });
+
+        Assert.AreNotEqual(left, right);
+    }
+
+    [TestMethod]
+    public void Equals_DifferentLengthSequences_AreNotEqual()
+    {
+        var left = new FileEditsDto(SamplePath, new[] { Edit(1, "a") });
+        var right = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+
+        Assert.AreNotEqual(left, right);
+        Assert.AreNotEqual(right, left, "inequality must be symmetric");
+    }
+
+    [TestMethod]
+    public void GetHashCode_IsOrderSensitive_NotCountBased()
+    {
+        var forward = new FileEditsDto(SamplePath, new[] { Edit(1, "a"), Edit(2, "b") });
+        var reversed = new FileEditsDto(SamplePath, new[] { Edit(2, "b"), Edit(1, "a") });
+
+        Assert.AreNotEqual(forward, reversed, "element order is part of the value");
+        Assert.AreNotEqual(
+            forward.GetHashCode(),
+            reversed.GetHashCode(),
+            "hash must fold each element in order, not merely the element count");
+    }
+
+    [TestMethod]
+    public void Equals_SelfAndNull_BehaveAsRecordEqualityRequires()
+    {
+        var dto = new FileEditsDto(SamplePath, new[] { Edit(1, "a") });
+
+        Assert.AreEqual(dto, dto);
+        Assert.IsFalse(dto.Equals(null));
+        Assert.IsFalse(dto.Equals((object?)null));
+        Assert.IsFalse(dto.Equals("not a FileEditsDto"));
+    }
+}


### PR DESCRIPTION
## Summary

`FileEditsDto.Edits` was declared `TextEditDto[]`, which broke record value equality (the synthesized `Equals`/`GetHashCode` route the property through `EqualityComparer<TextEditDto[]>.Default`, and `Array` never overrides `object.Equals` — so two instances holding distinct-but-content-equal edit sequences always compared unequal) and left an aliased-mutation hole (any holder could do `dto.Edits[0] = …` and silently corrupt every other holder of the same instance). This widens the property to `IReadOnlyList<TextEditDto>` and adds explicit structural `Equals`/`GetHashCode` overrides.

## Linked issue

No GitHub Issue mirrors this backlog row.

## Changes

- `src/RoslynMcp.Core/Models/FileEditsDto.cs` — `Edits` is now `IReadOnlyList<TextEditDto>`; added explicit `Equals(FileEditsDto?)` (ordinal `FilePath` compare + `Edits.SequenceEqual`) and `GetHashCode()` (order-sensitive element-wise fold), plus `<remarks>` documenting why the type swap alone is insufficient.
- `tests/RoslynMcp.Tests/FileEditsDtoTests.cs` — new file, 8 tests.
- `changelog.d/core-dto-fileeditsdto-array-to-readonlylist.md` — changelog fragment (`category: Fixed`).

### Why the type swap alone does not fix equality

Widening `TextEditDto[]` → `IReadOnlyList<TextEditDto>` only closes the *mutation* surface. `EqualityComparer<IReadOnlyList<TextEditDto>>.Default` still dispatches virtually to whatever concrete collection backs the interface at runtime — an array or a `List<T>`, neither of which overrides `object.Equals`. Restoring value equality requires the explicit overrides; the record-generated `==`/`!=` operators then route through them automatically.

### No downstream signature churn

Every consumer already types edit sequences as `IReadOnlyList<TextEditDto>`: `EditService.ValidateEdits`, `BuildPatchedSourceText`, `ApplyTextEditsCoreAsync`, and the `fileEdits` parameters on `IEditService` / `ISymbolRefactorService`. Existing `new FileEditsDto(path, new[] { … })` / `new FileEditsDto(path, [ … ])` call-sites across `ApplyTextEditVerifyTests`, `ChangeTrackerTests`, `ExpandedSurfaceIntegrationTests`, `EditUndoIntegrationTests`, `PreviewMultiFileEditSyntaxRegressionTests`, `SymbolRefactorPreviewTests`, `SuppressionServiceTests` compile unchanged (arrays satisfy `IReadOnlyList<T>`). Zero source edits were required in any existing file. The MCP tool-schema surface (`MultiFileEditTools.cs`'s outer `FileEditsDto[] fileEdits` parameter) is deliberately untouched.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds
- [x] `dotnet test RoslynMcp.slnx` passes
- [x] Manually verified the behavior (described below)

New `FileEditsDtoTests` (8 tests, all green) covers:

1. Two DTOs over separately-allocated content-equal arrays are `Equals`-true, `==`-true and hash-equal (this is the case that was previously **false**).
2. A `TextEditDto[]`-backed and a `List<TextEditDto>`-backed DTO with equal content compare equal — proof the fix is structural, not collection-type-dependent.
3. Collection-expression and array-literal construction forms both still compile and agree.
4. Differing `FilePath` → unequal (the path still participates in equality).
5. Same-length-different-content → unequal.
6. Differing-length sequences → unequal, symmetrically.
7. `GetHashCode` is order-sensitive, not `Count`-based, so `Equals`-true implies hash-equal.
8. Self / `null` / wrong-type comparisons behave as record equality requires.

Validation run in the worktree:

- `mcp__roslyn__compile_check` solution-wide: 0 errors, 0 warnings across all 5 projects.
- `eng/verify-release.ps1 -Configuration Release`: **green** — Release build 0 warnings / 0 errors, **1859/1859 tests passed**, publish + hash manifest + coverage produced.
- `eng/verify-ai-docs.ps1`: **green**.
- Targeted pre-CI runs: `FileEditsDtoTests` 8/8; the six named edit/refactor regression suites 47/47; `ExpandedSurfaceIntegrationTests` 29/29.

## Checklist

- [x] Followed the existing code style and project layering (see `CONTRIBUTING.md`)
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — `FileEditsDto.Edits` widens from `TextEditDto[]` to `IReadOnlyList<TextEditDto>`. Source-compatible for construction (arrays convert implicitly) and for all in-repo reads; a hypothetical external consumer indexing-to-write or calling array-only members (`.Length`, `Array.*`) would break, which is the intended point of the fix.

## Backlog (maintainer-only)

- Closes backlog row: `core-dto-fileeditsdto-array-to-readonlylist`

Closes: core-dto-fileeditsdto-array-to-readonlylist
