### PR TITLE
chore: temporarily bypass breaking-version release gate for v3.0.1

### DIFF
--- a/changelog.d/release-gate-bypass-v3-0-1.md
+++ b/changelog.d/release-gate-bypass-v3-0-1.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** temporarily bypassed `eng/verify-breaking-version-bump.ps1` to ship the next release as `3.0.1` (patch) despite pending `Changed — BREAKING` fragments — an explicit, twice-confirmed operator override, not a policy change. The pending breaking changes (protocol-logging retirement, MCP SDK 2.x wire-contract reconciliation, tool error-envelope redaction) genuinely change client-visible behavior and are documented as `Changed — BREAKING` in `3.0.1` regardless of the version number; consumers pinned to `^3.0` should review them before upgrading as if this were a major release. The gate bypass is reverted in the commit immediately following the `v3.0.1` tag's confirmed NuGet publish.

--- a/eng/verify-breaking-version-bump.ps1
+++ b/eng/verify-breaking-version-bump.ps1
@@ -25,6 +25,17 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# --- TEMPORARY: v3.0.1 release-gate override --------------------------------
+# Operator-approved, twice-confirmed override: shipping v3.0.1 as a patch
+# despite pending `Changed — BREAKING` fragments (MCP protocol-logging
+# retirement, MCP SDK 2.x wire-contract reconciliation, tool error-envelope
+# redaction across ~9 surfaces). This bypass must be reverted in the commit
+# immediately following the v3.0.1 tag + confirmed NuGet publish — do not
+# leave it in place for any other release.
+Write-Warning 'verify-breaking-version-bump.ps1: gate bypassed for v3.0.1 (temporary, operator-approved override).'
+exit 0
+# ------------------------------------------------------------------------------
+
 try {
     $resolvedRepoRoot = (Resolve-Path -LiteralPath $RepoRoot -ErrorAction Stop).Path
 }


### PR DESCRIPTION
## Summary
- Operator-approved, twice-confirmed override to ship the upcoming v3.0.1 as a **patch** despite pending `Changed — BREAKING` fragments (protocol-logging retirement, MCP SDK 2.x wire-contract reconciliation, tool error-envelope redaction).
- `eng/verify-breaking-version-bump.ps1` now exits 0 immediately with a warning, bypassing both the `/bump -BumpType patch` refusal and the `verify-release.ps1` / `publish-nuget.ps1` breaking-section-vs-major-version check.
- This is a **temporary** override, not a policy change — reverted in the commit immediately following v3.0.1's tag + confirmed NuGet publish.

## Test plan
- [x] `eng/verify-changelog-fragments.ps1` passes locally
- [ ] CI green