### PR TITLE
fix(compilation-cache): short-circuit already-canceled callers; cover mid-fetch cancel + fault eviction (compilation-cache-cancellation-coverage-and-entry-guard)

### DIFF
--- a/changelog.d/compilation-cache-cancellation-coverage-and-entry-guard.md
+++ b/changelog.d/compilation-cache-cancellation-coverage-and-entry-guard.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `CompilationCache.GetCompilationAsync` now short-circuits immediately for a caller whose token is already canceled on a cache miss, instead of first starting a full, uncancelable Roslyn compile pass (and installing a cache entry for it) whose result could only ever be discarded. Added regression coverage for the two previously unexercised branches: mid-fetch cancellation decoupling (a caller canceling after its request is in flight no longer affects another caller reading the same cache entry at the same workspace version) and faulted-shared-task eviction (a broken entry is removed so the next caller re-populates instead of replaying the failure). The `ICompilationCache` contract now states the per-caller cancellation and broken-entry-eviction guarantees the implementation already documented.

--- a/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
@@ -32,8 +32,12 @@ namespace RoslynMcp.Roslyn.Contracts;
 /// only that caller's own await of the shared entry: it must not cancel the shared compilation
 /// pass itself, and it must not affect any other caller reading the same cache slot at the same
 /// workspace version. A caller whose token is already canceled on entry observes
-/// <see cref="OperationCanceledException"/> without a compilation pass being started or an entry
-/// being installed. Conversely, an entry whose shared work ends up canceled or faulted must be
+/// <see cref="OperationCanceledException"/> in both cases. <see cref="GetCompilationAsync"/>
+/// additionally guarantees that no compilation pass is started and no entry is installed for such
+/// a caller; <see cref="GetCompilationWithAnalyzersAsync"/> does NOT yet carry that entry guard —
+/// an already-canceled caller there can still trigger the analyzer-bound build before observing
+/// cancellation. Closing that gap is tracked separately and is deliberately out of this change's
+/// scope. Conversely, an entry whose shared work ends up canceled or faulted must be
 /// dropped so the next caller re-populates it instead of replaying the failure until the next
 /// workspace version bump.
 /// </para>

--- a/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
@@ -36,8 +36,8 @@ namespace RoslynMcp.Roslyn.Contracts;
 /// additionally guarantees that no compilation pass is started and no entry is installed for such
 /// a caller; <see cref="GetCompilationWithAnalyzersAsync"/> does NOT yet carry that entry guard —
 /// an already-canceled caller there can still trigger the analyzer-bound build before observing
-/// cancellation. Closing that gap is tracked separately and is deliberately out of this change's
-/// scope. Conversely, an entry whose shared work ends up canceled or faulted must be
+/// cancellation. Closing that gap is deliberately out of this change's scope.
+/// Conversely, an entry whose shared work ends up canceled or faulted must be
 /// dropped so the next caller re-populates it instead of replaying the failure until the next
 /// workspace version bump.
 /// </para>

--- a/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
@@ -26,6 +26,17 @@ namespace RoslynMcp.Roslyn.Contracts;
 /// <c>(workspaceId, projectId, version)</c> tuple starts the underlying compilation; subsequent
 /// concurrent callers await the same in-flight task instead of racing.
 /// </para>
+/// <para>
+/// Cancellation is per-caller, never per-entry. The token a caller passes to
+/// <see cref="GetCompilationAsync"/> or <see cref="GetCompilationWithAnalyzersAsync"/> cancels
+/// only that caller's own await of the shared entry: it must not cancel the shared compilation
+/// pass itself, and it must not affect any other caller reading the same cache slot at the same
+/// workspace version. A caller whose token is already canceled on entry observes
+/// <see cref="OperationCanceledException"/> without a compilation pass being started or an entry
+/// being installed. Conversely, an entry whose shared work ends up canceled or faulted must be
+/// dropped so the next caller re-populates it instead of replaying the failure until the next
+/// workspace version bump.
+/// </para>
 /// </remarks>
 public interface ICompilationCache
 {

--- a/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
@@ -77,6 +77,16 @@ public sealed class CompilationCache : ICompilationCache, IDisposable
             return ObserveWithCallerToken(existing.Compilation, ct);
         }
 
+        // An already-canceled caller must not pay for — or install — a compile pass it can never
+        // observe. The shared task below is deliberately started with CancellationToken.None, so
+        // once it is running nothing can stop it; short-circuiting here mirrors
+        // ObserveWithCallerToken's own already-canceled check and restores the pre-cache behavior
+        // of handing a canceled token straight to Roslyn.
+        if (ct.IsCancellationRequested)
+        {
+            return Task.FromCanceled<Compilation?>(ct);
+        }
+
         // Cache miss or stale: install a fresh task. Multiple concurrent first-callers may
         // race here; AddOrUpdate's atomicity ensures only one entry is stored, and any racer
         // that lost will see the winner's task on the next read. The lost-racer's task will

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -101,6 +102,97 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
 
         // Must not throw: pre-fix this rethrew the first caller's OperationCanceledException.
         _ = await cache.GetCompilationWithAnalyzersAsync(workspace.WorkspaceId, project, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Covers the branch the two already-canceled tests above cannot reach: a caller that cancels
+    /// AFTER its request is in flight. Those tests short-circuit inside
+    /// <c>ObserveWithCallerToken</c>'s already-canceled check, so the <c>WaitAsync(ct)</c> branch —
+    /// the one that actually decouples a mid-flight cancellation from the shared entry — was never
+    /// exercised. Caller A starts with a live token and is canceled with no intervening
+    /// <c>await</c>, so the synchronous already-canceled check has provably already run and
+    /// committed to <c>WaitAsync</c>; caller B must still get a real compilation from the same
+    /// entry.
+    /// </summary>
+    [TestMethod]
+    public async Task GetCompilationAsync_CallerCanceledMidFetch_DoesNotAffectOtherCaller()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        using var cache = new CompilationCache(WorkspaceManager);
+        var project = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId).Projects.First();
+
+        using var midFetch = new CancellationTokenSource();
+
+        // No await between these two statements: the shared compile pass is started and observed
+        // through the caller's still-uncanceled token before the cancellation is requested.
+        var pending = cache.GetCompilationAsync(workspace.WorkspaceId, project, midFetch.Token);
+        var statusAtCancelTime = pending.Status;
+        midFetch.Cancel();
+
+        Assert.IsTrue(
+            statusAtCancelTime is not (TaskStatus.RanToCompletion or TaskStatus.Canceled or TaskStatus.Faulted),
+            $"Caller A's task was already in terminal state '{statusAtCancelTime}' before its token was " +
+            "canceled, so this test no longer exercises the mid-flight WaitAsync branch. A yield point " +
+            "added to GetCompilationAsync ahead of ObserveWithCallerToken would cause this — the test " +
+            "must be reworked rather than relaxed.");
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(
+            () => pending,
+            "A caller canceling mid-fetch must observe its own cancellation.");
+
+        var compilation = await cache.GetCompilationAsync(workspace.WorkspaceId, project, CancellationToken.None);
+        Assert.IsNotNull(compilation,
+            "Caller B reads the same (workspaceId, project) key at the unchanged workspace version, so " +
+            "caller A's mid-flight cancellation must not have canceled the shared compilation pass.");
+    }
+
+    /// <summary>
+    /// Covers <c>CompilationCache.EvictWhenBroken</c>'s compare-and-remove: an entry whose shared
+    /// task ends up faulted must be dropped so the next caller re-populates instead of replaying the
+    /// failure until the workspace version bumps. Reflection is the only deterministic route — the
+    /// real shared task is always started with <see cref="CancellationToken.None"/> and there is no
+    /// reliable way to force a genuine Roslyn compile fault from a test workspace, so the
+    /// <c>NotOnRanToCompletion</c> continuation never fires in the tests above. The continuation is
+    /// registered <c>ExecuteSynchronously</c> against an already-faulted antecedent, so it evicts
+    /// inline and needs no polling.
+    /// </summary>
+    [TestMethod]
+    public void EvictWhenBroken_FaultedSharedTask_RemovesEntryForNextCaller()
+    {
+        var entryType = typeof(CompilationCache).GetNestedType("CompilationEntry", BindingFlags.NonPublic);
+        Assert.IsNotNull(entryType,
+            "CompilationCache.CompilationEntry should remain discoverable by reflection — this test is " +
+            "deliberately implementation-coupled and must be updated alongside any rename.");
+
+        var evictWhenBroken = typeof(CompilationCache).GetMethod(
+            "EvictWhenBroken",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(evictWhenBroken,
+            "CompilationCache.EvictWhenBroken should remain discoverable by reflection — this test is " +
+            "deliberately implementation-coupled and must be updated alongside any rename.");
+
+        var mapType = typeof(ConcurrentDictionary<,>).MakeGenericType(typeof((string, ProjectId)), entryType);
+        var map = Activator.CreateInstance(mapType)!;
+        var faulted = Task.FromException<Compilation?>(new InvalidOperationException("synthetic compile fault"));
+        var entry = Activator.CreateInstance(
+            entryType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [1, faulted],
+            culture: null)!;
+        (string, ProjectId) key = ("workspace-under-test", ProjectId.CreateNewId());
+
+        mapType.GetProperty("Item")!.SetValue(map, entry, [key]);
+        Assert.IsTrue(
+            (bool)mapType.GetMethod("ContainsKey")!.Invoke(map, [key])!,
+            "Pre-seeding the synthetic cache map must succeed for the eviction assertion to mean anything.");
+
+        evictWhenBroken.MakeGenericMethod(entryType).Invoke(null, [map, key, entry, faulted]);
+
+        Assert.IsFalse(
+            (bool)mapType.GetMethod("ContainsKey")!.Invoke(map, [key])!,
+            "A faulted shared task must evict its own cache entry so the next caller re-populates " +
+            "instead of replaying the fault until the workspace version bumps.");
     }
 
     [TestMethod]


### PR DESCRIPTION
`CompilationCache.GetCompilationAsync`'s cache-miss branch started
`project.GetCompilationAsync(CancellationToken.None)` — and installed the resulting
shared entry — before ever consulting the calling caller's own token. A caller whose
token was already canceled therefore paid for a full, uncancelable Roslyn compile pass
whose result `ObserveWithCallerToken` could only discard, regressing the pre-cache
behavior where an already-canceled token short-circuited before any Roslyn call ran.
The guard now mirrors `ObserveWithCallerToken`'s own already-canceled check and returns
`Task.FromCanceled` before any compile starts or entry is installed.

`ICompilationCache`'s interface remarks now carry the cancellation contract the
implementation already documented: a caller's token cancels only that caller's await of
the shared entry, never the shared fetch nor another caller at the same workspace
version, and a broken (canceled/faulted) entry must be dropped so the next caller
re-populates.

Two previously unreachable branches gain regression coverage in
`CompilationCacheAdoptionTests`:

- `GetCompilationAsync_CallerCanceledMidFetch_DoesNotAffectOtherCaller` — the two
  pre-existing already-canceled tests hit `ObserveWithCallerToken`'s `FromCanceled`
  short-circuit and never reach `shared.WaitAsync(ct)`, the branch that actually
  decouples a mid-flight cancellation. Caller A now starts with a live token and is
  canceled with no intervening `await`, and the test asserts A's task was non-terminal
  at cancel time so a future yield point ahead of `ObserveWithCallerToken` fails loudly
  instead of silently degrading back to the covered branch.
- `EvictWhenBroken_FaultedSharedTask_RemovesEntryForNextCaller` — exercises the
  `NotOnRanToCompletion` compare-and-remove via reflection. The real shared task is
  always started with `CancellationToken.None` and cannot be made to fault from a test
  workspace, so reflection is the only deterministic route to this branch.

Validation: `dotnet build RoslynMcp.slnx -c Debug -p:TreatWarningsAsErrors=true` clean
(0 warnings); `CompilationCacheAdoptionTests` 23/23 green (incl. the two pre-existing
already-canceled tests, unchanged); sibling `CompilationCacheTests`,
`WorkspaceReloadedEventTests`, `HardeningBehaviorTests`, `PerformanceBehaviorTests`
16/16 green; `eng/verify-changelog-fragments.ps1` valid. A throwaway probe (not shipped)
confirmed the guard leaves `_compilations` empty after an already-canceled call while a
live caller still installs the entry.

Known deferral (Directive #3, out of this bounded batch):
`GetCompilationWithAnalyzersAsync`'s cache-miss branch has the identical
unconditional-build issue for an already-canceled caller; the item doc scopes ask (3) to
`GetCompilationAsync` only, so this is flagged for an amend to
`ai_docs/items/compilation-cache-adoption-read-side.md` rather than a new row.

Closes: (none — bounded child batch; parent row compilation-cache-adoption-read-side stays open)



## Files

```
 ...-cache-cancellation-coverage-and-entry-guard.md |  5 ++
 .../Contracts/ICompilationCache.cs                 | 11 +++
 src/RoslynMcp.Roslyn/Services/CompilationCache.cs  | 10 +++
 .../CompilationCacheAdoptionTests.cs               | 92 ++++++++++++++++++++++
 4 files changed, 118 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
