### PR TITLE
release: v3.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "roslyn-mcp",
       "source": "./",
       "description": "Semantic C# analysis and refactoring powered by Roslyn for navigation, diagnostics, refactoring, security, testing, and more.",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "author": {
         "name": "darylmcd"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Semantic C# analysis and refactoring for AI agents, powered by Roslyn. Load .sln/.csproj files, inspect the live MCP catalog at runtime, and use 32 bundled agent skills for analysis, refactoring, testing, architecture review, and release workflows.",
   "author": {
     "name": "darylmcd",

--- a/.claude-plugin/server.json
+++ b/.claude-plugin/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/darylmcd/Roslyn-Backed-MCP",
     "source": "github"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "websiteUrl": "https://github.com/darylmcd/Roslyn-Backed-MCP",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "Darylmcd.RoslynMcp",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Maintenance
 
+## [3.0.2] - 2026-08-19
+
+### Fixed
+
+- **Fixed:** `parameter_object_preview` mis-binding call-site arguments. Argument-to-parameter association is now derived from Roslyn's `IInvocationOperation` bindings instead of lexical argument position, so calls using in-position named arguments, reduced extension-method receivers, or an ungrouped trailing `params` tail rewrite correctly instead of dropping or transposing arguments. Invocation shapes that cannot be mapped completely — including out-of-order named arguments whose non-constant expressions would change evaluation order, and method-group or non-invocation references — are now refused before a preview token is stored.
+- **Fixed:** `parameter_object_preview` now validates `dtoNamespace` and `dtoFolders` before combining them with the project directory — refusing rooted and traversal segments that could place the generated DTO outside the target project — and refuses destination collisions (existing document, existing file on disk, or existing type of the same name) before a preview token is stored, so no token is minted and no directory is created or file overwritten on a refused request.
+- **Fixed:** `parameter_object_preview` emitted an unqualified generated-DTO type name in the rewritten method declaration and at every call site, so when the DTO's namespace differed from the target declaration's or a caller's namespace (explicit `dtoNamespace`, or the cross-project default) the applied edit produced CS0246. The rewriter now emits a `global::`-qualified reference when the DTO namespace is not already in scope for that document, and preserves the unqualified form otherwise.
+- **Fixed:** `parameter_object_preview` now validates every grouped parameter type before emitting the generated record — it refuses (instead of producing an uncompilable preview) when a parameter type depends on a method or containing-type type parameter, is less accessible than the chosen record visibility, or is unavailable from the selected DTO project. Refusals name the offending parameter and type, and no preview token is stored.
+- **Fixed:** `parameter_object_preview` now validates the target method's kind and dispatch contract before collecting call sites or storing a preview token. Constructors, destructors, operators and conversions, property/event accessors, overrides, virtual and abstract dispatch roots, interface implementations, `extern`/PInvoke declarations, and partial definition/implementation pairs are refused with an actionable message naming the unsupported contract. Previously these targets produced a redeemable preview that rewrote the declaration while leaving call sites or paired declarations untouched, yielding a compile-breaking partial rewrite.
+- **Fixed:** `parameter_object_preview` no longer silently changes program behavior when a grouped parameter is a mutable value type. Mutating member calls and nested field/property writes through a struct parameter are now detected and refused before a preview token is created, naming the affected parameter and source location. Reference-type member mutation and array-element writes remain supported.
+
 ## [3.0.1] - 2026-08-18
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
 
     <!-- Profile-guided optimization: runtime collects profiling data at tier-0 and uses it
          for optimized tier-1 recompilation, improving steady-state performance. -->

--- a/changelog.d/parameter-object-callsite-semantic-argument-binding.md
+++ b/changelog.d/parameter-object-callsite-semantic-argument-binding.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` mis-binding call-site arguments. Argument-to-parameter association is now derived from Roslyn's `IInvocationOperation` bindings instead of lexical argument position, so calls using in-position named arguments, reduced extension-method receivers, or an ungrouped trailing `params` tail rewrite correctly instead of dropping or transposing arguments. Invocation shapes that cannot be mapped completely — including out-of-order named arguments whose non-constant expressions would change evaluation order, and method-group or non-invocation references — are now refused before a preview token is stored.

--- a/changelog.d/parameter-object-dto-output-boundary-validation.md
+++ b/changelog.d/parameter-object-dto-output-boundary-validation.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` now validates `dtoNamespace` and `dtoFolders` before combining them with the project directory — refusing rooted and traversal segments that could place the generated DTO outside the target project — and refuses destination collisions (existing document, existing file on disk, or existing type of the same name) before a preview token is stored, so no token is minted and no directory is created or file overwritten on a refused request.

--- a/changelog.d/parameter-object-dto-reference-qualification.md
+++ b/changelog.d/parameter-object-dto-reference-qualification.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` emitted an unqualified generated-DTO type name in the rewritten method declaration and at every call site, so when the DTO's namespace differed from the target declaration's or a caller's namespace (explicit `dtoNamespace`, or the cross-project default) the applied edit produced CS0246. The rewriter now emits a `global::`-qualified reference when the DTO namespace is not already in scope for that document, and preserves the unqualified form otherwise.

--- a/changelog.d/parameter-object-generic-dto-type-validity.md
+++ b/changelog.d/parameter-object-generic-dto-type-validity.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` now validates every grouped parameter type before emitting the generated record — it refuses (instead of producing an uncompilable preview) when a parameter type depends on a method or containing-type type parameter, is less accessible than the chosen record visibility, or is unavailable from the selected DTO project. Refusals name the offending parameter and type, and no preview token is stored.

--- a/changelog.d/parameter-object-target-method-contract-validation.md
+++ b/changelog.d/parameter-object-target-method-contract-validation.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` now validates the target method's kind and dispatch contract before collecting call sites or storing a preview token. Constructors, destructors, operators and conversions, property/event accessors, overrides, virtual and abstract dispatch roots, interface implementations, `extern`/PInvoke declarations, and partial definition/implementation pairs are refused with an actionable message naming the unsupported contract. Previously these targets produced a redeemable preview that rewrote the declaration while leaving call sites or paired declarations untouched, yielding a compile-breaking partial rewrite.

--- a/changelog.d/parameter-object-value-type-mutation-semantics.md
+++ b/changelog.d/parameter-object-value-type-mutation-semantics.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Fixed:** `parameter_object_preview` no longer silently changes program behavior when a grouped parameter is a mutable value type. Mutating member calls and nested field/property writes through a struct parameter are now detected and refused before a preview token is created, naming the affected parameter and source location. Reference-type member mutation and array-element writes remain supported.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "roslyn-mcp",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "icon": "icon.png",
   "description": "A production-usable MCP server providing semantic C# analysis powered by Roslyn. Enables AI coding agents to navigate, analyze, and refactor real C# solutions without requiring Visual Studio.",
   "author": {


### PR DESCRIPTION
Version bump to 3.0.2. See CHANGELOG.md for details.

Consumes the six `changelog.d/` fragments from sweep `20260818T211226Z` (the parameter-object cluster) into a single `### Fixed` section — every entry hardens `parameter_object_preview` against producing a redeemable-but-uncompilable or semantics-changing preview:

- target method kind / dispatch contract validated before a token is stored (#1263)
- call-site arguments bound via `IInvocationOperation` instead of lexical position (#1265)
- mutable value-type parameter mutation refused instead of silently changing behaviour (#1267)
- grouped parameter types validated for generic scope, accessibility, and cross-project availability (#1269)
- generated-DTO references `global::`-qualified when the namespace is not in scope (#1271)
- `dtoNamespace`/`dtoFolders` boundary + destination-collision validation (#1273)

Local `verify-release.ps1`: 2167 passed / 0 failed / 5 skipped. `verify-ai-docs.ps1`: green. Version drift: all 6 files agree on 3.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)