### PR TITLE
fix(skills): prefix-agnostic connectivity gate for analyze, architecture-review, complexity, di-audit

### DIFF
--- a/changelog.d/shipped-skills-prefix-gate-batch-2.md
+++ b/changelog.d/shipped-skills-prefix-gate-batch-2.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the shipped `analyze`, `architecture-review`, `complexity`, and `di-audit` skills no longer hard-stop on a marketplace-plugin install. Their connectivity precheck now resolves the Roslyn MCP server by calling each tool whose name ends in `server_info` and identifying the Roslyn one by response shape, then pins that prefix for every later call — so the gate works under both the dev-build (`mcp__roslyn__*`) and plugin (`mcp__plugin_roslyn-mcp_roslyn__*`) registration paths. Part of an ongoing sweep; 13 shipped skill files remain.

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -20,14 +20,18 @@ When the tool list or workflows are unclear, call **`server_info`**, read the **
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/skills/architecture-review/SKILL.md
+++ b/skills/architecture-review/SKILL.md
@@ -22,14 +22,18 @@ When the tool list or workflows are unclear, call **`server_info`**, read the **
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 
@@ -165,4 +169,4 @@ If `classificationApplied == "csharp"` AND `semanticCalls == 0`:
 > - **Step 5** (`get_di_registrations`, `type_hierarchy`) — DI composition-root audit
 > - **Step 6** (`find_reflection_usages`) — reflection escape points
 >
-> Consider re-running with `mcp__roslyn__workspace_load` to enable semantic analysis for all steps.
+> Consider re-running with `workspace_load` (called under the prefix pinned in *Connectivity precheck*) to enable semantic analysis for all steps.

--- a/skills/complexity/SKILL.md
+++ b/skills/complexity/SKILL.md
@@ -20,14 +20,18 @@ Use **`discover_capabilities`** (`analysis` / `all`) or MCP prompt **`review_com
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/skills/di-audit/SKILL.md
+++ b/skills/di-audit/SKILL.md
@@ -25,14 +25,18 @@ When the tool list or workflows are unclear, call **`server_info`**, read the **
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Four shipped skills (`analyze`, `architecture-review`, `complexity`, `di-audit`) carried a Connectivity precheck that hard-coded the `mcp__roslyn__*` tool prefix. That prefix is **client-assigned from the registration path**, not server-controlled: a dev-build entry surfaces `mcp__roslyn__server_info` while the marketplace-plugin install surfaces `mcp__plugin_roslyn-mcp_roslyn__server_info`. For a marketplace consumer none of the hard-coded literals exist, so the gate hard-stopped a legitimate install.

Each file's 10-line precheck block is replaced with the **resolve-once-then-pin** block already shipped in PR #1204 (`skills/mcp-server-surface-test/SKILL.md`), condensed. Batch 2 of an ongoing sweep.

## Linked issue

No GitHub issue mirror — the backlog row for this work carries no `[gh #NNN]` reference.

Closes: (none — partial batch, row stays OPEN)

## Changes

- `skills/analyze/SKILL.md`, `skills/architecture-review/SKILL.md`, `skills/complexity/SKILL.md`, `skills/di-audit/SKILL.md` — replaced the hard-coded `## Connectivity precheck` block with a prefix-agnostic one that:
  1. **scans** the tool surface for *every* tool whose name ends in `server_info` (expecting multiple candidates — it is a common MCP name);
  2. **identifies** the Roslyn one by **response shape** (`connection.state` + `catalogVersion` + `surface.*`), never by prefix — a non-Roslyn-shaped response is "not this server", not a halt;
  3. **pins** that prefix and resolves every later bare tool name in the skill under that one pinned prefix only.

  The pin is load-bearing and deliberately **not** open-ended suffix matching: the `python-refactor` (Jedi) MCP server also exposes `find_references` and `get_symbol_outline`, so per-call suffix resolution would silently attribute another server's results to Roslyn.

  Bail happens only when **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` other than `ready`. Both `mcp__roslyn__…` and `mcp__plugin_roslyn-mcp_roslyn__…` remain in the text as **examples, not an allowed list**.

- `skills/architecture-review/SKILL.md` also had a 4th bare-literal occurrence outside the precheck block (the semantic-calls warning advising `mcp__roslyn__workspace_load`); genericized to `workspace_load` under the pinned prefix. Same file, no scope expansion.

- `changelog.d/shipped-skills-prefix-gate-batch-2.md` — new `Fixed` fragment.

The replacement block was authored once and pasted byte-identically into all four files (SHA-256 prefix `58467e696c69f3a5` in each) so the eventual byte-identity guard has a single canonical variant to lock onto.

## Test plan

- [x] `pwsh -File eng/verify-skills-are-generic.ps1` — PASS, 32 SKILL.md checked (unchanged count; the glob is untouched in this piece).
- [x] `pwsh -File eng/verify-ai-docs.ps1` — PASS, no link regressions.
- [x] `pwsh -File eng/verify-changelog-fragments.ps1` — PASS, 27 fragments valid.
- [x] `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj --filter FullyQualifiedName~SkillFrontmatterInstalledAsTests` — 1 passed. No YAML frontmatter line is touched by the diff (verified by grepping the diff for frontmatter keys — zero hits).
- [x] Post-edit grep of all four files for `mcp__`: every remaining hit sits inside explanatory "examples, not an allowed list" prose or the user-facing bail message — none is a standalone call instruction.
- [x] Byte-identity of the condensed block hash-verified across all four files before commit.

`eng/verify-release.ps1 -Configuration Release` was intentionally not duplicated locally: this diff is Markdown-only under `skills/` + one changelog fragment, and CI runs the full release verification on the self-hosted runner for this PR.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (no compiled sources touched)
- [x] Public API changes are intentional and documented (no API change; shipped-skill docs only)

## Backlog (maintainer-only)

- Related backlog row: `shipped-skills-hardcode-bare-roslyn-tool-prefix` — **stays OPEN**. This is batch 2 of the sweep; 4 of the 17 gate-carrying `skills/**/SKILL.md` files are fixed here. 13 remain: `exception-audit`, `format-sweep`, `generate-tests`, `impact-assessment`, `inheritance-explorer`, `modernize`, `nuget-preflight`, `review`, `semantic-find`, `test-coverage`, `trace-flow`, `version-bump`, `workspace-health`.
- Not touched by design (owned by sibling initiatives): `eng/verify-skills-are-generic.ps1`, `skills/refactor*/SKILL.md`, `skills/mcp-server-surface-test/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
