### PR TITLE
feat(compilation-cache): opt-in cache routing for the 3 group-c read-side helpers (compilation-cache-adoption-read-side)

### DIFF
--- a/changelog.d/compilation-cache-adoption-read-side.md
+++ b/changelog.d/compilation-cache-adoption-read-side.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `SymbolResolver.ResolveByMetadataNameAsync` / `SymbolResolver.FindClosestMatchesAsync` and `SymbolHandleSerializer.FindAllByMetadataNameAsync` can now route their per-project compilation fetch through the shared `ICompilationCache`, via optional `compilationCache` + `workspaceId` parameters (every existing caller keeps the raw fetch). Routing is gated on the supplied solution being the live workspace solution, so a forked/preview solution can never be served a compilation built from the live document text — it always falls back to the raw per-project fetch. Closes the remaining `ICompilationCache` read-side adoption tail (group c: the forked-solution hazard helpers).

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.CodeAnalysis;
+using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Roslyn.Helpers;
 
@@ -189,19 +190,34 @@ public static class SymbolHandleSerializer
     /// ambiguity (overload set, partial-class siblings, member-vs-type collisions) ahead of
     /// elicitation should call this and inspect <c>Count &gt; 1</c>.
     /// </remarks>
+    /// <param name="compilationCache">
+    /// compilation-cache-adoption-read-side: optional shared compilation cache. When supplied together
+    /// with <paramref name="workspaceId"/> AND <paramref name="solution"/> is the live workspace
+    /// solution, the per-project compilation fetch is routed through it. Omitted (the default) or a
+    /// forked solution takes the raw fetch — see
+    /// <see cref="SymbolResolver.CanUseCompilationCache"/>.
+    /// </param>
+    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
     public static async Task<IReadOnlyList<ISymbol>> FindAllByMetadataNameAsync(
-        Solution solution, string metadataName, CancellationToken ct)
+        Solution solution,
+        string metadataName,
+        CancellationToken ct,
+        ICompilationCache? compilationCache = null,
+        string? workspaceId = null)
     {
         ArgumentNullException.ThrowIfNull(solution);
         if (string.IsNullOrWhiteSpace(metadataName)) return Array.Empty<ISymbol>();
 
         var matches = new List<ISymbol>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        var useCache = SymbolResolver.CanUseCompilationCache(solution, compilationCache, workspaceId);
 
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = useCache
+                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
+                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             // Type-by-full-name fast path — collect, do not return early.

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
@@ -1,5 +1,6 @@
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Contracts;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,6 +23,50 @@ public static class SymbolResolver
         genericsOptions: SymbolDisplayGenericsOptions.None,
         memberOptions: SymbolDisplayMemberOptions.IncludeContainingType,
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.None);
+
+    /// <summary>
+    /// compilation-cache-adoption-read-side: liveness gate for the opt-in
+    /// <see cref="ICompilationCache"/> routing on the per-project compilation fetches in
+    /// <see cref="ResolveByMetadataNameAsync"/>, <see cref="FindClosestMatchesAsync"/>, and
+    /// <see cref="SymbolHandleSerializer.FindAllByMetadataNameAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="ICompilationCache"/> keys purely on <c>(workspaceId, ProjectId, workspaceVersion)</c>,
+    /// so serving a FORKED (preview) solution from it would hand back a compilation built from the LIVE
+    /// workspace content while the caller is reasoning about different document text. Caching is
+    /// therefore permitted only when the supplied solution IS the workspace's current solution: every
+    /// fork (e.g. <c>solution.WithDocumentText(...)</c>, or the never-applied solution
+    /// <c>CrossProjectRefactoringService.PreviewDependencyInversionAsync</c> builds) is
+    /// reference-distinct from <see cref="Workspace.CurrentSolution"/> and falls through to the raw
+    /// per-project fetch.
+    /// </para>
+    /// <para>
+    /// This is semantically <c>solution == IWorkspaceManager.GetCurrentSolution(workspaceId)</c> without
+    /// threading a workspace-manager reference into a static helper — <see cref="Solution.Workspace"/>
+    /// points at the same live <see cref="Workspace"/> instance that
+    /// <c>WorkspaceManager.GetCurrentSolution</c> reads.
+    /// </para>
+    /// </remarks>
+    internal static bool CanUseCompilationCache(Solution solution, ICompilationCache? cache, string? workspaceId)
+    {
+        if (cache is null || string.IsNullOrEmpty(workspaceId))
+        {
+            return false;
+        }
+
+        try
+        {
+            return ReferenceEquals(solution, solution.Workspace.CurrentSolution);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Mirrors WorkspaceManager.GetCurrentSolution's own reload-transition defense: a solution
+            // captured across a reload can observe the disposed prior workspace. Degrade to the raw
+            // per-project fetch rather than throwing out of a read-side helper.
+            return false;
+        }
+    }
 
     /// <summary>
     /// Resolves a symbol from the given <paramref name="locator"/> using whichever identification
@@ -105,11 +150,21 @@ public static class SymbolResolver
         return new SymbolNotFoundException(message, closestMatches);
     }
 
+    /// <param name="compilationCache">
+    /// compilation-cache-adoption-read-side: optional shared compilation cache. When supplied together
+    /// with <paramref name="workspaceId"/> AND <paramref name="solution"/> is the live workspace
+    /// solution, the per-project compilation fetch is routed through it so independent callers share
+    /// warm compilations. Omitted (the default) or a forked solution takes the raw fetch — see
+    /// <see cref="CanUseCompilationCache"/>.
+    /// </param>
+    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
     public static async Task<IReadOnlyList<SymbolClosestMatchDto>> FindClosestMatchesAsync(
         Solution solution,
         string query,
         int maxResults,
-        CancellationToken ct)
+        CancellationToken ct,
+        ICompilationCache? compilationCache = null,
+        string? workspaceId = null)
     {
         if (string.IsNullOrWhiteSpace(query) || maxResults <= 0)
             return Array.Empty<SymbolClosestMatchDto>();
@@ -117,12 +172,15 @@ public static class SymbolResolver
         var normalizedQuery = NormalizeForDistance(query);
         var matches = new List<(int Score, string MetadataName, string Kind, string? LocationHint)>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        var useCache = CanUseCompilationCache(solution, compilationCache, workspaceId);
 
         foreach (var project in solution.Projects)
         {
             if (ct.IsCancellationRequested) break;
 
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = useCache
+                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
+                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var symbol in EnumerateNamedTypesAndMembers(compilation.GlobalNamespace))
@@ -277,12 +335,28 @@ public static class SymbolResolver
     /// method even though no type has that exact name. Returns the first match; generic method
     /// overloads return the first arity match.
     /// </summary>
+    /// <param name="compilationCache">
+    /// compilation-cache-adoption-read-side: optional shared compilation cache. When supplied together
+    /// with <paramref name="workspaceId"/> AND <paramref name="solution"/> is the live workspace
+    /// solution, the per-project compilation fetch is routed through it. Omitted (the default) or a
+    /// forked solution takes the raw fetch — see <see cref="CanUseCompilationCache"/>.
+    /// </param>
+    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
     /// <returns>The first matching symbol, or <see langword="null"/> if not found.</returns>
-    public static async Task<ISymbol?> ResolveByMetadataNameAsync(Solution solution, string metadataName, CancellationToken ct)
+    public static async Task<ISymbol?> ResolveByMetadataNameAsync(
+        Solution solution,
+        string metadataName,
+        CancellationToken ct,
+        ICompilationCache? compilationCache = null,
+        string? workspaceId = null)
     {
+        var useCache = CanUseCompilationCache(solution, compilationCache, workspaceId);
+
         foreach (var project in solution.Projects)
         {
-            var compilation = await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = useCache
+                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
+                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
             if (compilation is null)
             {
                 continue;

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -23,7 +24,11 @@ namespace RoslynMcp.Tests;
 /// <see cref="SymbolRelationshipService"/>; group-b core adds <see cref="BuildService"/>,
 /// <see cref="FixAllService"/>, <see cref="BulkRefactoringService"/>, and
 /// <see cref="CrossProjectRefactoringService"/>; the group-b tail adds
-/// <see cref="InterfaceExtractionService"/>.
+/// <see cref="InterfaceExtractionService"/>; group c adds the three forked-solution-hazard static
+/// helpers <see cref="SymbolResolver.ResolveByMetadataNameAsync"/>,
+/// <see cref="SymbolResolver.FindClosestMatchesAsync"/>, and
+/// <see cref="SymbolHandleSerializer.FindAllByMetadataNameAsync"/> — whose routing is opt-in and
+/// gated on the supplied solution being the live workspace solution.
 /// <para>
 /// A reference-equality check alone cannot prove adoption — Roslyn memoizes a
 /// <see cref="Compilation"/> on its owning <see cref="Project"/>, so two direct calls would also
@@ -683,6 +688,131 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
                 CancellationToken.None));
 
         AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    /// <summary>
+    /// Group-c tail: <see cref="SymbolResolver.ResolveByMetadataNameAsync"/> routes its per-project
+    /// compilation fetch through the shared cache when handed the LIVE workspace solution plus a
+    /// cache + workspaceId. The new parameters are optional and default to <c>null</c>, so this test
+    /// (not any production caller) is the opt-in consumer for this batch.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolResolver_ResolveByMetadataNameAsync_LiveSolution_RoutesThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, async () =>
+        {
+            var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+            var symbol = await SymbolResolver.ResolveByMetadataNameAsync(
+                solution, "SampleLib.Dog", CancellationToken.None, cache, workspace.WorkspaceId);
+            Assert.IsNotNull(symbol, "SampleLib.Dog must resolve — otherwise the cached path is untested.");
+        });
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    /// <summary>
+    /// Group-c tail: <see cref="SymbolResolver.FindClosestMatchesAsync"/> (the symbol-not-found
+    /// nearest-match error path) routes its per-project compilation fetch through the shared cache
+    /// when handed the LIVE workspace solution plus a cache + workspaceId.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolResolver_FindClosestMatchesAsync_LiveSolution_RoutesThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, async () =>
+        {
+            var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+            // Deliberately misspelled so the helper walks every project scoring candidates rather
+            // than short-circuiting; it has no early exit, so any non-blank query drives the fetch.
+            var matches = await SymbolResolver.FindClosestMatchesAsync(
+                solution, "SampleLib.Dogg", maxResults: 5, CancellationToken.None, cache, workspace.WorkspaceId);
+            Assert.IsTrue(matches.Count > 0, "The nearest-match scan should surface candidates for a near-miss query.");
+        });
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    /// <summary>
+    /// Group-c tail: <see cref="SymbolHandleSerializer.FindAllByMetadataNameAsync"/> (the
+    /// multi-result disambiguation counterpart) routes its per-project compilation fetch through the
+    /// shared cache when handed the LIVE workspace solution plus a cache + workspaceId.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolHandleSerializer_FindAllByMetadataNameAsync_LiveSolution_RoutesThroughSharedCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+
+        var afterFirstRun = await RunTwiceAndCaptureAsync(cache, async () =>
+        {
+            var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+            var symbols = await SymbolHandleSerializer.FindAllByMetadataNameAsync(
+                solution, "SampleLib.Dog", CancellationToken.None, cache, workspace.WorkspaceId);
+            Assert.IsTrue(symbols.Count > 0, "SampleLib.Dog must resolve — otherwise the cached path is untested.");
+        });
+
+        AssertRoutedThroughCacheAndShared(cache, afterFirstRun);
+    }
+
+    /// <summary>
+    /// The HAZARD half of group c, and the reason the three helpers took an opt-in parameter rather
+    /// than an unconditional cache call: <see cref="ICompilationCache"/> keys on
+    /// <c>(workspaceId, ProjectId, workspaceVersion)</c> only, so serving a FORKED solution from it
+    /// would return a compilation built from the LIVE document text while the caller reasons about
+    /// different text. <see cref="SymbolResolver.CanUseCompilationCache"/> rejects any solution that
+    /// is not reference-equal to <c>Workspace.CurrentSolution</c>, so all three migrated helpers fall
+    /// back to the raw per-project fetch — asserted here as a hard zero cache call count even though
+    /// a cache AND a workspaceId were both supplied.
+    /// <para>
+    /// The known forked caller today is
+    /// <c>CrossProjectRefactoringService.PreviewDependencyInversionAsync</c>, which passes a
+    /// never-applied solution to <see cref="SymbolResolver.ResolveByMetadataNameAsync"/> and does not
+    /// pass the new optional parameters at all — so it is doubly protected. Deliberately still on the
+    /// raw path and untouched by this batch: <c>InterfaceExtractionService.ReplaceConcreteUsagesAsync</c>,
+    /// the two <c>RefactoringService</c> fetches, and <c>TypeMoveService</c> — all of which compile
+    /// forked solutions.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task MigratedHelpers_ForkedSolution_DoNotRouteThroughCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var cache = new RecordingCompilationCache(new CompilationCache(WorkspaceManager));
+
+        var liveSolution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var dogDocument = liveSolution.Projects.SelectMany(p => p.Documents).First(d => d.Name == "Dog.cs");
+        var originalText = await dogDocument.GetTextAsync(CancellationToken.None);
+
+        // A fork, never applied to the workspace: same Workspace back-reference, but NOT the
+        // workspace's CurrentSolution — exactly the shape PreviewDependencyInversionAsync builds.
+        var forkedSolution = liveSolution.WithDocumentText(
+            dogDocument.Id,
+            SourceText.From(originalText.ToString() + Environment.NewLine + "// fork marker"));
+
+        Assert.AreNotSame(liveSolution, forkedSolution,
+            "WithDocumentText must produce a distinct solution instance for this test to mean anything.");
+
+        var resolved = await SymbolResolver.ResolveByMetadataNameAsync(
+            forkedSolution, "SampleLib.Dog", CancellationToken.None, cache, workspace.WorkspaceId);
+        Assert.IsNotNull(resolved, "The forked solution must still resolve the symbol via the raw fetch.");
+
+        var all = await SymbolHandleSerializer.FindAllByMetadataNameAsync(
+            forkedSolution, "SampleLib.Dog", CancellationToken.None, cache, workspace.WorkspaceId);
+        Assert.IsTrue(all.Count > 0, "The forked solution must still resolve the symbol via the raw fetch.");
+
+        _ = await SymbolResolver.FindClosestMatchesAsync(
+            forkedSolution, "SampleLib.Dogg", maxResults: 5, CancellationToken.None, cache, workspace.WorkspaceId);
+
+        Assert.AreEqual(0, cache.GetCompilationCallCount,
+            "A forked (never-applied) solution must NEVER be served from the version-keyed compilation " +
+            "cache — the cache would hand back a compilation of the LIVE document text. All three " +
+            "migrated helpers must fall through to project.GetCompilationAsync when the liveness gate " +
+            "rejects the solution, even though a cache and a workspaceId were supplied.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes the remaining `ICompilationCache` read-side adoption tail — **group c: the forked-solution hazard helpers**. Groups (a) and (b) shipped in #1005/#1010/#1147/#1179.

Routes the per-project compilation fetch in three static helpers through the shared `ICompilationCache`:

- `SymbolResolver.ResolveByMetadataNameAsync` (`SymbolResolver.cs:285` pre-change)
- `SymbolResolver.FindClosestMatchesAsync` (`SymbolResolver.cs:125` pre-change)
- `SymbolHandleSerializer.FindAllByMetadataNameAsync` (`SymbolHandleSerializer.cs:204` pre-change)

## How

Routing is **opt-in** via new OPTIONAL trailing parameters `ICompilationCache? compilationCache = null, string? workspaceId = null`. These helpers are `static` with no DI surface, so a required parameter would have forced edits across 6+ production callers (`ChangeSignatureService`, `CrossProjectRefactoringService`, `SymbolHandleSerializer`, `RecordFieldAdditionService`, `SymbolRefactorService`, `SymbolRelationshipService`) and blown the 4-file cap. With optional defaults, every existing caller compiles and behaves **unchanged**, taking the raw `project.GetCompilationAsync` path.

### The forked-solution hazard, and the gate that closes it

`ICompilationCache` keys purely on `(workspaceId, ProjectId, workspaceVersion)`. Serving a **forked** (preview) solution from it would hand back a compilation built from the **live** document text while the caller is reasoning about different text.

New `internal static SymbolResolver.CanUseCompilationCache(solution, cache, workspaceId)` permits caching only when the supplied solution is reference-equal to `Workspace.CurrentSolution` — semantically `solution == GetCurrentSolution(workspaceId)` without threading a workspace-manager reference into a static helper. `ObjectDisposedException` degrades to the raw path, mirroring `WorkspaceManager.GetCurrentSolution`'s own reload-transition defense.

The known forked caller, `CrossProjectRefactoringService.PreviewDependencyInversionAsync:236`, is doubly protected: it never passes the new optional parameters, **and** its never-applied solution would fail the gate anyway.

### Deliberately unchanged (still raw — all compile forked solutions)

`InterfaceExtractionService.ReplaceConcreteUsagesAsync`, the two `RefactoringService` fetches, `TypeMoveService`, and `CrossProjectRefactoringService.PreviewDependencyInversionAsync`.

## Tests

4 new methods in `CompilationCacheAdoptionTests`, reusing the existing `RecordingCompilationCache` double (reference equality alone is insufficient — Roslyn memoizes a `Project`'s compilation, so a raw call and a cached call can return the same instance):

| Test | Asserts |
|---|---|
| `SymbolResolver_ResolveByMetadataNameAsync_LiveSolution_RoutesThroughSharedCache` | cache invoked; warm compilation shared at unchanged version |
| `SymbolResolver_FindClosestMatchesAsync_LiveSolution_RoutesThroughSharedCache` | same |
| `SymbolHandleSerializer_FindAllByMetadataNameAsync_LiveSolution_RoutesThroughSharedCache` | same |
| `MigratedHelpers_ForkedSolution_DoNotRouteThroughCache` | hard **zero** cache calls for all three helpers against a never-applied fork, even with a cache AND workspaceId both supplied |

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Targeted Release run over `CompilationCacheAdoptionTests` plus the sibling caller suites `SymbolResolverRenameCaretTests`, `SymbolDisambiguationElicitationTests`, `SymbolMapperTests`, `SymbolInfoNotFoundMessageTests`, `FindImplementationsCorlibHintTests` — **63/63 passed**.

## Scope note

This batch adds cache-routing **capability** (default-off) and hazard-gates it; it does not wire any production service call site onto the cache, since none of the three real callers holds an injected `ICompilationCache` and wiring one would add a DI dependency (a materially larger batch). All three are low-frequency preview/error-path/disambiguation paths, consistent with the row's own "real wins are cross-call sharing under GC pressure" caveat.

```
 changelog.d/compilation-cache-adoption-read-side.md |   5 +
 src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs |  20 +++-
 src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs         |  82 ++++++++++++-
 tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs | 132 ++++++++++++++++++++-
 4 files changed, 232 insertions(+), 7 deletions(-)
```

Closes: compilation-cache-adoption-read-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
