### PR TITLE
docs(procedures): point deep-review runbooks at canonical shape list

### DIFF
--- a/ai_docs/procedures/deep-review-backlog-intake.md
+++ b/ai_docs/procedures/deep-review-backlog-intake.md
@@ -15,7 +15,7 @@ Run the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) skill f
 
 The skill does end-to-end intake:
 
-1. **Stages** deep-review artifacts by invoking `eng/stage-review-inbox.ps1`, which discovers `*_mcp-server-audit.md`, `*_experimental-promotion.md`, and `*_roslyn-mcp-retro.md` files across sibling repos + this repo's own `ai_docs/audit-reports/` + `ai_docs/reports/`, and copies them into `review-inbox/` (default — preserves the canonical source location; pass `-Move` to clear the source instead).
+1. **Stages** deep-review artifacts by invoking `eng/stage-review-inbox.ps1`, which discovers the recognized deep-review artifact shapes (canonical list: see `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes"; do not re-list the globs here) across sibling repos + this repo's own `ai_docs/audit-reports/` + `ai_docs/reports/`, and copies them into `review-inbox/` (default — preserves the canonical source location; pass `-Move` to clear the source instead).
 2. **Extracts** actionable items via a subagent (context-protecting).
 3. **Deduplicates** semantically across files (not literal-text matching).
 4. **Verifies** each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest backlog-sweep plan, dropping items that have already shipped.

--- a/ai_docs/procedures/deep-review-command-reference.md
+++ b/ai_docs/procedures/deep-review-command-reference.md
@@ -10,7 +10,7 @@ Set-Location C:\Code-Repo\Roslyn-Backed-MCP
 
 ## Produce audits (per repo)
 
-Run the audit prompt inside the repo being audited. The prompt emits a raw `*_mcp-server-audit.md` (and, when applicable, `*_experimental-promotion.md` / `*_roslyn-mcp-retro.md`) into that repo's `ai_docs/audit-reports/` or `ai_docs/reports/`.
+Run the audit prompt inside the repo being audited. The prompt emits raw deep-review artifacts — a producer-side subset of the recognized shapes, whose canonical list lives in `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes"; do not re-list the globs here — into that repo's `ai_docs/audit-reports/` or `ai_docs/reports/`.
 
 ```
 /mcp-server-stress
@@ -28,7 +28,7 @@ From Roslyn-Backed-MCP repo root:
 
 This runs the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) skill, which:
 
-1. Stages `*_mcp-server-audit.md` / `*_experimental-promotion.md` / `*_roslyn-mcp-retro.md` from sibling repos + this repo into `review-inbox/`.
+1. Stages the recognized deep-review artifact shapes from sibling repos + this repo into `review-inbox/`. The canonical list of recognized shapes lives in `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes" — read it there; do not re-list the globs here. (`backlog.d/` fragments are the exception: they are consumed in place, not staged.)
 2. Extracts actionable items via a subagent (context-protecting).
 3. Deduplicates semantically across files.
 4. Verifies each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest backlog-sweep plan.

--- a/changelog.d/deep-review-shape-list-single-source.md
+++ b/changelog.d/deep-review-shape-list-single-source.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Completed the deep-review recognized-artifact-shape single-sourcing follow-up from the prior partial slice — `ai_docs/procedures/deep-review-backlog-intake.md` and `ai_docs/procedures/deep-review-command-reference.md` (the two human-facing runbook docs deferred out of PR #1189's 4-file Rule-3 cap) now point at `eng/stage-review-inbox.ps1`'s canonical `Recognized shapes` block instead of re-listing the glob set, closing the last 2 of the original 6 duplication sites.


### PR DESCRIPTION
## Summary

Completes the deep-review recognized-artifact-shape single-sourcing follow-up that PR #1189 deliberately deferred out of its 4-file Rule-3 cap. The two human-facing runbook docs were the last 2 of the original 6 duplication sites; both now point at `eng/stage-review-inbox.ps1`'s `.DESCRIPTION` -> "Recognized shapes" block instead of re-listing the glob set.

The stale inline lists named only 3 of the 6 recognized shapes — they were already missing `*_mcp-server-surface-test.md`, `*_roslyn-mcp-multisession-retro.md`, and `backlog.d/<finding-id>.md` fragments.

## Changes

| File | Line | Change |
|---|---|---|
| `ai_docs/procedures/deep-review-backlog-intake.md` | 18 | Inline 3-glob list -> canonical pointer, mirroring `eng/process-audit-reports.ps1:11-16`'s already-shipped phrasing. |
| `ai_docs/procedures/deep-review-command-reference.md` | 13 | Producer-side (`/mcp-server-stress` output) wording kept honest: "a producer-side subset of the recognized shapes" + canonical pointer, so producer and consumer scope are not conflated. |
| `ai_docs/procedures/deep-review-command-reference.md` | 31 | Consumer-side intake-staging step -> canonical pointer, mirroring `.claude/skills/backlog-intake/SKILL.md:48`, plus a note that `backlog.d/` fragments are consumed in place rather than staged. |

The canonical block itself (`eng/stage-review-inbox.ps1:27-35`) is unchanged — referenced only. No PowerShell, C#, or test surface touched.

## Validation

- `./eng/verify-ai-docs.ps1` — exit 0 ("AI docs validation passed", 32 shipped SKILL.md checked).
- `./eng/verify-changelog-fragments.ps1` — exit 0 (27 fragments valid).
- Post-edit `rg` for the three glob literals across both scoped files returns zero hits.
- Both docs re-read end-to-end; operator-facing `/backlog-intake` and `/mcp-server-stress` instructions still read coherently.

## Follow-on (out of scope, not fixed here)

`ai_docs/procedures/deep-review-program.md:25` still inlines the same 3-glob triple. It is outside this initiative's 2-file Scope — filing as a follow-on backlog row rather than expanding scope.

Closes: deep-review-shape-list-single-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
