### PR TITLE
fix(roslyn): re-evaluate compilation-cache liveness per project fetch

### DIFF
--- a/changelog.d/group-c-compilation-cache-gate-hardening.md
+++ b/changelog.d/group-c-compilation-cache-gate-hardening.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** hardened the opt-in `ICompilationCache` liveness gate (`SymbolResolver.CanUseCompilationCache`) so it is re-evaluated on every per-project compilation fetch instead of once before the loop, and now validates that the supplied solution belongs to the workspace identified by `workspaceId` — not just its own `Workspace` back-reference — closing a cache-poisoning race a mid-scan workspace reload could otherwise trigger. `ICompilationCache` gains `IsLiveSolution`; a `compilationCache` supplied without `workspaceId` now fails loudly with `ArgumentException` instead of silently disabling caching.

--- a/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/ICompilationCache.cs
@@ -60,6 +60,40 @@ public interface ICompilationCache
     Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct);
 
     /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="solution"/> is reference-equal to the
+    /// solution <see cref="IWorkspaceManager.GetCurrentSolution"/> currently reports for
+    /// <paramref name="workspaceId"/> — i.e. it is safe to serve that solution's per-project
+    /// compilations from this <c>(workspaceId, projectId, version)</c>-keyed cache.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the liveness gate the read-side helpers
+    /// (<c>SymbolResolver.CanUseCompilationCache</c>) delegate to. Two distinct failure modes are
+    /// both rejected by it: a FORKED solution (e.g. <c>solution.WithDocumentText(...)</c>, or a
+    /// never-applied preview solution) whose document text differs from the live workspace content,
+    /// and a solution belonging to a DIFFERENT workspace than <paramref name="workspaceId"/> names
+    /// — the latter cannot be detected from the solution's own <see cref="Solution.Workspace"/>
+    /// back-reference alone, which is why the check lives here (where the
+    /// <see cref="IWorkspaceManager"/> is available) rather than in the static helper.
+    /// </para>
+    /// <para>
+    /// Implementations must not throw for a workspace that is mid-reload or whose snapshot was
+    /// disposed by a concurrent reload; they return <see langword="false"/> so the caller degrades
+    /// to a raw <c>project.GetCompilationAsync</c> fetch instead of failing a read-side query. An
+    /// unknown <paramref name="workspaceId"/> is a caller bug and still surfaces as an exception,
+    /// matching <see cref="GetCompilationAsync"/>'s own behavior.
+    /// </para>
+    /// <para>
+    /// Callers must re-evaluate this per compilation fetch, not once before a project loop: a
+    /// workspace reload landing mid-scan bumps the version, and a stale-solution fetch made after
+    /// the bump would compute-and-store a pre-bump compilation under the post-bump cache key.
+    /// </para>
+    /// </remarks>
+    /// <param name="workspaceId">The workspace session identifier the solution is claimed to belong to.</param>
+    /// <param name="solution">The solution the caller intends to read compilations from.</param>
+    bool IsLiveSolution(string workspaceId, Solution solution);
+
+    /// <summary>
     /// Drops every cached compilation for a workspace. Called by
     /// <see cref="IWorkspaceManager"/> when the workspace is closed.
     /// </summary>

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolHandleSerializer.cs
@@ -197,7 +197,14 @@ public static class SymbolHandleSerializer
     /// forked solution takes the raw fetch — see
     /// <see cref="SymbolResolver.CanUseCompilationCache"/>.
     /// </param>
-    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
+    /// <param name="workspaceId">
+    /// The workspace session identifier, required to key the cache. Mandatory whenever
+    /// <paramref name="compilationCache"/> is supplied — the half-configured combination throws
+    /// <see cref="System.ArgumentException"/> instead of silently taking the uncached path.
+    /// </param>
+    /// <exception cref="System.ArgumentException">
+    /// Thrown when <paramref name="compilationCache"/> is supplied without a <paramref name="workspaceId"/>.
+    /// </exception>
     public static async Task<IReadOnlyList<ISymbol>> FindAllByMetadataNameAsync(
         Solution solution,
         string metadataName,
@@ -206,18 +213,17 @@ public static class SymbolHandleSerializer
         string? workspaceId = null)
     {
         ArgumentNullException.ThrowIfNull(solution);
+        SymbolResolver.ValidateCacheParameters(compilationCache, workspaceId);
         if (string.IsNullOrWhiteSpace(metadataName)) return Array.Empty<ISymbol>();
 
         var matches = new List<ISymbol>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        var useCache = SymbolResolver.CanUseCompilationCache(solution, compilationCache, workspaceId);
 
         foreach (var project in solution.Projects)
         {
             ct.ThrowIfCancellationRequested();
-            var compilation = useCache
-                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
-                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await SymbolResolver.GetProjectCompilationAsync(
+                solution, project, compilationCache, workspaceId, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             // Type-by-full-name fast path — collect, do not return early.

--- a/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SymbolResolver.cs
@@ -42,10 +42,21 @@ public static class SymbolResolver
     /// per-project fetch.
     /// </para>
     /// <para>
-    /// This is semantically <c>solution == IWorkspaceManager.GetCurrentSolution(workspaceId)</c> without
-    /// threading a workspace-manager reference into a static helper — <see cref="Solution.Workspace"/>
-    /// points at the same live <see cref="Workspace"/> instance that
-    /// <c>WorkspaceManager.GetCurrentSolution</c> reads.
+    /// group-c-compilation-cache-gate-hardening: the check is exactly
+    /// <c>solution == IWorkspaceManager.GetCurrentSolution(workspaceId)</c>, delegated to
+    /// <see cref="ICompilationCache.IsLiveSolution"/> (which holds the workspace-manager reference a
+    /// static helper cannot). The former self-referential form
+    /// <c>ReferenceEquals(solution, solution.Workspace.CurrentSolution)</c> proved liveness only
+    /// w.r.t. the solution's OWN <see cref="Solution.Workspace"/> back-reference; a LIVE solution
+    /// belonging to workspace B passed together with <c>workspaceId: "A"</c> satisfied it and would
+    /// have polluted A's cache slot. Keying on the caller-supplied id closes that identity gap.
+    /// </para>
+    /// <para>
+    /// This must be re-evaluated on EVERY per-project compilation fetch, never hoisted above the
+    /// project loop: <see cref="ICompilationCache"/> re-reads the workspace version on each call, so
+    /// a reload landing mid-scan would otherwise let a pre-bump <see cref="Project"/> be compiled and
+    /// STORED under the post-bump cache key, poisoning it for every later reader.
+    /// <see cref="GetProjectCompilationAsync"/> is the single fetch-dispatch site that guarantees it.
     /// </para>
     /// </remarks>
     internal static bool CanUseCompilationCache(Solution solution, ICompilationCache? cache, string? workspaceId)
@@ -55,17 +66,49 @@ public static class SymbolResolver
             return false;
         }
 
-        try
+        return cache.IsLiveSolution(workspaceId, solution);
+    }
+
+    /// <summary>
+    /// group-c-compilation-cache-gate-hardening: rejects the half-configured opt-in — a
+    /// <paramref name="compilationCache"/> supplied without a <paramref name="workspaceId"/> to key
+    /// it by. Previously this silently disabled caching, so a caller that meant to opt in got the
+    /// uncached path with no signal. Called once per public helper BEFORE its project loop, so a
+    /// solution with zero projects still fails loudly.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="compilationCache"/> is non-<see langword="null"/> and
+    /// <paramref name="workspaceId"/> is <see langword="null"/> or empty.
+    /// </exception>
+    internal static void ValidateCacheParameters(ICompilationCache? compilationCache, string? workspaceId)
+    {
+        // The reverse combination (workspaceId without a cache) stays a silent no-cache by design:
+        // every caller that threads a workspaceId through for other reasons must keep working.
+        if (compilationCache is not null && string.IsNullOrEmpty(workspaceId))
         {
-            return ReferenceEquals(solution, solution.Workspace.CurrentSolution);
+            throw new ArgumentException(
+                "workspaceId is required when compilationCache is supplied — the compilation cache keys on it.",
+                nameof(workspaceId));
         }
-        catch (ObjectDisposedException)
-        {
-            // Mirrors WorkspaceManager.GetCurrentSolution's own reload-transition defense: a solution
-            // captured across a reload can observe the disposed prior workspace. Degrade to the raw
-            // per-project fetch rather than throwing out of a read-side helper.
-            return false;
-        }
+    }
+
+    /// <summary>
+    /// group-c-compilation-cache-gate-hardening: the single per-project compilation fetch-dispatch
+    /// site shared by <see cref="ResolveByMetadataNameAsync"/>, <see cref="FindClosestMatchesAsync"/>,
+    /// and <see cref="SymbolHandleSerializer.FindAllByMetadataNameAsync"/>. Evaluates
+    /// <see cref="CanUseCompilationCache"/> FRESH on every call — the gate must never be hoisted
+    /// above the caller's project loop.
+    /// </summary>
+    internal static async Task<Compilation?> GetProjectCompilationAsync(
+        Solution solution,
+        Project project,
+        ICompilationCache? compilationCache,
+        string? workspaceId,
+        CancellationToken ct)
+    {
+        return CanUseCompilationCache(solution, compilationCache, workspaceId)
+            ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
+            : await project.GetCompilationAsync(ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -157,7 +200,14 @@ public static class SymbolResolver
     /// warm compilations. Omitted (the default) or a forked solution takes the raw fetch — see
     /// <see cref="CanUseCompilationCache"/>.
     /// </param>
-    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
+    /// <param name="workspaceId">
+    /// The workspace session identifier, required to key the cache. Mandatory whenever
+    /// <paramref name="compilationCache"/> is supplied — the half-configured combination throws
+    /// <see cref="System.ArgumentException"/> instead of silently taking the uncached path.
+    /// </param>
+    /// <exception cref="System.ArgumentException">
+    /// Thrown when <paramref name="compilationCache"/> is supplied without a <paramref name="workspaceId"/>.
+    /// </exception>
     public static async Task<IReadOnlyList<SymbolClosestMatchDto>> FindClosestMatchesAsync(
         Solution solution,
         string query,
@@ -166,21 +216,21 @@ public static class SymbolResolver
         ICompilationCache? compilationCache = null,
         string? workspaceId = null)
     {
+        ValidateCacheParameters(compilationCache, workspaceId);
+
         if (string.IsNullOrWhiteSpace(query) || maxResults <= 0)
             return Array.Empty<SymbolClosestMatchDto>();
 
         var normalizedQuery = NormalizeForDistance(query);
         var matches = new List<(int Score, string MetadataName, string Kind, string? LocationHint)>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        var useCache = CanUseCompilationCache(solution, compilationCache, workspaceId);
 
         foreach (var project in solution.Projects)
         {
             if (ct.IsCancellationRequested) break;
 
-            var compilation = useCache
-                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
-                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await GetProjectCompilationAsync(
+                solution, project, compilationCache, workspaceId, ct).ConfigureAwait(false);
             if (compilation is null) continue;
 
             foreach (var symbol in EnumerateNamedTypesAndMembers(compilation.GlobalNamespace))
@@ -341,7 +391,14 @@ public static class SymbolResolver
     /// solution, the per-project compilation fetch is routed through it. Omitted (the default) or a
     /// forked solution takes the raw fetch — see <see cref="CanUseCompilationCache"/>.
     /// </param>
-    /// <param name="workspaceId">The workspace session identifier, required to key the cache.</param>
+    /// <param name="workspaceId">
+    /// The workspace session identifier, required to key the cache. Mandatory whenever
+    /// <paramref name="compilationCache"/> is supplied — the half-configured combination throws
+    /// <see cref="System.ArgumentException"/> instead of silently taking the uncached path.
+    /// </param>
+    /// <exception cref="System.ArgumentException">
+    /// Thrown when <paramref name="compilationCache"/> is supplied without a <paramref name="workspaceId"/>.
+    /// </exception>
     /// <returns>The first matching symbol, or <see langword="null"/> if not found.</returns>
     public static async Task<ISymbol?> ResolveByMetadataNameAsync(
         Solution solution,
@@ -350,13 +407,12 @@ public static class SymbolResolver
         ICompilationCache? compilationCache = null,
         string? workspaceId = null)
     {
-        var useCache = CanUseCompilationCache(solution, compilationCache, workspaceId);
+        ValidateCacheParameters(compilationCache, workspaceId);
 
         foreach (var project in solution.Projects)
         {
-            var compilation = useCache
-                ? await compilationCache!.GetCompilationAsync(workspaceId!, project, ct).ConfigureAwait(false)
-                : await project.GetCompilationAsync(ct).ConfigureAwait(false);
+            var compilation = await GetProjectCompilationAsync(
+                solution, project, compilationCache, workspaceId, ct).ConfigureAwait(false);
             if (compilation is null)
             {
                 continue;

--- a/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompilationCache.cs
@@ -150,6 +150,33 @@ public sealed class CompilationCache : ICompilationCache, IDisposable
     }
 
     /// <summary>
+    /// group-c-compilation-cache-gate-hardening: authoritative liveness check for the read-side
+    /// opt-in gate. Reference-equality against <see cref="IWorkspaceManager.GetCurrentSolution"/>
+    /// for the CALLER-SUPPLIED <paramref name="workspaceId"/> — not against the solution's own
+    /// <see cref="Solution.Workspace"/> back-reference, which cannot distinguish a live solution
+    /// belonging to a different workspace from one belonging to this cache slot's workspace.
+    /// </summary>
+    public bool IsLiveSolution(string workspaceId, Solution solution)
+    {
+        if (solution is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return ReferenceEquals(solution, _workspaceManager.GetCurrentSolution(workspaceId));
+        }
+        catch (StaleWorkspaceTransitionException)
+        {
+            // The workspace is mid-reload (or its last reload failed) and has no valid snapshot to
+            // compare against. Degrade to the raw per-project fetch rather than throwing out of a
+            // read-side helper — mirrors the ObjectDisposedException defense this check replaced.
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Applies the calling caller's <see cref="CancellationToken"/> to a shared cached task
     /// without canceling that task for anyone else. An already-canceled token short-circuits so
     /// the caller sees <see cref="OperationCanceledException"/> deterministically, matching the

--- a/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
+++ b/tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs
@@ -857,6 +857,128 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
     }
 
     /// <summary>
+    /// group-c-compilation-cache-gate-hardening, bullet 1 — the mid-scan reload race. The liveness
+    /// gate used to be computed ONCE before the project loop, but
+    /// <see cref="CompilationCache.GetCompilationAsync"/> re-reads the workspace version on EVERY
+    /// call. A reload landing between two loop iterations therefore made the cache compute a
+    /// compilation from a PRE-bump <see cref="Project"/> and store it under the POST-bump key,
+    /// poisoning that slot for every later reader until the next bump.
+    /// <para>
+    /// The decorator here reloads the workspace as a side effect of its first fetch. With the gate
+    /// re-evaluated per iteration, iteration 2 observes that the captured solution is no longer the
+    /// workspace's current solution and falls back to <c>project.GetCompilationAsync</c> — so the
+    /// cache is entered exactly ONCE even though the sample solution has three projects. Pre-fix,
+    /// the hoisted <c>useCache</c> bool stayed <see langword="true"/> and the count would equal the
+    /// project count.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolResolver_MidScanWorkspaceReload_StopsRoutingThroughCache()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        using var inner = new CompilationCache(WorkspaceManager);
+        var cache = new ReloadOnFirstFetchCompilationCache(
+            inner, () => workspace.ReloadAsync(CancellationToken.None));
+
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+        var projectCount = solution.Projects.Count();
+        Assert.IsTrue(projectCount >= 2,
+            $"The mid-scan race needs at least two project iterations to be observable (saw {projectCount}).");
+
+        // FindClosestMatchesAsync has no early exit — it scans every project — so the loop is
+        // guaranteed to reach iteration 2 after the decorator's reload lands.
+        _ = await SymbolResolver.FindClosestMatchesAsync(
+            solution, "SampleLib.Dogg", maxResults: 5, CancellationToken.None, cache, workspace.WorkspaceId);
+
+        Assert.AreEqual(1, cache.GetCompilationCallCount,
+            "The liveness gate must be re-evaluated on every per-project fetch. After the mid-scan " +
+            "reload bumped the workspace version, the captured solution is stale and every remaining " +
+            $"project must take the raw fetch — expected exactly 1 cache call, saw {cache.GetCompilationCallCount} " +
+            $"across {projectCount} projects.");
+    }
+
+    /// <summary>
+    /// group-c-compilation-cache-gate-hardening, bullet 2 — a <c>compilationCache</c> supplied
+    /// without the <c>workspaceId</c> that keys it is a caller bug and must fail loudly instead of
+    /// silently degrading to the uncached path. The reverse combination (a <c>workspaceId</c> with
+    /// no cache) stays a silent no-cache by design and is asserted here too.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolResolver_CacheWithoutWorkspaceId_ThrowsArgumentException()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        using var inner = new CompilationCache(WorkspaceManager);
+        var cache = new RecordingCompilationCache(inner);
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => SymbolResolver.ResolveByMetadataNameAsync(
+                solution, "SampleLib.Dog", CancellationToken.None, cache, workspaceId: null));
+        Assert.AreEqual("workspaceId", ex.ParamName,
+            "The ArgumentException must name the missing parameter so the caller can fix the opt-in.");
+
+        var closestEx = await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => SymbolResolver.FindClosestMatchesAsync(
+                solution, "SampleLib.Dogg", maxResults: 5, CancellationToken.None, cache, workspaceId: string.Empty));
+        Assert.AreEqual("workspaceId", closestEx.ParamName);
+
+        var allEx = await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => SymbolHandleSerializer.FindAllByMetadataNameAsync(
+                solution, "SampleLib.Dog", CancellationToken.None, cache, workspaceId: null));
+        Assert.AreEqual("workspaceId", allEx.ParamName);
+
+        Assert.AreEqual(0, cache.GetCompilationCallCount,
+            "Validation must reject the half-configured opt-in before any compilation is fetched.");
+
+        // Reverse arm: a workspaceId without a cache is NOT an error — it stays a silent no-cache.
+        var resolved = await SymbolResolver.ResolveByMetadataNameAsync(
+            solution, "SampleLib.Dog", CancellationToken.None, compilationCache: null, workspaceId: workspace.WorkspaceId);
+        Assert.IsNotNull(resolved,
+            "A workspaceId supplied without a cache must keep working on the raw per-project fetch.");
+    }
+
+    /// <summary>
+    /// group-c-compilation-cache-gate-hardening, bullet 3 — the workspace-identity gap. The old gate
+    /// asked only whether the solution equaled its OWN <c>Workspace.CurrentSolution</c>, which a LIVE
+    /// solution from a DIFFERENT workspace also satisfies; it would then have been served from — and
+    /// stored into — the cache slot keyed by the caller-supplied (wrong) workspaceId. The gate now
+    /// compares against <c>IWorkspaceManager.GetCurrentSolution(workspaceId)</c>, so a live solution
+    /// belonging to workspace B paired with workspace A's id is rejected outright.
+    /// </summary>
+    [TestMethod]
+    public async Task SymbolResolver_LiveSolutionFromOtherWorkspace_DoesNotRouteThroughCache()
+    {
+        await using var workspaceA = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        await using var workspaceB = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        using var inner = new CompilationCache(WorkspaceManager);
+        var cache = new RecordingCompilationCache(inner);
+
+        var solutionB = WorkspaceManager.GetCurrentSolution(workspaceB.WorkspaceId);
+        Assert.AreNotSame(
+            solutionB,
+            WorkspaceManager.GetCurrentSolution(workspaceA.WorkspaceId),
+            "The two isolated workspaces must expose distinct solutions for this test to mean anything.");
+
+        // Deliberately mismatched: workspace B's LIVE solution, workspace A's id.
+        var resolved = await SymbolResolver.ResolveByMetadataNameAsync(
+            solutionB, "SampleLib.Dog", CancellationToken.None, cache, workspaceA.WorkspaceId);
+        Assert.IsNotNull(resolved, "The mismatched call must still resolve via the raw per-project fetch.");
+
+        var all = await SymbolHandleSerializer.FindAllByMetadataNameAsync(
+            solutionB, "SampleLib.Dog", CancellationToken.None, cache, workspaceA.WorkspaceId);
+        Assert.IsTrue(all.Count > 0, "The mismatched call must still resolve via the raw per-project fetch.");
+
+        _ = await SymbolResolver.FindClosestMatchesAsync(
+            solutionB, "SampleLib.Dogg", maxResults: 5, CancellationToken.None, cache, workspaceA.WorkspaceId);
+
+        Assert.AreEqual(0, cache.GetCompilationCallCount,
+            "A solution belonging to a DIFFERENT workspace must never be served from — or stored " +
+            "into — the cache slot keyed by the caller-supplied workspaceId, even though the " +
+            "solution is itself live and a cache plus a workspaceId were both supplied.");
+    }
+
+    /// <summary>
     /// Runs the service once (proving it touched the cache), snapshots the compilations the cache
     /// handed out, then runs it a second time at the unchanged workspace version so the caller can
     /// assert the warm compilations were reused.
@@ -993,7 +1115,9 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
     /// <summary>
     /// Minimal call-counting <see cref="ICompilationCache"/> for the hoist tests — increments a
     /// counter per <c>GetCompilationAsync</c> and returns the project's real compilation. The
-    /// analyzer/invalidate members are unused by the two hoisted helpers and throw if reached.
+    /// analyzer/liveness/invalidate members are unused by the two hoisted helpers (which take an
+    /// ad-hoc solution and a synthetic workspace id, never routing through the read-side liveness
+    /// gate) and throw if reached.
     /// </summary>
     private sealed class CountingAdhocCompilationCache : ICompilationCache
     {
@@ -1009,6 +1133,8 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
 
         public Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct) =>
             throw new NotSupportedException();
+
+        public bool IsLiveSolution(string workspaceId, Solution solution) => throw new NotSupportedException();
 
         public void Invalidate(string workspaceId) => throw new NotSupportedException();
     }
@@ -1046,6 +1172,50 @@ public sealed class CompilationCacheAdoptionTests : IsolatedWorkspaceTestBase
 
         public Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct) =>
             _inner.GetCompilationWithAnalyzersAsync(workspaceId, project, ct);
+
+        public bool IsLiveSolution(string workspaceId, Solution solution) => _inner.IsLiveSolution(workspaceId, solution);
+
+        public void Invalidate(string workspaceId) => _inner.Invalidate(workspaceId);
+    }
+
+    /// <summary>
+    /// group-c-compilation-cache-gate-hardening: <see cref="ICompilationCache"/> decorator that
+    /// reloads the workspace as a side effect of its FIRST <c>GetCompilationAsync</c> — simulating a
+    /// reload that lands mid-scan, between two iterations of a helper's project loop. Liveness
+    /// (<see cref="IsLiveSolution"/>) is delegated to a real <see cref="CompilationCache"/> so the
+    /// post-reload re-check reflects the genuine workspace state.
+    /// </summary>
+    private sealed class ReloadOnFirstFetchCompilationCache : ICompilationCache
+    {
+        private readonly ICompilationCache _inner;
+        private readonly Func<Task> _reload;
+        private int _getCompilationCallCount;
+
+        public ReloadOnFirstFetchCompilationCache(ICompilationCache inner, Func<Task> reload)
+        {
+            _inner = inner;
+            _reload = reload;
+        }
+
+        public int GetCompilationCallCount => Volatile.Read(ref _getCompilationCallCount);
+
+        public async Task<Compilation?> GetCompilationAsync(string workspaceId, Project project, CancellationToken ct)
+        {
+            if (Interlocked.Increment(ref _getCompilationCallCount) == 1)
+            {
+                await _reload().ConfigureAwait(false);
+            }
+
+            // Deliberately NOT delegated to the inner cache: the point of the test is the call
+            // count, and storing a pre-bump compilation under the post-bump key is the very
+            // poisoning this initiative prevents.
+            return await project.GetCompilationAsync(ct).ConfigureAwait(false);
+        }
+
+        public Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(string workspaceId, Project project, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public bool IsLiveSolution(string workspaceId, Solution solution) => _inner.IsLiveSolution(workspaceId, solution);
 
         public void Invalidate(string workspaceId) => _inner.Invalidate(workspaceId);
     }


### PR DESCRIPTION
Closes: group-c-compilation-cache-gate-hardening

Initiative 7 of the `20260813T172325Z_backlog-sweep` plan. Tool policy: `edit-only`.

## Diagnosis

Two independent defects in the opt-in `ICompilationCache` gate used by the three group-c read-side static helpers.

**1 — the gate was hoisted out of the project loop.** `SymbolResolver.FindClosestMatchesAsync`, `SymbolResolver.ResolveByMetadataNameAsync`, and `SymbolHandleSerializer.FindAllByMetadataNameAsync` each computed `var useCache = CanUseCompilationCache(...)` ONCE before their `foreach (var project in solution.Projects)` loop. But `CompilationCache.GetCompilationAsync` re-reads `_workspaceManager.GetCurrentVersion(workspaceId)` on EVERY call and keys purely on `(workspaceId, ProjectId, version)`. A workspace reload landing mid-loop therefore made the cache compute a compilation from the **pre-bump** `Project` instance and STORE it under the **post-bump** version key — poisoning that slot for every later caller reading the project at the new version, until the next bump.

**2 — the liveness check could not see the workspace it was gating.** `ReferenceEquals(solution, solution.Workspace.CurrentSolution)` proves liveness only w.r.t. the solution's OWN `Workspace` back-reference; it never confirms that back-reference is the workspace registered under the caller-supplied `workspaceId`. A **live** solution from workspace B, passed with `workspaceId: "A"`, satisfied the gate and would have been served from — and stored into — A's cache slot. The XML doc's claim that the check was "semantically `solution == IWorkspaceManager.GetCurrentSolution(workspaceId)`" was therefore false.

## Changes

| File | Change |
|---|---|
| `Contracts/ICompilationCache.cs` | New `bool IsLiveSolution(string workspaceId, Solution solution)` — the check the doc comment already claimed existed. Documents the must-re-evaluate-per-fetch contract. |
| `Services/CompilationCache.cs` | Implements `IsLiveSolution` against the already-injected `IWorkspaceManager.GetCurrentSolution(workspaceId)`, catching `StaleWorkspaceTransitionException` (reload-transition / disposed-snapshot window) and returning `false` so a read-side helper degrades to the raw fetch instead of throwing. |
| `Helpers/SymbolResolver.cs` | `CanUseCompilationCache` now delegates to `cache.IsLiveSolution(workspaceId, solution)`, closing the identity gap. New `GetProjectCompilationAsync` is the single fetch-dispatch site and evaluates the gate **fresh on every call**. New `ValidateCacheParameters` throws `ArgumentException(nameof(workspaceId))` for the half-configured opt-in, called before the loop so an empty-project solution still fails loudly. Stale XML remarks rewritten. |
| `Helpers/SymbolHandleSerializer.cs` | `FindAllByMetadataNameAsync` validates once at the top and routes through the shared `GetProjectCompilationAsync`. |

Both hoisted `useCache` bools + inline ternaries in `SymbolResolver`, and the third in `SymbolHandleSerializer`, are gone — the gate is now re-evaluated per project iteration at the one dispatch site.

Behavior note: a `compilationCache` supplied **without** a `workspaceId` now throws instead of silently disabling caching. The reverse combination (a `workspaceId` with no cache) stays a silent no-cache by design.

## Tests (`tests/RoslynMcp.Tests/CompilationCacheAdoptionTests.cs`)

Three new `[TestMethod]`s, one per acceptance bullet, plus the mechanical `IsLiveSolution` companion on the file's two existing `ICompilationCache` doubles:

1. `SymbolResolver_MidScanWorkspaceReload_StopsRoutingThroughCache` — a decorator cache that triggers `WorkspaceManager.ReloadAsync` as a side effect of its FIRST fetch; asserts exactly **1** cache call across the 3-project sample solution, proving iterations 2–3 detected staleness via the per-iteration re-check and fell back to `project.GetCompilationAsync`. Pre-fix the hoisted bool stayed `true` and the count would have been 3.
2. `SymbolResolver_CacheWithoutWorkspaceId_ThrowsArgumentException` — asserts `ArgumentException` naming `workspaceId` from all three helpers, zero compilation fetches, and that the reverse arm (workspaceId, no cache) still resolves normally.
3. `SymbolResolver_LiveSolutionFromOtherWorkspace_DoesNotRouteThroughCache` — two isolated workspaces; workspace B's **live** solution paired with workspace A's id must yield a hard zero cache-call count across all three helpers.

The existing `MigratedHelpers_ForkedSolution_DoNotRouteThroughCache` hard-zero contract, and the three `..._LiveSolution_RoutesThroughSharedCache` tests, pass unmodified.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors (addenda `fallback_compile`).
- `dotnet test --filter "FullyQualifiedName~CompilationCacheAdoptionTests"` — 31/31 passed.
- `dotnet test --filter "SymbolDisambiguationElicitationTests|MetadataNameLocatorTests|CompilationCache"` — 55/55 passed.
- `./eng/verify-ai-docs.ps1` — passed.

## Scope notes

- `Grep` re-confirmed exactly 3 repo-wide implementers of `ICompilationCache` (`CompilationCache` + the 2 test doubles); all are touched here, so the interface addition leaves no missed companion.
- Re-derived per Directive #5: no production caller passes `compilationCache`/`workspaceId` into these three helpers yet — this remains pre-consumer hardening, and the sibling row `compilation-cache-wire-group-c-consumer` should re-verify before wiring the first real caller.
- Deliberately untouched: `CompilationCache.GetCompilationWithAnalyzersAsync` (`IsLiveSolution` is a standalone member, not a gate on the analyzer-bound path), and the ~20 Batch-1 service consumers, which own their own gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
