### PR TITLE
fix(parameter-object): confine DTO output to the project boundary and refuse destination collisions

### DIFF
--- a/changelog.d/parameter-object-dto-output-boundary-validation.md
+++ b/changelog.d/parameter-object-dto-output-boundary-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `parameter_object_preview` now validates `dtoNamespace` and `dtoFolders` before combining them with the project directory — refusing rooted and traversal segments that could place the generated DTO outside the target project — and refuses destination collisions (existing document, existing file on disk, or existing type of the same name) before a preview token is stored, so no token is minted and no directory is created or file overwritten on a refused request.

--- a/src/RoslynMcp.Roslyn/Helpers/ProjectRelativePathValidation.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/ProjectRelativePathValidation.cs
@@ -1,0 +1,82 @@
+namespace RoslynMcp.Roslyn.Helpers;
+
+/// <summary>
+/// Validates caller-supplied folder segments and resolved output paths so a generated
+/// document can never land outside its target project's directory. Two failure classes
+/// are guarded: (1) hostile segments — rooted paths (<c>C:/evil</c>, <c>\\host\share</c>),
+/// traversal (<c>..</c>), separators, and invalid file-name characters — which
+/// <see cref="Path.Combine(string[])"/> would otherwise honor by discarding every
+/// preceding segment or walking out of the root; and (2) any combined result whose
+/// canonical form does not sit strictly under the canonical project root.
+///
+/// Mirrors the refusal-helper pattern of <see cref="IdentifierValidation"/>: static
+/// class, throwing checks, messages that name the offending input. Deliberately does
+/// NOT use <c>StartsWith(root)</c> for the containment check — that admits
+/// sibling-prefix escapes (<c>C:/Proj</c> vs <c>C:/Proj2</c>); it uses
+/// <see cref="Path.GetRelativePath(string, string)"/> and refuses any leading
+/// <c>..</c> segment instead.
+/// </summary>
+internal static class ProjectRelativePathValidation
+{
+    private static readonly char[] Separators = ['/', '\\'];
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> when any segment is empty or
+    /// whitespace, is <c>.</c> or <c>..</c>, contains a directory separator, is a
+    /// rooted path, or contains a character invalid in file names on this platform.
+    /// </summary>
+    /// <param name="segments">Folder segments that will each become one directory level.</param>
+    /// <param name="parameterLabel">Human-readable label for the offending parameter (e.g. "dtoFolders").</param>
+    public static void ValidateFolderSegments(IReadOnlyList<string> segments, string parameterLabel)
+    {
+        foreach (var segment in segments)
+        {
+            if (string.IsNullOrWhiteSpace(segment))
+                throw new InvalidOperationException(
+                    $"{parameterLabel} contains an empty or whitespace path segment " +
+                    "(check for doubled, leading, or trailing separators).");
+
+            if (segment is "." or "..")
+                throw new InvalidOperationException(
+                    $"{parameterLabel} segment '{segment}' is a relative directory reference; " +
+                    "folder segments must name directories inside the target project.");
+
+            if (segment.IndexOfAny(Separators) >= 0)
+                throw new InvalidOperationException(
+                    $"{parameterLabel} segment '{segment}' contains a directory separator; " +
+                    "supply one folder name per segment.");
+
+            if (Path.IsPathRooted(segment))
+                throw new InvalidOperationException(
+                    $"{parameterLabel} segment '{segment}' is a rooted path; " +
+                    "folder segments must be relative directory names inside the target project.");
+
+            var invalidIndex = segment.IndexOfAny(Path.GetInvalidFileNameChars());
+            if (invalidIndex >= 0)
+                throw new InvalidOperationException(
+                    $"{parameterLabel} segment '{segment}' contains the invalid file-name " +
+                    $"character '{segment[invalidIndex]}'.");
+        }
+    }
+
+    /// <summary>
+    /// Canonicalizes both paths and throws <see cref="InvalidOperationException"/> unless
+    /// <paramref name="candidatePath"/> sits strictly under <paramref name="rootDirectory"/>.
+    /// Returns the canonical candidate path on success.
+    /// </summary>
+    /// <param name="rootDirectory">The directory the candidate must live under.</param>
+    /// <param name="candidatePath">The path to check.</param>
+    /// <param name="parameterLabel">Human-readable label for the offending parameter (e.g. "dtoFolders").</param>
+    public static string EnsureDescendantOfRoot(string rootDirectory, string candidatePath, string parameterLabel)
+    {
+        var fullRoot = Path.GetFullPath(rootDirectory);
+        var fullCandidate = Path.GetFullPath(candidatePath);
+        var relative = Path.GetRelativePath(fullRoot, fullCandidate);
+        var firstSegment = relative.Split(Separators, 2)[0];
+        if (relative == "." || firstSegment == ".." || Path.IsPathRooted(relative))
+            throw new InvalidOperationException(
+                $"{parameterLabel} resolves to '{fullCandidate}', which is outside the " +
+                $"target project directory '{fullRoot}'.");
+        return fullCandidate;
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ParameterObjectService.cs
@@ -93,6 +93,8 @@ public sealed class ParameterObjectService : IParameterObjectService
 
         var (dtoNamespace, dtoFolders) = ResolveDtoLocation(dtoProject, request, method);
         var dtoFilePath = ResolveDtoFilePath(dtoProject, dtoFolders, request.NewTypeName);
+        await EnforceDtoDestinationIsFreeAsync(
+            dtoProject, dtoFilePath, dtoNamespace, request.NewTypeName, ct).ConfigureAwait(false);
         var dtoSource = BuildDtoSource(dtoNamespace, request.NewTypeName, groupedParameters, dtoVisibilityIsPublic);
 
         var originalTexts = new Dictionary<DocumentId, string>();
@@ -1154,17 +1156,59 @@ public sealed class ParameterObjectService : IParameterObjectService
                 ? method.ContainingNamespace.ToDisplayString()
                 : dtoProject.Name;
         }
+        else
+        {
+            // Caller-supplied namespace is untrusted boundary input: it is emitted into the
+            // DTO source AND (when dtoFolders is omitted) split into folder segments that
+            // feed Path.Combine, so every dot-separated part must be a legal identifier.
+            foreach (var part in ns.Split('.'))
+            {
+                if (part.Length == 0)
+                    throw new InvalidOperationException(
+                        $"dtoNamespace '{ns}' contains an empty namespace part " +
+                        "(check for doubled, leading, or trailing dots).");
+                IdentifierValidation.ThrowIfInvalidIdentifier(part, $"dtoNamespace part '{part}'");
+            }
+        }
 
         IReadOnlyList<string> folders;
         if (request.DtoFolders is { Count: > 0 })
         {
-            folders = request.DtoFolders;
+            folders = SplitCallerSuppliedFolders(request.DtoFolders);
         }
         else
         {
             folders = ResolveFolderSegmentsForNamespace(ns!, dtoProject.Name);
         }
+        ProjectRelativePathValidation.ValidateFolderSegments(folders, "dtoFolders");
         return (ns!, folders);
+    }
+
+    /// <summary>
+    /// Normalizes caller-supplied <c>dtoFolders</c> entries for validation: a nested-path
+    /// entry like <c>"Models/Requests"</c> is common ergonomics, so each entry is refused
+    /// only when rooted (which <see cref="Path.Combine(string[])"/> would honor by
+    /// discarding the project directory) and otherwise split on both separators into
+    /// per-directory segments for <see cref="ProjectRelativePathValidation.ValidateFolderSegments"/>.
+    /// Empty split products (doubled/trailing separators) are preserved so the validator
+    /// refuses them with an actionable message rather than silently dropping them.
+    /// </summary>
+    private static IReadOnlyList<string> SplitCallerSuppliedFolders(IReadOnlyList<string> dtoFolders)
+    {
+        var segments = new List<string>();
+        foreach (var entry in dtoFolders)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                throw new InvalidOperationException(
+                    "dtoFolders contains an empty or whitespace entry; " +
+                    "each entry must name a directory inside the target project.");
+            if (Path.IsPathRooted(entry))
+                throw new InvalidOperationException(
+                    $"dtoFolders entry '{entry}' is a rooted path; " +
+                    "entries must be relative directory paths inside the target project.");
+            segments.AddRange(entry.Split(['/', '\\']));
+        }
+        return segments;
     }
 
     private static IReadOnlyList<string> ResolveFolderSegmentsForNamespace(string typeNamespace, string projectName)
@@ -1184,7 +1228,47 @@ public sealed class ParameterObjectService : IParameterObjectService
         var projectDir = Path.GetDirectoryName(dtoProject.FilePath)
             ?? throw new InvalidOperationException(
                 $"DTO project '{dtoProject.Name}' has no resolvable directory (FilePath='{dtoProject.FilePath}').");
-        return Path.Combine([projectDir, .. folders, $"{typeName}.cs"]);
+        var combined = Path.Combine([projectDir, .. folders, $"{typeName}.cs"]);
+        // Belt-and-braces: even with validated segments, require the canonical result to
+        // sit strictly under the canonical project directory before it leaves this method.
+        return ProjectRelativePathValidation.EnsureDescendantOfRoot(projectDir, combined, "dtoFolders");
+    }
+
+    /// <summary>
+    /// Refuses the preview — before any document is added or a token is minted — when the
+    /// resolved DTO destination is already occupied: an existing document at the same
+    /// canonical path, an existing file on disk (an Added document has no pre-write
+    /// snapshot, so redeeming the token would overwrite it silently and irreversibly), or
+    /// an existing type <c>{dtoNamespace}.{newTypeName}</c> declared in the DTO project.
+    /// </summary>
+    private static async Task EnforceDtoDestinationIsFreeAsync(
+        Project dtoProject,
+        string dtoFilePath,
+        string dtoNamespace,
+        string newTypeName,
+        CancellationToken ct)
+    {
+        var canonicalTarget = Path.GetFullPath(dtoFilePath);
+        var occupied = dtoProject.Documents.Any(d =>
+            d.FilePath is not null &&
+            string.Equals(Path.GetFullPath(d.FilePath), canonicalTarget, StringComparison.OrdinalIgnoreCase));
+        if (occupied)
+            throw new InvalidOperationException(
+                $"parameter_object_preview refuses: project '{dtoProject.Name}' already contains a document at " +
+                $"'{canonicalTarget}'. Choose a different newTypeName or dtoFolders.");
+
+        if (File.Exists(canonicalTarget))
+            throw new InvalidOperationException(
+                $"parameter_object_preview refuses: a file already exists on disk at '{canonicalTarget}' and " +
+                "applying the preview would overwrite it with no rollback snapshot. " +
+                "Choose a different newTypeName or dtoFolders, or remove the file first.");
+
+        var compilation = await dtoProject.GetCompilationAsync(ct).ConfigureAwait(false);
+        var metadataName = $"{dtoNamespace}.{newTypeName}";
+        if (compilation?.Assembly.GetTypeByMetadataName(metadataName) is not null)
+            throw new InvalidOperationException(
+                $"parameter_object_preview refuses: type '{metadataName}' already exists in project " +
+                $"'{dtoProject.Name}'. Choose a different newTypeName or dtoNamespace.");
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -1609,6 +1609,239 @@ public sealed class ParameterObjectPreviewTests : TestBase
         }
     }
 
+    private const string BoundaryFixtureSource = """
+        namespace SampleLib;
+
+        public class POBoundaryFixture
+        {
+            public int Sum(int a, int b, int c) => a + b + c;
+
+            public int Caller() => Sum(1, 2, 3);
+        }
+        """;
+
+    /// <summary>
+    /// parameter-object-dto-output-boundary-validation: hostile <c>dtoFolders</c> input —
+    /// rooted segments, traversal, empty/whitespace entries, doubled separators, invalid
+    /// file-name characters — must refuse the preview before any token is minted, and no
+    /// DTO file may materialize anywhere in the solution tree.
+    /// </summary>
+    [TestMethod]
+    [DataRow(new[] { "/abs/evil" }, DisplayName = "rooted absolute segment")]
+    [DataRow(new[] { "\\\\host\\share" }, DisplayName = "UNC segment")]
+    [DataRow(new[] { ".." }, DisplayName = "single traversal segment")]
+    [DataRow(new[] { "Models/../../Outside" }, DisplayName = "embedded traversal")]
+    [DataRow(new[] { "" }, DisplayName = "empty entry")]
+    [DataRow(new[] { "   " }, DisplayName = "whitespace entry")]
+    [DataRow(new[] { "Models//Requests" }, DisplayName = "doubled separator")]
+    [DataRow(new[] { "Mod\0els" }, DisplayName = "invalid file-name char")]
+    public async Task HostileDtoFolders_RefusePreviewWithNoTokenAndNoFile(string[] dtoFolders)
+    {
+        var (workspaceId, fixturePath, fixtureDir) = await SetupSingleProjectFixtureAsync(
+            BoundaryFixtureSource, "POBoundaryFixture.cs");
+
+        try
+        {
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoFolders: dtoFolders),
+                    CancellationToken.None));
+
+            var solutionDir = Path.GetDirectoryName(fixtureDir)!;
+            Assert.IsFalse(
+                Directory.EnumerateFiles(solutionDir, "SumArgs.cs", SearchOption.AllDirectories).Any(),
+                "a refused preview must not materialize the DTO file anywhere in the solution tree");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task DriveRootedDtoFolders_RefusePreview()
+    {
+        if (!OperatingSystem.IsWindows())
+            Assert.Inconclusive("Drive-relative rooting (C:...) is a Windows path semantic.");
+
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            BoundaryFixtureSource, "POBoundaryFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoFolders: ["C:/Temp"]),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "C:/Temp", "refusal must name the offending entry");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task NonIdentifierDtoNamespace_RefusesPreview()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            BoundaryFixtureSource, "POBoundaryFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoNamespace: "Sample-Lib.Generated"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "Sample-Lib", "refusal must name the offending namespace part");
+
+            var emptyPart = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoNamespace: "SampleLib..Generated"),
+                    CancellationToken.None));
+            StringAssert.Contains(emptyPart.Message, "empty namespace part");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    /// <summary>
+    /// Do-not-over-refuse acceptance: a nested-path <c>dtoFolders</c> entry like
+    /// <c>"Models/Requests"</c> is common ergonomics and must keep working — split into
+    /// per-directory segments, not refused for carrying a separator.
+    /// </summary>
+    [TestMethod]
+    public async Task NestedPathDtoFoldersEntry_SplitsIntoSegmentsAndSucceeds()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            BoundaryFixtureSource, "POBoundaryFixture.cs");
+
+        try
+        {
+            var preview = await ParameterObjectService.PreviewParameterObjectAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs", DtoFolders: ["Models/Requests"]),
+                CancellationToken.None);
+
+            Assert.IsNotNull(preview.PreviewToken);
+            var expectedTail = Path.Combine("Models", "Requests", "SumArgs.cs");
+            Assert.IsTrue(
+                preview.Changes.Any(c => c.FilePath.EndsWith(expectedTail, StringComparison.OrdinalIgnoreCase)),
+                $"DTO must land under {expectedTail}. Paths: {string.Join(", ", preview.Changes.Select(c => c.FilePath))}");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExistingDocumentAtDtoPath_RefusesPreview()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var libDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(libDir, "POBoundaryFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, BoundaryFixtureSource);
+        // Occupy the DTO destination with a document that is part of the project but
+        // declares no SumArgs type, so the document check (not the type check) must fire.
+        await File.WriteAllTextAsync(
+            Path.Combine(libDir, "SumArgs.cs"),
+            "namespace SampleLib;\n\npublic class UnrelatedOccupant { }\n");
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    loadResult.WorkspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "already contains a document");
+            StringAssert.Contains(ex.Message, "SumArgs.cs");
+        }
+        finally
+        {
+            WorkspaceManager.Close(loadResult.WorkspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExistingFileOnDiskOutsideProject_RefusesPreviewAndLeavesFileIntact()
+    {
+        var (workspaceId, fixturePath, fixtureDir) = await SetupSingleProjectFixtureAsync(
+            BoundaryFixtureSource, "POBoundaryFixture.cs");
+        // Written AFTER the workspace load, so the file exists on disk but is not a
+        // project document — only the File.Exists guard can catch it.
+        var strayPath = Path.Combine(fixtureDir, "SumArgs.cs");
+        const string strayContent = "// pre-existing content that must never be overwritten\n";
+        await File.WriteAllTextAsync(strayPath, strayContent);
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 5, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "already exists on disk");
+            Assert.AreEqual(strayContent, await File.ReadAllTextAsync(strayPath),
+                "the pre-existing file must be untouched by a refused preview");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExistingTypeWithSameName_RefusesPreview()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public sealed record SumArgs(int X);
+
+            public class POBoundaryTypeFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int Caller() => Sum(1, 2, 3);
+            }
+            """,
+            "POBoundaryTypeFixture.cs");
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => ParameterObjectService.PreviewParameterObjectAsync(
+                    workspaceId,
+                    SymbolLocator.BySource(fixturePath, line: 7, column: 16),
+                    new ParameterObjectPreviewRequest(["a", "b", "c"], "SumArgs"),
+                    CancellationToken.None));
+            StringAssert.Contains(ex.Message, "SampleLib.SumArgs");
+            StringAssert.Contains(ex.Message, "already exists in project");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
     private static async Task<(string WorkspaceId, string FixturePath, string FixtureDir)> SetupSingleProjectFixtureAsync(
         string content,
         string fileName,

--- a/tests/RoslynMcp.Tests/ProjectRelativePathValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ProjectRelativePathValidationTests.cs
@@ -1,0 +1,113 @@
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Direct unit coverage for <see cref="ProjectRelativePathValidation"/>: hostile folder
+/// segments (rooted, traversal, separators, empty, invalid chars) must refuse, benign
+/// segments must pass, and <c>EnsureDescendantOfRoot</c> must catch escapes that segment
+/// validation alone cannot — including the sibling-prefix trap (<c>C:/Proj</c> vs
+/// <c>C:/Proj2</c>) that a naive <c>StartsWith</c> containment check admits.
+/// </summary>
+[TestClass]
+public class ProjectRelativePathValidationTests
+{
+    private static readonly string Root = Path.Combine(Path.GetTempPath(), "PrpvTestRoot");
+
+    [TestMethod]
+    public void Simple_Segments_Do_Not_Throw()
+        => ProjectRelativePathValidation.ValidateFolderSegments(["Models", "Requests"], "dtoFolders");
+
+    [TestMethod]
+    public void Empty_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["Models", ""], "dtoFolders"));
+
+    [TestMethod]
+    public void Whitespace_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["   "], "dtoFolders"));
+
+    [TestMethod]
+    public void Single_Dot_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["."], "dtoFolders"));
+
+    [TestMethod]
+    public void Traversal_Segment_Throws()
+    {
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments([".."], "dtoFolders"));
+        StringAssert.Contains(ex.Message, "..");
+        StringAssert.Contains(ex.Message, "dtoFolders");
+    }
+
+    [TestMethod]
+    public void ForwardSlash_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["Models/Requests"], "dtoFolders"));
+
+    [TestMethod]
+    public void BackSlash_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["Models\\Requests"], "dtoFolders"));
+
+    [TestMethod]
+    public void Rooted_Segment_Throws()
+    {
+        // "/abs" reads as rooted on Windows and Unix alike — but it also carries a
+        // separator, so exercise the rooted arm with a drive-relative Windows form too.
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["/abs"], "dtoFolders"));
+        if (OperatingSystem.IsWindows())
+            Assert.ThrowsExactly<InvalidOperationException>(
+                () => ProjectRelativePathValidation.ValidateFolderSegments(["C:Temp"], "dtoFolders"));
+    }
+
+    [TestMethod]
+    public void Nul_Char_Segment_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.ValidateFolderSegments(["Mod\0els"], "dtoFolders"));
+
+    [TestMethod]
+    public void Descendant_Path_Returns_Canonical_Path()
+    {
+        var candidate = Path.Combine(Root, "Models", "Requests", "Dto.cs");
+        var result = ProjectRelativePathValidation.EnsureDescendantOfRoot(Root, candidate, "dtoFolders");
+        Assert.AreEqual(Path.GetFullPath(candidate), result);
+    }
+
+    [TestMethod]
+    public void Root_Itself_Throws()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.EnsureDescendantOfRoot(Root, Root, "dtoFolders"));
+
+    [TestMethod]
+    public void Parent_Escape_Throws()
+    {
+        var candidate = Path.Combine(Root, "Models", "..", "..", "Escaped.cs");
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.EnsureDescendantOfRoot(Root, candidate, "dtoFolders"));
+        StringAssert.Contains(ex.Message, "outside");
+    }
+
+    [TestMethod]
+    public void Sibling_Prefix_Directory_Throws()
+    {
+        // The StartsWith(root) trap: "<root>2/file.cs" string-prefixes "<root>" but is a
+        // sibling directory, not a descendant.
+        var candidate = Path.Combine(Root + "2", "file.cs");
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => ProjectRelativePathValidation.EnsureDescendantOfRoot(Root, candidate, "dtoFolders"));
+    }
+
+    [TestMethod]
+    public void Segment_Starting_With_Dots_Is_Not_Mistaken_For_Traversal()
+    {
+        // A directory literally named "..foo" is inside the root; the first-segment
+        // traversal check must not refuse it via a loose StartsWith("..").
+        var candidate = Path.Combine(Root, "..foo", "Dto.cs");
+        var result = ProjectRelativePathValidation.EnsureDescendantOfRoot(Root, candidate, "dtoFolders");
+        Assert.AreEqual(Path.GetFullPath(candidate), result);
+    }
+}


### PR DESCRIPTION
## Summary

`parameter_object_preview` combined caller-supplied `dtoNamespace` / `dtoFolders` straight into `Path.Combine([projectDir, .. folders, ...])`. `Path.Combine` discards every preceding segment when a later segment is rooted, and `..` segments walk out of the project directory — so a caller-controlled request could place the generated DTO anywhere on disk, and redemption would silently overwrite a pre-existing file with no rollback snapshot (Added documents are never snapshotted).

- **New `ProjectRelativePathValidation` helper** (`src/RoslynMcp.Roslyn/Helpers/ProjectRelativePathValidation.cs`): `ValidateFolderSegments` refuses empty/whitespace, `.`/`..`, separator-bearing, rooted, and invalid-char segments; `EnsureDescendantOfRoot` canonicalizes with `Path.GetFullPath` + `Path.GetRelativePath` (no `StartsWith` sibling-prefix trap).
- **`ResolveDtoLocation`** validates each dot-separated `dtoNamespace` part via `IdentifierValidation`, splits nested `dtoFolders` entries (`"Models/Requests"` stays valid ergonomics) after refusing rooted entries, then validates the resolved segments. `ResolveDtoFilePath` requires the canonical combined path to sit strictly under the project directory.
- **`EnforceDtoDestinationIsFreeAsync`** refuses — before `AddDocument` and before any preview token is minted — when the destination is an existing project document, an existing file on disk, or an existing type `{dtoNamespace}.{newTypeName}` in the DTO project.

## Validation

- `dotnet build src/RoslynMcp.Roslyn` — clean, 0 warnings.
- `dotnet test --filter ProjectRelativePathValidationTests` — 14/14 pass (new).
- `dotnet test --filter ParameterObjectPreviewTests` — 60/60 pass (13 new: table-driven hostile-`dtoFolders` refusals, drive-rooted Windows case, non-identifier namespace, nested-folders acceptance, and the three destination-collision refusals; all pre-existing cases stay green).
- `./eng/verify-ai-docs.ps1` — pass. Release gate runs on the self-hosted CI runner for this PR.

Closes: parameter-object-dto-output-boundary-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)