### PR TITLE
fix: make release-gate test assertions cross-platform

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-17T18:34:26Z
+**updated_at:** 2026-08-18T15:55:14Z
 
 ## Agent contract
 
@@ -73,6 +73,7 @@
 | `prompt-shim-binding-error-detail-redaction` | High | public-exception-detail-policy,prompt-call-error-filter-boundary | **Sanitize prompt-shim binding failures** — keep property/schema guidance without echoing parser exception text or supplied values. [type: security] [source: 2026-08-17 adjacent review] | S | items/prompt-shim-binding-error-detail-redaction.md |
 | `semantic-grep-pattern-error-detail-redaction` | High | public-exception-detail-policy,tool-error-envelope-sensitive-detail-disclosure | **Sanitize invalid-regex errors** — preserve actionable pattern guidance without publishing regex parser detail or secret-bearing input. [type: security] [source: 2026-08-17 adjacent review] | S | items/semantic-grep-pattern-error-detail-redaction.md |
 | `scaffolding-project-parse-diagnostic-redaction` | High | public-exception-detail-policy,scaffolding-io-warning-detail-redaction | **Sanitize scaffolding project-parse fallbacks** — preserve deterministic framework/validation behavior without raw exception objects or project paths in diagnostics. [type: security] [source: 2026-08-17 adjacent review] | S | items/scaffolding-project-parse-diagnostic-redaction.md |
+| `ci-merge-publish-runner-os-parity` | High | — | Give the pre-merge gate a Linux leg so Windows-only-passing tests cannot merge then block publish (v3.0.1 shipped no package for this reason) | M | items/ci-merge-publish-runner-os-parity.md |
 
 ## Medium
 

--- a/ai_docs/items/ci-merge-publish-runner-os-parity.md
+++ b/ai_docs/items/ci-merge-publish-runner-os-parity.md
@@ -1,0 +1,41 @@
+## Problem
+
+The merge gate and the publish gate run on different operating systems, so a test
+that passes on one can block the other:
+
+| Gate | Workflow | Runner |
+|---|---|---|
+| merge | `ci.yml` `validate` | self-hosted **Windows** |
+| publish | `publish-nuget.yml` | GitHub-hosted **Linux** |
+
+A PR can therefore go green, merge, and tag — and only then fail at publish. This
+happened on the v3.0.1 cut (2026-08-18): three tests added after v3.0.0 had never
+run on Linux, all three failed in `publish-nuget`, and the tag shipped no package.
+
+Root causes found in that incident (all fixed in
+`fix/cross-platform-release-test-assertions`):
+
+- `NuGetAuditGateTests` read `"Justfile"`; the on-disk name is `justfile`. Resolves
+  on case-insensitive Windows, throws on Linux.
+- `BreakingVersionGateTests` and `VerifyReleaseChildScriptTests` asserted substrings
+  against raw PowerShell `Write-Error` output, which hard-wraps at console width and
+  prefixes continuation lines with a `|` gutter. The wrap column is host-dependent.
+
+## Fix
+
+Make the pre-merge gate exercise Linux so this class fails before the tag, not after.
+Options, cheapest first:
+
+1. Add a Linux leg to `ci.yml` `validate` (matrix over `windows-self-hosted` +
+   `ubuntu-latest`), at minimum for the release-gate test classes.
+2. Route the full suite to a matrix and keep the self-hosted runner for the
+   longer Roslyn/workspace tests only.
+
+Either way the acceptance check is: reintroduce a case-only path typo or a
+width-sensitive assertion and confirm the PR gate goes red.
+
+## Anchors
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/publish-nuget.yml`
+- `tests/RoslynMcp.Tests/TestInfrastructure/PowerShellOutputNormalizer.cs`

--- a/changelog.d/cross-platform-release-test-assertions.md
+++ b/changelog.d/cross-platform-release-test-assertions.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** three release-gate tests passed on the self-hosted Windows merge runner but failed on the GitHub-hosted Linux publish runner, so v3.0.1 tagged without ever publishing a package. `NuGetAuditGateTests` read `Justfile` where the on-disk name is `justfile` (resolves case-insensitively on Windows, throws on Linux); `BreakingVersionGateTests` and `VerifyReleaseChildScriptTests` asserted substrings against raw PowerShell `Write-Error` output, which hard-wraps at a host-dependent console width and prefixes continuation lines with a `|` gutter, splitting expected phrases mid-match. Adds a shared `PowerShellOutputNormalizer` that strips ANSI styling, rejoins gutter-wrapped lines, and collapses whitespace, with regression coverage built from the captured Linux output. The gates themselves were always correct — they fired exactly as designed and the assertions simply failed to recognize it. The underlying merge-vs-publish runner-OS split is tracked by `ci-merge-publish-runner-os-parity`.

--- a/tests/RoslynMcp.Tests/BreakingVersionGateTests.cs
+++ b/tests/RoslynMcp.Tests/BreakingVersionGateTests.cs
@@ -205,8 +205,13 @@ public sealed class BreakingVersionGateTests
                     testCase.RequireConsumedFragments);
                 var diagnostic = $"{testCase.Name}: stdout={result.StdOut} stderr={result.StdErr}";
 
+                // Normalize: PowerShell's error formatter wraps at console width, so the
+                // expected phrase splits across a '|' gutter at a host-dependent column.
+                var normalizedOutput = PowerShellOutputNormalizer.Normalize(
+                    result.StdOut + result.StdErr);
+
                 Assert.AreEqual(testCase.ExpectedExitCode, result.ExitCode, diagnostic);
-                StringAssert.Contains(result.StdOut + result.StdErr, testCase.ExpectedText, diagnostic);
+                StringAssert.Contains(normalizedOutput, testCase.ExpectedText, diagnostic);
             }
             finally
             {

--- a/tests/RoslynMcp.Tests/NuGetAuditGateTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetAuditGateTests.cs
@@ -8,7 +8,9 @@ public sealed class NuGetAuditGateTests
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
         var script = File.ReadAllText(Path.Combine(repositoryRoot, "eng", "verify-nuget-audit.ps1"));
-        var justfile = File.ReadAllText(Path.Combine(repositoryRoot, "Justfile"));
+        // Lowercase 'justfile' matches the on-disk name. A capitalized spelling resolves on
+        // case-insensitive Windows but throws on the case-sensitive Linux publish runner.
+        var justfile = File.ReadAllText(Path.Combine(repositoryRoot, "justfile"));
         var workflow = File.ReadAllText(Path.Combine(repositoryRoot, ".github", "workflows", "ci.yml"));
 
         StringAssert.Contains(script, "--force-evaluate");

--- a/tests/RoslynMcp.Tests/PowerShellOutputNormalizerTests.cs
+++ b/tests/RoslynMcp.Tests/PowerShellOutputNormalizerTests.cs
@@ -1,0 +1,40 @@
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class PowerShellOutputNormalizerTests
+{
+    private const char Esc = (char)0x1B;
+
+    [TestMethod]
+    public void Normalize_RejoinsGutterWrappedErrorText()
+    {
+        // Shape captured verbatim from the Linux publish runner, where the console width
+        // split "require a major bump" across the formatter's '|' continuation gutter and
+        // broke a substring assertion against output that was in fact correct.
+        var wrapped =
+            $"{Esc}[31;1mWrite-Error: {Esc}[0m/repo/eng/verify-breaking-version-bump.ps1:90{Esc}[0m\n" +
+            $"{Esc}[36;1mLine |{Esc}[0m\n" +
+            $"     | {Esc}[31;1mRefusing patch bump: pending breaking fragment(s) require a{Esc}[0m\n" +
+            $"     | {Esc}[31;1mmajor bump: pending.md{Esc}[0m\n";
+
+        var normalized = PowerShellOutputNormalizer.Normalize(wrapped);
+
+        StringAssert.Contains(normalized, "require a major bump: pending.md");
+        Assert.IsFalse(normalized.Contains(Esc), "ANSI styling should be stripped.");
+    }
+
+    [TestMethod]
+    public void Normalize_PreservesMidLinePipes()
+    {
+        // Only a newline-anchored gutter is a wrap artifact; a mid-line pipe is content.
+        Assert.AreEqual(
+            "dotnet test | grep fail",
+            PowerShellOutputNormalizer.Normalize("dotnet test | grep fail"));
+    }
+
+    [TestMethod]
+    public void Normalize_CollapsesWhitespaceRuns()
+    {
+        Assert.AreEqual("a b c", PowerShellOutputNormalizer.Normalize("  a \t\t b \n\n c  "));
+    }
+}

--- a/tests/RoslynMcp.Tests/TestInfrastructure/PowerShellOutputNormalizer.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/PowerShellOutputNormalizer.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Normalizes captured PowerShell console output so substring assertions survive the
+/// host's error formatter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Write-Error renders through PowerShell's formatter, which hard-wraps the message at the
+/// console width and prefixes every continuation line with a '|' gutter. The wrap column
+/// depends on the host, so the same message splits differently on a Windows self-hosted
+/// runner than on a GitHub-hosted Linux runner. A message reading "require a major bump" on
+/// one host arrives as "require a" + newline + " | major bump" on the other, and a naive
+/// substring assertion fails against output that is in fact correct.
+/// </para>
+/// <para>
+/// Normalizing strips ANSI styling, rejoins gutter-wrapped continuation lines, and collapses
+/// whitespace runs, yielding host-independent single-line text to assert against.
+/// </para>
+/// </remarks>
+internal static class PowerShellOutputNormalizer
+{
+    private const char AnsiEscape = (char)0x1B;
+
+    private static readonly Regex AnsiStylePattern = new(
+        AnsiEscape + @"\[[0-9;]*m",
+        RegexOptions.Compiled);
+
+    // PowerShell's wrapped-line gutter: newline, optional indent, '|', optional spacing.
+    // Anchoring on the newline keeps legitimate mid-line pipes intact.
+    private static readonly Regex ContinuationGutterPattern = new(
+        @"\r?\n[ \t]*\|[ \t]*",
+        RegexOptions.Compiled);
+
+    private static readonly Regex WhitespaceRunPattern = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns <paramref name="output"/> with ANSI styling removed, formatter line-wrapping
+    /// rejoined, and whitespace collapsed to single spaces.
+    /// </summary>
+    public static string Normalize(string output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        var withoutAnsi = AnsiStylePattern.Replace(output, string.Empty);
+        var rejoined = ContinuationGutterPattern.Replace(withoutAnsi, " ");
+        return WhitespaceRunPattern.Replace(rejoined, " ").Trim();
+    }
+}

--- a/tests/RoslynMcp.Tests/VerifyReleaseChildScriptTests.cs
+++ b/tests/RoslynMcp.Tests/VerifyReleaseChildScriptTests.cs
@@ -173,13 +173,9 @@ public sealed class VerifyReleaseChildScriptTests
                     cleanupMode: testCase.Mode,
                     failDotnetTest: testCase.FailDotnetTest);
                 var combinedOutput = result.StdOut + result.StdErr;
-                var normalizedOutput = System.Text.RegularExpressions.Regex.Replace(
-                    System.Text.RegularExpressions.Regex.Replace(
-                        combinedOutput,
-                        "\u001B\\[[0-9;]*m",
-                        string.Empty),
-                    "\\s+",
-                    " ");
+                // Also rejoins the formatter's '|' continuation gutter, which survives a
+                // plain whitespace collapse and splits expected phrases on Linux runners.
+                var normalizedOutput = PowerShellOutputNormalizer.Normalize(combinedOutput);
                 var diagnostic = $"{testCase.Name}: stdout={result.StdOut} stderr={result.StdErr}";
                 var attemptPath = Path.Combine(fixtureRoot, "cleanup-attempts.txt");
                 var targetPath = Path.Combine(fixtureRoot, "cleanup-target.txt");


### PR DESCRIPTION
## Summary

Unblocks the v3.0.1 publish. Three tests added after v3.0.0 passed on the self-hosted **Windows** merge runner but failed on the GitHub-hosted **Linux** publish runner, so `v3.0.1` tagged and then shipped **no package** (NuGet is still on 3.0.0).

| Test | Root cause |
|---|---|
| `NuGetAuditGateTests` | Read `"Justfile"`; on-disk name is `justfile`. Resolves case-insensitively on Windows, throws on Linux. |
| `BreakingVersionGateTests` | Asserted `"require a major bump"` against raw PowerShell `Write-Error` output, which wraps at console width into `"require a"` / `"major bump"`. |
| `VerifyReleaseChildScriptTests` | Same wrapping; its normalizer stripped ANSI and collapsed whitespace but not the `\|` continuation gutter. |

**The gates themselves were always correct.** `verify-breaking-version-bump.ps1` genuinely refused the fixture's patch bump exactly as designed — the assertions just failed to recognize their own success through the line wrap. No safety property is relaxed, no gate is weakened, and no expected-value was loosened to force a pass.

## Approach

Adds `PowerShellOutputNormalizer` (strip ANSI → rejoin `|` gutter → collapse whitespace) and routes both wrap-sensitive tests through it, replacing the partial inline normalizer.

Because the failure only reproduces at Linux console width, the regression test feeds the normalizer the **actual captured CI output** from the failed run — so the fix is verifiable on any platform rather than only provable by shipping.

## Follow-up

Files backlog row `ci-merge-publish-runner-os-parity` (High/M) for the real underlying problem: the merge gate runs Windows and the publish gate runs Linux, so Windows-only-passing tests can merge, tag, and only then block publication.

## Test plan

- [x] `PowerShellOutputNormalizerTests` — 3 pass, incl. real captured Linux output
- [x] The 3 previously-failing classes — 6 pass locally
- [x] `eng/verify-changelog-fragments.ps1` passes
- [ ] CI `validate` (Windows) green
- [ ] `publish-nuget` (Linux) green after re-tag — the gate that actually failed