### PR TITLE
fix(workspace): run LRU eviction under the execution gate's writer lock (lru-eviction-gate-layer-execution)

### DIFF
--- a/changelog.d/lru-eviction-gate-layer-execution.md
+++ b/changelog.d/lru-eviction-gate-layer-execution.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** LRU workspace eviction now routes through `WorkspaceExecutionGate`'s per-workspace writer lock, so it can no longer dispose a workspace holding an in-flight gated reader or writer — eviction blocks until the reader/writer drains instead of evicting out from under it, closing the gap PR #1159 documented but did not fix. The eviction path also drops the evicted workspace's lock-registry entry (`RemoveGate`), fixing an adjacent per-eviction registry leak.

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -350,20 +350,20 @@ internal static class ToolDispatch
     /// (<c>workspace_load(path, evictPolicy: "lru")</c>), just without the round trip.
     /// </para>
     /// <para>
-    /// <b>What the LRU scan does and does not protect
-    /// (<c>lru-eviction-concurrent-reader-safety-overstated</c>):</b> <c>WorkspaceManager</c>'s
-    /// eviction scan skips only sessions holding their <c>LoadLock</c>, which is acquired
-    /// exclusively while a <c>workspace_load</c>/reload is in flight. It does <b>not</b> consult
-    /// <c>WorkspaceExecutionGate</c>'s per-workspace reader/writer lock, so a workspace with
-    /// in-flight reads or writes can still be evicted and disposed mid-operation; that caller
-    /// observes <see cref="WorkspaceEvictedException"/> (a <see cref="KeyNotFoundException"/>) on
-    /// its next <c>WorkspaceManager</c> lookup. Earlier revisions of these remarks claimed an
-    /// in-flight workspace is never yanked out from under a concurrent caller — that guarantee
-    /// holds for the load path only, not for gated readers/writers. The gap is documented rather
-    /// than closed because <c>WorkspaceExecutionGate</c> already depends on
-    /// <c>IWorkspaceManager</c>, so gating eviction from inside <c>WorkspaceManager</c> would be a
-    /// DI cycle. Pinned by
-    /// <c>WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction</c>.
+    /// <b>What LRU eviction protects (<c>lru-eviction-gate-layer-execution</c>):</b> candidate
+    /// SELECTION skips only sessions holding their <c>LoadLock</c> — acquired exclusively while a
+    /// <c>workspace_load</c>/reload is in flight — so selection alone is not a safety boundary.
+    /// Eviction EXECUTION supplies it: <c>WorkspaceManager</c> closes the chosen candidate under
+    /// <c>IWorkspaceExecutionGate.RunWriteAsync</c> (reached through a lazily-resolved gate
+    /// reference, which is what keeps the back-edge from being a constructor-level DI cycle), the
+    /// same per-workspace writer-lock nesting <c>workspace_close</c> and <c>workspace_reload</c>
+    /// use. An in-flight gated reader or writer therefore drains BEFORE its workspace is removed
+    /// and disposed, instead of being yanked out from under mid-operation. What remains possible
+    /// is the ordinary between-calls case: a caller idle between two tool calls can find its
+    /// workspace evicted and observes <see cref="WorkspaceEvictedException"/> (a
+    /// <see cref="KeyNotFoundException"/>) on the next lookup — which is exactly what this helper
+    /// recovers from. Pinned by
+    /// <c>WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_BlocksUntilReaderDrains</c>.
     /// </para>
     /// <para>
     /// A failed reload is not additionally surfaced by this helper: the caller rethrows the

--- a/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
+++ b/src/RoslynMcp.Roslyn/ServiceCollectionExtensions.cs
@@ -26,6 +26,14 @@ public static class ServiceCollectionExtensions
             var opts = sp.GetService<ExecutionGateOptions>() ?? new ExecutionGateOptions();
             return new WorkspaceExecutionGate(opts, sp.GetRequiredService<IWorkspaceManager>());
         });
+        // lru-eviction-gate-layer-execution: WorkspaceManager needs a back-reference to the gate
+        // so cap-pressure LRU eviction can run under the evicted workspace's per-workspace writer
+        // lock. WorkspaceExecutionGate's constructor already takes IWorkspaceManager, so a direct
+        // injection would be a DI cycle. Registering the Lazy<T> breaks it: constructing the Lazy
+        // resolves nothing, and its factory only calls GetRequiredService on first .Value access —
+        // which happens during an eviction, long after both singletons are cached.
+        services.AddSingleton(sp =>
+            new Lazy<IWorkspaceExecutionGate>(() => sp.GetRequiredService<IWorkspaceExecutionGate>()));
         services.AddSingleton<IDotnetCommandRunner>(sp =>
             new DotnetCommandRunner(sp.GetRequiredService<ILogger<DotnetCommandRunner>>()));
         services.AddSingleton<IGatedCommandExecutor, GatedCommandExecutor>();

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -74,6 +74,23 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
     /// reference stripping, extracted from <see cref="LoadIntoSessionAsync"/>.
     /// </summary>
     private readonly UnresolvedAnalyzerReferenceStripper _analyzerReferenceStripper;
+    /// <summary>
+    /// lru-eviction-gate-layer-execution: lazily-resolved back-reference to the execution gate,
+    /// used to run cap-pressure LRU eviction under the evicted workspace's per-workspace WRITER
+    /// lock so in-flight gated readers/writers drain before the session is disposed.
+    /// <para>
+    /// The indirection is load-bearing: <see cref="WorkspaceExecutionGate"/>'s own constructor
+    /// takes <see cref="IWorkspaceManager"/>, so a direct back-reference would be a
+    /// constructor-level DI cycle. <see cref="Lazy{T}"/> defers the container lookup to first
+    /// <c>.Value</c> access — by which point both singletons are already constructed and cached.
+    /// </para>
+    /// <para>
+    /// <see langword="null"/> when unwired (direct test construction). On that path eviction
+    /// falls back to the historic ungated <see cref="Close"/>, which keeps the constructor
+    /// change purely additive for the test call sites that do not need the guarantee.
+    /// </para>
+    /// </summary>
+    private readonly Lazy<IWorkspaceExecutionGate>? _evictionGate;
     private readonly ConcurrentDictionary<string, WorkspaceSession> _sessions = new(StringComparer.Ordinal);
     /// <summary>
     /// mcp-error-category-workspace-evicted-on-host-recycle + workspace-id-recovery-hints:
@@ -101,8 +118,9 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         IPreviewStore previewStore,
         IFileWatcherService fileWatcher,
         WorkspaceManagerOptions? options = null,
-        IWorkspaceCacheStore? cacheStore = null)
-        : this(logger, previewStore, fileWatcher, options, cacheStore, sessionLoader: null)
+        IWorkspaceCacheStore? cacheStore = null,
+        Lazy<IWorkspaceExecutionGate>? evictionGate = null)
+        : this(logger, previewStore, fileWatcher, options, cacheStore, sessionLoader: null, evictionGate: evictionGate)
     {
     }
 
@@ -121,7 +139,8 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         IWorkspaceCacheStore? cacheStore,
         WorkspaceSessionLoader? sessionLoader,
         RestoreStalenessDetector? restoreStalenessDetector = null,
-        UnresolvedAnalyzerReferenceStripper? analyzerReferenceStripper = null)
+        UnresolvedAnalyzerReferenceStripper? analyzerReferenceStripper = null,
+        Lazy<IWorkspaceExecutionGate>? evictionGate = null)
     {
         _logger = logger;
         _previewStore = previewStore;
@@ -131,6 +150,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         _sessionLoader = sessionLoader ?? new WorkspaceSessionLoader();
         _restoreStalenessDetector = restoreStalenessDetector ?? new RestoreStalenessDetector();
         _analyzerReferenceStripper = analyzerReferenceStripper ?? new UnresolvedAnalyzerReferenceStripper();
+        _evictionGate = evictionGate;
         var max = _options.MaxConcurrentWorkspaces > 0 ? _options.MaxConcurrentWorkspaces : 8;
         _workspaceSlots = new SemaphoreSlim(max, max);
     }
@@ -247,25 +267,16 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 // LoadIntoSessionAsync, so this filter excludes exactly the sessions that are
                 // mid-workspace_load / mid-reload — and nothing else.
                 //
-                // lru-eviction-concurrent-reader-safety-overstated: the filter does NOT exclude
-                // a session with in-flight reads or writes. Ordinary tool calls serialise on
-                // WorkspaceExecutionGate's per-workspace reader/writer lock, which this scan
-                // never consults, so the Close() below can remove and dispose a session while a
-                // gated reader is still running against it. The in-flight caller then observes
-                // WorkspaceEvictedException (a KeyNotFoundException) on its next WorkspaceManager
-                // lookup, because Close() removes the session from _sessions and records the
-                // eviction before disposing it.
+                // lru-eviction-gate-layer-execution: the LoadLock filter alone does NOT exclude a
+                // session with in-flight gated reads or writes, so candidate SELECTION is not a
+                // safety boundary. Eviction EXECUTION supplies it: EvictForCapAsync runs Close()
+                // under WorkspaceExecutionGate's per-workspace WRITER lock (see that method), the
+                // same nesting workspace_close / workspace_reload use (WorkspaceTools.cs), so
+                // in-flight readers/writers drain before the session is removed and disposed.
+                // Pinned by
+                // WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_BlocksUntilReaderDrains.
                 //
-                // Contrast workspace_close / workspace_reload (WorkspaceTools.cs), which nest
-                // gate.RunWriteAsync inside gate.RunLoadGateAsync so in-flight readers drain
-                // first. LRU eviction is the one lifecycle transition that skips that pattern:
-                // WorkspaceExecutionGate's constructor already takes IWorkspaceManager, so taking
-                // the gate from here would be a constructor-level DI cycle. Closing the gap means
-                // moving eviction *execution* (not just candidate selection) up into the gate
-                // layer. Characterised by
-                // WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction.
-                //
-                // If all sessions are locked, fall through to the Strict error path.
+                // If all sessions are mid-load, fall through to the Strict error path.
                 var lruCandidate = _sessions.Values
                     .Where(s => s.LoadLock.CurrentCount > 0)
                     .OrderBy(s => s.LastAccessedUtc)
@@ -278,9 +289,10 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                         lruCandidate.WorkspaceId,
                         lruCandidate.LastAccessedUtc,
                         fullPath);
-                    Close(lruCandidate.WorkspaceId);
+                    await EvictForCapAsync(lruCandidate.WorkspaceId, ct).ConfigureAwait(false);
 
-                    // After Close() the semaphore slot has been released — retry immediately.
+                    // The eviction released a semaphore slot (or a concurrent caller already
+                    // evicted this candidate and released it) — retry immediately.
                     if (!await _workspaceSlots.WaitAsync(0, ct).ConfigureAwait(false))
                     {
                         // The slot was consumed by a concurrent caller between the Close() and
@@ -380,6 +392,72 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
                 _workspaceSlots.Release();
             }
         }
+    }
+
+    /// <summary>
+    /// lru-eviction-gate-layer-execution: close a cap-pressure LRU eviction candidate under
+    /// <see cref="IWorkspaceExecutionGate"/>'s per-workspace WRITER lock, so any in-flight gated
+    /// reader or writer on that workspace drains before the session is removed and disposed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Shape is copied from <c>workspace_close</c> (<c>WorkspaceTools.CloseWorkspace</c>):
+    /// <c>RunWriteAsync(id, …, applyStalenessPolicy: false)</c> — staleness policy is off because
+    /// an auto-reload of a workspace we are about to dispose is pure waste and can throw when the
+    /// on-disk solution is already gone — followed by <c>RemoveGate(id)</c> STRICTLY AFTER the
+    /// write completes, never from inside the closure, so the registry entry is dropped only once
+    /// the writer lock it guards has been released. Doing so also fixes an adjacent leak: the old
+    /// direct-<see cref="Close"/> eviction path never called <c>RemoveGate</c>, so every
+    /// LRU-evicted workspace left an orphaned lock entry in the gate's registry.
+    /// </para>
+    /// <para>
+    /// Reentrancy is safe. In production <c>LoadAsync</c> already runs inside
+    /// <c>gate.RunLoadGateAsync</c>, whose <c>WithGlobalThrottle</c> depth counter lets this
+    /// nested <c>RunWriteAsync</c> reuse the throttle slot instead of consuming a second one —
+    /// the identical nesting <c>workspace_close</c> and <c>workspace_reload</c> already rely on.
+    /// The writer lock taken here is for the EVICTED workspace, never the one being loaded, so it
+    /// cannot self-deadlock.
+    /// </para>
+    /// <para>
+    /// When no gate is wired (<c>_evictionGate is null</c> — direct test construction) this falls
+    /// back to the historic ungated <see cref="Close"/> so the added constructor parameter stays
+    /// purely additive.
+    /// </para>
+    /// </remarks>
+    private async Task EvictForCapAsync(string workspaceId, CancellationToken ct)
+    {
+        if (_evictionGate is null)
+        {
+            Close(workspaceId);
+            return;
+        }
+
+        var gate = _evictionGate.Value;
+        try
+        {
+            await gate.RunWriteAsync(
+                workspaceId,
+                _ =>
+                {
+                    Close(workspaceId);
+                    return Task.FromResult(true);
+                },
+                ct,
+                applyStalenessPolicy: false).ConfigureAwait(false);
+        }
+        catch (KeyNotFoundException)
+        {
+            // A concurrent caller (another LRU eviction, or an explicit workspace_close) already
+            // removed this candidate between our selection scan and the writer-lock acquisition.
+            // The gate raises KeyNotFoundException from either its pre-lock existence check or
+            // EnsureWorkspaceStillExists inside the lock. Nothing left to evict — and that caller
+            // owns the RemoveGate for the id — so return and let the caller's slot retry decide
+            // between proceeding and the Strict error path, mirroring the existing
+            // "slot consumed by a concurrent caller" fallback.
+            return;
+        }
+
+        gate.RemoveGate(workspaceId);
     }
 
     public async Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct)

--- a/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceCapLruEvictionTests.cs
@@ -15,9 +15,10 @@ namespace RoslynMcp.Tests;
 /// </list>
 ///
 /// <para>
-/// Also carries the <c>lru-eviction-concurrent-reader-safety-overstated</c> characterization
-/// guard: the LRU scan does not consult <see cref="WorkspaceExecutionGate"/>, so a workspace with
-/// a gated read in flight is still evicted underneath that reader.
+/// Also carries the <c>lru-eviction-gate-layer-execution</c> guard: when a gate reference is
+/// wired, eviction runs under <see cref="WorkspaceExecutionGate"/>'s per-workspace writer lock, so
+/// a workspace with a gated read in flight is NOT evicted underneath that reader — the eviction
+/// blocks until the reader drains.
 /// </para>
 /// </summary>
 [DoNotParallelize]
@@ -127,35 +128,49 @@ public sealed class WorkspaceCapLruEvictionTests
     }
 
     /// <summary>
-    /// <c>lru-eviction-concurrent-reader-safety-overstated</c>: characterization guard pinning the
-    /// documented gap between the LRU eviction scan and <see cref="WorkspaceExecutionGate"/>.
+    /// <c>lru-eviction-gate-layer-execution</c>: with a gate reference wired (as production DI
+    /// does), cap-pressure LRU eviction runs under <see cref="WorkspaceExecutionGate"/>'s
+    /// per-workspace WRITER lock, so it BLOCKS behind an in-flight gated reader instead of
+    /// disposing the workspace underneath it.
     ///
     /// <para>
-    /// The scan filters candidates on <c>LoadLock.CurrentCount &gt; 0</c>. <c>LoadLock</c> is
-    /// acquired only by <c>LoadIntoSessionAsync</c>, so it excludes sessions that are mid-load —
-    /// and nothing else. It never consults the gate's per-workspace reader/writer lock, so a
-    /// workspace with a gated read in flight is evicted and disposed underneath that reader,
-    /// which then observes <see cref="WorkspaceEvictedException"/> on its next lookup
-    /// (<c>Close()</c> removes the session and records the eviction before disposing it, so
-    /// <c>GetRequiredSession</c> throws before any disposed <c>MSBuildWorkspace</c> is touched).
+    /// Covers both failure modes from the row's acceptance criteria:
+    /// <list type="number">
+    ///   <item><description>
+    ///   the evicted workspace is still tracked (and the triggering load still pending) for as
+    ///   long as the reader holds the gate's reader lock; and
+    ///   </description></item>
+    ///   <item><description>
+    ///   a <c>GetProject</c> call made from inside that gated read — the
+    ///   <c>GetRequiredSession</c>-then-touch-<c>CurrentSolution</c> TOCTOU — no longer observes
+    ///   <see cref="WorkspaceEvictedException"/>, because both paths now serialize on the same
+    ///   per-workspace lock.
+    ///   </description></item>
+    /// </list>
     /// </para>
     ///
     /// <para>
-    /// This asserts the CURRENT (unsafe) behaviour deliberately. If the gap is ever closed — by
-    /// moving eviction execution up into the gate layer and taking
-    /// <c>IWorkspaceExecutionGate.RunWriteAsync</c> on the evicted candidate — this test must fail
-    /// and be rewritten to assert the eviction blocks until the reader drains.
+    /// Deterministic by construction, no <c>Task.Delay</c>: the reader signals that it holds the
+    /// lock, the eviction-triggering load is STARTED (not awaited — awaiting it here would
+    /// deadlock, since it now waits on the reader), the blocked state is asserted, and only then
+    /// is the reader released.
     /// </para>
     /// </summary>
     [TestMethod]
-    public async Task LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction()
+    public async Task LruEviction_WhileGatedReadInFlight_BlocksUntilReaderDrains()
     {
+        // Mutable indirection: the manager needs the gate and the gate needs the manager. The
+        // Lazy defers the read of `gate` until first eviction, which is exactly the cycle-break
+        // production DI performs with its Lazy<IWorkspaceExecutionGate> registration.
+        WorkspaceExecutionGate? gate = null;
+
         // Cap of 1 so a single loaded workspace saturates the semaphore and the second load
         // must evict.
-        using var manager = CreateManager(maxConcurrentWorkspaces: 1);
+        using var manager = CreateManager(
+            maxConcurrentWorkspaces: 1,
+            evictionGate: new Lazy<IWorkspaceExecutionGate>(() => gate!));
 
-        // Real gate + real manager, wired exactly as production DI does.
-        var gate = new WorkspaceExecutionGate(
+        gate = new WorkspaceExecutionGate(
             new ExecutionGateOptions { RequestTimeout = TimeSpan.FromMinutes(5) },
             manager);
 
@@ -167,52 +182,68 @@ public sealed class WorkspaceCapLruEvictionTests
             var status1 = await manager.LoadAsync(path1, CancellationToken.None);
 
             // Deterministic hand-off (no Task.Delay): readerHoldsLock signals that the gate's
-            // reader lock for workspace1 is held; evictionCompleted releases the reader only
-            // after the LRU eviction has already run.
+            // reader lock for workspace1 is held; readerMayRelease lets the reader finish only
+            // after the eviction-triggering load has been observed blocked.
             var readerHoldsLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var evictionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readerMayRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var readerTask = gate.RunReadAsync<Exception?>(
+            var readerTask = gate.RunReadAsync<(Exception? Error, bool StillTracked)>(
                 status1.WorkspaceId,
                 async _ =>
                 {
-                    readerHoldsLock.SetResult();
-                    await evictionCompleted.Task;
-
-                    // Still inside the gated read — the reader lock has NOT been released. A
-                    // lifecycle transition that respected the gate could not have run yet.
                     try
                     {
-                        manager.GetProject(status1.WorkspaceId, "SampleLibrary");
-                        return null;
+                        readerHoldsLock.SetResult();
+                        await readerMayRelease.Task.WaitAsync(TestTimeout);
+
+                        // Still inside the gated read — the reader lock has NOT been released, so
+                        // a gate-respecting eviction cannot have run yet.
+                        try
+                        {
+                            manager.GetProject(status1.WorkspaceId, "SampleLib");
+                            return (null, manager.ContainsWorkspace(status1.WorkspaceId));
+                        }
+                        catch (Exception ex)
+                        {
+                            return (ex, manager.ContainsWorkspace(status1.WorkspaceId));
+                        }
                     }
-                    catch (Exception ex)
+                    finally
                     {
-                        return ex;
+                        // Never strand the eviction on a reader that failed before releasing.
+                        readerMayRelease.TrySetResult();
                     }
                 },
                 CancellationToken.None);
 
-            await readerHoldsLock.Task;
+            await readerHoldsLock.Task.WaitAsync(TestTimeout);
 
-            // THE GAP: the LRU scan ignores the gate, so this evicts workspace1 out from under
-            // the in-flight reader instead of waiting for it to drain.
-            var status2 = await manager.LoadAsync(path2, EvictPolicy.Lru, CancellationToken.None);
+            // Start (do NOT await) the eviction-triggering load: it must now block on the
+            // evicted candidate's writer lock until the reader above drains.
+            var evictingLoad = manager.LoadAsync(path2, EvictPolicy.Lru, CancellationToken.None);
+
+            Assert.IsTrue(manager.ContainsWorkspace(status1.WorkspaceId),
+                "Eviction must not remove a workspace whose gate reader lock is still held.");
+            Assert.IsFalse(evictingLoad.IsCompleted,
+                "The triggering load cannot complete before the eviction it depends on, and the "
+                + "eviction is blocked behind the in-flight gated reader.");
+
+            readerMayRelease.SetResult();
+
+            var (observed, stillTrackedDuringRead) = await readerTask.WaitAsync(TestTimeout);
+            var status2 = await evictingLoad.WaitAsync(TestTimeout);
+
+            Assert.IsNull(observed,
+                "GetProject called from inside the gated read must not observe eviction now that "
+                + "eviction serializes on the same per-workspace lock. Actual: "
+                + (observed?.GetType().Name ?? "<none>"));
+            Assert.IsTrue(stillTrackedDuringRead,
+                "The workspace must still be tracked for the whole duration of the gated read.");
 
             Assert.IsFalse(manager.ContainsWorkspace(status1.WorkspaceId),
-                "Characterization: LRU eviction currently ignores WorkspaceExecutionGate's reader "
-                + "lock and evicts a workspace that has a read in flight.");
+                "Once the reader drained, the LRU candidate must actually be evicted.");
             Assert.IsTrue(manager.ContainsWorkspace(status2.WorkspaceId),
                 "The triggering load must have taken the slot freed by the eviction.");
-
-            evictionCompleted.SetResult();
-            var observed = await readerTask;
-
-            Assert.IsInstanceOfType<WorkspaceEvictedException>(observed,
-                "The in-flight reader must observe WorkspaceEvictedException on its next lookup — "
-                + "Close() removes the session from the live set and records the eviction before "
-                + "disposing it, so GetRequiredSession throws before any disposed MSBuildWorkspace "
-                + "is reached. Actual: " + (observed?.GetType().Name ?? "<no exception thrown>"));
         }
         finally
         {
@@ -221,12 +252,19 @@ public sealed class WorkspaceCapLruEvictionTests
         }
     }
 
-    private static WorkspaceManager CreateManager(int maxConcurrentWorkspaces = 4)
+    /// <summary>Fail fast rather than hang the suite if a hand-off regresses into a deadlock.</summary>
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(2);
+
+    private static WorkspaceManager CreateManager(
+        int maxConcurrentWorkspaces = 4,
+        Lazy<IWorkspaceExecutionGate>? evictionGate = null)
     {
         return new WorkspaceManager(
             NullLogger<WorkspaceManager>.Instance,
             new PreviewStore(),
             new FileWatcherService(NullLogger<FileWatcherService>.Instance),
-            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = maxConcurrentWorkspaces });
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = maxConcurrentWorkspaces },
+            cacheStore: null,
+            evictionGate: evictionGate);
     }
 }


### PR DESCRIPTION
Closes: lru-eviction-gate-layer-execution

## Problem

Cap-pressure LRU eviction (`WorkspaceManager.LoadAsync`, `EvictPolicy.Lru`) selected a candidate by filtering on `LoadLock.CurrentCount > 0` and then called `Close(candidateId)` directly. `LoadLock` is held only by `LoadIntoSessionAsync`, so the filter excluded exactly the mid-load sessions and nothing else — it never consulted `WorkspaceExecutionGate`'s per-workspace reader/writer lock. A workspace with an in-flight gated read or write could therefore be removed and disposed underneath that caller, which then saw `WorkspaceEvictedException` on its next lookup.

PR #1159 documented and characterization-tested this gap rather than closing it, because `WorkspaceExecutionGate`'s constructor already takes `IWorkspaceManager` and a direct back-reference would have been a constructor-level DI cycle.

## Fix — move eviction *execution* into the gate layer

- **`WorkspaceManager`** takes an optional trailing `Lazy<IWorkspaceExecutionGate>? evictionGate = null` on both constructors. The `Lazy` is the cycle-break: constructing it resolves nothing, and its factory only calls `GetRequiredService` on first `.Value` access — during an eviction, long after both singletons are cached.
- The LRU branch now calls a new `EvictForCapAsync`, which runs `Close()` inside `gate.RunWriteAsync(candidateId, …, applyStalenessPolicy: false)` and then `gate.RemoveGate(candidateId)` **strictly after** the write returns — the same nesting `workspace_close` / `workspace_reload` already use (`WorkspaceTools.cs:137-163`). In-flight readers and writers drain before the session is disposed.
- `RemoveGate` on this path also closes an adjacent leak: the old direct-`Close()` eviction never dropped the evicted workspace's `AsyncReaderWriterLockRegistry` entry, so **every** LRU eviction orphaned one.
- A concurrent evict/close of the same candidate surfaces as `KeyNotFoundException` from the gate (pre-lock check or `EnsureWorkspaceStillExists`); it is caught and falls through to the existing slot-retry / Strict-error path.
- **`ServiceCollectionExtensions`** registers `Lazy<IWorkspaceExecutionGate>` next to the gate itself; MS DI auto-injects it into `WorkspaceManager`.
- **`ToolDispatch.RehydrateEvictedWorkspaceAsync`** remarks rewritten — they still described the gap as open and cited the old test name.

The second failure mode in the row's acceptance (`GetProject`'s `GetRequiredSession` → touch `CurrentSolution` TOCTOU) is structurally closed by the same change: both paths now serialize on the one per-workspace lock. Covered by assertion, not by a separate code change.

### Reentrancy / deadlock

Safe. In production `LoadAsync` already runs inside `gate.RunLoadGateAsync`, whose `WithGlobalThrottle` `AsyncLocal` depth counter lets the nested `RunWriteAsync` reuse the throttle slot instead of consuming a second one — the exact mechanism built for `workspace_close`'s existing `RunLoadGateAsync → RunWriteAsync` nesting. The writer lock taken is for the *evicted* workspace, never the one being loaded, so it cannot self-deadlock.

### Why the parameter is optional (not a shim)

`null` keeps the seven test call sites that construct `WorkspaceManager` directly compiling on the historic ungated path — documented graceful degradation, zero forced fanout, per Directive #6. That default is precisely why `AddRoslynServices_WorkspaceManager_ReceivesLazyExecutionGate_WithoutDiCycle` exists: drop the `Lazy` registration and production would silently degrade with no build break and no other failing test.

## Tests

- `WorkspaceCapLruEvictionTests.LruEviction_WhileGatedReadInFlight_EvictsAnyway_AndReaderObservesEviction` → rewritten as `…_BlocksUntilReaderDrains`. Wires the mutable-indirection `Lazy`, starts (does not await — that would deadlock) the eviction-triggering load, asserts the workspace is still tracked and the load still pending while the reader holds the lock, then releases and asserts `GetProject` from inside the gated read observed **no** eviction. Deterministic TCS hand-off, no `Task.Delay`; the reader release is in a `finally` and every wait is `WaitAsync`-bounded.
- New `ServiceCollectionExtensionsTests.AddRoslynServices_WorkspaceManager_ReceivesLazyExecutionGate_WithoutDiCycle` — resolves `IWorkspaceManager` first (the cycle-sensitive order) and asserts the injected `Lazy` is non-null and resolves to the same gate singleton.
- The three unchanged-behavior tests in `WorkspaceCapLruEvictionTests` pass unmodified.

## Validation

| Check | Result |
|---|---|
| `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` | 0 warnings, 0 errors |
| `WorkspaceCapLruEvictionTests` + `ServiceCollectionExtensionsTests` + `ToolDiResolutionTests` + `WorkspaceManagerEvictionTests` + `WorkspaceEvictionAutoRetryTests` | 30/30 pass |
| Discriminating-test check | With `evictionGate: null` the rewritten test **fails** (`Eviction must not remove a workspace whose gate reader lock is still held`); with the gate wired it passes |
| `./eng/verify-ai-docs.ps1` | passed |
| `./eng/verify-release.ps1 -Configuration Release` | 1887/1888 — see note |

**verify-release note:** the single failure is `ServerInfoUpdateLatestTests.ServerInfo_RealFailedChecker_DoesNotResetStatusToPending`, a fixed 5-second `WaitAsync` on a background version-check task that starves under full-suite parallel load. It passes in isolation (7/7 for that class, 170 ms) and nothing in this diff touches `NuGetVersionChecker`, `ServerTools`, or the HTTP seam. Flagging separately as a test-hygiene backlog candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
