### PR TITLE
chore(backlog): 12 rows from the MCP token-overhead + conformance audit

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-12T23:47:34Z
+**updated_at:** 2026-08-13T03:05:51Z
 
 ## Agent contract
 
@@ -47,6 +47,8 @@
 
 | id | pri | deps | do | size | detail |
 |----|-----|------|----|------|--------|
+| `server-instructions-discovery-hint` | High | — | **Ship ServerInstructions discovery hint** — set a ≤2KB ServerInstructions on McpServerOptions (category map + when-to-search guidance); initialize ships 0 chars, so 173 deferred tools have zero discovery text under Claude Code tool search. [type: feature] [source: 20260813 mcp-audit] | S | items/server-instructions-discovery-hint.md |
+| `sdk-2x-upgrade` | High | mcp-logging-stderr-otel-migration | **ModelContextProtocol 1.4.1 → 2.x major** — protocol 2026-07-28 + server/discover; verify csharp-sdk#844 filter contract, structured raw emission, error codes; bundle contract-care breaks in one major. Blocked on logging migration (MCP9005). [type: feature] [source: 20260813 mcp-audit] | L | items/sdk-2x-upgrade.md |
 
 ## Medium
 
@@ -68,6 +70,12 @@
 | `mcp-roots-query-discovery-migration` | Medium | mcp-roots-configured-validation-migration | Replace deprecated roots/list query-anchored solution discovery with explicit configured roots or request-scoped MRTR input. | M | items/mcp-roots-query-discovery-migration.md |
 | `mcp-sampling-mrtr-migration` | Medium | — | Replace deprecated client Sampling with request-scoped MRTR input or retire the experimental option through public deprecation policy. | M | items/mcp-sampling-mrtr-migration.md |
 | `mcp-logging-stderr-otel-migration` | Medium | — | Replace deprecated protocol Logging with stderr plus configured structured observability, then retire the compatibility bridge. | M | items/mcp-logging-stderr-otel-migration.md |
+| `semantic-grep-description-2kb-overflow` | Medium | — | **Trim semantic_grep description under the 2KB client cap** — the 2,244-char Description exceeds Claude Code truncation (tail invisible today); rewrite ≤2,000 chars + add a surface test capping all method Descriptions. [type: bug] [source: 20260813 mcp-audit] | S | items/semantic-grep-description-2kb-overflow.md |
+| `parameter-object-stale-apply-route` | Medium | — | **Fix nonexistent apply_refactoring route in parameter_object_preview** — shipped Description + class doc direct agents to a tool that does not exist; point at preview_multi_file_edit_apply / apply_composite_preview. [type: bug] [source: 20260813 mcp-audit] | S | items/parameter-object-stale-apply-route.md |
+| `tool-output-schema-wire-projection` | Medium | — | **Project registered output schemas into tools/list** — 8 adopters emit structuredContent but the wire shows zero outputSchema; add a startup pass copying ToolOutputSchemaIndex into ProtocolTool.OutputSchema + re-baseline snapshots. [type: feature] [source: 20260813 mcp-audit] | M | items/tool-output-schema-wire-projection.md |
+| `tool-tier-gated-registration` | Medium | — | **Add ROSLYNMCP_TOOL_TIERS registration gate** — filter registration by ServerSurfaceCatalog supportTier; default stable,experimental (surface unchanged); stable = documented lean profile for non-deferring clients (~19k of ~55k tokens). [type: feature] [source: 20260813 mcp-audit] | M | items/tool-tier-gated-registration.md |
+| `method-description-diet` | Medium | server-instructions-discovery-hint | **Method-level description diet** — cap 393-char-avg Descriptions at ~200-char capability statements; relocate guidance to ServerInstructions/prompts/catalog (~8.5k tokens). Sweep across ~54 Tools/*.cs — split per category before planning. [type: refactor] [source: 20260813 mcp-audit] | L | items/method-description-diet.md |
+| `risk-aligned-tool-consolidation` | Medium | sdk-2x-upgrade | **Risk-aligned tool consolidation (173 → ~117)** — merge the 18 audit groups but keep apply merges within risk buckets so per-tool permissioning + destructive hints stay honest; alias old names through a deprecation cycle. [type: refactor] [source: 20260813 mcp-audit] | L | items/risk-aligned-tool-consolidation.md |
 
 ## Low
 
@@ -124,6 +132,10 @@
 | `fixall-scope-required-validation-hoist` | Low | — | **Hoist fix_all scope-required parameter validation ahead of provider discovery** — the projectName guard sits after the no-FixAll-provider early return, so a diagnostic with no provider masks the corrective error. [type: bug] [source: fixall-blank-projectname-silent-wrong-target cq review] | S | items/fixall-scope-required-validation-hoist.md |
 | `gate-owned-timeout-cts-oce-classification-audit` | Low | — | **Audit other internal-timeout CTS sites for the same unclassified-OperationCanceledException escape** found+fixed in WorkspaceExecutionGate by test-run-unfiltered-bare-error-rootcause. [source: 2026-08-11 post-review investigation] | L | items/gate-owned-timeout-cts-oce-classification-audit.md |
 | `gate-timeout-exception-drops-inner-oce` | Low | — | **TimeoutException reclassification sites drop the original OperationCanceledException** — WorkspaceExecutionGate + GatedCommandExecutor construct message-only TimeoutExceptions, discarding cancellation provenance. [type: bug] | M | items/gate-timeout-exception-drops-inner-oce.md |
+| `param-description-dedupe` | Low | — | **Param-description dedupe** — standardize the workspaceId/filePath boilerplate repeated across ~173 tools (723 param Descriptions, ~5.9k tokens); keep load-bearing discriminator/format guidance. Split per file-cluster before planning. [type: refactor] [source: 20260813 mcp-audit] | L | items/param-description-dedupe.md |
+| `tasks-extension-slow-ops` | Low | sdk-2x-upgrade | **Adopt MCP tasks extension for slow ops** — wire ModelContextProtocol.Extensions.Tasks (WithTasks) so workspace_load/build/test_run gain deferred results + tasks/get polling alongside progress notifications. [type: feature] [source: 20260813 mcp-audit] | M | items/tasks-extension-slow-ops.md |
+| `caching-hints-tools-list` | Low | sdk-2x-upgrade | **Caching hints + deterministic tools/list ordering** — populate ttlMs/cacheScope (SEP-2549) on list results and guarantee stable ordering so caching clients get prompt-cache hits on the ~55k-token surface. [type: feature] [source: 20260813 mcp-audit] | S | items/caching-hints-tools-list.md |
+| `input-examples-feasibility` | Low | — | **input_examples feasibility probe** — determine whether Anthropic input_examples are expressible for MCP-served tools (tool _meta / SDK 2.x); pilot on 3 complex preview tools if yes, else close wont-do with evidence. [type: chore] [source: 20260813 mcp-audit] | S | items/input-examples-feasibility.md |
 
 ## Defer
 

--- a/ai_docs/items/caching-hints-tools-list.md
+++ b/ai_docs/items/caching-hints-tools-list.md
@@ -1,0 +1,22 @@
+# caching-hints-tools-list — Caching hints + deterministic tools/list ordering
+
+**row:** `caching-hints-tools-list` · **pri:** `Low` · **size:** `S` · **deps:** `sdk-2x-upgrade`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Program.cs` (or a small list-result filter) — `ttlMs`/`cacheScope` population + ordering guarantee
+- `tests/RoslynMcp.Tests/` (ordering stability + hint presence)
+
+## Acceptance
+
+- [ ] tools/list returns tools in a deterministic, stable order across processes (enables client prompt-cache hits on the ~55k-token surface)
+- [ ] `ttlMs`/`cacheScope` (SEP-2549 CacheableResult) populated on tools/list, prompts/list, resources/list and other static list results
+- [ ] Wire probe confirms both
+
+## Evidence
+
+- 2026-07-28 spec requires CacheableResult fields on list/read results and recommends deterministic ordering; a second lever on session cost for clients that cache — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §4, §5
+
+## Notes
+
+- Blocked on `sdk-2x-upgrade` (CacheableResult types ship in SDK 2.x).

--- a/ai_docs/items/input-examples-feasibility.md
+++ b/ai_docs/items/input-examples-feasibility.md
@@ -1,0 +1,20 @@
+# input-examples-feasibility — Probe whether input_examples are expressible for MCP-served tools
+
+**row:** `input-examples-feasibility` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- Investigation note (outcome may be a wont-do close, not code)
+- `src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs` (pilot: change_signature_preview)
+- `src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs` (pilot: parameter_object_preview)
+- `src/RoslynMcp.Host.Stdio/Tools/SymbolRefactorTools.cs` (pilot: symbol_refactor_preview)
+
+## Acceptance
+
+- [ ] Determine whether Anthropic `input_examples` reach clients from an MCP server (tool `_meta`? SDK 2.x surface? client-side only?) — with a wire-probe or doc citation as proof
+- [ ] If expressible: pilot on the 3 named complex tools (~100–200 tokens each) and measure schema cost
+- [ ] If not expressible: close the row wont-do with the evidence recorded here
+
+## Evidence
+
+- Anthropic measured parameter-accuracy 72%→90% with input_examples; MCP expressibility unconfirmed in SDK release notes — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §5

--- a/ai_docs/items/mcp-logging-stderr-otel-migration.md
+++ b/ai_docs/items/mcp-logging-stderr-otel-migration.md
@@ -21,3 +21,4 @@
 
 - ModelContextProtocol 2.1 deprecates protocol Logging and recommends stderr for stdio plus OpenTelemetry for structured observability.
 - `McpLoggingProvider.SendLogAsync` currently swallows all send failures, leaving no signal when the compatibility notification path breaks.
+2026-08-13 mcp-audit evidence: McpLoggingProvider.cs:32 hardcodes an Information floor — client logging/setLevel is ignored, so the declared logging capability overstates conformance. Do NOT patch in place (surface deprecated under protocol 2026-07-28); fold into this migration. This row is also the prerequisite for sdk-2x-upgrade: SDK 2.x marks the MCP logging surface obsolete (MCP9005), a build break under warnings-as-errors. See ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md §5.

--- a/ai_docs/items/method-description-diet.md
+++ b/ai_docs/items/method-description-diet.md
@@ -1,0 +1,27 @@
+# method-description-diet — Method-level description diet across the tool surface
+
+**row:** `method-description-diet` · **pri:** `Medium` · **size:** `L` · **deps:** `server-instructions-discovery-hint`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Tools/*.cs` (54 files carry `[McpServerTool]` methods — L split-candidate; split per category/file-cluster before planning)
+- `src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs` (workspace_load — top offender after semantic_grep)
+- `src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs` (compile_check)
+- `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs` (server_info; also find_references, find_duplicated_methods in their files)
+- `tests/RoslynMcp.Tests/` (description-length ceiling test, tightened from the 2,000-char defect cap toward the diet target)
+
+## Acceptance
+
+- [ ] Method Descriptions become ~150–200-char capability statements (what it does, when to use); usage guidance/warnings relocated to ServerInstructions, prompts (via get_prompt_text), or the paginated catalog resource
+- [ ] Total method-description chars ≤ ~40k (from 68,408) — ~8.5k est. token cut on tools/list
+- [ ] No capability statement dropped — each tool still names its discriminating trigger vs sibling tools (ToolSearch discovery depends on it)
+- [ ] Per-slice regression: description-length ceiling test ratcheted down as slices land
+
+## Evidence
+
+- Method-level descriptions = 68,408 chars ≈ 17.1k tokens (31% of tools/list); avg 393 chars/tool — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §1
+
+## Notes
+
+- Depends on `server-instructions-discovery-hint` (the relocation target must exist before guidance moves).
+- Benefits ALL clients; deferring clients also pay less per on-demand tool load (~318 avg tokens/tool today).

--- a/ai_docs/items/param-description-dedupe.md
+++ b/ai_docs/items/param-description-dedupe.md
@@ -1,0 +1,22 @@
+# param-description-dedupe — Parameter-description dedupe across the tool surface
+
+**row:** `param-description-dedupe` · **pri:** `Low` · **size:** `L`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Tools/*.cs` (723 parameter `[Description]`s across 54 files — L split-candidate; split per file-cluster before planning)
+- `tests/RoslynMcp.Tests/` (param-description ceiling/regression per slice)
+
+## Acceptance
+
+- [ ] `workspaceId` / `filePath` / common-boilerplate params standardized to one terse canonical one-liner each (repeated across essentially all 173 tools today)
+- [ ] Total param-description chars cut ~40% (58,679 → ~35k; ~5.9k est. tokens)
+- [ ] Semantically load-bearing param descriptions (discriminators, format contracts, preview-token semantics) NOT trimmed — parameter guidance drives call accuracy (Anthropic input_examples data: 72%→90%)
+
+## Evidence
+
+- Schema-property descriptions = 58,679 chars ≈ 14.7k tokens (27% of tools/list), avg ~81 chars across 723 described params — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §1
+
+## Notes
+
+- Original audit synthesis also proposed trimming `title` annotations (~1.9k tokens) — WRONG: the wire probe's per-tool annotations (89–91 chars) are exactly the four boolean hints; no annotation titles exist. Scope is param descriptions only.

--- a/ai_docs/items/parameter-object-stale-apply-route.md
+++ b/ai_docs/items/parameter-object-stale-apply-route.md
@@ -1,0 +1,17 @@
+# parameter-object-stale-apply-route — Fix nonexistent apply_refactoring route in parameter_object_preview
+
+**row:** `parameter-object-stale-apply-route` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs:13` (class doc) and `:22` (tool `[Description]`) — both direct agents to `apply_refactoring`
+- `tests/RoslynMcp.Tests/` (optional regression: catalog test asserting backtick-quoted tool names inside descriptions resolve to registered tools)
+
+## Acceptance
+
+- [ ] Description and class doc name only real redemption routes (`preview_multi_file_edit_apply` / `apply_composite_preview`)
+- [ ] (Stretch, same PR if cheap) surface test cross-checks tool-name references in descriptions against the registered 173 names, preventing the next stale route
+
+## Evidence
+
+- `apply_refactoring` has zero matches anywhere in `src/` — a shipped tool description misdirects agents at the exact moment they try to redeem a preview — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §5

--- a/ai_docs/items/risk-aligned-tool-consolidation.md
+++ b/ai_docs/items/risk-aligned-tool-consolidation.md
@@ -1,0 +1,26 @@
+# risk-aligned-tool-consolidation — Consolidate 173 → ~117 tools within risk buckets
+
+**row:** `risk-aligned-tool-consolidation` · **pri:** `Medium` · **size:** `L` · **deps:** `sdk-2x-upgrade`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Tools/` (18 disjoint merge groups spanning most tool files — L umbrella; split per group at plan time)
+- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.*.cs` (catalog + alias machinery `ToolAliasDeprecation.ForSisterAlias`)
+- Structural anchors already shipped: every `*_apply` takes only previewToken+workspaceId; `symbol_refactor_preview` ships the kind-discriminated pattern
+
+## Acceptance
+
+- [ ] Preview merges per the audit's 18-group inventory (all 49 previews are uniformly readOnly=true/destructive=false — no annotation-granularity loss)
+- [ ] Apply merges stay WITHIN risk buckets — formatting / text-edit / code-transform / file-lifecycle / project-file (26 applies → ~9, NOT → 1) — preserving per-tool-name allow/deny permissioning and honest destructive hints
+- [ ] Old names survive as declared deprecated aliases for ≥1 minor cycle; removal only at the next major; ADR + migration note (public surface)
+- [ ] Net surface ≈117 tools ≈ ~10–13k tokens off tools/list; ToolSearch precision improves (kind names listed in merged descriptions)
+
+## Evidence
+
+- 18 disjoint groups, max merge 173→~113; risk-aligned variant gives up only 3–4 tools of reduction while keeping the safety surface — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §2
+
+## Notes
+
+- Ride the `sdk-2x-upgrade` major window; fold `apply-composite-preview-destructive-misnomer` (rename) into the same cycle.
+- Dynamic toolsets rejected: list_changed unreliable across clients; GitHub removed theirs 2026-05-20 (report §6).
+- Related-not-duplicate: `tool-surface-pagination-or-tool-sets` (catalog resources, no hiding).

--- a/ai_docs/items/sdk-2x-upgrade.md
+++ b/ai_docs/items/sdk-2x-upgrade.md
@@ -1,0 +1,27 @@
+# sdk-2x-upgrade — ModelContextProtocol 1.4.1 → 2.x major upgrade
+
+**row:** `sdk-2x-upgrade` · **pri:** `High` · **size:** `L` · **deps:** `mcp-logging-stderr-otel-migration`
+
+## Anchors
+
+- `Directory.Packages.props:6` (ModelContextProtocol 1.4.1 pin)
+- `src/RoslynMcp.Host.Stdio/Program.cs` (registration + `WithRequestFilters` pipeline)
+- `src/RoslynMcp.Host.Stdio/McpLoggingProvider.cs` (MCP9005 obsolescence target — see deps)
+- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs` (envelope vs SDK raw structured emission)
+- `tests/RoslynMcp.Tests/` incl. `Catalog/Snapshots/catalog-v2.3.1.json` re-baseline
+
+## Acceptance
+
+- [ ] ModelContextProtocol ≥2.1.0; protocol 2026-07-28 negotiated with `server/discover` + legacy-initialize fallback verified over stdio
+- [ ] csharp-sdk#844 binding-stage exception-propagation contract re-verified for the call-tool filter pipeline
+- [ ] Structured-content behavior reconciled (SDK raw emission vs bespoke StructuredCallToolFilter envelope); JSON-RPC error-code assertions re-baselined (-32020..-32022 renumbering)
+- [ ] Contract-care breaks bundled into this one major window: drop the deprecated logging capability, `apply_composite_preview` rename with alias (row `apply-composite-preview-destructive-misnomer`), any consolidation renames ready to ride along
+- [ ] ADR + CHANGELOG migration note per public-repo breaking-change posture
+
+## Evidence
+
+- 1.4.1 vs 2.1.0 (2.0.0 → 2026-07-28, 2.1.0 → 2026-08-05); MCP spec two revisions stale; 6 of 10 conformance fails are SDK-blocked — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §4, §5
+
+## Context
+
+L umbrella — split into prep/upgrade/re-baseline children at plan time. Blocked on `mcp-logging-stderr-otel-migration` (MCP9005 turns the logging bridge into a build break under warnings-as-errors; migrate first, then upgrade). Unlocks `tasks-extension-slow-ops`, `caching-hints-tools-list`, MRTR elicitation, JSON Schema 2020-12. Risks are release-note-derived, not compile-verified.

--- a/ai_docs/items/semantic-grep-description-2kb-overflow.md
+++ b/ai_docs/items/semantic-grep-description-2kb-overflow.md
@@ -1,0 +1,21 @@
+# semantic-grep-description-2kb-overflow — Trim semantic_grep description under the 2KB client cap
+
+**row:** `semantic-grep-description-2kb-overflow` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs:430` (semantic_grep `[Description]` — 2,244 chars, largest on the surface)
+- `tests/RoslynMcp.Tests/` (new/extended surface test: every tool method Description ≤2,000 chars)
+
+## Acceptance
+
+- [ ] semantic_grep method Description ≤2,000 chars with trigger/usage essentials retained; overflow guidance relocated (ServerInstructions / prompts / catalog resource)
+- [ ] Surface test asserts every registered tool's method Description ≤2,000 chars (only semantic_grep violates today, so the cap test goes green with this one fix and pins the ceiling)
+
+## Evidence
+
+- Claude Code truncates tool descriptions at 2KB; semantic_grep is 2,244 chars source / 2,745 chars wire — content past the cap is invisible dead weight today — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §1
+
+## Context
+
+Deliberately split out of `method-description-diet` (an L sweep) because this is a live defect in the dominant client, shippable as a single-file S row now.

--- a/ai_docs/items/server-instructions-discovery-hint.md
+++ b/ai_docs/items/server-instructions-discovery-hint.md
@@ -1,0 +1,22 @@
+# server-instructions-discovery-hint — Ship ServerInstructions discovery hint
+
+**row:** `server-instructions-discovery-hint` · **pri:** `High` · **size:** `S`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Program.cs:45-53` (McpServerOptions — sets only ServerInfo Name/Title/Version today)
+- `tests/RoslynMcp.Tests/` (new host-level test: instructions non-empty, ≤2,048 chars)
+
+## Acceptance
+
+- [ ] initialize result carries a non-empty `instructions` string ≤2,048 chars (Claude Code truncates at 2KB)
+- [ ] Content is discovery-hint shaped: tool-category map (analysis / refactoring preview→apply / workspace lifecycle / validation), workspace_load-first bootstrap, when-to-search guidance
+- [ ] Test guards non-empty + the 2,048-char cap so future edits cannot silently exceed the client truncation
+
+## Evidence
+
+- Wire probe: `instructionsChars: 0`; Claude Code tool search loads only tool names + server instructions at session start, so 173 deferred tools have zero discovery text in the dominant client — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §1, §5
+
+## Context
+
+Highest practical impact per unit effort of the whole audit. API exists in SDK 1.4.x — no upgrade needed. This row is also the relocation target for `method-description-diet` (guidance moved out of per-tool descriptions needs this to exist first).

--- a/ai_docs/items/tasks-extension-slow-ops.md
+++ b/ai_docs/items/tasks-extension-slow-ops.md
@@ -1,0 +1,24 @@
+# tasks-extension-slow-ops — Adopt the MCP tasks extension for slow operations
+
+**row:** `tasks-extension-slow-ops` · **pri:** `Low` · **size:** `M` · **deps:** `sdk-2x-upgrade`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Program.cs` (`WithTasks(...)` wiring + `ModelContextProtocol.Extensions.Tasks` package)
+- `src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs` (workspace_load / workspace_warm)
+- `src/RoslynMcp.Host.Stdio/Tools/` build + test_run tool files
+- `tests/RoslynMcp.Tests/` (task lifecycle: create → poll → result; cancellation)
+
+## Acceptance
+
+- [ ] workspace_load, build_*, test_run offer task-augmented execution (deferred result + `tasks/get` polling) alongside existing progress notifications
+- [ ] Cancellation propagates through the task path (reuse the hardened gate classification — commits 656efda2 / cadc7e42 / a61c2e2a)
+- [ ] New public contract surface documented per product-contract tiering
+
+## Evidence
+
+- The server's slowest ops stream progress only; tasks are the spec-blessed shape for long-running MCP operations (SEP-2663, official extension under 2026-07-28) — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §4, §5
+
+## Notes
+
+- Blocked on `sdk-2x-upgrade` (Extensions.Tasks requires SDK 2.x).

--- a/ai_docs/items/tool-output-schema-wire-projection.md
+++ b/ai_docs/items/tool-output-schema-wire-projection.md
@@ -1,0 +1,20 @@
+# tool-output-schema-wire-projection — Project registered output schemas into tools/list
+
+**row:** `tool-output-schema-wire-projection` · **pri:** `Medium` · **size:** `M`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs` (schema source — reflects `OutputSchemaTypeRef` → JSON Schema)
+- `src/RoslynMcp.Host.Stdio/Program.cs` (startup pass writing each registered tool's `ProtocolTool.OutputSchema`)
+- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallContentProjector.cs` (consistency check only — runtime emission already works)
+- `tests/RoslynMcp.Tests/` (SurfaceCatalogTests + catalog snapshot re-baseline)
+
+## Acceptance
+
+- [ ] `tools/list` publishes `outputSchema` for exactly the `OutputSchemaTypeRef` adopters (8 today: server_info, server_heartbeat, workspace_drift_check, workspace_list, workspace_status, workspace_health, workspace_readiness_report, workspace_support_bundle) and auto-covers future adopters
+- [ ] Both channels still emitted per MCP spec (structuredContent + serialized content[].text)
+- [ ] Catalog snapshot / surface tests updated; wire probe shows toolsWithOutputSchema == adopter count
+
+## Evidence
+
+- 8 tools emit runtime structuredContent but wire probe shows `toolsWithOutputSchema: 0` — schemas are published only via the catalog resource because all tools return `Task<string>` (SDK generates none) and nothing projects the index into the protocol objects. Projection gap, not adoption gap — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §5

--- a/ai_docs/items/tool-tier-gated-registration.md
+++ b/ai_docs/items/tool-tier-gated-registration.md
@@ -1,0 +1,25 @@
+# tool-tier-gated-registration — ROSLYNMCP_TOOL_TIERS registration gate
+
+**row:** `tool-tier-gated-registration` · **pri:** `Medium` · **size:** `M`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Program.cs:55-57` (blanket `WithToolsFromAssembly()` trio) and `:195-309` (env-binding block the new var joins)
+- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` (`TryGetTool` O(1) supportTier lookup — parity-tested)
+- `ai_docs/runtime.md` env-var table + `README.md` (document the lean profile)
+- `tests/RoslynMcp.Tests/` (default-surface snapshot unchanged; stable-only count; bad-value fail-fast)
+
+## Acceptance
+
+- [ ] Default (var unset or `stable,experimental`): registered surface byte-identical to today — zero behavior change for existing installs
+- [ ] `ROSLYNMCP_TOOL_TIERS=stable`: exactly the 113 stable tools register (tools/list ≈ 36k of 55k est. tokens)
+- [ ] Unknown tier value → fail-fast startup error naming the valid vocabulary
+- [ ] runtime.md + README document the profile as the recommendation for non-deferring clients (Claude Desktop, Codex CLI, Gemini CLI, Cursor)
+
+## Evidence
+
+- supportTier exists on all 173 tools but is reporting-only — no enforcement consumer anywhere; experimental tier = 60 tools ≈ ~19k tokens for opt-in users — see `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` §3
+
+## Context
+
+First enforcement consumer for supportTier. Distinct from `tool-surface-pagination-or-tool-sets` (bounded catalog resources WITHOUT hiding tools — complementary, do not merge). Decide in plan: whether prompts referencing experimental tools tier-gate too or degrade gracefully. Ecosystem prior art: GitHub `--toolsets`, Playwright `--caps`, Azure MCP modes (report §6).

--- a/ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md
+++ b/ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md
@@ -1,0 +1,60 @@
+# MCP token-overhead + SDK/spec conformance audit — 2026-08-13
+
+<!-- Evidence report for the backlog rows tagged [source: 20260813 mcp-audit].
+     Method: live stdio probe of the installed v2.3.8 binary (initialize + tools/list +
+     prompts/list + resources/list), source-level surface inventory, SDK release-note
+     research, MCP spec/best-practices research. Token figures = ceil(chars/4) on wire
+     JSON; treat as ±15%. No build/test run (self-hosted runner constraint). -->
+
+## 1. Measured startup surface (wire probe, v2.3.8, protocol 2025-06-18)
+
+| Component | Chars | Est. tokens |
+|---|---|---|
+| tools/list (173 tools, 1 page) | 220,068 | ~55,017 (avg 318/tool) |
+| prompts/list (20) | 9,562 | ~2,391 |
+| resources/list (5 fixed; 9 templates unprobed) | ~2,008 | ~502 |
+| initialize `instructions` | **0** | 0 |
+| **Total per non-deferring session** | ~231,600 | **~57,900** |
+
+- Description text = 127,087 chars (57.8%): method-level 68,408 + schema-property 58,679. Annotations 15,488 chars.
+- Claude Code default ToolSearch deferral: names-only at start ≈ **1.5–2k tokens** — already ~97% reduced. Server-side reduction serves non-deferring clients (Claude Desktop, Codex CLI, Gemini CLI, Cursor, proxies, pre-4.5 platforms).
+- Top offenders (chars): workspace_load 3,746 · semantic_grep 3,348 (description 2,244 — **exceeds Claude Code's 2KB truncation**) · compile_check 3,136 · find_references 3,061.
+
+## 2. Surface inventory (source, HEAD)
+
+- 173 tools = 113 stable + 60 experimental; 49 preview-side + 26 apply-family; 17 strict preview/apply name pairs.
+- All 49 previews `readOnly=true, destructive=false` (uniform class — preview merges lose no annotation granularity).
+- Apply-family risk buckets: formatting 3 · text-edit 3 · code-transform 10 · file-lifecycle 5 · project-file 1 · composite/undo/fork 4+.
+- 18 disjoint consolidation groups; max merge 173→~113; **risk-aligned merge (buckets preserved) 173→~117**, est. net ~10–13k tokens.
+- Every apply takes only `previewToken` (+workspaceId) — structural proof for the apply merges. `symbol_refactor_preview` already ships the kind-discriminated pattern.
+
+## 3. Gating: taxonomy exists, zero enforcement
+
+- Registration is blanket `WithToolsFromAssembly()` (Program.cs:55-57); no env/CLI gate; `supportTier` consumed only by reporting (catalog summary, server_info, promotion diff) — never at registration/list time.
+- Prompts/resources are on-demand; catalog resource is paginated + cap-safe.
+
+## 4. SDK / spec currency
+
+| | Pinned | Latest | |
+|---|---|---|---|
+| ModelContextProtocol | 1.4.1 | 2.1.0 (2.0.0 → 2026-07-28; 2.1.0 → 2026-08-05) | major behind |
+| Microsoft.CodeAnalysis.* | 5.6.0 | 5.6.0 | current |
+| MCP protocol | 2025-06-18 | **2026-07-28** (2025-11-25 intermediate) | two revisions stale |
+
+SDK 2.x buys: protocol 2026-07-28 negotiation + `server/discover` (automatic), tasks extension (`ModelContextProtocol.Extensions.Tasks`, SEP-2663), caching hints (`ttlMs`/`cacheScope`, SEP-2549), structured-content fidelity + JSON Schema 2020-12 (SEP-2106), MRTR elicitation, filter/request-handler expansion (MCPEXP002), OTel trace-context (SEP-414).
+
+Breaking risk 1.4.1→2.x for this repo: **MCP9005** (Logging deprecated — hits `McpLoggingProvider`; build break under warnings-as-errors; prerequisite = `mcp-logging-stderr-otel-migration` row) · structured raw-emission vs bespoke `StructuredCallToolFilter` envelope (Medium) · csharp-sdk#844 binding-exception contract re-verify (Medium) · error-code renumbering -32020..22 (Low-Med). Release-note-derived, not compile-verified.
+
+## 5. Conformance scorecard (vs 2026-08 best practices)
+
+7 pass · 12 partial · 10 fail. Fail cluster: 6 SDK-blocked (protocol rev, server/discover, tasks, caching hints, 2020-12 dialect) + 4 fixable on 1.4.1 (ServerInstructions; outputSchema wire projection; output-size handling; input_examples).
+
+Key partials/facts:
+- **outputSchema**: 8 adopter tools (server_info, server_heartbeat, workspace_* family) emit runtime `structuredContent`, but wire `toolsWithOutputSchema: 0` — schemas live only in the catalog resource; nothing projects `ToolOutputSchemaIndex` into `ProtocolTool.OutputSchema` (all tools return `Task<string>`). Projection gap, not adoption gap.
+- **Logging**: declared capability + `notifications/message` bridge, but `McpLoggingProvider.cs:32` hardcodes an Information floor — `logging/setLevel` ignored. Do NOT patch: the whole surface is deprecated (2026-07-28); migrate per `mcp-logging-stderr-otel-migration` and let the bug die with it.
+- Annotations 173/173 honest (four boolean hints; no per-tool `title`). Elicitation spec-shaped with strict allowlist. Progress + cancellation broadly implemented. Handle-based state already 2026-07-28-shaped.
+- `ParameterObjectTools.cs:22` (+ class doc :13) routes agents to nonexistent `apply_refactoring` — shipped-surface defect.
+
+## 6. Prior art (why no dynamic toolsets)
+
+`tools/list_changed` honored reliably only by VS Code; Claude Desktop/Codex/Gemini CLI/Cursor drop it. GitHub MCP server removed its dynamic-toolsets mode 2026-05-20 (github/github-mcp-server PR #2512) — static selection + client deferral won. Static tier/toolset flags (GitHub `--toolsets`, Playwright `--caps`, Azure MCP modes) are the ecosystem-proven shape.


### PR DESCRIPTION
## Summary

Files the outcomes of the 2026-08-13 MCP token-overhead + SDK/spec conformance audit as backlog rows, plus the evidence report they cite.

- **Evidence report** `ai_docs/reports/20260813T025903Z_roslyn-backed-mcp_mcp-token-overhead-and-conformance-audit.md` — live wire probe of v2.3.8 (tools/list = 173 tools ≈ 55k est. tokens, ~58k/session total for non-deferring clients; instructions 0 chars), surface inventory (18 consolidation groups; preview/apply risk-flag census), SDK currency (ModelContextProtocol 1.4.1 vs 2.1.0; protocol 2025-06-18 vs 2026-07-28), conformance scorecard (7 pass / 12 partial / 10 fail).
- **12 new rows** (all via `backlog.mjs`, lint 0 ERROR): High — `server-instructions-discovery-hint`, `sdk-2x-upgrade`; Medium — `semantic-grep-description-2kb-overflow`, `parameter-object-stale-apply-route`, `tool-output-schema-wire-projection`, `tool-tier-gated-registration`, `method-description-diet`, `risk-aligned-tool-consolidation`; Low — `param-description-dedupe`, `tasks-extension-slow-ops`, `caching-hints-tools-list`, `input-examples-feasibility`.
- **1 note appended** to existing `mcp-logging-stderr-otel-migration` (setLevel-floor evidence; marked as the `sdk-2x-upgrade` prerequisite via deps).

No production code changes — backlog + items + report only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)