### PR TITLE
chore(backlog): file 2 spin-off rows from PR #1211 code-quality review

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-11T02:42:59Z
+**updated_at:** 2026-08-11T03:02:39Z
 
 ## Agent contract
 
@@ -115,6 +115,8 @@
 | `elicitation-doc-drift-and-delegate-chain` | Low | elicitation-trychoice-cancellation-swallow | **Single-source the TryElicitChoiceAsync docs + collapse the 3-hop forwarders** — the param/returns block is byte-identical in 3 files and the coordinator summary claims a body that moved; the middle hops carry no production traffic. [type: refactor] [source: PR #1205 cq review] | M | items/elicitation-doc-drift-and-delegate-chain.md |
 | `group-c-compilation-cache-gate-hardening` | Low | — | **Harden the opt-in group-c cache gate before a consumer is wired** — the liveness check is evaluated once before the project loop while the cache re-reads the workspace version per call, so a mid-scan bump can serve a stale snapshot. [type: refactor] [source: PR #1207 cq review] | M | items/group-c-compilation-cache-gate-hardening.md |
 | `filewatcher-clearstale-timeout-flake-triage` | Low | — | **Make the ClearStale awaiter test deterministic** — re-filed: `known-flakes.md` cited this row id but the row was gone, so the fix was untracked. Replace the wall-clock bound at `ExternalEditStalenessTests.cs:405` with a signal assertion. [type: test] [source: known-flakes dangling cite] | S | items/filewatcher-clearstale-timeout-flake-triage.md |
+| `ci-yml-doc-citations-brittle-line-numbers` | Low | — | **Replace brittle ci.yml:<line> citations with anchor names** — docs/self-hosted-runner.md cites exact ci.yml line numbers that drift on any edit. [type: docs] [source: PR #1211 code-quality review] | S | items/ci-yml-doc-citations-brittle-line-numbers.md |
+| `ci-router-runner-label-duplication` | Low | — | **Single-source the roslynmcp-dev runner label in the ci.yml route job** — the label is hardcoded independently in the runs_on payload and the online-runner filter; drift silently disables the fallback. [type: refactor] [source: PR #1211 code-quality review] | S | items/ci-router-runner-label-duplication.md |
 
 ## Defer
 

--- a/ai_docs/items/ci-router-runner-label-duplication.md
+++ b/ai_docs/items/ci-router-runner-label-duplication.md
@@ -1,0 +1,20 @@
+# ci-router-runner-label-duplication — single-source the roslynmcp-dev runner label in the ci.yml route job
+
+**row:** `ci-router-runner-label-duplication` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `.github/workflows/ci.yml` (route job — runs_on JSON payload + online-runner filter)
+
+## Acceptance
+
+- [ ] The `roslynmcp-dev` literal appears exactly once in the `route` step; both the `runs_on` JSON payload and the online-runner `-contains` filter derive from that single variable.
+- [ ] `docs/self-hosted-runner.md` § Troubleshooting quotes the single-source variable rather than a raw JSON literal, if applicable.
+
+## Evidence
+
+- Found during code-quality review of PR #1211 (`ci-runner-offline-hosted-fallback-router`): the router job embeds `roslynmcp-dev` independently in the `runs_on` JSON payload and in the online-runner filter predicate. Renaming the runner's label updates neither in lockstep — the probe then matches zero runners and routes hosted permanently, announced only by an `::notice` on the fallback branch (a silent, self-consistent-looking degrade).
+
+## Context
+
+Spin-off from the code-quality review of PR #1211. Deliberately left unfixed in that PR — not required by its acceptance criteria, and low urgency (only fires on a runner rename, which is rare and already produces a working, if under-optimal, hosted-fallback outcome rather than an outage).

--- a/ai_docs/items/ci-yml-doc-citations-brittle-line-numbers.md
+++ b/ai_docs/items/ci-yml-doc-citations-brittle-line-numbers.md
@@ -1,0 +1,20 @@
+# ci-yml-doc-citations-brittle-line-numbers — replace brittle ci.yml:<line> citations with anchor names
+
+**row:** `ci-yml-doc-citations-brittle-line-numbers` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `docs/self-hosted-runner.md:19,170,203`
+
+## Acceptance
+
+- [ ] No `ci.yml:<line>` / `ci.yml:<start>-<end>` citation remains in `docs/self-hosted-runner.md`; each is replaced by a job/step name (`route` job, `Decide target runner` step, `validate`'s `runs-on:`) that survives future line shifts.
+- [ ] Optionally extend `eng/verify-ai-docs.ps1` to flag `\.ya?ml:\d+` citations in tracked markdown so this class cannot regress silently.
+
+## Evidence
+
+- Found during code-quality review of PR #1211 (`ci-runner-offline-hosted-fallback-router`): a same-PR follow-up fix commit shifted `ci.yml` line numbers by 7 lines, silently invalidating three citations the first commit had written correctly. `verify-ai-docs.ps1` checks only a fixed stale-pattern list plus relative-link targets, so nothing caught it.
+
+## Context
+
+Spin-off from the code-quality review of PR #1211. Not fixed inline because it's a doc-hygiene/tooling hardening item, not required by that row's acceptance criteria.


### PR DESCRIPTION
## Summary
- Files two Low-priority backlog rows flagged by the code-quality review of PR #1211 (`ci-runner-offline-hosted-fallback-router`), per Directive #3: bad code observed in review must be tracked even when not fixed inline.
  - `ci-yml-doc-citations-brittle-line-numbers`: docs/self-hosted-runner.md cites exact ci.yml line numbers that already drifted once within that same PR.
  - `ci-router-runner-label-duplication`: the `roslynmcp-dev` label is hardcoded twice in the new router job with no shared source.

Docs-only change (backlog.md + items/*.md). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)