### PR TITLE
fix(gate): preserve OperationCanceledException as InnerException on timeout reclassification

### DIFF
--- a/changelog.d/gate-timeout-exception-drops-inner-oce.md
+++ b/changelog.d/gate-timeout-exception-drops-inner-oce.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `TimeoutException` raised by the gate's internal-timeout reclassification (`WorkspaceExecutionGate.RunPerWorkspaceAsync`/`RunLoadGateAsync`, `GatedCommandExecutor.ExecuteAsync`) now carries the original `OperationCanceledException` as `InnerException`, preserving cancellation provenance (which token fired, original stack trace) in logs and diagnostics instead of discarding it.

--- a/src/RoslynMcp.Roslyn/Services/GatedCommandExecutor.cs
+++ b/src/RoslynMcp.Roslyn/Services/GatedCommandExecutor.cs
@@ -92,10 +92,13 @@ public sealed class GatedCommandExecutor : IGatedCommandExecutor
 
             return execution;
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        catch (OperationCanceledException oce) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
         {
+            // The caught OCE is carried as InnerException so cancellation provenance (which token
+            // fired, original stack trace) survives the reclassification for logs/diagnostics.
             throw new TimeoutException(
-                $"The command 'dotnet {string.Join(" ", arguments)}' did not complete within the total timeout budget of {timeout.TotalMinutes:F1} minute(s), including queue wait.");
+                $"The command 'dotnet {string.Join(" ", arguments)}' did not complete within the total timeout budget of {timeout.TotalMinutes:F1} minute(s), including queue wait.",
+                oce);
         }
         finally
         {

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -135,16 +135,19 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 }
             }, linked).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        catch (OperationCanceledException oce) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
         {
             // gate-timeout-escapes-as-bare-sdk-error (test-run-unfiltered-bare-error-rootcause):
             // see the identical catch in RunPerWorkspaceAsync below for the full mechanism. This
             // load-gate leg (workspace_load/workspace_reload/workspace_close) shares the same
             // timeoutCts/linkedCts construction and was therefore exposed to the same gap.
+            // The caught OCE is carried as InnerException so cancellation provenance (which token
+            // fired, original stack trace) survives the reclassification for logs/diagnostics.
             throw new TimeoutException(
                 $"The gated load operation did not complete within the request timeout of " +
                 $"{_requestTimeout.TotalSeconds:F0}s. Increase ROSLYNMCP_REQUEST_TIMEOUT_SECONDS if this " +
-                "operation is expected to run longer.");
+                "operation is expected to run longer.",
+                oce);
         }
     }
 
@@ -273,7 +276,7 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
                 }
             }, linked).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        catch (OperationCanceledException oce) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
         {
             // gate-timeout-escapes-as-bare-sdk-error (test-run-unfiltered-bare-error-rootcause):
             // without this reclassification, a gate-internal RequestTimeout (armed above, default
@@ -297,11 +300,14 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
             // to TimeoutException here — the same pattern GatedCommandExecutor.ExecuteAsync and
             // WorkspaceValidationService already apply to THEIR OWN internal timeout CTS's — routes
             // it through ToolErrorHandler.ClassifyAndFormat's existing "Timeout" category instead
-            // of letting it slip past every structured-envelope layer in the server.
+            // of letting it slip past every structured-envelope layer in the server. The caught OCE
+            // is carried as InnerException so cancellation provenance (which token fired, original
+            // stack trace) survives the reclassification for logs/diagnostics.
             throw new TimeoutException(
                 $"The gated operation on workspace '{workspaceId}' did not complete within the request " +
                 $"timeout of {_requestTimeout.TotalSeconds:F0}s. Increase ROSLYNMCP_REQUEST_TIMEOUT_SECONDS " +
-                "if this operation is expected to run longer.");
+                "if this operation is expected to run longer.",
+                oce);
         }
     }
 

--- a/tests/RoslynMcp.Tests/Services/GatedCommandExecutorTests.cs
+++ b/tests/RoslynMcp.Tests/Services/GatedCommandExecutorTests.cs
@@ -119,6 +119,13 @@ public sealed class GatedCommandExecutorTests
             stopwatch.Stop();
 
             StringAssert.Contains(exception.Message, "including queue wait");
+
+            // gate-timeout-exception-drops-inner-oce: the reclassification must carry the original
+            // OperationCanceledException so cancellation provenance (which token fired, original
+            // stack trace) survives into logs instead of being discarded.
+            Assert.IsInstanceOfType<OperationCanceledException>(exception.InnerException,
+                "The reclassified TimeoutException should preserve the caught OCE as InnerException.");
+
             Assert.IsTrue(
                 stopwatch.Elapsed < TimeSpan.FromSeconds(2),
                 $"Queue wait should be bounded by the 100 ms budget; elapsed {stopwatch.Elapsed}.");

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -346,6 +346,12 @@ public class WorkspaceExecutionGateTests
             "The timeout message should identify which workspace's gated operation timed out.");
         StringAssert.Contains(ex.Message, "ROSLYNMCP_REQUEST_TIMEOUT_SECONDS",
             "The message should point the caller at the env var that controls this timeout.");
+
+        // gate-timeout-exception-drops-inner-oce: the reclassification must carry the original
+        // OperationCanceledException so cancellation provenance (which token fired, original stack
+        // trace) survives into logs — StructuredCallToolFilter logs the exception object whole.
+        Assert.IsInstanceOfType<OperationCanceledException>(ex.InnerException,
+            "The reclassified TimeoutException should preserve the caught OCE as InnerException.");
     }
 
     // Counterpart to the reclassification above: TRUE caller-initiated cancellation (the client's
@@ -396,6 +402,10 @@ public class WorkspaceExecutionGateTests
             }, CancellationToken.None));
 
         StringAssert.Contains(ex.Message, "ROSLYNMCP_REQUEST_TIMEOUT_SECONDS");
+
+        // gate-timeout-exception-drops-inner-oce: same provenance guarantee on the load-gate leg.
+        Assert.IsInstanceOfType<OperationCanceledException>(ex.InnerException,
+            "The reclassified TimeoutException should preserve the caught OCE as InnerException.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## What

All three gate-internal timeout reclassification sites constructed a message-only `TimeoutException`, discarding the caught `OperationCanceledException` — and with it the cancellation provenance (which token fired, original stack trace):

| Site | File:line (pre-change) |
|---|---|
| `WorkspaceExecutionGate.RunLoadGateAsync` | `src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs:138` |
| `WorkspaceExecutionGate.RunPerWorkspaceAsync` | `src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs:276` |
| `GatedCommandExecutor.ExecuteAsync` | `src/RoslynMcp.Roslyn/Services/GatedCommandExecutor.cs:95` |

Each `catch (OperationCanceledException)` now binds the instance (`oce`) and passes it to the BCL two-arg `TimeoutException(string, Exception?)` overload.

## What did NOT change

- Control flow, message text, and the `when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)` filter that separates gate-internal timeout from genuine caller-initiated cancellation are all untouched.
- `ToolErrorHandler.cs` needs no change: `StructuredCallToolFilter.cs:222` already logs the exception object whole (`logger?.Log(level, ex, ...)`), so standard `ILogger` exception serialization now surfaces the inner OCE and its stack trace automatically.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter "FullyQualifiedName~WorkspaceExecutionGateTests|FullyQualifiedName~GatedCommandExecutorTests"` — 36 passed, 0 failed.
- `./eng/verify-ai-docs.ps1` — passed.
- The three existing timeout tests were extended with `Assert.IsInstanceOfType<OperationCanceledException>(ex.InnerException, ...)` alongside the existing message assertions; the `Assert.ThrowsExactlyAsync<TimeoutException>` shape is unweakened.

Closes: gate-timeout-exception-drops-inner-oce

🤖 Generated with [Claude Code](https://claude.com/claude-code)
