### PR TITLE
refactor(host-stdio): break Middleware<->Tools namespace cycle via Elicitation namespace

### DIFF
--- a/changelog.d/hoststdio-middleware-tools-namespace-cycle.md
+++ b/changelog.d/hoststdio-middleware-tools-namespace-cycle.md
@@ -1,0 +1,4 @@
+---
+category: Maintenance
+---
+Broke the `RoslynMcp.Host.Stdio.Middleware` <-> `RoslynMcp.Host.Stdio.Tools` namespace cycle by extracting the shared elicitation-choice contract (`HasElicitation`, `TryElicitChoiceAsync`) into a new `RoslynMcp.Host.Stdio.Elicitation` namespace; `Middleware` and `Tools` now both depend on it instead of on each other. The Middleware-internal static call surface is preserved via thin delegates, so no elicitation test needed editing. Added a namespace-dependency regression test asserting the cycle stays broken.

--- a/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Elicitation;
+
+/// <summary>
+/// The shared elicitation-choice contract, extracted to its own namespace so
+/// <c>RoslynMcp.Host.Stdio.Middleware</c> and <c>RoslynMcp.Host.Stdio.Tools</c> can both depend on
+/// it instead of on each other. Owns the two members that were the sole reason
+/// <c>Tools</c> imported <c>Middleware</c>: the client-capability predicate
+/// (<see cref="HasElicitation"/>) and the select-from-N picker
+/// (<see cref="TryElicitChoiceAsync"/>).
+///
+/// <para>
+/// <b>Layering invariant:</b> this type must never import <c>RoslynMcp.Host.Stdio.Middleware</c>,
+/// <c>RoslynMcp.Host.Stdio.Tools</c>, or any other <c>RoslynMcp.*</c> namespace — only the MCP SDK
+/// and BCL. Any such <c>using</c> re-creates the namespace cycle this type exists to break, and is
+/// caught by
+/// <c>ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis.No_Circular_Namespace_Dependency_Between_Middleware_And_Tools</c>.
+/// </para>
+///
+/// <para>
+/// <c>ElicitationAllowlistPolicy.HasElicitation</c> and
+/// <c>StructuredCallElicitationCoordinator.TryElicitChoiceAsync</c> are retained as thin delegates
+/// forwarding here, so the historical Middleware-internal static call surface (consumed by
+/// <c>StructuredCallToolFilter</c> and the existing elicitation test suites) is preserved
+/// byte-for-byte.
+/// </para>
+/// </summary>
+internal static class ElicitationChoicePrompt
+{
+    /// <summary>
+    /// Capability-check helper: returns <see langword="true"/> when the connected client
+    /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
+    /// Canonical home for the predicate — both the Middleware allowlist policy and the
+    /// <c>Tools</c> symbol-disambiguation path call it (directly or via a delegate) rather than
+    /// copy-pasting the null-coalescing dance.
+    /// </summary>
+    /// <param name="capabilities">
+    /// The <see cref="McpServer.ClientCapabilities"/> snapshot, typically obtained as
+    /// <c>context.Server.ClientCapabilities</c> inside a request filter or tool method.
+    /// May be <see langword="null"/> on the server's pre-initialize path.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when both <paramref name="capabilities"/> and
+    /// <c>capabilities.Elicitation</c> are non-null. Zero-allocation and side-effect-free.
+    /// </returns>
+    public static bool HasElicitation(ClientCapabilities? capabilities) =>
+        capabilities?.Elicitation is not null;
+
+    /// <summary>
+    /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
+    /// helper. Builds an enum-shaped <c>elicitation/create</c> request whose options carry
+    /// short candidate labels and stable string keys, calls the SDK, and returns the chosen
+    /// key (or <see langword="null"/> when the user declined / the client lacks elicitation /
+    /// the request itself failed). The caller uses the returned key to map back to the
+    /// original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call against that
+    /// chosen candidate.
+    /// </summary>
+    /// <param name="server">The connected <see cref="McpServer"/>; <see langword="null"/> short-circuits to null.</param>
+    /// <param name="paramName">
+    /// Name of the schema field carrying the picked option — also the dictionary key the
+    /// SDK populates in <see cref="ElicitResult.Content"/>. Conventionally <c>"choice"</c>.
+    /// </param>
+    /// <param name="title">Short title shown above the option list.</param>
+    /// <param name="description">Longer description (one or two sentences) explaining why the user is being asked.</param>
+    /// <param name="options">
+    /// The select-from-N options. <c>Key</c> is the stable identifier returned to the caller,
+    /// <c>Label</c> is the human-readable text shown in the picker.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
+    /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
+    public static async Task<string?> TryElicitChoiceAsync(
+        McpServer? server,
+        string paramName,
+        string title,
+        string description,
+        IReadOnlyList<(string Key, string Label)> options,
+        CancellationToken cancellationToken)
+    {
+        if (server is null) return null;
+        if (!HasElicitation(server.ClientCapabilities)) return null;
+        if (string.IsNullOrEmpty(paramName) || options is null || options.Count == 0) return null;
+
+        var oneOf = new List<ElicitRequestParams.EnumSchemaOption>(options.Count);
+        for (var i = 0; i < options.Count; i++)
+        {
+            var (key, label) = options[i];
+            if (string.IsNullOrEmpty(key)) continue;
+            oneOf.Add(new ElicitRequestParams.EnumSchemaOption
+            {
+                Const = key,
+                Title = string.IsNullOrEmpty(label) ? key : label,
+            });
+        }
+        if (oneOf.Count == 0) return null;
+
+        var request = new ElicitRequestParams
+        {
+            Message = description,
+            RequestedSchema = new ElicitRequestParams.RequestSchema
+            {
+                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
+                {
+                    [paramName] = new ElicitRequestParams.TitledSingleSelectEnumSchema
+                    {
+                        Title = title,
+                        Description = description,
+                        OneOf = oneOf,
+                    },
+                },
+                Required = [paramName],
+            },
+        };
+
+        ElicitResult result;
+        try
+        {
+            result = await server.ElicitAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // ElicitAsync can throw InvalidOperationException (transport gone, capability
+            // mismatch) or McpException (client-side error). Either way, the disambiguation
+            // path falls through to the additive list response — never masks a real failure.
+            return null;
+        }
+
+        if (!result.IsAccepted || result.Content is null) return null;
+        if (!result.Content.TryGetValue(paramName, out var chosen)) return null;
+        var chosenKey = chosen.ValueKind == JsonValueKind.String ? chosen.GetString() : null;
+        return string.IsNullOrEmpty(chosenKey) ? null : chosenKey;
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Protocol;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Elicitation;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
 
@@ -49,8 +50,11 @@ internal static class ElicitationAllowlistPolicy
     /// <summary>
     /// Capability-check helper: returns <see langword="true"/> when the connected client
     /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
-    /// Public so initiative #9 (<c>elicit-disambiguation-on-multi-symbol-resolve</c>) can
-    /// reuse the same predicate without copy-pasting the null-coalescing dance.
+    /// Thin delegate onto <see cref="ElicitationChoicePrompt.HasElicitation"/>, which is the
+    /// canonical home — the predicate lives in the cycle-free
+    /// <c>RoslynMcp.Host.Stdio.Elicitation</c> namespace so <c>Tools</c> can call it without
+    /// importing <c>Middleware</c>. Retained here so this class's historical static call
+    /// surface (and its test suite) keeps compiling unchanged.
     /// </summary>
     /// <param name="capabilities">
     /// The <see cref="McpServer.ClientCapabilities"/> snapshot, typically obtained as
@@ -62,7 +66,7 @@ internal static class ElicitationAllowlistPolicy
     /// <c>capabilities.Elicitation</c> are non-null. Zero-allocation and side-effect-free.
     /// </returns>
     public static bool HasElicitation(ClientCapabilities? capabilities) =>
-        capabilities?.Elicitation is not null;
+        ElicitationChoicePrompt.HasElicitation(capabilities);
 
     /// <summary>
     /// Defense-in-depth predicate: returns <see langword="true"/> when the parameter name

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Elicitation;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
 
@@ -271,67 +272,22 @@ internal static class StructuredCallElicitationCoordinator
     /// </param>
     /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
     /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
-    public static async Task<string?> TryElicitChoiceAsync(
+    /// <remarks>
+    /// Thin delegate onto <see cref="ElicitationChoicePrompt.TryElicitChoiceAsync"/>, which is the
+    /// canonical home — the picker lives in the cycle-free
+    /// <c>RoslynMcp.Host.Stdio.Elicitation</c> namespace so <c>Tools</c> can call it without
+    /// importing <c>Middleware</c>. Retained here so this class's historical static call surface
+    /// (and its test suite) keeps compiling unchanged.
+    /// </remarks>
+    public static Task<string?> TryElicitChoiceAsync(
         McpServer? server,
         string paramName,
         string title,
         string description,
         IReadOnlyList<(string Key, string Label)> options,
-        CancellationToken cancellationToken)
-    {
-        if (server is null) return null;
-        if (!ElicitationAllowlistPolicy.HasElicitation(server.ClientCapabilities)) return null;
-        if (string.IsNullOrEmpty(paramName) || options is null || options.Count == 0) return null;
-
-        var oneOf = new List<ElicitRequestParams.EnumSchemaOption>(options.Count);
-        for (var i = 0; i < options.Count; i++)
-        {
-            var (key, label) = options[i];
-            if (string.IsNullOrEmpty(key)) continue;
-            oneOf.Add(new ElicitRequestParams.EnumSchemaOption
-            {
-                Const = key,
-                Title = string.IsNullOrEmpty(label) ? key : label,
-            });
-        }
-        if (oneOf.Count == 0) return null;
-
-        var request = new ElicitRequestParams
-        {
-            Message = description,
-            RequestedSchema = new ElicitRequestParams.RequestSchema
-            {
-                Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
-                {
-                    [paramName] = new ElicitRequestParams.TitledSingleSelectEnumSchema
-                    {
-                        Title = title,
-                        Description = description,
-                        OneOf = oneOf,
-                    },
-                },
-                Required = [paramName],
-            },
-        };
-
-        ElicitResult result;
-        try
-        {
-            result = await server.ElicitAsync(request, cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            // ElicitAsync can throw InvalidOperationException (transport gone, capability
-            // mismatch) or McpException (client-side error). Either way, the disambiguation
-            // path falls through to the additive list response — never masks a real failure.
-            return null;
-        }
-
-        if (!result.IsAccepted || result.Content is null) return null;
-        if (!result.Content.TryGetValue(paramName, out var chosen)) return null;
-        var chosenKey = chosen.ValueKind == JsonValueKind.String ? chosen.GetString() : null;
-        return string.IsNullOrEmpty(chosenKey) ? null : chosenKey;
-    }
+        CancellationToken cancellationToken) =>
+        ElicitationChoicePrompt.TryElicitChoiceAsync(
+            server, paramName, title, description, options, cancellationToken);
 
     /// <summary>
     /// Inspects <paramref name="ex"/> for the InvalidArgument-shaped binding-failure

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
-using RoslynMcp.Host.Stdio.Middleware;
+using RoslynMcp.Host.Stdio.Elicitation;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Helpers;
 using RoslynMcp.Roslyn.Services;
@@ -90,7 +90,7 @@ public static class SymbolTools
             // client supports MCP elicitation do we open the blocking operator picker and return ONLY
             // the chosen symbol with a chosenViaElicitation marker. If elicitation is unsupported OR
             // the user declines, fall through to the existing list shape.
-            if (allowElicitation && paged.Count > 1 && StructuredCallToolFilter.HasElicitation(server?.ClientCapabilities))
+            if (allowElicitation && paged.Count > 1 && ElicitationChoicePrompt.HasElicitation(server?.ClientCapabilities))
             {
                 var options = new List<(string Key, string Label)>(paged.Count);
                 for (var i = 0; i < paged.Count; i++)
@@ -102,7 +102,7 @@ public static class SymbolTools
                     options.Add((i.ToString(System.Globalization.CultureInfo.InvariantCulture), label));
                 }
 
-                var chosenKey = await StructuredCallToolFilter.TryElicitChoiceAsync(
+                var chosenKey = await ElicitationChoicePrompt.TryElicitChoiceAsync(
                     server,
                     paramName: "choice",
                     title: "Pick a symbol",
@@ -930,7 +930,7 @@ public static class SymbolTools
         }
 
         // Try elicitation only when the caller explicitly opted in AND the client supports it.
-        if (allowElicitation && StructuredCallToolFilter.HasElicitation(server?.ClientCapabilities))
+        if (allowElicitation && ElicitationChoicePrompt.HasElicitation(server?.ClientCapabilities))
         {
             var options = new List<(string Key, string Label)>(candidates.Count);
             for (var i = 0; i < candidates.Count; i++)
@@ -938,7 +938,7 @@ public static class SymbolTools
                 options.Add((i.ToString(System.Globalization.CultureInfo.InvariantCulture), labels[i]));
             }
 
-            var chosenKey = await StructuredCallToolFilter.TryElicitChoiceAsync(
+            var chosenKey = await ElicitationChoicePrompt.TryElicitChoiceAsync(
                 server,
                 paramName: "choice",
                 title: "Pick a symbol",

--- a/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs
+++ b/tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs
@@ -47,4 +47,81 @@ public sealed class ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis : Share
             WorkspaceManager.Close(status.WorkspaceId);
         }
     }
+
+    /// <summary>
+    /// hoststdio-middleware-tools-namespace-cycle regression guard: the
+    /// <c>RoslynMcp.Host.Stdio.Middleware</c> &lt;-&gt; <c>RoslynMcp.Host.Stdio.Tools</c> namespace
+    /// cycle was broken by extracting the shared elicitation-choice contract into
+    /// <c>RoslynMcp.Host.Stdio.Elicitation</c>. <c>Middleware -&gt; Tools</c> survives (the filter's
+    /// <c>WorkspaceTools.ResolveOptionalWorkspaceId</c> call); <c>Tools -&gt; Middleware</c> must NOT
+    /// come back. Re-adding <c>using RoslynMcp.Host.Stdio.Middleware;</c> to any file in the
+    /// <c>Tools</c> namespace — or a <c>RoslynMcp.Host.Stdio.{Middleware,Tools}</c> import inside
+    /// <c>ElicitationChoicePrompt</c> — reds this test.
+    /// <see cref="RoslynMcp.Roslyn.Services.NamespaceDependencyService"/> builds its edges strictly
+    /// from <c>UsingDirectiveSyntax</c>, so this asserts the layering, not merely the reference graph.
+    /// </summary>
+    [TestMethod]
+    public async Task No_Circular_Namespace_Dependency_Between_Middleware_And_Tools()
+    {
+        const string MiddlewareNamespace = "RoslynMcp.Host.Stdio.Middleware";
+        const string ToolsNamespace = "RoslynMcp.Host.Stdio.Tools";
+
+        var repositorySolutionPath = Path.Combine(RepositoryRootPath, "RoslynMcp.slnx");
+        var status = await WorkspaceManager.LoadAsync(repositorySolutionPath, CancellationToken.None);
+
+        try
+        {
+            var graph = await NamespaceDependencyService.GetNamespaceDependenciesAsync(
+                status.WorkspaceId,
+                projectFilter: "RoslynMcp.Host.Stdio",
+                CancellationToken.None);
+
+            Assert.IsTrue(
+                graph.AnalyzedProjectCount > 0,
+                "Test precondition: namespace-dependency analysis must have walked at least one project — " +
+                "an empty CircularDependencies list from a zero-project walk proves nothing.");
+
+            // Precondition: both namespaces must actually be present in the walked graph, otherwise
+            // a typo'd/renamed namespace would make the cycle assertion vacuously pass.
+            var namespacesInGraph = graph.Nodes.Select(node => node.Namespace).ToHashSet(StringComparer.Ordinal);
+            Assert.IsTrue(
+                namespacesInGraph.Contains(MiddlewareNamespace),
+                $"Test precondition: expected '{MiddlewareNamespace}' in the analyzed namespace graph.");
+            Assert.IsTrue(
+                namespacesInGraph.Contains(ToolsNamespace),
+                $"Test precondition: expected '{ToolsNamespace}' in the analyzed namespace graph.");
+
+            // Precondition: the surviving Middleware -> Tools edge is intentional and must stay
+            // (StructuredCallToolFilter's WorkspaceTools.ResolveOptionalWorkspaceId call). Only ONE
+            // direction had to be broken.
+            Assert.IsTrue(
+                graph.Edges.Any(edge =>
+                    edge.FromNamespace == MiddlewareNamespace && edge.ToNamespace == ToolsNamespace),
+                $"Test precondition: expected the surviving '{MiddlewareNamespace}' -> '{ToolsNamespace}' edge.");
+
+            // The actual guard: no Tools -> Middleware edge, hence no cycle between the two.
+            Assert.IsFalse(
+                graph.Edges.Any(edge =>
+                    edge.FromNamespace == ToolsNamespace && edge.ToNamespace == MiddlewareNamespace),
+                $"'{ToolsNamespace}' must not import '{MiddlewareNamespace}' — the shared elicitation-choice " +
+                "contract lives in RoslynMcp.Host.Stdio.Elicitation precisely so this edge stays absent.");
+
+            var offendingCycles = graph.CircularDependencies
+                .Where(cycle =>
+                    cycle.Cycle.Contains(MiddlewareNamespace, StringComparer.Ordinal)
+                    && cycle.Cycle.Contains(ToolsNamespace, StringComparer.Ordinal))
+                .Select(cycle => string.Join(" -> ", cycle.Cycle))
+                .ToList();
+
+            Assert.AreEqual(
+                0,
+                offendingCycles.Count,
+                $"Expected no namespace cycle spanning '{MiddlewareNamespace}' and '{ToolsNamespace}'. Found: "
+                + string.Join(" | ", offendingCycles));
+        }
+        finally
+        {
+            WorkspaceManager.Close(status.WorkspaceId);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Extracted the shared elicitation-choice contract into a new, dependency-free
`RoslynMcp.Host.Stdio.Elicitation` namespace so `Middleware` and `Tools` both
depend on it instead of on each other.

- NEW `Elicitation/ElicitationChoicePrompt.cs`: canonical `HasElicitation`
  (client-capability predicate) and `TryElicitChoiceAsync` (select-from-N
  `elicitation/create` picker). Imports only the MCP SDK + BCL, so it cannot
  re-introduce a cycle.
- `Middleware/ElicitationAllowlistPolicy.HasElicitation` and
  `Middleware/StructuredCallElicitationCoordinator.TryElicitChoiceAsync` are now
  thin signature-preserving delegates onto the new home, so the historical
  Middleware-internal static call surface (and `StructuredCallToolFilter`'s own
  forwards) keeps compiling byte-for-byte. Zero elicitation test edits required.
- `Tools/SymbolTools.cs`: dropped `using RoslynMcp.Host.Stdio.Middleware;` and
  repointed its 4 call sites at `ElicitationChoicePrompt`.
- `StructuredCallToolFilter.cs` deliberately untouched: its
  `using ...Tools;` + `WorkspaceTools.ResolveOptionalWorkspaceId` call is the
  surviving Middleware -> Tools edge, and only ONE direction had to break.

Added `No_Circular_Namespace_Dependency_Between_Middleware_And_Tools` to
`ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis`, asserting via
`NamespaceDependencyService` (using-directive-derived edges) that the
Tools -> Middleware edge is absent, the intentional Middleware -> Tools edge
survives, and no cycle spans the two namespaces. Negative-control verified: the
test reds when the `using` is put back.

Validation: `dotnet build -c Release -p:TreatWarningsAsErrors=true` clean
(0 warnings); `--filter FullyQualifiedName~Elicitation` 48/48 green with no test
edits; RepoSolutionAnalysis class 2/2 green; blast-radius slice
(StructuredCall|Symbol|NamespaceDepend|DependencyAnalysis) 192/192 green;
`eng/verify-changelog-fragments.ps1` valid.

Closes: hoststdio-middleware-tools-namespace-cycle



## Changes

```
 .../hoststdio-middleware-tools-namespace-cycle.md  |   4 +
 .../Elicitation/ElicitationChoicePrompt.cs         | 135 +++++++++++++++++++++
 .../Middleware/ElicitationAllowlistPolicy.cs       |  10 +-
 .../StructuredCallElicitationCoordinator.cs        |  68 ++---------
 src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs      |  10 +-
 ...SurfaceIntegrationTests.RepoSolutionAnalysis.cs |  77 ++++++++++++
 6 files changed, 240 insertions(+), 64 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
