### PR TITLE
refactor(elicitation): collapse the HasElicitation forwarder chain

### DIFF
--- a/changelog.d/elicitation-forwarder-collapse-haselicitation.md
+++ b/changelog.d/elicitation-forwarder-collapse-haselicitation.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Collapsed the `HasElicitation` forwarder chain — the predicate now has a single definition on `ElicitationChoicePrompt`, with the `StructuredCallToolFilter` and `ElicitationAllowlistPolicy` thin delegates (and their duplicated doc blocks) deleted and the one remaining production caller in `StructuredCallElicitationCoordinator` retargeted at the canonical member. All members are `internal`; no published-surface change. (elicitation-doc-drift-and-delegate-chain, part 1 of 2)

--- a/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
@@ -24,8 +24,7 @@ namespace RoslynMcp.Host.Stdio.Elicitation;
 /// </para>
 ///
 /// <para>
-/// <c>ElicitationAllowlistPolicy.HasElicitation</c> and
-/// <c>StructuredCallElicitationCoordinator.TryElicitChoiceAsync</c> are retained as thin delegates
+/// <c>StructuredCallElicitationCoordinator.TryElicitChoiceAsync</c> is retained as a thin delegate
 /// forwarding here, so the historical Middleware-internal static call surface (consumed by
 /// <c>StructuredCallToolFilter</c> and the existing elicitation test suites) is preserved
 /// byte-for-byte.
@@ -36,8 +35,8 @@ internal static class ElicitationChoicePrompt
     /// <summary>
     /// Capability-check helper: returns <see langword="true"/> when the connected client
     /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
-    /// Canonical home for the predicate — both the Middleware allowlist policy and the
-    /// <c>Tools</c> symbol-disambiguation path call it (directly or via a delegate) rather than
+    /// Sole definition of the predicate — the Middleware elicitation/retry gate and the
+    /// <c>Tools</c> symbol-disambiguation path both call it directly rather than
     /// copy-pasting the null-coalescing dance.
     /// </summary>
     /// <param name="capabilities">

--- a/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs
@@ -1,6 +1,4 @@
-using ModelContextProtocol.Protocol;
 using RoslynMcp.Host.Stdio.Catalog;
-using RoslynMcp.Host.Stdio.Elicitation;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
 
@@ -46,27 +44,6 @@ internal static class ElicitationAllowlistPolicy
         {
             (WorkspaceLoadToolName, PathParameterName),
         };
-
-    /// <summary>
-    /// Capability-check helper: returns <see langword="true"/> when the connected client
-    /// declares the <c>elicitation</c> capability per MCP 2025-06-18 § Client Capabilities.
-    /// Thin delegate onto <see cref="ElicitationChoicePrompt.HasElicitation"/>, which is the
-    /// canonical home — the predicate lives in the cycle-free
-    /// <c>RoslynMcp.Host.Stdio.Elicitation</c> namespace so <c>Tools</c> can call it without
-    /// importing <c>Middleware</c>. Retained here so this class's historical static call
-    /// surface (and its test suite) keeps compiling unchanged.
-    /// </summary>
-    /// <param name="capabilities">
-    /// The <see cref="McpServer.ClientCapabilities"/> snapshot, typically obtained as
-    /// <c>context.Server.ClientCapabilities</c> inside a request filter or tool method.
-    /// May be <see langword="null"/> on the server's pre-initialize path.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> when both <paramref name="capabilities"/> and
-    /// <c>capabilities.Elicitation</c> are non-null. Zero-allocation and side-effect-free.
-    /// </returns>
-    public static bool HasElicitation(ClientCapabilities? capabilities) =>
-        ElicitationChoicePrompt.HasElicitation(capabilities);
 
     /// <summary>
     /// Defense-in-depth predicate: returns <see langword="true"/> when the parameter name

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
@@ -88,7 +88,7 @@ internal static class StructuredCallElicitationCoordinator
 
         // Layer 3: client must support elicitation. server.ClientCapabilities.Elicitation
         // is established at initialize-handshake time; this is a property read, not an RPC.
-        if (!ElicitationAllowlistPolicy.HasElicitation(context.Server?.ClientCapabilities))
+        if (!ElicitationChoicePrompt.HasElicitation(context.Server?.ClientCapabilities))
         {
             return null;
         }

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -227,14 +227,6 @@ internal static class StructuredCallToolFilter
     }
 
     /// <summary>
-    /// Thin delegate preserving the historical static call surface. The policy lives in
-    /// <see cref="ElicitationAllowlistPolicy.HasElicitation"/>; kept here so existing callers
-    /// (<c>SymbolTools</c>, the filter test suites) compile unchanged.
-    /// </summary>
-    public static bool HasElicitation(ClientCapabilities? capabilities) =>
-        ElicitationAllowlistPolicy.HasElicitation(capabilities);
-
-    /// <summary>
     /// Thin delegate preserving the historical static call surface. See
     /// <see cref="ElicitationAllowlistPolicy.IsSensitiveFieldName"/>.
     /// </summary>

--- a/tests/RoslynMcp.Tests/ElicitationAllowlistPolicyTests.cs
+++ b/tests/RoslynMcp.Tests/ElicitationAllowlistPolicyTests.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Protocol;
+using RoslynMcp.Host.Stdio.Elicitation;
 using RoslynMcp.Host.Stdio.Middleware;
 
 namespace RoslynMcp.Tests;
@@ -10,8 +11,16 @@ namespace RoslynMcp.Tests;
 /// policy members <b>directly</b> (not through the filter's thin delegates), pinning the
 /// decomposed unit on its own so the policy contract is guarded even if the filter's forwarding
 /// surface changes. The pre-existing <c>StructuredCallToolFilterElicitationTests</c> continue to
-/// assert the same guarantees through the filter delegates, proving the delegates are
-/// behavior-preserving.
+/// assert the same guarantees through the filter's remaining delegates
+/// (<c>IsSensitiveFieldName</c>, <c>IsElicitationAllowedFor</c>,
+/// <c>IsWorkspaceIdRecoveryAllowedFor</c>), proving those delegates are behavior-preserving.
+///
+/// <para>
+/// The <c>HasElicitation</c> assertions below target
+/// <see cref="ElicitationChoicePrompt.HasElicitation"/> — its sole definition since the
+/// <c>elicitation-forwarder-collapse-haselicitation</c> initiative deleted the
+/// <see cref="ElicitationAllowlistPolicy"/> and <see cref="StructuredCallToolFilter"/> forwarders.
+/// </para>
 /// </summary>
 [TestClass]
 public sealed class ElicitationAllowlistPolicyTests
@@ -26,7 +35,7 @@ public sealed class ElicitationAllowlistPolicyTests
             Elicitation = new ElicitationCapability(),
         };
 
-        Assert.IsTrue(ElicitationAllowlistPolicy.HasElicitation(capabilities),
+        Assert.IsTrue(ElicitationChoicePrompt.HasElicitation(capabilities),
             "An ElicitationCapability instance present on ClientCapabilities means the client " +
             "supports elicitation/create — the elicit recovery path is permitted.");
     }
@@ -34,7 +43,7 @@ public sealed class ElicitationAllowlistPolicyTests
     [TestMethod]
     public void HasElicitation_WhenCapabilitiesNull_ReturnsFalse()
     {
-        Assert.IsFalse(ElicitationAllowlistPolicy.HasElicitation(null),
+        Assert.IsFalse(ElicitationChoicePrompt.HasElicitation(null),
             "Null ClientCapabilities means no handshake-established capability set; refuse to elicit.");
     }
 
@@ -43,7 +52,7 @@ public sealed class ElicitationAllowlistPolicyTests
     {
         var capabilities = new ClientCapabilities();
 
-        Assert.IsFalse(ElicitationAllowlistPolicy.HasElicitation(capabilities),
+        Assert.IsFalse(ElicitationChoicePrompt.HasElicitation(capabilities),
             "Client must explicitly advertise the elicitation capability; absence means refuse.");
     }
 

--- a/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallToolFilterElicitationTests.cs
@@ -3,6 +3,7 @@ using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Elicitation;
 using RoslynMcp.Host.Stdio.Middleware;
 
 namespace RoslynMcp.Tests;
@@ -56,7 +57,7 @@ public sealed class StructuredCallToolFilterElicitationTests
             Elicitation = new ElicitationCapability(),
         };
 
-        Assert.IsTrue(StructuredCallToolFilter.HasElicitation(capabilities),
+        Assert.IsTrue(ElicitationChoicePrompt.HasElicitation(capabilities),
             "An ElicitationCapability instance present on ClientCapabilities means the " +
             "client supports elicitation/create — the elicit recovery path is permitted.");
     }
@@ -124,7 +125,7 @@ public sealed class StructuredCallToolFilterElicitationTests
     {
         // Pre-initialize-handshake or a transport that doesn't establish capabilities —
         // the filter MUST NOT call ElicitAsync; it falls through to the existing envelope.
-        Assert.IsFalse(StructuredCallToolFilter.HasElicitation(null),
+        Assert.IsFalse(ElicitationChoicePrompt.HasElicitation(null),
             "Null ClientCapabilities means no handshake-established capability set; refuse to elicit.");
     }
 
@@ -138,7 +139,7 @@ public sealed class StructuredCallToolFilterElicitationTests
             // No Elicitation set, no Roots set, no Sampling set.
         };
 
-        Assert.IsFalse(StructuredCallToolFilter.HasElicitation(capabilities),
+        Assert.IsFalse(ElicitationChoicePrompt.HasElicitation(capabilities),
             "Client must explicitly advertise the elicitation capability; absence means refuse.");
     }
 

--- a/tests/RoslynMcp.Tests/SymbolDisambiguationElicitationTests.cs
+++ b/tests/RoslynMcp.Tests/SymbolDisambiguationElicitationTests.cs
@@ -30,7 +30,7 @@ namespace RoslynMcp.Tests;
 /// Pins:
 /// <list type="bullet">
 ///   <item><b>(a) elicit-supported preconditions</b> — the
-///         <see cref="StructuredCallToolFilter.HasElicitation"/> capability check returns
+///         <see cref="ElicitationChoicePrompt.HasElicitation"/> capability check returns
 ///         true for a properly handshaken client AND the candidate-discovery helper finds
 ///         the multiple-overload set; the gate logic is therefore wired correctly. The
 ///         end-to-end <c>ElicitAsync</c> pre-cancellation path uses a real SDK client/server pair
@@ -70,18 +70,18 @@ public sealed class SymbolDisambiguationElicitationTests : IsolatedWorkspaceTest
     public void HasElicitation_PinsTheCapabilityCheckUsedByDisambiguation()
     {
         // The disambiguation gate inside SymbolTools.TryDisambiguateMetadataNameAsync
-        // delegates to the same StructuredCallToolFilter.HasElicitation predicate the
+        // calls the same ElicitationChoicePrompt.HasElicitation predicate the
         // workspace-path initiative pinned. This regression test pins that we still rely
         // on the same predicate (so a future refactor of either site can't drift).
         var capabilities = new ClientCapabilities
         {
             Elicitation = new ElicitationCapability(),
         };
-        Assert.IsTrue(StructuredCallToolFilter.HasElicitation(capabilities),
+        Assert.IsTrue(ElicitationChoicePrompt.HasElicitation(capabilities),
             "An ElicitationCapability instance present on ClientCapabilities means the " +
             "client supports elicitation/create — the disambiguation gate is permitted.");
 
-        Assert.IsFalse(StructuredCallToolFilter.HasElicitation(null),
+        Assert.IsFalse(ElicitationChoicePrompt.HasElicitation(null),
             "Null capabilities (pre-handshake) MUST NOT permit elicitation.");
     }
 
@@ -117,10 +117,10 @@ public sealed class SymbolDisambiguationElicitationTests : IsolatedWorkspaceTest
         const bool optIn = true;
 
         Assert.IsTrue(
-            optIn && StructuredCallToolFilter.HasElicitation(capable),
+            optIn && ElicitationChoicePrompt.HasElicitation(capable),
             "Opt-in + capable client is the only combination that reaches the elicit branch.");
         Assert.IsFalse(
-            optIn && StructuredCallToolFilter.HasElicitation(null),
+            optIn && ElicitationChoicePrompt.HasElicitation(null),
             "Opt-in against a non-capable (null-capabilities) client must still fall back " +
             "to the candidate list.");
     }


### PR DESCRIPTION
## Summary

`HasElicitation` had three definitions — the canonical predicate on `ElicitationChoicePrompt` plus thin forwarders on `ElicitationAllowlistPolicy` and `StructuredCallToolFilter`, each carrying its own copy of the doc block. This collapses the chain to the single canonical definition. All members are `internal`; no published-surface change.

## Linked issue

No GitHub issue — this is a maintainer backlog row (see the Backlog section below).

## Changes

- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs` — retarget the one live production caller (the Layer-3 client-capability gate inside `TryElicitAndRetryAsync`) at `ElicitationChoicePrompt.HasElicitation`. Done first so the deletions below cannot break the build.
- `src/RoslynMcp.Host.Stdio/Middleware/ElicitationAllowlistPolicy.cs` — delete the `HasElicitation` forwarder and its duplicated 18-line doc block, plus the two `using` directives (`ModelContextProtocol.Protocol`, `RoslynMcp.Host.Stdio.Elicitation`) that lost their only consumer with it.
- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs` — delete the `HasElicitation` forwarder and its doc. The sibling delegates (`IsSensitiveFieldName`, `IsElicitationAllowedFor`, `TryElicitAndRetryAsync`) are untouched.
- `src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs` — doc-only: the layering paragraph and the `HasElicitation` summary no longer claim delegates that this PR deletes.
- Tests — retarget the 10 call sites across `ElicitationAllowlistPolicyTests`, `StructuredCallToolFilterElicitationTests`, and `SymbolDisambiguationElicitationTests` at the canonical member; fix the two type-qualified prose/`see cref` mentions and the stale "delegates are behavior-preserving" claim. No new test methods, no assertion changes.

## Test plan

- [x] Added or updated unit/integration tests covering the change *(retargeted existing coverage; no new methods by design)*
- [x] `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` succeeds — 0 warnings, 0 errors
- [x] `dotnet test` passes for the affected suites — 50/50 passed, 0 failed (`ElicitationAllowlistPolicyTests`, `StructuredCallToolFilterElicitationTests`, `StructuredCallElicitationCoordinatorTests`, `SymbolDisambiguationElicitationTests`, `No_Circular_Namespace_Dependency_Between_Middleware_And_Tools`)
- [x] Manually verified: `symbol_search` for `HasElicitation` now returns exactly ONE production definition, on `ElicitationChoicePrompt`
- [x] `./eng/verify-ai-docs.ps1` and `./eng/verify-changelog-fragments.ps1` pass

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — all touched members are `internal`; no published-surface change

## Backlog (maintainer-only)

Closes: elicitation-doc-drift-and-delegate-chain

Part 1 of 2. The row stays open until the sibling initiative `elicitation-forwarder-collapse-trychoice-docs` lands the same collapse for `TryElicitChoiceAsync` and closes it.
