### PR TITLE
fix(mutation): preserve original BOM/encoding in composite-apply and solution-snapshot revert writes

### DIFF
--- a/changelog.d/composite-apply-undo-encoding-still-lossy.md
+++ b/changelog.d/composite-apply-undo-encoding-still-lossy.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `apply_composite_preview` and `revert_last_apply`'s solution-snapshot restore path now preserve a file's original BOM/encoding instead of silently re-encoding as UTF-8-no-BOM, closing the two write paths PR #1157 (`mutation-write-paths-drop-original-encoding`) deferred.

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -79,7 +79,21 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
                     Directory.CreateDirectory(directory);
                 }
 
-                await AtomicFileWriter.WriteAllTextAsync(mutation.FilePath, mutation.UpdatedContent ?? string.Empty, ct, _logger).ConfigureAwait(false);
+                // composite-apply-undo-encoding-still-lossy: `CompositeFileMutation` carries only
+                // the replacement text, so the file's original BOM/encoding has to be recovered at
+                // write time from the pre-apply on-disk bytes — the same pattern
+                // `ProjectMutationService.ApplyProjectMutationAsync` uses. Without it every composite
+                // apply silently re-encoded the target as UTF-8-no-BOM.
+                var preApplyBytes = File.Exists(mutation.FilePath)
+                    ? await File.ReadAllBytesAsync(mutation.FilePath, ct).ConfigureAwait(false)
+                    : null;
+
+                await AtomicFileWriter.WriteAllTextAsync(
+                    mutation.FilePath,
+                    mutation.UpdatedContent ?? string.Empty,
+                    ct,
+                    _logger,
+                    encoding: AtomicFileWriter.ResolveWriteEncoding(preApplyBytes)).ConfigureAwait(false);
                 appliedFiles.Add(mutation.FilePath);
             }
 

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
 using Microsoft.CodeAnalysis;
@@ -425,7 +426,11 @@ public sealed class UndoService : IUndoService, IDisposable
         }
 
         var currentSolution = workspace.GetCurrentSolution(workspaceId);
-        var diskRestores = new List<(string FilePath, string Text)>();
+        // composite-apply-undo-encoding-still-lossy: the queued restores carry the pre-apply
+        // `SourceText.Encoding` alongside the text so `PersistRevertChangesAsync` can rewrite each
+        // file with its original BOM/encoding instead of collapsing everything to UTF-8-no-BOM.
+        // `Encoding` is null for in-memory-synthesized text; `ResolveWriteEncoding` handles that.
+        var diskRestores = new List<(string FilePath, string Text, Encoding? Encoding)>();
 
         // Phase 1 (primary): trust the Solution diff to tell us what changed.
         var (targetSolution, changedDocumentCount) = await CollectChangesFromSolutionDiffAsync(
@@ -464,7 +469,7 @@ public sealed class UndoService : IUndoService, IDisposable
     private static async Task<(Solution TargetSolution, int ChangedDocumentCount)> CollectChangesFromSolutionDiffAsync(
         Solution preApplySolution,
         Solution currentSolution,
-        List<(string FilePath, string Text)> diskRestores,
+        List<(string FilePath, string Text, Encoding? Encoding)> diskRestores,
         CancellationToken cancellationToken)
     {
         var targetSolution = currentSolution;
@@ -485,7 +490,7 @@ public sealed class UndoService : IUndoService, IDisposable
                 var path = currentDoc?.FilePath ?? oldDoc.FilePath;
                 if (!string.IsNullOrWhiteSpace(path))
                 {
-                    diskRestores.Add((path!, oldText.ToString()));
+                    diskRestores.Add((path!, oldText.ToString(), oldText.Encoding));
                 }
             }
         }
@@ -501,7 +506,7 @@ public sealed class UndoService : IUndoService, IDisposable
     /// </summary>
     private async Task<int> CollectChangesFromDiskWalkAsync(
         Solution preApplySolution,
-        List<(string FilePath, string Text)> diskRestores,
+        List<(string FilePath, string Text, Encoding? Encoding)> diskRestores,
         CancellationToken cancellationToken)
     {
         var changedDocumentCount = 0;
@@ -524,10 +529,11 @@ public sealed class UndoService : IUndoService, IDisposable
                     continue;
                 }
 
-                var oldText = (await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false)).ToString();
+                var oldSourceText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var oldText = oldSourceText.ToString();
                 if (!string.Equals(currentDiskText, oldText, StringComparison.Ordinal))
                 {
-                    diskRestores.Add((oldDoc.FilePath, oldText));
+                    diskRestores.Add((oldDoc.FilePath, oldText, oldSourceText.Encoding));
                     changedDocumentCount++;
                 }
             }
@@ -549,7 +555,7 @@ public sealed class UndoService : IUndoService, IDisposable
         IWorkspaceManager workspace,
         UndoSnapshot snapshot,
         Solution targetSolution,
-        IReadOnlyList<(string FilePath, string Text)> diskRestores,
+        IReadOnlyList<(string FilePath, string Text, Encoding? Encoding)> diskRestores,
         CancellationToken cancellationToken)
     {
         var workspaceApplied = workspace.TryApplyChanges(workspaceId, targetSolution);
@@ -564,11 +570,17 @@ public sealed class UndoService : IUndoService, IDisposable
 
         var diskOk = true;
         var anyDiskWrite = false;
-        foreach (var (filePath, text) in diskRestores)
+        foreach (var (filePath, text, encoding) in diskRestores)
         {
             try
             {
-                await AtomicFileWriter.WriteAllTextAsync(filePath, text, cancellationToken).ConfigureAwait(false);
+                // composite-apply-undo-encoding-still-lossy: restore with the pre-apply
+                // `SourceText.Encoding` so a reverted file keeps its original BOM/encoding.
+                await AtomicFileWriter.WriteAllTextAsync(
+                    filePath,
+                    text,
+                    cancellationToken,
+                    encoding: AtomicFileWriter.ResolveWriteEncoding(encoding)).ConfigureAwait(false);
                 anyDiskWrite = true;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
+++ b/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
@@ -175,6 +176,93 @@ public sealed class CompositeApplyOrchestratorTests
         Assert.IsNotNull(result.Error);
         Assert.IsFalse(result.Error!.StartsWith("Partial composite apply: ", StringComparison.Ordinal),
             "A failure with zero prior writes is a clean failure, not a partial apply.");
+    }
+
+    /// <summary>
+    /// Regression guard for <c>composite-apply-undo-encoding-still-lossy</c>:
+    /// <c>apply_composite_preview</c> wrote every mutation through
+    /// <c>AtomicFileWriter.WriteAllTextAsync</c> with no <see cref="Encoding"/>, so a UTF-8-BOM or
+    /// UTF-16 source file was silently re-encoded as UTF-8-no-BOM on every composite apply. This is
+    /// the third write path PR #1157 (<c>mutation-write-paths-drop-original-encoding</c>) deferred.
+    /// The <c>utf8-nobom</c> row is the inverse guard: a file that had no BOM must not gain one.
+    /// </summary>
+    [TestMethod]
+    [DataRow("utf8-nobom")]
+    [DataRow("utf8-bom")]
+    [DataRow("utf16-bom")]
+    public async Task ApplyComposite_Preserves_Original_File_Encoding(string encodingKind)
+    {
+        var path = Path.Combine(_tempDir, "target.cs");
+        Encoding encoding = encodingKind switch
+        {
+            "utf16-bom" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            _ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        };
+        var preamble = encoding.GetPreamble();
+
+        const string originalContent = "class C { }\n";
+        await File.WriteAllBytesAsync(
+            path,
+            preamble.Concat(encoding.GetBytes(originalContent)).ToArray(),
+            CancellationToken.None);
+
+        const string updatedContent = "class C { int Marker; }\n";
+        var store = new CompositePreviewStore();
+        var token = store.Store(
+            "ws-1",
+            1,
+            "encoding round-trip",
+            [new CompositeFileMutation(path, updatedContent, DeleteFile: false)]);
+        var orchestrator = new CompositeApplyOrchestrator(new RecordingWorkspaceManager(), store);
+
+        var result = await orchestrator.ApplyCompositeAsync(token, CancellationToken.None);
+        Assert.IsTrue(result.Success, result.Error);
+
+        var afterBytes = await File.ReadAllBytesAsync(path, CancellationToken.None);
+        Assert.IsTrue(
+            afterBytes.AsSpan().StartsWith(preamble),
+            $"apply_composite_preview must re-emit the original {encodingKind} byte-order mark instead of rewriting the file as UTF-8-no-BOM.");
+        if (preamble.Length == 0)
+        {
+            Assert.IsFalse(
+                afterBytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()),
+                "A file that had no BOM must not gain one.");
+        }
+
+        Assert.AreEqual(
+            updatedContent,
+            encoding.GetString(afterBytes, preamble.Length, afterBytes.Length - preamble.Length),
+            "The mutation must be readable back through the original encoding.");
+    }
+
+    /// <summary>
+    /// Companion guard to <see cref="ApplyComposite_Preserves_Original_File_Encoding"/>: a mutation
+    /// that CREATES a file (no pre-apply bytes on disk) must keep the historic UTF-8-no-BOM default
+    /// — <c>ResolveWriteEncoding(null)</c> must not be allowed to start emitting a preamble.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyComposite_NewFile_Is_Written_Utf8_Without_Bom()
+    {
+        var path = Path.Combine(_tempDir, "created.cs");
+        Assert.IsFalse(File.Exists(path));
+
+        var store = new CompositePreviewStore();
+        var token = store.Store(
+            "ws-1",
+            1,
+            "new file",
+            [new CompositeFileMutation(path, "class New { }\n", DeleteFile: false)]);
+        var orchestrator = new CompositeApplyOrchestrator(new RecordingWorkspaceManager(), store);
+
+        var result = await orchestrator.ApplyCompositeAsync(token, CancellationToken.None);
+        Assert.IsTrue(result.Success, result.Error);
+
+        var afterBytes = await File.ReadAllBytesAsync(path, CancellationToken.None);
+        Assert.IsFalse(
+            afterBytes.AsSpan().StartsWith(Encoding.UTF8.GetPreamble()),
+            "A newly created file must not gain a BOM.");
+        Assert.AreEqual("class New { }\n", Encoding.UTF8.GetString(afterBytes));
     }
 
     private sealed class RecordingLogger<T> : ILogger<T>

--- a/tests/RoslynMcp.Tests/UndoServiceTests.cs
+++ b/tests/RoslynMcp.Tests/UndoServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 
@@ -341,5 +343,156 @@ public sealed class UndoServiceTests : IsolatedWorkspaceTestBase
         StringAssert.Contains(catAfterRetry, "// apply B",
             "Cat.cs should retain apply B's edit — only apply A was reverted.");
         Assert.AreNotEqual(catOriginal, catAfterRetry, "Cat.cs should still be at its post-apply-B state.");
+    }
+
+    // ---- composite-apply-undo-encoding-still-lossy: solution-snapshot revert encoding fidelity ----
+    //
+    // `RevertFromSolutionSnapshotAsync` collapsed each restore to a bare string, discarding the
+    // pre-apply `SourceText.Encoding`, then wrote through the encoding-less `AtomicFileWriter`
+    // overload — so a UTF-8-BOM or UTF-16 file reverted through the solution-snapshot path was
+    // silently rewritten as UTF-8-no-BOM. `EditService` always supplies file snapshots, so the
+    // solution-snapshot branch is unreachable from a normal apply; both tests below force it by
+    // calling `CaptureBeforeApply` directly with `fileSnapshots: null`. They cover the two
+    // collection phases separately: the Solution-diff phase and the disk-walk safety net.
+
+    /// <summary>
+    /// Phase-1 (Solution diff) coverage. The <c>utf8-nobom</c> row is the inverse guard: Roslyn
+    /// reports a no-preamble UTF-8 <c>SourceText.Encoding</c> for a BOM-less file, which
+    /// <c>AtomicFileWriter.ResolveWriteEncoding(Encoding?)</c> must normalize so the revert does
+    /// not ADD a BOM to a file that never had one.
+    /// </summary>
+    [TestMethod]
+    [DataRow("utf8-nobom")]
+    [DataRow("utf8-bom")]
+    [DataRow("utf16-bom")]
+    public async Task RevertAsync_SolutionSnapshotPath_SolutionDiff_PreservesOriginalEncoding(string encodingKind)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var (encoding, preamble, originalBytes) = await SeedEncodedFileAsync(dogFilePath, encodingKind);
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preApplySolution = WorkspaceManager.GetCurrentSolution(workspaceId);
+        await MaterializeDocumentTextAsync(preApplySolution, dogFilePath);
+
+        // A real apply, so the snapshot is diffed against a genuinely mutated workspace + disk.
+        var applyResult = await EditService.ApplyTextEditsAsync(
+            workspaceId,
+            dogFilePath,
+            new[] { new TextEditDto(1, 1, 1, 1, "// apply\n") },
+            "apply_text_edit",
+            CancellationToken.None);
+        Assert.IsTrue(applyResult.Success, "Precondition: the apply should succeed.");
+
+        // EditService records file snapshots, which route RevertAsync down the fast path. Overwrite
+        // the pending snapshot with a solution-only one to force the solution-snapshot branch.
+        UndoService.CaptureBeforeApply(
+            workspaceId,
+            "solution-snapshot encoding round-trip",
+            preApplySolution,
+            fileSnapshots: null);
+
+        Assert.IsTrue(
+            await UndoService.RevertAsync(workspaceId, CancellationToken.None),
+            "The solution-snapshot revert should succeed.");
+
+        CollectionAssert.AreEqual(
+            originalBytes,
+            await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None),
+            $"revert_last_apply's solution-snapshot path must restore the exact pre-apply {encodingKind} bytes, " +
+            "including the byte-order mark, instead of rewriting the file as UTF-8-no-BOM.");
+    }
+
+    /// <summary>
+    /// Phase-2 (disk-walk safety net) coverage: the drift is disk-only, so
+    /// <c>preApplySolution.GetChanges(currentSolution)</c> is empty and the restore is collected by
+    /// the disk walk instead. UTF-16 is the strongest signal — a dropped preamble there also
+    /// corrupts every character, not just the first bytes.
+    /// </summary>
+    [TestMethod]
+    public async Task RevertAsync_SolutionSnapshotPath_DiskWalk_PreservesOriginalEncoding()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+
+        ChangeTracker.Clear(workspaceId);
+        UndoService.Clear(workspaceId);
+
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var (encoding, preamble, originalBytes) = await SeedEncodedFileAsync(dogFilePath, "utf16-bom");
+        await workspace.ReloadAsync(CancellationToken.None);
+
+        var preApplySolution = WorkspaceManager.GetCurrentSolution(workspaceId);
+        await MaterializeDocumentTextAsync(preApplySolution, dogFilePath);
+        UndoService.CaptureBeforeApply(
+            workspaceId,
+            "disk-walk encoding round-trip",
+            preApplySolution,
+            fileSnapshots: null);
+
+        // Disk-only drift: the workspace solution is untouched, so phase 1 finds nothing.
+        var originalText = encoding.GetString(originalBytes, preamble.Length, originalBytes.Length - preamble.Length);
+        await File.WriteAllBytesAsync(
+            dogFilePath,
+            preamble.Concat(encoding.GetBytes("// drifted\n" + originalText)).ToArray(),
+            CancellationToken.None);
+
+        Assert.IsTrue(
+            await UndoService.RevertAsync(workspaceId, CancellationToken.None),
+            "The disk-walk safety net should restore the drifted file and report success.");
+
+        CollectionAssert.AreEqual(
+            originalBytes,
+            await File.ReadAllBytesAsync(dogFilePath, CancellationToken.None),
+            "The disk-walk restore must re-emit the original UTF-16 byte-order mark and encoding.");
+    }
+
+    /// <summary>
+    /// Rewrites <paramref name="filePath"/> in the requested encoding, preserving its text, and
+    /// returns the encoding, its preamble, and the exact bytes now on disk.
+    /// </summary>
+    private static async Task<(Encoding Encoding, byte[] Preamble, byte[] OriginalBytes)> SeedEncodedFileAsync(
+        string filePath,
+        string encodingKind)
+    {
+        var text = await File.ReadAllTextAsync(filePath, CancellationToken.None);
+        Encoding encoding = encodingKind switch
+        {
+            "utf16-bom" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            "utf8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            _ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        };
+        var preamble = encoding.GetPreamble();
+        var bytes = preamble.Concat(encoding.GetBytes(text)).ToArray();
+        await File.WriteAllBytesAsync(filePath, bytes, CancellationToken.None);
+        return (encoding, preamble, bytes);
+    }
+
+    /// <summary>
+    /// Forces the snapshot solution to hold <paramref name="filePath"/>'s text (and therefore its
+    /// detected <c>SourceText.Encoding</c>) in memory. Roslyn loads document text lazily, so an
+    /// un-materialized snapshot would re-read whatever is on disk at revert time and conclude
+    /// nothing changed. Real solution-based callers (<c>RefactoringService</c>) always read the
+    /// document while computing their change, so this only reproduces their state.
+    /// </summary>
+    private static async Task MaterializeDocumentTextAsync(Solution solution, string filePath)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        var document = solution.Projects
+            .SelectMany(p => p.Documents)
+            .FirstOrDefault(d => d.FilePath is not null
+                && string.Equals(Path.GetFullPath(d.FilePath), fullPath, StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(document, $"Expected '{filePath}' to be part of the loaded solution.");
+
+        var text = await document!.GetTextAsync(CancellationToken.None);
+        Assert.IsNotNull(
+            text.Encoding,
+            "Precondition: Roslyn must have detected an encoding for the seeded file — otherwise the " +
+            "test cannot distinguish a preserved encoding from the UTF-8-no-BOM fallback.");
     }
 }


### PR DESCRIPTION
Closes: composite-apply-undo-encoding-still-lossy

## Problem

PR #1157 (`mutation-write-paths-drop-original-encoding`) fixed `EditService` and `ProjectMutationService` but explicitly deferred two other write paths. Both were still lossy at HEAD:

1. **`CompositeApplyOrchestrator.ApplyCompositeAsync`** wrote every mutation through `AtomicFileWriter.WriteAllTextAsync` with no `encoding:` argument, so `apply_composite_preview` silently re-encoded a UTF-8-BOM or UTF-16 file as UTF-8-no-BOM.
2. **`UndoService.RevertFromSolutionSnapshotAsync`** collapsed each queued restore to a bare `string`, discarding the pre-apply `SourceText.Encoding` before it could be used, then wrote through the same encoding-less overload — so a `revert_last_apply` that took the solution-snapshot path always rewrote reverted files as UTF-8-no-BOM.

## Fix

- **`CompositeApplyOrchestrator.cs`** — read the pre-apply on-disk bytes and pass `encoding: AtomicFileWriter.ResolveWriteEncoding(preApplyBytes)`, byte-for-byte the pattern already used by `ProjectMutationService.ApplyProjectMutationAsync`. `CompositeFileMutation` is deliberately left untouched: threading an `Encoding` field through it would ripple into 14 construction sites for no behavioral gain, since the write-time resolve reads the same bytes just later.
- **`UndoService.cs`** — widen `diskRestores` from `(string, string)` to `(string, string, Encoding?)` across the local, the three private helper signatures, and the destructure; carry `SourceText.Encoding` from both collection phases; write via `ResolveWriteEncoding(Encoding?)`. All three helpers are `private` with exactly one call site each, so fanout is zero.

The third anchor cited by the backlog row (`UndoService.cs:372`, the `OriginalBytes`-absent fallback in `RevertFromFileSnapshotsAsync`) was re-derived and is **not** a live bug — `FileSnapshotDto.OriginalBytes` is only left default when the file did not exist pre-mutation, where `ResolveWriteEncoding(null)` already returns `Utf8NoBom`. Left untouched.

## Tests

`CompositeApplyOrchestratorTests.cs` and `UndoServiceTests.cs` extended (no new files):

- `ApplyComposite_Preserves_Original_File_Encoding` — `[DataRow]` over utf8-nobom / utf8-bom / utf16-bom.
- `ApplyComposite_NewFile_Is_Written_Utf8_Without_Bom` — the create-a-file case must keep the historic no-BOM default.
- `RevertAsync_SolutionSnapshotPath_SolutionDiff_PreservesOriginalEncoding` — `[DataRow]` over the same three encodings, forcing the solution-snapshot branch via a direct `CaptureBeforeApply(..., fileSnapshots: null)`.
- `RevertAsync_SolutionSnapshotPath_DiskWalk_PreservesOriginalEncoding` — covers the phase-2 disk-walk safety net separately.

The `utf8-nobom` rows are inverse guards: a file that never had a BOM must not gain one.

**Guards verified to bite.** With the two production files stashed, exactly the 5 BOM-bearing cases fail and the 3 no-BOM rows pass; with the fix, 20/20 in both classes pass.

## Validation

- `dotnet build RoslynMcp.slnx` — 0 warnings, 0 errors.
- `dotnet test --filter "FullyQualifiedName~CompositeApplyOrchestratorTests|FullyQualifiedName~UndoServiceTests"` — 20/20 passed.
- `eng/verify-ai-docs.ps1` — passed.
- `eng/verify-release.ps1 -Configuration Release` — started locally but still running at hand-off; CI on this PR is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)