### PR TITLE
docs(deep-review): single-source recognized-artifact-shape list (deep-review-shape-list-single-source)

### DIFF
--- a/.claude/agents/backlog-intake-extractor.md
+++ b/.claude/agents/backlog-intake-extractor.md
@@ -1,6 +1,6 @@
 ---
 name: backlog-intake-extractor
-description: Extract, dedupe, classify, and rank actionable items from deep-review artifacts in `review-inbox/` (`*_mcp-server-audit.md`, `*_experimental-promotion.md`, `*_roslyn-mcp-retro.md`). Returns a compact structured row list + notes. Used as Phase 1 of the `/backlog-intake` skill to protect main-agent context from multi-thousand-line source reads.
+description: Extract, dedupe, classify, and rank actionable items from deep-review artifacts (server audits, surface tests, experimental-promotion reports, session retros) staged in `review-inbox/`. Returns a compact structured row list + notes. Used as Phase 1 of the `/backlog-intake` skill to protect main-agent context from multi-thousand-line source reads.
 tools: Read, Glob, Grep, Bash
 model: sonnet
 ---
@@ -19,11 +19,16 @@ Missing required field → emit `ERROR: missing <field>` and exit.
 
 ## Context
 
-The Roslyn-Backed-MCP repo is a C# MCP server that exposes Roslyn-powered tools (refactor, analyze, review, …) to Claude Code. It is consumed as a plugin by several sibling C# repos and by itself. Review files come in three shapes:
+The Roslyn-Backed-MCP repo is a C# MCP server that exposes Roslyn-powered tools (refactor, analyze, review, …) to Claude Code. It is consumed as a plugin by several sibling C# repos and by itself.
 
-- `*_mcp-server-audit.md` — audits exercising the server's tools against a real codebase. Findings split between "bug in the audited codebase" and "gap/limitation in the MCP server tools."
-- `*_experimental-promotion.md` — audits of whether an experimental feature is ready for promotion.
-- `*_roslyn-mcp-retro.md` — session retrospectives on using the server. Richest source of items actionable in THIS repo.
+**Which artifact shapes exist is defined in exactly one place:** `eng/stage-review-inbox.ps1` `.DESCRIPTION` → **Recognized shapes**. Read that block (it is short) rather than assuming a fixed list — the set grows. Do not re-list the globs here.
+
+Interpretation notes for the shape families you will encounter (guidance only, NOT an authoritative list — a shape present in `review-inbox/` but not described below still gets extracted using the general rules):
+
+- **Server audits** — exercise the server's tools against a real codebase. Findings split between "bug in the audited codebase" and "gap/limitation in the MCP server tools."
+- **Surface tests** — consumer-facing sweeps of the server's live tool surface. Same bug-vs-gap split as server audits.
+- **Experimental-promotion reports** — audits of whether an experimental feature is ready for promotion.
+- **Session retros** (single- and multi-session) — retrospectives on using the server. Richest source of items actionable in THIS repo.
 
 ## Scope
 

--- a/.claude/skills/backlog-intake/SKILL.md
+++ b/.claude/skills/backlog-intake/SKILL.md
@@ -45,9 +45,9 @@ Default (no flags): stage if `review-inbox/` is empty, verify against CHANGELOG,
 
 Skip this phase if `--skip-stage` is set.
 
-`eng/stage-review-inbox.ps1` discovers TWO artifact shapes from this repo and configured siblings:
+`eng/stage-review-inbox.ps1` discovers artifacts from this repo and configured siblings. The canonical list of recognized shapes lives in that script's `.DESCRIPTION` → **Recognized shapes** block — read it there; do not re-list the globs here. Those shapes fall into TWO handling categories:
 
-1. **Prose audit / retro / promotion reports** (`*_mcp-server-audit.md`, `*_experimental-promotion.md`, `*_roslyn-mcp-retro.md`) — moved into `review-inbox/` for the existing extraction flow.
+1. **Prose audit / retro / promotion reports** — moved into `review-inbox/` for the existing extraction flow.
 2. **`backlog.d/<finding-id>.md` fragments** — discovered at `<sibling-repo-root>/backlog.d/*.md` and at this repo's `backlog.d/`. Disambiguated from prose reports by the `severity:` frontmatter key; canonical schema at `ai_docs/items/backlog-d-fragment-schema.md`.
 
 ```bash

--- a/changelog.d/deep-review-shape-list-single-source.md
+++ b/changelog.d/deep-review-shape-list-single-source.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Single-sourced the deep-review recognized-artifact-shape list for the automation-consumed sites — `eng/process-audit-reports.ps1`, `.claude/skills/backlog-intake/SKILL.md`, and `.claude/agents/backlog-intake-extractor.md` now point at `eng/stage-review-inbox.ps1`'s canonical `Recognized shapes` block instead of re-listing the glob set, and that script's `.DESCRIPTION` no longer hardcodes a shape count. (Partial slice — 2 human-facing procedure docs remain and are tracked in a follow-up row.)

--- a/eng/process-audit-reports.ps1
+++ b/eng/process-audit-reports.ps1
@@ -8,11 +8,12 @@
     full audit-report consolidation pipeline runs from one command:
 
       1. eng/stage-review-inbox.ps1
-         Discovers `*_mcp-server-audit.md`, `*_mcp-server-surface-test.md`,
-         `*_experimental-promotion.md`, and `*_roslyn-mcp-retro.md` under
-         either `audit-reports/` or `ai_docs/audit-reports/` across this
-         repo and every sibling under the parent folder. Self -> COPY,
-         siblings -> MOVE (defaults). Reports land in `review-inbox/`.
+         Discovers the recognized deep-review artifact shapes (canonical list:
+         see `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes";
+         do not re-list the globs here) under either `audit-reports/` or
+         `ai_docs/audit-reports/` across this repo and every sibling under the
+         parent folder. Self -> COPY, siblings -> MOVE (defaults). Reports land
+         in `review-inbox/`.
 
       2. eng/aggregate-promotion-scorecards.ps1
          Probes the canonical repo-root `audit-reports/` first, then the

--- a/eng/stage-review-inbox.ps1
+++ b/eng/stage-review-inbox.ps1
@@ -4,10 +4,10 @@
     Stage deep-review artifacts (audits, retros, experimental-promotion reports) into review-inbox/ for backlog intake.
 
 .DESCRIPTION
-    Discovers the three deep-review artifact shapes across this repo + sibling repos under the
-    parent directory and copies them into this repo's review-inbox/ folder. Source filenames
-    already carry a repo-id prefix (e.g. 20260424T030145Z_roslyn-backed-mcp_roslyn-mcp-retro.md)
-    so no renaming is needed.
+    Discovers the deep-review artifact shapes listed below (see "Recognized shapes") across this
+    repo + sibling repos under the parent directory and copies them into this repo's review-inbox/
+    folder. Source filenames already carry a repo-id prefix (e.g.
+    20260424T030145Z_roslyn-backed-mcp_roslyn-mcp-retro.md) so no renaming is needed.
 
     Default behavior is **per-source**:
       - Sibling repos: MOVE (delete after staging). Sibling repos shouldn't


### PR DESCRIPTION
## Summary

The deep-review recognized-artifact-shape glob set was copy-pasted across 7 sites, so PR #1146's glob-miss patch updated 1 of them and the other 6 immediately re-drifted. This PR makes `eng/stage-review-inbox.ps1`'s existing `.DESCRIPTION` -> **Recognized shapes** block the canonical single source and points the automation-consumed sites at it instead of re-listing the globs.

## Linked issue

No GitHub Issue mirrors this backlog row — `ai_docs/backlog.md` row `deep-review-shape-list-single-source` carries no `[gh #NNN]` reference, so there is nothing to auto-close.

## Changes

- `eng/stage-review-inbox.ps1` — `.DESCRIPTION` opener no longer hardcodes a shape count ("the three deep-review artifact shapes" was stale before PR #1146 at four shapes, and stale again after at six). It now points at the Recognized-shapes block below it, declares that block canonical, and names which sites are converted vs still pending. The Recognized-shapes block itself is byte-identical.
- `eng/process-audit-reports.ps1` — replaced the inline 4-glob enumeration (missing `*_roslyn-mcp-multisession-retro.md` and the `backlog.d/` fragment shape) with a pointer to the canonical block. The surrounding `audit-reports/` vs `ai_docs/audit-reports/` discovery sentence and the self->COPY / siblings->MOVE description are unchanged.
- `.claude/skills/backlog-intake/SKILL.md` — removed the stale parenthetical glob list and the "TWO artifact shapes" miscount. The real prose-report vs `backlog.d/` fragment handling split (and its `severity:`-frontmatter disambiguation) is preserved — that is a behavioral distinction, not glob duplication.
- `.claude/agents/backlog-intake-extractor.md` — frontmatter `description:` stays a self-contained agent-dispatch summary (prose shape families, no glob list, so selector matching is unaffected); `## Context` now points at the canonical block and keeps the per-family interpretation guidance (bug-vs-gap split, "retros are the richest source") explicitly marked as non-authoritative guidance rather than a fixed list.
- `changelog.d/deep-review-shape-list-single-source.md` — new Maintenance fragment.

### Deliberate partial slice

Two human-facing runbook docs still re-list the glob set and are out of scope here to stay within the 4-production-file cap:

- `ai_docs/procedures/deep-review-backlog-intake.md:18`
- `ai_docs/procedures/deep-review-command-reference.md:13,31`

They are named as "still re-listing (pending follow-up)" in the canonical block itself, and need a follow-up backlog row before `deep-review-shape-list-single-source` can close.

## Test plan

- [x] Manually verified the behavior (described below)
- [ ] Added or updated unit/integration tests covering the change — N/A: docstring/markdown prose only, no automated test exercises these comment blocks
- [ ] `dotnet build RoslynMcp.slnx` / `dotnet test RoslynMcp.slnx` — N/A locally: zero C# files touched; CI covers it

Verification performed:

- `pwsh -File eng/stage-review-inbox.ps1 -DryRun` exits 0 with unchanged discovery output (edit is inside `.DESCRIPTION`; no logic change).
- `pwsh -File eng/verify-ai-docs.ps1` passes ("AI docs validation passed").
- `rg -n "three|TWO artifact shapes|the three deep-review"` over all four files returns no matches.
- `rg` sweep confirmed `eng/aggregate-promotion-scorecards.ps1` and `eng/propose-promotion-scorecard-backlog-rows.ps1` carry no copy of the shape list, so the known site set is exhaustive.
- `eng/verify-ai-docs.ps1` does not link-check `.claude/**`; both pointer paths in those two files were eyeballed and resolve to `eng/stage-review-inbox.ps1`.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (no C# changed)
- [x] Public API changes are intentional and documented (none)

## Backlog (maintainer-only)

Closes: (none — partial slice; do not close `deep-review-shape-list-single-source` yet)
Related: `deep-review-shape-list-single-source`

- Closes backlog row: N/A — partial slice, row stays open pending the follow-up covering the two `ai_docs/procedures/` sites.
