### PR TITLE
refactor(snapshots): route RefactoringService snapshot sites through FileSnapshotCapture

### DIFF
--- a/changelog.d/file-snapshot-capture-callsite-migration.md
+++ b/changelog.d/file-snapshot-capture-callsite-migration.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** consolidated the last hand-rolled pre-apply snapshot ternaries (`RefactoringService.AddFileSnapshotAsync` and `RefactoringService.AddProjectFileSnapshotAsync`) onto the shared `FileSnapshotCapture.FromBytesOrFallback` helper, so `FileSnapshotDto.FromExistingBytes` is now named by exactly one production call site. Closes `file-snapshot-capture-helper-consolidation`.

--- a/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
+++ b/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
@@ -3,24 +3,25 @@ using RoslynMcp.Core.Services;
 namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
-/// Owner of the pre-apply file-snapshot policy for the direct-file mutation paths that
-/// delegate to it (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a
-/// file held before the mutation — or the knowledge that it held none — produce the
+/// Single owner of the pre-apply file-snapshot policy for every mutation path in the server
+/// (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a file held before
+/// the mutation — or the knowledge that it held none — produce the
 /// <see cref="FileSnapshotDto"/> <c>revert_last_apply</c> needs.
 /// <para>
 /// The policy is one line, but it was hand-rolled as an independent ternary at every call
 /// site (<see cref="EditService"/> twice, <see cref="EditorConfigService"/>,
-/// <see cref="ProjectMutationService"/>), so a fix to one never reached the others. Two
-/// entry points exist because two of those callers already read the bytes for a SECOND
-/// purpose — <c>AtomicFileWriter.ResolveWriteEncoding</c> — and must not read the file
-/// twice: they call <see cref="FromBytesOrFallback"/> with the bytes they already hold,
-/// while callers with nothing pre-read call <see cref="CaptureAsync"/>.
+/// <see cref="ProjectMutationService"/>, <c>RefactoringService.AddFileSnapshotAsync</c> and
+/// <c>RefactoringService.AddProjectFileSnapshotAsync</c>), so a fix to one never reached the
+/// others. All of them now delegate here, and no production call site outside this type
+/// names <see cref="FileSnapshotDto.FromExistingBytes"/>.
 /// </para>
 /// <para>
-/// Ownership is not yet universal: <c>RefactoringService.AddFileSnapshotAsync</c> still
-/// hand-rolls the same exists/missing ternary rather than calling in here. That last copy
-/// is tracked by row <c>file-snapshot-capture-helper-consolidation</c>; until it migrates,
-/// this type owns the policy for the four delegating paths named above only.
+/// Two entry points exist because some callers already read the bytes for a SECOND purpose —
+/// <c>AtomicFileWriter.ResolveWriteEncoding</c>, or a three-way missing-file branch — and
+/// must not read the file twice: they call <see cref="FromBytesOrFallback"/> with the bytes
+/// they already hold, while callers with nothing pre-read call <see cref="CaptureAsync"/>
+/// (which itself delegates to <see cref="FromBytesOrFallback"/> on both branches, so the
+/// ternary exists exactly once).
 /// </para>
 /// </summary>
 internal static class FileSnapshotCapture

--- a/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
+++ b/src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs
@@ -3,7 +3,8 @@ using RoslynMcp.Core.Services;
 namespace RoslynMcp.Roslyn.Services;
 
 /// <summary>
-/// Single owner of the pre-apply file-snapshot policy for every mutation path in the server
+/// Single owner of the pre-apply file-snapshot policy for every mutation path that captures a
+/// <see cref="FileSnapshotDto"/>
 /// (<c>file-snapshot-capture-helper-consolidation</c>): given the bytes a file held before
 /// the mutation — or the knowledge that it held none — produce the
 /// <see cref="FileSnapshotDto"/> <c>revert_last_apply</c> needs.

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -1061,7 +1061,12 @@ public sealed class RefactoringService : IRefactoringService
         bool missingFileIsNew,
         CancellationToken ct)
     {
-        var filePath = document?.FilePath;
+        if (document is null)
+        {
+            return;
+        }
+
+        var filePath = document.FilePath;
         if (string.IsNullOrWhiteSpace(filePath) || !seenPaths.Add(filePath))
         {
             return;
@@ -1077,11 +1082,6 @@ public sealed class RefactoringService : IRefactoringService
         string? fallbackText = null;
         if (existingBytes is null && !missingFileIsNew)
         {
-            if (document is null)
-            {
-                return;
-            }
-
             fallbackText = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
         }
 

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -1067,25 +1067,25 @@ public sealed class RefactoringService : IRefactoringService
             return;
         }
 
-        if (File.Exists(filePath))
+        var existingBytes = File.Exists(filePath)
+            ? await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false)
+            : null;
+
+        // Only the missing-file case has a fallback to compute, and only when the file is not
+        // brand new. GetTextAsync stays inside this branch deliberately: materializing the whole
+        // SourceText is wasted work on the common file-exists path.
+        string? fallbackText = null;
+        if (existingBytes is null && !missingFileIsNew)
         {
-            snapshots.Add(FileSnapshotDto.FromExistingBytes(
-                filePath,
-                await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false)));
-            return;
+            if (document is null)
+            {
+                return;
+            }
+
+            fallbackText = (await document.GetTextAsync(ct).ConfigureAwait(false)).ToString();
         }
 
-        if (missingFileIsNew)
-        {
-            snapshots.Add(new FileSnapshotDto(filePath, OriginalText: null));
-            return;
-        }
-
-        if (document is not null)
-        {
-            var sourceText = await document.GetTextAsync(ct).ConfigureAwait(false);
-            snapshots.Add(new FileSnapshotDto(filePath, sourceText.ToString()));
-        }
+        snapshots.Add(FileSnapshotCapture.FromBytesOrFallback(filePath, existingBytes, fallbackText));
     }
 
     private static async Task AddProjectFileSnapshotAsync(
@@ -1102,9 +1102,10 @@ public sealed class RefactoringService : IRefactoringService
             return;
         }
 
-        snapshots.Add(FileSnapshotDto.FromExistingBytes(
+        snapshots.Add(FileSnapshotCapture.FromBytesOrFallback(
             projectPath,
-            await File.ReadAllBytesAsync(projectPath, ct).ConfigureAwait(false)));
+            await File.ReadAllBytesAsync(projectPath, ct).ConfigureAwait(false),
+            fallbackText: null));
     }
 
     private static string GetDefaultFixId(string diagnosticId) =>

--- a/tests/RoslynMcp.Tests/FileSnapshotCaptureTests.cs
+++ b/tests/RoslynMcp.Tests/FileSnapshotCaptureTests.cs
@@ -5,7 +5,10 @@ namespace RoslynMcp.Tests;
 
 /// <summary>
 /// Direct unit coverage for <c>FileSnapshotCapture</c>, the shared owner of the pre-apply
-/// exists/missing snapshot policy previously hand-rolled at four call sites
+/// exists/missing snapshot policy previously hand-rolled at six call sites — <c>EditService</c>
+/// twice, <c>EditorConfigService</c>, <c>ProjectMutationService</c>,
+/// <c>RefactoringService.AddFileSnapshotAsync</c> and
+/// <c>RefactoringService.AddProjectFileSnapshotAsync</c>
 /// (<c>file-snapshot-capture-helper-consolidation</c>). Pure temp-directory tests — no MSBuild
 /// workspace required.
 /// </summary>


### PR DESCRIPTION
## Summary

`AddFileSnapshotAsync` and `AddProjectFileSnapshotAsync` were the last two production sites naming `FileSnapshotDto.FromExistingBytes` directly, each re-implementing the exists->bytes / missing->fallback policy that `FileSnapshotCapture` exists to own. Both now delegate to `FileSnapshotCapture.FromBytesOrFallback`.

- **`RefactoringService.AddFileSnapshotAsync`** — reads pre-mutation bytes once when the file exists, otherwise computes the fallback text (`missingFileIsNew` -> null text; document present -> `GetTextAsync`) and hands both to `FromBytesOrFallback` in a single call. The three-way missing-file branch, the `seenPaths` guard, and the "no snapshot at all when the document is null" outcome are unchanged; `GetTextAsync` stays inside the missing branch so the common file-exists path pays nothing extra.
- **`RefactoringService.AddProjectFileSnapshotAsync`** — bytes-only path (it early-returns on missing files) now goes through the same helper.
- **`FileSnapshotCapture` class doc** — the single-ownership claim is now unconditional and the caller list is complete. The prior "one remaining hand-rolled copy, tracked by row ..." hedge became false with this change and is removed.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — clean, 0 warnings.
- 74 tests pass under `--filter "FullyQualifiedName~FileSnapshotCapture|FullyQualifiedName~Undo|FullyQualifiedName~Revert"`.
- 72 tests pass under `--filter "FullyQualifiedName~Refactoring|FullyQualifiedName~ProjectMutation|FullyQualifiedName~ProjectReference"` (blast radius for the snapshot-construction change).
- `rg -n "FromExistingBytes" src` now returns only the definition (`IUndoService.cs:133`), the single delegating use inside `FileSnapshotCapture.FromBytesOrFallback`, and two doc `<see cref>` references.

## Diffstat

```
 changelog.d/file-snapshot-capture-callsite-migration.md |  5 ++++
 src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs    | 25 ++++++-------
 src/RoslynMcp.Roslyn/Services/RefactoringService.cs     | 35 +++++++++--------
 3 files changed, 36 insertions(+), 29 deletions(-)
```

Closes: file-snapshot-capture-helper-consolidation
