### PR TITLE
refactor(elicitation): single-source the TryElicitChoiceAsync docs (elicitation-forwarder-collapse-trychoice-docs)

### DIFF
--- a/changelog.d/elicitation-forwarder-collapse-trychoice-docs.md
+++ b/changelog.d/elicitation-forwarder-collapse-trychoice-docs.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Single-sourced the `TryElicitChoiceAsync` XML doc — previously byte-identical across three files, one of which still claimed ownership of a body that moved to `ElicitationChoicePrompt` in PR #1205 — by deleting the two traffic-free forwarders in `StructuredCallToolFilter` and `StructuredCallElicitationCoordinator`. Also corrected the `returns` contract, which still claimed cancellation yields `null` after `elicitation-trychoice-cancellation-swallow` changed it to propagate `OperationCanceledException`, and de-hardcoded the namespace-cycle guard test's method name from the layering-invariant doc. All members are `internal`; no published-surface change. (elicitation-doc-drift-and-delegate-chain, part 2 of 2)

--- a/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
@@ -19,15 +19,10 @@ namespace RoslynMcp.Host.Stdio.Elicitation;
 /// <b>Layering invariant:</b> this type must never import <c>RoslynMcp.Host.Stdio.Middleware</c>,
 /// <c>RoslynMcp.Host.Stdio.Tools</c>, or any other <c>RoslynMcp.*</c> namespace — only the MCP SDK
 /// and BCL. Any such <c>using</c> re-creates the namespace cycle this type exists to break, and is
-/// caught by
-/// <c>ExpandedSurfaceIntegrationTests_RepoSolutionAnalysis.No_Circular_Namespace_Dependency_Between_Middleware_And_Tools</c>.
-/// </para>
-///
-/// <para>
-/// <c>StructuredCallElicitationCoordinator.TryElicitChoiceAsync</c> is retained as a thin delegate
-/// forwarding here, so the historical Middleware-internal static call surface (consumed by
-/// <c>StructuredCallToolFilter</c> and the existing elicitation test suites) is preserved
-/// byte-for-byte.
+/// caught by the namespace-cycle guard test in
+/// <c>tests/RoslynMcp.Tests/ExpandedSurfaceIntegrationTests.RepoSolutionAnalysis.cs</c> (the guard
+/// is named by file rather than by method so a test rename cannot silently rot this reference —
+/// elicitation-forwarder-collapse-trychoice-docs).
 /// </para>
 /// </summary>
 internal static class ElicitationChoicePrompt
@@ -55,10 +50,10 @@ internal static class ElicitationChoicePrompt
     /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
     /// helper. Builds an enum-shaped <c>elicitation/create</c> request whose options carry
     /// short candidate labels and stable string keys, calls the SDK, and returns the chosen
-    /// key (or <see langword="null"/> when the user declined / the client lacks elicitation /
-    /// the request itself failed). The caller uses the returned key to map back to the
-    /// original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call against that
-    /// chosen candidate.
+    /// key (see <c>returns</c> for the exact null arms). The caller uses the returned key to
+    /// map back to the original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call
+    /// against that chosen candidate. Sole definition of the picker — <c>Middleware</c> and
+    /// <c>Tools</c> both call it here; no forwarding delegates exist.
     /// </summary>
     /// <param name="server">The connected <see cref="McpServer"/>; <see langword="null"/> short-circuits to null.</param>
     /// <param name="paramName">
@@ -72,7 +67,22 @@ internal static class ElicitationChoicePrompt
     /// <c>Label</c> is the human-readable text shown in the picker.
     /// </param>
     /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
-    /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
+    /// <returns>
+    /// The chosen <c>Key</c> when the user accepts. <see langword="null"/> when:
+    /// <paramref name="server"/> is <see langword="null"/>; the client did not declare the
+    /// <c>elicitation</c> capability; the request is malformed (<paramref name="paramName"/> empty,
+    /// <paramref name="options"/> null or empty, or every option's <c>Key</c> empty); the user
+    /// declined or the SDK returned no <see cref="ElicitResult.Content"/>; the accepted content
+    /// omits <paramref name="paramName"/> or carries a non-string / empty value; or the SDK threw
+    /// <see cref="InvalidOperationException"/> or <see cref="McpException"/> (logged at Debug, then
+    /// degraded to the additive-list fallback).
+    ///
+    /// <para>
+    /// <b>Not</b> null on cancellation: <see cref="OperationCanceledException"/> propagates to the
+    /// caller rather than degrading to <see langword="null"/>, so a cancelled request unwinds
+    /// instead of being reported as a decline (elicitation-trychoice-cancellation-swallow).
+    /// </para>
+    /// </returns>
     public static async Task<string?> TryElicitChoiceAsync(
         McpServer? server,
         string paramName,

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
@@ -10,18 +10,23 @@ namespace RoslynMcp.Host.Stdio.Middleware;
 /// The elicitation/retry orchestration layer extracted from <see cref="StructuredCallToolFilter"/>.
 /// Owns the <em>how</em> of asking the user for a missing value via MCP <c>elicitation/create</c>
 /// and re-dispatching the original call — the exception-path recovery
-/// (<see cref="TryElicitAndRetryAsync"/>), the workspaceId-specific recover-load-retry loop
-/// (<see cref="TryRecoverMissingWorkspaceIdAsync"/>), and the shared select-from-N picker
-/// (<see cref="TryElicitChoiceAsync"/>). Whether a parameter <em>may</em> be elicited stays in
-/// <see cref="ElicitationAllowlistPolicy"/>; metrics stay in <see cref="CallMetricsRecorder"/>;
-/// the pre-dispatch auto-resolve/auto-load flow and error-envelope construction stay in the filter.
+/// (<see cref="TryElicitAndRetryAsync"/>) and the workspaceId-specific recover-load-retry loop
+/// (<see cref="TryRecoverMissingWorkspaceIdAsync"/>). Whether a parameter <em>may</em> be elicited
+/// stays in <see cref="ElicitationAllowlistPolicy"/>; metrics stay in
+/// <see cref="CallMetricsRecorder"/>; the pre-dispatch auto-resolve/auto-load flow and
+/// error-envelope construction stay in the filter. The shared select-from-N picker is NOT owned
+/// here — its canonical (and only) home is
+/// <see cref="ElicitationChoicePrompt.TryElicitChoiceAsync"/>, in the cycle-free
+/// <c>RoslynMcp.Host.Stdio.Elicitation</c> namespace so <c>Tools</c> can call it without importing
+/// <c>Middleware</c>.
 ///
 /// <para>
-/// <see cref="StructuredCallToolFilter"/> keeps thin delegates that forward to these members, so
-/// its historical static call surface (consumed by <c>SymbolTools</c> and the existing filter test
-/// suites) is preserved byte-for-byte. <see cref="DispatchWithTemporaryArgumentsAsync"/> and
-/// <see cref="TryExtractWorkspaceId"/> are <c>internal</c> (not <c>private</c>) so the filter's
-/// retained <c>TryAutoLoadWorkspaceAsync</c> can keep calling them directly.
+/// <see cref="StructuredCallToolFilter"/> keeps thin delegates forwarding to
+/// <see cref="TryElicitAndRetryAsync"/> and <see cref="TryRecoverMissingWorkspaceIdAsync"/>, so its
+/// historical static call surface (consumed by the existing filter test suites) is preserved.
+/// <see cref="DispatchWithTemporaryArgumentsAsync"/> and <see cref="TryExtractWorkspaceId"/> are
+/// <c>internal</c> (not <c>private</c>) so the filter's retained <c>TryAutoLoadWorkspaceAsync</c>
+/// can keep calling them directly.
 /// </para>
 /// </summary>
 internal static class StructuredCallElicitationCoordinator
@@ -249,45 +254,6 @@ internal static class StructuredCallElicitationCoordinator
             return null;
         }
     }
-
-    /// <summary>
-    /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
-    /// helper. Builds an enum-shaped <c>elicitation/create</c> request whose options carry
-    /// short candidate labels and stable string keys, calls the SDK, and returns the chosen
-    /// key (or <see langword="null"/> when the user declined / the client lacks elicitation /
-    /// the request itself failed). The caller uses the returned key to map back to the
-    /// original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call against that
-    /// chosen candidate.
-    /// </summary>
-    /// <param name="server">The connected <see cref="McpServer"/>; <see langword="null"/> short-circuits to null.</param>
-    /// <param name="paramName">
-    /// Name of the schema field carrying the picked option — also the dictionary key the
-    /// SDK populates in <see cref="ElicitResult.Content"/>. Conventionally <c>"choice"</c>.
-    /// </param>
-    /// <param name="title">Short title shown above the option list.</param>
-    /// <param name="description">Longer description (one or two sentences) explaining why the user is being asked.</param>
-    /// <param name="options">
-    /// The select-from-N options. <c>Key</c> is the stable identifier returned to the caller,
-    /// <c>Label</c> is the human-readable text shown in the picker.
-    /// </param>
-    /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
-    /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
-    /// <remarks>
-    /// Thin delegate onto <see cref="ElicitationChoicePrompt.TryElicitChoiceAsync"/>, which is the
-    /// canonical home — the picker lives in the cycle-free
-    /// <c>RoslynMcp.Host.Stdio.Elicitation</c> namespace so <c>Tools</c> can call it without
-    /// importing <c>Middleware</c>. Retained here so this class's historical static call surface
-    /// (and its test suite) keeps compiling unchanged.
-    /// </remarks>
-    public static Task<string?> TryElicitChoiceAsync(
-        McpServer? server,
-        string paramName,
-        string title,
-        string description,
-        IReadOnlyList<(string Key, string Label)> options,
-        CancellationToken cancellationToken) =>
-        ElicitationChoicePrompt.TryElicitChoiceAsync(
-            server, paramName, title, description, options, cancellationToken);
 
     /// <summary>
     /// Inspects <paramref name="ex"/> for the InvalidArgument-shaped binding-failure

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -454,38 +454,6 @@ internal static class StructuredCallToolFilter
             toolName, originalArguments, elicitAsync, dispatchAsync, logger, cancellationToken);
 
     /// <summary>
-    /// elicit-disambiguation-on-multi-symbol-resolve: shared select-from-N elicitation
-    /// helper. Builds an enum-shaped <c>elicitation/create</c> request whose options carry
-    /// short candidate labels and stable string keys, calls the SDK, and returns the chosen
-    /// key (or <see langword="null"/> when the user declined / the client lacks elicitation /
-    /// the request itself failed). The caller uses the returned key to map back to the
-    /// original candidate (e.g. an <c>ISymbol</c>) and re-runs the tool call against that
-    /// chosen candidate.
-    /// </summary>
-    /// <param name="server">The connected <see cref="McpServer"/>; <see langword="null"/> short-circuits to null.</param>
-    /// <param name="paramName">
-    /// Name of the schema field carrying the picked option — also the dictionary key the
-    /// SDK populates in <see cref="ElicitResult.Content"/>. Conventionally <c>"choice"</c>.
-    /// </param>
-    /// <param name="title">Short title shown above the option list.</param>
-    /// <param name="description">Longer description (one or two sentences) explaining why the user is being asked.</param>
-    /// <param name="options">
-    /// The select-from-N options. <c>Key</c> is the stable identifier returned to the caller,
-    /// <c>Label</c> is the human-readable text shown in the picker.
-    /// </param>
-    /// <param name="cancellationToken">Cancellation token (request-scoped).</param>
-    /// <returns>The chosen <c>Key</c> on accept; <see langword="null"/> on decline / cancel / unsupported / error.</returns>
-    public static Task<string?> TryElicitChoiceAsync(
-        McpServer? server,
-        string paramName,
-        string title,
-        string description,
-        IReadOnlyList<(string Key, string Label)> options,
-        CancellationToken cancellationToken) =>
-        StructuredCallElicitationCoordinator.TryElicitChoiceAsync(
-            server, paramName, title, description, options, cancellationToken);
-
-    /// <summary>
     /// Produces the <see cref="CallToolResult"/> envelope the filter emits when a tool call
     /// throws. Visible to tests so the classifier→envelope→<c>_meta</c> pipeline can be
     /// asserted without standing up a real <c>RequestContext</c> / <c>McpServer</c>.

--- a/tests/RoslynMcp.Tests/StructuredCallElicitationCoordinatorTests.cs
+++ b/tests/RoslynMcp.Tests/StructuredCallElicitationCoordinatorTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using ModelContextProtocol.Protocol;
 using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Elicitation;
 using RoslynMcp.Host.Stdio.Middleware;
 
 namespace RoslynMcp.Tests;
@@ -17,8 +18,11 @@ namespace RoslynMcp.Tests;
 /// The recover-load-retry loop takes its elicit + dispatch collaborators as delegates, so it is
 /// fully unit-testable without standing up a live MCP transport. <see cref="McpServer"/>-bound
 /// entry points (<c>TryElicitAndRetryAsync</c>, the transport-driven arms of
-/// <c>TryElicitChoiceAsync</c>) still require a real server; their gate logic is covered via the
-/// null-short-circuit and the allowlist tests in <see cref="StructuredCallToolFilterElicitationTests"/>.
+/// <see cref="ElicitationChoicePrompt.TryElicitChoiceAsync"/>) still require a real server; their
+/// gate logic is covered via the null-short-circuit and the allowlist tests in
+/// <see cref="StructuredCallToolFilterElicitationTests"/>. The picker itself is not a coordinator
+/// member — its canonical home is <see cref="ElicitationChoicePrompt"/>; the null-server
+/// short-circuit is pinned here for historical continuity with this suite.
 /// </para>
 /// </summary>
 [TestClass]
@@ -186,7 +190,7 @@ public sealed class StructuredCallElicitationCoordinatorTests
     {
         // The disambiguation picker short-circuits to null when there is no connected server,
         // so a caller with no elicitation-capable client falls through to its additive list.
-        var result = await StructuredCallElicitationCoordinator.TryElicitChoiceAsync(
+        var result = await ElicitationChoicePrompt.TryElicitChoiceAsync(
             server: null,
             paramName: "choice",
             title: "Pick a symbol",


### PR DESCRIPTION
Part 2 of 2 of `elicitation-doc-drift-and-delegate-chain` (part 1 was #1237, `elicitation-forwarder-collapse-haselicitation`). Backlog sweep `20260813T172325Z`, initiative `elicitation-forwarder-collapse-trychoice-docs`.

## Problem

The ~13-line param/returns XML doc block for `TryElicitChoiceAsync` was **byte-identical in three files** — the canonical `ElicitationChoicePrompt`, plus traffic-free forwarders in `StructuredCallElicitationCoordinator` and `StructuredCallToolFilter`. `StructuredCallElicitationCoordinator`'s class summary still claimed to own the picker even though its body moved to `ElicitationChoicePrompt` in #1205. And all three copies of `<returns>` said "null on decline / **cancel** / unsupported / error", which stopped being true when `elicitation-trychoice-cancellation-swallow` narrowed the catch to `InvalidOperationException` / `McpException` — `OperationCanceledException` now propagates rather than degrading to null.

Production callers of both forwarders: **zero**. `SymbolTools.cs:105,941` already call `ElicitationChoicePrompt.TryElicitChoiceAsync` directly.

## Changes

| File | Change |
|---|---|
| `StructuredCallToolFilter.cs` | Delete the `TryElicitChoiceAsync` forwarder + its duplicated doc block. No using churn — it forwarded to a same-namespace type. |
| `StructuredCallElicitationCoordinator.cs` | Delete the forwarder, its doc block, and its `<remarks>`. Rewrite the class summary to name `ElicitationChoicePrompt` as the picker's canonical home and narrow the retained-delegates paragraph to the two members the filter still forwards (`TryElicitAndRetryAsync`, `TryRecoverMissingWorkspaceIdAsync`). |
| `ElicitationChoicePrompt.cs` | Rewrite `<returns>` to enumerate every null arm read from the body, and state explicitly that `OperationCanceledException` propagates. De-hardcode the namespace-cycle guard test's FQN — reference the test *file* instead. Drop the now-false retained-delegates paragraph. |
| `StructuredCallElicitationCoordinatorTests.cs` | Retarget the single call site to `ElicitationChoicePrompt.TryElicitChoiceAsync` (mirroring `SymbolDisambiguationElicitationTests.cs:344`). No new tests, no assertion changes. |

### Silent-cref note

The coordinator summary's `<see cref="TryElicitChoiceAsync"/>` would have dangled once the member was deleted. `GenerateDocumentationFile` is unset, so **CS1574 never fires** and the build would have stayed green with a broken cref. It is removed as part of the summary rewrite.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — **0 warnings, 0 errors**.
- `./eng/verify-ai-docs.ps1` — passed (32 shipped SKILL.md checked).
- Targeted tests — **51 passed, 0 failed**: `StructuredCallElicitationCoordinatorTests`, `SymbolDisambiguationElicitationTests`, `StructuredCallToolFilterElicitationTests`, `ElicitationAllowlistPolicyTests`, and `No_Circular_Namespace_Dependency_Between_Middleware_And_Tools`.
- `grep src/` — `TryElicitChoiceAsync` and `HasElicitation` each have **exactly one definition**, both on `ElicitationChoicePrompt`; remaining call sites are `SymbolTools.cs:105,941`.
- `grep src/` for `No_Circular_Namespace_Dependency` — zero hits (hardcoded FQN gone).

All members are `internal`; no published-surface change.

Closes: elicitation-doc-drift-and-delegate-chain
