### PR TITLE
fix(composite-apply): redact AtomicFileWriter temp-cleanup warning (atomic-file-cleanup-error-detail-redaction)

### DIFF
--- a/changelog.d/atomic-file-cleanup-error-detail-redaction.md
+++ b/changelog.d/atomic-file-cleanup-error-detail-redaction.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** temp-file cleanup failures in `AtomicFileWriter` no longer log the raw exception or absolute temp/target paths. The best-effort cleanup and the re-thrown primary write failure are unchanged; the warning now carries only a stable cleanup category, the target file name, and the shared secret-safe projection (correlation id, exception-type topology, stack depth).

--- a/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
+++ b/src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs
@@ -151,7 +151,10 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
 /// original exception is re-thrown for the caller's catch filter. If an optional
 /// <paramref name="logger"/> is supplied, a failure to delete the orphaned <c>.tmp</c> is logged
 /// at Warning level (the primary write failure is still re-thrown either way) so a stray artifact
-/// left on disk leaves an observability trail instead of being silently discarded.
+/// left on disk leaves an observability trail instead of being silently discarded. That warning
+/// carries only a stable cleanup category, the target's file name, and the shared secret-safe
+/// projection from <see cref="PublicExceptionDetailPolicy"/> (correlation id, exception-type
+/// topology, stack depth) — never the raw exception or absolute temp/target paths.
 /// <para>
 /// Text writes accept an optional <see cref="Encoding"/> so a mutated file keeps its original
 /// BOM/encoding (<c>mutation-write-paths-drop-original-encoding</c>). Callers resolve it through
@@ -164,6 +167,12 @@ public sealed class CompositeApplyOrchestrator : ICompositeApplyOrchestrator
 /// </summary>
 internal static class AtomicFileWriter
 {
+    /// <summary>
+    /// Stable, greppable category token for the temp-cleanup-failure warning. Aligned with the
+    /// <see cref="UnexpectedExceptionCategory.CompositeApply"/> vocabulary.
+    /// </summary>
+    private const string TempCleanupCategory = "CompositeApplyTempCleanup";
+
     /// <summary>
     /// Atomically writes <paramref name="content"/> to <paramref name="path"/>.
     /// </summary>
@@ -225,11 +234,20 @@ internal static class AtomicFileWriter
             // Best-effort cleanup — a stray .tmp is non-fatal and must not mask the original failure.
             // The primary write exception is still re-thrown by the caller; this only records that the
             // orphaned temp artifact could not be removed so it is not left on disk silently.
-            logger?.LogWarning(
-                ex,
-                "AtomicFileWriter: failed to delete orphaned temp file {TempPath} after a failed write to {TargetPath}; a stray .tmp artifact may remain on disk.",
-                tmp,
-                path);
+            // The caught exception and the absolute temp/target paths are deliberately NOT logged
+            // (atomic-file-cleanup-error-detail-redaction): only the stable cleanup category, the
+            // target's file name, and the shared secret-safe projection reach the sinks.
+            if (logger is not null)
+            {
+                var diagnostic = PublicExceptionDetailPolicy.ProjectUnexpected(ex, correlationId: null).Server;
+                logger.LogWarning(
+                    "{CleanupCategory}: failed to delete orphaned temp file {TargetFile}.tmp after a failed write; a stray .tmp artifact may remain on disk. correlationId={CorrelationId} exceptionTypes={ExceptionTypes} stackFrameCount={StackFrameCount}",
+                    TempCleanupCategory,
+                    Path.GetFileName(path),
+                    diagnostic.CorrelationId,
+                    string.Join(" -> ", diagnostic.ExceptionTypes),
+                    diagnostic.StackFrameCount);
+            }
         }
     }
 }

--- a/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
+++ b/tests/RoslynMcp.Tests/CompositeApplyOrchestratorTests.cs
@@ -100,10 +100,19 @@ public sealed class CompositeApplyOrchestratorTests
         await Assert.ThrowsExactlyAsync<IOException>(
             () => AtomicFileWriter.WriteAllTextAsync(path, "// content", CancellationToken.None, logger));
 
-        // (b) Exactly one Warning naming the .tmp path is recorded.
+        // (b) Exactly one Warning is recorded, and it is redacted: no raw exception attached, no
+        // absolute temp/target paths, no caught-exception message text — only the stable cleanup
+        // category, the target file name, and the shared secret-safe projection
+        // (atomic-file-cleanup-error-detail-redaction).
         var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
         Assert.AreEqual(1, warnings.Count, "Exactly one Warning should be logged for the failed temp cleanup.");
-        StringAssert.Contains(warnings[0].Message, tmp, "The warning must name the orphaned .tmp path.");
+        Assert.IsNull(warnings[0].Exception, "The caught cleanup exception must not be attached to the log record.");
+        Assert.IsFalse(warnings[0].Message.Contains(_tempDir, StringComparison.OrdinalIgnoreCase), "The warning must not contain the absolute directory path.");
+        Assert.IsFalse(warnings[0].Message.Contains(tmp, StringComparison.OrdinalIgnoreCase), "The warning must not contain the absolute .tmp path.");
+        StringAssert.Contains(warnings[0].Message, "CompositeApplyTempCleanup", "The warning must carry the stable cleanup category token.");
+        StringAssert.Contains(warnings[0].Message, Path.GetFileName(path), "The warning must name the target file (file name only).");
+        StringAssert.Contains(warnings[0].Message, "correlationId=unavailable", "With no request scope active, the correlation token must be 'unavailable'.");
+        StringAssert.Contains(warnings[0].Message, nameof(IOException), "The warning must carry the exception-type topology from the shared projection.");
 
         // (c) The .tmp still exists — cleanup genuinely failed (it is still locked open), not a no-op.
         Assert.IsTrue(File.Exists(tmp), "The locked .tmp must remain on disk because its cleanup delete failed.");
@@ -294,7 +303,7 @@ public sealed class CompositeApplyOrchestratorTests
 
     private sealed class RecordingLogger<T> : ILogger<T>
     {
-        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -306,7 +315,7 @@ public sealed class CompositeApplyOrchestratorTests
             TState state,
             Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => Entries.Add((logLevel, formatter(state, exception)));
+            => Entries.Add((logLevel, formatter(state, exception), exception));
     }
 
     private sealed class RecordingWorkspaceManager : IWorkspaceManager


### PR DESCRIPTION
## Summary

- `AtomicFileWriter.TryDeleteTemp` (src/RoslynMcp.Roslyn/Services/CompositeApplyOrchestrator.cs) no longer passes the caught cleanup exception to `LogWarning` and no longer logs the absolute temp/target paths.
- The warning now carries a stable category token (`CompositeApplyTempCleanup`), the target's file name only, and the shared secret-safe projection from `PublicExceptionDetailPolicy.ProjectUnexpected` (correlation id, exception-type topology, stack-frame count).
- Best-effort cleanup semantics unchanged: the narrow `IOException`/`UnauthorizedAccessException` catch filter stays, and the primary write failure is still re-thrown by the caller.
- Test: `AtomicFileWriter_Logs_Warning_When_Temp_Cleanup_Fails_After_Write_Failure` assertions inverted to require redaction (no attached exception, no absolute paths; category + file name + `correlationId=unavailable` + exception-type topology present); `RecordingLogger<T>` extended to record the `Exception?` argument.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter FullyQualifiedName~CompositeApplyOrchestratorTests` — 9/9 passed.
- `./eng/verify-ai-docs.ps1` — passed. Full Release gate runs in CI (self-hosted runner active; local verify-release skipped per standing policy).

Closes: atomic-file-cleanup-error-detail-redaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)