### PR TITLE
fix(resources): route workspace resources/read failures over the JSON-RPC error channel (resource-read-protocol-error-semantics-workspace)

### DIFF
--- a/changelog.d/resource-read-protocol-error-semantics-workspace.md
+++ b/changelog.d/resource-read-protocol-error-semantics-workspace.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** `resources/read` failures on workspace resources (`roslyn://workspaces*`, `roslyn://workspace/**`) now travel over the JSON-RPC error channel instead of being serialized into a successful `contents` body. Missing workspaces/files return `-32002` (`ResourceNotFound`) under protocol `2025-11-25` and `-32602` (`InvalidParams`) under `2026-07-28`; malformed line ranges return `-32602` in both eras; unexpected handler failures return a sanitized `-32603`. Error payloads carry only a stable category, remediation text, the requested resource URI, and a correlation id — never exception types, stack traces, or raw paths. **Migration:** clients that parsed `{"error":true,"category":...}` out of the resource body must read the JSON-RPC `error` member instead. Server-catalog resources follow in the next release.

--- a/src/RoslynMcp.Host.Stdio/Middleware/RequestProtocolFeatureGate.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/RequestProtocolFeatureGate.cs
@@ -22,4 +22,15 @@ internal static class RequestProtocolFeatureGate
         return !string.IsNullOrEmpty(protocolVersion)
             && StringComparer.Ordinal.Compare(protocolVersion, July2026ProtocolVersion) >= 0;
     }
+
+    /// <summary>
+    /// Era selector for the <c>resources/read</c> failure channel: revisions before
+    /// 2026-07-28 report a missing resource with the dedicated <c>ResourceNotFound</c>
+    /// (-32002) code, while 2026-07-28+ folds it into <c>InvalidParams</c> (-32602).
+    /// The SDK's own <c>McpProtocolVersions</c> helper is <c>internal</c> and unavailable
+    /// to server filters, so this named gate is the single local equivalent — filters must
+    /// route through it rather than duplicating a protocol-string comparison.
+    /// </summary>
+    public static bool UseInvalidParamsForMissingResource<TParams>(RequestContext<TParams> context) =>
+        SupportsJuly2026Features(context);
 }

--- a/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
@@ -1,12 +1,21 @@
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Host.Stdio.Middleware;
 
 /// <summary>
-/// Applies conservative caching hints to resource bodies on protocol revisions that define them.
-/// Resource reads may reflect live workspace state or the process's selected surface profile, so
-/// clients must treat every body as immediately stale and never share it across users or servers.
+/// Read boundary for <c>resources/read</c>. On success, applies conservative caching hints to
+/// resource bodies on protocol revisions that define them — resource reads may reflect live
+/// workspace state or the process's selected surface profile, so clients must treat every body
+/// as immediately stale and never share it across users or servers. On failure, translates the
+/// handler exception into a JSON-RPC protocol error (<see cref="McpProtocolException"/>) so a
+/// failed read answers on the error channel instead of a "successful" result whose contents
+/// body is a serialized error document. Error payloads carry only the stable category, its
+/// remediation text, the offending parameter name, the requested URI, and a correlation id —
+/// never the exception type, a stack frame, or a raw server-side path.
 /// </summary>
 internal static class ResourceReadResultFilter
 {
@@ -15,9 +24,28 @@ internal static class ResourceReadResultFilter
     public static McpRequestHandler<ReadResourceRequestParams, ReadResourceResult> Create(
         McpRequestHandler<ReadResourceRequestParams, ReadResourceResult> next) =>
         async (context, cancellationToken) =>
-            Normalize(
-                await next(context, cancellationToken).ConfigureAwait(false),
-                RequestProtocolFeatureGate.SupportsJuly2026Features(context));
+        {
+            try
+            {
+                return Normalize(
+                    await next(context, cancellationToken).ConfigureAwait(false),
+                    RequestProtocolFeatureGate.SupportsJuly2026Features(context));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (McpException)
+            {
+                // Already protocol-shaped — e.g. the SDK's unknown-resource rejection, or a
+                // McpProtocolException with an explicit error code. Never reclassify.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TranslateToProtocolError(ex, context);
+            }
+        };
 
     internal static ReadResourceResult Normalize(ReadResourceResult result, bool supportsCachingHints)
     {
@@ -25,5 +53,42 @@ internal static class ResourceReadResultFilter
         result.TimeToLive = supportsCachingHints ? CacheTimeToLive : null;
         result.CacheScope = supportsCachingHints ? CacheScope.Private : null;
         return result;
+    }
+
+    /// <summary>
+    /// Classifies a resource-handler failure via <see cref="ToolErrorHandler.ClassifyError"/>
+    /// (the same sanitized category/remediation source the tool surface uses) and maps the
+    /// category onto the protocol-correct JSON-RPC error code for the request's negotiated era.
+    /// </summary>
+    private static McpProtocolException TranslateToProtocolError(
+        Exception ex, RequestContext<ReadResourceRequestParams> context)
+    {
+        // McpToolException is a labelling wrapper some handlers use for non-JSON MIME types;
+        // classify its cause so a wrapped KeyNotFoundException still maps to not-found
+        // semantics instead of the InternalError fallback.
+        var cause = ex is McpToolException { InnerException: { } inner } ? inner : ex;
+
+        var uri = context.Params?.Uri ?? "<unknown>";
+        var info = ToolErrorHandler.ClassifyError(cause, uri);
+        var code = MapErrorCode(info.Category, RequestProtocolFeatureGate.UseInvalidParamsForMissingResource(context));
+        return new McpProtocolException(BuildSanitizedMessage(info, uri), code);
+    }
+
+    private static McpErrorCode MapErrorCode(string category, bool useInvalidParamsForMissingResource) =>
+        category switch
+        {
+            "NotFound" or "FileNotFound" or "DirectoryNotFound" or "WorkspaceEvicted" =>
+                useInvalidParamsForMissingResource ? McpErrorCode.InvalidParams : McpErrorCode.ResourceNotFound,
+            "InvalidArgument" => McpErrorCode.InvalidParams,
+            _ => McpErrorCode.InternalError,
+        };
+
+    private static string BuildSanitizedMessage(ToolErrorHandler.ErrorInfo info, string uri)
+    {
+        // info.Message is already a sanitized remediation template (BuildSafe* helpers /
+        // PublicExceptionDetailPolicy) — raw exception detail stays server-side.
+        var correlationId = info.CorrelationId ?? RequestCorrelationContext.Current ?? "unavailable";
+        var paramSuffix = string.IsNullOrEmpty(info.ParamName) ? string.Empty : $"; param: {info.ParamName}";
+        return $"{info.Category}: {info.Message} (resource: {uri}{paramSuffix}; correlationId: {correlationId})";
     }
 }

--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -15,7 +15,7 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspaces", Name = "workspaces", MimeType = "application/json")]
     [Description("List all currently loaded workspace sessions with a lean summary per workspace (counts and load state, no per-project tree). For the verbose payload use roslyn://workspaces/verbose. Workspace-scoped resources (status, projects, diagnostics, source_file) use URI templates — if your MCP client only shows static resources from resources/list, read roslyn://server/resource-templates to discover those templates.")]
     public static string GetWorkspaces(IWorkspaceManager workspace) =>
-        ToolErrorHandler.ExecuteResource("roslyn://workspaces", () =>
+        ToolErrorHandler.ExecuteResourceScope("roslyn://workspaces", () =>
         {
             var workspaces = workspace.ListWorkspaces();
             var summaries = workspaces.Select(WorkspaceStatusSummaryDto.From).ToList();
@@ -25,7 +25,7 @@ public static class WorkspaceResources
     [McpServerResource(UriTemplate = "roslyn://workspaces/verbose", Name = "workspaces_verbose", MimeType = "application/json")]
     [Description("Verbose variant of roslyn://workspaces — returns the full per-project tree and workspace diagnostics for every loaded session. Can be large on multi-project solutions; prefer the summary resource at roslyn://workspaces unless you need the full payload.")]
     public static string GetWorkspacesVerbose(IWorkspaceManager workspace) =>
-        ToolErrorHandler.ExecuteResource("roslyn://workspaces/verbose", () =>
+        ToolErrorHandler.ExecuteResourceScope("roslyn://workspaces/verbose", () =>
         {
             var workspaces = workspace.ListWorkspaces();
             return JsonSerializer.Serialize(new { count = workspaces.Count, workspaces }, JsonDefaults.Indented);
@@ -43,7 +43,7 @@ public static class WorkspaceResources
         // workspace_load / workspace_reload cannot race this resource dispatch and yield
         // a KeyNotFoundException / partially-loaded snapshot. Matches the tool's semantics
         // (staleness auto-reload, rate limit, global throttle, TOCTOU-safe existence check).
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status", () =>
+        ToolErrorHandler.ExecuteResourceScopeAsync("roslyn://workspace/{workspaceId}/status", () =>
             gate.RunReadAsync(workspaceId, async innerCt =>
             {
                 var status = await workspace.GetStatusAsync(workspaceId, innerCt).ConfigureAwait(false);
@@ -57,7 +57,7 @@ public static class WorkspaceResources
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/status/verbose", () =>
+        ToolErrorHandler.ExecuteResourceScopeAsync("roslyn://workspace/{workspaceId}/status/verbose", () =>
             gate.RunReadAsync(workspaceId, async innerCt =>
             {
                 var status = await workspace.GetStatusAsync(workspaceId, innerCt).ConfigureAwait(false);
@@ -71,7 +71,7 @@ public static class WorkspaceResources
         IWorkspaceManager workspace,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/projects", () =>
+        ToolErrorHandler.ExecuteResourceScopeAsync("roslyn://workspace/{workspaceId}/projects", () =>
             gate.RunReadAsync(workspaceId, innerCt =>
             {
                 var graph = workspace.GetProjectGraph(workspaceId);
@@ -93,7 +93,7 @@ public static class WorkspaceResources
         IDiagnosticService diagnosticService,
         [Description("The workspace session identifier")] string workspaceId,
         CancellationToken ct = default) =>
-        ToolErrorHandler.ExecuteResourceAsync("roslyn://workspace/{workspaceId}/diagnostics", () =>
+        ToolErrorHandler.ExecuteResourceScopeAsync("roslyn://workspace/{workspaceId}/diagnostics", () =>
             gate.RunReadAsync(workspaceId, async innerCt =>
             {
                 // diagnostics-resource-timeout: the resource has no pagination affordance, so apply
@@ -155,9 +155,10 @@ public static class WorkspaceResources
         return taken;
     }
 
-    // source_file is text/x-csharp, not JSON, so we cannot return a JSON envelope on error.
-    // Throwing McpToolException with the OriginatingSource keeps the framework's default
-    // exception path; the MCP client will see a generic error rather than a structured envelope.
+    // source_file is text/x-csharp, not JSON, so there is no JSON envelope to return on error.
+    // Throwing McpToolException with the OriginatingSource lets ResourceReadResultFilter
+    // classify the wrapped cause and answer on the JSON-RPC error channel with the
+    // protocol-correct code (e.g. ResourceNotFound/InvalidParams by negotiated era).
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}", Name = "source_file", MimeType = "text/x-csharp")]
     [Description("Read the source text of a file in the loaded workspace. filePath accepts URL-encoded form (recommended for cross-client portability — Windows absolute paths contain `:` and `\\` which are reserved in URI grammar) or a raw absolute path; both are normalized server-side. Forward slashes are converted to the platform separator. For a line range, use the sibling template roslyn://workspace/{workspaceId}/file/{filePath}/lines/{startLine}-{endLine}.")]
     public static async Task<string> GetSourceFile(
@@ -218,14 +219,14 @@ public static class WorkspaceResources
     /// surface. The returned text is prefixed with a `// roslyn://… lines N..M of T` marker
     /// so agents can tell the slice apart from a whole-file read.
     /// </summary>
-    // dr-9-13-flag-resource-invalid-range-resource-returns-ge:
-    // Wrapped in ToolErrorHandler.ExecuteResourceAsync so invalid lineRange/filePath inputs
-    // return a structured JSON error envelope (category, message, tool) instead of bubbling
-    // a generic JSON-RPC -32603 through the framework. On success the response is still the
-    // marker-prefixed source slice; on failure clients get an actionable error document with
-    // the resource URI template as the `tool` field.
+    // resource-read-protocol-error-semantics-workspace (supersedes
+    // dr-9-13-flag-resource-invalid-range-resource-returns-ge): wrapped in the success-only
+    // ToolErrorHandler.ExecuteResourceScopeAsync — invalid lineRange/filePath inputs propagate
+    // to ResourceReadResultFilter, which answers on the JSON-RPC error channel with a
+    // sanitized, categorized InvalidParams (-32602) error instead of serializing an error
+    // document into a "successful" contents body.
     [McpServerResource(UriTemplate = "roslyn://workspace/{workspaceId}/file/{filePath}/lines/{lineRange}", Name = "source_file_lines", MimeType = "text/x-csharp")]
-    [Description("Read a 1-based inclusive line range from a file in the loaded workspace. filePath accepts URL-encoded form (recommended for cross-client portability — Windows absolute paths contain `:` and `\\` which are reserved in URI grammar) or a raw absolute path; both are normalized server-side. Forward slashes are converted to the platform separator. lineRange is \"startLine-endLine\" (e.g. /lines/100-200). The response is prefixed with a comment marker noting the slice. For the whole file, use the sibling template without /lines/. Invalid ranges (e.g. non-numeric, endLine < startLine, or startLine past EOF) return a structured JSON error envelope — not the C# MIME success shape.")]
+    [Description("Read a 1-based inclusive line range from a file in the loaded workspace. filePath accepts URL-encoded form (recommended for cross-client portability — Windows absolute paths contain `:` and `\\` which are reserved in URI grammar) or a raw absolute path; both are normalized server-side. Forward slashes are converted to the platform separator. lineRange is \"startLine-endLine\" (e.g. /lines/100-200). The response is prefixed with a comment marker noting the slice. For the whole file, use the sibling template without /lines/. Invalid ranges (e.g. non-numeric, endLine < startLine, or startLine past EOF) fail the read with a JSON-RPC InvalidParams (-32602) error — no C# MIME success body is returned.")]
     public static Task<string> GetSourceFileLines(
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
@@ -235,7 +236,7 @@ public static class WorkspaceResources
         CancellationToken ct = default)
     {
         const string source = "roslyn://workspace/{workspaceId}/file/{filePath}/lines/{lineRange}";
-        return ToolErrorHandler.ExecuteResourceAsync(source, () =>
+        return ToolErrorHandler.ExecuteResourceScopeAsync(source, () =>
             gate.RunReadAsync(workspaceId, async innerCt =>
             {
                 var normalizedPath = NormalizeFilePathForResource(filePath);

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -208,6 +208,65 @@ internal static class ToolErrorHandler
     }
 
     /// <summary>
+    /// Success-only sibling of <see cref="ExecuteResource"/> for resource handlers whose
+    /// failures travel over the JSON-RPC error channel: keeps the ambient gate-metrics scope
+    /// and success-path <c>_meta</c> injection, but has NO catch arm — every exception
+    /// propagates to <c>ResourceReadResultFilter</c>, which translates it into a protocol
+    /// error (<c>McpProtocolException</c>) instead of a serialized error document in the
+    /// resource body. Elapsed time is recorded in a <see langword="finally"/> so failed
+    /// reads still stamp <c>ElapsedMs</c> on the ambient metrics.
+    /// </summary>
+    public static string ExecuteResourceScope(string source, Func<string> action)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        using var metricsScope = AmbientGateMetrics.BeginRequest();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            var result = action();
+            // Stamp elapsed BEFORE _meta injection so the success snapshot carries it;
+            // the finally re-stamp is idempotent (Stopwatch freezes on first Stop).
+            RecordElapsed(stopwatch);
+            return InjectMetaIfPossible(result, source);
+        }
+        finally
+        {
+            RecordElapsed(stopwatch);
+        }
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="ExecuteResourceScope"/> for awaitable resource handlers.
+    /// </summary>
+    public static async Task<string> ExecuteResourceScopeAsync(string source, Func<Task<string>> action)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        using var metricsScope = AmbientGateMetrics.BeginRequest();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            var result = await action().ConfigureAwait(false);
+            RecordElapsed(stopwatch);
+            return InjectMetaIfPossible(result, source);
+        }
+        finally
+        {
+            RecordElapsed(stopwatch);
+        }
+    }
+
+    private static void RecordElapsed(System.Diagnostics.Stopwatch stopwatch)
+    {
+        stopwatch.Stop();
+        if (AmbientGateMetrics.Current is { } metrics)
+        {
+            metrics.ElapsedMs = stopwatch.ElapsedMilliseconds;
+        }
+    }
+
+    /// <summary>
     /// P3: Parse the JSON result and add a top-level <c>_meta</c> property carrying the gate
     /// metrics snapshot. Only injected when the root is a JSON object — non-object roots
     /// (arrays, primitives) are returned unchanged so we don't break consumers that expect a

--- a/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
+++ b/tests/RoslynMcp.Tests/ErrorResponseObservabilityTests.cs
@@ -132,32 +132,22 @@ public sealed class ErrorResponseObservabilityTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
-    public async Task Resource_GetWorkspaceStatus_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
+    public async Task Resource_GetWorkspaceStatus_WithUnknownWorkspaceId_PropagatesNotFound()
     {
-        // Pre-fix: a resource exception bubbled to the framework which labelled it
-        // tool: "unknown". Post-fix: ExecuteResource catches the exception and emits
-        // the canonical error envelope with the resource URI as the tool field.
-        var json = await WorkspaceResources.GetWorkspaceStatus(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
-            $"Expected structured error envelope. Actual: {json}");
-        Assert.IsTrue(errorProp.GetBoolean());
-        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString());
-        Assert.AreEqual("roslyn://workspace/{workspaceId}/status",
-            doc.RootElement.GetProperty("tool").GetString(),
-            "Resource URI must populate the tool field, not 'unknown'.");
+        // resource-read-protocol-error-semantics-workspace: workspace resource handlers
+        // use the success-only ExecuteResourceScopeAsync — the gate's KeyNotFoundException
+        // PROPAGATES to ResourceReadResultFilter, which answers on the JSON-RPC error
+        // channel (ResourceNotFound/InvalidParams by negotiated era) instead of
+        // serializing an error envelope into a "successful" contents body.
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
+            WorkspaceResources.GetWorkspaceStatus(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None));
     }
 
     [TestMethod]
-    public async Task Resource_GetProjects_WithUnknownWorkspaceId_ReturnsErrorEnvelopeWithSourceUri()
+    public async Task Resource_GetProjects_WithUnknownWorkspaceId_PropagatesNotFound()
     {
-        var json = await WorkspaceResources.GetProjects(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out _));
-        Assert.AreEqual("roslyn://workspace/{workspaceId}/projects",
-            doc.RootElement.GetProperty("tool").GetString());
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
+            WorkspaceResources.GetProjects(WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None));
     }
 
     // inv-arg-envelope-schema-hint: cold-context callers (parallel-mode subagents) cannot

--- a/tests/RoslynMcp.Tests/FetchMcpResourceReadinessTests.cs
+++ b/tests/RoslynMcp.Tests/FetchMcpResourceReadinessTests.cs
@@ -123,23 +123,17 @@ public sealed class FetchMcpResourceReadinessTests : SharedWorkspaceTestBase
     }
 
     /// <summary>
-    /// Error-envelope path still works when the workspaceId does not exist — the gate
-    /// throws <c>KeyNotFoundException</c>, caught by <c>ToolErrorHandler</c>, surfaced as
-    /// a structured <c>NotFound</c> envelope (not a client-side "server not ready").
+    /// resource-read-protocol-error-semantics-workspace: an unknown workspaceId now
+    /// PROPAGATES the gate's <c>KeyNotFoundException</c> out of the handler — the
+    /// <c>ResourceReadResultFilter</c> read boundary translates it into a JSON-RPC
+    /// protocol error (<c>ResourceNotFound</c>/<c>InvalidParams</c> by negotiated era)
+    /// instead of a "successful" contents body carrying a serialized error document.
     /// </summary>
     [TestMethod]
-    public async Task WorkspaceStatusResource_UnknownWorkspace_ReturnsStructuredNotFound()
+    public async Task WorkspaceStatusResource_UnknownWorkspace_PropagatesNotFound()
     {
-        var json = await WorkspaceResources.GetWorkspaceStatus(
-            WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None);
-
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
-            $"Expected error envelope for unknown workspace. Actual: {json}");
-        Assert.IsTrue(errorProp.GetBoolean());
-        Assert.AreEqual("NotFound", doc.RootElement.GetProperty("category").GetString());
-        Assert.AreEqual("roslyn://workspace/{workspaceId}/status",
-            doc.RootElement.GetProperty("tool").GetString(),
-            "Resource URI must populate the tool field — never a bare 'server not ready'.");
+        await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
+            WorkspaceResources.GetWorkspaceStatus(
+                WorkspaceExecutionGate, WorkspaceManager, "ffffffffffffffffffffffffffffffff", CancellationToken.None));
     }
 }

--- a/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
+++ b/tests/RoslynMcp.Tests/Top10V2RegressionTests.cs
@@ -79,64 +79,53 @@ public sealed class Top10V2RegressionTests : IsolatedWorkspaceTestBase
         Assert.IsTrue(bodyLineCount < 20, $"Slice should be small (<20 lines including marker); got {bodyLineCount}.");
     }
 
-    // dr-9-13-flag-resource-invalid-range-resource-returns-ge:
-    // Pre-fix: invalid ranges threw McpToolException → framework surfaced -32603 JSON-RPC.
-    // Post-fix: the handler is wrapped in ToolErrorHandler.ExecuteResourceAsync which returns
-    // a structured JSON error envelope (category, message, tool) for every input-validation
-    // failure.
+    // resource-read-protocol-error-semantics-workspace (supersedes
+    // dr-9-13-flag-resource-invalid-range-resource-returns-ge):
+    // the handler now uses the success-only ToolErrorHandler.ExecuteResourceScopeAsync —
+    // input-validation failures PROPAGATE to ResourceReadResultFilter, which answers on
+    // the JSON-RPC error channel with a sanitized InvalidParams (-32602) error instead of
+    // serializing an error envelope into a "successful" contents body.
     [TestMethod]
-    public async Task SourceFileLinesResource_EndBeforeStart_ReturnsStructuredInvalidArgument()
+    public async Task SourceFileLinesResource_EndBeforeStart_PropagatesInvalidArgument()
     {
         var animalServicePath = Path.Combine(Path.GetDirectoryName(SampleSolutionPath)!, "SampleLib", "AnimalService.cs");
         var encoded = Uri.EscapeDataString(animalServicePath);
 
-        var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "10-5", CancellationToken.None);
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+            WorkspaceResources.GetSourceFileLines(
+                WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "10-5", CancellationToken.None));
 
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
-            $"Expected structured error envelope. Actual: {json}");
-        Assert.IsTrue(errorProp.GetBoolean());
-        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
-        Assert.AreEqual("roslyn://workspace/{workspaceId}/file/{filePath}/lines/{lineRange}",
-            doc.RootElement.GetProperty("tool").GetString(),
-            "Resource URI template must populate the tool field, not 'unknown'.");
+        Assert.AreEqual("lineRange", ex.ParamName,
+            "The offending parameter must be named so the read filter can surface it.");
     }
 
     [TestMethod]
-    public async Task SourceFileLinesResource_NonNumericRange_ReturnsStructuredInvalidArgument()
+    public async Task SourceFileLinesResource_NonNumericRange_PropagatesInvalidArgument()
     {
         var animalServicePath = Path.Combine(Path.GetDirectoryName(SampleSolutionPath)!, "SampleLib", "AnimalService.cs");
         var encoded = Uri.EscapeDataString(animalServicePath);
 
-        var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "abc-def", CancellationToken.None);
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+            WorkspaceResources.GetSourceFileLines(
+                WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "abc-def", CancellationToken.None));
 
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
-            $"Expected structured error envelope. Actual: {json}");
-        Assert.IsTrue(errorProp.GetBoolean());
-        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
+        Assert.AreEqual("lineRange", ex.ParamName);
     }
 
     [TestMethod]
-    public async Task SourceFileLinesResource_StartLinePastEof_ReturnsStructuredInvalidArgument()
+    public async Task SourceFileLinesResource_StartLinePastEof_PropagatesInvalidArgument()
     {
         var animalServicePath = Path.Combine(Path.GetDirectoryName(SampleSolutionPath)!, "SampleLib", "AnimalService.cs");
         var encoded = Uri.EscapeDataString(animalServicePath);
 
         // AnimalService.cs is ~30 lines; 9999 is safely past EOF.
-        var json = await WorkspaceResources.GetSourceFileLines(
-            WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "9999-10000", CancellationToken.None);
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() =>
+            WorkspaceResources.GetSourceFileLines(
+                WorkspaceExecutionGate, WorkspaceManager, _workspaceId, encoded, lineRange: "9999-10000", CancellationToken.None));
 
-        using var doc = JsonDocument.Parse(json);
-        Assert.IsTrue(doc.RootElement.TryGetProperty("error", out var errorProp),
-            $"Expected structured error envelope. Actual: {json}");
-        Assert.IsTrue(errorProp.GetBoolean());
-        Assert.AreEqual("InvalidArgument", doc.RootElement.GetProperty("category").GetString());
-        StringAssert.Contains(doc.RootElement.GetProperty("message").GetString() ?? string.Empty,
-            "past the end",
-            "Error message should explain the startLine-past-EOF condition.");
+        Assert.AreEqual("lineRange", ex.ParamName);
+        StringAssert.Contains(ex.Message, "past the end",
+            "Exception message should explain the startLine-past-EOF condition.");
     }
 
     // ── apply-with-verify-and-rollback ──


### PR DESCRIPTION
## Summary

- **BREAKING (wire):** failures on workspace resources (`roslyn://workspaces*`, `roslyn://workspace/**`) now answer over the JSON-RPC error channel instead of a SUCCESS result whose `contents` body is a serialized `{"error":true,...}` document.
- `ToolErrorHandler` gains success-only `ExecuteResourceScope` / `ExecuteResourceScopeAsync` wrappers (metrics scope + `_meta` injection kept; `ElapsedMs` stamped in a `finally` so failed reads still record timing; no catch arm). The legacy catching `ExecuteResource*` overloads remain for the not-yet-migrated `ServerResources.cs` sites — part 2 deletes them.
- `ResourceReadResultFilter` now wraps `next` in try/catch: rethrows `OperationCanceledException` and `McpException`, and translates everything else into `McpProtocolException` via the existing sanitized `ToolErrorHandler.ClassifyError` categories — `NotFound`/`FileNotFound`/`DirectoryNotFound`/`WorkspaceEvicted` → `-32002` (`ResourceNotFound`) or `-32602` (`InvalidParams`) by protocol era; `InvalidArgument` → `-32602` both eras; everything else → sanitized `-32603`. Payloads carry only category, remediation text, param name, requested URI, correlation id.
- `RequestProtocolFeatureGate.UseInvalidParamsForMissingResource` is the single named era selector (the SDK's `McpProtocolVersions` helper is `internal` and unreachable — documented stale acceptance anchor).
- All 7 `WorkspaceResources.cs` call sites switched to the scope wrappers; stale comments/description refreshed.

## Validation

- `compile_check` clean solution-wide; Release build with `-p:TreatWarningsAsErrors=true` clean; `verify-ai-docs.ps1` + `verify-changelog-fragments.ps1` pass.
- Targeted suites green (93 tests): ErrorResponseObservabilityTests, Top10V2RegressionTests, FetchMcpResourceReadinessTests, WorkspaceResourceTests, WindowsPathResourceTests, WorkspaceToolsIntegrationTests, ServerDiscoveryWireTests, StaticListResultFilterTests, SurfaceCatalogTests.
- Manual raw JSON-RPC repro against the built stdio server, both eras: missing workspace → `-32002` under `2025-11-25` / `-32602` under `2026-07-28`; `lines/10-5` → `-32602` both eras with `param: lineRange`; success reads intact with era-correct caching hints (`ttlMs=0`/`private` under 2026-07-28, absent under 2025-11-25); no payload leaks exception types, stack frames, or raw paths.
- Full `verify-release.ps1` intentionally not run locally (self-hosted CI runner is active on this box); CI validates on this PR.

## Notes

Part 1 of 2 (split from `resource-read-protocol-error-semantics` per Rule 4). The sibling initiative `resource-read-protocol-error-semantics-server-catalog` migrates the `ServerResources.cs` family, deletes the legacy catching wrappers, adds the table-driven wire matrix, and closes the backlog row.

Closes: (none — row closes with the sibling part-2 initiative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)