### PR TITLE
fix(test_run): paginate the failures array and bound per-failure detail

### DIFF
--- a/changelog.d/test-run-failures-pagination-truncation.md
+++ b/changelog.d/test-run-failures-pagination-truncation.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** `test_run` now paginates its failures array (`failuresOffset`/`failuresLimit`, default limit 25) and head-truncates each failure's `Message` (500 chars) / `StackTrace` (1500 chars) with a visible `"... [truncated]"` marker, mirroring `test_discover`'s existing pagination and `DotnetCommandRunner`'s StdOut/StdErr truncation precedent. Aggregate `total`/`passed`/`failed`/`skipped` counts are never truncated. This changes the default JSON response shape (adds `failuresOffset`/`failuresLimit`/`failuresTotal`/`hasMoreFailures` fields) and may shorten previously-unbounded failure detail for very long assertion messages/stack traces — pass a higher `failuresLimit` or re-fetch with `failuresOffset` to see more.

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -188,7 +188,7 @@ public static class ValidationTools
         }, ct);
     }
 
-    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results. When the run cannot produce TRX output (MSBuild file lock, build failure, timeout, unknown exit) the result carries a populated FailureEnvelope with ErrorKind ('FileLock'|'BuildFailure'|'Timeout'|'Unknown'), IsRetryable, Summary, and tails of StdOut/StdErr — instead of throwing a bare invocation error. Windows note: MSB3027/MSB3021 file-lock failures typically mean another testhost.exe (IDE test runner, background build) is holding the test assembly; the envelope classifies these as retryable so callers can close the conflicting runner and retry without touching source.")]
+    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results. When the run cannot produce TRX output (MSBuild file lock, build failure, timeout, unknown exit) the result carries a populated FailureEnvelope with ErrorKind ('FileLock'|'BuildFailure'|'Timeout'|'Unknown'), IsRetryable, Summary, and tails of StdOut/StdErr — instead of throwing a bare invocation error. Windows note: MSB3027/MSB3021 file-lock failures typically mean another testhost.exe (IDE test runner, background build) is holding the test assembly; the envelope classifies these as retryable so callers can close the conflicting runner and retry without touching source. The `failures` array is paginated (failuresOffset/failuresLimit, default limit 25) and each entry's Message/StackTrace is head-truncated to 500/1500 chars with a trailing '... [truncated]' marker — a broad/unfiltered run over a large suite would otherwise produce an unbounded payload. Aggregate total/passed/failed/skipped always reflect the full run; failuresTotal/hasMoreFailures tell you when more failure detail exists.")]
     [McpToolMetadata("validation", "stable", false, false,
         "Run dotnet test for the workspace or a selected project.")]
     public static Task<string> RunTests(
@@ -197,12 +197,15 @@ public static class ValidationTools
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Optional: specific test project name or file path")] string? projectName = null,
         [Description("Optional: dotnet test filter expression")] string? filter = null,
+        [Description("Number of failing tests to skip before returning failure detail (default: 0)")] int failuresOffset = 0,
+        [Description("Maximum number of failing tests to return detail for (default: 25). Aggregate counts (total/passed/failed/skipped) are never truncated — only the per-failure detail array is paginated to keep the response within client context budgets.")] int failuresLimit = 25,
         IProgress<ProgressNotificationValue>? progress = null,
         IWorkspaceManager? workspaceManager = null,
         ILoggerFactory? loggerFactory = null,
         CancellationToken ct = default)
         => RunTestsWithEvictionRetryAsync(
-            gate, testRunnerService, workspaceManager, workspaceId, projectName, filter, progress, loggerFactory, ct);
+            gate, testRunnerService, workspaceManager, workspaceId, projectName, filter,
+            failuresOffset, failuresLimit, progress, loggerFactory, ct);
 
     /// <summary>
     /// <c>workspace-eviction-no-auto-retry-on-tool-call</c> — runs <c>test_run</c> once and, when
@@ -239,13 +242,17 @@ public static class ValidationTools
         string workspaceId,
         string? projectName,
         string? filter,
+        int failuresOffset,
+        int failuresLimit,
         IProgress<ProgressNotificationValue>? progress,
         ILoggerFactory? loggerFactory,
         CancellationToken ct)
     {
         try
         {
-            return await RunTestsOnceAsync(gate, testRunnerService, workspaceId, projectName, filter, progress, ct)
+            return await RunTestsOnceAsync(
+                    gate, testRunnerService, workspaceId, projectName, filter,
+                    failuresOffset, failuresLimit, progress, ct)
                 .ConfigureAwait(false);
         }
         catch (KeyNotFoundException ex)
@@ -270,7 +277,9 @@ public static class ValidationTools
                 throw;
             }
 
-            return await RunTestsOnceAsync(gate, testRunnerService, reloadedId, projectName, filter, progress, ct)
+            return await RunTestsOnceAsync(
+                    gate, testRunnerService, reloadedId, projectName, filter,
+                    failuresOffset, failuresLimit, progress, ct)
                 .ConfigureAwait(false);
         }
     }
@@ -281,6 +290,8 @@ public static class ValidationTools
         string workspaceId,
         string? projectName,
         string? filter,
+        int failuresOffset,
+        int failuresLimit,
         IProgress<ProgressNotificationValue>? progress,
         CancellationToken ct)
     {
@@ -294,11 +305,44 @@ public static class ValidationTools
         {
             try
             {
+                if (failuresLimit <= 0)
+                    throw new ArgumentException("failuresLimit must be greater than 0.", nameof(failuresLimit));
+                if (failuresOffset < 0)
+                    throw new ArgumentException("failuresOffset must be non-negative.", nameof(failuresOffset));
+
                 ProgressHelper.ReportStage(progress, 0, 3, "discovering-tests");
                 ProgressHelper.ReportStage(progress, 1, 3, "running-tests");
                 var result = await testRunnerService.RunTestsAsync(workspaceId, projectName, filter, c);
                 ProgressHelper.ReportStage(progress, 3, 3, "done");
-                return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+
+                // test-run-failures-pagination-truncation: Failures carries one entry per failing
+                // test, and pre-fix the whole list was serialized with no cap on COUNT (the
+                // per-entry Message/StackTrace cap lives in DotnetOutputParser). A broad or
+                // unfiltered run over a large suite therefore produced a payload that grew
+                // linearly with the failure count, with no protocol-level ceiling to catch it —
+                // neither this repo nor the pinned MCP SDK declares a response-size constant, so
+                // the only real ceiling is the consuming client's context budget. Page the list
+                // the same way test_discover pages test cases: aggregate counts (total/passed/
+                // failed/skipped) always reflect the FULL run; only the per-failure detail array
+                // is capped, with failuresTotal/hasMoreFailures so callers can tell.
+                var failuresTotal = result.Failures.Count;
+                var pagedFailures = result.Failures.Skip(failuresOffset).Take(failuresLimit).ToList();
+                var hasMoreFailures = failuresOffset + pagedFailures.Count < failuresTotal;
+
+                return JsonSerializer.Serialize(new
+                {
+                    result.Execution,
+                    result.Total,
+                    result.Passed,
+                    result.Failed,
+                    result.Skipped,
+                    failures = pagedFailures,
+                    failuresOffset,
+                    failuresLimit,
+                    failuresTotal,
+                    hasMoreFailures,
+                    result.FailureEnvelope,
+                }, JsonDefaults.Indented);
             }
             catch (OperationCanceledException)
             {

--- a/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
@@ -17,6 +17,29 @@ internal static partial class DotnetOutputParser
 
     private const int FailureTailMaxChars = 2000;
 
+    // test-run-failures-pagination-truncation: unlike StdOut/StdErr (bounded to 12000 chars by
+    // DotnetCommandRunner), TRX-parsed per-test Message/StackTrace were previously unbounded,
+    // and ValidationTools.RunTests serialized every failing test with no cap on the list length.
+    // A broad/unfiltered run over a large suite therefore produced a payload that grew linearly
+    // with the failure count and per-failure text size.
+    //
+    // Measured ceiling (see RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling in
+    // TestRunFailureEnvelopeTests): neither this repo nor the pinned ModelContextProtocol 2.1.0
+    // SDK declares ANY response-size constant — verified by grep over src/ and by symbol search
+    // over the shipped SDK assemblies. There is no protocol-level ceiling to point at; the real
+    // ceiling is the consuming client's context budget. So the caps below are sized against that
+    // budget rather than a protocol constant: with both halves of the fix in place, a worst-case
+    // page (25 failures, every Message/StackTrace at the caps) measures 56,923 chars of indented
+    // JSON (~14k tokens) — comparable to test_discover's own documented "1000 cases is roughly
+    // 350KB" guidance. Lifting the count cap on the same 400-failure run measures 904,200 chars
+    // (~883KB). Without truncation a single pathological failure is unbounded outright. Both
+    // halves are load-bearing.
+    //
+    // Truncate from the HEAD (not the tail, unlike StdOut/StdErr) because the assertion message
+    // and the throw-site frame — which come first — are the diagnostically useful part.
+    private const int TestFailureMessageMaxChars = 500;
+    private const int TestFailureStackTraceMaxChars = 1500;
+
     /// <summary>
     /// Parses MSBuild-style diagnostic lines from <c>dotnet build</c> standard output.
     /// </summary>
@@ -196,6 +219,28 @@ internal static partial class DotnetOutputParser
             : value[^FailureTailMaxChars..];
     }
 
+    /// <summary>
+    /// Bounds a per-test-failure <c>Message</c>/<c>StackTrace</c> value to <paramref name="maxChars"/>,
+    /// keeping the HEAD — unlike <see cref="Tail"/>, which keeps the tail for command StdOut/StdErr
+    /// where the final lines are the relevant ones. For an assertion message or a stack trace the
+    /// start (the assertion text, the throw-site frame) is what a caller needs to diagnose the
+    /// failure. Appends a marker so truncation is visible rather than silent. Returns <c>null</c>
+    /// for a null or empty input so callers can apply their own fallback.
+    /// </summary>
+    private static string? TruncateHead(string? value, int maxChars)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+        return value.Length <= maxChars
+            ? value
+            : value[..maxChars] + TruncationMarker;
+    }
+
+    /// <summary>
+    /// Appended to a head-truncated failure <c>Message</c>/<c>StackTrace</c> so consumers can tell
+    /// a value was shortened. Public consumers may match on this exact suffix.
+    /// </summary>
+    internal const string TruncationMarker = "... [truncated]";
+
     private static (int Total, int Passed, int Failed, int Skipped, List<TestFailureDto> Failures) ParseSingleTrxFile(string trxPath)
     {
         if (!File.Exists(trxPath))
@@ -242,8 +287,8 @@ internal static partial class DotnetOutputParser
                 return new TestFailureDto(
                     DisplayName: GetDisplayName(fullyQualifiedName),
                     FullyQualifiedName: fullyQualifiedName,
-                    Message: messageEl?.Value ?? "Test failed",
-                    StackTrace: stackEl?.Value);
+                    Message: TruncateHead(messageEl?.Value, TestFailureMessageMaxChars) ?? "Test failed",
+                    StackTrace: TruncateHead(stackEl?.Value, TestFailureStackTraceMaxChars));
             })
             .ToList();
 

--- a/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
@@ -164,6 +164,425 @@ public sealed class TestRunFailureEnvelopeTests
         Assert.AreEqual(1, result.Failed);
     }
 
+    // ---------------------------------------------------------------------------------------
+    // test-run-failures-pagination-truncation
+    //
+    // test_run serialized TestRunResultDto whole: the Failures list had no cap on COUNT and each
+    // entry's Message/StackTrace was unbounded in LENGTH — unlike StdOut/StdErr, which
+    // DotnetCommandRunner already bounds to 12000 chars, and unlike test_discover, which already
+    // pages its testProjects array. A broad/unfiltered run over a large suite therefore produced
+    // a payload that grew linearly with the failure count.
+    //
+    // Cap investigation (the row's acceptance criterion — measured, not assumed): there is NO
+    // response-size constant anywhere to guard against. `rg` over src/ finds no
+    // MaximumResponseSize/MaxResponseSize/ResponseSizeLimit/OutputSizeLimit, and a symbol sweep
+    // over the pinned ModelContextProtocol 2.1.0 assemblies finds no
+    // MaxMessageSize/MaximumMessageSize/MaxResponseSize/SizeLimit either. The MCP protocol
+    // imposes no ceiling; the real ceiling is the consuming client's context budget. The tests
+    // below therefore MEASURE the serialized payload rather than comparing it to a constant, and
+    // pin the measured bound so a regression that removes either half of the fix shows up as a
+    // size assertion failure.
+    //
+    // A large SYNTHETIC failure set is used instead of this repo's real 1000+-test suite — same
+    // signal, without spinning up a slow `dotnet test` invocation.
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public void ParseTestRun_FailureWithHugeMessageAndStackTrace_TruncatesFromTheHead()
+    {
+        var hugeMessage = "Assert.Equal() Failure: expected [A] but got [B]. " + new string('m', 5000);
+        var hugeStackTrace = "   at RoslynMcp.Tests.SomeFixture.TestMethod() line 1\n" + new string('s', 5000);
+        var trxPath = WriteTrxFixture([("RoslynMcp.Tests.SomeFixture.TestMethod", hugeMessage, hugeStackTrace)]);
+
+        try
+        {
+            var execution = FakeExecution(exitCode: 1, stdOut: "Test run complete.", stdErr: string.Empty);
+            var result = DotnetOutputParser.ParseTestRun(execution, [trxPath]);
+
+            Assert.AreEqual(1, result.Failures.Count);
+            var failure = result.Failures[0];
+
+            Assert.AreEqual(500 + TruncationMarker.Length, failure.Message.Length,
+                "A 5000+ char failure message must be head-truncated to exactly 500 chars + the marker.");
+            StringAssert.StartsWith(failure.Message, "Assert.Equal() Failure: expected [A] but got [B].",
+                "Truncation must keep the HEAD (the assertion text), not the tail.");
+            StringAssert.EndsWith(failure.Message, TruncationMarker);
+
+            Assert.IsNotNull(failure.StackTrace);
+            Assert.AreEqual(1500 + TruncationMarker.Length, failure.StackTrace!.Length,
+                "A 5000+ char stack trace must be head-truncated to exactly 1500 chars + the marker.");
+            StringAssert.StartsWith(failure.StackTrace, "   at RoslynMcp.Tests.SomeFixture.TestMethod() line 1",
+                "Truncation must keep the HEAD (the throw-site frame), not the tail.");
+            StringAssert.EndsWith(failure.StackTrace, TruncationMarker);
+        }
+        finally
+        {
+            File.Delete(trxPath);
+        }
+    }
+
+    [TestMethod]
+    public void ParseTestRun_FailureAtExactlyTheLimit_PassesThroughUnchanged()
+    {
+        // Boundary: the marker must appear only when the value is STRICTLY longer than the cap.
+        var exactMessage = new string('m', 500);
+        var exactStackTrace = new string('s', 1500);
+        var trxPath = WriteTrxFixture([("RoslynMcp.Tests.SomeFixture.AtLimit", exactMessage, exactStackTrace)]);
+
+        try
+        {
+            var execution = FakeExecution(exitCode: 1, stdOut: string.Empty, stdErr: string.Empty);
+            var result = DotnetOutputParser.ParseTestRun(execution, [trxPath]);
+
+            Assert.AreEqual(1, result.Failures.Count);
+            Assert.AreEqual(exactMessage, result.Failures[0].Message,
+                "A message exactly at the cap must pass through byte-identical, with no marker.");
+            Assert.AreEqual(exactStackTrace, result.Failures[0].StackTrace,
+                "A stack trace exactly at the cap must pass through byte-identical, with no marker.");
+        }
+        finally
+        {
+            File.Delete(trxPath);
+        }
+    }
+
+    [TestMethod]
+    public void ParseTestRun_FailureWithoutStackTrace_LeavesStackTraceNull()
+    {
+        // StackTrace is stackEl?.Value — a TRX failure with no <StackTrace> element must keep
+        // flowing through as null, not become an empty string or a marker-only value.
+        var trxPath = WriteTrxFixture(
+            [("RoslynMcp.Tests.SomeFixture.NoStack", "Assert failed.", null)]);
+
+        try
+        {
+            var execution = FakeExecution(exitCode: 1, stdOut: string.Empty, stdErr: string.Empty);
+            var result = DotnetOutputParser.ParseTestRun(execution, [trxPath]);
+
+            Assert.AreEqual(1, result.Failures.Count);
+            Assert.AreEqual("Assert failed.", result.Failures[0].Message);
+            Assert.IsNull(result.Failures[0].StackTrace);
+        }
+        finally
+        {
+            File.Delete(trxPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task RunTests_LargeUnfilteredFailureCount_PaginatesInsteadOfUnboundedPayload()
+    {
+        const int syntheticFailureCount = 400;
+        var runner = new LargeFailureSetTestRunnerService(
+            total: 1247, passed: 847, failed: syntheticFailureCount, skipped: 0, failureCount: syntheticFailureCount);
+
+        var json = await ValidationTools.RunTests(
+            new PassthroughGate(),
+            runner,
+            workspaceId: "ws-test-run-large-failure-set",
+            projectName: null,
+            filter: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.TryGetProperty("error", out _),
+            "A run that produced valid TRX output (even with many failures) must return a structured " +
+            $"result, not an error envelope. Actual: {json[..Math.Min(json.Length, 500)]}");
+
+        // Aggregate counts always reflect the FULL run, never truncated.
+        Assert.AreEqual(1247, root.GetProperty("total").GetInt32());
+        Assert.AreEqual(847, root.GetProperty("passed").GetInt32());
+        Assert.AreEqual(syntheticFailureCount, root.GetProperty("failed").GetInt32());
+        Assert.AreEqual(0, root.GetProperty("skipped").GetInt32());
+
+        // The per-failure detail array is capped at the default limit (25), with paging metadata
+        // so callers can tell more exist — same shape family as test_discover's offset/limit/hasMore.
+        Assert.AreEqual(0, root.GetProperty("failuresOffset").GetInt32());
+        Assert.AreEqual(25, root.GetProperty("failuresLimit").GetInt32());
+        Assert.AreEqual(syntheticFailureCount, root.GetProperty("failuresTotal").GetInt32());
+        Assert.IsTrue(root.GetProperty("hasMoreFailures").GetBoolean());
+        Assert.AreEqual(25, root.GetProperty("failures").GetArrayLength(),
+            "Default failuresLimit=25 must cap the returned array regardless of how many tests failed.");
+    }
+
+    [TestMethod]
+    public async Task RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling()
+    {
+        // Acceptance criterion for test-run-failures-pagination-truncation: no MCP/SDK/in-repo
+        // response-size constant exists (verified by grep over src/ and a symbol sweep over the
+        // pinned ModelContextProtocol 2.1.0 assemblies), so the guard has to be an explicitly
+        // MEASURED budget rather than a comparison against a protocol constant.
+        //
+        // This drives the true worst case at the shipped defaults: every returned failure carries
+        // a Message and StackTrace already at the DotnetOutputParser caps (500 / 1500 chars).
+        // MEASURED 2026-08-13 by this very test: 56,923 chars (~56KB) of indented JSON for the
+        // default page of 25 — roughly 14k tokens, comparable to test_discover's documented
+        // "1000 cases is roughly 350KB". The SAME 400-failure run with the count cap lifted
+        // measures 904,200 chars (~883KB), ~16x larger — the unbounded shape this row fixes.
+        const int syntheticFailureCount = 400;
+        var runner = new LargeFailureSetTestRunnerService(
+            total: 400, passed: 0, failed: syntheticFailureCount, skipped: 0,
+            failureCount: syntheticFailureCount, maxLengthDetail: true);
+
+        var json = await ValidationTools.RunTests(
+            new PassthroughGate(),
+            runner,
+            workspaceId: "ws-test-run-worst-case",
+            projectName: null,
+            filter: null,
+            progress: null,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(25, doc.RootElement.GetProperty("failures").GetArrayLength());
+
+        Assert.IsTrue(json.Length < 80_000,
+            "Worst-case paginated test_run response must stay within the measured ~56KB budget " +
+            $"(80KB assertion headroom); was {json.Length} chars. Both halves of the fix are load-bearing: " +
+            "per-entry truncation bounds each failure, pagination bounds the count.");
+
+        // Sanity-check the counterfactual: the same run WITHOUT the count cap is an order of
+        // magnitude larger, which is exactly the unbounded-payload shape this row fixes.
+        var unpaginated = await ValidationTools.RunTests(
+            new PassthroughGate(),
+            runner,
+            workspaceId: "ws-test-run-worst-case-unpaged",
+            projectName: null,
+            filter: null,
+            failuresOffset: 0,
+            failuresLimit: syntheticFailureCount,
+            progress: null,
+            ct: CancellationToken.None);
+
+        Assert.IsTrue(unpaginated.Length > 500_000,
+            "The unpaginated payload should be several hundred KB — this is the hazard the default " +
+            $"failuresLimit guards against. Was {unpaginated.Length} chars.");
+    }
+
+    [TestMethod]
+    public async Task RunTests_FailuresOffsetAndLimit_PageThroughAllFailures()
+    {
+        const int syntheticFailureCount = 30;
+        var runner = new LargeFailureSetTestRunnerService(
+            total: 30, passed: 0, failed: syntheticFailureCount, skipped: 0, failureCount: syntheticFailureCount);
+
+        var firstPage = await ValidationTools.RunTests(
+            new PassthroughGate(), runner, workspaceId: "ws-page-1", projectName: null, filter: null,
+            failuresOffset: 0, failuresLimit: 20, progress: null, ct: CancellationToken.None);
+        var secondPage = await ValidationTools.RunTests(
+            new PassthroughGate(), runner, workspaceId: "ws-page-2", projectName: null, filter: null,
+            failuresOffset: 20, failuresLimit: 20, progress: null, ct: CancellationToken.None);
+
+        using var firstDoc = JsonDocument.Parse(firstPage);
+        using var secondDoc = JsonDocument.Parse(secondPage);
+
+        Assert.AreEqual(20, firstDoc.RootElement.GetProperty("failures").GetArrayLength());
+        Assert.IsTrue(firstDoc.RootElement.GetProperty("hasMoreFailures").GetBoolean());
+
+        Assert.AreEqual(10, secondDoc.RootElement.GetProperty("failures").GetArrayLength(),
+            "The second page should return the remaining 10 failures (30 total - 20 already paged).");
+        Assert.IsFalse(secondDoc.RootElement.GetProperty("hasMoreFailures").GetBoolean(),
+            "hasMoreFailures must be false once the offset+returned count reaches the total.");
+
+        // Paging must not perturb the aggregate counts on either page.
+        Assert.AreEqual(30, firstDoc.RootElement.GetProperty("failed").GetInt32());
+        Assert.AreEqual(30, secondDoc.RootElement.GetProperty("failed").GetInt32());
+        Assert.AreEqual(30, secondDoc.RootElement.GetProperty("failuresTotal").GetInt32());
+    }
+
+    [TestMethod]
+    public async Task RunTests_FailuresOffsetPastTotal_ReturnsEmptyPageNotAnError()
+    {
+        var runner = new LargeFailureSetTestRunnerService(
+            total: 5, passed: 0, failed: 5, skipped: 0, failureCount: 5);
+
+        var json = await ValidationTools.RunTests(
+            new PassthroughGate(), runner, workspaceId: "ws-page-past-end", projectName: null, filter: null,
+            failuresOffset: 500, failuresLimit: 25, progress: null, ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.TryGetProperty("error", out _),
+            $"An offset past the end is an empty page, not an error. Actual: {json}");
+        Assert.AreEqual(0, root.GetProperty("failures").GetArrayLength());
+        Assert.AreEqual(5, root.GetProperty("failuresTotal").GetInt32());
+        Assert.IsFalse(root.GetProperty("hasMoreFailures").GetBoolean(),
+            "hasMoreFailures must be false past the end, not true.");
+    }
+
+    [TestMethod]
+    public async Task RunTests_TimeoutEnvelopePath_StillCarriesPagingFields()
+    {
+        // The FailureEnvelope path emits Failed=1 with an EMPTY Failures list. The paging fields
+        // must still be present (and coherent) so a client never has to branch on their absence.
+        var runner = new TimeoutEnvelopeTestRunnerService();
+
+        var json = await ValidationTools.RunTests(
+            new PassthroughGate(), runner, workspaceId: "ws-timeout-envelope", projectName: null, filter: null,
+            progress: null, ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual(1, root.GetProperty("failed").GetInt32());
+        Assert.AreEqual("Timeout", root.GetProperty("failureEnvelope").GetProperty("errorKind").GetString());
+        Assert.AreEqual(0, root.GetProperty("failures").GetArrayLength());
+        Assert.AreEqual(0, root.GetProperty("failuresTotal").GetInt32());
+        Assert.AreEqual(0, root.GetProperty("failuresOffset").GetInt32());
+        Assert.AreEqual(25, root.GetProperty("failuresLimit").GetInt32());
+        Assert.IsFalse(root.GetProperty("hasMoreFailures").GetBoolean());
+    }
+
+    [TestMethod]
+    [DataRow(0, 0, "failuresLimit")]
+    [DataRow(0, -1, "failuresLimit")]
+    [DataRow(-1, 25, "failuresOffset")]
+    public async Task RunTests_InvalidPagingArguments_ReturnInvalidArgumentEnvelope(
+        int failuresOffset, int failuresLimit, string expectedParameter)
+    {
+        // Mirrors DiscoverTests' guard, which also lives INSIDE the try — so the ArgumentException
+        // is classified into the tool's structured InvalidArgument envelope rather than escaping.
+        var runner = new LargeFailureSetTestRunnerService(
+            total: 1, passed: 0, failed: 1, skipped: 0, failureCount: 1);
+
+        var json = await ValidationTools.RunTests(
+            new PassthroughGate(), runner, workspaceId: "ws-bad-paging", projectName: null, filter: null,
+            failuresOffset: failuresOffset, failuresLimit: failuresLimit,
+            progress: null, ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.GetProperty("error").GetBoolean(), $"Envelope: {json}");
+        Assert.AreEqual("InvalidArgument", root.GetProperty("category").GetString());
+        Assert.AreEqual("test_run", root.GetProperty("tool").GetString());
+        StringAssert.Contains(root.GetProperty("message").GetString() ?? string.Empty, expectedParameter);
+    }
+
+    /// <summary>
+    /// Mirrors <c>DotnetOutputParser.TruncationMarker</c>. Kept as a literal here on purpose: the
+    /// marker is part of the tool's observable response contract, so the test must fail if the
+    /// production constant is changed rather than silently tracking it.
+    /// </summary>
+    private const string TruncationMarker = "... [truncated]";
+
+    private static string WriteTrxFixture(IReadOnlyList<(string TestName, string Message, string? StackTrace)> failures)
+    {
+        const string ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        var unitTestResults = string.Join("\n", failures.Select(f =>
+        {
+            var stackElement = f.StackTrace is null
+                ? string.Empty
+                : $"\n          <StackTrace>{System.Security.SecurityElement.Escape(f.StackTrace)}</StackTrace>";
+            return $"""
+                <UnitTestResult testName="{f.TestName}" outcome="Failed">
+                  <Output>
+                    <ErrorInfo>
+                      <Message>{System.Security.SecurityElement.Escape(f.Message)}</Message>{stackElement}
+                    </ErrorInfo>
+                  </Output>
+                </UnitTestResult>
+                """;
+        }));
+
+        var xml = $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <TestRun xmlns="{ns}">
+              <Results>
+            {unitTestResults}
+              </Results>
+              <ResultSummary outcome="Failed">
+                <Counters total="{failures.Count}" executed="{failures.Count}" passed="0" failed="{failures.Count}" notExecuted="0" />
+              </ResultSummary>
+            </TestRun>
+            """;
+
+        var path = Path.Combine(Path.GetTempPath(), $"roslynmcp-testrun-fixture-{Guid.NewGuid():N}.trx");
+        File.WriteAllText(path, xml);
+        return path;
+    }
+
+    /// <summary>
+    /// Returns a synthetic large failure set. With <c>maxLengthDetail</c> every failure carries a
+    /// Message/StackTrace already at the DotnetOutputParser caps (500 / 1500 chars), which is the
+    /// true worst case a paginated response can serialize.
+    /// </summary>
+    private sealed class LargeFailureSetTestRunnerService : ITestRunnerService
+    {
+        private readonly int _total;
+        private readonly int _passed;
+        private readonly int _failed;
+        private readonly int _skipped;
+        private readonly int _failureCount;
+        private readonly bool _maxLengthDetail;
+
+        public LargeFailureSetTestRunnerService(
+            int total, int passed, int failed, int skipped, int failureCount, bool maxLengthDetail = false)
+        {
+            _total = total;
+            _passed = passed;
+            _failed = failed;
+            _skipped = skipped;
+            _failureCount = failureCount;
+            _maxLengthDetail = maxLengthDetail;
+        }
+
+        public Task<TestRunResultDto> RunTestsAsync(
+            string workspaceId, string? projectName, string? filter, CancellationToken ct)
+        {
+            var failures = Enumerable.Range(0, _failureCount)
+                .Select(i => new TestFailureDto(
+                    DisplayName: $"TestMethod_Should_Do_Something_When_Given_Input_{i}",
+                    FullyQualifiedName: $"RoslynMcp.Tests.SomeNamespace.SomeFixture{i}.TestMethod_{i}",
+                    Message: _maxLengthDetail
+                        ? new string('m', 500) + TruncationMarker
+                        : $"Assert.Equal() Failure: expected [ExpectedValue{i}] but got [ActualValue{i}].",
+                    StackTrace: _maxLengthDetail
+                        ? new string('s', 1500) + TruncationMarker
+                        : string.Join("\n", Enumerable.Range(0, 10).Select(f =>
+                            $"   at RoslynMcp.Tests.SomeFixture{i}.TestMethod{f}() line {100 + f}"))))
+                .ToList();
+
+            var execution = new CommandExecutionDto(
+                Command: "dotnet",
+                Arguments: ["test"],
+                WorkingDirectory: "C:/fake",
+                TargetPath: "C:/fake/proj.sln",
+                ExitCode: 1,
+                Succeeded: false,
+                DurationMs: 120_370,
+                StdOut: string.Empty,
+                StdErr: string.Empty);
+
+            return Task.FromResult(new TestRunResultDto(
+                execution, _total, _passed, _failed, _skipped, failures));
+        }
+    }
+
+    private sealed class TimeoutEnvelopeTestRunnerService : ITestRunnerService
+    {
+        public Task<TestRunResultDto> RunTestsAsync(
+            string workspaceId, string? projectName, string? filter, CancellationToken ct)
+        {
+            var shell = new CommandExecutionDto(
+                Command: "dotnet",
+                Arguments: ["test"],
+                WorkingDirectory: "C:/fake",
+                TargetPath: "C:/fake/proj.csproj",
+                ExitCode: -1,
+                Succeeded: false,
+                DurationMs: 600_000,
+                StdOut: string.Empty,
+                StdErr: "The command 'dotnet test' exceeded the timeout of 10.0 minute(s).");
+
+            return Task.FromResult(DotnetOutputParser.BuildTimeoutResult(shell, shell.StdErr));
+        }
+    }
+
     [TestMethod]
     public async Task RunTests_ToolRunnerThrows_ReturnsStructuredEnvelopeWithSchemaHint()
     {


### PR DESCRIPTION
## Summary

`test_run` serialized `TestRunResultDto` whole: the `Failures` list had no cap on COUNT and each entry's `Message`/`StackTrace` was unbounded in LENGTH — unlike `StdOut`/`StdErr`, which `DotnetCommandRunner` already bounds to 12000 chars, and unlike `test_discover`, which already pages its `testProjects` array. A broad or unfiltered run over a large suite therefore produced a payload that grew linearly with the failure count. This adds per-failure head truncation plus `failures` pagination, mirroring the two existing in-repo precedents.

## Linked issue

No GitHub issue mirror for this backlog row.

## Cap investigation (the row's acceptance criterion — measured, not assumed)

The row required the real MCP output cap be determined before asserting a default. Result: **there is no response-size constant anywhere to guard against.**

| Probe | Result |
|---|---|
| `rg 'MaximumResponseSize\|MaxResponseSize\|ResponseSizeLimit\|OutputSizeLimit'` over `src/` + `tests/` | 0 hits |
| Symbol sweep for `MaxMessageSize\|MaximumMessageSize\|MaxResponseSize\|SizeLimit` over the pinned `ModelContextProtocol` / `ModelContextProtocol.Core` **2.1.0** assemblies | 0 hits |

The MCP protocol imposes no ceiling; the real ceiling is the consuming client's context budget. The caps are therefore sized against that budget and **pinned by a test that measures the payload** (`RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling`):

| Scenario (400 synthetic failures, every `Message`/`StackTrace` at the caps) | Serialized indented JSON |
|---|---|
| Default page — `failuresLimit=25` | **56,923 chars** (~56KB, ~14k tokens) |
| Same run with the count cap lifted — `failuresLimit=400` | **904,200 chars** (~883KB) — ~16x larger |

~56KB is comparable to `test_discover`'s own documented "1000 cases is roughly 350KB" guidance. Both halves of the fix are load-bearing: truncation bounds each entry (a single pathological failure is otherwise unbounded outright), pagination bounds the count.

## Changes

- `src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs` — new `TestFailureMessageMaxChars` (500) / `TestFailureStackTraceMaxChars` (1500) consts and a `TruncateHead` helper, applied at the `TestFailureDto` construction in `ParseSingleTrxFile`. Truncates from the HEAD (not the tail like `Tail`/StdOut/StdErr) because the assertion text and throw-site frame come first; appends `"... [truncated]"` so truncation is visible, never silent. A null `StackTrace` still passes through as null.
- `src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs` — `test_run` gains `failuresOffset` (default 0) / `failuresLimit` (default 25), threaded through **both** `RunTestsOnceAsync` call sites in `RunTestsWithEvictionRetryAsync` so a post-eviction retry is paginated too. The success path now emits an anonymous envelope that passes `execution`/`total`/`passed`/`failed`/`skipped`/`failureEnvelope` through untouched and pages only `failures`, adding `failuresOffset`/`failuresLimit`/`failuresTotal`/`hasMoreFailures` — the same shape family as `test_discover`'s `offset/limit/returnedCount/totalCount/hasMore`. Argument guards mirror `DiscoverTests` (inside the `try`, so they surface as the tool's structured `InvalidArgument` envelope). Tool `Description` updated to document both behaviors.
- `tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs` — 9 new regression tests (below).

## Breaking change

This changes `test_run`'s default JSON response shape (adds four paging fields) and may shorten previously-unbounded failure detail. `roslyn-mcp` is published, so external clients parsing full failure text beyond 500/1500 chars are affected — the `"... [truncated]"` marker makes it detectable rather than invisible, and callers can pass a higher `failuresLimit` or re-fetch with `failuresOffset`. Fragment filed under `changelog.d/` with category `Changed — BREAKING`.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds (Debug **and** Release, 0 warnings / 0 errors)
- [x] Targeted `dotnet test` slices pass — full-suite CI parity delegated to the self-hosted runner on this PR
- [x] Manually verified the behavior (the size figures above are live measurements from this branch, not estimates)

New tests:

| Test | Covers |
|---|---|
| `ParseTestRun_FailureWithHugeMessageAndStackTrace_TruncatesFromTheHead` | 5000-char message/stack → exactly 500/1500 + marker, head kept |
| `ParseTestRun_FailureAtExactlyTheLimit_PassesThroughUnchanged` | Boundary — exactly at cap is byte-identical, no marker |
| `ParseTestRun_FailureWithoutStackTrace_LeavesStackTraceNull` | Null `StackTrace` still flows through as null |
| `RunTests_LargeUnfilteredFailureCount_PaginatesInsteadOfUnboundedPayload` | 400 failures → 25 returned; `total`/`passed`/`failed`/`skipped` untruncated |
| `RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling` | The measurement above, pinned as an assertion |
| `RunTests_FailuresOffsetAndLimit_PageThroughAllFailures` | Two-page walk; aggregates stable across pages |
| `RunTests_FailuresOffsetPastTotal_ReturnsEmptyPageNotAnError` | Offset past the end → empty page, `hasMoreFailures=false`, not an exception |
| `RunTests_TimeoutEnvelopePath_StillCarriesPagingFields` | `FailureEnvelope` path still emits coherent paging fields |
| `RunTests_InvalidPagingArguments_ReturnInvalidArgumentEnvelope` (3 rows) | `failuresLimit<=0` / `failuresOffset<0` → structured `InvalidArgument` |

Verified slices: `TestRunFailureEnvelopeTests` + `WorkspaceEvictionAutoRetryTests` + `ProgressEmissionTests` (40 passed) · catalog/surface/schema conformance (134 passed) · `TestRunResultDto` consumers `ValidateWorkspaceMarkdownFormatterTests` / `WorkspaceValidationOverallStatusTests` / `ValidationIntegrationTests` (33 passed). CI gates run locally: `verify-changelog-fragments`, `verify-ai-docs`, `verify-version-drift`, `verify-skills-are-generic`, `verify-plugin-package-files` — all green.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (Debug and Release both 0 warnings)
- [x] Public API changes are intentional and documented (tool `Description` + changelog fragment)

## Backlog (maintainer-only)

Closes: test-run-failures-pagination-truncation

- Closes backlog row: `test-run-failures-pagination-truncation`
