### PR TITLE
refactor(services): consolidate pre-apply file-snapshot capture into a shared helper (file-snapshot-capture-helper-consolidation)

### DIFF
--- a/changelog.d/file-snapshot-capture-helper-consolidation.md
+++ b/changelog.d/file-snapshot-capture-helper-consolidation.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Consolidated the pre-apply file-snapshot exists/missing-fallback decision (previously inlined independently in `EditService`, `EditorConfigService`, and `ProjectMutationService`) into a single shared `FileSnapshotCapture` helper. No behavior change; reduces drift risk across the undo/revert byte-fidelity paths.

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -81,11 +81,10 @@ public sealed class EditService : IEditService
         var normalizedFilePath = Path.GetFullPath(filePath);
         var fileSnapshots = new[]
         {
-            File.Exists(normalizedFilePath)
-                ? FileSnapshotDto.FromExistingBytes(
-                    normalizedFilePath,
-                    await File.ReadAllBytesAsync(normalizedFilePath, ct).ConfigureAwait(false))
-                : new FileSnapshotDto(normalizedFilePath, sourceText.ToString()),
+            await FileSnapshotCapture.CaptureAsync(
+                normalizedFilePath,
+                () => sourceText.ToString(),
+                ct).ConfigureAwait(false),
         };
         _undoService?.CaptureBeforeApply(
             workspaceId,
@@ -143,11 +142,10 @@ public sealed class EditService : IEditService
         var fileSnapshots = new List<FileSnapshotDto>(perFileSnapshots.Count);
         foreach (var t in perFileSnapshots)
         {
-            fileSnapshots.Add(File.Exists(t.NormalizedPath)
-                ? FileSnapshotDto.FromExistingBytes(
-                    t.NormalizedPath,
-                    await File.ReadAllBytesAsync(t.NormalizedPath, ct).ConfigureAwait(false))
-                : new FileSnapshotDto(t.NormalizedPath, t.SourceText.ToString()));
+            fileSnapshots.Add(await FileSnapshotCapture.CaptureAsync(
+                t.NormalizedPath,
+                () => t.SourceText.ToString(),
+                ct).ConfigureAwait(false));
         }
         _undoService?.CaptureBeforeApply(
             workspaceId,

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -352,9 +352,7 @@ public sealed class EditorConfigService : IEditorConfigService
         {
             var snapshot = new[]
             {
-                existingBytes is not null
-                    ? FileSnapshotDto.FromExistingBytes(editorconfigPath, existingBytes)
-                    : new FileSnapshotDto(editorconfigPath, OriginalText: null),
+                FileSnapshotCapture.FromBytesOrFallback(editorconfigPath, existingBytes, fallbackText: null),
             };
             _undoService.CaptureBeforeApply(
                 workspaceId,

--- a/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
+++ b/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
@@ -1,0 +1,73 @@
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Single owner of the pre-apply file-snapshot policy shared by every direct-file mutation
+/// path (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a file held
+/// before the mutation — or the knowledge that it held none — produce the
+/// <see cref="FileSnapshotDto"/> <c>revert_last_apply</c> needs.
+/// <para>
+/// The policy is one line, but it was hand-rolled as an independent ternary at every call
+/// site (<see cref="EditService"/> twice, <see cref="EditorConfigService"/>,
+/// <see cref="ProjectMutationService"/>), so a fix to one never reached the others. Two
+/// entry points exist because two of those callers already read the bytes for a SECOND
+/// purpose — <c>AtomicFileWriter.ResolveWriteEncoding</c> — and must not read the file
+/// twice: they call <see cref="FromBytesOrFallback"/> with the bytes they already hold,
+/// while callers with nothing pre-read call <see cref="CaptureAsync"/>.
+/// </para>
+/// </summary>
+internal static class FileSnapshotCapture
+{
+    /// <summary>
+    /// Builds a snapshot from bytes already read off disk, or from a text fallback when the
+    /// file did not exist.
+    /// </summary>
+    /// <param name="filePath">Absolute path of the file about to be mutated.</param>
+    /// <param name="bytes">
+    /// The exact pre-mutation on-disk bytes, or <see langword="null"/> when the file did not
+    /// exist. An existing zero-length file yields an empty array, NOT <see langword="null"/>,
+    /// and correctly takes the bytes path.
+    /// </param>
+    /// <param name="fallbackText">
+    /// Text recorded as <c>OriginalText</c> when <paramref name="bytes"/> is
+    /// <see langword="null"/>. Pass <see langword="null"/> when the caller has no meaningful
+    /// pre-mutation text for a file that did not exist.
+    /// </param>
+    /// <remarks>
+    /// The null check is load-bearing and must stay OUTSIDE the
+    /// <see cref="FileSnapshotDto.FromExistingBytes"/> call: its parameter is a
+    /// <see cref="ReadOnlySpan{T}"/>, so a null <c>byte[]</c> converts implicitly to an EMPTY
+    /// span and would silently yield an empty-bytes snapshot instead of the fallback.
+    /// </remarks>
+    internal static FileSnapshotDto FromBytesOrFallback(string filePath, byte[]? bytes, string? fallbackText)
+        => bytes is not null
+            ? FileSnapshotDto.FromExistingBytes(filePath, bytes)
+            : new FileSnapshotDto(filePath, fallbackText);
+
+    /// <summary>
+    /// Reads the pre-mutation bytes off disk (when the file exists) and builds the snapshot,
+    /// for callers that do not already hold them.
+    /// </summary>
+    /// <param name="filePath">Absolute path of the file about to be mutated.</param>
+    /// <param name="fallbackTextFactory">
+    /// Invoked ONLY when the file does not exist, to produce the <c>OriginalText</c> fallback.
+    /// Deliberately lazy: the callers on the edit-apply path hold a Roslyn <c>SourceText</c>
+    /// whose <c>ToString()</c> materializes the whole file, and the file-exists case (the
+    /// common one) must not pay for a string it discards.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    internal static async Task<FileSnapshotDto> CaptureAsync(
+        string filePath,
+        Func<string?>? fallbackTextFactory,
+        CancellationToken ct)
+    {
+        if (!File.Exists(filePath))
+        {
+            return new FileSnapshotDto(filePath, fallbackTextFactory?.Invoke());
+        }
+
+        var bytes = await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false);
+        return FileSnapshotDto.FromExistingBytes(filePath, bytes);
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -557,9 +557,10 @@ public sealed class ProjectMutationService : IProjectMutationService
             var preApplyBytes = File.Exists(projectFilePath)
                 ? await File.ReadAllBytesAsync(projectFilePath, ct).ConfigureAwait(false)
                 : null;
-            var preApplySnapshot = preApplyBytes is not null
-                ? FileSnapshotDto.FromExistingBytes(normalizedProjectFilePath, preApplyBytes)
-                : new FileSnapshotDto(normalizedProjectFilePath, OriginalText: null);
+            var preApplySnapshot = FileSnapshotCapture.FromBytesOrFallback(
+                normalizedProjectFilePath,
+                preApplyBytes,
+                fallbackText: null);
             _undoService?.CaptureBeforeApply(
                 workspaceId,
                 $"Project mutation: {Path.GetFileName(projectFilePath)}",

--- a/tests/RoslynMcp.Tests/FileSnapshotCaptureTests.cs
+++ b/tests/RoslynMcp.Tests/FileSnapshotCaptureTests.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct unit coverage for <c>FileSnapshotCapture</c>, the shared owner of the pre-apply
+/// exists/missing snapshot policy previously hand-rolled at four call sites
+/// (<c>file-snapshot-capture-helper-consolidation</c>). Pure temp-directory tests — no MSBuild
+/// workspace required.
+/// </summary>
+[TestClass]
+public sealed class FileSnapshotCaptureTests
+{
+    private string _tempDir = string.Empty;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "roslynmcp-snapshotcapture-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort temp cleanup.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort temp cleanup.
+        }
+    }
+
+    [TestMethod]
+    public void FromBytesOrFallback_With_Bytes_Captures_Them_Byte_Exact()
+    {
+        var bytes = new byte[] { 0xEF, 0xBB, 0xBF, (byte)'h', (byte)'i' };
+
+        var snapshot = FileSnapshotCapture.FromBytesOrFallback("C:/x/y.cs", bytes, fallbackText: "ignored");
+
+        Assert.AreEqual("C:/x/y.cs", snapshot.FilePath);
+        CollectionAssert.AreEqual(bytes, snapshot.OriginalBytes.ToArray());
+        Assert.AreEqual("hi", snapshot.OriginalText, "The BOM must be consumed when decoding, not surfaced as text.");
+    }
+
+    [TestMethod]
+    public void FromBytesOrFallback_With_Empty_Bytes_Takes_The_Bytes_Path_Not_The_Fallback()
+    {
+        // An existing zero-length file yields an empty array, never null — it must NOT be
+        // mistaken for a missing file, or revert would recreate it from the fallback text.
+        var snapshot = FileSnapshotCapture.FromBytesOrFallback("C:/x/empty.cs", [], fallbackText: "not this");
+
+        Assert.AreEqual(string.Empty, snapshot.OriginalText);
+        Assert.IsTrue(snapshot.OriginalBytes.IsEmpty);
+        Assert.IsFalse(snapshot.OriginalBytes.IsDefault, "Empty-but-present bytes must be recorded, not left default.");
+    }
+
+    [TestMethod]
+    public void FromBytesOrFallback_With_Null_Bytes_Uses_The_Text_Fallback()
+    {
+        var snapshot = FileSnapshotCapture.FromBytesOrFallback("C:/x/new.cs", bytes: null, fallbackText: "pre-existing text");
+
+        Assert.AreEqual("pre-existing text", snapshot.OriginalText);
+        Assert.IsTrue(snapshot.OriginalBytes.IsDefault, "A file that never existed has no bytes to record.");
+    }
+
+    [TestMethod]
+    public void FromBytesOrFallback_With_Null_Bytes_And_Null_Fallback_Yields_A_Null_Text_Snapshot()
+    {
+        var snapshot = FileSnapshotCapture.FromBytesOrFallback("C:/x/new.cs", bytes: null, fallbackText: null);
+
+        Assert.IsNull(snapshot.OriginalText);
+        Assert.IsTrue(snapshot.OriginalBytes.IsDefault);
+    }
+
+    [TestMethod]
+    public async Task CaptureAsync_On_Existing_File_Reads_Bytes_And_Skips_The_Fallback_Factory()
+    {
+        var path = Path.Combine(_tempDir, "existing.cs");
+        var bytes = Encoding.Unicode.GetPreamble().Concat(Encoding.Unicode.GetBytes("class C {}")).ToArray();
+        await File.WriteAllBytesAsync(path, bytes);
+        var factoryInvoked = false;
+
+        var snapshot = await FileSnapshotCapture.CaptureAsync(
+            path,
+            () => { factoryInvoked = true; return "unused"; },
+            CancellationToken.None);
+
+        CollectionAssert.AreEqual(bytes, snapshot.OriginalBytes.ToArray(), "UTF-16 bytes must survive byte-exact.");
+        Assert.AreEqual("class C {}", snapshot.OriginalText);
+        Assert.IsFalse(factoryInvoked, "The fallback must stay lazy so the hot path never materializes a discarded string.");
+    }
+
+    [TestMethod]
+    public async Task CaptureAsync_On_Existing_Empty_File_Records_Empty_Bytes()
+    {
+        var path = Path.Combine(_tempDir, "empty.cs");
+        await File.WriteAllBytesAsync(path, []);
+
+        var snapshot = await FileSnapshotCapture.CaptureAsync(path, () => "not this", CancellationToken.None);
+
+        Assert.AreEqual(string.Empty, snapshot.OriginalText);
+        Assert.IsFalse(snapshot.OriginalBytes.IsDefault);
+    }
+
+    [TestMethod]
+    public async Task CaptureAsync_On_Missing_File_Uses_The_Fallback_Factory()
+    {
+        var path = Path.Combine(_tempDir, "missing.cs");
+
+        var snapshot = await FileSnapshotCapture.CaptureAsync(path, () => "in-memory text", CancellationToken.None);
+
+        Assert.AreEqual(path, snapshot.FilePath);
+        Assert.AreEqual("in-memory text", snapshot.OriginalText);
+        Assert.IsTrue(snapshot.OriginalBytes.IsDefault);
+    }
+
+    [TestMethod]
+    public async Task CaptureAsync_On_Missing_File_With_No_Factory_Yields_A_Null_Text_Snapshot()
+    {
+        var path = Path.Combine(_tempDir, "missing.cs");
+
+        var snapshot = await FileSnapshotCapture.CaptureAsync(path, fallbackTextFactory: null, CancellationToken.None);
+
+        Assert.IsNull(snapshot.OriginalText);
+        Assert.IsTrue(snapshot.OriginalBytes.IsDefault);
+    }
+}


### PR DESCRIPTION
## Summary

The pre-apply file-snapshot policy — *file exists → byte-exact `FromExistingBytes`; file missing → text-fallback-or-null* — was hand-rolled as an independent ternary at four call sites, so a fix to one never reached the others. This extracts `FileSnapshotCapture` (`src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs`) as the single owner of that decision.

Closes: (none — backlog row `file-snapshot-capture-helper-consolidation` stays OPEN; 4 of its 5 cited call sites are converted here)

## Design

Two entry points, because two of the callers already read the bytes for a **second** purpose (`AtomicFileWriter.ResolveWriteEncoding`) and must not read the file twice:

| Member | Used by | Why |
|---|---|---|
| `FromBytesOrFallback(path, bytes, fallbackText)` | `EditorConfigService.SetOptionAsync`, `ProjectMutationService.ApplyProjectMutationAsync` | Pure, no I/O — the callers pass the `existingBytes` / `preApplyBytes` locals they already hold. Read order stays read → snapshot → write; no second disk read, no new TOCTOU window. |
| `CaptureAsync(path, fallbackTextFactory, ct)` | `EditService.ApplyTextEditsAsync`, `EditService.ApplyMultiFileTextEditsAsync` | Performs the `File.Exists` + `ReadAllBytesAsync` itself for callers holding nothing pre-read. |

Two details worth reviewer attention:

- **The fallback is a `Func<string?>`, not an eager `string`.** The plan sketched an eager parameter, but that would make every apply materialize `SourceText.ToString()` — a full copy of the file — even in the file-exists case that discards it. The pre-refactor ternary was already lazy there, and `ApplyMultiFileTextEditsAsync` pays it per file in a loop, so laziness had to be preserved rather than regressed.
- **The null check is load-bearing and lives outside `FromExistingBytes`.** That method takes a `ReadOnlySpan<byte>`, so a null `byte[]` converts implicitly to an *empty span* and would silently yield an empty-bytes snapshot instead of the fallback. Covered by a dedicated regression test alongside the empty-but-present-file case that must NOT take the fallback path.

## Scope

Deliberately excluded: `RefactoringService.AddFileSnapshotAsync` (`:1057-1089`), the fifth call site named by the backlog row. It already implements the correct policy (including the three-way `missingFileIsNew` branch) and is not at risk; converting it is a trivial 1-file follow-up. Excluding it is what keeps this change inside the 4-production-file cap. **The backlog row therefore stays open** and needs that follow-up row filed before it closes. `AddProjectFileSnapshotAsync` (`:1091-1108`) early-returns on missing files and never duplicated the policy — out of scope entirely.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- New `FileSnapshotCaptureTests` — 8/8 pass. Covers exists→bytes, empty-but-present→bytes (not fallback), missing→text fallback, missing→null fallback, UTF-16-with-BOM byte-exact round-trip, and an assertion that the fallback factory is *not* invoked when the file exists.
- `EditUndoIntegrationTests` 9/9, `EditorConfigServiceTests` 13/13, `ProjectMutationIntegrationTests` 30/30, `CompositeApplyOrchestratorTests` 5/5 — each run as its own filtered pass.
- `eng/verify-ai-docs.ps1` and `eng/verify-changelog-fragments.ps1` pass.

Flake note: running those suites under one combined filter produces failures from cross-suite MSBuild-fixture interference. Verified pre-existing — the identical combined filter on the stashed baseline (no changes) failed **5** tests, versus 1 with these changes; every suite is green when run separately.
