### PR TITLE
refactor(edit): decompose EditService validation and preview orchestration (edit-preview-validation-decomposition)

### DIFF
--- a/changelog.d/edit-preview-validation-decomposition.md
+++ b/changelog.d/edit-preview-validation-decomposition.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** decomposed `EditService.ValidateEdits`, `BuildPatchedSourceText`, and the duplicated `PreviewMultiFileTextEditsAsync`/`PreviewMultiFileTextEditsOnSolutionAsync` preview-orchestration bodies into named single-purpose helpers, reducing per-method cyclomatic complexity below 10 with no change to coordinate-validation, overlap-validation, or syntax-preflight behavior.

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -11,6 +11,14 @@ namespace RoslynMcp.Roslyn.Services;
 
 public sealed class EditService : IEditService
 {
+    /// <summary>
+    /// <see cref="ArgumentException.ParamName"/> reported by every edit-validation failure. Held as
+    /// a constant so <see cref="ValidateEditRange"/> — which sees one edit rather than the batch —
+    /// keeps reporting the caller-visible <c>edits</c> parameter it was extracted from
+    /// (<c>edit-preview-validation-decomposition</c>).
+    /// </summary>
+    private const string EditsParamName = "edits";
+
     private readonly IWorkspaceManager _workspace;
     private readonly ILogger<EditService> _logger;
     private readonly IUndoService? _undoService;
@@ -281,20 +289,42 @@ public sealed class EditService : IEditService
         }
 
         var initialSolution = _workspace.GetCurrentSolution(workspaceId);
+        var (accumulator, changes, warnings) =
+            await SimulatePreviewAsync(initialSolution, fileEdits, ct, skipSyntaxCheck).ConfigureAwait(false);
 
-        // Pre-validate every file's edits BEFORE issuing any preview token. A malformed edit
-        // aborts the whole preview so callers see the error without a dangling token.
+        var description = $"Preview multi-file edit across {changes.Count} file(s)";
+        var token = _previewStore.Store(workspaceId, accumulator, _workspace.GetCurrentVersion(workspaceId), description);
+        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
+    }
+
+    /// <summary>
+    /// Shared preview-orchestration body behind <see cref="PreviewMultiFileTextEditsAsync"/> and
+    /// <see cref="PreviewMultiFileTextEditsOnSolutionAsync"/>, which previously carried
+    /// line-for-line duplicates of it (<c>edit-preview-validation-decomposition</c>). Pre-validates
+    /// every file's edits, then simulates them against a progressively accumulated
+    /// <see cref="Solution"/> so each file's diff sees its predecessors' rewrites. Touches neither
+    /// the workspace, the disk, nor <see cref="Contracts.IPreviewStore"/> — the two callers differ
+    /// only in how they package this result.
+    /// </summary>
+    /// <remarks>
+    /// Pre-validation runs to completion BEFORE any simulation so a malformed edit aborts the whole
+    /// preview and the token-issuing caller never leaves a dangling token behind.
+    /// </remarks>
+    private static async Task<(Solution Accumulator, List<FileChangeDto> Changes, List<string> Warnings)> SimulatePreviewAsync(
+        Solution inputSolution,
+        IReadOnlyList<FileEditsDto> fileEdits,
+        CancellationToken ct,
+        bool skipSyntaxCheck)
+    {
         var perFile = new List<(Document Document, SourceText SourceText, string FilePath, IReadOnlyList<TextEditDto> Edits)>();
         foreach (var fileEdit in fileEdits)
         {
-            var (document, sourceText) = await ResolveDocumentAndTextAsync(initialSolution, fileEdit.FilePath, ct).ConfigureAwait(false);
+            var (document, sourceText) = await ResolveDocumentAndTextAsync(inputSolution, fileEdit.FilePath, ct).ConfigureAwait(false);
             ValidateEdits(fileEdit.FilePath, fileEdit.Edits, sourceText);
             perFile.Add((document, sourceText, fileEdit.FilePath, fileEdit.Edits));
         }
 
-        // Simulate edits on a running Solution snapshot so the stored preview matches what
-        // apply_composite_preview will redeem.
-        var accumulator = initialSolution;
+        var accumulator = inputSolution;
         var changes = new List<FileChangeDto>();
         var warnings = new List<string>();
 
@@ -333,9 +363,7 @@ public sealed class EditService : IEditService
             throw new InvalidOperationException("preview_multi_file_edit produced no diffs. See Warnings for per-file reasons.");
         }
 
-        var description = $"Preview multi-file edit across {changes.Count} file(s)";
-        var token = _previewStore.Store(workspaceId, accumulator, _workspace.GetCurrentVersion(workspaceId), description);
-        return new RefactoringPreviewDto(token, description, changes, warnings.Count > 0 ? warnings : null);
+        return (accumulator, changes, warnings);
     }
 
     /// <summary>
@@ -361,49 +389,8 @@ public sealed class EditService : IEditService
             throw new InvalidOperationException("preview_multi_file_edit requires at least one file edit.");
         }
 
-        var perFile = new List<(Document Document, SourceText SourceText, string FilePath, IReadOnlyList<TextEditDto> Edits)>();
-        foreach (var fileEdit in fileEdits)
-        {
-            var (document, sourceText) = await ResolveDocumentAndTextAsync(inputSolution, fileEdit.FilePath, ct).ConfigureAwait(false);
-            ValidateEdits(fileEdit.FilePath, fileEdit.Edits, sourceText);
-            perFile.Add((document, sourceText, fileEdit.FilePath, fileEdit.Edits));
-        }
-
-        var accumulator = inputSolution;
-        var changes = new List<FileChangeDto>();
-        var warnings = new List<string>();
-
-        foreach (var (document, sourceText, filePath, edits) in perFile)
-        {
-            var merged = BuildPatchedSourceText(sourceText, edits);
-            if (!skipSyntaxCheck
-                && string.Equals(Path.GetExtension(filePath), ".cs", StringComparison.OrdinalIgnoreCase))
-            {
-                var syntaxErrors = GetCSharpSyntaxErrors(merged, filePath);
-                if (syntaxErrors.Count > 0)
-                {
-                    throw new InvalidOperationException(
-                        $"preview_multi_file_edit: simulated edits for '{filePath}' produce {syntaxErrors.Count} syntax error(s). " +
-                        "Pass skipSyntaxCheck=true if the intermediate state is intentional.");
-                }
-            }
-
-            var docInAccum = accumulator.GetDocument(document.Id);
-            if (docInAccum is null)
-            {
-                warnings.Add($"Skipped '{filePath}': document no longer present in the working solution.");
-                continue;
-            }
-            accumulator = accumulator.WithDocumentText(docInAccum.Id, merged);
-
-            var unified = DiffGenerator.GenerateUnifiedDiff(sourceText.ToString(), merged.ToString(), filePath);
-            changes.Add(new FileChangeDto(filePath, unified));
-        }
-
-        if (changes.Count == 0)
-        {
-            throw new InvalidOperationException("preview_multi_file_edit produced no diffs. See Warnings for per-file reasons.");
-        }
+        var (accumulator, changes, warnings) =
+            await SimulatePreviewAsync(inputSolution, fileEdits, ct, skipSyntaxCheck).ConfigureAwait(false);
 
         var description = $"Preview multi-file edit across {changes.Count} file(s)";
         return (accumulator, changes, description, warnings.Count > 0 ? warnings : null);
@@ -449,69 +436,98 @@ public sealed class EditService : IEditService
     {
         if (edits.Count == 0)
         {
-            throw new ArgumentException($"At least one text edit is required for '{filePath}'.", nameof(edits));
+            throw new ArgumentException($"At least one text edit is required for '{filePath}'.", EditsParamName);
         }
 
         var lineCount = sourceText.Lines.Count;
 
         for (var i = 0; i < edits.Count; i++)
         {
-            var edit = edits[i];
-
-            if (edit.NewText is null)
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' has a null NewText. Use an empty string for deletions.",
-                    nameof(edits));
-            }
-
-            if (edit.StartLine < 1 || edit.StartColumn < 1 || edit.EndLine < 1 || edit.EndColumn < 1)
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' has non-positive line/column: " +
-                    $"({edit.StartLine},{edit.StartColumn})-({edit.EndLine},{edit.EndColumn}). " +
-                    "Line and column are 1-based.",
-                    nameof(edits));
-            }
-
-            if (edit.StartLine > lineCount || edit.EndLine > lineCount)
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' references line {Math.Max(edit.StartLine, edit.EndLine)} " +
-                    $"but the file only has {lineCount} line(s).",
-                    nameof(edits));
-            }
-
-            var startLineLength = sourceText.Lines[edit.StartLine - 1].SpanIncludingLineBreak.Length;
-            if (edit.StartColumn > startLineLength + 1)
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' has StartColumn {edit.StartColumn} but line {edit.StartLine} " +
-                    $"only has {startLineLength} character(s). Columns are 1-based and may be one past the end.",
-                    nameof(edits));
-            }
-
-            var endLineLength = sourceText.Lines[edit.EndLine - 1].SpanIncludingLineBreak.Length;
-            if (edit.EndColumn > endLineLength + 1)
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' has EndColumn {edit.EndColumn} but line {edit.EndLine} " +
-                    $"only has {endLineLength} character(s).",
-                    nameof(edits));
-            }
-
-            if (edit.StartLine > edit.EndLine
-                || (edit.StartLine == edit.EndLine && edit.StartColumn > edit.EndColumn))
-            {
-                throw new ArgumentException(
-                    $"Edit #{i} for '{filePath}' has a reversed range: " +
-                    $"start ({edit.StartLine},{edit.StartColumn}) is after end ({edit.EndLine},{edit.EndColumn}). " +
-                    "Zero-width ranges are allowed (inserts) but the end position must not precede the start.",
-                    nameof(edits));
-            }
+            ValidateEditShape(filePath, i, edits[i]);
+            ValidateEditBounds(filePath, i, edits[i], lineCount, sourceText);
         }
 
         ValidateNoOverlappingEdits(filePath, edits, sourceText);
+    }
+
+    /// <summary>
+    /// First half of the per-edit checks extracted from <see cref="ValidateEdits"/>'s loop body
+    /// (<c>edit-preview-validation-decomposition</c>): the two conditions that depend only on the
+    /// edit itself, not on the document it targets — null <c>NewText</c>, then non-positive
+    /// coordinates. Runs BEFORE <see cref="ValidateEditBounds"/> because a non-positive line index
+    /// would otherwise be used to index into <see cref="SourceText.Lines"/>.
+    /// </summary>
+    /// <param name="index">Zero-based position of <paramref name="edit"/> in the caller's batch; used verbatim in error text.</param>
+    private static void ValidateEditShape(string filePath, int index, TextEditDto edit)
+    {
+        if (edit.NewText is null)
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' has a null NewText. Use an empty string for deletions.",
+                EditsParamName);
+        }
+
+        if (edit.StartLine < 1 || edit.StartColumn < 1 || edit.EndLine < 1 || edit.EndColumn < 1)
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' has non-positive line/column: " +
+                $"({edit.StartLine},{edit.StartColumn})-({edit.EndLine},{edit.EndColumn}). " +
+                "Line and column are 1-based.",
+                EditsParamName);
+        }
+    }
+
+    /// <summary>
+    /// Second half of the per-edit checks extracted from <see cref="ValidateEdits"/>'s loop body
+    /// (<c>edit-preview-validation-decomposition</c>): the conditions that measure the edit against
+    /// the target document — out-of-range line, StartColumn overflow, EndColumn overflow, then
+    /// reversed range. Assumes <see cref="ValidateEditShape"/> already ran, so every coordinate is
+    /// positive and safe to use as a 1-based index. The branch ORDER is load-bearing: callers
+    /// depend on the first violation in that sequence being the one reported.
+    /// </summary>
+    /// <param name="index">Zero-based position of <paramref name="edit"/> in the caller's batch; used verbatim in error text.</param>
+    private static void ValidateEditBounds(
+        string filePath,
+        int index,
+        TextEditDto edit,
+        int lineCount,
+        SourceText sourceText)
+    {
+        if (edit.StartLine > lineCount || edit.EndLine > lineCount)
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' references line {Math.Max(edit.StartLine, edit.EndLine)} " +
+                $"but the file only has {lineCount} line(s).",
+                EditsParamName);
+        }
+
+        var startLineLength = sourceText.Lines[edit.StartLine - 1].SpanIncludingLineBreak.Length;
+        if (edit.StartColumn > startLineLength + 1)
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' has StartColumn {edit.StartColumn} but line {edit.StartLine} " +
+                $"only has {startLineLength} character(s). Columns are 1-based and may be one past the end.",
+                EditsParamName);
+        }
+
+        var endLineLength = sourceText.Lines[edit.EndLine - 1].SpanIncludingLineBreak.Length;
+        if (edit.EndColumn > endLineLength + 1)
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' has EndColumn {edit.EndColumn} but line {edit.EndLine} " +
+                $"only has {endLineLength} character(s).",
+                EditsParamName);
+        }
+
+        if (edit.StartLine > edit.EndLine
+            || (edit.StartLine == edit.EndLine && edit.StartColumn > edit.EndColumn))
+        {
+            throw new ArgumentException(
+                $"Edit #{index} for '{filePath}' has a reversed range: " +
+                $"start ({edit.StartLine},{edit.StartColumn}) is after end ({edit.EndLine},{edit.EndColumn}). " +
+                "Zero-width ranges are allowed (inserts) but the end position must not precede the start.",
+                EditsParamName);
+        }
     }
 
     /// <summary>
@@ -576,24 +592,66 @@ public sealed class EditService : IEditService
             var endPosition = sourceText.Lines.GetPosition(new LinePosition(edit.EndLine - 1, edit.EndColumn - 1));
             var span = TextSpan.FromBounds(startPosition, endPosition);
 
-            var replacementText = edit.NewText;
-            if (edit.EndColumn == 1 && span.Length > 0 && replacementText.Length > 0)
-            {
-                var lastCharInSpan = sourceText[span.End - 1];
-                var endsWithNewline = replacementText[^1] is '\n' or '\r';
-                if (lastCharInSpan is '\n' or '\r' && !endsWithNewline)
-                {
-                    var lineBreak = (span.End >= 2 && sourceText[span.End - 2] == '\r' && lastCharInSpan == '\n')
-                        ? "\r\n"
-                        : lastCharInSpan == '\n' ? "\n" : "\r";
-                    replacementText += lineBreak;
-                }
-            }
-
+            var replacementText = AdjustReplacementForTrailingLineBreak(sourceText, span, edit.EndColumn, edit.NewText);
             textChanges.Add(new TextChange(span, replacementText));
         }
 
         return sourceText.WithChanges(textChanges);
+    }
+
+    /// <summary>
+    /// Line-break preservation for a replacement whose span ends at column 1, extracted from
+    /// <see cref="BuildPatchedSourceText"/> (<c>edit-preview-validation-decomposition</c>). A span
+    /// ending at column 1 swallows the previous line's terminator, so a replacement that does not
+    /// itself end in a newline gets the swallowed terminator re-appended — preserving the file's
+    /// existing <c>\r\n</c> / <c>\n</c> / <c>\r</c> convention at that position.
+    /// </summary>
+    /// <remarks>
+    /// The <c>\r\n</c>-before-<c>\n</c>-before-<c>\r</c> detection order is load-bearing: probing
+    /// for the paired <c>\r</c> first is what keeps CRLF files from degrading to bare LF. Reordering
+    /// these branches silently corrupts line endings with no compile-time signal.
+    /// </remarks>
+    /// <returns><paramref name="replacementText"/> unchanged, or with the preserved terminator appended.</returns>
+    private static string AdjustReplacementForTrailingLineBreak(
+        SourceText sourceText,
+        TextSpan span,
+        int editEndColumn,
+        string replacementText)
+    {
+        if (editEndColumn != 1 || span.Length == 0 || replacementText.Length == 0)
+        {
+            return replacementText;
+        }
+
+        // A replacement that already carries its own terminator needs no help.
+        if (replacementText[^1] is '\n' or '\r')
+        {
+            return replacementText;
+        }
+
+        return replacementText + GetSwallowedLineBreak(sourceText, span);
+    }
+
+    /// <summary>
+    /// The line terminator (if any) consumed by the tail of <paramref name="span"/>, as it appears
+    /// in <paramref name="sourceText"/>. Returns <see cref="string.Empty"/> when the span does not
+    /// end on a terminator. Split out of
+    /// <see cref="AdjustReplacementForTrailingLineBreak"/> (<c>edit-preview-validation-decomposition</c>).
+    /// </summary>
+    /// <remarks>
+    /// The <c>\n</c> case must probe the preceding character for a paired <c>\r</c> before settling
+    /// for a bare <c>\n</c> — that probe is the only thing keeping CRLF files from degrading to
+    /// mixed line endings, and the degradation carries no compile-time or syntax-check signal.
+    /// </remarks>
+    private static string GetSwallowedLineBreak(SourceText sourceText, TextSpan span)
+    {
+        var lastCharInSpan = sourceText[span.End - 1];
+        if (lastCharInSpan == '\n')
+        {
+            return span.End >= 2 && sourceText[span.End - 2] == '\r' ? "\r\n" : "\n";
+        }
+
+        return lastCharInSpan == '\r' ? "\r" : string.Empty;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
+++ b/tests/RoslynMcp.Tests/EditUndoCohesionTests.cs
@@ -86,6 +86,88 @@ public sealed class EditUndoCohesionTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task ApplyTextEdit_StartColumnPastEndOfLine_ThrowsArgumentException()
+    {
+        // edit-preview-validation-decomposition: the StartColumn-overflow branch of the extracted
+        // ValidateEditRange. Line 1 of Dog.cs is `namespace SampleLib;` — column 500 is far past its
+        // one-past-the-end limit, and the failure must name StartColumn (not EndColumn).
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var edit = new TextEditDto(1, 500, 1, 500, "oops");
+
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
+        StringAssert.Contains(ex.Message, "StartColumn 500", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_EndColumnPastEndOfLine_ThrowsArgumentException()
+    {
+        // edit-preview-validation-decomposition: the EndColumn-overflow branch of the extracted
+        // ValidateEditRange. StartColumn is valid here, so this can only trip the *end* check —
+        // pinning the branch order (start-overflow before end-overflow before reversed-range).
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        var edit = new TextEditDto(1, 1, 1, 500, "oops");
+
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+            EditService.ApplyTextEditsAsync(workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None));
+        StringAssert.Contains(ex.Message, "EndColumn 500", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_WholeLineReplacement_PreservesLfTerminator()
+    {
+        // edit-preview-validation-decomposition: exercises the extracted
+        // AdjustReplacementForTrailingLineBreak. A span ending at column 1 of the NEXT line swallows
+        // line 5's terminator; the replacement carries none of its own, so the LF must be
+        // re-appended or lines 5 and 6 silently merge.
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalText = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+
+        var edit = new TextEditDto(5, 1, 6, 1, "    public string Name => \"Cat\";");
+        var result = await EditService.ApplyTextEditsAsync(
+            workspace.WorkspaceId, dogFilePath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(result.Success);
+
+        var after = await File.ReadAllTextAsync(dogFilePath, CancellationToken.None);
+        Assert.AreEqual(originalText.Replace("\"Dog\"", "\"Cat\"", StringComparison.Ordinal), after,
+            "A whole-line replacement whose span ends at column 1 must preserve the swallowed line terminator.");
+    }
+
+    [TestMethod]
+    public async Task ApplyTextEdit_WholeLineReplacementInCrlfFile_PreservesCrlfTerminator()
+    {
+        // edit-preview-validation-decomposition, risk (b): the \r\n branch of the extracted
+        // AdjustReplacementForTrailingLineBreak. Detection probes for the paired \r BEFORE settling
+        // for a bare \n — without that ordering a CRLF file silently degrades to mixed endings on
+        // every whole-line replacement, with no compile-time or syntax-check signal.
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        var crlfPath = workspace.GetPath("SampleLib", "CrlfLineEndingFixture.cs");
+        const string crlfSource =
+            "namespace SampleLib;\r\n" +
+            "\r\n" +
+            "public class CrlfLineEndingFixture\r\n" +
+            "{\r\n" +
+            "    public string Value => \"before\";\r\n" +
+            "}\r\n";
+        await File.WriteAllTextAsync(crlfPath, crlfSource, CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var edit = new TextEditDto(5, 1, 6, 1, "    public string Value => \"after\";");
+        var result = await EditService.ApplyTextEditsAsync(
+            workspace.WorkspaceId, crlfPath, new[] { edit }, "apply_text_edit", CancellationToken.None);
+        Assert.IsTrue(result.Success);
+
+        var after = await File.ReadAllTextAsync(crlfPath, CancellationToken.None);
+        Assert.AreEqual(crlfSource.Replace("\"before\"", "\"after\"", StringComparison.Ordinal), after,
+            "A whole-line replacement in a CRLF file must re-append \\r\\n, not a bare \\n.");
+    }
+
+    [TestMethod]
     public async Task ApplyTextEdit_RejectsBadEdit_WithoutTouchingDisk()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);

--- a/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs
@@ -83,4 +83,83 @@ public sealed class PreviewMultiFileEditSyntaxRegressionTests : IsolatedWorkspac
         Assert.IsFalse(string.IsNullOrEmpty(dto.PreviewToken));
         Assert.IsTrue(dto.Changes?.Count > 0);
     }
+
+    // ------------------------------------------------------------------
+    // edit-preview-validation-decomposition: both preview entry points now share one
+    // SimulatePreviewAsync body. These cases pin the shared body's two observable behaviours —
+    // syntax preflight and cross-file diff ordering — from BOTH call sites, so a future change to
+    // the shared helper cannot silently diverge the public and internal surfaces.
+    // ------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task PreviewMultiFileOnSolution_F17NamespaceCommentBrace_ThrowsWhenSyntaxCheckEnabled()
+    {
+        var edit = NewEditService();
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+        var fileEdits = new[] { new FileEditsDto(dogFilePath, new[] { await F17EditAsync(dogFilePath) }) };
+        var solution = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId);
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+        {
+            await edit.PreviewMultiFileTextEditsOnSolutionAsync(
+                solution, fileEdits, CancellationToken.None, skipSyntaxCheck: false);
+        });
+        StringAssert.Contains(ex.Message, "preview_multi_file_edit", StringComparison.Ordinal);
+        StringAssert.Contains(ex.Message, "syntax", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [TestMethod]
+    public async Task PreviewMultiFile_BothEntryPoints_ProduceIdenticalCrossFileDiffOrdering()
+    {
+        var edit = NewEditService();
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var workspaceId = workspace.WorkspaceId;
+        var catFilePath = workspace.GetPath("SampleLib", "Cat.cs");
+        var dogFilePath = workspace.GetPath("SampleLib", "Dog.cs");
+
+        // Cat first, Dog second — the shared helper must emit diffs in the caller's input order,
+        // not in path or document order.
+        var fileEdits = new[]
+        {
+            new FileEditsDto(catFilePath, new[] { new TextEditDto(1, 1, 1, 1, "// cat marker\n") }),
+            new FileEditsDto(dogFilePath, new[] { new TextEditDto(1, 1, 1, 1, "// dog marker\n") }),
+        };
+
+        var viaSolution = await edit.PreviewMultiFileTextEditsOnSolutionAsync(
+            WorkspaceManager.GetCurrentSolution(workspaceId), fileEdits, CancellationToken.None);
+        var viaWorkspace = await edit.PreviewMultiFileTextEditsAsync(
+            workspaceId, fileEdits, CancellationToken.None);
+
+        CollectionAssert.AreEqual(
+            viaSolution.Changes.Select(c => c.FilePath).ToArray(),
+            viaWorkspace.Changes!.Select(c => c.FilePath).ToArray(),
+            "Both preview entry points must report the same files in the same order.");
+        CollectionAssert.AreEqual(
+            viaSolution.Changes.Select(c => c.UnifiedDiff).ToArray(),
+            viaWorkspace.Changes!.Select(c => c.UnifiedDiff).ToArray(),
+            "Both preview entry points must produce byte-identical unified diffs.");
+        Assert.AreEqual(catFilePath, viaWorkspace.Changes![0].FilePath, "Input order must be preserved.");
+        Assert.AreEqual(viaSolution.Description, viaWorkspace.Description);
+    }
+
+    private static EditService NewEditService() => new(
+        WorkspaceManager,
+        NullLogger<EditService>.Instance,
+        UndoService,
+        ChangeTracker,
+        PreviewStore,
+        CompileCheckService);
+
+    /// <summary>
+    /// The Jellyfin F17 parser-recovery shape (file-scoped namespace + line comment + stray brace)
+    /// appended to the end of line 1 of <paramref name="filePath"/>.
+    /// </summary>
+    private static async Task<TextEditDto> F17EditAsync(string filePath)
+    {
+        var firstLine = (await File.ReadAllTextAsync(filePath, CancellationToken.None))
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries)[0];
+        var colAfterLine1 = firstLine.Length + 1;
+        return new TextEditDto(1, colAfterLine1, 1, colAfterLine1, "\n// F17\n{\n");
+    }
 }


### PR DESCRIPTION
## Summary

Splits three over-complex `EditService` members into named single-purpose helpers. Pure structural refactor — coordinate validation, overlap validation, line-break preservation, and syntax preflight all behave exactly as before, and no public or internal signature changes.

## Linked issue

No GitHub issue — the `edit-preview-validation-decomposition` backlog row carries no `[gh #NNN]` mirror.

## Changes

- `src/RoslynMcp.Roslyn/Services/EditService.cs`
  - `ValidateEdits` (was CC 15 / 71 lines) is now a thin orchestrator. Its per-edit loop body splits into `ValidateEditShape` (checks that need only the edit — null `NewText`, non-positive coordinates) and `ValidateEditBounds` (checks against the target document — out-of-range line, StartColumn/EndColumn overflow, reversed range). The split point is the safety boundary: `ValidateEditShape` proves every coordinate is positive before `ValidateEditBounds` uses one as a 1-based index into `SourceText.Lines`. Branch order within and across the two is unchanged, so a multi-violation edit still reports the same first violation.
  - `BuildPatchedSourceText`'s inline trailing-line-break branch moves into `AdjustReplacementForTrailingLineBreak` + `GetSwallowedLineBreak`, preserving the `\r\n`-before-`\n`-before-`\r` detection order.
  - `PreviewMultiFileTextEditsAsync` and `PreviewMultiFileTextEditsOnSolutionAsync` were ~90% duplicated. Their shared validate-then-simulate body is now `SimulatePreviewAsync`; the two callers differ only in packaging (preview token + `RefactoringPreviewDto` vs. the raw tuple). That duplication was the root cause of the spread complexity — any new preflight check previously had to be hand-mirrored across both bodies, with drift going unnoticed.
  - Also introduces `EditsParamName`, so `ValidateEditShape`/`ValidateEditBounds` — which see one edit, not the batch — keep reporting the caller-visible `edits` parameter name in `ArgumentException.ParamName`.
- `tests/RoslynMcp.Tests/EditUndoCohesionTests.cs` — adds the two genuinely-uncovered validation branches (StartColumn overflow, EndColumn overflow) plus LF and CRLF whole-line-replacement terminator-preservation cases.
- `tests/RoslynMcp.Tests/PreviewMultiFileEditSyntaxRegressionTests.cs` — adds syntax-preflight and cross-file-diff-ordering parity assertions driven through **both** preview entry points, so the new shared helper cannot silently diverge the public and internal surfaces.
- `changelog.d/edit-preview-validation-decomposition.md` — Maintenance fragment.

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds — clean in both Debug and Release with `-p:TreatWarningsAsErrors=true` (0 warnings, 0 errors)
- [x] `dotnet test RoslynMcp.slnx` passes — 299/299 across `EditUndoCohesionTests`, `PreviewMultiFileEditSyntaxRegressionTests`, `SymbolRefactorPreview*`, `ApplyTextEditVerify*`, `EditUndoIntegration*`, `MultiFileEdit*`, `IntegrationTests*`
- [x] Manually verified the behavior (see below)

**Mutation-check on the highest-risk extraction.** The CRLF branch of `GetSwallowedLineBreak` is the one place a reordering corrupts files with no compile-time or syntax-check signal, so the new test was verified to actually bite: forcing the paired-`\r` probe to yield a bare `\n` fails `ApplyTextEdit_WholeLineReplacementInCrlfFile_PreservesCrlfTerminator` on exactly the silent degradation it guards —

```
expected: "...    public string Value => \"after\";\r\n}\r\n"
actual:   "...    public string Value => \"after\";\n}\r\n"
```

**Complexity ceiling.** `get_complexity_metrics` over the post-refactor file reports every method in `EditService.cs` at CC ≤ 8, against the initiative's CC < 10 acceptance ceiling (`ValidateEditBounds` 8, `SimulatePreviewAsync` 7, `AdjustReplacementForTrailingLineBreak` and `GetSwallowedLineBreak` well below). An intermediate single-helper shape measured CC 13/10 and was split further rather than shipped against the ceiling.

Also green: `eng/verify-ai-docs.ps1`, `eng/verify-changelog-fragments.ps1`.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings (warnings are treated as errors)
- [x] Public API changes are intentional and documented — there are none. `IEditService`, `SymbolRefactorService`, and `MultiFileEditTools` reference the two preview methods; neither signature changed, so all three are untouched.

## Backlog (maintainer-only)

- Closes backlog row: `edit-preview-validation-decomposition`

Closes: edit-preview-validation-decomposition
