### PR TITLE
refactor(roslyn): route InterfaceExtractionService conflict check through ICompilationCache (compilation-cache-adoption-read-side)

### DIFF
--- a/changelog.d/compilation-cache-adoption-read-side-3.md
+++ b/changelog.d/compilation-cache-adoption-read-side-3.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Routed `InterfaceExtractionService`'s live-solution conflict check (`ValidateNoConflictsAsync`) through the shared `ICompilationCache`, closing the group-b tail of the read-side compilation-cache adoption sweep; the companion forked-solution site (`ReplaceConcreteUsagesAsync`) is confirmed to stay raw. Advances `compilation-cache-adoption-read-side` (row stays open — group-c helpers remain).

--- a/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -17,12 +18,18 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly ICompilationCache _compilationCache;
     private readonly ILogger<InterfaceExtractionService> _logger;
 
-    public InterfaceExtractionService(IWorkspaceManager workspace, IPreviewStore previewStore, ILogger<InterfaceExtractionService> logger)
+    public InterfaceExtractionService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        ICompilationCache compilationCache,
+        ILogger<InterfaceExtractionService> logger)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _compilationCache = compilationCache;
         _logger = logger;
     }
 
@@ -67,7 +74,7 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         // before we synthesize a new file.
         if (!alreadyImplements)
         {
-            await ValidateNoConflictsAsync(solution, typeSymbol, interfaceName, ct).ConfigureAwait(false);
+            await ValidateNoConflictsAsync(workspaceId, solution, typeSymbol, interfaceName, ct).ConfigureAwait(false);
         }
 
         // BUG-003: Match the interface accessibility to the source type so an internal class
@@ -377,8 +384,14 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
             brace.WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(Environment.NewLine))));
     }
 
+    /// <remarks>
+    /// Reads compilations through the shared <see cref="ICompilationCache"/>: the only call site
+    /// passes the LIVE <see cref="IWorkspaceManager.GetCurrentSolution"/> snapshot taken before any
+    /// in-memory fork, so the version-keyed cache is a valid source. Mirrors
+    /// <c>CrossProjectRefactoringService.DetectExistingTypeConflictAsync</c>.
+    /// </remarks>
     private async Task ValidateNoConflictsAsync(
-        Solution solution, INamedTypeSymbol typeSymbol, string interfaceName, CancellationToken ct)
+        string workspaceId, Solution solution, INamedTypeSymbol typeSymbol, string interfaceName, CancellationToken ct)
     {
         var namespaceName = typeSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
@@ -391,7 +404,7 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         {
             try
             {
-                var comp = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+                var comp = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
                 if (comp?.GetTypeByMetadataName(fullyQualifiedInterfaceName) is not null)
                 {
                     throw new InvalidOperationException(
@@ -407,6 +420,14 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
         }
     }
 
+    /// <remarks>
+    /// Deliberately NOT routed through <see cref="ICompilationCache"/>. The caller hands in a
+    /// FORKED solution (built with <c>WithDocumentSyntaxRoot</c> + <c>AddDocument</c> and not yet
+    /// applied to the workspace), so it carries the same workspace version as the live solution.
+    /// A version-keyed cache would either hand back the pre-fork compilation — which lacks the
+    /// synthesized interface document — or pollute the shared cache with an in-memory-only fork.
+    /// The raw <c>project.GetCompilationAsync</c> below is the correct read here.
+    /// </remarks>
     private static async Task<Solution> ReplaceConcreteUsagesAsync(
         Solution solution, ProjectId projectId, INamedTypeSymbol typeSymbol,
         string interfaceName, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -21,7 +21,8 @@ namespace RoslynMcp.Tests;
 /// <see cref="ImpactSweepService"/>, <see cref="MutationAnalysisService"/>, and
 /// <see cref="SymbolRelationshipService"/>; group-b core adds <see cref="BuildService"/>,
 /// <see cref="FixAllService"/>, <see cref="BulkRefactoringService"/>, and
-/// <see cref="CrossProjectRefactoringService"/>.
+/// <see cref="CrossProjectRefactoringService"/>; the group-b tail adds
+/// <see cref="InterfaceExtractionService"/>.
 /// <para>
 /// A reference-equality check alone cannot prove adoption — Roslyn memoizes a
 /// <see cref="Compilation"/> on its owning <see cref="Project"/>, so two direct calls would also
@@ -556,6 +557,37 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
                 "AnimalService",
                 interfaceName: "IAnimalServiceCompilationCacheProbe",
                 targetProjectName: null,
+                CancellationToken.None));
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    [TestMethod]
+    public async Task InterfaceExtractionService_ObtainsCompilations_ThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+        var service = new InterfaceExtractionService(
+            WorkspaceManager, new PreviewStore(), cache,
+            NullLogger<InterfaceExtractionService>.Instance);
+
+        // ValidateNoConflictsAsync is the converted site — it sweeps every project of the LIVE
+        // pre-fork solution for a same-name type. It only runs inside the `!alreadyImplements`
+        // guard, so the probe interface name must be one AnimalService cannot already implement,
+        // otherwise the cache is never touched and the call-count assertion below fails.
+        // Explicitly NOT covered here: ReplaceConcreteUsagesAsync, which compiles a FORKED
+        // solution and therefore stays on the raw project.GetCompilationAsync path — hence
+        // replaceUsages: false.
+        var sourceFilePath = workspace.GetPath("SampleLib", "AnimalService.cs");
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, () =>
+            service.PreviewExtractInterfaceAsync(
+                workspace.WorkspaceId,
+                sourceFilePath,
+                "AnimalService",
+                interfaceName: "IAnimalServiceInterfaceExtractionCacheProbe",
+                memberNames: null,
+                replaceUsages: false,
                 CancellationToken.None));
 
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);

--- a/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs
@@ -252,6 +252,7 @@ internal sealed class TestServiceContainer
             InterfaceExtractionService = new InterfaceExtractionService(
                 workspaceManager,
                 previewStore,
+                compilationCache,
                 NullLogger<InterfaceExtractionService>.Instance),
             TypeMoveService = new TypeMoveService(
                 workspaceManager,


### PR DESCRIPTION
Closes the **group-b tail** of the read-side compilation-cache adoption sweep.

## What changed

`src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs` had the last two raw `GetCompilationAsync` sites in this file. They split cleanly by solution provenance:

| Site | Solution passed in | Verdict |
|---|---|---|
| `ValidateNoConflictsAsync` | LIVE `IWorkspaceManager.GetCurrentSolution`, taken before any in-memory mutation | **Migrated** to `ICompilationCache` |
| `ReplaceConcreteUsagesAsync` | FORKED (`WithDocumentSyntaxRoot` + `AddDocument`, not yet applied) | **Stays raw** — documented in place |

- `ValidateNoConflictsAsync` gains a `workspaceId` parameter and reads through the injected `_compilationCache`. Mirrors the already-migrated `CrossProjectRefactoringService.DetectExistingTypeConflictAsync` (PR #1147), which is the identical per-project name-conflict scan shape.
- The existing per-project `catch (InvalidOperationException) { throw; } / catch (Exception ex) when (ex is not OperationCanceledException)` swallow-and-log-debug pair is preserved byte-identical. `CompilationCache` rethrows the underlying exception on await and evicts broken entries via `EvictWhenBroken` rather than replaying them, so what this catch observes is unchanged.
- `ReplaceConcreteUsagesAsync` is left functionally untouched. Its forked solution carries the same workspace version as the live one, so a version-keyed cache would either hand back the pre-fork compilation (missing the synthesized interface document) or pollute the shared cache with an in-memory-only fork. A `<remarks>` block now records why.
- Constructor gains `ICompilationCache` before the trailing logger. No DI registration change needed — both `ICompilationCache` and `IInterfaceExtractionService` are already singletons in `ServiceCollectionExtensions.cs`.

## Tests

- New `InterfaceExtractionService_ObtainsCompilations_ThroughSharedCache` in `tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs`, mirroring the cross-project twin: runs `PreviewExtractInterfaceAsync` twice at an unchanged workspace version through a `RecordingCompilationCache` and asserts both that the cache was hit and that the warm compilation is reference-equal across runs. Uses `replaceUsages: false` so the deliberately-uncached forked path is not exercised, and a probe interface name the sample type cannot already implement (otherwise the `!alreadyImplements` guard skips the converted site entirely).
- `tests/RoslynMcp.Tests/TestInfrastructure/TestServiceContainer.cs` passes the already-in-scope `compilationCache` into the explicit construction.

## Validation

- `dotnet build tests/RoslynMcp.Tests` — 0 errors, 0 warnings.
- `dotnet test --filter "FullyQualifiedName~CompilationCacheAdoptionTests"` — 21/21 passed (was 20 before this PR).
- `dotnet test --filter "FullyQualifiedName~InterfaceExtraction"` — 1/1 passed (the new test).
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1 -Configuration Release` — version/skill/allowlist/changelog-fragment gates passed locally; the full Release test phase is delegated to this PR's CI run (the self-hosted runner owns that gate).

## Notes

- No shims added. `shims-added: 0`.
- Row `compilation-cache-adoption-read-side` **stays open** — group-c helpers (`SymbolResolver.ResolveByMetadataNameAsync` / `FindClosestMatchesAsync`, `SymbolHandleSerializer`) still need their own bounded batch.

Closes: compilation-cache-adoption-read-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
