### PR TITLE
fix(compile-check): normalize whitespace-only projectFilter to null

### DIFF
--- a/changelog.d/compile-check-project-filter-normalize.md
+++ b/changelog.d/compile-check-project-filter-normalize.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `compile_check`'s `projectFilter` handling is now normalized once at `CheckAsync` entry so a whitespace-only `projectName` is treated as "no filter" consistently across `ProjectFilterHelper.FilterProjects`, scope classification (`requestedScope`/`actualScope`), and the zero-projects hint — previously it was silently matched as a literal (nonexistent) project name, producing `actualScope:"solution"` alongside `TotalProjects:0`.

--- a/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
@@ -39,6 +39,7 @@ public sealed class CompileCheckService : ICompileCheckService
         CancellationToken ct)
     {
         var (projectFilter, emitValidation, severityFilter, fileFilter, offset, limit, fileFilters) = options;
+        projectFilter = string.IsNullOrWhiteSpace(projectFilter) ? null : projectFilter;
         var sw = Stopwatch.StartNew();
         var solution = _workspace.GetCurrentSolution(workspaceId);
 

--- a/tests/RoslynMcp.Tests/CompileCheckServiceTests.cs
+++ b/tests/RoslynMcp.Tests/CompileCheckServiceTests.cs
@@ -65,4 +65,28 @@ public sealed class CompileCheckServiceTests : IsolatedWorkspaceTestBase
         Assert.AreNotEqual(result.RequestedScope, result.ActualScope,
             "A widened file scope must be detectable structurally, not only by parsing restoreHint.");
     }
+
+    [TestMethod]
+    public async Task CheckAsync_WhitespaceOnlyProjectFilterWithMultiProjectFiles_NoLongerMisreportsSolutionScope()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+        var programPath = workspace.GetPath("SampleApp", "Program.cs");
+
+        var result = await CompileCheckService.CheckAsync(
+            workspace.WorkspaceId,
+            new CompileCheckOptions(
+                SeverityFilter: "Error",
+                ProjectFilter: " ",
+                FileFilters: [dogPath, programPath]),
+            CancellationToken.None);
+
+        Assert.IsTrue(result.TotalProjects > 1,
+            "A whitespace-only projectFilter must be treated as no filter, not as a literal (nonexistent) project name.");
+        Assert.AreEqual("solution", result.ActualScope);
+        Assert.AreEqual("files", result.RequestedScope,
+            "Whitespace-only projectFilter must not be classified as a project-scoped request.");
+        StringAssert.Contains(result.RestoreHint, "file filter fallback");
+    }
 }


### PR DESCRIPTION
## Summary
- `CheckAsync` now normalizes `projectFilter` (whitespace-only -> `null`) once at entry, immediately after destructuring `options`.
- This makes every downstream consumer within `CheckAsync`'s scope — `ResolveProjectScope` (-> `ProjectFilterHelper.FilterProjects`), `ComputeRequestedScope`, and `BuildHint` — treat a whitespace-only `projectName` as "no filter" consistently.
- Previously, `ProjectFilterHelper.FilterProjects`'s bare `is null` check matched whitespace as a literal (nonexistent) project name, matching **zero** projects, while `ResolveProjectScope`'s own gate (`IsNullOrWhiteSpace`) treated the same input as "no filter" and took the multi-project file-fallback branch. The result: `TotalProjects=0` while `fileScopeHint` was non-null, so `ActualScope` reported `"solution"` alongside `TotalProjects:0` — a silently-vacuous "success-shaped" scope report.
- No public signature changes; `CompileCheckOptions.ProjectFilter` and `ICompileCheckService.CheckAsync` are untouched. `ProjectFilterHelper.cs`'s own null-check and `CompileCheckTools.cs`'s tool-layer guard are unchanged — both are already correct once they never receive whitespace.

## Test plan
- [x] Added `CheckAsync_WhitespaceOnlyProjectFilterWithMultiProjectFiles_NoLongerMisreportsSolutionScope` to `tests/RoslynMcp.Tests/CompileCheckServiceTests.cs`, passing `ProjectFilter: " "` with `FileFilters` spanning `SampleLib` + `SampleApp`; asserts `TotalProjects > 1` and `ActualScope == "solution"` together (the exact prior misreport) plus `RequestedScope == "files"`.
- [x] `mcp__roslyn__compile_check` on `RoslynMcp.Roslyn` and `RoslynMcp.Tests` — clean, 0 errors/warnings.
- [x] `dotnet test --filter FullyQualifiedName~CompileCheckServiceTests` — 3/3 passed (2 pre-existing scope tests unmodified + 1 new regression test).
- [ ] Full CI (`verify-release.ps1` equivalent) runs on this PR — not duplicated locally per repo policy (self-hosted runner already active on this box).

Closes: compile-check-project-filter-normalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)