### PR TITLE
refactor(file-snapshot): CaptureAsync delegates to FromBytesOrFallback (file-snapshot-capture-helper-consolidation)

### DIFF
--- a/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
+++ b/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
@@ -3,9 +3,9 @@ using RoslynMcp.Core.Services;
 namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
-/// Single owner of the pre-apply file-snapshot policy shared by every direct-file mutation
-/// path (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a file held
-/// before the mutation — or the knowledge that it held none — produce the
+/// Owner of the pre-apply file-snapshot policy for the direct-file mutation paths that
+/// delegate to it (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a
+/// file held before the mutation — or the knowledge that it held none — produce the
 /// <see cref="FileSnapshotDto"/> <c>revert_last_apply</c> needs.
 /// <para>
 /// The policy is one line, but it was hand-rolled as an independent ternary at every call
@@ -15,6 +15,12 @@ namespace RoslynMcp.Roslyn.Services;
 /// purpose — <c>AtomicFileWriter.ResolveWriteEncoding</c> — and must not read the file
 /// twice: they call <see cref="FromBytesOrFallback"/> with the bytes they already hold,
 /// while callers with nothing pre-read call <see cref="CaptureAsync"/>.
+/// </para>
+/// <para>
+/// Ownership is not yet universal: <c>RefactoringService.AddFileSnapshotAsync</c> still
+/// hand-rolls the same exists/missing ternary rather than calling in here. That last copy
+/// is tracked by row <c>file-snapshot-capture-helper-consolidation</c>; until it migrates,
+/// this type owns the policy for the four delegating paths named above only.
 /// </para>
 /// </summary>
 internal static class FileSnapshotCapture
@@ -64,10 +70,10 @@ internal static class FileSnapshotCapture
     {
         if (!File.Exists(filePath))
         {
-            return new FileSnapshotDto(filePath, fallbackTextFactory?.Invoke());
+            return FromBytesOrFallback(filePath, bytes: null, fallbackTextFactory?.Invoke());
         }
 
         var bytes = await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false);
-        return FileSnapshotDto.FromExistingBytes(filePath, bytes);
+        return FromBytesOrFallback(filePath, bytes, fallbackText: null);
     }
 }


### PR DESCRIPTION
## Summary

`FileSnapshotCapture.CaptureAsync` re-implemented the exists/missing snapshot
ternary inline instead of delegating to the sibling `FromBytesOrFallback` in the
same file that already owns that policy — a second independent copy of the policy
inside the very class created to consolidate it. It now delegates on both arms, so
the load-bearing null-versus-empty-bytes guard (a null `byte[]` converts implicitly
to an EMPTY `ReadOnlySpan<byte>`) lives in exactly one place. Behavior-identical by
construction; the fallback factory stays lazy (invoked only on the missing-file arm).

Also truthed the class XML doc, which claimed single ownership of the policy across
every direct-file mutation path while `RefactoringService.AddFileSnapshotAsync` still
hand-rolls it. The doc now scopes ownership to the four delegating paths and names
the remaining hand-rolled copy in prose.

Closes: none — pre-split child 1 of 2; row `file-snapshot-capture-helper-consolidation`
stays OPEN until child 2 (`file-snapshot-capture-callsite-migration`) migrates
`RefactoringService.AddFileSnapshotAsync`.

Validation: dotnet build with TreatWarningsAsErrors clean; 28 tests green across
FileSnapshotCaptureTests, EditUndoIntegrationTests, EditUndoCohesionTests.

Co-Authored-By: Claude <noreply@anthropic.com>


## Changes

```
 src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs | 16 +++++++++++-----
 1 file changed, 11 insertions(+), 5 deletions(-)
```
