### PR TITLE
fix(mutation): preserve original file encoding on apply writes (mutation-write-paths-drop-original-encoding)

### DIFF
--- a/changelog.d/mutation-write-paths-drop-original-encoding.md
+++ b/changelog.d/mutation-write-paths-drop-original-encoding.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `apply_text_edit`, `apply_project_mutation`, and `set_editorconfig_option` now preserve a source file's original BOM/encoding on write instead of silently re-encoding it as UTF-8-no-BOM; `AtomicFileWriter.WriteAllTextAsync` gained an optional `Encoding` parameter threaded from the pre-mutation `SourceText`/on-disk bytes at each call site (`apply_composite_preview`'s write path has the same underlying gap and is tracked separately).

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -1,6 +1,8 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
 
 namespace RoslynMcp.Roslyn.Services;
 
@@ -127,13 +129,47 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
 /// <paramref name="logger"/> is supplied, a failure to delete the orphaned <c>.tmp</c> is logged
 /// at Warning level (the primary write failure is still re-thrown either way) so a stray artifact
 /// left on disk leaves an observability trail instead of being silently discarded.
+/// <para>
+/// Text writes accept an optional <see cref="Encoding"/> so a mutated file keeps its original
+/// BOM/encoding (<c>mutation-write-paths-drop-original-encoding</c>). Callers resolve it through
+/// <see cref="ResolveWriteEncoding(byte[])"/> (from the pre-mutation on-disk bytes) or
+/// <see cref="ResolveWriteEncoding(Encoding)"/> (from a Roslyn <c>SourceText.Encoding</c>).
+/// Omitting it keeps the historic UTF-8-no-BOM behavior.
+/// </para>
 /// </summary>
 internal static class AtomicFileWriter
 {
-    public static async Task WriteAllTextAsync(string path, string content, CancellationToken ct, ILogger? logger = null)
+    /// <summary>
+    /// UTF-8 without a byte-order mark — the encoding .NET's <c>Encoding</c>-less
+    /// <see cref="File.WriteAllTextAsync(string, string?, CancellationToken)"/> overload uses.
+    /// Also the correct default for a brand-new file and for any source whose original encoding
+    /// could not be determined, so omitting <c>encoding</c> preserves the pre-existing behavior
+    /// byte-for-byte. Deliberately NOT <see cref="Encoding.UTF8"/>: that static instance emits a
+    /// BOM, so using it would ADD a preamble to every no-BOM file.
+    /// </summary>
+    internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    /// <summary>
+    /// Atomically writes <paramref name="content"/> to <paramref name="path"/>.
+    /// </summary>
+    /// <param name="encoding">
+    /// Optional. When supplied, the temp file is written with this encoding so a source file's
+    /// original BOM/encoding survives the round-trip (<c>mutation-write-paths-drop-original-encoding</c>).
+    /// When <see langword="null"/> the encoding-less BCL overload is used, i.e. UTF-8 with no BOM.
+    /// Declared AFTER <paramref name="logger"/> on purpose: callers that pass a logger positionally
+    /// must keep binding it to <paramref name="logger"/>.
+    /// </param>
+    public static async Task WriteAllTextAsync(
+        string path,
+        string content,
+        CancellationToken ct,
+        ILogger? logger = null,
+        Encoding? encoding = null)
         => await WriteAtomicAsync(
             path,
-            tmp => File.WriteAllTextAsync(tmp, content, ct),
+            tmp => encoding is null
+                ? File.WriteAllTextAsync(tmp, content, ct)
+                : File.WriteAllTextAsync(tmp, content, encoding, ct),
             logger).ConfigureAwait(false);
 
     public static async Task WriteAllBytesAsync(string path, byte[] content, CancellationToken ct, ILogger? logger = null)
@@ -141,6 +177,56 @@ internal static class AtomicFileWriter
             path,
             tmp => File.WriteAllBytesAsync(tmp, content, ct),
             logger).ConfigureAwait(false);
+
+    /// <summary>
+    /// Resolves the <see cref="Encoding"/> a file should be REWRITTEN with, given the bytes it
+    /// held before the mutation. Returns <see cref="Utf8NoBom"/> when <paramref name="existingBytes"/>
+    /// is <see langword="null"/> (the file is being created) or when the original carried no
+    /// preamble. Otherwise returns the BOM-derived encoding so the preamble is re-emitted verbatim.
+    /// </summary>
+    /// <remarks>
+    /// The <c>HasPreamble</c> gate is load-bearing. <see cref="CsprojSemanticEquality.CreateSnapshot"/>
+    /// reports <see cref="Encoding.UTF8"/> (BOM-emitting) for a plain no-BOM UTF-8 file, because that
+    /// is the <see cref="StreamReader"/> fallback when no byte-order mark is detected. Writing with
+    /// that instance would add a BOM to every no-BOM file, so the no-preamble case must fall back to
+    /// <see cref="Utf8NoBom"/> instead of trusting the detected encoding.
+    /// Encoding detection is BOM-based only: a BOM-less UTF-16/codepage file is indistinguishable
+    /// from UTF-8 here and is rewritten as UTF-8-no-BOM, matching the pre-fix behavior.
+    /// </remarks>
+    internal static Encoding ResolveWriteEncoding(byte[]? existingBytes)
+    {
+        if (existingBytes is null || existingBytes.Length == 0)
+        {
+            return Utf8NoBom;
+        }
+
+        var snapshot = CsprojSemanticEquality.CreateSnapshot(existingBytes);
+        return snapshot.HasPreamble ? snapshot.TextEncoding : Utf8NoBom;
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="Encoding"/> to write with from an encoding Roslyn already attached
+    /// to a <c>SourceText</c> (<c>SourceText.Encoding</c>), which is <see langword="null"/> for text
+    /// synthesized in memory.
+    /// </summary>
+    /// <remarks>
+    /// A UTF-8 encoding that emits no preamble is normalized to the shared <see cref="Utf8NoBom"/>
+    /// instance rather than passed through: Roslyn's own no-BOM UTF-8 instance is constructed with
+    /// <c>throwOnInvalidBytes: true</c>, so writing through it would turn an unpaired surrogate into
+    /// a mid-write <see cref="EncoderFallbackException"/> where the pre-fix path silently emitted
+    /// U+FFFD. Non-UTF-8 and BOM-carrying encodings are preserved as-is.
+    /// </remarks>
+    internal static Encoding ResolveWriteEncoding(Encoding? sourceEncoding)
+    {
+        if (sourceEncoding is null)
+        {
+            return Utf8NoBom;
+        }
+
+        return sourceEncoding.CodePage == Utf8NoBom.CodePage && sourceEncoding.GetPreamble().Length == 0
+            ? Utf8NoBom
+            : sourceEncoding;
+    }
 
     private static async Task WriteAtomicAsync(
         string path,

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Helpers;
@@ -711,8 +712,17 @@ public sealed class EditService : IEditService
 
         try
         {
-            var text = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
-            await AtomicFileWriter.WriteAllTextAsync(document.FilePath, text, ct).ConfigureAwait(false);
+            // mutation-write-paths-drop-original-encoding: keep the SourceText object rather than
+            // collapsing it to a string immediately — SourceText.Encoding carries the encoding
+            // Roslyn detected when the document was loaded from disk (and SourceText.WithChanges
+            // propagates it through the edit), so threading it into the write keeps a UTF-8-BOM or
+            // UTF-16 source file byte-faithful instead of silently re-encoding it as UTF-8-no-BOM.
+            var sourceText = await document.GetTextAsync(ct).ConfigureAwait(false);
+            await AtomicFileWriter.WriteAllTextAsync(
+                document.FilePath,
+                sourceText.ToString(),
+                ct,
+                encoding: AtomicFileWriter.ResolveWriteEncoding(sourceText.Encoding)).ConfigureAwait(false);
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -372,7 +372,12 @@ public sealed class EditorConfigService : IEditorConfigService
             Directory.CreateDirectory(directory);
         }
 
-        File.WriteAllLines(editorconfigPath, lines);
+        // mutation-write-paths-drop-original-encoding: the encoding-less File.WriteAllLines overload
+        // is UTF-8-no-BOM by definition, so it silently stripped/rewrote the BOM of an existing
+        // .editorconfig. existingBytes is already in scope for the undo snapshot — reuse it to
+        // detect the original encoding (null when we are creating the file, which correctly
+        // resolves to UTF-8-no-BOM).
+        File.WriteAllLines(editorconfigPath, lines, AtomicFileWriter.ResolveWriteEncoding(existingBytes));
 
         // workspace-changes-log-missing-editorconfig-writers: route the editorconfig write
         // through ChangeTracker so `workspace_changes` surfaces the originating tool name

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -551,10 +551,14 @@ public sealed class ProjectMutationService : IProjectMutationService
             // `null` OriginalText is impossible here because Retrieve above succeeded and
             // the preview-store entry was created from File.ReadAllTextAsync.
             var normalizedProjectFilePath = Path.GetFullPath(projectFilePath);
-            var preApplySnapshot = File.Exists(projectFilePath)
-                ? FileSnapshotDto.FromExistingBytes(
-                    normalizedProjectFilePath,
-                    await File.ReadAllBytesAsync(projectFilePath, ct).ConfigureAwait(false))
+            // mutation-write-paths-drop-original-encoding: the pre-apply bytes are read here for
+            // the undo snapshot anyway, so reuse them to detect the file's original BOM/encoding
+            // and write it back with the same one instead of defaulting to UTF-8-no-BOM.
+            var preApplyBytes = File.Exists(projectFilePath)
+                ? await File.ReadAllBytesAsync(projectFilePath, ct).ConfigureAwait(false)
+                : null;
+            var preApplySnapshot = preApplyBytes is not null
+                ? FileSnapshotDto.FromExistingBytes(normalizedProjectFilePath, preApplyBytes)
                 : new FileSnapshotDto(normalizedProjectFilePath, OriginalText: null);
             _undoService?.CaptureBeforeApply(
                 workspaceId,
@@ -562,7 +566,11 @@ public sealed class ProjectMutationService : IProjectMutationService
                 preApplySolution: null,
                 fileSnapshots: new[] { preApplySnapshot });
 
-            await AtomicFileWriter.WriteAllTextAsync(projectFilePath, updatedContent, ct).ConfigureAwait(false);
+            await AtomicFileWriter.WriteAllTextAsync(
+                projectFilePath,
+                updatedContent,
+                ct,
+                encoding: AtomicFileWriter.ResolveWriteEncoding(preApplyBytes)).ConfigureAwait(false);
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
             _previewStore.Invalidate(previewToken);
             _changeTracker?.RecordChange(workspaceId, $"Project mutation: {Path.GetFileName(projectFilePath)}", [projectFilePath], "apply_project_mutation");

--- a/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -362,6 +363,71 @@ public sealed class ApplyTextEditVerifyTests : IsolatedWorkspaceTestBase
             originalText,
             await File.ReadAllTextAsync(dogFilePath, CancellationToken.None),
             "The edit must be rolled back when the complete diagnostic set exposes a regression.");
+    }
+
+    // ------------------------------------------------------------------
+    // mutation-write-paths-drop-original-encoding: the on-disk write must
+    // round-trip the source file's original BOM/encoding.
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Regression guard for <c>mutation-write-paths-drop-original-encoding</c>:
+    /// <c>apply_text_edit</c> persisted the edited document through
+    /// <c>AtomicFileWriter.WriteAllTextAsync</c> without an <see cref="Encoding"/>, and the
+    /// encoding-less BCL overload is UTF-8-no-BOM by definition — so editing a UTF-8-BOM or
+    /// UTF-16 source file silently stripped its byte-order mark and re-encoded the whole file.
+    /// The <c>utf8-nobom</c> row is the inverse guard: a file that had no BOM must not gain one.
+    /// </summary>
+    [TestMethod]
+    [DataRow("utf8-nobom")]
+    [DataRow("utf8-bom")]
+    [DataRow("utf16-bom")]
+    public async Task ApplyTextEdit_PreservesOriginalFileEncoding(string encodingKind)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var originalContent = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Encoding encoding = encodingKind switch
+        {
+            "utf16-bom" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            _ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        };
+        var preamble = encoding.GetPreamble();
+
+        await File.WriteAllBytesAsync(
+            dogFilePath,
+            preamble.Concat(encoding.GetBytes(originalContent)).ToArray(),
+            CancellationToken.None);
+        // Reload so Roslyn re-reads the file and populates SourceText.Encoding from the new BOM.
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        const string probe = "// encoding-preservation probe";
+        var result = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { AppendCommentEdit(originalContent, probe) },
+            "apply_text_edit",
+            CancellationToken.None);
+        Assert.IsTrue(result.Success, "Edit must apply cleanly as a precondition.");
+
+        var afterBytes = await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None);
+        Assert.IsTrue(
+            afterBytes.AsSpan().StartsWith(preamble),
+            $"apply_text_edit must re-emit the original {encodingKind} byte-order mark instead of rewriting the file as UTF-8-no-BOM.");
+        if (preamble.Length == 0)
+        {
+            Assert.IsFalse(
+                afterBytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()),
+                "A source file that had no BOM must not gain one.");
+        }
+
+        StringAssert.Contains(
+            encoding.GetString(afterBytes, preamble.Length, afterBytes.Length - preamble.Length),
+            probe,
+            "Sanity check: the edit must be readable back through the original encoding.");
     }
 
     // ------------------------------------------------------------------

--- a/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
+++ b/tests/RoslynMcp.Tests/EditorConfigServiceTests.cs
@@ -93,6 +93,62 @@ public sealed class EditorConfigServiceTests : IsolatedWorkspaceTestBase
     }
 
     /// <summary>
+    /// Regression guard for <c>mutation-write-paths-drop-original-encoding</c>: the FORWARD apply
+    /// half of the byte-fidelity contract. <c>SetOptionAsync</c> rewrote the file through the
+    /// <c>Encoding</c>-less <see cref="File.WriteAllLines(string, IEnumerable{string})"/> overload,
+    /// which is UTF-8-no-BOM by definition — so a UTF-8-BOM or UTF-16 <c>.editorconfig</c> lost its
+    /// byte-order mark on every set. The sibling revert test above only covers the restore path.
+    /// The <c>utf8-nobom</c> row is the inverse guard: a file that had no BOM must not gain one.
+    /// </summary>
+    [TestMethod]
+    [DataRow("utf8-nobom")]
+    [DataRow("utf8-bom")]
+    [DataRow("utf16-bom")]
+    public async Task SetOptionAsync_PreservesOriginalFileEncoding(string encodingKind)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var editorconfigPath = Path.Combine(workspace.RootPath, ".editorconfig");
+        const string key = "dotnet_diagnostic.CA9878.severity";
+        const string originalContent = "[*.{cs,csx,cake}]\ndotnet_diagnostic.CA9878.severity = warning\n";
+
+        Encoding encoding = encodingKind switch
+        {
+            "utf16-bom" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            _ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        };
+        var preamble = encoding.GetPreamble();
+
+        await File.WriteAllBytesAsync(
+            editorconfigPath,
+            preamble.Concat(encoding.GetBytes(originalContent)).ToArray(),
+            CancellationToken.None);
+
+        var setResult = await EditorConfigService.SetOptionAsync(
+            workspaceId, dogFilePath, key, "error", "set_editorconfig_option", CancellationToken.None);
+        Assert.IsFalse(setResult.CreatedNewFile, "File already existed; CreatedNewFile must be false.");
+
+        var afterBytes = await File.ReadAllBytesAsync(editorconfigPath, CancellationToken.None);
+        Assert.IsTrue(
+            afterBytes.AsSpan().StartsWith(preamble),
+            $"set_editorconfig_option must re-emit the original {encodingKind} byte-order mark instead of rewriting the file as UTF-8-no-BOM.");
+        if (preamble.Length == 0)
+        {
+            Assert.IsFalse(
+                afterBytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()),
+                "An .editorconfig that had no BOM must not gain one.");
+        }
+
+        StringAssert.Contains(
+            encoding.GetString(afterBytes, preamble.Length, afterBytes.Length - preamble.Length),
+            "error",
+            "Sanity check: the option must be readable back through the original encoding.");
+    }
+
+    /// <summary>
     /// Regression test for <c>editorconfig-write-no-auto-invalidation</c>:
     /// <see cref="IEditorConfigService.GetOptionsAsync"/> must return the value that
     /// <see cref="IEditorConfigService.SetOptionAsync"/> just wrote for a <em>known</em>

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -598,6 +598,64 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
             "Restored .csproj must exactly match the pre-apply byte sequence, including its BOM and encoding.");
     }
 
+    /// <summary>
+    /// Regression guard for <c>mutation-write-paths-drop-original-encoding</c>: the FORWARD apply
+    /// half of the byte-fidelity contract. <c>apply_project_mutation</c> wrote the updated .csproj
+    /// through <c>AtomicFileWriter.WriteAllTextAsync</c> with no <see cref="Encoding"/>, so a
+    /// UTF-8-BOM or UTF-16 project file was silently re-encoded as UTF-8-no-BOM on every mutation —
+    /// the sibling revert test above only covers the restore path and passes either way.
+    /// The <c>utf8-nobom</c> row is the inverse guard: a file that had no BOM must not gain one.
+    /// </summary>
+    [TestMethod]
+    [DataRow("utf8-nobom")]
+    [DataRow("utf8-bom")]
+    [DataRow("utf16-bom")]
+    public async Task Apply_Project_Mutation_Preserves_Original_File_Encoding(string encodingKind)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var projectFilePath = workspace.GetPath("SampleLib", "SampleLib.csproj");
+
+        var originalContent = await File.ReadAllTextAsync(projectFilePath, CancellationToken.None);
+        Encoding encoding = encodingKind switch
+        {
+            "utf16-bom" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            _ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        };
+        var preamble = encoding.GetPreamble();
+
+        await File.WriteAllBytesAsync(
+            projectFilePath,
+            preamble.Concat(encoding.GetBytes(originalContent)).ToArray(),
+            CancellationToken.None);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preview = await ProjectMutationService.PreviewAddPackageReferenceAsync(
+            workspaceId,
+            new AddPackageReferenceDto("SampleLib", "Humanizer.Core", "2.14.1"),
+            CancellationToken.None);
+
+        var applyResult = await ProjectMutationService.ApplyProjectMutationAsync(preview.PreviewToken, CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+
+        var afterBytes = await File.ReadAllBytesAsync(projectFilePath, CancellationToken.None);
+        Assert.IsTrue(
+            afterBytes.AsSpan().StartsWith(preamble),
+            $"apply_project_mutation must re-emit the original {encodingKind} byte-order mark instead of rewriting the .csproj as UTF-8-no-BOM.");
+        if (preamble.Length == 0)
+        {
+            Assert.IsFalse(
+                afterBytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()),
+                "A .csproj that had no BOM must not gain one.");
+        }
+
+        StringAssert.Contains(
+            encoding.GetString(afterBytes, preamble.Length, afterBytes.Length - preamble.Length),
+            "Humanizer.Core",
+            "Sanity check: the mutation must be readable back through the original encoding.");
+    }
+
     [TestMethod]
     public async Task Set_Conditional_Property_Preview_Invalid_Condition_Error_Message_Includes_MSBuild_Quoting_Example()
     {


### PR DESCRIPTION
## Summary

Three mutation apply paths wrote pre-mutation content back to disk through BCL overloads whose `Encoding`-less form is UTF-8-no-BOM by definition, so `apply_text_edit`, `apply_project_mutation`, and `set_editorconfig_option` silently stripped a source file's original BOM/encoding on every apply. Each write now threads the file's detected encoding through.

## Linked issue

No GitHub Issue mirror — tracked only as backlog row `mutation-write-paths-drop-original-encoding` (spun off from the PR #1144 review).

Closes: mutation-write-paths-drop-original-encoding

## Changes

- `src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs` — `AtomicFileWriter.WriteAllTextAsync` gains an optional `Encoding? encoding` parameter, appended **after** the existing `logger` parameter so the positional-logger caller in `ApplyCompositeAsync` keeps binding correctly. Adds two `ResolveWriteEncoding` overloads plus a shared `Utf8NoBom` instance.
- `src/RoslynMcp.Roslyn/Services/EditService.cs` — `PersistDocumentTextToDiskAsync` keeps the `SourceText` object instead of collapsing it to a `string`, and threads `SourceText.Encoding` into the write.
- `src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs` — hoists the pre-apply bytes (already read for the undo snapshot) into a local and reuses them to resolve the write encoding.
- `src/RoslynMcp.Roslyn/Services/EditorConfigService.cs` — `File.WriteAllLines` now uses the `Encoding` overload, resolved from the already-in-scope `existingBytes`.

### Correctness notes

- **BOM-gating is load-bearing.** `CsprojSemanticEquality.CreateSnapshot` reports the BOM-emitting static `Encoding.UTF8` for a plain no-BOM UTF-8 file (that's the `StreamReader` fallback when no BOM is detected). `ResolveWriteEncoding(byte[]?)` gates on `HasPreamble` so a no-BOM file never *gains* one.
- **Roslyn's UTF-8 instance is normalized.** `SourceText.Encoding` for a no-BOM file is a `UTF8Encoding` built with `throwOnInvalidBytes: true`; passing it straight through would turn an unpaired surrogate into a mid-write `EncoderFallbackException` where the pre-fix path emitted U+FFFD. `ResolveWriteEncoding(Encoding?)` maps that case to the shared replacement-fallback instance.
- Omitting the new `encoding` argument preserves the historic UTF-8-no-BOM behavior byte-for-byte, so untouched callers are unaffected.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds
- [x] `dotnet test RoslynMcp.slnx` passes
- [x] Manually verified the behavior (described below)

Three new `[DataRow("utf8-nobom")] [DataRow("utf8-bom")] [DataRow("utf16-bom")]` tests — one per affected tool — assert the post-apply byte-order mark and read the mutated content back through the original encoding:

- `tests/RoslynMcp.Tests/ApplyTextEditVerifyTests.cs` → `ApplyTextEdit_PreservesOriginalFileEncoding`
- `tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs` → `Apply_Project_Mutation_Preserves_Original_File_Encoding`
- `tests/RoslynMcp.Tests/EditorConfigServiceTests.cs` → `SetOptionAsync_PreservesOriginalFileEncoding`

**Tests proven non-vacuous:** stashed the four production files, rebuilt, and re-ran the nine rows — the six BOM rows failed (`Assert.IsTrue(afterBytes.AsSpan().StartsWith(preamble))`) and the three `utf8-nobom` inverse guards passed, exactly as designed. Restored and re-verified green.

Full CI-parity run on the final tree: `./eng/verify-release.ps1 -Configuration Release` → **1869/1869 passed**, Release build 0 warnings / 0 errors, 18 changelog fragments valid. `./eng/verify-ai-docs.ps1` → passed.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — `AtomicFileWriter` is `internal`; the new parameter is optional and trailing.

## Backlog (maintainer-only)

- Closes backlog row: `mutation-write-paths-drop-original-encoding`

## Deliberately out of scope

Same root cause, no pre-apply encoding metadata available to thread through — flagged for follow-up rows rather than fixed here:

1. `CompositeApplyOrchestrator.ApplyCompositeAsync` (`apply_composite_preview`) — `CompositeFileMutation` carries no encoding, so wiring it up means touching preview-construction code in a different file.
2. `UndoService`'s `WriteAllTextAsync(..., OriginalText, ...)` fallback paths still lose encoding when `OriginalBytes` was not captured (pre-existing gap in PR #1144's scope).
3. `CsprojSemanticEquality.CreateSnapshot` is a generic byte→encoding detector despite its csproj-scoped name, and is now reused for `.editorconfig`/`.cs` paths — a rename to a neutral helper name is a reasonable follow-up.
