### PR TITLE
fix(workspace): correct overstated LRU-eviction reader-safety claims (lru-eviction-concurrent-reader-safety-overstated)

### DIFF
--- a/changelog.d/lru-eviction-concurrent-reader-safety-overstated.md
+++ b/changelog.d/lru-eviction-concurrent-reader-safety-overstated.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Corrected the LRU-eviction safety claims in `WorkspaceManager` and `ToolDispatch` that overstated protection for in-flight callers. The eviction scan skips only workspaces holding their `LoadLock` (i.e. mid-`workspace_load`/reload); it never consults `WorkspaceExecutionGate`'s per-workspace reader/writer lock, so a workspace with an in-flight read or write can still be evicted and disposed mid-operation, surfacing to that caller as `WorkspaceEvictedException`. Added a characterization test pinning the gap.

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -334,10 +334,24 @@ internal static class ToolDispatch
     /// workspaces") for the primary case this helper exists to fix, recovering nothing and
     /// replacing the caller's eviction envelope with a confusing cap-reached one.
     /// <see cref="EvictPolicy.Lru"/> makes room by evicting the current least-recently-used
-    /// session, and <c>WorkspaceManager</c>'s LRU scan already skips sessions holding their load
-    /// lock, so an in-flight workspace is never yanked out from under a concurrent caller. This
-    /// is exactly the recovery a caller would perform by hand
+    /// session. This is exactly the recovery a caller would perform by hand
     /// (<c>workspace_load(path, evictPolicy: "lru")</c>), just without the round trip.
+    /// </para>
+    /// <para>
+    /// <b>What the LRU scan does and does not protect
+    /// (<c>lru-eviction-concurrent-reader-safety-overstated</c>):</b> <c>WorkspaceManager</c>'s
+    /// eviction scan skips only sessions holding their <c>LoadLock</c>, which is acquired
+    /// exclusively while a <c>workspace_load</c>/reload is in flight. It does <b>not</b> consult
+    /// <c>WorkspaceExecutionGate</c>'s per-workspace reader/writer lock, so a workspace with
+    /// in-flight reads or writes can still be evicted and disposed mid-operation; that caller
+    /// observes <see cref="WorkspaceEvictedException"/> (a <see cref="KeyNotFoundException"/>) on
+    /// its next <c>WorkspaceManager</c> lookup. Earlier revisions of these remarks claimed an
+    /// in-flight workspace is never yanked out from under a concurrent caller — that guarantee
+    /// holds for the load path only, not for gated readers/writers. The gap is documented rather
+    /// than closed because <c>WorkspaceExecutionGate</c> already depends on
+    /// <c>IWorkspaceManager</c>, so gating eviction from inside <c>WorkspaceManager</c> would be a
+    /// DI cycle. Pinned by
+    /// <c>WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction</c>.
     /// </para>
     /// <para>
     /// A failed reload is deliberately not surfaced: the original eviction exception is richer

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -243,7 +243,28 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             {
                 // parallel-mode-workspace-cap-lru-or-raise: LRU eviction path.
                 // Pick the session with the smallest LastAccessedUtc, skipping any that
-                // currently hold their LoadLock (i.e. are actively being loaded or read).
+                // currently hold their LoadLock. LoadLock is acquired ONLY by
+                // LoadIntoSessionAsync, so this filter excludes exactly the sessions that are
+                // mid-workspace_load / mid-reload — and nothing else.
+                //
+                // lru-eviction-concurrent-reader-safety-overstated: the filter does NOT exclude
+                // a session with in-flight reads or writes. Ordinary tool calls serialise on
+                // WorkspaceExecutionGate's per-workspace reader/writer lock, which this scan
+                // never consults, so the Close() below can remove and dispose a session while a
+                // gated reader is still running against it. The in-flight caller then observes
+                // WorkspaceEvictedException (a KeyNotFoundException) on its next WorkspaceManager
+                // lookup, because Close() removes the session from _sessions and records the
+                // eviction before disposing it.
+                //
+                // Contrast workspace_close / workspace_reload (WorkspaceTools.cs), which nest
+                // gate.RunWriteAsync inside gate.RunLoadGateAsync so in-flight readers drain
+                // first. LRU eviction is the one lifecycle transition that skips that pattern:
+                // WorkspaceExecutionGate's constructor already takes IWorkspaceManager, so taking
+                // the gate from here would be a constructor-level DI cycle. Closing the gap means
+                // moving eviction *execution* (not just candidate selection) up into the gate
+                // layer. Characterised by
+                // WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction.
+                //
                 // If all sessions are locked, fall through to the Strict error path.
                 var lruCandidate = _sessions.Values
                     .Where(s => s.LoadLock.CurrentCount > 0)

--- a/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
@@ -13,6 +13,12 @@ namespace RoslynMcp.Tests;
 ///   <item><description><see cref="EvictPolicy.Lru"/> silently evicts the least-recently-used unlocked session when the cap is reached.</description></item>
 ///   <item><description><see cref="EvictPolicy.Strict"/> throws with <c>activeWorkspaces</c> and <c>lruCandidate</c> context.</description></item>
 /// </list>
+///
+/// <para>
+/// Also carries the <c>lru-eviction-concurrent-reader-safety-overstated</c> characterization
+/// guard: the LRU scan does not consult <see cref="WorkspaceExecutionGate"/>, so a workspace with
+/// a gated read in flight is still evicted underneath that reader.
+/// </para>
 /// </summary>
 [DoNotParallelize]
 [TestClass]
@@ -112,6 +118,101 @@ public sealed class WorkspaceCapLruEvictionTests
                 "Strict-mode error must include 'lruCandidate' field for agent self-recovery.");
             StringAssert.Contains(ex.Message, status1.WorkspaceId,
                 "The active workspace ID must appear in the error to identify the eviction candidate.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    /// <summary>
+    /// <c>lru-eviction-concurrent-reader-safety-overstated</c>: characterization guard pinning the
+    /// documented gap between the LRU eviction scan and <see cref="WorkspaceExecutionGate"/>.
+    ///
+    /// <para>
+    /// The scan filters candidates on <c>LoadLock.CurrentCount &gt; 0</c>. <c>LoadLock</c> is
+    /// acquired only by <c>LoadIntoSessionAsync</c>, so it excludes sessions that are mid-load —
+    /// and nothing else. It never consults the gate's per-workspace reader/writer lock, so a
+    /// workspace with a gated read in flight is evicted and disposed underneath that reader,
+    /// which then observes <see cref="WorkspaceEvictedException"/> on its next lookup
+    /// (<c>Close()</c> removes the session and records the eviction before disposing it, so
+    /// <c>GetRequiredSession</c> throws before any disposed <c>MSBuildWorkspace</c> is touched).
+    /// </para>
+    ///
+    /// <para>
+    /// This asserts the CURRENT (unsafe) behaviour deliberately. If the gap is ever closed — by
+    /// moving eviction execution up into the gate layer and taking
+    /// <c>IWorkspaceExecutionGate.RunWriteAsync</c> on the evicted candidate — this test must fail
+    /// and be rewritten to assert the eviction blocks until the reader drains.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction()
+    {
+        // Cap of 1 so a single loaded workspace saturates the semaphore and the second load
+        // must evict.
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+
+        // Real gate + real manager, wired exactly as production DI does.
+        var gate = new WorkspaceExecutionGate(
+            new ExecutionGateOptions { RequestTimeout = TimeSpan.FromMinutes(5) },
+            manager);
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var status1 = await manager.LoadAsync(path1, CancellationToken.None);
+
+            // Deterministic hand-off (no Task.Delay): readerHoldsLock signals that the gate's
+            // reader lock for workspace1 is held; evictionCompleted releases the reader only
+            // after the LRU eviction has already run.
+            var readerHoldsLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var evictionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var readerTask = gate.RunReadAsync<Exception?>(
+                status1.WorkspaceId,
+                async _ =>
+                {
+                    readerHoldsLock.SetResult();
+                    await evictionCompleted.Task;
+
+                    // Still inside the gated read — the reader lock has NOT been released. A
+                    // lifecycle transition that respected the gate could not have run yet.
+                    try
+                    {
+                        manager.GetProject(status1.WorkspaceId, "SampleLibrary");
+                        return null;
+                    }
+                    catch (Exception ex)
+                    {
+                        return ex;
+                    }
+                },
+                CancellationToken.None);
+
+            await readerHoldsLock.Task;
+
+            // THE GAP: the LRU scan ignores the gate, so this evicts workspace1 out from under
+            // the in-flight reader instead of waiting for it to drain.
+            var status2 = await manager.LoadAsync(path2, EvictPolicy.Lru, CancellationToken.None);
+
+            Assert.IsFalse(manager.ContainsWorkspace(status1.WorkspaceId),
+                "Characterization: LRU eviction currently ignores WorkspaceExecutionGate's reader "
+                + "lock and evicts a workspace that has a read in flight.");
+            Assert.IsTrue(manager.ContainsWorkspace(status2.WorkspaceId),
+                "The triggering load must have taken the slot freed by the eviction.");
+
+            evictionCompleted.SetResult();
+            var observed = await readerTask;
+
+            Assert.IsInstanceOfType<WorkspaceEvictedException>(observed,
+                "The in-flight reader must observe WorkspaceEvictedException on its next lookup — "
+                + "Close() removes the session from the live set and records the eviction before "
+                + "disposing it, so GetRequiredSession throws before any disposed MSBuildWorkspace "
+                + "is reached. Actual: " + (observed?.GetType().Name ?? "<no exception thrown>"));
         }
         finally
         {


### PR DESCRIPTION
## Summary

Two comments claimed LRU eviction never yanks a workspace out from under a concurrent caller. That guarantee holds only for the **load** path. `WorkspaceManager`'s eviction scan filters candidates on `LoadLock.CurrentCount > 0`, and `LoadLock` is acquired exclusively by `LoadIntoSessionAsync` — so the filter excludes exactly the sessions that are mid-`workspace_load`/reload and nothing else. It never consults `WorkspaceExecutionGate`'s per-workspace reader/writer lock, so `Close()` can remove and dispose a session while a gated read is still in flight.

This PR corrects both comments to state the real guarantee and pins the gap with a characterization test.

## Linked issue

No GitHub issue mirrors this backlog row.

## Changes

- `src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs` — rewrote the LRU eviction-scan comment. Removed the false parenthetical *"(i.e. are actively being loaded or read)"*; states precisely what `LoadLock` covers, that gated readers/writers are **not** excluded, the observable failure shape, and the contrast with `workspace_close`/`workspace_reload` (`WorkspaceTools.cs`), which nest `gate.RunWriteAsync` inside `gate.RunLoadGateAsync` so readers drain first.
- `src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs` — rewrote the `TryReloadEvictedWorkspaceForRetryAsync` remarks. Dropped the *"never yanked out from under a concurrent caller"* clause from the `EvictPolicy.Lru` rationale and added a dedicated `<para>` naming what the scan does and does not protect, the observable shape, and why the gap is documented rather than closed.
- `tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs` — added `LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction`, a characterization test wiring a real `WorkspaceExecutionGate` + `WorkspaceManager` (production DI shape).
- `changelog.d/lru-eviction-concurrent-reader-safety-overstated.md` — new fragment (`category: Fixed`).

### Why documented rather than fixed

The real fix requires the eviction step to take the evicted candidate's write lock via `IWorkspaceExecutionGate.RunWriteAsync` before `Close()`. `WorkspaceExecutionGate`'s constructor already takes `IWorkspaceManager`, so injecting the gate into `WorkspaceManager` is a direct constructor-level DI cycle. The only clean fix moves eviction *execution* (not just candidate selection) up into the gate layer — surgery on `LoadAsync`'s `goto slotAcquired`/`goto strictError` retry loop, L-sized and out of scope for this M row. The backlog row's own acceptance criteria sanction the documentation+pin path as a complete resolution.

### Correction to the plan's stated failure shape

The plan asserted the in-flight reader would see `ObjectDisposedException` via `WorkspaceManager.GetProject`. Re-derived against live source: `Close()` does `_sessions.TryRemove` + `RecordEviction` **before** `session.Dispose()`, so `GetProject`'s first statement (`GetRequiredSession`) throws `WorkspaceEvictedException` (a `KeyNotFoundException`) before any disposed `MSBuildWorkspace` is reached. The test and both comments describe the shape that actually occurs.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` succeeds — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~WorkspaceCapLruEvictionTests"` passes — 4/4, run **3×** consecutively to rule out race flakiness (the test uses `TaskCompletionSource` hand-off, never `Task.Delay`)
- [x] `./eng/verify-ai-docs.ps1` passes
- [x] Grepped `src/` for both stale phrases (`yanked`, `actively being loaded or read`) post-edit — no remaining stale copies

The three pre-existing tests in the file (`DefaultMaxConcurrentWorkspaces_Is_16`, `LruEviction_WhenCapReached_EvictsLeastRecentlyUsed_AndSucceeds`, `StrictEviction_WhenCapReached_Throws_WithDiagnosticContext`) are unmodified and still pass.

`verify-release.ps1` was not run locally: a self-hosted CI runner services this box, and a concurrently-running test process was observed wiping the shared `%TEMP%\RoslynMcpTests` root mid-run. CI is the authoritative gate here.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — none; comment/XML-doc-only production changes plus one test

## Backlog (maintainer-only)

- Closes backlog row: `lru-eviction-concurrent-reader-safety-overstated`

Closes: lru-eviction-concurrent-reader-safety-overstated
