### PR TITLE
test(undo): assert apply mutated file before revert in byte-fidelity tests

### DIFF
--- a/changelog.d/undo-tests-assert-vacuous-noop-protection.md
+++ b/changelog.d/undo-tests-assert-vacuous-noop-protection.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Hardened the three byte-fidelity undo regression tests (added in PR #1144) to assert the apply actually mutated the file before revert, closing a vacuous-pass gap where a future no-op regression on the undo path would have left them green.

--- a/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs
@@ -79,14 +79,17 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
         await File.WriteAllBytesAsync(dogFilePath, originalBytes, CancellationToken.None);
         await workspace.ReloadAsync(CancellationToken.None);
 
-        var lines = originalText.Split('\n');
-        var lastLine = lines.Length;
-        var lastColumn = lines[^1].Length + 1;
-        var edit = new TextEditDto(lastLine, lastColumn, lastLine, lastColumn, "\n// inserted by test");
+        var edit = AppendCommentEdit(originalText, "// inserted by test");
 
         var result = await EditService.ApplyTextEditsAsync(
             workspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
         Assert.IsTrue(result.Success, "ApplyTextEditsAsync should report success.");
+
+        var afterApplyBytes = await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None);
+        CollectionAssert.AreNotEqual(
+            originalBytes,
+            afterApplyBytes,
+            "Sanity check: apply must have mutated the file before revert is meaningful.");
 
         var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
         Assert.IsTrue(reverted, "Revert should succeed.");
@@ -180,6 +183,17 @@ public sealed class EditUndoIntegrationTests : IsolatedWorkspaceTestBase
 
         var dto = await EditService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, "apply_multi_file_edit", CancellationToken.None);
         Assert.IsTrue(dto.Success);
+
+        var afterApplyDogBytes = await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None);
+        var afterApplyCatBytes = await File.ReadAllBytesAsync(catFilePath, CancellationToken.None);
+        CollectionAssert.AreNotEqual(
+            originalDogBytes,
+            afterApplyDogBytes,
+            "Sanity check: apply must have mutated Dog.cs before revert is meaningful.");
+        CollectionAssert.AreNotEqual(
+            originalCatBytes,
+            afterApplyCatBytes,
+            "Sanity check: apply must have mutated Cat.cs before revert is meaningful.");
 
         var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
         Assert.IsTrue(reverted, "Multi-file revert should succeed.");

--- a/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs
@@ -589,6 +589,12 @@ public sealed class ProjectMutationIntegrationTests : IsolatedWorkspaceTestBase
         var applyResult = await ProjectMutationService.ApplyProjectMutationAsync(preview.PreviewToken, CancellationToken.None);
         Assert.IsTrue(applyResult.Success, applyResult.Error);
 
+        var postApplyBytes = await File.ReadAllBytesAsync(projectFilePath, CancellationToken.None);
+        CollectionAssert.AreNotEqual(
+            originalBytes,
+            postApplyBytes,
+            "Sanity check: apply must have mutated the .csproj before revert is meaningful.");
+
         var reverted = await UndoService.RevertAsync(workspaceId, CancellationToken.None);
         Assert.IsTrue(reverted, "revert_last_apply must succeed.");
 


### PR DESCRIPTION
## Summary

Three of the four byte-fidelity undo regression tests added in PR #1144 asserted only `result.Success` then post-revert byte-equality, never that the apply actually mutated the file in between — a future no-op regression on the undo path would have left them green. This adds intermediate `CollectionAssert.AreNotEqual` sanity checks (mirroring the sibling test's existing pre/post-apply diff check) and dedupes the inlined `TextEditDto` construction in `ApplyTextEdit_ThenRevert_RestoresOriginalBytes` to reuse the existing `AppendCommentEdit` helper.

- `tests/RoslynMcp.Tests/EditUndoIntegrationTests.cs`: `ApplyTextEdit_ThenRevert_RestoresOriginalBytes` and `ApplyMultiFileEdit_ThenRevert_RestoresOriginalBytes` now assert post-apply bytes differ from pre-apply bytes before reverting.
- `tests/RoslynMcp.Tests/ProjectMutationIntegrationTests.cs`: `Apply_Project_Mutation_Then_Revert_Restores_Original_Bytes` now asserts post-apply bytes differ from pre-apply bytes before reverting.

Test-only change — zero production files touched.

## Test plan

- [x] `mcp__roslyn__compile_check` on both edited test files — clean, 0 errors.
- [x] `mcp__roslyn__test_run --filter "FullyQualifiedName~EditUndoIntegrationTests|FullyQualifiedName~ProjectMutationIntegrationTests"` — 39/39 passed.
- [x] Regression-catching property manually verified: temporarily short-circuited `ApplyTextEdit_ThenRevert_RestoresOriginalBytes`'s post-apply read to a byte-identical no-op — new `CollectionAssert.AreNotEqual` failed as expected, confirming it catches the vacuous-pass scenario. Change reverted before commit.
- [x] `./eng/verify-ai-docs.ps1` — passed.

Closes: `undo-tests-assert-vacuous-noop-protection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)