### PR TITLE
fix(parameter-object): validate grouped parameter types before DTO emission (parameter-object-generic-dto-type-validity)

### DIFF
--- a/changelog.d/parameter-object-generic-dto-type-validity.md
+++ b/changelog.d/parameter-object-generic-dto-type-validity.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `parameter_object_preview` now validates every grouped parameter type before emitting the generated record — it refuses (instead of producing an uncompilable preview) when a parameter type depends on a method or containing-type type parameter, is less accessible than the chosen record visibility, or is unavailable from the selected DTO project. Refusals name the offending parameter and type, and no preview token is stored.

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -78,6 +78,8 @@ public sealed class ParameterObjectService : IParameterObjectService
         var callSites = await CollectCallSiteBindingsAsync(solution, method, groupedParameters, ct).ConfigureAwait(false);
         var methodProject = solution.GetProject(method.ContainingAssembly, ct)!;
         EnforceCrossProjectReferences(solution, methodProject, dtoProject, callSites);
+        await EnforceGroupedParameterTypesAreDtoCompatibleAsync(
+            solution, methodProject, dtoProject, groupedParameters, dtoVisibilityIsPublic, ct).ConfigureAwait(false);
 
         var defaultValueWarnings = await CollectDefaultValueWarningsAsync(
             solution, groupedParameters, callSites, ct).ConfigureAwait(false);
@@ -978,6 +980,139 @@ public sealed class ParameterObjectService : IParameterObjectService
                 "parameter_object_preview refuses: one or more caller projects do not reference the DTO project. " +
                 "Add a project reference (use add_project_reference_preview) for each entry, then retry. " +
                 "Missing references: " + string.Join("; ", missing));
+    }
+
+    /// <summary>
+    /// Validates that every grouped parameter type can legally appear as a positional member
+    /// of the generated record. Three refusal classes, each thrown before any preview token is
+    /// stored: (1) the type depends on a method or containing-type type parameter, which a
+    /// non-generic top-level record cannot bind; (2) some constituent type is less accessible
+    /// than the record visibility chosen by <see cref="ResolveDtoProject"/>, which would emit
+    /// an inconsistent-accessibility (CS0051-style) DTO; (3) for a cross-project DTO, some
+    /// source-declared constituent type lives in an assembly the DTO project cannot see, so
+    /// the emitted type name would not resolve (CS0246).
+    /// </summary>
+    private static async Task EnforceGroupedParameterTypesAreDtoCompatibleAsync(
+        Solution solution,
+        Project methodProject,
+        Project dtoProject,
+        IReadOnlyList<IParameterSymbol> grouped,
+        bool dtoVisibilityIsPublic,
+        CancellationToken ct)
+    {
+        var crossProject = dtoProject.Id != methodProject.Id;
+        var dtoCompilation = crossProject
+            ? await dtoProject.GetCompilationAsync(ct).ConfigureAwait(false)
+            : null;
+        var neededRank = dtoVisibilityIsPublic ? PublicAccessibilityRank : InternalAccessibilityRank;
+        var recordVisibility = dtoVisibilityIsPublic ? "public" : "internal";
+
+        foreach (var parameter in grouped)
+        {
+            foreach (var constituent in EnumerateConstituentTypes(parameter.Type))
+            {
+                if (constituent is ITypeParameterSymbol typeParameter)
+                {
+                    var declarer = typeParameter.DeclaringMethod is { } declaringMethod
+                        ? $"method '{declaringMethod.ToDisplayString()}'"
+                        : $"type '{typeParameter.DeclaringType?.ToDisplayString()}'";
+                    throw new ArgumentException(
+                        $"parameter_object_preview refuses: parameter '{parameter.Name}' has type '{parameter.Type.ToDisplayString()}' " +
+                        $"which depends on type parameter '{typeParameter.Name}' declared by {declarer}. " +
+                        "The generated record is non-generic and its new top-level file cannot bind that type parameter; " +
+                        "remove the parameter from parameterNames.",
+                        nameof(grouped));
+                }
+
+                if (constituent is not INamedTypeSymbol named || named.TypeKind == TypeKind.Error)
+                    continue;
+
+                if (AccessibilityRank(named.DeclaredAccessibility) < neededRank)
+                    throw new ArgumentException(
+                        $"parameter_object_preview refuses: parameter '{parameter.Name}' has type '{parameter.Type.ToDisplayString()}' " +
+                        $"involving '{named.ToDisplayString()}', which is '{named.DeclaredAccessibility.ToString().ToLowerInvariant()}' — " +
+                        $"less accessible than the generated '{recordVisibility}' record. " +
+                        "Widen the type's accessibility, or remove the parameter from parameterNames.",
+                        nameof(grouped));
+
+                if (crossProject
+                    && named.Locations.Any(l => l.IsInSource)
+                    && !IsAssemblyReachable(dtoCompilation!, named.ContainingAssembly))
+                {
+                    var typeProjectName = solution.GetProject(named.ContainingAssembly, ct)?.Name
+                        ?? named.ContainingAssembly.Name;
+                    throw new ArgumentException(
+                        $"parameter_object_preview refuses: parameter '{parameter.Name}' has type '{parameter.Type.ToDisplayString()}' " +
+                        $"involving '{named.ToDisplayString()}', which is declared in '{typeProjectName}' — not referenced by DTO project '{dtoProject.Name}'. " +
+                        "Add a project reference (use add_project_reference_preview) for each entry, then retry. " +
+                        $"Missing references: {dtoProject.Name} -> {typeProjectName}",
+                        nameof(grouped));
+                }
+            }
+        }
+    }
+
+    private const int PublicAccessibilityRank = 4;
+    private const int InternalAccessibilityRank = 2;
+
+    /// <summary>
+    /// Rank order for "accessible from a new top-level file": protected/private-family
+    /// accessibility never qualifies, because the generated record is never nested inside
+    /// the declaring type.
+    /// </summary>
+    private static int AccessibilityRank(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Public => PublicAccessibilityRank,
+        Accessibility.ProtectedOrInternal => 3,
+        Accessibility.Internal => InternalAccessibilityRank,
+        _ => 1,
+    };
+
+    /// <summary>
+    /// Yields <paramref name="type"/> and every type it structurally depends on: array
+    /// element types, pointer/function-pointer constituents, generic type arguments, and
+    /// containing types of nested types.
+    /// </summary>
+    private static IEnumerable<ITypeSymbol> EnumerateConstituentTypes(ITypeSymbol type)
+    {
+        var seen = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+        var pending = new Stack<ITypeSymbol>();
+        pending.Push(type);
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (!seen.Add(current)) continue;
+            yield return current;
+            switch (current)
+            {
+                case IArrayTypeSymbol array:
+                    pending.Push(array.ElementType);
+                    break;
+                case IPointerTypeSymbol pointer:
+                    pending.Push(pointer.PointedAtType);
+                    break;
+                case IFunctionPointerTypeSymbol functionPointer:
+                    pending.Push(functionPointer.Signature.ReturnType);
+                    foreach (var p in functionPointer.Signature.Parameters) pending.Push(p.Type);
+                    break;
+                case INamedTypeSymbol named:
+                    foreach (var argument in named.TypeArguments) pending.Push(argument);
+                    if (named.ContainingType is { } outer) pending.Push(outer);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="assembly"/>'s types resolve inside <paramref name="dtoCompilation"/>:
+    /// it is the DTO assembly itself or one of its referenced assemblies (compared by identity,
+    /// because the symbols originate from different compilations).
+    /// </summary>
+    private static bool IsAssemblyReachable(Compilation dtoCompilation, IAssemblySymbol assembly)
+    {
+        if (dtoCompilation.Assembly.Identity.Equals(assembly.Identity)) return true;
+        return dtoCompilation.SourceModule.ReferencedAssemblySymbols
+            .Any(referenced => referenced.Identity.Equals(assembly.Identity));
     }
 
     private static async Task<List<string>> CollectDefaultValueWarningsAsync(

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -697,6 +697,146 @@ public sealed class ParameterObjectPreviewTests : TestBase
     }
 
     [TestMethod]
+    [DataRow(
+        """
+        namespace SampleLib;
+
+        public class POGenericMethodFixture
+        {
+            public T Pick<T>(T value, int index) => value;
+        }
+        """,
+        "POGenericMethodFixture.cs", 5, 14, "value,index",
+        "type parameter 'T'", "'value'",
+        DisplayName = "method type parameter")]
+    [DataRow(
+        """
+        namespace SampleLib;
+
+        public class POGenericTypeFixture<T>
+        {
+            public void Store(T item, int slot) { _ = item; _ = slot; }
+        }
+        """,
+        "POGenericTypeFixture.cs", 5, 17, "item,slot",
+        "type parameter 'T'", "'item'",
+        DisplayName = "containing-type type parameter")]
+    [DataRow(
+        """
+        namespace SampleLib;
+
+        internal sealed class POInternalThing;
+
+        public class POAccessFixture
+        {
+            internal void Use(POInternalThing secret, int a) { _ = secret; _ = a; }
+        }
+        """,
+        "POAccessFixture.cs", 7, 19, "secret,a",
+        "'SampleLib.POInternalThing'", "'secret'",
+        DisplayName = "internal type into public record")]
+    [DataRow(
+        """
+        namespace SampleLib;
+
+        internal sealed class POInternalElement;
+
+        public class POAccessListFixture
+        {
+            internal void UseAll(List<POInternalElement> items, int a) { _ = items; _ = a; }
+        }
+        """,
+        "POAccessListFixture.cs", 7, 19, "items,a",
+        "'SampleLib.POInternalElement'", "'items'",
+        DisplayName = "internal type argument inside public generic")]
+    [DataRow(
+        """
+        namespace SampleLib;
+
+        public class POPrivateNestedFixture
+        {
+            private sealed class Secret;
+
+            internal void Keep(Secret secret, int a) { _ = secret; _ = a; }
+        }
+        """,
+        "POPrivateNestedFixture.cs", 7, 19, "secret,a",
+        "'SampleLib.POPrivateNestedFixture.Secret'", "'secret'",
+        DisplayName = "private-nested type into public record")]
+    public async Task GroupedParameterTypeInvalidForDto_RefusesPreview(
+        string fixtureSource,
+        string fileName,
+        int line,
+        int column,
+        string parameterNames,
+        string expectedTypeFragment,
+        string expectedParameterFragment)
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(fixtureSource, fileName);
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line, column),
+                    new ParameterObjectPreviewRequest([.. parameterNames.Split(',')], "GroupedArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "parameter_object_preview refuses");
+            StringAssert.Contains(ex.Message, expectedTypeFragment);
+            StringAssert.Contains(ex.Message, expectedParameterFragment);
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task CrossProject_RefusesWhenParameterTypeUnavailableFromDtoProject()
+    {
+        // SampleApp references SampleLib, so the existing caller-side reference gate passes
+        // when the DTO is routed to SampleLib — but the parameter type below is declared in
+        // SampleApp, which SampleLib does NOT reference, so the emitted record could never
+        // resolve the type name. The preview must refuse before storing a token.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var appDir = Path.Combine(solutionDir, "SampleApp");
+
+        var appFile = Path.Combine(appDir, "POAvailFixture.cs");
+        await File.WriteAllTextAsync(appFile,
+            """
+            namespace SampleApp;
+
+            public sealed class POAppOnlyType;
+
+            public class POAvailFixture
+            {
+                public void Run(POAppOnlyType first, POAppOnlyType second) { _ = first; _ = second; }
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(appFile, line: 7, column: 17),
+                    new ParameterObjectPreviewRequest(["first", "second"], "RunArgs", DtoProjectName: "SampleLib"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "'first'");
+            StringAssert.Contains(ex.Message, "'SampleApp.POAppOnlyType'");
+            StringAssert.Contains(ex.Message, "SampleLib -> SampleApp");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
     public async Task CrossProject_RewritesCallSiteWhenReferenceExists()
     {
         // SampleApp already references SampleLib in the SampleSolution fixture, so a method


### PR DESCRIPTION
## Summary

`parameter_object_preview` emitted `grouped[i].Type.ToDisplayString()` straight into the generated non-generic `sealed record` with zero validation, so three classes of input produced an uncompilable preview whose token was still stored and handed back:

- **Generic scope** — a parameter typed by a method or containing-type type parameter emits `public sealed record Foo(T Value);` in a new top-level file where `T` is unbound (CS0246).
- **Accessibility** — a `public` record (visibility forced by `ResolveDtoProject`, always public cross-project) referencing an `internal`/private-nested constituent type yields inconsistent-accessibility errors (CS0051-shape).
- **Cross-project availability** — `EnforceCrossProjectReferences` only checked caller → DTO-project references, never the reverse, so a DTO in project B naming a type declared only in project A emitted an unresolvable type name.

## Fix

New `EnforceGroupedParameterTypesAreDtoCompatibleAsync` gate in `ParameterObjectService`, called after `EnforceCrossProjectReferences` and before `BuildDtoSource` / `_previewStore.Store`, extending the existing throw-before-store refusal pattern. It walks every constituent type (array elements, pointer/function-pointer signatures, generic type arguments, containing types of nested types) and refuses with an actionable `ArgumentException` naming the offending parameter and type when:

1. any constituent is a type parameter (refusal chosen over generic propagation — threading type parameters through the record, rewritten signature, and every callsite is a materially larger initiative);
2. any constituent's accessibility ranks below the chosen record visibility (`List<InternalThing>` into a public record refuses);
3. (cross-project only) a source-declared constituent's assembly is not reachable from the DTO project's compilation — mirroring the existing missing-reference message shape with the `add_project_reference_preview` pointer and `A -> B` list; metadata/framework assemblies are treated as available to avoid false refusals on `System.*`.

Because the throw precedes `_previewStore.Store`, no malformed preview token is ever persisted.

## Tests

`ParameterObjectPreviewTests`: one data-driven refusal test (method type parameter, containing-type type parameter, internal type into public record, internal type argument inside `List<>`, private-nested type) + one cross-project availability `[TestMethod]` on the `SampleApp`→`SampleLib` fixture. Existing positive controls and adjacent refusals (`RefOutParameter…`, `CrossProject_RefusesWhenCallerProjectMissingReference`, `DefaultValueOmission…`) all still pass — full `ParameterObjectPreviewTests` suite: 44/44.

Closes: parameter-object-generic-dto-type-validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)