### PR TITLE
fix(roslyn): normalize whitespace-only projectFilter in ProjectFilterHelper

### DIFF
--- a/changelog.d/project-filter-helper-whitespace-normalize.md
+++ b/changelog.d/project-filter-helper-whitespace-normalize.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `ProjectFilterHelper.FilterProjects` now treats a whitespace-only `projectFilter` as "no filter" (matching the semantics `compile_check` already enforced), so `list_analyzers`, `format_verify_solution`, and the other 15 tools sharing the helper no longer silently return zero-project results on a blank filter string. Closes `project-filter-helper-whitespace-normalize`.

--- a/src/RoslynMcp.Roslyn/Helpers/ProjectFilterHelper.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ProjectFilterHelper.cs
@@ -6,7 +6,7 @@ internal static class ProjectFilterHelper
 {
     public static IEnumerable<Project> FilterProjects(Solution solution, string? projectFilter)
     {
-        return projectFilter is null
+        return string.IsNullOrWhiteSpace(projectFilter)
             ? solution.Projects
             : solution.Projects.Where(p =>
                 string.Equals(p.Name, projectFilter, StringComparison.OrdinalIgnoreCase));

--- a/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
@@ -39,7 +39,6 @@ public sealed class CompileCheckService : ICompileCheckService
         CancellationToken ct)
     {
         var (projectFilter, emitValidation, severityFilter, fileFilter, offset, limit, fileFilters) = options;
-        projectFilter = string.IsNullOrWhiteSpace(projectFilter) ? null : projectFilter;
         var sw = Stopwatch.StartNew();
         var solution = _workspace.GetCurrentSolution(workspaceId);
 

--- a/tests/RoslynMcp.Tests/AnalyzerInfoToolsTests.cs
+++ b/tests/RoslynMcp.Tests/AnalyzerInfoToolsTests.cs
@@ -3,7 +3,8 @@ using RoslynMcp.Core.Models;
 namespace RoslynMcp.Tests;
 
 /// <summary>
-/// Regression tests for non-deterministic <c>totalRules</c> in <c>list_analyzers</c>.
+/// Regression tests for non-deterministic <c>totalRules</c> in <c>list_analyzers</c>, and for
+/// project-filter normalization shared via <c>ProjectFilterHelper</c>.
 ///
 /// Root cause (list-analyzers-totalrules-variance): the service-layer deduplication guard
 /// exited early on the first project to reference an analyzer assembly, discarding rules
@@ -93,5 +94,26 @@ public sealed class AnalyzerInfoToolsTests : SharedWorkspaceTestBase
 
         Assert.IsTrue(unfilteredTotal >= filteredTotal,
             $"Unfiltered totalRules ({unfilteredTotal}) must be >= filtered totalRules ({filteredTotal}) for project '{firstProjectName}'.");
+    }
+
+    /// <summary>
+    /// A whitespace-only <c>projectFilter</c> must be treated as "no filter" (matching the
+    /// semantics <c>compile_check</c> already enforced), not as a literal filter that can never
+    /// match a real project name. Regression coverage for the shared root cause fixed in
+    /// <c>ProjectFilterHelper.FilterProjects</c> (project-filter-helper-whitespace-normalize) —
+    /// prior to the fix, a whitespace-only filter silently returned zero analyzers here.
+    /// </summary>
+    [TestMethod]
+    public async Task ListAnalyzers_WhitespaceOnlyProjectFilter_TreatedAsNoFilter()
+    {
+        var unfiltered = await AnalyzerInfoService.ListAnalyzersAsync(WorkspaceId, projectFilter: null, CancellationToken.None);
+        var whitespaceFiltered = await AnalyzerInfoService.ListAnalyzersAsync(WorkspaceId, projectFilter: " ", CancellationToken.None);
+
+        var unfilteredTotal = unfiltered.Sum(a => a.Rules.Count);
+        var whitespaceFilteredTotal = whitespaceFiltered.Sum(a => a.Rules.Count);
+
+        Assert.AreEqual(unfilteredTotal, whitespaceFilteredTotal,
+            $"A whitespace-only projectFilter must yield the same totalRules as no filter. Unfiltered={unfilteredTotal}, WhitespaceFiltered={whitespaceFilteredTotal}.");
+        Assert.IsTrue(whitespaceFilteredTotal > 0, "Whitespace-only projectFilter must not silently return zero rules.");
     }
 }


### PR DESCRIPTION
## Summary

`ProjectFilterHelper.FilterProjects` gated on `projectFilter is null`, so a whitespace-only value fell through to a literal-name match that can never succeed, silently returning zero projects for every one of its 17 callers (`list_analyzers`, `format_verify_solution`, `compile_check`, etc). PR #1163 fixed this only in `CompileCheckService`'s caller-side normalization.

This fixes the shared root: `FilterProjects` now treats `IsNullOrWhiteSpace` as "no filter", and the now-redundant caller-side normalization line in `CompileCheckService` is removed. Adds a regression test in `AnalyzerInfoToolsTests` covering a non-`compile_check` consumer.

## Test plan
- [x] `mcp__roslyn__compile_check` on `RoslynMcp.Roslyn` and `RoslynMcp.Tests` — clean
- [x] `mcp__roslyn__test_run --filter "AnalyzerInfoToolsTests"` — 4/4 passed (including new `ListAnalyzers_WhitespaceOnlyProjectFilter_TreatedAsNoFilter`)
- [x] `mcp__roslyn__test_run --filter "CompileCheckServiceTests"` — 4/4 passed (confirms PR #1163's whitespace regression test still passes after removing the caller-side normalization)

Closes: project-filter-helper-whitespace-normalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)