### PR TITLE
build(test): update Test SDK to 18.8.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.Build" Version="17.14.28" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.28" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/changelog.d/microsoft-net-test-sdk-18-8-1.md
+++ b/changelog.d/microsoft-net-test-sdk-18-8-1.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Updated Microsoft.NET.Test.Sdk to 18.8.1 and revalidated the real-process workspace drain regression coverage on the current runner pipeline.


### PR DESCRIPTION
## Summary
- update Microsoft.NET.Test.Sdk from 17.14.1 to 18.8.1
- revalidate the real-process workspace drain regression that failed on the stale Dependabot branch
- record the maintenance change for release notes

## Verification
- targeted WorkspaceCloseDrainTests.CloseWorkspace_DrainProcessesTrue_DoesNotLeakTesthostInWorkingDir: passed
- just ci: 1,933 passed, 0 failed; publish/hash and vulnerability scan passed

Supersedes #1082.