### PR TITLE
refactor(host-stdio): consolidate error-envelope literals into BuildErrorEnvelope

### DIFF
--- a/changelog.d/tool-error-handler-envelope-duplication.md
+++ b/changelog.d/tool-error-handler-envelope-duplication.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** consolidated the five duplicated error-envelope anonymous-object literals in `ToolErrorHandler.FormatErrorResponse` into a single `BuildErrorEnvelope` helper — no observable behavior change; adding a new structured error field going forward is now a one-line call instead of a new literal.

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -507,89 +507,80 @@ internal static class ToolErrorHandler
         return string.Join("\n", frames);
     }
 
+    /// <summary>
+    /// tool-error-handler-envelope-duplication: single constructor for the JSON error envelope.
+    /// Emits the five base properties (<c>error</c>, <c>category</c>, <c>tool</c>, <c>message</c>,
+    /// <c>exceptionType</c>) in a fixed order, then optionally one structured extra field appended
+    /// last — the same shape the per-branch anonymous-object literals used to produce. Adding a new
+    /// structured error field is a call-site argument, not a sixth copy of the envelope.
+    /// </summary>
+    /// <param name="extraFieldName">
+    /// camelCase key for the extra field, or <see langword="null"/> to emit the bare envelope. The
+    /// key is written verbatim — <see cref="JsonDefaults.Indented"/>'s naming policy applies only to
+    /// the serialized <paramref name="extraFieldValue"/>, never to <see cref="JsonObject"/> keys.
+    /// </param>
+    /// <param name="extraFieldValue">
+    /// Value for the extra field, serialized with the shared options so nested records/lists keep the
+    /// camelCase + enum-as-string shape. Declared <see cref="object"/> so the runtime type drives
+    /// serialization (e.g. <c>List&lt;T&gt;</c> extras stay arrays of objects).
+    /// </param>
+    private static string BuildErrorEnvelope(
+        ErrorInfo info,
+        string toolName,
+        Exception ex,
+        string? extraFieldName = null,
+        object? extraFieldValue = null)
+    {
+        var envelope = new JsonObject
+        {
+            ["error"] = true,
+            ["category"] = info.Category,
+            ["tool"] = toolName,
+            ["message"] = info.Message,
+            ["exceptionType"] = ex.GetType().Name,
+        };
+
+        if (extraFieldName is not null)
+        {
+            envelope[extraFieldName] = JsonSerializer.SerializeToNode(extraFieldValue, JsonDefaults.Indented);
+        }
+
+        return envelope.ToJsonString(JsonDefaults.Indented);
+    }
+
     internal static string FormatErrorResponse(ErrorInfo info, string toolName, Exception ex)
     {
         if (info.Category == "InternalError")
         {
-            var error = new
-            {
-                error = true,
-                category = info.Category,
-                tool = toolName,
-                message = info.Message,
-                exceptionType = ex.GetType().Name,
-                stackTrace = GetAbbreviatedStackTrace(ex),
-            };
-            return JsonSerializer.Serialize(error, JsonDefaults.Indented);
+            return BuildErrorEnvelope(info, toolName, ex, "stackTrace", GetAbbreviatedStackTrace(ex));
         }
-        else
+
+        if (ex is SymbolNotFoundException { ClosestMatches.Count: > 0 } symbolNotFound)
         {
-            if (ex is SymbolNotFoundException { ClosestMatches.Count: > 0 } symbolNotFound)
-            {
-                var error = new
-                {
-                    error = true,
-                    category = info.Category,
-                    tool = toolName,
-                    message = info.Message,
-                    exceptionType = ex.GetType().Name,
-                    closestMatches = symbolNotFound.ClosestMatches,
-                };
-                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
-            }
-
-            // extract-type-preview-refusal-missing-blocking-deps: mirror the closestMatches
-            // treatment above for extract_type_preview's refusals — the prose message and the
-            // InvalidOperation category are unchanged; the envelope just gains the structured
-            // per-member blocking data the refusal was computed from.
-            if (ex is ExtractTypeBlockingDependencyException { BlockingDependencies.Count: > 0 } blockedExtraction)
-            {
-                var error = new
-                {
-                    error = true,
-                    category = info.Category,
-                    tool = toolName,
-                    message = info.Message,
-                    exceptionType = ex.GetType().Name,
-                    blockingDependencies = blockedExtraction.BlockingDependencies,
-                };
-                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
-            }
-
-            // inv-arg-envelope-schema-hint: attach a one-line schema hint for InvalidArgument
-            // envelopes so cold-context callers can re-call without round-tripping through
-            // server_info. Hint is omitted (rather than emitted as null) when the failing
-            // parameter cannot be resolved against the tool catalog — keeps the envelope
-            // shape stable for downstream parsers that do not expect the field.
-            var schemaHint = info.Category == "InvalidArgument"
-                ? BuildSchemaHint(toolName, info.ParamName)
-                : null;
-            if (schemaHint is not null)
-            {
-                var error = new
-                {
-                    error = true,
-                    category = info.Category,
-                    tool = toolName,
-                    message = info.Message,
-                    exceptionType = ex.GetType().Name,
-                    schemaHint,
-                };
-                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
-            }
-            else
-            {
-                var error = new
-                {
-                    error = true,
-                    category = info.Category,
-                    tool = toolName,
-                    message = info.Message,
-                    exceptionType = ex.GetType().Name,
-                };
-                return JsonSerializer.Serialize(error, JsonDefaults.Indented);
-            }
+            return BuildErrorEnvelope(info, toolName, ex, "closestMatches", symbolNotFound.ClosestMatches);
         }
+
+        // extract-type-preview-refusal-missing-blocking-deps: mirror the closestMatches
+        // treatment above for extract_type_preview's refusals — the prose message and the
+        // InvalidOperation category are unchanged; the envelope just gains the structured
+        // per-member blocking data the refusal was computed from.
+        if (ex is ExtractTypeBlockingDependencyException { BlockingDependencies.Count: > 0 } blockedExtraction)
+        {
+            return BuildErrorEnvelope(info, toolName, ex, "blockingDependencies", blockedExtraction.BlockingDependencies);
+        }
+
+        // inv-arg-envelope-schema-hint: attach a one-line schema hint for InvalidArgument
+        // envelopes so cold-context callers can re-call without round-tripping through
+        // server_info. Hint is omitted (rather than emitted as null) when the failing
+        // parameter cannot be resolved against the tool catalog — keeps the envelope
+        // shape stable for downstream parsers that do not expect the field.
+        var schemaHint = info.Category == "InvalidArgument"
+            ? BuildSchemaHint(toolName, info.ParamName)
+            : null;
+
+        return schemaHint is not null
+            ? BuildErrorEnvelope(info, toolName, ex, "schemaHint", schemaHint)
+            : BuildErrorEnvelope(info, toolName, ex);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`ToolErrorHandler.FormatErrorResponse` built the JSON error envelope from **five near-identical anonymous-object literals**, each repeating the same five base properties (`error`, `category`, `tool`, `message`, `exceptionType`) and differing only in one appended structured field:

| Branch | Extra field |
|---|---|
| `InternalError` | `stackTrace` |
| `SymbolNotFoundException` w/ matches | `closestMatches` |
| `ExtractTypeBlockingDependencyException` w/ deps | `blockingDependencies` (added by #1138) |
| `InvalidArgument` w/ resolvable hint | `schemaHint` |
| fallback | *(none)* |

Every future structured field cost a sixth copy of the literal.

## Change

- New private `BuildErrorEnvelope(ErrorInfo, string toolName, Exception, string? extraFieldName = null, object? extraFieldValue = null)` composes a `JsonObject` with the five base properties **in the existing order**, then conditionally appends one extra property via `JsonSerializer.SerializeToNode(extraFieldValue, JsonDefaults.Indented)`.
- `FormatErrorResponse` collapses to a straight-line dispatch (5 branches -> 5 one-line calls); its signature and all three call sites are untouched.
- `JsonObject` insertion order is guaranteed and its keys are literal already-camelCase strings, so property order, casing, and `WriteIndented` output are byte-identical. Nested extra-field values still flow through the same options object, preserving the camelCase + `JsonStringEnumConverter` shape for `List<T>` extras.
- `extraFieldValue` is declared `object?` so the runtime type drives serialization (`ClosestMatches` / `BlockingDependencies` stay arrays of objects).
- Preserved contracts: `stackTrace` is still emitted when `GetAbbreviatedStackTrace` returns `""`; `schemaHint` stays *omitted* (not null) when `BuildSchemaHint` returns null; the `extract-type-preview-refusal-missing-blocking-deps` comment stays with its branch.

No behavior change, no public/internal signature change, no new type.

## Validation

- `mcp__roslyn__compile_check` on `ToolErrorHandler.cs` — 0 errors, 0 warnings (after `dotnet build RoslynMcp.slnx`: Build succeeded, 0 warnings).
- `mcp__roslyn__test_run --filter "ErrorResponseObservabilityTests|StructuredCallToolFilterTests|WorkspaceReloadedNotFoundConflationTests|ValidationToolsIntegrationTests"` — 43/44 passed. These four suites are the complete set of files referencing `FormatErrorResponse`/`ClassifyAndFormat`.
- The single failure, `ValidationToolsIntegrationTests.CompileCheck_Service_GetDiagnostics_Succeeds_For_SampleSolution` ("Sample solution should compile without errors. Got 31 error(s)."), is **pre-existing and unrelated** — reproduced identically on the untouched baseline tree (`git stash` + rerun) before this change. It is a test-fixture sample-solution restore issue, not an envelope issue.
- `./eng/verify-ai-docs.ps1` — passed. `./eng/verify-changelog-fragments.ps1` — 23 fragments valid.

## Notes

Design alternative considered and rejected: a `Dictionary<string, object?>` base instead of `JsonObject` — `Dictionary` enumeration order is an implementation detail, whereas `JsonObject` insertion order is a documented guarantee, and `JsonObject` composes with `SerializeToNode` without a boxing/re-serialize step.

Deliberately untouched (separate post-hoc `JsonNode` mutators, not envelope constructors): `InjectMetaIfPossible`, `InjectSchemaHintIfPossible`, `BuildSchemaHint`.

Closes: tool-error-handler-envelope-duplication

Generated with [Claude Code](https://claude.com/claude-code)
