### PR TITLE
fix(parameter-object): refuse mutable value-type parameter mutations before preview

### DIFF
--- a/changelog.d/parameter-object-value-type-mutation-semantics.md
+++ b/changelog.d/parameter-object-value-type-mutation-semantics.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `parameter_object_preview` no longer silently changes program behavior when a grouped parameter is a mutable value type. Mutating member calls and nested field/property writes through a struct parameter are now detected and refused before a preview token is created, naming the affected parameter and source location. Reference-type member mutation and array-element writes remain supported.

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -386,7 +386,7 @@ public sealed class ParameterObjectService : IParameterObjectService
                     continue;
                 }
 
-                var useKind = ClassifyVariableRequiredUse(reference, semanticModel, ct);
+                var useKind = ClassifyVariableRequiredUse(reference, parameter, semanticModel, ct);
                 if (useKind is null) continue;
 
                 var lineSpan = reference.GetLocation().GetLineSpan();
@@ -408,11 +408,15 @@ public sealed class ParameterObjectService : IParameterObjectService
 
     private static string? ClassifyVariableRequiredUse(
         IdentifierNameSyntax reference,
+        IParameterSymbol parameter,
         SemanticModel semanticModel,
         CancellationToken ct)
     {
         var semanticUseKind = ClassifySemanticVariableRequiredUse(reference, semanticModel, ct);
         if (semanticUseKind is not null) return semanticUseKind;
+
+        var valueTypeMutationKind = ClassifyValueTypeMutation(reference, parameter, semanticModel, ct);
+        if (valueTypeMutationKind is not null) return valueTypeMutationKind;
 
         var assignment = reference.Ancestors().OfType<AssignmentExpressionSyntax>()
             .FirstOrDefault(candidate => IsDirectAssignmentTarget(candidate.Left, reference));
@@ -477,6 +481,81 @@ public sealed class ParameterObjectService : IParameterObjectService
             var receiver = invocation.TargetMethod.ReducedFrom?.Parameters.FirstOrDefault();
             if (receiver?.RefKind == RefKind.Ref)
                 return "ref extension receiver";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Detects mutations that flow THROUGH a mutable value-type parameter — a non-readonly
+    /// instance member call or a nested member/element write — which the positional-record
+    /// rewrite would silently redirect onto a temporary struct copy (the mutation would
+    /// compile cleanly and be discarded). Reference-type parameters and readonly structs
+    /// short-circuit to null: member mutation through a reference lands on the shared heap
+    /// object either way, so those uses stay eligible.
+    /// </summary>
+    private static string? ClassifyValueTypeMutation(
+        IdentifierNameSyntax reference,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        CancellationToken ct)
+    {
+        if (!parameter.Type.IsValueType) return null;
+        if (parameter.Type is INamedTypeSymbol { IsReadOnly: true }) return null;
+
+        var operation = semanticModel.GetOperation(reference, ct);
+        if (operation is not null)
+        {
+            var unwrapped = UnwrapTransparentOperation(operation);
+            if (unwrapped.Parent is IInvocationOperation invocation
+                && ReferenceEquals(invocation.Instance, unwrapped)
+                && invocation.TargetMethod.ContainingType?.IsValueType == true
+                && !invocation.TargetMethod.IsReadOnly)
+            {
+                return "mutable value-type member call";
+            }
+        }
+
+        // Walk the receiver chain rooted at this reference (param.Field, param[i], and
+        // nested combinations). A write through the chain mutates the parameter only when
+        // every intermediate receiver is itself value-typed — the first reference-typed
+        // segment re-anchors the write onto a shared heap object, keeping it eligible.
+        var chainRoot = UnwrapParentheses(reference);
+        ExpressionSyntax current = chainRoot;
+        while (true)
+        {
+            ExpressionSyntax? next = current.Parent switch
+            {
+                MemberAccessExpressionSyntax member when member.Expression == current => member,
+                ElementAccessExpressionSyntax element when element.Expression == current => element,
+                _ => null,
+            };
+            if (next is null) break;
+
+            if (current != chainRoot
+                && semanticModel.GetTypeInfo(current, ct).Type?.IsValueType != true)
+            {
+                return null;
+            }
+
+            current = UnwrapParentheses(next);
+        }
+
+        if (current == chainRoot) return null;
+
+        if (current.Parent is AssignmentExpressionSyntax assignment && assignment.Left == current)
+            return "value-type member assignment";
+        if (current.Parent is PrefixUnaryExpressionSyntax prefix
+            && (prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+        {
+            return "value-type member assignment";
+        }
+        if (current.Parent is PostfixUnaryExpressionSyntax postfix
+            && (postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                || postfix.IsKind(SyntaxKind.PostDecrementExpression)))
+        {
+            return "value-type member assignment";
         }
 
         return null;

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -180,6 +180,148 @@ public sealed class ParameterObjectPreviewTests : TestBase
         }
     }
 
+    /// <summary>
+    /// parameter-object-value-type-mutation-semantics: a mutating instance member call or a
+    /// nested field write through a mutable struct parameter must refuse the preview —
+    /// previously the rewrite silently redirected the mutation onto a temporary struct copy
+    /// (the positional-record property read), compiling cleanly with changed runtime behavior.
+    /// </summary>
+    [TestMethod]
+    public async Task MutableValueTypeParameterMutations_RefusePreviewWithActionableUses()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public struct POMutableStruct
+            {
+                public int State;
+                public void Mutate() => State++;
+            }
+
+            public class POValueTypeFixture
+            {
+                public int Compute(POMutableStruct called, POMutableStruct written)
+                {
+                    called.Mutate();
+                    written.State = 1;
+                    return called.State + written.State;
+                }
+            }
+            """,
+            "POValueTypeFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 11, column: 16),
+                    new ParameterObjectPreviewRequest(["called", "written"], "ComputeArgs"),
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "'called'");
+            StringAssert.Contains(ex.Message, "(mutable value-type member call)");
+            StringAssert.Contains(ex.Message, "'written'");
+            StringAssert.Contains(ex.Message, "(value-type member assignment)");
+            StringAssert.Contains(ex.Message, "POValueTypeFixture.cs:13");
+            StringAssert.Contains(ex.Message, "POValueTypeFixture.cs:14");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// parameter-object-value-type-mutation-semantics, do-not-over-refuse acceptance:
+    /// member mutation through a reference-type parameter, an array element write, and
+    /// readonly-struct member use are all semantically preserved by the DTO property read,
+    /// so the preview must succeed and the apply must keep the mutation semantics intact.
+    /// </summary>
+    [TestMethod]
+    public async Task ReferenceTypeAndReadOnlyStructParameters_PreviewSucceedsAndApplies()
+    {
+        var (workspaceId, fixturePath, fixtureDir) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class PORefHolder
+            {
+                public int Value { get; set; }
+            }
+
+            public readonly struct POReadOnlySnapshot
+            {
+                public readonly int State;
+                public POReadOnlySnapshot(int state) => State = state;
+                public int Read() => State;
+            }
+
+            public class POEligibleFixture
+            {
+                public int Compute(PORefHolder holder, int[] items, POReadOnlySnapshot snapshot)
+                {
+                    holder.Value = 1;
+                    items[0] = 2;
+                    return holder.Value + items[0] + snapshot.Read() + snapshot.State;
+                }
+
+                public int Caller() => Compute(new PORefHolder(), new int[1], new POReadOnlySnapshot(3));
+            }
+            """,
+            "POEligibleFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 17, column: 16),
+                new ParameterObjectPreviewRequest(["holder", "items", "snapshot"], "ComputeArgs"),
+                CancellationToken.None);
+
+            Assert.IsNotNull(preview.PreviewToken, "reference-type and readonly-struct parameters must stay eligible");
+            var fixtureDiff = preview.Changes.First(c =>
+                c.FilePath.EndsWith("POEligibleFixture.cs", StringComparison.OrdinalIgnoreCase)).UnifiedDiff;
+            StringAssert.Contains(fixtureDiff, "computeArgs.Holder.Value = 1");
+            StringAssert.Contains(fixtureDiff, "computeArgs.Items[0] = 2");
+            StringAssert.Contains(fixtureDiff, "new ComputeArgs(new PORefHolder(), new int[1], new POReadOnlySnapshot(3))");
+
+            var workflowService = new ApplyUndoWorkflowService(
+                RefactoringService,
+                CompileCheckService,
+                UndoService,
+                PreviewStore);
+            var applyJson = await ApplyWithVerifyTool.ApplyWithVerify(
+                WorkspaceExecutionGate,
+                workflowService,
+                PreviewStore,
+                preview.PreviewToken,
+                rollbackOnError: true,
+                ct: CancellationToken.None);
+            using var apply = JsonDocument.Parse(applyJson);
+            Assert.AreEqual(
+                "applied",
+                apply.RootElement.GetProperty("status").GetString(),
+                $"apply_with_verify must redeem the preview token. Response: {applyJson}");
+            Assert.AreEqual(
+                apply.RootElement.GetProperty("preErrorCount").GetInt32(),
+                apply.RootElement.GetProperty("postErrorCount").GetInt32(),
+                $"Applying the preview must introduce no diagnostics. Response: {applyJson}");
+
+            Assert.IsTrue(File.Exists(Path.Combine(fixtureDir, "ComputeArgs.cs")), "DTO file must be written to disk");
+            var fixtureText = await File.ReadAllTextAsync(fixturePath);
+            StringAssert.Contains(fixtureText, "Compute(ComputeArgs computeArgs)");
+            StringAssert.Contains(fixtureText, "computeArgs.Holder.Value = 1");
+            StringAssert.Contains(fixtureText, "computeArgs.Items[0] = 2");
+            StringAssert.Contains(fixtureText, "new ComputeArgs(new PORefHolder(), new int[1], new POReadOnlySnapshot(3))");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
     [TestMethod]
     public async Task NewParameterName_InvalidRetainedOrLocalCollision_RefusesPreview()
     {


### PR DESCRIPTION
## Summary

`parameter_object_preview` silently changed program behavior when a grouped parameter was a mutable value type: the positional-record rewrite turned the parameter into a DTO property read, so a mutating instance member call (`value.Mutate()`) or a nested field/property write (`value.Field = 1`) landed on a temporary struct copy — compiling cleanly and discarding the mutation.

- `ClassifyVariableRequiredUse` now takes the bound `IParameterSymbol` and delegates to a new `ClassifyValueTypeMutation` classifier after the existing semantic checks.
- The classifier fires only for non-readonly value-type parameters and detects two shapes: a non-readonly instance member call whose `IInvocationOperation.Instance` is the parameter reference (`mutable value-type member call`), and a member/element receiver-chain write whose segments are all value-typed (`value-type member assignment`).
- The receiver-chain walk stops at the first reference-typed segment, so `refParam.Prop = 1`, `items[0] = 2`, and `structParam.RefField.ValueField = 1` remain eligible — mutation through a reference lands on the shared heap object either way.
- Refusal happens in `EnforceGroupedParametersAreReadOnlyAsync` before any preview token is stored, naming each parameter, use kind, and `file:line`.

## Validation

- `dotnet build` on `RoslynMcp.Roslyn` and `RoslynMcp.Tests`: clean.
- `dotnet test --filter ParameterObjectPreviewTests`: 38/38 pass, including two new tests — a refusal test (member-call + nested-field-write shapes with message assertions) and a positive preview+apply regression over reference-type / array / readonly-struct parameters.
- `./eng/verify-changelog-fragments.ps1` and `./eng/verify-ai-docs.ps1`: pass. Full `verify-release.ps1` left to CI (self-hosted runner policy).

Closes: parameter-object-value-type-mutation-semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)