### PR TITLE
fix(workspace-validation): scope compiler-arm corroboration gate to Category=="Compiler" (validate-workspace-compiler-gate-scope-to-category)

### DIFF
--- a/changelog.d/validate-workspace-compiler-gate-scope-to-category.md
+++ b/changelog.d/validate-workspace-compiler-gate-scope-to-category.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `validate_workspace`'s compiler-arm corroboration gate (`WorkspaceValidationService.MergeErrorDiagnostics`) now scopes to `Category=="Compiler"` rows only. Previously the gate suppressed the entire `CompilerDiagnostics` harvest arm on an uncorroborated/clean compile pass, which also silently dropped the unrelated `WORKSPACE001` (`Category=="Workspace"`) row — a genuine "failed to load this project's compilation" signal — reporting a false `clean` verdict.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -517,9 +517,14 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     //
     // The corroboration rule below extends the trust boundary ComputeOverallStatus already commits to
     // (compile.ErrorCount is the SOLE compile-error signal) from the verdict string to the count and
-    // the list. AnalyzerDiagnostics merges unconditionally — those are the CA*/IDE* rows this stage
-    // exists to contribute. WorkspaceDiagnostics stays excluded, as before. The gate is applied
-    // BEFORE the concat so the Severity filter and DistinctBy dedup semantics are untouched.
+    // the list. The gate is scoped to Category=="Compiler" rows WITHIN the CompilerDiagnostics arm —
+    // not the whole arm. Any other row riding along in that arm (today only the synthetic WORKSPACE001
+    // row DiagnosticService emits with Category=="Workspace" when a project's compilation fails to
+    // materialize) merges unconditionally, exactly like AnalyzerDiagnostics does two lines below —
+    // those are the CA*/IDE* rows this stage exists to contribute, and WORKSPACE001 is a genuine
+    // "failed to load this project's compilation" signal, not a phantom this gate was built to catch.
+    // The gate is applied BEFORE the concat so the Severity filter and DistinctBy dedup semantics are
+    // untouched.
     //
     // The gate keys on compile_check's AUTHORITY, not merely on its count. compile.ErrorCount is
     // authoritative only when the compile pass actually finished: CompileCheckService.CheckAsync
@@ -529,8 +534,8 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
     // In that shape ErrorCount==0 means "did not look", not "found nothing", and the second harvest
     // is the ONLY view of real CS* errors in the un-compiled projects. Dropping those rows would
     // turn a timed-out validation into a false "clean" on the pre-ship gate — strictly worse than
-    // the phantom-row false positive this initiative set out to fix. So the compiler arm merges
-    // whenever compile_check either corroborates (ErrorCount > 0) or forfeits authority
+    // the phantom-row false positive this initiative set out to fix. So a Category=="Compiler" row
+    // merges whenever compile_check either corroborates (ErrorCount > 0) or forfeits authority
     // (Cancelled, or CompletedProjects < TotalProjects). Only a complete, genuinely-green compile
     // pass suppresses an uncorroborated Compiler-category row. Today Cancelled is the sole way
     // CompletedProjects can lag TotalProjects, but the incompleteness test is the invariant that
@@ -548,12 +553,18 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
                 && compile.TotalProjects is int total
                 && completed < total);
 
+        var compilerCategoryRows = diagResult.CompilerDiagnostics
+            .Where(d => string.Equals(d.Category, "Compiler", StringComparison.Ordinal));
+        var nonCompilerCategoryRows = diagResult.CompilerDiagnostics
+            .Where(d => !string.Equals(d.Category, "Compiler", StringComparison.Ordinal));
+
         var corroboratedCompilerRows = compile.ErrorCount > 0 || compileIncomplete
-            ? diagResult.CompilerDiagnostics
-            : Array.Empty<DiagnosticDto>();
+            ? compilerCategoryRows
+            : Enumerable.Empty<DiagnosticDto>();
 
         return compile.Diagnostics
             .Concat(corroboratedCompilerRows)
+            .Concat(nonCompilerCategoryRows)
             .Concat(diagResult.AnalyzerDiagnostics)
             .Where(d => string.Equals(d.Severity, "Error", StringComparison.Ordinal))
             .DistinctBy(d => (d.Id, d.FilePath, d.StartLine, d.StartColumn))

--- a/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceValidationOverallStatusTests.cs
@@ -487,4 +487,69 @@ public sealed class WorkspaceValidationOverallStatusTests
         Assert.AreEqual(2, merged.Length, "both harvests contribute; the shared row dedups exactly once.");
         Assert.AreEqual("compile-error", status);
     }
+
+    // ---- validate-workspace-compiler-gate-scope-to-category: gate scoped to Category=="Compiler" ----
+
+    /// <summary>
+    /// Acceptance-bullet-2 repro: a complete, genuinely-green compile pass (Cancelled=false,
+    /// CompletedProjects==TotalProjects, ErrorCount==0) plus a synthetic WORKSPACE001
+    /// (Category=="Workspace") row riding in the same CompilerDiagnostics arm. The corroboration gate
+    /// must apply ONLY to Category=="Compiler" rows — WORKSPACE001 is a genuine "failed to load this
+    /// project's compilation" signal and must survive, driving the verdict away from "clean".
+    /// </summary>
+    [TestMethod]
+    public void MergeErrorDiagnostics_CleanCompile_WorkspaceCategoryRow_Survives_AndIsNotClean()
+    {
+        var compileClean = CleanCompile();
+        var diagResult = DiagResult(
+            compilerDiagnostics: [new DiagnosticDto("WORKSPACE001", "Could not get compilation for project 'P'", "Error", "Workspace", "P.csproj", null, null, null, null)]);
+
+        var merged = WorkspaceValidationService.MergeErrorDiagnostics(compileClean, diagResult);
+        var status = WorkspaceValidationService.ComputeOverallStatus(compileClean, merged, null, runTests: false);
+
+        Assert.AreEqual(1, merged.Length, "a Workspace-category row is not subject to the compiler-arm corroboration gate and must survive a clean, complete compile pass.");
+        Assert.AreEqual("WORKSPACE001", merged[0].Id);
+        Assert.AreNotEqual("clean", status, "a real 'failed to load compilation' signal must not be reported as a clean build.");
+        Assert.AreEqual("analyzer-error", status, "compile.ErrorCount is 0, so the surviving row degrades to analyzer-error rather than compile-error.");
+    }
+
+    /// <summary>
+    /// Proves the partition is per-row, not per-arm: with the SAME clean, complete compile pass, a
+    /// WORKSPACE001 (Category=="Workspace") row and an uncorroborated phantom (Category=="Compiler")
+    /// row both ride in CompilerDiagnostics. Only the Workspace-category row survives — the
+    /// Compiler-category row is still dropped by the corroboration gate.
+    /// </summary>
+    [TestMethod]
+    public void MergeErrorDiagnostics_MixedCategoryRows_OnlyNonCompilerRowSurvives()
+    {
+        var compileClean = CleanCompile();
+        var diagResult = DiagResult(
+            compilerDiagnostics: [
+                new DiagnosticDto("WORKSPACE001", "Could not get compilation for project 'P'", "Error", "Workspace", "P.csproj", null, null, null, null),
+                new DiagnosticDto("CS0103", "x", "Error", "Compiler", "Y.cs", 2, 1, 2, 5)
+            ]);
+
+        var merged = WorkspaceValidationService.MergeErrorDiagnostics(compileClean, diagResult);
+
+        Assert.AreEqual(1, merged.Length, "the partition is per-row: the Workspace-category row survives while the Compiler-category row is still gated.");
+        Assert.AreEqual("WORKSPACE001", merged[0].Id);
+    }
+
+    /// <summary>
+    /// Regression guard: an incomplete/cancelled compile pass plus a WORKSPACE001 row still merges —
+    /// this combination already worked pre-fix (the whole arm was unconditionally merged whenever the
+    /// compile pass forfeited authority) and must keep working once the gate is scoped per-row.
+    /// </summary>
+    [TestMethod]
+    public void MergeErrorDiagnostics_CancelledCompile_WorkspaceCategoryRow_StillMerges()
+    {
+        var cancelled = CancelledCompile(completedProjects: 1, totalProjects: 4);
+        var diagResult = DiagResult(
+            compilerDiagnostics: [new DiagnosticDto("WORKSPACE001", "Could not get compilation for project 'P'", "Error", "Workspace", "P.csproj", null, null, null, null)]);
+
+        var merged = WorkspaceValidationService.MergeErrorDiagnostics(cancelled, diagResult);
+
+        Assert.AreEqual(1, merged.Length, "a Workspace-category row must still merge when the compile pass is incomplete, mirroring the pre-existing Compiler-category authority-gate behavior.");
+        Assert.AreEqual("WORKSPACE001", merged[0].Id);
+    }
 }


### PR DESCRIPTION
## Summary

- `WorkspaceValidationService.MergeErrorDiagnostics` previously gated the ENTIRE `CompilerDiagnostics` harvest arm on `compile.ErrorCount > 0 || compileIncomplete`, treating it as one corroboration unit instead of testing each row's own `Category`.
- The synthetic `WORKSPACE001` row (`DiagnosticService.CollectProjectDiagnosticsAsync`, `Severity="Error"`, `Category="Workspace"`) rides in the same `CompilerDiagnostics` arm, so a clean-and-complete-but-uncorroborated compile pass silently dropped it too — reporting a false `clean` verdict for a project whose compilation genuinely failed to materialize.
- The gate now partitions `diagResult.CompilerDiagnostics` by `Category=="Compiler"` before applying corroboration. Only the `Compiler`-category partition stays gated; every other row (today only `WORKSPACE001`) concatenates unconditionally, mirroring how `AnalyzerDiagnostics` already merges unconditionally two lines below.
- Updated the descriptive comment block above `MergeErrorDiagnostics` to state the gate is scoped to `Category=="Compiler"` rows within the arm, not the whole arm.
- Added 3 new `[TestMethod]`s to `WorkspaceValidationOverallStatusTests.cs` pinning: (a) the acceptance-bullet-2 repro (clean+complete compile + `WORKSPACE001` → merged.Length==1, status != "clean"), (b) mixed Category rows in the same arm — only the `Workspace`-category row survives, proving per-row not per-arm partitioning, (c) an incomplete/cancelled compile + `WORKSPACE001` still merges (pre-existing behavior, regression guard).

## Validation

- `mcp__roslyn__compile_check` on both touched files — clean.
- `mcp__roslyn__test_run --filter WorkspaceValidationOverallStatusTests` — 20/20 passed (17 pre-existing + 3 new), including all 3 pre-existing `MergeErrorDiagnostics_*` tests pinning the `Category=="Compiler"` gate, unmodified and still green.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1 -Configuration Release` — **skipped**: the self-hosted CI runner is active on this box (standing local policy is to never duplicate a full build/test run locally while it's running). CI will run it on this PR.

Closes: `validate-workspace-compiler-gate-scope-to-category`

🤖 Generated with [Claude Code](https://claude.com/claude-code)