### PR TITLE
fix(extract-type): wire composition field through every instance constructor

### DIFF
--- a/changelog.d/type-extraction-composition-constructor-coverage.md
+++ b/changelog.d/type-extraction-composition-constructor-coverage.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `extract_type_preview` leaving the injected composition field uninitialized on most construction paths. The extracted type is now wired through every instance constructor — implicit (a constructor is synthesized), overloaded, `this(...)`-chained (the delegating call forwards the new argument), and expression-bodied (rewritten to a block body with the assignment) — and unsupported topologies (primary constructors/records, bodyless constructors) are refused before a preview is generated instead of producing a diff whose applied result is silently broken.

--- a/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/TypeExtractionService.cs
@@ -99,7 +99,7 @@ public sealed class TypeExtractionService : ITypeExtractionService
         var fieldName = "_" + char.ToLowerInvariant(newTypeName[0]) + newTypeName[1..];
         var updatedTypeDecl = InjectFieldAndCtorParameter(
             typeDecl.WithMembers(SyntaxFactory.List(membersToKeep)),
-            newTypeName, fieldName);
+            typeDecl, semanticModel, newTypeName, fieldName, sourceTypeName, ct);
 
         // Replace in source root (normalize so field/modifier tokens get proper spacing)
         var updatedSourceRoot = sourceRoot.ReplaceNode(typeDecl, updatedTypeDecl);
@@ -442,9 +442,52 @@ public sealed class TypeExtractionService : ITypeExtractionService
         return typeDecl.WithLeadingTrivia(existing.Insert(0, blankLine));
     }
 
+    /// <summary>
+    /// Injects the <c>private readonly {NewType} _field</c> composition field and wires it through
+    /// EVERY instance constructor of the source type (type-extraction-composition-constructor-coverage).
+    /// <para>
+    /// The previous implementation mutated only <c>FirstOrDefault()</c> constructor, which left the
+    /// readonly field silently null on the implicit-constructor and overloaded-constructor paths,
+    /// produced CS1729 on <c>this(...)</c>-chained constructors, and skipped the assignment entirely
+    /// for expression-bodied constructors. The rewrite classifies the whole constructor topology:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Zero instance constructors: a <c>public {SourceType}({NewType} p)</c>
+    /// constructor is synthesized that assigns the field.</description></item>
+    /// <item><description>Root constructors (no initializer, or <c>base(...)</c>): the parameter is
+    /// inserted before the first optional parameter (preserving the BUG-005 CS1737 fix per
+    /// constructor) and the assignment is appended; expression-bodied roots are rewritten to a block
+    /// body so the assignment has somewhere to live.</description></item>
+    /// <item><description><c>this(...)</c>-chained constructors: the parameter is added and forwarded
+    /// to the delegated constructor's argument list at the target's insertion ordinal — the root the
+    /// chain terminates in owns the single write of the readonly field.</description></item>
+    /// <item><description>Static constructors are never mutated.</description></item>
+    /// </list>
+    /// <para>
+    /// Unsupported topologies REFUSE before any syntax is emitted (matching the refusal idiom used by
+    /// the external-consumer guard) instead of shipping a preview whose applied result is silently
+    /// broken: primary constructors (records / <c>class C(...)</c>), bodyless instance constructors
+    /// (extern/partial), named arguments in a <c>this(...)</c> initializer, and delegation targets
+    /// the semantic model cannot resolve.
+    /// </para>
+    /// <paramref name="originalTypeDecl"/> is the in-tree declaration <paramref name="semanticModel"/>
+    /// can answer questions about; <paramref name="typeDecl"/> is the detached copy whose members have
+    /// already been partitioned. Constructors are never extracted (see
+    /// <see cref="ValidateRequestedMemberShapes"/>), so the two constructor sequences correspond 1:1.
+    /// </summary>
     private static TypeDeclarationSyntax InjectFieldAndCtorParameter(
-        TypeDeclarationSyntax typeDecl, string newTypeName, string fieldName)
+        TypeDeclarationSyntax typeDecl, TypeDeclarationSyntax originalTypeDecl,
+        SemanticModel semanticModel, string newTypeName, string fieldName, string sourceTypeName,
+        CancellationToken ct)
     {
+        if (typeDecl.ParameterList is not null)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to extract type '{newTypeName}' from '{sourceTypeName}': the source type declares a " +
+                $"primary constructor, and the extraction cannot wire the composition field through primary-constructor " +
+                $"parameters. Convert the primary constructor to an explicit constructor first, then retry.");
+        }
+
         var fieldDecl = SyntaxFactory.FieldDeclaration(
             SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName(newTypeName))
                 .WithVariables(SyntaxFactory.SingletonSeparatedList(
@@ -453,37 +496,119 @@ public sealed class TypeExtractionService : ITypeExtractionService
                 SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
                 SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
 
-        var existingCtor = typeDecl.Members.OfType<ConstructorDeclarationSyntax>().FirstOrDefault();
-        if (existingCtor is not null)
+        var paramName = char.ToLowerInvariant(newTypeName[0]) + newTypeName[1..];
+        var newParam = SyntaxFactory.Parameter(SyntaxFactory.Identifier(paramName))
+            .WithType(SyntaxFactory.ParseTypeName(newTypeName));
+        var assignment = SyntaxFactory.ExpressionStatement(
+            SyntaxFactory.AssignmentExpression(
+                SyntaxKind.SimpleAssignmentExpression,
+                SyntaxFactory.IdentifierName(fieldName),
+                SyntaxFactory.IdentifierName(paramName)));
+
+        var ctors = typeDecl.Members.OfType<ConstructorDeclarationSyntax>().ToList();
+        var originalCtors = originalTypeDecl.Members.OfType<ConstructorDeclarationSyntax>().ToList();
+        var instanceIndexes = Enumerable.Range(0, ctors.Count)
+            .Where(i => !ctors[i].Modifiers.Any(SyntaxKind.StaticKeyword))
+            .ToList();
+
+        if (instanceIndexes.Count == 0)
         {
-            var paramName = char.ToLowerInvariant(newTypeName[0]) + newTypeName[1..];
-            var newParam = SyntaxFactory.Parameter(SyntaxFactory.Identifier(paramName))
-                .WithType(SyntaxFactory.ParseTypeName(newTypeName));
+            // Implicit constructor: the compiler-supplied parameterless constructor cannot assign the
+            // new readonly field, so synthesize an explicit one that does. Inserted right after the
+            // field; NormalizeWhitespace at the call site handles formatting.
+            var synthesizedCtor = SyntaxFactory.ConstructorDeclaration(SyntaxFactory.Identifier(typeDecl.Identifier.Text))
+                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+                .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(newParam)))
+                .WithBody(SyntaxFactory.Block(assignment));
 
-            // BUG-005 (#1): Insert the new required parameter BEFORE any optional parameters.
-            // AddParameterListParameters appends to the end, which produced CS1737
-            // ("required after optional") whenever the existing constructor ended with an
-            // ILogger? logger = null or similar default.
-            var existingParams = existingCtor.ParameterList.Parameters;
-            var firstOptionalIndex = existingParams.IndexOf(p => p.Default is not null);
-            ConstructorDeclarationSyntax updatedCtor = firstOptionalIndex < 0
-                ? existingCtor.AddParameterListParameters(newParam)
-                : existingCtor.WithParameterList(
-                    existingCtor.ParameterList.WithParameters(
-                        existingParams.Insert(firstOptionalIndex, newParam)));
-
-            var assignment = SyntaxFactory.ExpressionStatement(
-                SyntaxFactory.AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    SyntaxFactory.IdentifierName(fieldName),
-                    SyntaxFactory.IdentifierName(paramName)));
-
-            if (updatedCtor.Body is not null)
-                updatedCtor = updatedCtor.WithBody(updatedCtor.Body.AddStatements(assignment));
-
-            typeDecl = typeDecl.ReplaceNode(existingCtor, updatedCtor);
+            return typeDecl.WithMembers(typeDecl.Members.Insert(0, fieldDecl).Insert(1, synthesizedCtor));
         }
 
+        // BUG-005 (#1), preserved per constructor: insert the new required parameter BEFORE any
+        // optional parameters. Appending produced CS1737 ("required after optional") whenever a
+        // constructor ended with an ILogger? logger = null or similar default. C# requires all
+        // optional parameters to trail the required ones, so this index is also the count of
+        // required parameters — the ordinal a forwarded this(...) argument must be inserted at.
+        static int ParameterInsertIndex(ConstructorDeclarationSyntax ctor)
+        {
+            var firstOptionalIndex = ctor.ParameterList.Parameters.IndexOf(p => p.Default is not null);
+            return firstOptionalIndex < 0 ? ctor.ParameterList.Parameters.Count : firstOptionalIndex;
+        }
+
+        var replacements = new Dictionary<ConstructorDeclarationSyntax, ConstructorDeclarationSyntax>();
+        foreach (var i in instanceIndexes)
+        {
+            var ctor = ctors[i];
+            if (ctor.Body is null && ctor.ExpressionBody is null)
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to extract type '{newTypeName}' from '{sourceTypeName}': constructor " +
+                    $"'{ctor.Identifier.Text}({ctor.ParameterList.Parameters.Count} parameter(s))' has no body " +
+                    $"(extern or partial), so the composition field cannot be assigned on that construction path. " +
+                    $"Give the constructor a body first, then retry.");
+            }
+
+            var insertIndex = ParameterInsertIndex(ctor);
+            var updatedCtor = ctor.WithParameterList(
+                ctor.ParameterList.WithParameters(
+                    ctor.ParameterList.Parameters.Insert(insertIndex, newParam)));
+
+            if (ctor.Initializer is { } initializer && initializer.IsKind(SyntaxKind.ThisConstructorInitializer))
+            {
+                // Chained constructor: forward the new argument to the delegated constructor — the
+                // root the chain terminates in owns the single write of the readonly field, so no
+                // assignment is added here. The argument's ordinal must match the position the
+                // parameter was inserted at on the DELEGATION TARGET, which the semantic model
+                // resolves against the original in-tree initializer.
+                if (initializer.ArgumentList.Arguments.Any(a => a.NameColon is not null))
+                {
+                    throw new InvalidOperationException(
+                        $"Refusing to extract type '{newTypeName}' from '{sourceTypeName}': a 'this(...)' constructor " +
+                        $"initializer uses named arguments, so the forwarded '{paramName}' argument cannot be inserted " +
+                        $"positionally. Convert the initializer to positional arguments first, then retry.");
+                }
+
+                var originalInitializer = originalCtors[i].Initializer!;
+                var targetSymbol = semanticModel.GetSymbolInfo(originalInitializer, ct).Symbol as IMethodSymbol;
+                var targetCtorIndex = targetSymbol is null ? -1 : originalCtors.FindIndex(c =>
+                    targetSymbol.DeclaringSyntaxReferences.Any(r =>
+                        r.Span == c.Span &&
+                        string.Equals(r.SyntaxTree.FilePath, c.SyntaxTree.FilePath, StringComparison.Ordinal)));
+                if (targetCtorIndex < 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Refusing to extract type '{newTypeName}' from '{sourceTypeName}': the delegation target of a " +
+                        $"'this(...)' constructor initializer could not be resolved, so the forwarded '{paramName}' " +
+                        $"argument cannot be placed safely. Fix the constructor chain so it compiles, then retry.");
+                }
+
+                var arguments = initializer.ArgumentList.Arguments;
+                var argumentIndex = Math.Min(ParameterInsertIndex(ctors[targetCtorIndex]), arguments.Count);
+                updatedCtor = updatedCtor.WithInitializer(
+                    initializer.WithArgumentList(
+                        initializer.ArgumentList.WithArguments(
+                            arguments.Insert(argumentIndex, SyntaxFactory.Argument(SyntaxFactory.IdentifierName(paramName))))));
+            }
+            else if (ctor.ExpressionBody is { } expressionBody)
+            {
+                // Expression-bodied root: rewrite to a block body so the assignment has a home —
+                // the old `Body is not null` guard silently skipped these, leaving the field null.
+                updatedCtor = updatedCtor
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(default)
+                    .WithBody(SyntaxFactory.Block(
+                        SyntaxFactory.ExpressionStatement(expressionBody.Expression),
+                        assignment));
+            }
+            else
+            {
+                updatedCtor = updatedCtor.WithBody(ctor.Body!.AddStatements(assignment));
+            }
+
+            replacements[ctor] = updatedCtor;
+        }
+
+        typeDecl = typeDecl.ReplaceNodes(replacements.Keys, (original, _) => replacements[original]);
         return typeDecl.WithMembers(typeDecl.Members.Insert(0, fieldDecl));
     }
 

--- a/tests/RoslynMcp.Tests/TypeExtractionTests.cs
+++ b/tests/RoslynMcp.Tests/TypeExtractionTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using ModelContextProtocol.Protocol;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Tools;
@@ -807,6 +808,254 @@ public sealed class TypeExtractionTests : IsolatedWorkspaceTestBase
             WorkspaceManager.Close(wsId);
             TryDeleteDirectory(solutionDir);
         }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_ImplicitConstructor_SynthesizesAssigningConstructor()
+    {
+        // Regression for type-extraction-composition-constructor-coverage (1/4): a source type
+        // with no declared constructor previously got the readonly composition field with no
+        // parameter and no assignment — a permanently-null field that compiled cleanly, so the
+        // breakage was silent. The extraction must now synthesize a constructor that assigns it.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ImplicitCtorFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ImplicitCtorFixture",
+                "{",
+                "    public int InternalUser() => 42;",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, fixturePath, "ImplicitCtorFixture", ["Compute"], "ComputeHelper", null,
+                CancellationToken.None);
+
+            var updatedSource = await GetModifiedDocumentTextAsync(result.PreviewToken, fixturePath);
+            StringAssert.Contains(updatedSource, "public ImplicitCtorFixture(ComputeHelper computeHelper)",
+                "a constructor accepting the extracted type must be synthesized when the type had only the implicit constructor");
+            StringAssert.Contains(updatedSource, "_computeHelper = computeHelper;",
+                "the synthesized constructor must assign the composition field");
+
+            await AssertModifiedSolutionCompilesAsync(result.PreviewToken);
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_ChainedConstructorOverloads_WiresEveryConstructor()
+    {
+        // Regression for type-extraction-composition-constructor-coverage (2/4): with overloaded
+        // constructors only the FIRST declared one gained the parameter/assignment; a
+        // `: this(...)`-chained overload additionally produced CS1729 at apply time because the
+        // delegated argument list was never updated. Every constructor must now carry the
+        // parameter, only the root assigns, and the chain forwards the new argument.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ChainedCtorFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ChainedCtorFixture",
+                "{",
+                "    private readonly int _seed;",
+                "    public ChainedCtorFixture(int seed) { _seed = seed; }",
+                "    public ChainedCtorFixture() : this(7) { }",
+                "    public int InternalUser() => _seed;",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, fixturePath, "ChainedCtorFixture", ["Compute"], "ComputeHelper", null,
+                CancellationToken.None);
+
+            var updatedSource = await GetModifiedDocumentTextAsync(result.PreviewToken, fixturePath);
+            StringAssert.Contains(updatedSource, "ChainedCtorFixture(int seed, ComputeHelper computeHelper)",
+                "the root constructor must gain the new parameter");
+            StringAssert.Contains(updatedSource, "ChainedCtorFixture(ComputeHelper computeHelper)",
+                "the chained constructor must gain the new parameter too");
+            StringAssert.Contains(updatedSource, "this(7, computeHelper)",
+                "the chained initializer must forward the new argument to the delegated constructor");
+            var assignmentCount = updatedSource.Split("_computeHelper = computeHelper;").Length - 1;
+            Assert.AreEqual(1, assignmentCount,
+                "only the ROOT constructor assigns the readonly field — the chain delegates the single write. " +
+                $"Updated source:\n{updatedSource}");
+
+            await AssertModifiedSolutionCompilesAsync(result.PreviewToken);
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_ExpressionBodiedConstructor_RewritesToBlockWithAssignment()
+    {
+        // Regression for type-extraction-composition-constructor-coverage (3/4): an
+        // expression-bodied constructor gained the parameter but the `Body is not null` guard
+        // silently skipped the assignment, so callers passed a value that was thrown away. The
+        // constructor must be rewritten to a block body carrying both the original expression
+        // and the field assignment.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "ExpressionBodiedCtorFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public class ExpressionBodiedCtorFixture",
+                "{",
+                "    private readonly int _seed;",
+                "    public ExpressionBodiedCtorFixture(int seed) => _seed = seed;",
+                "    public int InternalUser() => _seed;",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var result = await TypeExtractionService.PreviewExtractTypeAsync(
+                wsId, fixturePath, "ExpressionBodiedCtorFixture", ["Compute"], "ComputeHelper", null,
+                CancellationToken.None);
+
+            var updatedSource = await GetModifiedDocumentTextAsync(result.PreviewToken, fixturePath);
+            StringAssert.Contains(updatedSource, "ExpressionBodiedCtorFixture(int seed, ComputeHelper computeHelper)",
+                "the expression-bodied constructor must gain the new parameter");
+            StringAssert.Contains(updatedSource, "_seed = seed;",
+                "the original expression body must survive as a block statement");
+            StringAssert.Contains(updatedSource, "_computeHelper = computeHelper;",
+                "the rewritten block body must assign the composition field");
+            Assert.IsFalse(updatedSource.Contains("=> _seed = seed;", StringComparison.Ordinal),
+                $"the constructor must no longer be expression-bodied. Updated source:\n{updatedSource}");
+
+            await AssertModifiedSolutionCompilesAsync(result.PreviewToken);
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractType_PrimaryConstructor_RefusesWithTopologyMessage()
+    {
+        // Regression for type-extraction-composition-constructor-coverage (4/4): a primary
+        // constructor (record or `class C(...)`) is invisible to the
+        // `OfType<ConstructorDeclarationSyntax>()` scan, so the old code shipped a preview with
+        // an unassigned composition field. The topology must be refused before any syntax is
+        // emitted, with prose naming the unsupported shape and the remedy.
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sampleLibDir = Path.Combine(solutionDir, "SampleLib");
+        var fixturePath = Path.Combine(sampleLibDir, "PrimaryCtorFixture.cs");
+        await File.WriteAllTextAsync(fixturePath,
+            string.Join("\r\n", new[]
+            {
+                "namespace SampleLib;",
+                "",
+                "public record PrimaryCtorFixture(int Seed)",
+                "{",
+                "    public int InternalUser() => Compute(42);",
+                "    private int Compute(int x) => x * 2;",
+                "}",
+                "",
+            }));
+
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var wsId = loadResult.WorkspaceId;
+
+        try
+        {
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                TypeExtractionService.PreviewExtractTypeAsync(
+                    wsId, fixturePath, "PrimaryCtorFixture", ["Compute"], "ComputeHelper", null,
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "Refusing to extract type",
+                "the refusal must use the standard refusal prose so ToolErrorHandler maps it");
+            StringAssert.Contains(ex.Message, "primary constructor",
+                "the refusal must name the unsupported topology");
+        }
+        finally
+        {
+            WorkspaceManager.Close(wsId);
+            TryDeleteDirectory(solutionDir);
+        }
+    }
+
+    /// <summary>
+    /// Fetches the post-extraction text of <paramref name="filePath"/> from the preview's stored
+    /// modified solution — the exact content an apply would write to disk.
+    /// </summary>
+    private static async Task<string> GetModifiedDocumentTextAsync(string previewToken, string filePath)
+    {
+        var retrieved = PreviewStore.Retrieve(previewToken);
+        Assert.IsNotNull(retrieved, "the preview token must be redeemable immediately after the preview");
+        var document = retrieved.Value.ModifiedSolution.Projects
+            .SelectMany(p => p.Documents)
+            .FirstOrDefault(d => string.Equals(
+                Path.GetFullPath(d.FilePath ?? string.Empty), Path.GetFullPath(filePath), StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(document, $"modified solution must contain the source document '{filePath}'");
+        return (await document.GetTextAsync()).ToString();
+    }
+
+    /// <summary>
+    /// Acceptance gate for type-extraction-composition-constructor-coverage: the previewed source
+    /// (updated source type + generated new type) must compile with zero errors — specifically none
+    /// of CS1737 (required after optional), CS1729 (no matching constructor overload for the
+    /// `this(...)` chain), or CS0191 (readonly field assigned outside a constructor).
+    /// </summary>
+    private static async Task AssertModifiedSolutionCompilesAsync(string previewToken)
+    {
+        var retrieved = PreviewStore.Retrieve(previewToken);
+        Assert.IsNotNull(retrieved, "the preview token must be redeemable immediately after the preview");
+        var project = retrieved.Value.ModifiedSolution.Projects
+            .FirstOrDefault(p => string.Equals(p.Name, "SampleLib", StringComparison.Ordinal));
+        Assert.IsNotNull(project, "modified solution must contain the SampleLib project");
+        var compilation = await project.GetCompilationAsync(CancellationToken.None);
+        Assert.IsNotNull(compilation);
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ToArray();
+        Assert.AreEqual(0, errors.Length,
+            "the previewed solution must compile clean (no CS1737/CS1729/CS0191 or any other error). " +
+            $"Errors:\n{string.Join(Environment.NewLine, errors)}");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`extract_type_preview` injected the `private readonly {NewType}` composition field but wired it through only `FirstOrDefault()` constructor, breaking four construction topologies — silently null field on implicit and overloaded constructors, CS1729 on `this(...)`-chained overloads, and a thrown-away argument on expression-bodied constructors.

`InjectFieldAndCtorParameter` is now a whole-topology pass:

- **Implicit constructor:** a `public {SourceType}({NewType} p) { _field = p; }` constructor is synthesized.
- **Root constructors** (no initializer or `base(...)`): every one gains the parameter (preserving the BUG-005 before-first-optional insertion per constructor) plus the field assignment; expression-bodied roots are rewritten to block bodies.
- **`this(...)`-chained constructors:** gain the parameter and forward it to their semantically resolved delegation target at the target's insertion ordinal; the root owns the single readonly write.
- **Static constructors:** never mutated (previously a static ctor could be the `FirstOrDefault()` candidate).
- **Refused up front** (standard "Refusing to extract type" prose): primary constructors (records / `class C(...)`), bodyless constructors (extern/partial), named-argument `this(...)` chains, unresolvable delegation targets.

## Validation

- 4 new tests in `TypeExtractionTests` (implicit / chained-overload / expression-bodied / primary-ctor refusal); cases 1–3 compile the previewed modified solution and assert zero errors.
- `./eng/verify-release.ps1 -Configuration Release` — pass.
- `./eng/verify-ai-docs.ps1` — pass.

## Notes

Pre-existing gaps flagged, not fixed here (spin-off rows recommended): external `new SourceType(...)` call sites are not updated when extraction changes constructor arity, and kept members calling extracted members are not rewritten to `_field.Member(...)` (previewed solution has CS0103 whenever a kept member references an extracted one — surfaced by this PR's compile-gated tests during development).

Closes: type-extraction-composition-constructor-coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)