### PR TITLE
test(elicitation): resolve in-flight cancellation harness deadlock (elicitation-inflight-cancellation-test-harness-deadlock)

### DIFF
--- a/changelog.d/elicitation-inflight-cancellation-test-harness-deadlock.md
+++ b/changelog.d/elicitation-inflight-cancellation-test-harness-deadlock.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Resolved the long-standing in-flight elicitation-cancellation test dead end — the hang was `McpClient.DisposeAsync` waiting on a deliberately never-completing test elicitation handler during harness teardown, not `server.ElicitAsync` (which cancels correctly in ~2 ms with the client unresponsive, confirming a stalled client cannot wedge the server or leak its `WorkspaceExecutionGate` slot). Added the previously-untestable genuinely-in-flight cancellation regression test, made the test harness release pending handlers before disposal, and moved `SymbolDisambiguationElicitationTests` to MSTest's cooperative `[Timeout(..., CooperativeCancellation = true)]` shape.

--- a/tests/RoslynMcp.Tests/Helpers/InMemoryMcpClientServerHarness.cs
+++ b/tests/RoslynMcp.Tests/Helpers/InMemoryMcpClientServerHarness.cs
@@ -11,6 +11,45 @@ namespace RoslynMcp.Tests.Helpers;
 /// Hosts a real MCP client/server pair over in-memory duplex pipes for integration tests that
 /// need connection-scoped client capabilities and request handlers.
 /// </summary>
+/// <remarks>
+/// <para><b>Disposal invariant — every client request handler this harness is given MUST be
+/// completable, and MUST be completed before <see cref="DisposeAsync"/> runs.</b>
+/// <see cref="DisposeOwnedResourcesAsync"/> disposes <see cref="Client"/> first (line ~155), and
+/// <c>McpClient.DisposeAsync</c> waits for outstanding inbound request handlers to finish. A
+/// handler that returns a never-completing task (e.g.
+/// <c>new TaskCompletionSource&lt;ElicitResult&gt;().Task</c>) therefore wedges teardown
+/// <i>forever</i> once the request actually reaches it — and because that hang is in
+/// <c>await using</c> teardown rather than in the test body, MSTest's non-cooperative
+/// <c>[Timeout]</c> backstop cannot recover it either; the whole test process has to be killed.</para>
+///
+/// <para><b>This was the root cause of the long-standing
+/// <c>elicitation-inflight-cancellation-test-harness-deadlock</c> dead end</b>, isolated
+/// 2026-08-13 with a standalone out-of-process repro of this exact harness. Findings, so a future
+/// attempt does not re-walk it:
+/// <list type="bullet">
+///   <item><c>server.ElicitAsync(request, token)</c> is <b>not</b> the culprit and never was. With
+///         the client permanently unresponsive, it observed cancellation and threw
+///         <c>TaskCanceledException</c> <b>~2 ms</b> after <c>Cancel()</c> in all three in-flight
+///         cancel shapes previously tried (inline from the client handler, decoupled via
+///         <c>Task.Run</c>, and from a dedicated OS thread). No <c>.AsTask().WaitAsync(token)</c>
+///         wrapper is needed — which is why adding one never helped.</item>
+///   <item>ThreadPool starvation: <b>ruled out</b>. At the hang point 32767 of 32767 worker threads
+///         and 1000 of 1000 IO threads were available (<c>ThreadPool.ThreadCount</c> 4), so
+///         <c>[DoNotParallelize]</c> and single-process hosting are irrelevant here.</item>
+///   <item><c>Pipe</c> backpressure / missing reader: <b>ruled out</b>. Both directions kept
+///         flowing (bytes written == bytes read, one pending read outstanding per reader, which is
+///         the healthy idle shape).</item>
+///   <item>The discriminator is solely <i>whether the client handler completes</i>: a handler that
+///         returns a result disposes cleanly in ~6 ms; an entered handler that never completes
+///         hangs indefinitely. A request that never reaches the handler (the pre-cancelled-token
+///         case) also disposes cleanly, because nothing is outstanding.</item>
+/// </list></para>
+///
+/// <para>Consequence: pass a <see cref="TaskCompletionSource{TResult}"/>-backed handler the test
+/// owns and complete it before disposal (see
+/// <c>SymbolDisambiguationElicitationTests.ControllableElicitationHarness</c>, which enforces the
+/// ordering in its own <c>DisposeAsync</c>) rather than a handler that can never complete.</para>
+/// </remarks>
 internal sealed class InMemoryMcpClientServerHarness(
     McpServer server,
     McpClient client,

--- a/tests/RoslynMcp.Tests/SymbolDisambiguationElicitationTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolDisambiguationElicitationTests.cs
@@ -33,10 +33,10 @@ namespace RoslynMcp.Tests;
 ///         <see cref="StructuredCallToolFilter.HasElicitation"/> capability check returns
 ///         true for a properly handshaken client AND the candidate-discovery helper finds
 ///         the multiple-overload set; the gate logic is therefore wired correctly. The
-///         end-to-end <c>ElicitAsync</c> pre-cancellation path uses a real SDK client/server pair
-///         over the shared in-memory transport harness. Genuinely in-flight cancellation remains
-///         tracked separately because the single-process duplex transport deadlocks in that
-///         scenario.</item>
+///         end-to-end <c>ElicitAsync</c> cancellation paths use a real SDK client/server pair
+///         over the shared in-memory transport harness — both pre-cancelled and genuinely
+///         in-flight (the latter previously believed untestable; see
+///         <see cref="ControllableElicitationHarness"/> for why it now is).</item>
 ///   <item><b>(b) fallback</b> — when the caller does not opt in, or the client lacks the
 ///         elicitation capability (or the user declines), the tool returns a structured
 ///         <c>{ ambiguous: true, count, candidates }</c> envelope with a stable
@@ -312,23 +312,28 @@ public sealed class SymbolDisambiguationElicitationTests : IsolatedWorkspaceTest
     // (InvalidOperationException, McpException). Callers (SymbolTools.GoToDefinition /
     // FindReferences / SearchSymbols) treat a null return as "user declined" and answer
     // with the additive candidate-list response — so a cancelled request looked
-    // indistinguishable from a deliberate decline. This test pins that a pre-cancelled
-    // token now propagates out of TryElicitChoiceAsync instead. It does NOT cover
-    // cancellation that arrives while a request is genuinely in flight against an
-    // unresponsive client — two independent attempts at that variant deadlocked the test
-    // process; see the tracked follow-up elicitation-inflight-cancellation-test-harness-deadlock.
+    // indistinguishable from a deliberate decline. Two tests pin it: a pre-cancelled token
+    // (below) and cancellation arriving while the request is genuinely in flight against an
+    // unresponsive client (further below).
+    //
+    // elicitation-inflight-cancellation-test-harness-deadlock: the in-flight variant was
+    // believed untestable — three prior attempts hung the test process and needed taskkill.
+    // The blocking point was never TryElicitChoiceAsync or server.ElicitAsync; it was the old
+    // never-completing ElicitationHandler wedging McpClient.DisposeAsync during `await using`
+    // teardown, AFTER the assertions had already passed. ControllableElicitationHarness fixes
+    // that by owning a completable handler; see its remarks and those on
+    // InMemoryMcpClientServerHarness for the full ruled-in/ruled-out evidence.
 
     [TestMethod]
-    [Timeout(15_000)]
+    [Timeout(15_000, CooperativeCancellation = true)]
     public async Task TryElicitChoiceAsync_PreCancelledToken_PropagatesCancellation_NotAdditiveListFallback()
     {
         // A real McpServer/McpClient pair over the shared in-memory duplex harness is required
         // to reach the try body at all: HasElicitation must return true, which needs a
         // genuine post-handshake ClientCapabilities.Elicitation, not a null/fake server.
-        // The client's ElicitationHandler never completes; the token below is cancelled
-        // BEFORE the call, not while the request is in flight (see the section comment
-        // above for why the in-flight variant isn't covered here).
-        await using var harness = await CreateServerWithHangingElicitationAsync(CancellationToken.None);
+        // The token below is cancelled BEFORE the call, so the request never reaches the
+        // client's handler at all; the in-flight variant is the next test.
+        await using var harness = await CreateServerWithControllableElicitationAsync(CancellationToken.None);
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -363,33 +368,133 @@ public sealed class SymbolDisambiguationElicitationTests : IsolatedWorkspaceTest
             "McpException catch and converted to the additive-list null fallback.");
     }
 
+    [TestMethod]
+    [Timeout(15_000, CooperativeCancellation = true)]
+    public async Task TryElicitChoiceAsync_CancelledWhileRequestInFlight_PropagatesCancellation()
+    {
+        // The non-vacuous variant of the test above: the elicitation/create request genuinely
+        // reaches the client (RequestReceived below only completes from inside the client's own
+        // handler), the client then never answers, and only THEN is the caller's token cancelled.
+        // This pins that a real MCP client going unresponsive mid-elicitation cannot wedge the
+        // server: the await unblocks and the caller's WorkspaceExecutionGate slot is released.
+        await using var harness = await CreateServerWithControllableElicitationAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+
+        var call = ElicitationChoicePrompt.TryElicitChoiceAsync(
+            harness.Server,
+            paramName: "choice",
+            title: "Pick a symbol",
+            description: "symbol_search returned candidates. Pick one to focus on.",
+            options: [("0", "Candidate A"), ("1", "Candidate B")],
+            cancellationToken: cts.Token);
+
+        // Cancelling only after this completes is what makes the test non-vacuous — before it,
+        // the request may still be sitting in the transport rather than truly in flight. Bounded
+        // well inside the [Timeout] above so a regression here fails fast instead of hanging.
+        await harness.RequestReceived.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.IsFalse(call.IsCompleted,
+            "The client's elicitation handler is deliberately unanswered, so TryElicitChoiceAsync " +
+            "must still be pending at the moment cancellation is requested — otherwise this test " +
+            "would be vacuously asserting the pre-cancelled path again.");
+
+        await cts.CancelAsync();
+
+        OperationCanceledException? caught = null;
+        try
+        {
+            var result = await call;
+            Assert.Fail(
+                "Expected TryElicitChoiceAsync to throw when its token was cancelled with the " +
+                $"request in flight, but it returned {(result is null ? "null" : $"\"{result}\"")} " +
+                "instead — an unresponsive client plus a cancelled caller must never be reported " +
+                "as a user decline.");
+        }
+        catch (OperationCanceledException ex)
+        {
+            // The SDK surfaces TaskCanceledException here, so catch the base class manually
+            // (ThrowsExactlyAsync<OperationCanceledException> would reject the subclass).
+            caught = ex;
+        }
+
+        Assert.IsNotNull(caught,
+            "Cancelling while an elicitation/create request is genuinely in flight must surface " +
+            "as OperationCanceledException out of TryElicitChoiceAsync, so the caller unwinds and " +
+            "releases its WorkspaceExecutionGate slot instead of hanging until process restart.");
+    }
+
     /// <summary>
     /// Wires a real <see cref="McpServer"/> to a real <see cref="McpClient"/> over an in-memory
-    /// duplex pipe supplied by <see cref="InMemoryMcpClientServerHarness"/>
-    /// so <c>server.ClientCapabilities.Elicitation</c> is genuinely populated via the MCP
-    /// initialize handshake and <c>server.ElicitAsync</c> genuinely round-trips to a client. The
-    /// client's <see cref="McpClientHandlers.ElicitationHandler"/> never completes, so any
-    /// <c>elicitation/create</c> request stays pending indefinitely — letting a test pre-cancel
-    /// the caller's own token before the call in isolation from whether the client ever
-    /// actually answers. Cancelling AFTER the request is dispatched (a genuinely in-flight
-    /// race) is NOT safe to test against this harness: it deadlocks — see
-    /// elicitation-inflight-cancellation-test-harness-deadlock.
+    /// duplex pipe supplied by <see cref="InMemoryMcpClientServerHarness"/> so
+    /// <c>server.ClientCapabilities.Elicitation</c> is genuinely populated via the MCP initialize
+    /// handshake and <c>server.ElicitAsync</c> genuinely round-trips to a client that never
+    /// volunteers an answer.
     /// </summary>
-    private static async Task<InMemoryMcpClientServerHarness> CreateServerWithHangingElicitationAsync(
+    private static async Task<ControllableElicitationHarness> CreateServerWithControllableElicitationAsync(
         CancellationToken ct)
     {
-        return await InMemoryMcpClientServerHarness.CreateAsync(
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pendingElicitation =
+            new TaskCompletionSource<ElicitResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var harness = await InMemoryMcpClientServerHarness.CreateAsync(
             transportName: "test-server-elicitation-cancellation",
             clientCapabilities: new ClientCapabilities { Elicitation = new ElicitationCapability() },
             clientHandlers: new McpClientHandlers
             {
-                // Never completes — the server must observe its own token's cancellation
-                // rather than waiting forever for a reply that never comes.
+                // Answers only when the test says so, so the server must observe its own token's
+                // cancellation rather than waiting for a reply. Deliberately NOT a task that can
+                // never complete — see ControllableElicitationHarness.DisposeAsync.
                 ElicitationHandler = (_, _) =>
-                    new ValueTask<ElicitResult>(new TaskCompletionSource<ElicitResult>().Task),
+                {
+                    requestReceived.TrySetResult();
+                    return new ValueTask<ElicitResult>(pendingElicitation.Task);
+                },
             },
             disposalFailureContext: "elicitation-cancellation",
             ct).ConfigureAwait(false);
+
+        return new ControllableElicitationHarness(harness, requestReceived.Task, pendingElicitation);
+    }
+
+    /// <summary>
+    /// Owns an <see cref="InMemoryMcpClientServerHarness"/> whose client answers
+    /// <c>elicitation/create</c> only when the test releases it, and — critically — releases any
+    /// still-pending answer <b>before</b> disposing the harness.
+    /// </summary>
+    /// <remarks>
+    /// That ordering is the whole point of this type
+    /// (elicitation-inflight-cancellation-test-harness-deadlock). <c>McpClient.DisposeAsync</c>
+    /// waits for outstanding inbound request handlers, so leaving the handler unanswered wedges
+    /// teardown forever — in <c>await using</c>, i.e. after the test body has already passed,
+    /// where a non-cooperative <c>[Timeout]</c> cannot rescue it and the process must be killed.
+    /// Three earlier attempts at an in-flight-cancellation test hit exactly this and were
+    /// misattributed to the awaited <c>server.ElicitAsync</c> call, to ThreadPool starvation, or
+    /// to duplex-<c>Pipe</c> backpressure; a standalone out-of-process repro ruled all three out
+    /// (details in the <see cref="InMemoryMcpClientServerHarness"/> remarks). Encoding the release
+    /// in disposal — rather than relying on each test to remember a <c>finally</c> — is what keeps
+    /// the dead end from being re-discovered.
+    /// </remarks>
+    private sealed class ControllableElicitationHarness(
+        InMemoryMcpClientServerHarness harness,
+        Task requestReceived,
+        TaskCompletionSource<ElicitResult> pendingElicitation) : IAsyncDisposable
+    {
+        /// <summary>The live server, for tests that call server-side elicitation directly.</summary>
+        public McpServer Server => harness.Server;
+
+        /// <summary>
+        /// Completes from inside the client's elicitation handler, proving the
+        /// <c>elicitation/create</c> request genuinely arrived rather than still being in transit.
+        /// </summary>
+        public Task RequestReceived => requestReceived;
+
+        public async ValueTask DisposeAsync()
+        {
+            // Must precede harness disposal — see the remarks above.
+            pendingElicitation.TrySetResult(new ElicitResult { Action = "decline" });
+            await harness.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     // ── (b) fallback when client lacks elicitation capability ───────────────


### PR DESCRIPTION
## Summary

Root-causes the long-standing dead end behind the in-flight elicitation-cancellation regression test and lands the test that three prior attempts could not write. The hang was never in the code under test: it was `McpClient.DisposeAsync` waiting on the harness's deliberately never-completing `ElicitationHandler` during `await using` teardown.

Closes: elicitation-inflight-cancellation-test-harness-deadlock

## Linked issue

No GitHub issue mirrors this backlog row — see the Backlog section below.

## Changes

Diagnosis was done with a standalone out-of-process repro of `InMemoryMcpClientServerHarness`'s duplex-pipe client/server pair, deliberately kept outside `dotnet test`/CI (the underlying hang previously needed `taskkill`, and this repo's CI runs on a single self-hosted runner a wedged test process would block). Nothing from that repro is committed.

Findings, matrix over the harness arms:

| arm | handler entered | handler completes | `server.ElicitAsync` | teardown |
|---|---|---|---|---|
| pre-cancelled token (shipped test) | no | n/a | `OperationCanceledException`, 3 ms | clean, 1 ms |
| handler answers | yes | yes | returns accept | clean, 6 ms |
| cancel inline from handler (attempt #1) | yes | never | `TaskCanceledException`, 2 ms | **hangs in `client.DisposeAsync`** |
| cancel via `Task.Run` (attempt #2) | yes | never | `TaskCanceledException`, 2 ms | **hangs in `client.DisposeAsync`** |
| cancel from dedicated OS thread | yes | never | `TaskCanceledException`, 2 ms | **hangs in `client.DisposeAsync`** |

- `server.ElicitAsync` observes its token and unblocks in ~2 ms with the client permanently unresponsive, in every in-flight cancel shape. No `.AsTask().WaitAsync(token)` wrapper is needed — which is why attempt #3 adding one never helped.
- ThreadPool starvation: **ruled out** — 32767/32767 workers and 1000/1000 IO threads available at the hang point (`ThreadPool.ThreadCount` 4), so `[DoNotParallelize]` and single-process hosting are irrelevant.
- Duplex-`Pipe` backpressure: **ruled out** — both directions kept flowing, bytes written == bytes read, one pending read per reader (the healthy idle shape).
- The sole discriminator is whether the client handler completes. Because the hang lands in teardown *after* the assertions pass, a non-cooperative `[Timeout]` cannot recover it.

Code:

- `tests/RoslynMcp.Tests/SymbolDisambiguationElicitationTests.cs` — new `ControllableElicitationHarness` owning a completable elicitation handler that releases any pending answer **before** disposing the harness, encoding the ordering invariant rather than relying on a per-test `finally`; new `TryElicitChoiceAsync_CancelledWhileRequestInFlight_PropagatesCancellation` regression test; both cancellation tests moved to `[Timeout(15_000, CooperativeCancellation = true)]` (MSTEST0045); stale "in-flight is untestable" comments replaced at both sites.
- `tests/RoslynMcp.Tests/Helpers/InMemoryMcpClientServerHarness.cs` — class remarks documenting the disposal invariant and the full ruled-in/ruled-out evidence, so the dead end is not re-discovered.

Test-only change: **zero production files touched**, no new test files, no shims.

The new test also answers the row's open production-risk question in the safe direction: a real MCP client going unresponsive mid-elicitation cannot wedge the server — the await unwinds and the caller's `WorkspaceExecutionGate` slot is released. Caveat recorded for the reviewer: this is proven over the in-process transport; a genuine cross-process client repro remains a separate, larger effort.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` succeeds (0 warnings)
- [x] `dotnet test --filter FullyQualifiedName~SymbolDisambiguationElicitationTests` — 12/12 pass in 3 s (previously this class could not host an in-flight test at all)
- [x] `dotnet test --filter FullyQualifiedName~InMemoryMcpClientServerHarness` — 1/1 pass
- [x] `./eng/verify-ai-docs.ps1` passes
- [x] `./eng/verify-changelog-fragments.ps1` — 27 fragments valid
- [x] Fix shape verified reproducibly out-of-process (3/3 runs clean teardown after in-flight cancel)

Full `./eng/verify-release.ps1` deferred to CI, per this repo's standing rule against duplicating the single self-hosted runner locally.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — n/a, test-only

## Backlog (maintainer-only)

- Closes backlog row: `elicitation-inflight-cancellation-test-harness-deadlock`
