### PR TITLE
refactor(roslyn): extract SourceFileEncoding out of AtomicFileWriter

### DIFF
--- a/changelog.d/extract-atomicfilewriter-encoding-helper.md
+++ b/changelog.d/extract-atomicfilewriter-encoding-helper.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extracted the BOM/encoding-sniffing logic shared by `AtomicFileWriter`, `EditorConfigService`, `ProjectMutationService`, `EditService`, `UndoService`, and `CsprojSemanticEquality` into a single `SourceFileEncoding` helper (`src/RoslynMcp.Roslyn/Helpers/SourceFileEncoding.cs`). Removes an inverted dependency where non-atomic writers borrowed `AtomicFileWriter` purely as an encoding sniffer, and removes a full-file decode + discarded snapshot allocation from every mutation-apply write path that only needed the detected encoding. No behavior change.

--- a/src/RoslynMcp.Roslyn/Helpers/CsprojSemanticEquality.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/CsprojSemanticEquality.cs
@@ -261,18 +261,25 @@ internal static class CsprojSemanticEquality
         return snapshots;
     }
 
+    /// <remarks>
+    /// BOM detection is delegated to <see cref="SourceFileEncoding.Sniff"/> so this helper — scoped
+    /// by its doc header to csproj-XML semantic comparison — is no longer the app's de-facto shared
+    /// BOM detector (<c>extract-atomicfilewriter-encoding-helper</c>). The second
+    /// <see cref="StreamReader"/> below is constructed with the already-detected encoding, so it
+    /// still strips a matching preamble (<see cref="StreamReader"/> checks the preamble of the
+    /// encoding it was given regardless of <c>detectEncodingFromByteOrderMarks</c>) and the decoded
+    /// <c>Content</c> is byte-for-byte what the single-reader version produced.
+    /// </remarks>
     internal static ProjectFileSnapshot CreateSnapshot(byte[] bytes)
     {
+        var (encoding, hasPreamble) = SourceFileEncoding.Sniff(bytes);
         using var stream = new MemoryStream(bytes, writable: false);
         using var reader = new StreamReader(
             stream,
-            Encoding.UTF8,
-            detectEncodingFromByteOrderMarks: true,
+            encoding,
+            detectEncodingFromByteOrderMarks: false,
             leaveOpen: false);
         var content = reader.ReadToEnd();
-        var encoding = reader.CurrentEncoding;
-        var preamble = encoding.GetPreamble();
-        var hasPreamble = preamble.Length > 0 && bytes.AsSpan().StartsWith(preamble);
         return new ProjectFileSnapshot(content, bytes, encoding, hasPreamble);
     }
 

--- a/src/RoslynMcp.Roslyn/Helpers/SourceFileEncoding.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/SourceFileEncoding.cs
@@ -1,0 +1,117 @@
+using System.Text;
+
+namespace RoslynMcp.Roslyn.Helpers;
+
+/// <summary>
+/// Shared BOM/encoding detection for every path that rewrites a file on disk and must keep the
+/// file's original encoding byte-faithful (<c>mutation-write-paths-drop-original-encoding</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <c>AtomicFileWriter</c> (<c>extract-atomicfilewriter-encoding-helper</c>).
+/// Encoding sniffing is not atomic-write plumbing, yet five non-atomic-write call sites —
+/// <c>EditorConfigService</c> (which writes via <see cref="File.WriteAllLines(string, IEnumerable{string}, Encoding)"/>),
+/// <c>ProjectMutationService</c>, <c>EditService</c>, <c>UndoService</c>, and
+/// <c>CompositeApplyOrchestrator</c> — depended on <c>AtomicFileWriter</c> purely as a sniffer.
+/// That inverted dependency also made <see cref="CsprojSemanticEquality"/> (scoped by its own doc
+/// header to csproj-XML semantic comparison) the de-facto BOM detector for <c>.editorconfig</c>
+/// and every mutation-write path. Detection now lives here; <c>CsprojSemanticEquality</c> is a
+/// consumer like everyone else.
+/// </para>
+/// <para>
+/// Detection is BOM-based only, delegated to <see cref="StreamReader"/>'s own byte-order-mark
+/// detection rather than a hand-rolled preamble table (a manual table has to get the
+/// UTF-32LE/UTF-16LE BOM-prefix overlap right; the BCL already does). A BOM-less UTF-16 or
+/// codepage file is indistinguishable from UTF-8 here and is rewritten as UTF-8-no-BOM, matching
+/// the pre-extraction behavior.
+/// </para>
+/// </remarks>
+internal static class SourceFileEncoding
+{
+    /// <summary>
+    /// UTF-8 without a byte-order mark — the encoding .NET's <c>Encoding</c>-less
+    /// <see cref="File.WriteAllTextAsync(string, string?, CancellationToken)"/> overload uses.
+    /// Also the correct default for a brand-new file and for any source whose original encoding
+    /// could not be determined, so omitting <c>encoding</c> preserves the pre-existing behavior
+    /// byte-for-byte. Deliberately NOT <see cref="Encoding.UTF8"/>: that static instance emits a
+    /// BOM, so using it would ADD a preamble to every no-BOM file.
+    /// </summary>
+    internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    /// <summary>
+    /// Detects the encoding of <paramref name="bytes"/> from its byte-order mark, reporting both
+    /// the detected <see cref="Encoding"/> and whether the bytes actually carry that encoding's
+    /// preamble.
+    /// </summary>
+    /// <remarks>
+    /// The two results are NOT redundant. With no BOM present <see cref="StreamReader"/> falls back
+    /// to the encoding it was constructed with — <see cref="Encoding.UTF8"/>, which is
+    /// BOM-<em>emitting</em> — so callers that want to re-emit the original preamble must gate on
+    /// <c>HasPreamble</c> rather than trusting the detected instance (see <see cref="FromBytes"/>).
+    /// Only <see cref="TextReader.Peek"/> is called: that forces <see cref="StreamReader"/>'s lazy
+    /// BOM detection on its first internal buffer fill WITHOUT decoding the file to EOF, so callers
+    /// that only want the encoding no longer pay for a full-file decode.
+    /// </remarks>
+    internal static (Encoding Encoding, bool HasPreamble) Sniff(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            leaveOpen: false);
+        reader.Peek();
+        var encoding = reader.CurrentEncoding;
+        var preamble = encoding.GetPreamble();
+        var hasPreamble = preamble.Length > 0 && bytes.AsSpan().StartsWith(preamble);
+        return (encoding, hasPreamble);
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="Encoding"/> a file should be REWRITTEN with, given the bytes it
+    /// held before the mutation. Returns <see cref="Utf8NoBom"/> when <paramref name="existingBytes"/>
+    /// is <see langword="null"/> or empty (the file is being created) or when the original carried
+    /// no preamble. Otherwise returns the BOM-derived encoding so the preamble is re-emitted verbatim.
+    /// </summary>
+    /// <remarks>
+    /// The <c>HasPreamble</c> gate is load-bearing. <see cref="Sniff"/> reports
+    /// <see cref="Encoding.UTF8"/> (BOM-emitting) for a plain no-BOM UTF-8 file, because that is the
+    /// <see cref="StreamReader"/> fallback when no byte-order mark is detected. Writing with that
+    /// instance would add a BOM to every no-BOM file, so the no-preamble case must fall back to
+    /// <see cref="Utf8NoBom"/> instead of trusting the detected encoding.
+    /// </remarks>
+    internal static Encoding FromBytes(byte[]? existingBytes)
+    {
+        if (existingBytes is null || existingBytes.Length == 0)
+        {
+            return Utf8NoBom;
+        }
+
+        var (encoding, hasPreamble) = Sniff(existingBytes);
+        return hasPreamble ? encoding : Utf8NoBom;
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="Encoding"/> to write with from an encoding Roslyn already attached
+    /// to a <c>SourceText</c> (<c>SourceText.Encoding</c>), which is <see langword="null"/> for text
+    /// synthesized in memory.
+    /// </summary>
+    /// <remarks>
+    /// A UTF-8 encoding that emits no preamble is normalized to the shared <see cref="Utf8NoBom"/>
+    /// instance rather than passed through: Roslyn's own no-BOM UTF-8 instance is constructed with
+    /// <c>throwOnInvalidBytes: true</c>, so writing through it would turn an unpaired surrogate into
+    /// a mid-write <see cref="EncoderFallbackException"/> where the pre-fix path silently emitted
+    /// U+FFFD. Non-UTF-8 and BOM-carrying encodings are preserved as-is.
+    /// </remarks>
+    internal static Encoding FromSourceText(Encoding? sourceEncoding)
+    {
+        if (sourceEncoding is null)
+        {
+            return Utf8NoBom;
+        }
+
+        return sourceEncoding.CodePage == Utf8NoBom.CodePage && sourceEncoding.GetPreamble().Length == 0
+            ? Utf8NoBom
+            : sourceEncoding;
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -93,7 +93,7 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
                     mutation.UpdatedContent ?? string.Empty,
                     ct,
                     _logger,
-                    encoding: AtomicFileWriter.ResolveWriteEncoding(preApplyBytes)).ConfigureAwait(false);
+                    encoding: SourceFileEncoding.FromBytes(preApplyBytes)).ConfigureAwait(false);
                 appliedFiles.Add(mutation.FilePath);
             }
 
@@ -146,23 +146,15 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
 /// <para>
 /// Text writes accept an optional <see cref="Encoding"/> so a mutated file keeps its original
 /// BOM/encoding (<c>mutation-write-paths-drop-original-encoding</c>). Callers resolve it through
-/// <see cref="ResolveWriteEncoding(byte[])"/> (from the pre-mutation on-disk bytes) or
-/// <see cref="ResolveWriteEncoding(Encoding)"/> (from a Roslyn <c>SourceText.Encoding</c>).
-/// Omitting it keeps the historic UTF-8-no-BOM behavior.
+/// <see cref="SourceFileEncoding.FromBytes(byte[])"/> (from the pre-mutation on-disk bytes) or
+/// <see cref="SourceFileEncoding.FromSourceText(Encoding)"/> (from a Roslyn <c>SourceText.Encoding</c>).
+/// Detection deliberately does NOT live on this class — it is not atomic-write plumbing
+/// (<c>extract-atomicfilewriter-encoding-helper</c>). Omitting the encoding keeps the historic
+/// UTF-8-no-BOM behavior.
 /// </para>
 /// </summary>
 internal static class AtomicFileWriter
 {
-    /// <summary>
-    /// UTF-8 without a byte-order mark — the encoding .NET's <c>Encoding</c>-less
-    /// <see cref="File.WriteAllTextAsync(string, string?, CancellationToken)"/> overload uses.
-    /// Also the correct default for a brand-new file and for any source whose original encoding
-    /// could not be determined, so omitting <c>encoding</c> preserves the pre-existing behavior
-    /// byte-for-byte. Deliberately NOT <see cref="Encoding.UTF8"/>: that static instance emits a
-    /// BOM, so using it would ADD a preamble to every no-BOM file.
-    /// </summary>
-    internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
     /// <summary>
     /// Atomically writes <paramref name="content"/> to <paramref name="path"/>.
     /// </summary>
@@ -191,56 +183,6 @@ internal static class AtomicFileWriter
             path,
             tmp => File.WriteAllBytesAsync(tmp, content, ct),
             logger).ConfigureAwait(false);
-
-    /// <summary>
-    /// Resolves the <see cref="Encoding"/> a file should be REWRITTEN with, given the bytes it
-    /// held before the mutation. Returns <see cref="Utf8NoBom"/> when <paramref name="existingBytes"/>
-    /// is <see langword="null"/> (the file is being created) or when the original carried no
-    /// preamble. Otherwise returns the BOM-derived encoding so the preamble is re-emitted verbatim.
-    /// </summary>
-    /// <remarks>
-    /// The <c>HasPreamble</c> gate is load-bearing. <see cref="CsprojSemanticEquality.CreateSnapshot"/>
-    /// reports <see cref="Encoding.UTF8"/> (BOM-emitting) for a plain no-BOM UTF-8 file, because that
-    /// is the <see cref="StreamReader"/> fallback when no byte-order mark is detected. Writing with
-    /// that instance would add a BOM to every no-BOM file, so the no-preamble case must fall back to
-    /// <see cref="Utf8NoBom"/> instead of trusting the detected encoding.
-    /// Encoding detection is BOM-based only: a BOM-less UTF-16/codepage file is indistinguishable
-    /// from UTF-8 here and is rewritten as UTF-8-no-BOM, matching the pre-fix behavior.
-    /// </remarks>
-    internal static Encoding ResolveWriteEncoding(byte[]? existingBytes)
-    {
-        if (existingBytes is null || existingBytes.Length == 0)
-        {
-            return Utf8NoBom;
-        }
-
-        var snapshot = CsprojSemanticEquality.CreateSnapshot(existingBytes);
-        return snapshot.HasPreamble ? snapshot.TextEncoding : Utf8NoBom;
-    }
-
-    /// <summary>
-    /// Resolves the <see cref="Encoding"/> to write with from an encoding Roslyn already attached
-    /// to a <c>SourceText</c> (<c>SourceText.Encoding</c>), which is <see langword="null"/> for text
-    /// synthesized in memory.
-    /// </summary>
-    /// <remarks>
-    /// A UTF-8 encoding that emits no preamble is normalized to the shared <see cref="Utf8NoBom"/>
-    /// instance rather than passed through: Roslyn's own no-BOM UTF-8 instance is constructed with
-    /// <c>throwOnInvalidBytes: true</c>, so writing through it would turn an unpaired surrogate into
-    /// a mid-write <see cref="EncoderFallbackException"/> where the pre-fix path silently emitted
-    /// U+FFFD. Non-UTF-8 and BOM-carrying encodings are preserved as-is.
-    /// </remarks>
-    internal static Encoding ResolveWriteEncoding(Encoding? sourceEncoding)
-    {
-        if (sourceEncoding is null)
-        {
-            return Utf8NoBom;
-        }
-
-        return sourceEncoding.CodePage == Utf8NoBom.CodePage && sourceEncoding.GetPreamble().Length == 0
-            ? Utf8NoBom
-            : sourceEncoding;
-    }
 
     private static async Task WriteAtomicAsync(
         string path,

--- a/src/RoslynMcp.Roslyn/Services/EditService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditService.cs
@@ -778,7 +778,7 @@ public sealed class EditService : IEditService
                 document.FilePath,
                 sourceText.ToString(),
                 ct,
-                encoding: AtomicFileWriter.ResolveWriteEncoding(sourceText.Encoding)).ConfigureAwait(false);
+                encoding: SourceFileEncoding.FromSourceText(sourceText.Encoding)).ConfigureAwait(false);
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
+++ b/src/RoslynMcp.Roslyn/Services/EditorConfigService.cs
@@ -375,7 +375,7 @@ public sealed class EditorConfigService : IEditorConfigService
         // .editorconfig. existingBytes is already in scope for the undo snapshot — reuse it to
         // detect the original encoding (null when we are creating the file, which correctly
         // resolves to UTF-8-no-BOM).
-        File.WriteAllLines(editorconfigPath, lines, AtomicFileWriter.ResolveWriteEncoding(existingBytes));
+        File.WriteAllLines(editorconfigPath, lines, SourceFileEncoding.FromBytes(existingBytes));
 
         // workspace-changes-log-missing-editorconfig-writers: route the editorconfig write
         // through ChangeTracker so `workspace_changes` surfaces the originating tool name

--- a/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ProjectMutationService.cs
@@ -571,7 +571,7 @@ public sealed class ProjectMutationService : IProjectMutationService
                 projectFilePath,
                 updatedContent,
                 ct,
-                encoding: AtomicFileWriter.ResolveWriteEncoding(preApplyBytes)).ConfigureAwait(false);
+                encoding: SourceFileEncoding.FromBytes(preApplyBytes)).ConfigureAwait(false);
             await _workspace.ReloadAsync(workspaceId, ct).ConfigureAwait(false);
             _previewStore.Invalidate(previewToken);
             _changeTracker?.RecordChange(workspaceId, $"Project mutation: {Path.GetFileName(projectFilePath)}", [projectFilePath], "apply_project_mutation");

--- a/src/RoslynMcp.Roslyn/Services/UndoService.cs
+++ b/src/RoslynMcp.Roslyn/Services/UndoService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
@@ -429,7 +430,8 @@ public sealed class UndoService : IUndoService, IDisposable
         // composite-apply-undo-encoding-still-lossy: the queued restores carry the pre-apply
         // `SourceText.Encoding` alongside the text so `PersistRevertChangesAsync` can rewrite each
         // file with its original BOM/encoding instead of collapsing everything to UTF-8-no-BOM.
-        // `Encoding` is null for in-memory-synthesized text; `ResolveWriteEncoding` handles that.
+        // `Encoding` is null for in-memory-synthesized text; `SourceFileEncoding.FromSourceText`
+        // handles that.
         var diskRestores = new List<(string FilePath, string Text, Encoding? Encoding)>();
 
         // Phase 1 (primary): trust the Solution diff to tell us what changed.
@@ -580,7 +582,7 @@ public sealed class UndoService : IUndoService, IDisposable
                     filePath,
                     text,
                     cancellationToken,
-                    encoding: AtomicFileWriter.ResolveWriteEncoding(encoding)).ConfigureAwait(false);
+                    encoding: SourceFileEncoding.FromSourceText(encoding)).ConfigureAwait(false);
                 anyDiskWrite = true;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/tests/RoslynMcp.Tests/SourceFileEncodingTests.cs
+++ b/tests/RoslynMcp.Tests/SourceFileEncodingTests.cs
@@ -1,0 +1,219 @@
+using System.Text;
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct coverage for <see cref="SourceFileEncoding"/> — the BOM/encoding sniffer extracted from
+/// <c>AtomicFileWriter</c> by <c>extract-atomicfilewriter-encoding-helper</c>. Before the
+/// extraction this logic was reachable only through integration suites
+/// (<c>ApplyTextEditVerifyTests</c>, <c>CsprojReserializationTests</c>, <c>UndoFileOperationsTests</c>),
+/// so its edge cases — no-BOM UTF-8 must NOT normalize to the BOM-emitting <see cref="Encoding.UTF8"/>,
+/// empty/short byte arrays, UTF-32LE/UTF-16LE BOM-prefix overlap — were only ever asserted
+/// indirectly. These are unit tests against the helper itself.
+/// </summary>
+[TestClass]
+public sealed class SourceFileEncodingTests
+{
+    // === Sniff ===
+
+    [TestMethod]
+    public void Sniff_NoBom_ReportsUtf8FallbackWithoutPreamble()
+    {
+        var bytes = Encoding.UTF8.GetBytes("<Project />");
+
+        var (encoding, hasPreamble) = SourceFileEncoding.Sniff(bytes);
+
+        // StreamReader's no-BOM fallback is the encoding it was constructed with — the
+        // BOM-EMITTING Encoding.UTF8 — so HasPreamble is the load-bearing signal, not the
+        // returned instance. Callers must gate on it (see FromBytes) or they would add a BOM.
+        Assert.AreEqual(Encoding.UTF8.CodePage, encoding.CodePage);
+        Assert.IsFalse(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_Utf8Bom_DetectsPreamble()
+    {
+        var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var bytes = WithPreamble(encoding, "<Project />");
+
+        var (detected, hasPreamble) = SourceFileEncoding.Sniff(bytes);
+
+        Assert.AreEqual(encoding.CodePage, detected.CodePage);
+        Assert.IsTrue(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_Utf16Le_DetectsPreambleAndCodePage()
+    {
+        var encoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+        var bytes = WithPreamble(encoding, "<Project />");
+
+        var (detected, hasPreamble) = SourceFileEncoding.Sniff(bytes);
+
+        Assert.AreEqual(encoding.CodePage, detected.CodePage);
+        Assert.IsTrue(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_Utf16Be_DetectsPreambleAndCodePage()
+    {
+        var encoding = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+        var bytes = WithPreamble(encoding, "<Project />");
+
+        var (detected, hasPreamble) = SourceFileEncoding.Sniff(bytes);
+
+        Assert.AreEqual(encoding.CodePage, detected.CodePage);
+        Assert.IsTrue(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_Utf32Le_IsNotMisreadAsUtf16Le()
+    {
+        // The UTF-32LE BOM (FF FE 00 00) starts with the complete UTF-16LE BOM (FF FE). A
+        // hand-rolled preamble table that tests UTF-16LE first silently mis-detects every
+        // UTF-32LE file; delegating to StreamReader avoids that trap. This test is the guard.
+        var encoding = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+        var bytes = WithPreamble(encoding, "<Project />");
+
+        var (detected, hasPreamble) = SourceFileEncoding.Sniff(bytes);
+
+        Assert.AreEqual(encoding.CodePage, detected.CodePage);
+        Assert.AreNotEqual(Encoding.Unicode.CodePage, detected.CodePage);
+        Assert.IsTrue(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_BytesShorterThanPreamble_ReportsNoPreamble()
+    {
+        // Two bytes cannot carry a three-byte UTF-8 BOM; the StartsWith guard must not throw.
+        var (encoding, hasPreamble) = SourceFileEncoding.Sniff([0xEF, 0xBB]);
+
+        Assert.AreEqual(Encoding.UTF8.CodePage, encoding.CodePage);
+        Assert.IsFalse(hasPreamble);
+    }
+
+    [TestMethod]
+    public void Sniff_EmptyBytes_ReportsNoPreamble()
+    {
+        var (encoding, hasPreamble) = SourceFileEncoding.Sniff([]);
+
+        Assert.AreEqual(Encoding.UTF8.CodePage, encoding.CodePage);
+        Assert.IsFalse(hasPreamble);
+    }
+
+    // === FromBytes ===
+
+    [TestMethod]
+    public void FromBytes_Null_ReturnsUtf8NoBom()
+        => AssertIsUtf8NoBom(SourceFileEncoding.FromBytes(null));
+
+    [TestMethod]
+    public void FromBytes_Empty_ReturnsUtf8NoBom()
+        => AssertIsUtf8NoBom(SourceFileEncoding.FromBytes([]));
+
+    [TestMethod]
+    public void FromBytes_NoBom_ReturnsUtf8NoBomNotBomEmittingUtf8()
+    {
+        // The regression this gate exists for: Sniff reports Encoding.UTF8 (BOM-emitting) for a
+        // plain no-BOM file, so a pass-through would ADD a preamble to every no-BOM file.
+        var resolved = SourceFileEncoding.FromBytes(Encoding.UTF8.GetBytes("a = b"));
+
+        AssertIsUtf8NoBom(resolved);
+    }
+
+    [TestMethod]
+    public void FromBytes_Utf8Bom_RoundTripsPreamble()
+    {
+        var original = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var resolved = SourceFileEncoding.FromBytes(WithPreamble(original, "a = b"));
+
+        Assert.AreEqual(original.CodePage, resolved.CodePage);
+        CollectionAssert.AreEqual(original.GetPreamble(), resolved.GetPreamble());
+        // End-to-end: re-encoding through the resolved encoding reproduces the original bytes.
+        CollectionAssert.AreEqual(WithPreamble(original, "a = b"), WithPreamble(resolved, "a = b"));
+    }
+
+    [TestMethod]
+    public void FromBytes_Utf16Le_PreservesEncoding()
+    {
+        var original = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+        var resolved = SourceFileEncoding.FromBytes(WithPreamble(original, "a = b"));
+
+        Assert.AreEqual(original.CodePage, resolved.CodePage);
+        CollectionAssert.AreEqual(original.GetPreamble(), resolved.GetPreamble());
+    }
+
+    // === FromSourceText ===
+
+    [TestMethod]
+    public void FromSourceText_Null_ReturnsUtf8NoBom()
+        => AssertIsUtf8NoBom(SourceFileEncoding.FromSourceText(null));
+
+    [TestMethod]
+    public void FromSourceText_RoslynThrowOnInvalidBytesUtf8_NormalizesToSharedUtf8NoBom()
+    {
+        // Roslyn attaches a no-BOM UTF-8 built with throwOnInvalidBytes: true. Passing it through
+        // would turn an unpaired surrogate into a mid-write EncoderFallbackException where the
+        // pre-fix path emitted U+FFFD, so it must normalize to the shared lenient instance.
+        var roslynStyle = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+        var resolved = SourceFileEncoding.FromSourceText(roslynStyle);
+
+        Assert.AreSame(SourceFileEncoding.Utf8NoBom, resolved);
+        // The normalization is observable: the shared instance substitutes rather than throws.
+        Assert.AreEqual("�", resolved.GetString(resolved.GetBytes("\uD800")));
+    }
+
+    [TestMethod]
+    public void FromSourceText_Utf8WithBom_IsPreserved()
+    {
+        var bomUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+        var resolved = SourceFileEncoding.FromSourceText(bomUtf8);
+
+        Assert.AreSame(bomUtf8, resolved);
+        Assert.AreNotEqual(0, resolved.GetPreamble().Length);
+    }
+
+    [TestMethod]
+    public void FromSourceText_NonUtf8_IsPreserved()
+    {
+        var utf16 = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+
+        Assert.AreSame(utf16, SourceFileEncoding.FromSourceText(utf16));
+    }
+
+    // === Cross-check: the extracted sniffer agrees with CsprojSemanticEquality's snapshot ===
+
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    public void Sniff_AgreesWithCreateSnapshot(bool useUtf16, bool omitBom)
+    {
+        Encoding encoding = useUtf16
+            ? new UnicodeEncoding(bigEndian: false, byteOrderMark: !omitBom)
+            : new UTF8Encoding(encoderShouldEmitUTF8Identifier: !omitBom);
+        const string Content = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup /></Project>";
+        var bytes = WithPreamble(encoding, Content);
+
+        var (sniffedEncoding, sniffedHasPreamble) = SourceFileEncoding.Sniff(bytes);
+        var snapshot = CsprojSemanticEquality.CreateSnapshot(bytes);
+
+        Assert.AreEqual(snapshot.TextEncoding.CodePage, sniffedEncoding.CodePage);
+        Assert.AreEqual(snapshot.HasPreamble, sniffedHasPreamble);
+        // CreateSnapshot now decodes with the sniffed encoding instead of re-detecting; the
+        // content it produces must still be BOM-free and byte-faithful.
+        Assert.AreEqual(Content, snapshot.Content);
+    }
+
+    private static byte[] WithPreamble(Encoding encoding, string content)
+        => [.. encoding.GetPreamble(), .. encoding.GetBytes(content)];
+
+    private static void AssertIsUtf8NoBom(Encoding encoding)
+    {
+        Assert.AreSame(SourceFileEncoding.Utf8NoBom, encoding);
+        Assert.AreEqual(0, encoding.GetPreamble().Length);
+    }
+}


### PR DESCRIPTION
## Why

`AtomicFileWriter` (in `CompositeApplyOrchestrator.cs`) carried a general-purpose encoding sniffer — `Utf8NoBom` plus both `ResolveWriteEncoding` overloads — that has nothing to do with atomic writes. Five call sites depended on it purely as a BOM detector, including `EditorConfigService`, which writes via `File.WriteAllLines` and never touches `AtomicFileWriter` at all.

Worse, `ResolveWriteEncoding(byte[]?)` reached into `CsprojSemanticEquality.CreateSnapshot` just to read `.HasPreamble`/`.TextEncoding`. That made a helper whose own doc header scopes it to csproj-XML semantic comparison the de-facto BOM detector for `.editorconfig` and every mutation-write path in the app — and made every such write pay for a full `StreamReader.ReadToEnd()` decode plus a `ProjectFileSnapshot` allocation whose `Content`/`Bytes` were immediately discarded.

## What

New `src/RoslynMcp.Roslyn/Helpers/SourceFileEncoding.cs`:

| Member | Replaces | Notes |
|---|---|---|
| `Utf8NoBom` | `AtomicFileWriter.Utf8NoBom` | Moved verbatim. |
| `Sniff(byte[]) → (Encoding, bool HasPreamble)` | new | Delegates to `StreamReader`'s own BOM detection, forced via `Peek()` — no full-file decode. |
| `FromBytes(byte[]?)` | `ResolveWriteEncoding(byte[]?)` | Body unchanged apart from calling `Sniff` instead of `CreateSnapshot`. |
| `FromSourceText(Encoding?)` | `ResolveWriteEncoding(Encoding?)` | Moved verbatim. |

`Sniff` delegates to the BCL rather than hand-rolling a preamble table, which sidesteps the UTF-32LE/UTF-16LE BOM-prefix overlap (`FF FE 00 00` starts with the complete UTF-16LE BOM) that a naive table gets wrong. There is a regression test for exactly that.

`CsprojSemanticEquality.CreateSnapshot` becomes a *consumer* of `Sniff` and decodes with the already-detected encoding, so detection has exactly one home. Its `Content` output is byte-for-byte what the single-reader version produced: `StreamReader` checks the preamble of the encoding it was constructed with regardless of `detectEncodingFromByteOrderMarks`, so a matching BOM is still stripped.

`AtomicFileWriter` keeps only genuine atomic-write plumbing (`WriteAllTextAsync`, `WriteAllBytesAsync`, `WriteAtomicAsync`, `TryDeleteTemp`).

The six call sites — `CompositeApplyOrchestrator`, `EditorConfigService`, `ProjectMutationService`, `EditService`, `UndoService` (which also needed a `using RoslynMcp.Roslyn.Helpers;`) — are one-line swaps. They are in scope because the C# compiler forces them: removing the members from `AtomicFileWriter` breaks every caller in the same change (CS0117/CS1061).

## Incidental perf win

The three `FromBytes` call sites (`CompositeApplyOrchestrator`, `EditorConfigService`, `ProjectMutationService`) previously triggered a full-file decode plus a discarded snapshot allocation on every non-delete mutation apply. `Sniff` only peeks. `CreateSnapshot` itself does the same total work as before — it still needs the full content for XML parsing — so the win is scoped to callers that only wanted the encoding.

## Testing

New `tests/RoslynMcp.Tests/SourceFileEncodingTests.cs` (19 tests) covers the helper directly, where before this logic was only reachable through integration suites:

- no-BOM UTF-8 must resolve to `Utf8NoBom`, **not** the BOM-emitting `Encoding.UTF8` (the load-bearing gate — a pass-through would add a BOM to every no-BOM file)
- null / empty / shorter-than-preamble byte arrays
- UTF-8-BOM byte-level round-trip, UTF-16LE/BE preserved
- UTF-32LE not mis-detected as UTF-16LE
- Roslyn's `throwOnInvalidBytes` UTF-8 normalizes to the shared lenient instance (asserted observably: it substitutes U+FFFD rather than throwing)
- cross-check that `Sniff` agrees with `CsprojSemanticEquality.CreateSnapshot` on encoding, preamble, and decoded content

Parity gate — all green, unchanged:

```
dotnet test --filter SourceFileEncodingTests|CsprojReserializationTests|UndoFileOperationsTests|
  ApplyTextEditVerifyTests|EditorConfigServiceTests|ProjectMutationIntegrationTests|
  CompositeApplyOrchestratorTests|UndoServiceTests
→ Passed: 114, Failed: 0
```

`dotnet build -c Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors. `./eng/verify-ai-docs.ps1` → passed.

## Follow-on (not in this PR)

`src/RoslynMcp.Roslyn/Services/FileSnapshotCapture.cs:21` has a now-stale doc reference to `AtomicFileWriter.ResolveWriteEncoding`. It is a plain `<c>` span, not a cref, so it does not break the build. Left untouched deliberately — editing it would make an 8th production file and blow this initiative's scope ceiling. Worth a small follow-on row.

Closes: extract-atomicfilewriter-encoding-helper
