### PR TITLE
test(tool-di): derive loggerFactory schema-leak guard by reflection

### DIFF
--- a/changelog.d/tool-di-resolution-leak-pin-compile-check-test-run.md
+++ b/changelog.d/tool-di-resolution-leak-pin-compile-check-test-run.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extended the DI-resolution leak-guard test (`ToolDiResolutionTests`) to derive its guarded tool list by reflection instead of a hardcoded array, closing a gap where `compile_check` and `test_run` — which gained the same `ILoggerFactory` DI parameter in a prior PR — had no schema-leak regression coverage.

--- a/tests/RoslynMcp.Tests/ToolDiResolutionTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDiResolutionTests.cs
@@ -97,13 +97,24 @@ public sealed class ToolDiResolutionTests
     }
 
     [TestMethod]
-    public void WorkspaceLifecycleTools_DoNotExposeLoggerFactoryInMcpInputSchema()
+    public void ToolMethods_DoNotExposeLoggerFactoryInMcpInputSchema()
     {
         using var provider = BuildHostServiceProvider(includeMcpTools: true);
         var tools = provider.GetServices<McpServerTool>()
             .ToDictionary(tool => tool.ProtocolTool.Name, StringComparer.Ordinal);
 
-        foreach (var toolName in new[] { "workspace_load", "workspace_reload", "workspace_close" })
+        var toolAssembly = typeof(ServerTools).Assembly;
+        var loggerFactoryToolNames = toolAssembly.GetTypes()
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .Where(m => m.GetParameters().Any(p => p.ParameterType == typeof(ILoggerFactory)))
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()!.Name!)
+            .ToList();
+
+        Assert.IsTrue(loggerFactoryToolNames.Count > 0,
+            "No [McpServerTool] methods with an ILoggerFactory parameter were discovered — test fixture broken.");
+
+        foreach (var toolName in loggerFactoryToolNames)
         {
             Assert.IsTrue(tools.TryGetValue(toolName, out var tool),
                 $"{toolName} must be registered by WithToolsFromAssembly.");


### PR DESCRIPTION
## Summary
- `ToolDiResolutionTests.WorkspaceLifecycleTools_DoNotExposeLoggerFactoryInMcpInputSchema` renamed to `ToolMethods_DoNotExposeLoggerFactoryInMcpInputSchema` and rewritten to derive its guarded tool-name list by reflection (any `[McpServerTool]` method with an `ILoggerFactory` parameter) instead of a hardcoded 3-element array.
- Closes a regression-coverage gap: PR #1172 added `ILoggerFactory? loggerFactory = null` to `compile_check` and `test_run` without updating the hardcoded array, so those two tools had zero schema-leak pin coverage.
- No production code changes — test-only.

## Test plan
- [x] `mcp__roslyn__compile_check` on the edited test file — 0 errors
- [x] `mcp__roslyn__test_run --filter ToolDiResolutionTests` — 3/3 passed (confirms the reflection-derived list now covers all 5 `ILoggerFactory`-parameterized tools: `workspace_load`, `workspace_reload`, `workspace_close`, `compile_check`, `test_run`)
- [x] `./eng/verify-ai-docs.ps1` — passed
- CI (self-hosted runner) will run full `verify-release.ps1`

Closes: tool-di-resolution-leak-pin-compile-check-test-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)