### PR TITLE
fix(nuget): declare the sanctioned-roots default in the packaged server.json

### DIFF
--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -17,7 +17,14 @@
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "environmentVariables": [
+        {
+          "name": "ROSLYNMCP_SANCTIONED_ROOTS",
+          "value": ".",
+          "description": "Server-owned filesystem boundary for path validation and solution discovery. Path-separator-delimited (';' on Windows, ':' on macOS/Linux). '.' scopes the server to its working directory. An empty value fails closed: every path-taking tool rejects its input."
+        }
+      ]
     }
   ],
   "_meta": {

--- a/changelog.d/nuget-server-json-sanctioned-roots-env.md
+++ b/changelog.d/nuget-server-json-sanctioned-roots-env.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the NuGet package's `.mcp/server.json` now declares `ROSLYNMCP_SANCTIONED_ROOTS=.` via the registry schema's `environmentVariables`, so `dnx` and registry-aware clients configure the filesystem boundary automatically instead of starting from an empty (fail-closed) boundary that rejects every path-taking tool. This brings the discovery-driven NuGet path to parity with the Claude Code plugin (`.claude-plugin/mcp.json`) and the Desktop extension (`manifest.json`), both of which already shipped the default. Note the residual: a plain `dotnet tool install -g` followed by a hand-written `mcp.json` does not read `server.json`, so that path still requires configuring the variable explicitly — see the README's Configuration section.


### PR DESCRIPTION
The Claude Code plugin and Desktop extension both ship `ROSLYNMCP_SANCTIONED_ROOTS: "."`. The NuGet package shipped only the binary plus `.mcp/server.json`, which had **no `env` block** — so registry- and `dnx`-discovered installs started from an empty boundary and fail-closed on every path-taking tool.

## Change

```json
"environmentVariables": [
  { "name": "ROSLYNMCP_SANCTIONED_ROOTS", "value": ".", "description": "..." }
]
```

`environmentVariables` is a documented property on the `Package` object in the `2025-12-11` registry schema — an array of `KeyValueInput` (`name` / `value` / `isSecret` / `isRequired`). I verified that against the published schema before using it rather than assuming it was allowed.

## Validation

| Gate | Result |
|---|---|
| `verify-registry-readiness.ps1` | 27 pass / 0 fail / 0 warn |
| `verify-version-drift.ps1` | all 6 version files agree |
| JSON parse | valid |

## Scope — what this does NOT fix

A plain `dotnet tool install -g Darylmcd.RoslynMcp` followed by a hand-written `mcp.json` never reads `server.json`; the user's own config is the only input. **That path is irreducibly docs-only** unless the code default changes from `empty → deny` to something self-configuring. Tracked by `nuget-facing-docs-sanctioned-roots-migration`.

## Note

`.claude-plugin/server.json` is release-managed; I used the documented `.release-managed-edit-allowed` sentinel rather than working around the guard. That guard also surfaced a doc bug — `ai_docs/workflow.md`'s table omits this very file and miscounts six version files as five — filed as `workflow-md-release-managed-guard-list-drift`.