### PR TITLE
fix(docs): correct GitStatusTimeout scope to name both call sites

### DIFF
--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -60,7 +60,7 @@ Optional overrides are read at startup from `src/RoslynMcp.Host.Stdio/Program.cs
 | `ROSLYNMCP_TEST_TIMEOUT_SECONDS` | `ValidationServiceOptions.TestTimeout` | 10 minutes |
 | `ROSLYNMCP_VULN_SCAN_TIMEOUT_SECONDS` | `ValidationServiceOptions.VulnerabilityScanTimeout` | 5 minutes |
 | `ROSLYNMCP_APPLY_REVERT_TIMEOUT_SECONDS` | `ValidationServiceOptions.ApplyRevertTimeout` | 30 seconds |
-| `ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` | `ValidationServiceOptions.GitStatusTimeout` — bounds the `git status` scope-collection in `validate_recent_git_changes`; on timeout the bundle reports `overallStatus: git-status-unknown` instead of `clean` | 10 seconds |
+| `ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` | `ValidationServiceOptions.GitStatusTimeout` — bounds the `git status` subprocess at both `validate_recent_git_changes`'s scope-collection (on timeout, reports `overallStatus: git-status-unknown` instead of `clean`) and `validate_workspace`'s change-tracker reconcile fallback when `changedFilePaths` is omitted (on timeout, silently falls back to the unfiltered tracker list, no verdict change) | 10 seconds |
 | `ROSLYNMCP_MAX_RELATED_FILES` | `ValidationServiceOptions.MaxRelatedFiles` | 25 |
 | `ROSLYNMCP_FAST_FAIL_FILE_LOCK` | Early terminate `dotnet test` on MSB3027/MSB3021 file-lock failures | `true` |
 | `ROSLYNMCP_PREVIEW_MAX_ENTRIES` | `PreviewStoreOptions.MaxEntries` | 20 |

--- a/changelog.d/git-status-timeout-docs-scope-correction.md
+++ b/changelog.d/git-status-timeout-docs-scope-correction.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `GitStatusTimeout`/`ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` docs now correctly state the timeout bounds the `git status` subprocess in both `validate_recent_git_changes`'s scope collection and `validate_workspace`'s change-tracker reconcile, and that only the former degrades the verdict to `git-status-unknown`.

--- a/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
+++ b/src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs
@@ -45,13 +45,17 @@ public sealed record ValidationServiceOptions
     public TimeSpan ApplyRevertTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets the maximum time allowed for the <c>git status --porcelain</c> invocation that
-    /// <c>validate_recent_git_changes</c> uses to derive its changed-file scope.
-    /// Defaults to 10 seconds. Distinct from the broader per-phase validation timeout: this one
-    /// bounds only the git subprocess. When it fires the bundle can no longer trust an otherwise
-    /// <c>clean</c> verdict and reports <c>git-status-unknown</c> instead, so a repository large
-    /// or cold enough to routinely exceed 10 seconds should raise this rather than live with a
-    /// degraded verdict.
+    /// Gets the maximum time allowed for the <c>git status --porcelain</c> invocation used by
+    /// <c>CollectGitChangedFilesAsync</c>, which bounds this same subprocess at two call sites
+    /// with different on-timeout behavior. Defaults to 10 seconds. Distinct from the broader
+    /// per-phase validation timeout: this one bounds only the git subprocess.
+    /// In <c>ValidateRecentGitChangesAsync</c> (the <c>validate_recent_git_changes</c> scope-collection
+    /// path), a timeout means the bundle can no longer trust an otherwise <c>clean</c> verdict, so it
+    /// reports <c>git-status-unknown</c> instead. In <c>ReconcileChangeTrackerFilesAsync</c> (the
+    /// <c>validate_workspace</c> change-tracker reconcile path, used when the caller omits
+    /// <c>changedFilePaths</c>), a timeout instead silently falls back to the unfiltered tracker list
+    /// with no verdict degradation. A repository large or cold enough to routinely exceed 10 seconds
+    /// should raise this rather than live with either degraded behavior.
     /// </summary>
     public TimeSpan GitStatusTimeout { get; init; } = TimeSpan.FromSeconds(10);
 }


### PR DESCRIPTION
## Summary

`ValidationServiceOptions.GitStatusTimeout`'s XML doc and the `ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` row in `ai_docs/runtime.md` both stated the timeout bounds only the `git status --porcelain` invocation used by `validate_recent_git_changes`. That's incomplete: `_gitStatusTimeout` is passed to `CollectGitChangedFilesAsync` at TWO call sites in `WorkspaceValidationService.cs` — `ValidateRecentGitChangesAsync` and `ReconcileChangeTrackerFilesAsync` (the latter reached from `validate_workspace`'s change-tracker fallback when `changedFilePaths` is omitted). The two sites behave differently on timeout: the former degrades `OverallStatus` to `git-status-unknown`; the latter silently discards the `TimedOut` flag and falls back to the unfiltered tracker list with no verdict change.

- Rewrote `GitStatusTimeout`'s XML `<summary>` in `src/RoslynMcp.Roslyn/Services/ValidationServiceOptions.cs` to name both call sites and their differing on-timeout behavior.
- Extended the `ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` row's "Affects" cell in `ai_docs/runtime.md` to mirror the corrected doc wording.

Doc-only correction — no code, test, or DI changes; `_gitStatusTimeout` itself is untouched.

Closes: git-status-timeout-docs-scope-correction

## Test plan

- [x] `mcp__roslyn__compile_check` on `ValidationServiceOptions.cs` — 0 errors, 0 warnings.
- [x] `./eng/verify-ai-docs.ps1` — passed, no markdown-lint/link-syntax regression.
- [x] Manual re-read of both edited files confirming both call sites and their differing on-timeout behavior are named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)