### PR TITLE
fix(parameter-object): qualify generated DTO references across namespaces

### DIFF
--- a/changelog.d/parameter-object-dto-reference-qualification.md
+++ b/changelog.d/parameter-object-dto-reference-qualification.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `parameter_object_preview` emitted an unqualified generated-DTO type name in the rewritten method declaration and at every call site, so when the DTO's namespace differed from the target declaration's or a caller's namespace (explicit `dtoNamespace`, or the cross-project default) the applied edit produced CS0246. The rewriter now emits a `global::`-qualified reference when the DTO namespace is not already in scope for that document, and preserves the unqualified form otherwise.

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -99,10 +99,10 @@ public sealed class ParameterObjectService : IParameterObjectService
         var perFileCallsites = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         var accumulator = await RewriteMethodDeclarationAsync(
-            solution, method, groupedParameters, request.NewTypeName, newParameterName, originalTexts, ct).ConfigureAwait(false);
+            solution, method, groupedParameters, dtoNamespace, request.NewTypeName, newParameterName, originalTexts, ct).ConfigureAwait(false);
 
         accumulator = await RewriteCallSitesAsync(
-            accumulator, solution, method, groupedParameters, request.NewTypeName, callSites,
+            accumulator, solution, method, groupedParameters, dtoNamespace, request.NewTypeName, callSites,
             originalTexts, perFileCallsites, ct).ConfigureAwait(false);
 
         // Add the new DTO document last so its diff is appended cleanly; we capture no
@@ -1187,6 +1187,61 @@ public sealed class ParameterObjectService : IParameterObjectService
         return Path.Combine([projectDir, .. folders, $"{typeName}.cs"]);
     }
 
+    /// <summary>
+    /// Returns the type reference to emit for the generated DTO from the document position of
+    /// <paramref name="contextNode"/>: the bare <paramref name="typeName"/> when the DTO
+    /// namespace is already in scope there (the enclosing namespace chain equals or is nested
+    /// under it, or a plain using directive visible to the node imports it), otherwise
+    /// <c>global::{dtoNamespace}.{typeName}</c> so the emitted reference binds regardless of
+    /// the document's local imports. Kept private to the service, mirroring the conditional
+    /// qualification pattern in <c>ExtractMethodService</c>. Note: a <c>global using</c>
+    /// declared in a different file of the same project is invisible to this syntax-only scan,
+    /// so such callers receive a technically-unnecessary but still-correct qualification.
+    /// </summary>
+    private static string ResolveDtoTypeReference(SyntaxNode contextNode, string dtoNamespace, string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(dtoNamespace))
+            return typeName;
+
+        // Enclosing namespace chain, outermost-first (handles nested block namespaces).
+        var namespaceParts = new List<string>();
+        foreach (var ns in contextNode.AncestorsAndSelf().OfType<BaseNamespaceDeclarationSyntax>())
+            namespaceParts.Insert(0, ns.Name.ToString());
+        var contextNamespace = string.Join('.', namespaceParts);
+
+        // Name lookup searches each enclosing namespace outward, so the bare name binds when
+        // the context namespace equals the DTO namespace or is nested anywhere under it.
+        if (string.Equals(contextNamespace, dtoNamespace, StringComparison.Ordinal)
+            || contextNamespace.StartsWith(dtoNamespace + ".", StringComparison.Ordinal))
+        {
+            return typeName;
+        }
+
+        // Plain (non-alias, non-static) using directives on the compilation unit or any
+        // enclosing namespace declaration — including same-file `global using` — also bring
+        // the DTO namespace into scope.
+        foreach (var node in contextNode.AncestorsAndSelf())
+        {
+            var usings = node switch
+            {
+                CompilationUnitSyntax cu => cu.Usings,
+                BaseNamespaceDeclarationSyntax nsDecl => nsDecl.Usings,
+                _ => default,
+            };
+            foreach (var directive in usings)
+            {
+                if (directive.Alias is null
+                    && directive.StaticKeyword.IsKind(SyntaxKind.None)
+                    && string.Equals(directive.Name?.ToString(), dtoNamespace, StringComparison.Ordinal))
+                {
+                    return typeName;
+                }
+            }
+        }
+
+        return $"global::{dtoNamespace}.{typeName}";
+    }
+
     private static string BuildDtoSource(
         string ns, string typeName, IReadOnlyList<IParameterSymbol> grouped, bool isPublic)
     {
@@ -1214,6 +1269,7 @@ public sealed class ParameterObjectService : IParameterObjectService
         Solution solution,
         IMethodSymbol method,
         IReadOnlyList<IParameterSymbol> grouped,
+        string dtoNamespace,
         string newTypeName,
         string newParameterName,
         Dictionary<DocumentId, string> originalTexts,
@@ -1258,6 +1314,7 @@ public sealed class ParameterObjectService : IParameterObjectService
                     semanticModel,
                     groupedNames,
                     groupedMembersByOrdinal,
+                    dtoNamespace,
                     newTypeName,
                     newParameterName,
                     ct);
@@ -1274,10 +1331,12 @@ public sealed class ParameterObjectService : IParameterObjectService
         SemanticModel semanticModel,
         HashSet<string> groupedNames,
         IReadOnlyDictionary<int, string> groupedMembersByOrdinal,
+        string dtoNamespace,
         string newTypeName,
         string newParameterName,
         CancellationToken ct)
     {
+        var dtoTypeReference = ResolveDtoTypeReference(declaration, dtoNamespace, newTypeName);
         var declaredMethod = semanticModel.GetDeclaredSymbol(declaration, ct) as IMethodSymbol;
         var parameterMembers = new Dictionary<IParameterSymbol, string>(SymbolEqualityComparer.Default);
         if (declaredMethod is not null)
@@ -1309,7 +1368,7 @@ public sealed class ParameterObjectService : IParameterObjectService
             {
                 if (!insertedDtoParam)
                 {
-                    newParamTexts.Add($"{newTypeName} {newParameterName}");
+                    newParamTexts.Add($"{dtoTypeReference} {newParameterName}");
                     insertedDtoParam = true;
                 }
                 continue;
@@ -1317,7 +1376,7 @@ public sealed class ParameterObjectService : IParameterObjectService
             newParamTexts.Add(parameter.ToString());
         }
         if (!insertedDtoParam)
-            newParamTexts.Add($"{newTypeName} {newParameterName}");
+            newParamTexts.Add($"{dtoTypeReference} {newParameterName}");
 
         var newListText = "(" + string.Join(", ", newParamTexts) + ")";
         var newList = SyntaxFactory.ParseParameterList(newListText).WithTriviaFrom(existingList);
@@ -1389,6 +1448,7 @@ public sealed class ParameterObjectService : IParameterObjectService
         Solution baselineSolution,
         IMethodSymbol method,
         IReadOnlyList<IParameterSymbol> grouped,
+        string dtoNamespace,
         string newTypeName,
         Dictionary<DocumentId, List<CallSiteBinding>> callSites,
         Dictionary<DocumentId, string> originalTexts,
@@ -1422,8 +1482,11 @@ public sealed class ParameterObjectService : IParameterObjectService
             var newRoot = oldRoot.ReplaceNodes(targets.Keys, (original, rewrittenNode) =>
             {
                 var invocation = (InvocationExpressionSyntax)rewrittenNode;
+                // Resolve scope against `original` — it is still attached to oldRoot, so
+                // its namespace/using context is visible; `rewrittenNode` may be detached.
+                var dtoTypeReference = ResolveDtoTypeReference(original, dtoNamespace, newTypeName);
                 var newArgList = BuildRewrittenArgumentList(
-                    invocation.ArgumentList, method, grouped, newTypeName, targets[original]);
+                    invocation.ArgumentList, method, grouped, dtoTypeReference, targets[original]);
                 if (newArgList is null) return invocation;
                 rewrittenCount++;
                 return invocation.WithArgumentList(newArgList);
@@ -1470,7 +1533,7 @@ public sealed class ParameterObjectService : IParameterObjectService
         ArgumentListSyntax argList,
         IMethodSymbol method,
         IReadOnlyList<IParameterSymbol> grouped,
-        string newTypeName,
+        string dtoTypeReference,
         CallSiteBinding binding)
     {
         // Argument-to-parameter association was computed semantically at binding time
@@ -1493,7 +1556,7 @@ public sealed class ParameterObjectService : IParameterObjectService
 
         var dtoCreation = SyntaxFactory.ObjectCreationExpression(
             SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),
-            SyntaxFactory.IdentifierName(newTypeName),
+            SyntaxFactory.ParseTypeName(dtoTypeReference),
             SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(dtoArgs)),
             initializer: null);
 

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -11,7 +11,10 @@ namespace RoslynMcp.Tests;
 /// regression set named in <c>ai_docs/items/parameter-object-preview-design.md</c> §(f):
 /// (1) positional grouping, (2) named + mixed call sites, (3) default-value refusal,
 /// (4) ref/out refusal, (5) cross-project success, (6) cross-project missing-reference
-/// refusal, (7) end-to-end redemption through <c>apply_with_verify</c>.
+/// refusal, (7) end-to-end redemption through <c>apply_with_verify</c>. Two later cases
+/// cover DTO-reference namespace qualification: (8) explicit <c>dtoNamespace</c> qualifies
+/// the declaration and call-site references, (9) a cross-namespace caller with no matching
+/// using directive applies cleanly via a <c>global::</c>-qualified reference.
 /// </summary>
 [TestClass]
 public sealed class ParameterObjectPreviewTests : TestBase
@@ -989,6 +992,139 @@ public sealed class ParameterObjectPreviewTests : TestBase
             StringAssert.Contains(fixtureText, "Sum(SumArgs sumArgs)");
             StringAssert.Contains(fixtureText, "sumArgs.A + sumArgs.B + sumArgs.C");
             StringAssert.Contains(fixtureText, "new SumArgs(1, 2, 3)");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExplicitDtoNamespace_QualifiesDeclarationAndCallsiteReferences()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class PONsFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int Caller() => Sum(1, 2, 3);
+            }
+            """,
+            "PONsFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16), // 'Sum'
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoNamespace: "SampleLib.Contracts"),
+                CancellationToken.None);
+
+            Assert.IsNotNull(preview.PreviewToken);
+            var fixtureDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("PONsFixture.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(fixtureDiff);
+            StringAssert.Contains(
+                fixtureDiff,
+                "Sum(global::SampleLib.Contracts.SumArgs sumArgs)",
+                "SampleLib.Contracts is not in scope in the declaring document (a child namespace is not searched by name lookup), so the parameter type must be qualified");
+            StringAssert.Contains(
+                fixtureDiff,
+                "new global::SampleLib.Contracts.SumArgs(1, 2, 3)",
+                "the caller shares the declaring document's namespace, so the object creation must be qualified too");
+
+            var addedDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("SumArgs.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(addedDiff, "preview must include the new DTO file");
+            StringAssert.Contains(addedDiff, "namespace SampleLib.Contracts;");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task CrossNamespaceCaller_NoUsingDirective_AppliesCleanlyWithQualifiedReference()
+    {
+        // Regression for the unqualified-DTO-reference defect: the caller reaches the method
+        // through a fully-qualified receiver and carries NO `using SampleLib;`, so the DTO's
+        // namespace is not in scope in the calling document — an unqualified
+        // `new QualArgs(...)` there would produce CS0246 on apply.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var libDir = Path.Combine(solutionDir, "SampleLib");
+        var appDir = Path.Combine(solutionDir, "SampleApp");
+
+        var libFile = Path.Combine(libDir, "POQualLib.cs");
+        await File.WriteAllTextAsync(libFile,
+            """
+            namespace SampleLib;
+
+            public class POQualLib
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+            }
+            """);
+        var appFile = Path.Combine(appDir, "POQualApp.cs");
+        await File.WriteAllTextAsync(appFile,
+            """
+            namespace SampleApp;
+
+            public static class POQualApp
+            {
+                public static int Run() => new SampleLib.POQualLib().Sum(1, 2, 3);
+            }
+            """);
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(libFile, line: 5, column: 16), // 'Sum'
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "QualArgs"),
+                CancellationToken.None);
+
+            var libDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("POQualLib.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(libDiff);
+            StringAssert.Contains(
+                libDiff,
+                "Sum(QualArgs qualArgs)",
+                "the declaring document shares the DTO namespace, so the parameter type must stay unqualified");
+            var appDiff = preview.Changes.FirstOrDefault(c => c.FilePath.EndsWith("POQualApp.cs", StringComparison.OrdinalIgnoreCase))?.UnifiedDiff;
+            Assert.IsNotNull(appDiff, "cross-namespace caller must be rewritten");
+            StringAssert.Contains(
+                appDiff,
+                "new global::SampleLib.QualArgs(1, 2, 3)",
+                "the DTO namespace is not in scope in the calling document, so the object creation must be qualified");
+
+            var workflowService = new ApplyUndoWorkflowService(
+                RefactoringService,
+                CompileCheckService,
+                UndoService,
+                PreviewStore);
+            var applyJson = await ApplyWithVerifyTool.ApplyWithVerify(
+                WorkspaceExecutionGate,
+                workflowService,
+                PreviewStore,
+                preview.PreviewToken,
+                rollbackOnError: true,
+                ct: CancellationToken.None);
+            using var apply = JsonDocument.Parse(applyJson);
+            Assert.AreEqual(
+                "applied",
+                apply.RootElement.GetProperty("status").GetString(),
+                $"apply_with_verify must redeem the preview token. Response: {applyJson}");
+            Assert.AreEqual(
+                apply.RootElement.GetProperty("preErrorCount").GetInt32(),
+                apply.RootElement.GetProperty("postErrorCount").GetInt32(),
+                $"Applying the preview must introduce no compiler errors. Response: {applyJson}");
+
+            var appText = await File.ReadAllTextAsync(appFile);
+            StringAssert.Contains(appText, "new global::SampleLib.QualArgs(1, 2, 3)");
         }
         finally
         {


### PR DESCRIPTION
## Summary
- `parameter_object_preview` computed the generated DTO's namespace but never threaded it into the rewriters, so the method-declaration parameter and every call-site `new` expression carried a bare type name. When the DTO namespace differed from the emitting document's namespace (explicit `dtoNamespace`, or the cross-project default) the applied edit produced CS0246.
- Threads `dtoNamespace` through `RewriteMethodDeclarationAsync` / `RewriteCallSitesAsync` and adds a private `ResolveDtoTypeReference` helper that emits the bare name when the DTO namespace is already in scope for the emitting document (enclosing namespace chain equals or is nested under it, or a plain/same-file-global `using` imports it) and `global::{ns}.{Type}` otherwise — mirroring the conditional-qualification pattern in `ExtractMethodService`.
- Call-site object creation now uses `SyntaxFactory.ParseTypeName` so qualified names parse into proper `QualifiedNameSyntax`.

## Tests
- New: `ExplicitDtoNamespace_QualifiesDeclarationAndCallsiteReferences` (child-namespace DTO must be qualified at declaration and call site).
- New: `CrossNamespaceCaller_NoUsingDirective_AppliesCleanlyWithQualifiedReference` — end-to-end through `apply_with_verify` with equal pre/post error counts.
- Existing same-namespace (`SumArgs sumArgs`, `new SumArgs(1, 2, 3)`) and cross-project-with-`using` assertions unchanged and green — no qualification churn on in-scope callers.
- `ParameterObjectPreviewTests`: 46/46 passed locally; `verify-ai-docs.ps1` + changelog-fragment gate pass. Full release gate runs on CI (self-hosted runner).

Known caveat (noted in the helper doc-comment, from the plan's Risks): a `global using` declared in a different file of the same project is invisible to the syntax-only scan, so such callers get a technically-unnecessary but still-correct `global::` qualification.

Closes: parameter-object-dto-reference-qualification

🤖 Generated with [Claude Code](https://claude.com/claude-code)