### PR TITLE
fix(compile-check): restoreHint returns null instead of empty string on clean checks

### DIFF
--- a/changelog.d/compile-check-restorehint-empty-not-null.md
+++ b/changelog.d/compile-check-restorehint-empty-not-null.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `compile_check`'s `restoreHint` field now serializes as `null` (not an empty string) when no restore/zero-projects/file-filter-fallback hint applies, matching `BuildHint`'s documented contract. Callers that probed for hint presence via null-checks were previously always seeing a truthy empty string on every clean response. Closes `compile-check-restorehint-empty-not-null`.

--- a/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompileCheckService.cs
@@ -69,7 +69,7 @@ public sealed class CompileCheckService : ICompileCheckService
         // compile-check-multi-project-fallback-structured-scope: surface the requested-vs-actual
         // compile scope as structured fields so callers can detect the silent file-filter widening
         // without string-matching restoreHint prose. fileScopeHint (not `hint`) is the fallback
-        // signal — BuildHint joins into an empty string, never null, when no hint applies.
+        // signal.
         var requestedScope = ComputeRequestedScope(projectFilter, normalizedFileFilters);
         // projectList.Count > 0 guard: the zero-resolution file-scope arm sets fileScopeHint but
         // compiles nothing, so reporting ActualScope=="solution" there would claim a widening
@@ -274,8 +274,9 @@ public sealed class CompileCheckService : ICompileCheckService
                 : $"compile_check evaluated 0 projects: projectFilter '{projectFilter}' did not match any project in the workspace. Project names are matched case-insensitively against Project.Name (e.g. 'MyProject', not 'MyProject.csproj'). Call workspace_status for the current project list.";
         }
 
-        return string.Join(" ", new[] { zeroProjectsHint, restoreHint, fileScopeHint }
+        var joined = string.Join(" ", new[] { zeroProjectsHint, restoreHint, fileScopeHint }
             .Where(static hint => !string.IsNullOrWhiteSpace(hint)));
+        return string.IsNullOrEmpty(joined) ? null : joined;
     }
 
     private static IReadOnlySet<string>? NormalizeFileFilters(string? fileFilter, IReadOnlyList<string>? fileFilters)

--- a/tests/RoslynMcp.Tests/CompileCheckServiceTests.cs
+++ b/tests/RoslynMcp.Tests/CompileCheckServiceTests.cs
@@ -39,6 +39,8 @@ public sealed class CompileCheckServiceTests : IsolatedWorkspaceTestBase
         Assert.AreEqual("files", result.RequestedScope);
         Assert.AreEqual(result.RequestedScope, result.ActualScope,
             "A file filter honoured by its single owning project must not report a widened scope.");
+        Assert.IsNull(result.RestoreHint,
+            "A clean scoped compile check with no CS0234 flood, zero-projects fallback, or file-filter widening must not carry a restoreHint.");
     }
 
     [TestMethod]
@@ -90,7 +92,8 @@ public sealed class CompileCheckServiceTests : IsolatedWorkspaceTestBase
 
         Assert.IsTrue(result.TotalProjects > 1,
             "File filters spanning multiple projects should fall back to the full project scope.");
-        Assert.IsNotNull(result.RestoreHint);
+        Assert.IsFalse(string.IsNullOrEmpty(result.RestoreHint),
+            "Fallback restoreHint must be non-empty when file filters span multiple projects.");
         StringAssert.Contains(result.RestoreHint, "file filter fallback");
         Assert.AreEqual("files", result.RequestedScope);
         Assert.AreEqual("solution", result.ActualScope);


### PR DESCRIPTION
## Summary
- `BuildHint`'s own XML summary claims it returns `null` when no restore/zero-projects/file-filter-fallback hint applies, but `string.Join` over a filtered-to-empty sequence returns `string.Empty` per BCL contract, so every clean `compile_check` response was serializing `restoreHint:""` — misleading callers that null-check for hint presence.
- `BuildHint` now checks the joined result before returning and yields `null` when empty.
- Trimmed the now-stale inline comment documenting this exact bug as a known limitation.
- Hardened the two related test assertions: added an explicit `Assert.IsNull(result.RestoreHint, ...)` to the clean single-owning-project test, and replaced a vacuous `Assert.IsNotNull` (which also passes on `""`) with `Assert.IsFalse(string.IsNullOrEmpty(...))` on the multi-project fallback test.

## Validation
- `mcp__roslyn__compile_check` on the touched files: 0 errors after restore.
- `mcp__roslyn__test_run --filter FullyQualifiedName~CompileCheckServiceTests`: 4/4 passed.
- `mcp__roslyn__test_run --filter FullyQualifiedName~CompileCheckZeroProjectsTests` (regression guard, unaffected path): 2/2 passed.

Closes: compile-check-restorehint-empty-not-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)