### PR TITLE
refactor(workspace-validation): drop dead degrade wrapper, single-source git-status default (workspace-validation-dead-path-and-duplicated-default)

### DIFF
--- a/changelog.d/workspace-validation-dead-path-and-duplicated-default.md
+++ b/changelog.d/workspace-validation-dead-path-and-duplicated-default.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Removed a dead status-degrade wrapper on `WorkspaceValidationService`'s git-status-timeout fallback branch (it could never change the timeout verdict, since `CreateTimeoutResult` always reports `"timeout"` and the degrade only fires on `"clean"`) and consolidated the duplicated 10-second git-status-timeout default onto `ValidationServiceOptions.GitStatusTimeout` as the single source of truth.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -19,7 +19,9 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class WorkspaceValidationService : IWorkspaceValidationService
 {
     private const int MaxRelatedTestsCap = 50;
-    private static readonly TimeSpan DefaultGitStatusTimeout = TimeSpan.FromSeconds(10);
+    // workspace-validation-dead-path-and-duplicated-default: single-source the 10-second default
+    // onto ValidationServiceOptions.GitStatusTimeout rather than re-declaring the literal here.
+    private static readonly TimeSpan DefaultGitStatusTimeout = new ValidationServiceOptions().GitStatusTimeout;
     private static readonly TimeSpan DefaultValidationPhaseTimeout = TimeSpan.FromSeconds(25);
 
     private static readonly Action<ILogger, int, string, Exception?> LogProcessKillFailed =
@@ -168,9 +170,11 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         }
         catch (InternalValidationTimeoutException ex)
         {
-            return DegradeStatusWhenGitStatusUnknown(
-                CreateTimeoutResult(ex, Array.Empty<string>(), gitWarnings),
-                gitTimedOut);
+            // workspace-validation-dead-path-and-duplicated-default: no DegradeStatusWhenGitStatusUnknown
+            // wrapper here. CreateTimeoutResult always reports OverallStatus "timeout", and the degrade
+            // only rewrites "clean", so the wrapper was a structural no-op on this branch. Mirrors the
+            // bare-return shape ValidateAsync's own timeout catch already uses.
+            return CreateTimeoutResult(ex, Array.Empty<string>(), gitWarnings);
         }
     }
 


### PR DESCRIPTION
Closes: workspace-validation-dead-path-and-duplicated-default

Two hygiene fixes in `src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs`:

- **Dead status-degrade wrapper removed.** `ValidateRecentGitChangesAsync`'s git-unavailable fallback catch returned `DegradeStatusWhenGitStatusUnknown(CreateTimeoutResult(...), gitTimedOut)`. `CreateTimeoutResult` always sets `OverallStatus: "timeout"` (single assignment site, `WorkspaceValidationService.cs:979`), and the degrade only rewrites `"clean"`, so the wrapper was a structural no-op on that branch. Now a bare `return CreateTimeoutResult(...)`, mirroring the shape `ValidateAsync`'s own timeout catch already uses. `DegradeStatusWhenGitStatusUnknown` itself is retained — it stays live for its success-path caller.
- **Duplicated 10-second default consolidated.** `DefaultGitStatusTimeout` was a second hardcoded `TimeSpan.FromSeconds(10)`, independent of `ValidationServiceOptions.GitStatusTimeout`'s own default. Its initializer now reads `new ValidationServiceOptions().GitStatusTimeout`, so the value is declared exactly once. Both existing read sites (public-ctor forward, internal-ctor zero-guard) are unchanged.

No test changes — existing `ValidateRecentGitChangesTests` already pin both branches with zero expected diff.

### Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Scoped test run (`ValidateRecentGitChangesTests`, `WorkspaceValidationTimeoutTests`, `WorkspaceValidationOverallStatusTests`, `ValidateWorkspaceChangeTrackerReconcileTests`, `ValidateWorkspaceSummaryTests`, `ValidationBundleToolsTests`) — 83 passed, 0 failed.

### Diffstat

```
 changelog.d/workspace-validation-dead-path-and-duplicated-default.md |  5 +++++
 src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs          | 12 ++++++++----
 2 files changed, 13 insertions(+), 4 deletions(-)
```
