### PR TITLE
feat(security): report the filesystem boundary instead of failing silently

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-13T22:12:14Z
+**updated_at:** 2026-08-14T13:30:23Z
 
 ## Agent contract
 
@@ -56,6 +56,7 @@
 | `parameter-object-dto-reference-qualification` | High | — | Bind generated DTO type references correctly when target declarations and callers use different namespaces. | S | items/parameter-object-dto-reference-qualification.md |
 | `parameter-object-dto-output-boundary-validation` | High | — | Confine generated DTO output to the project boundary and refuse destination collisions before preview storage. | M | items/parameter-object-dto-output-boundary-validation.md |
 | `suppression-tools-missing-root-boundary-validation` | High | — | **Enforce the sanctioned-root boundary on the pragma-suppression write tools** — `add_pragma_suppression` / `pragma_scope_widen` reach `EditService`'s physical write with NO `ClientRootPathValidator` call at all. [type: bug] [source: 2026-08-13 sweep 20260813T172325Z, PR #1230 code-quality review] | M | items/suppression-tools-missing-root-boundary-validation.md |
+| `nuget-facing-docs-sanctioned-roots-migration` | High | — | **NuGet-facing docs miss the boundary migration** — README Option A shows a bare install with no env guidance, `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` is absent from the config table, and the `roots/list` deprecation is documented only in the ADR. [type: chore] [source: 2026-08-14 release-cut preflight] | M | items/nuget-facing-docs-sanctioned-roots-migration.md |
 
 ## Medium
 
@@ -153,6 +154,7 @@
 | `xmldoc-crefs-not-compile-checked` | Low | — | **Make XML doc `<see cref>` compile-checked** — no csproj sets `GenerateDocumentationFile`, so the compiler never validates crefs and dangling ones ship green under `TreatWarningsAsErrors`. [type: chore] [source: 2026-08-13 sweep 20260813T172325Z, PR #1241 code-quality review] | M | items/xmldoc-crefs-not-compile-checked.md |
 | `sourcefileencoding-core-relocation` | Low | — | **Move `SourceFileEncoding` to `RoslynMcp.Core`** so `FileSnapshotDto.FromExistingBytes` stops hand-rolling a second BOM-detecting `StreamReader` — the extraction landed in `.Roslyn` and Core cannot reference upward. [type: chore] [source: 2026-08-13 sweep 20260813T172325Z, PR #1243 code-quality review] | M | items/sourcefileencoding-core-relocation.md |
 | `cancellation-invariant-regression-locks` | Low | — | **Lock the safe-cancellation invariants the OCE-classification audit relied on** — `ScriptExecutionSupervisor`'s ambient-token-only-throw and `WorkspaceForkApplyService`'s timeout path are both load-bearing and untested. [type: chore] [source: 2026-08-13 sweep 20260813T172325Z, plan Risk 2 follow-up] | M | items/cancellation-invariant-regression-locks.md |
+| `workflow-md-release-managed-guard-list-drift` | Low | — | **`ai_docs/workflow.md`'s release-managed guard table omits `.claude-plugin/server.json`** and miscounts the version-source files as five when `/bump` edits six. Agents trust the table and get blocked by an undocumented guard. [type: bug] [source: 2026-08-14 sanctioned-roots fix] | S | items/workflow-md-release-managed-guard-list-drift.md |
 
 ## Defer
 

--- a/ai_docs/items/nuget-facing-docs-sanctioned-roots-migration.md
+++ b/ai_docs/items/nuget-facing-docs-sanctioned-roots-migration.md
@@ -1,0 +1,32 @@
+# nuget-facing-docs-sanctioned-roots-migration — the page an upgrader lands on omits the escape hatch
+
+## Anchors
+
+- `README.md`
+- `docs/setup.md`
+
+## Acceptance
+
+- [ ] `README.md` "Option A — Install As A Global Tool" states that a filesystem boundary must be configured before use, with a copy-ready `env` snippet — the current section shows only the install command.
+- [ ] `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` appears in the README configuration table with its default and its intended use as a temporary compatibility escape hatch for the empty-boundary case only.
+- [ ] A short "Upgrading from 2.x" note (README or a linked doc) states what an existing consumer must do BEFORE upgrading, and that client `roots/list` no longer drives discovery — supply a file path, configure a single-solution root, or call `workspace_load` explicitly.
+- [ ] The README Security section reflects the server-owned boundary model rather than only the generic "path validation is defense in depth" framing.
+
+## Evidence
+
+Verified at HEAD, and deliberately scoped AGAINST a full rewrite — the README is NOT broadly stale:
+
+- It was last updated 2026-08-13 in the same PR that landed the breaking change, and already documents `ROSLYNMCP_SANCTIONED_ROOTS` in prose and in the config table, including the per-platform delimiter and the fail-closed behavior.
+- Its surface counts are CI-gated by `ReadmeSurfaceCountTests`, so they cannot drift.
+- All 17 of its relative links resolve.
+
+The real gaps are narrow and specific:
+
+1. `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` appears ZERO times in `README.md` (once in `docs/setup.md`, and in the thrown error string). It is the one escape hatch a broken upgrader needs, missing from the page they land on.
+2. The `roots/list` deprecation appears only in `docs/decisions/0002-configured-sanctioned-root-boundary.md`. Nothing user-facing tells a client author that Roots-driven discovery stopped working.
+3. No consumer migration guidance exists. `docs/upgrade-matrix.md` is maintainer-facing (toolchain/TFM/Roslyn pins), not a consumer upgrade path.
+4. README "Option A" shows `dotnet tool install -g Darylmcd.RoslynMcp` with no env guidance, ~110 lines above where the required variable is documented.
+
+## Context
+
+Scope note: do NOT rewrite the README. The surface-count line is pinned by a regex in `ReadmeSurfaceCountTests`; churning it risks a red gate for no gain.

--- a/ai_docs/items/workflow-md-release-managed-guard-list-drift.md
+++ b/ai_docs/items/workflow-md-release-managed-guard-list-drift.md
@@ -1,0 +1,26 @@
+# workflow-md-release-managed-guard-list-drift — guard doc disagrees with the guard script
+
+## Anchors
+
+- `ai_docs/workflow.md`
+- `eng/guard-release-managed-files.ps1`
+
+## Acceptance
+
+- [ ] The `Release-managed file guard` table in `ai_docs/workflow.md` lists every path the script actually guards, including `.claude-plugin/server.json`.
+- [ ] The follow-on sentence's count is corrected: `eng/verify-version-drift.ps1` reports "All 6 version files agree", so the doc's "five version-source locations" is wrong.
+- [ ] Ideally the doc cites the script as canonical (or the script's list is generated/asserted against the doc) so the two cannot drift again.
+
+## Evidence
+
+Hit live while making an intentional ad-hoc edit to `.claude-plugin/server.json`:
+
+- `eng/guard-release-managed-files.ps1` `$managedExact` contains TEN entries — `directory.build.props`, `manifest.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.claude-plugin/server.json`, `changelog.md`, `eng/verify-version-drift.ps1`, `hooks/hooks.json`, `eng/verify-skills-are-generic.ps1`, plus `BannedSymbols.txt` matched by basename.
+- `ai_docs/workflow.md`'s table lists NINE and omits `.claude-plugin/server.json` entirely.
+- The same section then says "Files 1, 3, 4, 5, and 6 are the five version-source locations enumerated by `eng/verify-version-drift.ps1`" — but that script prints "All 6 version files agree on 2.3.8". The sixth is the omitted `server.json`.
+
+Impact is small but real: an agent reads the table, concludes `server.json` is freely editable, and gets a hard PreToolUse block with no matching row in the documented set — exactly what happened here.
+
+## Context
+
+Surfaced while adding `environmentVariables` to the packaged `.mcp/server.json` so registry/dnx installs configure `ROSLYNMCP_SANCTIONED_ROOTS` automatically.

--- a/changelog.d/sanctioned-roots-empty-boundary-fails-silently-until-first-call.md
+++ b/changelog.d/sanctioned-roots-empty-boundary-fails-silently-until-first-call.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** the server now says so when no filesystem boundary is configured, instead of looking healthy until the first path call. `server_info` carries a `pathBoundary` object (`configuredRootCount`, `failOpen`, `enforcing`, `hint`) and the host logs a startup warning naming `ROSLYNMCP_SANCTIONED_ROOTS` and the `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` escape hatch when the boundary is empty and fail-closed. Both derive their remediation text from one projection, so the log and the tool response cannot drift. `pathBoundary` reports the root **count** and never the configured paths — the boundary is a server-owned control, not client-visible configuration — and is `null` (meaning "unknown", not "unconfigured") when the host was not booted. This matters most on the NuGet channel, where `dotnet tool install` ships no default configuration and an unconfigured host previously rejected every path-taking tool with no prior signal; the same empty boundary also silently bounds query-anchored discovery to zero results, which the hint now calls out.

--- a/src/RoslynMcp.Core/Models/ServerToolDtos.cs
+++ b/src/RoslynMcp.Core/Models/ServerToolDtos.cs
@@ -32,7 +32,32 @@ public sealed record ServerInfoDto(
     ResourceServerNameHintsDto ResourceServerNames,
     IReadOnlyList<string> ProductBoundaries,
     ServerCapabilitiesDto Capabilities,
-    ServerUpdateInfoDto? Update);
+    ServerUpdateInfoDto? Update,
+    PathBoundaryDto? PathBoundary);
+
+/// <summary>
+/// sanctioned-roots-empty-boundary-fails-silently-until-first-call: filesystem-boundary state, so
+/// an unconfigured host is diagnosable from <c>server_info</c> instead of only from the first
+/// path call's rejection. Deliberately reports the root COUNT and never the root paths — the
+/// boundary is a security control and its contents are not client business.
+/// <para>
+/// The field is null on unit-test paths that construct <c>ServerTools</c> without booting the
+/// host (the runtime <c>SecurityOptionsSnapshot</c> is unset), matching
+/// <see cref="SurfaceRegisteredCountsDto"/>'s convention. Null means "unknown", never
+/// "unconfigured".
+/// </para>
+/// </summary>
+/// <param name="ConfiguredRootCount">Number of entries parsed from <c>ROSLYNMCP_SANCTIONED_ROOTS</c>.</param>
+/// <param name="FailOpen">Whether <c>ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN</c> is set. Only rescues the
+/// zero-root case; it never bypasses a non-empty boundary.</param>
+/// <param name="Enforcing">True when a non-empty boundary is actively constraining paths.</param>
+/// <param name="Hint">Null when the configuration is coherent; otherwise an actionable one-liner
+/// naming the variable to set. Non-null means path-taking tools are rejecting (or unbounded).</param>
+public sealed record PathBoundaryDto(
+    int ConfiguredRootCount,
+    bool FailOpen,
+    bool Enforcing,
+    string? Hint);
 
 /// <summary>
 /// Surface-count subtree on <see cref="ServerInfoDto"/>. <see cref="Registered"/> is null on

--- a/src/RoslynMcp.Host.Stdio/Diagnostics/SecurityOptionsSnapshot.cs
+++ b/src/RoslynMcp.Host.Stdio/Diagnostics/SecurityOptionsSnapshot.cs
@@ -1,0 +1,26 @@
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Host.Stdio.Diagnostics;
+
+/// <summary>
+/// sanctioned-roots-empty-boundary-fails-silently-until-first-call: holds the
+/// <see cref="SecurityOptions"/> bound at host startup so <c>server_info</c> can report the
+/// filesystem-boundary state without injecting the options into every tool that wants them.
+/// Mirrors <see cref="SurfaceRegistrationSnapshot"/>, which exists for the same reason.
+/// <para>
+/// Tool-call paths must tolerate <see cref="Value"/> being <see langword="null"/> — unit tests
+/// that exercise tools without booting the full host never populate this snapshot. A null
+/// snapshot means "unknown", NOT "unconfigured": reporting a fabricated fail-closed boundary
+/// from an unbooted host would be the same silent-wrong-answer class this row exists to remove.
+/// </para>
+/// </summary>
+public static class SecurityOptionsSnapshot
+{
+    private static volatile SecurityOptions? s_value;
+
+    public static SecurityOptions? Value
+    {
+        get => s_value;
+        set => s_value = value;
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Middleware;
 using RoslynMcp.Host.Stdio.Security;
+using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn;
 using RoslynMcp.Roslyn.Services;
 
@@ -144,6 +145,21 @@ if (startupWorkspaceManager.ListWorkspaces().Count == 0)
     startupLogger.LogInformation(
         "Roslyn MCP host started with zero loaded workspaces. " +
         "If this is a transparent subprocess restart, call workspace_load to rehydrate the prior session.");
+}
+
+// sanctioned-roots-empty-boundary-fails-silently-until-first-call: an unconfigured boundary is
+// fail-closed, so EVERY path-taking tool rejects — but nothing said so until the first call threw.
+// Warn at startup for the same reason as the zero-workspaces notice above: clients that surface
+// MCP `notifications/message` learn proactively instead of discovering it tool-by-tool. Only the
+// genuinely broken shape warns; fail-open is an explicit operator choice and stays quiet.
+var startupSecurityOptions = host.Services.GetRequiredService<SecurityOptions>();
+SecurityOptionsSnapshot.Value = startupSecurityOptions;
+// The remediation text is derived from the SAME projection server_info reports, so the startup
+// warning and the tool response can never drift apart — and the message is unit-tested there.
+if (ServerTools.BuildPathBoundary(startupSecurityOptions)
+    is { Enforcing: false, FailOpen: false, Hint: { } boundaryHint })
+{
+    startupLogger.LogWarning("Filesystem boundary is not configured. {BoundaryHint}", boundaryHint);
 }
 
 // Register graceful shutdown to dispose all workspaces

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -6,7 +6,9 @@ using RoslynMcp.Core.Models;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Security;
 using RoslynMcp.Host.Stdio.Services;
+using RoslynMcp.Roslyn.Services;
 using ModelContextProtocol.Server;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -139,9 +141,54 @@ public static class ServerTools
                 "Remote HTTP/SSE hosting is not part of the current stable release contract."
             ],
             Capabilities: new ServerCapabilitiesDto(Tools: true, Resources: true, Prompts: true, Logging: true, Progress: true),
-            Update: BuildUpdateInfo(currentSemver, versionChecker));
+            Update: BuildUpdateInfo(currentSemver, versionChecker),
+            PathBoundary: BuildPathBoundary(SecurityOptionsSnapshot.Value));
 
         return Task.FromResult(JsonSerializer.Serialize(info, JsonDefaults.Indented));
+    }
+
+    /// <summary>
+    /// sanctioned-roots-empty-boundary-fails-silently-until-first-call: projects the filesystem
+    /// boundary into <c>server_info</c> so an unconfigured host is diagnosable before the first
+    /// path call rejects. Reports the root COUNT only — never the paths, which are a server-owned
+    /// security control rather than client-visible configuration.
+    /// </summary>
+    /// <remarks>
+    /// Three coherent states. Roots configured: enforcing, no hint. Zero roots + fail-open: not
+    /// enforcing, hinted because the host is deliberately unbounded and an operator should know.
+    /// Zero roots + fail-closed: not enforcing and every path tool rejects — the shape that
+    /// previously looked healthy right up until first use.
+    /// </remarks>
+    internal static PathBoundaryDto? BuildPathBoundary(SecurityOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        var rootCount = options.SanctionedRoots.Count;
+        var failOpen = options.PathValidationFailOpen;
+
+        string? hint = (rootCount, failOpen) switch
+        {
+            (0, true) =>
+                $"No sanctioned roots are configured and {SecurityOptionsEnvironmentBinder.PathValidationFailOpenVariable} " +
+                "is set, so path access is unbounded. This is a temporary compatibility measure — set " +
+                $"{SecurityOptionsEnvironmentBinder.SanctionedRootsVariable} and remove it.",
+            (0, false) =>
+                $"No sanctioned roots are configured, so path validation is fail-closed and every " +
+                $"path-taking tool will reject its input. Set {SecurityOptionsEnvironmentBinder.SanctionedRootsVariable} " +
+                $"to a '{Path.PathSeparator}'-delimited root list ('.' for a project-scoped host), or set " +
+                $"{SecurityOptionsEnvironmentBinder.PathValidationFailOpenVariable}=true as a temporary " +
+                "compatibility measure. Query-anchored solution discovery is bounded by the same list.",
+            _ => null,
+        };
+
+        return new PathBoundaryDto(
+            ConfiguredRootCount: rootCount,
+            FailOpen: failOpen,
+            Enforcing: rootCount > 0,
+            Hint: hint);
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ServerInfoPathBoundaryTests.cs
+++ b/tests/RoslynMcp.Tests/ServerInfoPathBoundaryTests.cs
@@ -1,0 +1,234 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression for <c>sanctioned-roots-empty-boundary-fails-silently-until-first-call</c>.
+/// <para>
+/// An unconfigured filesystem boundary is fail-closed, so every path-taking tool rejects its
+/// input — but nothing surfaced that state until the first call threw. A NuGet / hand-rolled
+/// install (the plugin and Desktop manifests ship <c>ROSLYNMCP_SANCTIONED_ROOTS</c>, the NuGet
+/// package does not) therefore looked healthy right up until first use. <c>server_info</c> now
+/// reports the boundary so the misconfiguration is diagnosable up front.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class ServerInfoPathBoundaryTests
+{
+    /// <summary>
+    /// The load-bearing security property: the boundary is a server-owned control, so the wire
+    /// shape carries a COUNT and never the configured paths. A client that could read the roots
+    /// would learn the host's filesystem layout from a read-only diagnostic tool.
+    /// </summary>
+    [TestMethod]
+    public void BuildPathBoundary_NeverExposesConfiguredRootPaths()
+    {
+        var options = new SecurityOptions
+        {
+            SanctionedRoots = ["C:/secret-project", "D:/another-secret"],
+        };
+
+        var boundary = ServerTools.BuildPathBoundary(options);
+
+        Assert.IsNotNull(boundary);
+        Assert.AreEqual(2, boundary.ConfiguredRootCount);
+        var serialized = System.Text.Json.JsonSerializer.Serialize(boundary);
+        StringAssert.DoesNotMatch(
+            serialized,
+            new System.Text.RegularExpressions.Regex("secret", System.Text.RegularExpressions.RegexOptions.IgnoreCase),
+            "server_info must report the sanctioned-root COUNT, never the paths themselves.");
+    }
+
+    /// <summary>
+    /// Null snapshot means the host was never booted (unit-test path), which is "unknown" — NOT
+    /// "unconfigured". Fabricating a fail-closed boundary here would report a misconfiguration
+    /// that does not exist, which is the same silent-wrong-answer class this row removes.
+    /// </summary>
+    [TestMethod]
+    public void BuildPathBoundary_UnbootedHost_ReturnsNullRatherThanFabricatingUnconfigured()
+    {
+        Assert.IsNull(ServerTools.BuildPathBoundary(null));
+    }
+
+    [TestMethod]
+    public void BuildPathBoundary_RootsConfigured_IsEnforcingWithNoHint()
+    {
+        var boundary = ServerTools.BuildPathBoundary(new SecurityOptions
+        {
+            SanctionedRoots = ["."],
+        });
+
+        Assert.IsNotNull(boundary);
+        Assert.IsTrue(boundary.Enforcing);
+        Assert.IsFalse(boundary.FailOpen);
+        Assert.AreEqual(1, boundary.ConfiguredRootCount);
+        Assert.IsNull(boundary.Hint, "A correctly configured boundary must not emit a remediation hint.");
+    }
+
+    /// <summary>
+    /// The shape that previously looked healthy until first use. The hint must name BOTH the
+    /// variable to set and the escape hatch — an operator hitting this mid-session needs the
+    /// remediation without leaving the tool output.
+    /// </summary>
+    [TestMethod]
+    public void BuildPathBoundary_ZeroRootsFailClosed_HintsBothVariables()
+    {
+        var boundary = ServerTools.BuildPathBoundary(new SecurityOptions());
+
+        Assert.IsNotNull(boundary);
+        Assert.IsFalse(boundary.Enforcing);
+        Assert.IsFalse(boundary.FailOpen);
+        Assert.AreEqual(0, boundary.ConfiguredRootCount);
+        Assert.IsNotNull(boundary.Hint);
+        StringAssert.Contains(boundary.Hint, "ROSLYNMCP_SANCTIONED_ROOTS");
+        StringAssert.Contains(boundary.Hint, "ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN");
+        StringAssert.Contains(
+            boundary.Hint,
+            "discovery",
+            "The hint must mention the silent half — query-anchored discovery returns nothing " +
+            "rather than throwing when the boundary is empty.");
+    }
+
+    /// <summary>
+    /// Fail-open is a deliberate operator choice, so it is not an error — but it leaves the host
+    /// unbounded, which is worth saying out loud in a diagnostic.
+    /// </summary>
+    [TestMethod]
+    public void BuildPathBoundary_ZeroRootsFailOpen_ReportsUnboundedNotEnforcing()
+    {
+        var boundary = ServerTools.BuildPathBoundary(new SecurityOptions
+        {
+            PathValidationFailOpen = true,
+        });
+
+        Assert.IsNotNull(boundary);
+        Assert.IsFalse(boundary.Enforcing);
+        Assert.IsTrue(boundary.FailOpen);
+        Assert.IsNotNull(boundary.Hint, "An unbounded host should still say so.");
+        StringAssert.Contains(boundary.Hint, "unbounded");
+    }
+
+    /// <summary>
+    /// A non-empty boundary is always enforced; <c>PathValidationFailOpen</c> only ever rescues
+    /// the zero-root case (ADR 0002 decision 2). Guards against a future edit letting the escape
+    /// hatch punch through a configured boundary.
+    /// </summary>
+    [TestMethod]
+    public void BuildPathBoundary_FailOpenDoesNotDisableAConfiguredBoundary()
+    {
+        var boundary = ServerTools.BuildPathBoundary(new SecurityOptions
+        {
+            SanctionedRoots = ["."],
+            PathValidationFailOpen = true,
+        });
+
+        Assert.IsNotNull(boundary);
+        Assert.IsTrue(
+            boundary.Enforcing,
+            "Fail-open must never report a configured boundary as unenforced.");
+        Assert.IsNull(boundary.Hint);
+    }
+
+    /// <summary>
+    /// Wiring test. The helper above is pure, so every assertion in this class still passes if
+    /// <c>server_info</c> stops calling it — deleting the <c>PathBoundary:</c> argument would be
+    /// invisible. This drives the real tool and asserts the field reaches the wire under its
+    /// camelCase name, so the projection cannot be silently disconnected from the response.
+    /// </summary>
+    [TestMethod]
+    public async Task ServerInfo_CarriesPathBoundary_FromTheStartupSnapshot()
+    {
+        var previous = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions { SanctionedRoots = ["."] };
+
+            var json = await ServerTools.GetServerInfo(
+                new FakeWorkspaceManager(),
+                new FakeVersionProvider(null));
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsTrue(
+                doc.RootElement.TryGetProperty("pathBoundary", out var boundary),
+                "server_info must emit pathBoundary (camelCase) — the projection is wired but unreported.");
+            Assert.AreEqual(1, boundary.GetProperty("configuredRootCount").GetInt32());
+            Assert.IsTrue(boundary.GetProperty("enforcing").GetBoolean());
+            Assert.AreEqual(JsonValueKind.Null, boundary.GetProperty("hint").ValueKind);
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previous;
+        }
+    }
+
+    /// <summary>
+    /// An unbooted host reports <c>pathBoundary: null</c> rather than omitting the field —
+    /// matching the DTO's documented convention that nullable members emit explicit nulls.
+    /// </summary>
+    [TestMethod]
+    public async Task ServerInfo_UnbootedHost_EmitsExplicitNullBoundary()
+    {
+        var previous = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = null;
+
+            var json = await ServerTools.GetServerInfo(
+                new FakeWorkspaceManager(),
+                new FakeVersionProvider(null));
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("pathBoundary", out var boundary));
+            Assert.AreEqual(JsonValueKind.Null, boundary.ValueKind);
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previous;
+        }
+    }
+
+    /// <summary>
+    /// Minimal fake — only <see cref="IWorkspaceManager.ListWorkspaces"/> is reached by the
+    /// server_info path. Mirrors the per-file fakes in <c>ServerHeartbeatTests</c> and
+    /// <c>HostProcessMetadataTests</c> rather than introducing shared test infrastructure.
+    /// </summary>
+    private sealed class FakeWorkspaceManager : IWorkspaceManager
+    {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+        public event Action<string>? WorkspaceReloaded { add { } remove { } }
+
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => false;
+        public bool IsStale(string workspaceId) => false;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+    }
+
+    private sealed class FakeVersionProvider(string? latest) : ILatestVersionProvider
+    {
+        public string? GetLatestVersion() => latest;
+        public VersionCheckStatus LastCheckStatus => latest is null
+            ? VersionCheckStatus.Pending
+            : VersionCheckStatus.Succeeded;
+        public DateTime? LastCheckedAt => latest is null ? null : DateTime.UtcNow;
+    }
+}


### PR DESCRIPTION
An unconfigured `ROSLYNMCP_SANCTIONED_ROOTS` is fail-closed, so every path-taking tool rejects its input — but nothing said so until the first call threw.

This matters most on the **NuGet channel**: `.claude-plugin/mcp.json` and `manifest.json` both ship `ROSLYNMCP_SANCTIONED_ROOTS: "."`, but `dotnet tool install` ships only a binary, so those users start from an empty boundary. It is also the failure mode of a Layer-1-only upgrade, where a new binary reads a stale plugin config with no `env` block.

## What changed

| Surface | Behavior |
|---|---|
| `server_info.pathBoundary` | `configuredRootCount` / `failOpen` / `enforcing` / `hint` |
| Startup log | `LogWarning` when the boundary is empty **and** fail-closed |

Both derive their remediation text from the **same projection**, so the log and the tool response cannot drift, and the message is unit-tested in one place.

## Design notes

- **Count, never paths.** `pathBoundary` reports how many roots are configured and not what they are. A read-only diagnostic that echoed the roots would hand a client the host's filesystem layout. There is a dedicated regression for this.
- **Null means unknown, not unconfigured.** On an unbooted host (unit-test paths) the field is `null`, matching `SurfaceRegisteredCountsDto.Registered`'s existing convention. Reporting a fabricated fail-closed boundary would be the same silent-wrong-answer class this PR removes.
- **`SecurityOptionsSnapshot` follows `SurfaceRegistrationSnapshot`**, which exists verbatim for this problem — reporting host state from `server_info` without injecting it into every tool. Injecting `SecurityOptions` into `GetServerInfo` instead would have churned call sites across five test files for no behavioral gain.
- The hint names the **silent half** too: an empty boundary bounds query-anchored discovery to zero results without throwing.

## Validation

- 8/8 new tests pass.
- **Wiring inversion verified empirically, not asserted:** the helper is pure, so every unit assertion still passes if `server_info` stops calling it. Stubbing `PathBoundary: null` at the call site makes the wiring test **fail**; restoring it passes. Source restored byte-exact afterward.
- `verify-ai-docs.ps1` passes; `verify-version-drift.ps1` reports all 6 version files agree.

## Follow-ups filed (not in this PR)

- `nuget-facing-docs-sanctioned-roots-migration` (High) — README Option A shows a bare install with no env guidance, `ROSLYNMCP_PATH_VALIDATION_FAIL_OPEN` is absent from the config table, and the `roots/list` deprecation is documented only in the ADR.
- `workflow-md-release-managed-guard-list-drift` (Low) — the guard doc's table omits `.claude-plugin/server.json` and miscounts six version files as five.

Closes `sanctioned-roots-empty-boundary-fails-silently-until-first-call`.