### PR TITLE
fix(extract-type): refuse unsafe extraction member shapes

### DIFF
--- a/changelog.d/type-extraction-member-shape-validation.md
+++ b/changelog.d/type-extraction-member-shape-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_type` preview now refuses unsafe extraction member shapes — a source-type constructor named in `memberNames` is refused instead of being emitted unchanged into the new type, a multi-declarator field is split so only the requested variables move (unrequested siblings are never silently dragged along), and an ambiguous method-overload name is refused with the candidate signatures listed instead of silently picking the first-declared overload by source order.

--- a/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
@@ -44,9 +44,9 @@ public sealed class TypeExtractionService : ITypeExtractionService
         var typeSymbol = semanticModel.GetDeclaredSymbol(typeDecl, ct) as INamedTypeSymbol
             ?? throw new InvalidOperationException($"Could not resolve type '{sourceTypeName}'.");
 
-        var (membersToExtract, membersToKeep) = PartitionMembers(typeDecl, memberNames, sourceTypeName);
+        var (membersToExtract, membersToKeep, analysisNodes) = PartitionMembers(typeDecl, memberNames, sourceTypeName);
 
-        var warnings = CollectExtractTypeDanglingReferenceWarnings(semanticModel, typeSymbol, membersToExtract, ct);
+        var warnings = CollectExtractTypeDanglingReferenceWarnings(semanticModel, typeSymbol, analysisNodes, ct);
 
         // BUG-005 (#2/#3): Refuse to generate code that the warnings prove will not compile.
         // The previous behavior emitted the warnings but still produced a preview that referenced
@@ -75,7 +75,7 @@ public sealed class TypeExtractionService : ITypeExtractionService
         // caller knows to either pull the affected callers into the extraction redesign, or to
         // first refactor those callers to interact with the new type directly via DI / factory.
         var externalConsumerWarnings = await CollectExternalConsumerWarningsAsync(
-            solution, sourceDocument, semanticModel, membersToExtract, ct).ConfigureAwait(false);
+            solution, sourceDocument, semanticModel, analysisNodes, ct).ConfigureAwait(false);
         if (externalConsumerWarnings.Count > 0)
         {
             var summary = string.Join("; ", externalConsumerWarnings);
@@ -126,20 +126,50 @@ public sealed class TypeExtractionService : ITypeExtractionService
             warnings.Count > 0 ? warnings.Select(w => w.Reason).ToList() : null);
     }
 
-    private static (List<MemberDeclarationSyntax> ToExtract, List<MemberDeclarationSyntax> ToKeep) PartitionMembers(
+    /// <summary>
+    /// Splits the source type's members into the set that moves to the new type and the set that
+    /// stays behind, plus the ORIGINAL, in-tree syntax nodes that downstream semantic analysis must
+    /// run against (<c>AnalysisNodes</c>).
+    /// <para>
+    /// type-extraction-member-shape-validation: the extraction pipeline moves members by name, and
+    /// three name shapes cannot be moved safely — a constructor (whose identifier is the source
+    /// type's name), an ambiguous method-overload name, and one declarator of a multi-declarator
+    /// field. The first two are refused up front by <see cref="ValidateRequestedMemberShapes"/>; the
+    /// third is handled per declarator by <see cref="PartitionFieldDeclarators"/>.
+    /// </para>
+    /// <para>
+    /// <c>AnalysisNodes</c> is a separate list because the extracted half of a split field is a
+    /// synthesized node that belongs to no syntax tree, and <see cref="SemanticModel"/> rejects
+    /// foreign nodes. Semantic passes therefore consume the original declarators, never the
+    /// synthesized declaration.
+    /// </para>
+    /// </summary>
+    private static (List<MemberDeclarationSyntax> ToExtract, List<MemberDeclarationSyntax> ToKeep, List<SyntaxNode> AnalysisNodes) PartitionMembers(
         TypeDeclarationSyntax typeDecl, IReadOnlyList<string> memberNames, string sourceTypeName)
     {
-        var memberNameSet = new HashSet<string>(memberNames, StringComparer.Ordinal);
+        var requestedNames = new HashSet<string>(memberNames, StringComparer.Ordinal);
+
+        ValidateRequestedMemberShapes(typeDecl, requestedNames, sourceTypeName);
+
+        var matchedNames = new HashSet<string>(StringComparer.Ordinal);
         var toExtract = new List<MemberDeclarationSyntax>();
         var toKeep = new List<MemberDeclarationSyntax>();
+        var analysisNodes = new List<SyntaxNode>();
 
         foreach (var member in typeDecl.Members)
         {
+            if (member is FieldDeclarationSyntax field)
+            {
+                PartitionFieldDeclarators(field, requestedNames, matchedNames, toExtract, toKeep, analysisNodes);
+                continue;
+            }
+
             var name = GetMemberName(member);
-            if (name is not null && memberNameSet.Contains(name))
+            if (name is not null && requestedNames.Contains(name))
             {
                 toExtract.Add(member);
-                memberNameSet.Remove(name);
+                analysisNodes.Add(member);
+                matchedNames.Add(name);
             }
             else
             {
@@ -147,25 +177,167 @@ public sealed class TypeExtractionService : ITypeExtractionService
             }
         }
 
-        if (memberNameSet.Count > 0)
+        // Every declaration carrying a requested name is now moved. The pre-pass above already
+        // refused the only shapes where several declarations can legally share a name (overloads,
+        // constructors), so this no longer silently drops later same-named declarations the way the
+        // previous "remove on first match" loop did.
+        var unmatchedNames = requestedNames.Where(name => !matchedNames.Contains(name)).ToList();
+        if (unmatchedNames.Count > 0)
         {
             // extract-type-preview-refusal-missing-blocking-deps: prose message unchanged; the
             // unmatched names are also projected into structured blocking dependencies so the
             // caller can correct `memberNames` without parsing the sentence.
-            var unmatched = memberNameSet
+            var unmatched = unmatchedNames
                 .Select(name => new BlockingDependencyDto(
                     name,
                     $"Member '{name}' not found in type '{sourceTypeName}'."))
                 .ToList();
             throw new ExtractTypeBlockingDependencyException(
-                $"Members not found in type '{sourceTypeName}': {string.Join(", ", memberNameSet)}",
+                $"Members not found in type '{sourceTypeName}': {string.Join(", ", unmatchedNames)}",
                 unmatched);
         }
 
         if (toExtract.Count == 0)
             throw new InvalidOperationException("No members matched for extraction.");
 
-        return (toExtract, toKeep);
+        return (toExtract, toKeep, analysisNodes);
+    }
+
+    /// <summary>
+    /// type-extraction-member-shape-validation: refuses the requested member names that this
+    /// extraction cannot honour unambiguously, before any partitioning happens. Reuses the same
+    /// <see cref="ExtractTypeBlockingDependencyException"/> / <see cref="BlockingDependencyDto"/>
+    /// contract as the existing unmatched-name and dangling-reference refusals so callers face one
+    /// structured refusal shape rather than three ad hoc ones.
+    /// </summary>
+    private static void ValidateRequestedMemberShapes(
+        TypeDeclarationSyntax typeDecl, HashSet<string> requestedNames, string sourceTypeName)
+    {
+        var blocking = new List<BlockingDependencyDto>();
+
+        // (1) Constructors. A constructor's identifier is ALWAYS the source type's name, so a
+        // requested name matching it used to select the constructor and emit it verbatim inside
+        // `public sealed class {newTypeName}` — where it is no longer a constructor at all but an
+        // ill-formed method named after the old type (CS1520). Static constructors hit the same arm.
+        foreach (var ctorName in typeDecl.Members
+            .OfType<ConstructorDeclarationSyntax>()
+            .Select(c => c.Identifier.Text)
+            .Where(requestedNames.Contains)
+            .Distinct(StringComparer.Ordinal))
+        {
+            blocking.Add(new BlockingDependencyDto(
+                ctorName,
+                $"'{ctorName}' names a constructor of '{sourceTypeName}'. Constructors are never eligible for " +
+                $"extraction: the new type is declared under a different name, so the moved declaration would " +
+                $"stop being a constructor and would not compile. Drop it from memberNames and extract the " +
+                $"members it initializes instead."));
+        }
+
+        // (2) Method overloads. `memberNames` carries bare names, so an overloaded name cannot
+        // identify a single declaration. The previous loop extracted whichever overload came first
+        // in source order and silently left the rest behind.
+        foreach (var group in typeDecl.Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => requestedNames.Contains(m.Identifier.Text))
+            .GroupBy(m => m.Identifier.Text, StringComparer.Ordinal))
+        {
+            var candidates = group.ToList();
+            if (candidates.Count < 2)
+                continue;
+
+            // The defining and implementing halves of a `partial` method are ONE logical member,
+            // not an overload set — both halves move together, so there is nothing ambiguous.
+            if (candidates.All(m => m.Modifiers.Any(SyntaxKind.PartialKeyword)))
+                continue;
+
+            foreach (var candidate in candidates)
+            {
+                blocking.Add(new BlockingDependencyDto(
+                    group.Key,
+                    $"'{group.Key}' is ambiguous in '{sourceTypeName}': {candidates.Count} overloads declare that " +
+                    $"name, including '{DescribeMethodSignature(candidate)}'. Extraction selects members by bare " +
+                    $"name, so it cannot tell which overload was meant. Extract a name that resolves to exactly " +
+                    $"one declaration, or move the specific overload by hand."));
+            }
+        }
+
+        if (blocking.Count > 0)
+        {
+            throw new ExtractTypeBlockingDependencyException(
+                $"Refusing to extract from '{sourceTypeName}': {string.Join("; ", blocking.Select(b => b.Reason))}",
+                blocking);
+        }
+    }
+
+    /// <summary>
+    /// Renders a method's disambiguating signature. The type-parameter list is included so
+    /// <c>Foo&lt;T&gt;(int)</c> and <c>Foo(int)</c> are reported as the distinct overloads they are.
+    /// </summary>
+    private static string DescribeMethodSignature(MethodDeclarationSyntax method)
+    {
+        return method.Identifier.Text
+            + (method.TypeParameterList?.ToString() ?? string.Empty)
+            + method.ParameterList.ToString();
+    }
+
+    /// <summary>
+    /// type-extraction-member-shape-validation: a field declaration may declare several variables
+    /// (<c>private int a, b, c;</c>) while <see cref="GetMemberName"/> only ever named the first, so
+    /// requesting <c>a</c> silently dragged <c>b</c>/<c>c</c> along and requesting <c>b</c> matched
+    /// nothing. Matching now happens per declarator: the node moves whole only when EVERY declarator
+    /// was requested, otherwise it is split into an extracted half and a retained half that both
+    /// preserve the original attributes, modifiers, type and initializers.
+    /// <para>
+    /// <c>EventFieldDeclarationSyntax</c> (<c>event EventHandler A, B;</c>) is deliberately NOT
+    /// handled here — it derives from <c>BaseFieldDeclarationSyntax</c>, not
+    /// <c>FieldDeclarationSyntax</c>, and <see cref="GetMemberName"/> never named it, so event fields
+    /// remain unextractable exactly as before.
+    /// </para>
+    /// </summary>
+    private static void PartitionFieldDeclarators(
+        FieldDeclarationSyntax field,
+        HashSet<string> requestedNames,
+        HashSet<string> matchedNames,
+        List<MemberDeclarationSyntax> toExtract,
+        List<MemberDeclarationSyntax> toKeep,
+        List<SyntaxNode> analysisNodes)
+    {
+        var declarators = field.Declaration.Variables;
+        var requested = declarators.Where(v => requestedNames.Contains(v.Identifier.Text)).ToList();
+        if (requested.Count == 0)
+        {
+            toKeep.Add(field);
+            return;
+        }
+
+        foreach (var declarator in requested)
+            matchedNames.Add(declarator.Identifier.Text);
+
+        // Semantic analysis runs against the ORIGINAL in-tree nodes only: the declared type and
+        // attributes of the field, plus the specific declarators that move. A synthesized split half
+        // has no syntax tree, so passing it to the SemanticModel would throw; feeding only the
+        // requested declarators also stops a retained sibling's initializer from producing a
+        // dangling-reference refusal for state that never leaves the source type.
+        analysisNodes.AddRange(field.AttributeLists);
+        analysisNodes.Add(field.Declaration.Type);
+        analysisNodes.AddRange(requested);
+
+        if (requested.Count == declarators.Count)
+        {
+            toExtract.Add(field);
+            return;
+        }
+
+        var retained = declarators.Where(v => !requestedNames.Contains(v.Identifier.Text)).ToList();
+        toExtract.Add(WithDeclarators(field, requested));
+        toKeep.Add(WithDeclarators(field, retained));
+    }
+
+    private static FieldDeclarationSyntax WithDeclarators(
+        FieldDeclarationSyntax field, IEnumerable<VariableDeclaratorSyntax> declarators)
+    {
+        return field.WithDeclaration(
+            field.Declaration.WithVariables(SyntaxFactory.SeparatedList(declarators)));
     }
 
     private static CompilationUnitSyntax BuildNewFileRoot(
@@ -329,17 +501,19 @@ public sealed class TypeExtractionService : ITypeExtractionService
         Solution solution,
         Document sourceDocument,
         SemanticModel semanticModel,
-        IReadOnlyList<MemberDeclarationSyntax> membersToExtract,
+        IReadOnlyList<SyntaxNode> analysisNodes,
         CancellationToken ct)
     {
         var warnings = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var sourceFilePath = sourceDocument.FilePath;
 
-        foreach (var member in membersToExtract)
+        foreach (var node in analysisNodes)
         {
             ct.ThrowIfCancellationRequested();
-            var memberSymbol = semanticModel.GetDeclaredSymbol(member, ct);
+            if (!IsDeclarationNode(node)) continue;
+
+            var memberSymbol = semanticModel.GetDeclaredSymbol(node, ct);
             if (memberSymbol is null) continue;
 
             // Only public / internal members can be referenced from outside the source type
@@ -382,12 +556,14 @@ public sealed class TypeExtractionService : ITypeExtractionService
     private static List<BlockingDependencyDto> CollectExtractTypeDanglingReferenceWarnings(
         SemanticModel semanticModel,
         INamedTypeSymbol typeSymbol,
-        IReadOnlyList<MemberDeclarationSyntax> membersToExtract,
+        IReadOnlyList<SyntaxNode> analysisNodes,
         CancellationToken ct)
     {
         var extractedDeclared = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-        foreach (var m in membersToExtract)
+        foreach (var m in analysisNodes)
         {
+            if (!IsDeclarationNode(m)) continue;
+
             var sym = semanticModel.GetDeclaredSymbol(m, ct);
             if (sym is not null)
                 extractedDeclared.Add(sym);
@@ -396,12 +572,12 @@ public sealed class TypeExtractionService : ITypeExtractionService
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var warnings = new List<BlockingDependencyDto>();
 
-        foreach (var member in membersToExtract)
+        foreach (var member in analysisNodes)
         {
-            // GetMemberName returns null for shapes it does not name (operators, indexers,
+            // GetAnalysisNodeName returns null for shapes it does not name (operators, indexers,
             // destructors); fall back to the syntax kind so the structured entry always
             // carries a non-null attribution.
-            var memberName = GetMemberName(member) ?? member.Kind().ToString();
+            var memberName = GetAnalysisNodeName(member) ?? member.Kind().ToString();
 
             foreach (var node in member.DescendantNodesAndSelf())
             {
@@ -446,15 +622,51 @@ public sealed class TypeExtractionService : ITypeExtractionService
         return false;
     }
 
+    /// <summary>
+    /// True for the node kinds the semantic passes may hand to
+    /// <c>SemanticModel.GetDeclaredSymbol</c>. The analysis list also carries non-declaration
+    /// context nodes (a field's declared type and attribute lists) purely so their descendants get
+    /// walked for dangling references.
+    /// </summary>
+    private static bool IsDeclarationNode(SyntaxNode node)
+    {
+        return node is MemberDeclarationSyntax or VariableDeclaratorSyntax;
+    }
+
+    /// <summary>
+    /// Attribution label for an analysis node. A single declarator of a multi-declarator field is
+    /// named by its own identifier so the structured refusal points at the exact variable the caller
+    /// requested, not at the first declarator of the declaration that happens to contain it.
+    /// </summary>
+    private static string? GetAnalysisNodeName(SyntaxNode node)
+    {
+        return node switch
+        {
+            VariableDeclaratorSyntax v => v.Identifier.Text,
+            MemberDeclarationSyntax m => GetMemberName(m),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Maps a member declaration to the single name that selects it for extraction, or
+    /// <see langword="null"/> when no such name exists.
+    /// <para>
+    /// type-extraction-member-shape-validation: fields and constructors are deliberately absent.
+    /// A field can declare several names, so it is matched per declarator by
+    /// <see cref="PartitionFieldDeclarators"/> instead of by its first declarator. A constructor's
+    /// identifier is the SOURCE type's name, so naming one here made a request for the source type's
+    /// own name select the constructor and emit it verbatim into the differently-named new type;
+    /// <see cref="ValidateRequestedMemberShapes"/> refuses that request explicitly instead.
+    /// </para>
+    /// </summary>
     private static string? GetMemberName(MemberDeclarationSyntax member)
     {
         return member switch
         {
             MethodDeclarationSyntax m => m.Identifier.Text,
             PropertyDeclarationSyntax p => p.Identifier.Text,
-            FieldDeclarationSyntax f => f.Declaration.Variables.FirstOrDefault()?.Identifier.Text,
             EventDeclarationSyntax e => e.Identifier.Text,
-            ConstructorDeclarationSyntax c => c.Identifier.Text,
             _ => null
         };
     }

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -644,6 +644,184 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
         }
     }
 
+    [TestMethod]
+    public async Task ExtractType_ConstructorRequested_RefusesWithStructuredBlockingDependency()
+    {
+        // Regression for `type-extraction-member-shape-validation` (1/3): a constructor's identifier
+        // is ALWAYS the source type's name, so `GetMemberName` mapped it to that name and
+        // `PartitionMembers` happily selected it. Neither `BuildNewFileRoot` nor
+        // `EnsurePublicAccessibility` retargets a constructor identifier, so the declaration was
+        // emitted verbatim inside `public sealed class {newTypeName}` — an ill-formed member named
+        // after the OLD type (CS1520-class breakage). It must be refused with structured data now.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ConstructorShapeFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ConstructorShapeFixture",
+                "{",
+                "    public ConstructorShapeFixture() { }",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<ExtractTypeBlockingDependencyException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, fixturePath, "ConstructorShapeFixture", ["ConstructorShapeFixture"], "ComputeHelper",
+                    null, CancellationToken.None));
+
+            Assert.IsTrue(ex.BlockingDependencies.Count > 0,
+                "the constructor refusal must carry structured blocking dependencies, not prose only");
+            Assert.IsTrue(ex.BlockingDependencies.Any(d =>
+                    string.Equals(d.Member, "ConstructorShapeFixture", StringComparison.Ordinal)),
+                "the blocking dependency must be attributed to the requested constructor name");
+            Assert.IsTrue(ex.BlockingDependencies.Any(d => d.Reason.Contains("constructor", StringComparison.Ordinal)),
+                $"the reason must say why the shape is refused. Actual: {string.Join(" | ", ex.BlockingDependencies.Select(d => d.Reason))}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_MultiDeclaratorField_SplitsOnlyRequestedVariables()
+    {
+        // Regression for `type-extraction-member-shape-validation` (2/3): `GetMemberName` named a
+        // field by its FIRST declarator only, so requesting "a" from `private int a = 1, b = 2;`
+        // moved the whole declaration and silently dragged `b` along (and requesting "b" matched
+        // nothing at all). The declaration must now be split, with attributes/modifiers/type and
+        // every initializer preserved on BOTH halves — including the retained, non-extracted one.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "MultiDeclaratorFieldFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class MultiDeclaratorFieldFixture",
+                "{",
+                "    private int a = 1, b = 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, fixturePath, "MultiDeclaratorFieldFixture", ["a"], "ValueHolder", null,
+                CancellationToken.None);
+
+            Assert.IsNotNull(result);
+
+            var newFileDiff = result.Changes.FirstOrDefault(
+                c => c.FilePath.EndsWith("ValueHolder.cs", StringComparison.OrdinalIgnoreCase));
+            Assert.IsNotNull(newFileDiff, "preview must emit a change entry for the new extracted type file");
+            var newFileAdded = AddedDiffLines(newFileDiff!.UnifiedDiff);
+
+            Assert.IsTrue(newFileAdded.Any(l => l.Contains("a = 1", StringComparison.Ordinal)),
+                $"the requested declarator (with its initializer) must move to the new type. Diff:\n{newFileDiff.UnifiedDiff}");
+            Assert.IsFalse(newFileAdded.Any(l => System.Text.RegularExpressions.Regex.IsMatch(l, @"\bb\b")),
+                $"the unrequested sibling declarator must NOT be dragged into the new type. Diff:\n{newFileDiff.UnifiedDiff}");
+
+            var sourceDiff = result.Changes.FirstOrDefault(
+                c => c.FilePath.EndsWith("MultiDeclaratorFieldFixture.cs", StringComparison.OrdinalIgnoreCase));
+            Assert.IsNotNull(sourceDiff, "preview must emit a change entry for the edited source file");
+            var sourceAdded = AddedDiffLines(sourceDiff!.UnifiedDiff);
+
+            Assert.IsTrue(sourceAdded.Any(l => l.Contains("private int b = 2;", StringComparison.Ordinal)),
+                $"the retained half must keep the original modifiers, type and initializer. Diff:\n{sourceDiff.UnifiedDiff}");
+            Assert.IsFalse(sourceAdded.Any(l => l.Contains("a = 1", StringComparison.Ordinal)),
+                $"the extracted declarator must be gone from the source type. Diff:\n{sourceDiff.UnifiedDiff}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_AmbiguousOverload_RefusesWithStructuredCandidates()
+    {
+        // Regression for `type-extraction-member-shape-validation` (3/3): `PartitionMembers` removed
+        // a name from its pending set on the FIRST source-order match, so for an overloaded name the
+        // first-declared overload was extracted and every later same-named overload silently fell
+        // through to the keep list — the caller was never told a choice had been made for them.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "OverloadShapeFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class OverloadShapeFixture",
+                "{",
+                "    private int Foo(int x) => x;",
+                "    private int Foo(string s) => s.Length;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<ExtractTypeBlockingDependencyException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, fixturePath, "OverloadShapeFixture", ["Foo"], "FooHelper", null,
+                    CancellationToken.None));
+
+            Assert.IsTrue(ex.BlockingDependencies.Count >= 2,
+                $"every ambiguous candidate must be reported, not just the first. Actual count: {ex.BlockingDependencies.Count}");
+            Assert.IsTrue(ex.BlockingDependencies.All(d => string.Equals(d.Member, "Foo", StringComparison.Ordinal)),
+                "each candidate entry must be attributed to the ambiguous requested name");
+
+            var reasons = string.Join(" | ", ex.BlockingDependencies.Select(d => d.Reason));
+            StringAssert.Contains(reasons, "(int x)",
+                "the refusal must list each candidate's signature so the caller can disambiguate");
+            StringAssert.Contains(reasons, "(string s)",
+                "the refusal must list each candidate's signature so the caller can disambiguate");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    /// <summary>
+    /// Returns the added ('+') lines of a unified diff with the marker stripped, skipping the
+    /// '+++' file header.
+    /// </summary>
+    private static string[] AddedDiffLines(string unifiedDiff)
+    {
+        return unifiedDiff
+            .Split('\n')
+            .Where(line => line.StartsWith('+') && !line.StartsWith("+++"))
+            .Select(line => line.TrimEnd('\r')[1..])
+            .ToArray();
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try


### PR DESCRIPTION
## Summary

`extract_type_preview` selected members by bare name through `GetMemberName`, which produced three unsafe outcomes in `TypeExtractionService`:

1. **Constructors were extractable.** A constructor's identifier is always the SOURCE type's name, so a `memberNames` entry matching it selected the constructor and emitted it unchanged inside `public sealed class {newTypeName}` — an ill-formed member named after the old type (CS1520-class breakage). Neither `BuildNewFileRoot` nor `EnsurePublicAccessibility` retargets a constructor identifier.
2. **Multi-declarator fields moved whole.** A field was named by its FIRST declarator only, so requesting `a` from `private int a, b, c;` silently dragged `b`/`c` into the new type, and requesting `b` or `c` alone matched nothing at all — with no signal to the caller.
3. **Overloads were picked by source order.** The pending-name set dropped a name on the first match, so the first-declared overload was extracted and every later same-named overload silently fell through to the keep list.

## Approach

`PartitionMembers` is now validate-then-partition:

- **Pre-pass refusal** (`ValidateRequestedMemberShapes`) rejects constructors and ambiguous method-overload names through the *existing* `ExtractTypeBlockingDependencyException` / `BlockingDependencyDto` contract, so callers face one structured refusal shape rather than a third ad hoc one. Candidate signatures include the type-parameter list, so `Foo<T>(int)` and `Foo(int)` read as the distinct overloads they are; the defining and implementing halves of a `partial` method are treated as one logical member and are not refused.
- **Per-declarator field partition** (`PartitionFieldDeclarators`) moves a field node whole only when every declarator was requested, otherwise splits it into an extracted half and a retained half that both preserve the original attributes, modifiers, type and initializers.
- **In-tree analysis nodes.** The semantic passes (`CollectExtractTypeDanglingReferenceWarnings`, `CollectExternalConsumerWarningsAsync`) now consume a separate list of ORIGINAL syntax nodes, because a split half synthesized via `WithDeclaration(...)` belongs to no syntax tree and `SemanticModel` rejects foreign nodes. Feeding only the requested declarators also stops a retained sibling's initializer from producing a dangling-reference refusal for state that never leaves the source type.
- The field and constructor arms are **removed** from `GetMemberName` so the hazardous name mapping cannot be reintroduced.

No `ITypeExtractionService` signature change — `memberNames` stays a flat string list.

## Validation

- `dotnet build RoslynMcp.slnx` — 0 warnings, 0 errors.
- `TypeExtractionTests` — 17/17 pass (14 pre-existing + 3 new), confirming no regression on `ExtractType_OverrideMember_StripsOverrideFromNewType`, `ExtractType_NewMember_StripsNewModifierFromNewType`, `ExtractType_MemberNotFound_ThrowsWithStructuredBlockingDependencies`, `ExtractType_DanglingReference_ThrowsWithStructuredBlockingDependencies`, `ExtractType_NoExternalConsumers_ProducesPreview`.
- Adjacent classes `TypeMoveTests` / `ErrorResponseObservabilityTests` / `DeadLoggerFieldsTests` — 24/24 pass.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1 -Configuration Release` is delegated to the self-hosted CI runner on this PR rather than duplicated locally (standing repo memory: never run it locally while the self-hosted runner is active).

New regression tests: `ExtractType_ConstructorRequested_RefusesWithStructuredBlockingDependency`, `ExtractType_MultiDeclaratorField_SplitsOnlyRequestedVariables` (covers initializer preservation on the retained, non-extracted declarator), `ExtractType_AmbiguousOverload_RefusesWithStructuredCandidates`.

## Bad code surfaced (Directive #3 — follow-up row recommended, NOT fixed here)

`src/RoslynMcp.Roslyn/Services/ClassSplitOrchestrator.cs:100` and `src/RoslynMcp.Roslyn/Services/SymbolRefactorService.cs:1666` each declare their own independent `private static string? GetMemberName(MemberDeclarationSyntax)` carrying the identical first-declarator-only field naming and no constructor/overload guard. They are not callers of the edited symbols (blast radius stays at 1 file), so they are deliberately out of scope per the plan's negative space — but the same bug class likely reproduces there and deserves its own backlog row.

Closes: type-extraction-member-shape-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
