### PR TITLE
Log swallowed workspace-eviction retry reload failure

### DIFF
--- a/changelog.d/workspace-eviction-retry-swallowed-log.md
+++ b/changelog.d/workspace-eviction-retry-swallowed-log.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the workspace-eviction auto-retry seam (`compile_check`/`test_run`) now logs the swallowed reload failure (deleted `LoadedPath`, cap-saturated reload) via an optional DI-bound `ILoggerFactory`, matching the `workspace_load` logging pattern — a failed auto-recovery is no longer silent. Fallback behavior (rethrow of the original error) is unchanged.

--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -33,6 +34,7 @@ public static class CompileCheckTools
         [Description("Number of diagnostics to skip before returning results (default: 0)")] int offset = 0,
         [Description("Maximum number of diagnostics to return (default: 50)")] int limit = 50,
         IWorkspaceManager? workspaceManager = null,
+        ILoggerFactory? loggerFactory = null,
         CancellationToken ct = default)
     {
         ParameterValidation.ValidateSeverity(severity);
@@ -63,7 +65,8 @@ public static class CompileCheckTools
 
                 return result;
             },
-            ct);
+            ct,
+            loggerFactory);
     }
 
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
 
@@ -29,6 +30,12 @@ namespace RoslynMcp.Host.Stdio.Tools;
 ///   <item><see cref="ReadByWorkspaceIdAsync{TDto}(IWorkspaceExecutionGate, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>
 ///     — read-only tools that accept an explicit <c>workspaceId</c> and run under the
 ///     per-workspace read gate.
+///   </item>
+///   <item><see cref="ReadByWorkspaceIdWithEvictionRetryAsync{TDto}(IWorkspaceExecutionGate, IWorkspaceManager?, string, Func{string, CancellationToken, Task{TDto}}, CancellationToken, ILoggerFactory?)"/>
+///     — eviction-tolerant variant of <see cref="ReadByWorkspaceIdAsync{TDto}(IWorkspaceExecutionGate, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>
+///     for read-only tools (<c>compile_check</c>) that should transparently rehydrate an
+///     evicted workspace from its recorded <c>LoadedPath</c> and retry the read once, instead
+///     of surfacing the miss to the caller.
 ///   </item>
 /// </list>
 /// </para>
@@ -254,13 +261,18 @@ internal static class ToolDispatch
     /// the retry leg must run against the post-reload id.
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>
+    /// <param name="loggerFactory">
+    /// Optional DI-bound logger factory used to log a swallowed reload failure during the
+    /// eviction-retry attempt, or <see langword="null"/> to skip logging (direct/test callers).
+    /// </param>
     /// <returns>The DTO serialized with <see cref="JsonDefaults.Indented"/>.</returns>
     public static async Task<string> ReadByWorkspaceIdWithEvictionRetryAsync<TDto>(
         IWorkspaceExecutionGate gate,
         IWorkspaceManager? workspaceManager,
         string workspaceId,
         Func<string, CancellationToken, Task<TDto>> serviceCall,
-        CancellationToken ct)
+        CancellationToken ct,
+        ILoggerFactory? loggerFactory = null)
     {
         try
         {
@@ -269,7 +281,7 @@ internal static class ToolDispatch
         }
         catch (KeyNotFoundException ex) when (workspaceManager is not null)
         {
-            var reloadedId = await TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct)
+            var reloadedId = await TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct, loggerFactory)
                 .ConfigureAwait(false);
             if (reloadedId is null)
             {
@@ -354,16 +366,29 @@ internal static class ToolDispatch
     /// <c>WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction</c>.
     /// </para>
     /// <para>
-    /// A failed reload is deliberately not surfaced: the original eviction exception is richer
-    /// (it carries the id, the recorded path, and a copy-pasteable <c>workspace_load</c> recovery
-    /// hint), and the caller rethrows it, so no diagnostic is lost.
+    /// A failed reload is not additionally surfaced by this helper: the caller rethrows the
+    /// original failure it was given, unchanged. That original failure is only richly
+    /// diagnostic — carrying the id, the recorded path, and a copy-pasteable
+    /// <c>workspace_load</c> recovery hint — when it arrived here already as a
+    /// <see cref="WorkspaceEvictedException"/> (the mid-call case). On the more common
+    /// gate-precheck miss the caller instead rethrows the bare <see cref="KeyNotFoundException"/>
+    /// the gate raised, which carries no eviction context at all — on that path a failed reload
+    /// previously left no trace anywhere. This helper now logs the reload failure itself
+    /// (the evicted workspace id, the recorded <c>LoadedPath</c>, and the reload exception) via
+    /// the optional <paramref name="loggerFactory"/>, so the failure is no longer silent on
+    /// either path.
     /// </para>
     /// </remarks>
+    /// <param name="loggerFactory">
+    /// Optional DI-bound logger factory used to log a reload failure, or
+    /// <see langword="null"/> to skip logging (direct/test callers).
+    /// </param>
     internal static async Task<string?> TryReloadEvictedWorkspaceForRetryAsync(
         IWorkspaceManager workspaceManager,
         string workspaceId,
         KeyNotFoundException failure,
-        CancellationToken ct)
+        CancellationToken ct,
+        ILoggerFactory? loggerFactory = null)
     {
         var evicted = failure as WorkspaceEvictedException
             ?? TryReclassifyAsEvicted(workspaceManager, workspaceId);
@@ -383,9 +408,19 @@ internal static class ToolDispatch
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            CreateLogger(loggerFactory)?.LogWarning(
+                ex,
+                "Failed to rehydrate evicted workspace {WorkspaceId} from LoadedPath \"{LoadedPath}\": {ExceptionType}: {ExceptionMessage}",
+                workspaceId,
+                loadedPath,
+                ex.GetType().Name,
+                ex.Message);
             return null;
         }
     }
+
+    private static ILogger? CreateLogger(ILoggerFactory? loggerFactory) =>
+        loggerFactory?.CreateLogger(typeof(ToolDispatch).FullName ?? nameof(ToolDispatch));
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
@@ -198,9 +199,10 @@ public static class ValidationTools
         [Description("Optional: dotnet test filter expression")] string? filter = null,
         IProgress<ProgressNotificationValue>? progress = null,
         IWorkspaceManager? workspaceManager = null,
+        ILoggerFactory? loggerFactory = null,
         CancellationToken ct = default)
         => RunTestsWithEvictionRetryAsync(
-            gate, testRunnerService, workspaceManager, workspaceId, projectName, filter, progress, ct);
+            gate, testRunnerService, workspaceManager, workspaceId, projectName, filter, progress, loggerFactory, ct);
 
     /// <summary>
     /// <c>workspace-eviction-no-auto-retry-on-tool-call</c> — runs <c>test_run</c> once and, when
@@ -238,6 +240,7 @@ public static class ValidationTools
         string? projectName,
         string? filter,
         IProgress<ProgressNotificationValue>? progress,
+        ILoggerFactory? loggerFactory,
         CancellationToken ct)
     {
         try
@@ -249,7 +252,7 @@ public static class ValidationTools
         {
             var reloadedId = workspaceManager is null
                 ? null
-                : await ToolDispatch.TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct)
+                : await ToolDispatch.TryReloadEvictedWorkspaceForRetryAsync(workspaceManager, workspaceId, ex, ct, loggerFactory)
                     .ConfigureAwait(false);
 
             if (reloadedId is null)

--- a/tests/RoslynMcp.Tests/WorkspaceEvictionAutoRetryTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceEvictionAutoRetryTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -418,6 +419,112 @@ public sealed class WorkspaceEvictionAutoRetryTests
     }
 
     /// <summary>
+    /// <c>workspace-eviction-retry-swallowed-log</c> — a failed rehydration reload must now emit
+    /// a Warning-or-higher log entry (via the optional <see cref="ILoggerFactory"/>) referencing
+    /// the evicted workspace id, in addition to the pre-existing byte-for-byte-preserved fallback
+    /// behaviour (the original NotFound envelope is unchanged).
+    /// </summary>
+    [TestMethod]
+    public async Task CompileCheck_EvictedWorkspace_RehydrationReloadFails_LogsWarning()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var compileCheckService = new CompileCheckService(manager, NullLogger<CompileCheckService>.Instance);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+        var logger = new RecordingLogger();
+        var loggerFactory = new RecordingLoggerFactory(logger);
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            // Make the recorded LoadedPath unloadable so the rehydration attempt fails.
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+
+            var json = await ToolExecutionTestHarness.RunAsync(
+                "compile_check",
+                () => CompileCheckTools.CompileCheck(
+                    gate,
+                    compileCheckService,
+                    workspaceId: evictedId,
+                    workspaceManager: manager,
+                    loggerFactory: loggerFactory,
+                    ct: CancellationToken.None));
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("error", out var errorProp) && errorProp.GetBoolean(),
+                $"A failed reload must still surface the original NotFound envelope unchanged. Actual: {json}");
+            Assert.AreEqual("NotFound", root.GetProperty("category").GetString(),
+                $"Fallback behaviour must be byte-for-byte preserved — only a log emission is added. Actual: {json}");
+
+            Assert.AreEqual(1,
+                logger.Entries.Count(e =>
+                    e.Level >= LogLevel.Warning && e.Message.Contains(evictedId, StringComparison.Ordinal)),
+                $"Expected exactly one Warning-or-higher log entry referencing the evicted workspace id. Entries: {string.Join(" | ", logger.Entries.Select(e => $"[{e.Level}] {e.Message}"))}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    /// <summary>
+    /// <c>workspace-eviction-retry-swallowed-log</c> — the <c>test_run</c> analogue of
+    /// <see cref="CompileCheck_EvictedWorkspace_RehydrationReloadFails_LogsWarning"/>: a failed
+    /// rehydration reload must log a Warning-or-higher entry while the original
+    /// <see cref="KeyNotFoundException"/> still propagates unchanged.
+    /// </summary>
+    [TestMethod]
+    public async Task RunTests_EvictedWorkspace_RehydrationReloadFails_LogsWarning()
+    {
+        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        var gate = new WorkspaceExecutionGate(new ExecutionGateOptions(), manager);
+        var runner = new RecordingTestRunnerService();
+        var logger = new RecordingLogger();
+        var loggerFactory = new RecordingLoggerFactory(logger);
+
+        var path1 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+        var path2 = TestFixtureFileSystem.CreateSampleSolutionCopy(s_repositoryRootPath, s_sampleSolutionPath);
+
+        try
+        {
+            var evictedId = await StageEvictionAsync(manager, path1, path2);
+
+            // Make the recorded LoadedPath unloadable so the rehydration attempt fails.
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+
+            await Assert.ThrowsExactlyAsync<KeyNotFoundException>(
+                () => ValidationTools.RunTests(
+                    gate,
+                    runner,
+                    workspaceId: evictedId,
+                    projectName: null,
+                    filter: null,
+                    progress: null,
+                    workspaceManager: manager,
+                    loggerFactory: loggerFactory,
+                    ct: CancellationToken.None));
+
+            Assert.AreEqual(0, runner.ObservedWorkspaceIds.Count,
+                "A failed rehydration must not run the suite against some other session.");
+
+            Assert.AreEqual(1,
+                logger.Entries.Count(e =>
+                    e.Level >= LogLevel.Warning && e.Message.Contains(evictedId, StringComparison.Ordinal)),
+                $"Expected exactly one Warning-or-higher log entry referencing the evicted workspace id. Entries: {string.Join(" | ", logger.Entries.Select(e => $"[{e.Level}] {e.Message}"))}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path1)!);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(Path.GetDirectoryName(path2)!);
+        }
+    }
+
+    /// <summary>
     /// Loads <paramref name="path1"/> into the (cap-saturated) manager, then LRU-loads
     /// <paramref name="path2"/> so the first session is evicted with a recoverable eviction
     /// record. Returns the now-evicted workspace id.
@@ -500,4 +607,41 @@ public sealed class WorkspaceEvictionAutoRetryTests
             throw _eviction;
         }
     }
+
+    /// <summary>
+    /// Copied from <c>WorkspaceCloseDrainTests.cs</c> — a minimal <see cref="ILoggerFactory"/>
+    /// that always resolves to the single <see cref="RecordingLogger"/> it wraps, so the test can
+    /// assert on emitted log entries regardless of the category name the caller requests.
+    /// </summary>
+    private sealed class RecordingLoggerFactory(RecordingLogger logger) : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => logger;
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<LogEntry> _entries = [];
+
+        public IReadOnlyList<LogEntry> Entries => _entries;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
 }


### PR DESCRIPTION
## Summary

- The `compile_check`/`test_run` eviction auto-retry seam (`ToolDispatch.TryReloadEvictedWorkspaceForRetryAsync`) caught a failed rehydration reload with `catch (Exception) { return null; }` and zero logging — a failed auto-recovery (deleted `LoadedPath`, cap-saturated reload) was completely invisible.
- Add an optional DI-bound `ILoggerFactory? loggerFactory = null` parameter to the retry seam (matching the `WorkspaceTools.LoadWorkspace` pattern), threaded through `ToolDispatch.ReadByWorkspaceIdWithEvictionRetryAsync`, `CompileCheckTools.CompileCheck`, and `ValidationTools.RunTests`/`RunTestsWithEvictionRetryAsync`. A `LogWarning` now fires on reload failure with the evicted workspace id, recorded `LoadedPath`, and the exception.
- Corrected the XML `<remarks>` on `TryReloadEvictedWorkspaceForRetryAsync` that overstated "no diagnostic is lost" — that claim only ever held for the mid-call `WorkspaceEvictedException` case; the more common gate-precheck miss rethrows a bare `KeyNotFoundException` with no eviction context. Also added the missing 4th dispatch-shape `<item>` (`ReadByWorkspaceIdWithEvictionRetryAsync`) to the class-level doc list.
- Fallback behavior (rethrow of the original error) is byte-for-byte unchanged — only a log emission is added. All new parameters default to `null` so every existing call site keeps compiling unmodified.

## Test plan

- [x] `mcp__roslyn__compile_check` on all touched production files and the test file — 0 errors.
- [x] `mcp__roslyn__test_run --filter FullyQualifiedName~WorkspaceEvictionAutoRetryTests` — 9/9 passed (7 pre-existing + 2 new: `CompileCheck_EvictedWorkspace_RehydrationReloadFails_LogsWarning`, `RunTests_EvictedWorkspace_RehydrationReloadFails_LogsWarning`).
- [x] `./eng/verify-ai-docs.ps1` — passed.
- [ ] `./eng/verify-release.ps1 -Configuration Release` — skipped locally (self-hosted CI runner active on this box per standing session policy against duplicating its build/test load); CI will run it on this PR.

Closes: `workspace-eviction-retry-swallowed-log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)