### PR TITLE
fix(prompts): route prompt failures through a sanitized get_prompt error boundary (prompt-call-error-filter-boundary)

### DIFF
--- a/changelog.d/prompt-call-error-filter-boundary.md
+++ b/changelog.d/prompt-call-error-filter-boundary.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Prompt failures now travel the JSON-RPC error channel through a single `get_prompt` boundary filter (`GetPromptErrorFilter`) instead of being returned as successful user-role prompt messages. Unexpected prompt exceptions are projected to a sanitized `InternalError` (`-32603`) carrying only a category, remediation, and correlation id — the raw exception message, type chain, inner exceptions, stack text, and local paths are no longer disclosed to clients; server-side diagnostics retain the full secret-safe structure under the new `GetPrompt` observability category. The legacy `PromptMessageBuilder.CreateErrorMessage` body is sanitized the same way until the per-handler catches are retired. Cancellation and parameter-validation (`InvalidParams`) semantics are unchanged. Compatibility note: clients that previously received a successful `prompts/get` result describing a failure now receive a JSON-RPC error response instead.

--- a/src/RoslynMcp.Core/Services/IUnexpectedExceptionReporter.cs
+++ b/src/RoslynMcp.Core/Services/IUnexpectedExceptionReporter.cs
@@ -15,6 +15,7 @@ public enum UnexpectedExceptionCategory
     CompositeApply,
     FixAll,
     WorkspaceReadiness,
+    GetPrompt,
 }
 
 /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Middleware/GetPromptErrorFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/GetPromptErrorFilter.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Host.Stdio.Middleware;
+
+/// <summary>
+/// The single error-handling and observability boundary for every <c>prompts/get</c> the server
+/// dispatches. Wired in <see cref="Program"/> via
+/// <c>WithRequestFilters(b =&gt; b.AddGetPromptFilter(GetPromptErrorFilter.Create))</c>, mirroring
+/// the decorator shape of <see cref="StructuredCallToolFilter"/> for <c>tools/call</c>.
+///
+/// <para><b>Why prompt failures ride the JSON-RPC error channel:</b></para>
+/// <para>
+/// Unlike <c>tools/call</c> (whose result contract carries an <c>isError</c> envelope the LLM can
+/// self-correct from, per MCP SEP-1303), <c>prompts/get</c> has no error shape inside a successful
+/// result — a "prompt message describing the failure" is indistinguishable from real prompt
+/// content. Unexpected prompt failures are therefore converted into a sanitized
+/// <see cref="McpProtocolException"/> with <see cref="McpErrorCode.InternalError"/> (-32603) so
+/// the client observes a protocol-level failure, never a fabricated user-role message.
+/// </para>
+///
+/// <para><b>Sanitization contract:</b></para>
+/// <para>
+/// Unexpected exceptions are projected through
+/// <see cref="PublicExceptionDetailPolicy.ProjectUnexpected"/> +
+/// <see cref="IUnexpectedExceptionReporter"/> (category
+/// <see cref="UnexpectedExceptionCategory.GetPrompt"/>): the client sees only a fixed category,
+/// summary, remediation, and correlation id; the server-side observability sink retains the
+/// exception type chain and stack-frame count but never the message, data, or raw stack text.
+/// </para>
+///
+/// <para><b>Preserved semantics:</b></para>
+/// <list type="bullet">
+///   <item><see cref="OperationCanceledException"/> is rethrown untouched so the SDK translates it
+///         into the protocol-level cancellation envelope (same as
+///         <see cref="StructuredCallToolFilter"/>).</item>
+///   <item><see cref="McpProtocolException"/> (unknown prompt name, SDK-level parameter
+///         validation) is rethrown untouched, keeping the SDK's <c>InvalidParams</c>
+///         contract.</item>
+///   <item>Binding-stage <see cref="ArgumentException"/> / <see cref="JsonException"/> failures
+///         are converted to <see cref="McpErrorCode.InvalidParams"/> so parameter mistakes stay
+///         actionable instead of collapsing into <c>InternalError</c>.</item>
+/// </list>
+/// </summary>
+internal static class GetPromptErrorFilter
+{
+    /// <summary>
+    /// Decorator factory matching the SDK's request-filter contract: receive
+    /// <paramref name="next"/> (the dispatcher handler produced by
+    /// <c>WithPromptsFromAssembly</c>) and return a handler that wraps it with the sanitizing
+    /// error boundary described on the class.
+    /// </summary>
+    public static McpRequestHandler<GetPromptRequestParams, GetPromptResult> Create(
+        McpRequestHandler<GetPromptRequestParams, GetPromptResult> next)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+
+        return async (context, cancellationToken) =>
+        {
+            var promptName = context.Params?.Name ?? "unknown";
+            var logger = context.Services?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger("RoslynMcp.GetPromptErrorFilter");
+
+            try
+            {
+                return await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is a cooperative signal, not a prompt error. Let the SDK
+                // translate it into the protocol-level cancellation envelope.
+                logger?.LogWarning("Prompt {PromptName} was cancelled", promptName);
+                throw;
+            }
+            catch (McpProtocolException)
+            {
+                // Already protocol-shaped (unknown prompt, SDK parameter validation). The SDK's
+                // messages carry no exception internals, so pass them through unchanged to keep
+                // the InvalidParams contract intact.
+                logger?.LogWarning("Prompt {PromptName} failed with a protocol error", promptName);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw TranslateException(
+                    ex,
+                    promptName,
+                    context.Services?.GetService<IUnexpectedExceptionReporter>(),
+                    logger);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Classifies a non-cancellation, non-protocol exception thrown by prompt binding or a prompt
+    /// handler into the protocol exception the boundary throws in its place. Exposed for focused
+    /// unit tests; the returned exception never carries the source exception's message, type
+    /// names, inner chain, stack text, or paths except for the binding-validation shapes noted
+    /// on the class.
+    /// </summary>
+    internal static McpProtocolException TranslateException(
+        Exception exception,
+        string promptName,
+        IUnexpectedExceptionReporter? reporter,
+        ILogger? logger)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        switch (exception)
+        {
+            case ArgumentException argumentException:
+                // Binding-stage validation (missing/unknown required parameter). The binder's
+                // message names the parameter, never the supplied value — keep it actionable.
+                logger?.LogWarning(
+                    "Prompt {PromptName} failed parameter validation: {Reason}",
+                    promptName,
+                    argumentException.Message);
+                return new McpProtocolException(
+                    $"Invalid parameters for prompt '{promptName}': {argumentException.Message}",
+                    McpErrorCode.InvalidParams);
+
+            case JsonException:
+                // Argument deserialization failure. JsonException messages can echo payload
+                // fragments, so emit a fixed description instead of the raw message.
+                logger?.LogWarning(
+                    "Prompt {PromptName} failed argument deserialization", promptName);
+                return new McpProtocolException(
+                    $"Invalid parameters for prompt '{promptName}': the supplied arguments could not be deserialized.",
+                    McpErrorCode.InvalidParams);
+        }
+
+        var details = UnexpectedExceptionReporting.Report(
+            reporter,
+            exception,
+            UnexpectedExceptionCategory.GetPrompt);
+        logger?.LogError(
+            "Prompt {PromptName} failed with unexpected-error; correlationId={CorrelationId}",
+            promptName,
+            details.Public.CorrelationId);
+        return new McpProtocolException(
+            $"{details.Public.Summary} {details.Public.Remediation} (correlationId: {details.Public.CorrelationId})",
+            McpErrorCode.InternalError);
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Program.cs
+++ b/src/RoslynMcp.Host.Stdio/Program.cs
@@ -83,6 +83,11 @@ builder.Services
         requestFilters.AddListResourceTemplatesFilter(StaticListResultFilter.CreateResourceTemplates);
         requestFilters.AddReadResourceFilter(ResourceReadResultFilter.Create);
         requestFilters.AddCallToolFilter(StructuredCallToolFilter.Create);
+        // Single error-handling and observability boundary for every prompts/get dispatch.
+        // Unexpected prompt failures ride the JSON-RPC error channel as a sanitized
+        // InternalError (-32603) instead of being returned as successful user-role prompt
+        // messages carrying raw exception text. See GetPromptErrorFilter.
+        requestFilters.AddGetPromptFilter(GetPromptErrorFilter.Create);
     });
 builder.Services.AddRoslynMcpSurfaceRegistrationPolicy(toolTierSelection);
 

--- a/src/RoslynMcp.Host.Stdio/Prompts/PromptMessageBuilder.cs
+++ b/src/RoslynMcp.Host.Stdio/Prompts/PromptMessageBuilder.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
 
 namespace RoslynMcp.Host.Stdio.Prompts;
 
@@ -33,15 +35,31 @@ internal static class PromptMessageBuilder
             Content = new TextContentBlock { Text = text }
         };
 
-    internal static PromptMessage CreateErrorMessage(string promptName, Exception ex) =>
-        new()
+    /// <summary>
+    /// Sanitized failure message for the legacy per-handler catch sites. The raw exception is
+    /// projected through <see cref="PublicExceptionDetailPolicy.ProjectUnexpected"/> so the
+    /// client sees only the fixed remediation text plus a correlation id — never
+    /// <c>ex.Message</c>, which can carry connection strings, tokens, or local paths from inner
+    /// exceptions. The catches themselves are slated for retirement (rows
+    /// <c>prompt-error-catch-retirement-*</c>) in favor of the <c>GetPromptErrorFilter</c>
+    /// boundary; this builder goes with them.
+    /// </summary>
+    internal static PromptMessage CreateErrorMessage(string promptName, Exception ex)
+    {
+        var details = PublicExceptionDetailPolicy.ProjectUnexpected(
+            ex,
+            RequestCorrelationContext.Current);
+        return new()
         {
             Role = Role.User,
             Content = new TextContentBlock
             {
-                Text = $"The `{promptName}` prompt failed to gather context: {ex.Message}\n\nPlease verify the workspace is loaded and the parameters are correct, then try again."
+                Text = $"The `{promptName}` prompt failed to gather context. {details.Public.Summary} " +
+                    $"Please verify the workspace is loaded and the parameters are correct, then try again. " +
+                    $"{details.Public.Remediation} (correlationId: {details.Public.CorrelationId})"
             }
         };
+    }
 
     internal static string FormatSourceContext(string sourceText, int startLine, int? endLine)
     {

--- a/tests/RoslynMcp.Tests/PromptCallErrorFilterTests.cs
+++ b/tests/RoslynMcp.Tests/PromptCallErrorFilterTests.cs
@@ -1,0 +1,305 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Middleware;
+using RoslynMcp.Host.Stdio.Prompts;
+using RoslynMcp.Tests.Helpers;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Focused contract tests for the <c>prompts/get</c> error boundary
+/// (<see cref="GetPromptErrorFilter"/>) and the sanitized legacy
+/// <see cref="PromptMessageBuilder.CreateErrorMessage"/> body. Wire tests stand up a real
+/// in-proc client/server pair so the assertions run against the serialized JSON-RPC payloads a
+/// client actually receives.
+/// </summary>
+[TestClass]
+public sealed class PromptCallErrorFilterTests
+{
+    private const string _secretSentinel =
+        "SECRET-SENTINEL-Server=db.internal;Password=hunter2;C:/private/source.cs";
+
+    private const int _internalErrorCode = -32603;
+    private const int _invalidParamsCode = -32602;
+
+    [TestMethod]
+    public async Task UnexpectedPromptFailure_RidesJsonRpcErrorChannelWithSanitizedPayload()
+    {
+        var sink = new CapturingSink();
+        await using var harness = await CreateHarnessAsync("prompt-error-filter-wire", sink);
+
+        var priorMessageCount = harness.RawServerMessages.Count;
+        await Assert.ThrowsAsync<McpException>(async () => await harness.Client.GetPromptAsync(
+            "throwing_prompt",
+            new Dictionary<string, object?> { ["target"] = "anything" },
+            cancellationToken: CancellationToken.None));
+
+        var (error, rawMessages) = FindSingleNewError(harness.RawServerMessages, priorMessageCount);
+        Assert.AreEqual(_internalErrorCode, error.GetProperty("code").GetInt32());
+        StringAssert.Contains(
+            error.GetProperty("message").GetString(),
+            "correlationId",
+            StringComparison.Ordinal);
+
+        // No successful prompts/get result may exist for this request — a "prompt message
+        // describing the failure" is indistinguishable from real prompt content.
+        foreach (var rawMessage in rawMessages)
+        {
+            using var document = JsonDocument.Parse(rawMessage);
+            if (document.RootElement.TryGetProperty("result", out var result))
+            {
+                Assert.IsFalse(
+                    result.TryGetProperty("messages", out _),
+                    "A prompt failure must not produce a successful prompts/get result.");
+            }
+        }
+
+        // The serialized wire payload must not disclose exception internals.
+        var serializedResponses = string.Join('\n', rawMessages);
+        Assert.IsFalse(serializedResponses.Contains(_secretSentinel, StringComparison.Ordinal));
+        Assert.IsFalse(serializedResponses.Contains("InvalidOperationException", StringComparison.Ordinal));
+        Assert.IsFalse(serializedResponses.Contains("IOException", StringComparison.Ordinal));
+        Assert.IsFalse(serializedResponses.Contains("   at ", StringComparison.Ordinal));
+        Assert.IsFalse(serializedResponses.Contains("private/source.cs", StringComparison.Ordinal));
+
+        // Server-side observability retains the secret-safe structure under the GetPrompt category.
+        Assert.HasCount(1, sink.Events);
+        var diagnosticEvent = sink.Events.Single();
+        Assert.AreEqual("GetPrompt", diagnosticEvent.Category);
+        Assert.AreEqual("UnexpectedFailure", diagnosticEvent.EventName);
+        Assert.IsTrue(diagnosticEvent.Exception.ExceptionTypes.Any(
+            static type => type.EndsWith(nameof(InvalidOperationException), StringComparison.Ordinal)));
+        Assert.IsTrue(diagnosticEvent.Exception.ExceptionTypes.Any(
+            static type => type.EndsWith(nameof(IOException), StringComparison.Ordinal)));
+        var serializedEvent = JsonSerializer.Serialize(diagnosticEvent);
+        Assert.IsFalse(serializedEvent.Contains(_secretSentinel, StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task MissingRequiredParameter_KeepsInvalidParamsContract()
+    {
+        var sink = new CapturingSink();
+        await using var harness = await CreateHarnessAsync("prompt-invalid-params-wire", sink);
+
+        var priorMessageCount = harness.RawServerMessages.Count;
+        await Assert.ThrowsAsync<McpException>(async () => await harness.Client.GetPromptAsync(
+            "throwing_prompt",
+            cancellationToken: CancellationToken.None));
+
+        var (error, rawMessages) = FindSingleNewError(harness.RawServerMessages, priorMessageCount);
+        Assert.AreEqual(_invalidParamsCode, error.GetProperty("code").GetInt32());
+        var serializedResponses = string.Join('\n', rawMessages);
+        Assert.IsFalse(serializedResponses.Contains(_secretSentinel, StringComparison.Ordinal));
+
+        // Parameter validation is an expected failure — never reported as unexpected.
+        Assert.IsEmpty(sink.Events);
+    }
+
+    [TestMethod]
+    public async Task UnknownPromptName_KeepsSdkProtocolErrorUntouched()
+    {
+        var sink = new CapturingSink();
+        await using var harness = await CreateHarnessAsync("prompt-unknown-name-wire", sink);
+
+        var priorMessageCount = harness.RawServerMessages.Count;
+        await Assert.ThrowsAsync<McpException>(async () => await harness.Client.GetPromptAsync(
+            "no_such_prompt",
+            cancellationToken: CancellationToken.None));
+
+        var (error, _) = FindSingleNewError(harness.RawServerMessages, priorMessageCount);
+        Assert.AreEqual(_invalidParamsCode, error.GetProperty("code").GetInt32());
+        Assert.IsEmpty(sink.Events);
+    }
+
+    [TestMethod]
+    public async Task CancelledPromptCall_PropagatesCancellationUntouchedByTheBoundary()
+    {
+        var sink = new CapturingSink();
+        await using var harness = await CreateHarnessAsync("prompt-cancellation-wire", sink);
+
+        var priorMessageCount = harness.RawServerMessages.Count;
+        await Assert.ThrowsAsync<McpException>(async () => await harness.Client.GetPromptAsync(
+            "cancelling_prompt",
+            cancellationToken: CancellationToken.None));
+
+        // The boundary must rethrow OperationCanceledException untouched: no unexpected-failure
+        // report may have been made, and the resulting SDK error must not carry the filter's
+        // sanitized InternalError envelope (its "correlationId" marker).
+        Assert.IsEmpty(sink.Events);
+        var (error, _) = FindSingleNewError(harness.RawServerMessages, priorMessageCount);
+        Assert.IsFalse(
+            error.GetProperty("message").GetString()!.Contains("correlationId", StringComparison.Ordinal),
+            "Cancellation must not be converted into the boundary's sanitized InternalError.");
+    }
+
+    [TestMethod]
+    public void TranslateException_ArgumentExceptionKeepsActionableInvalidParams()
+    {
+        var translated = GetPromptErrorFilter.TranslateException(
+            new ArgumentException("Missing required parameter 'target'.", "target"),
+            "throwing_prompt",
+            reporter: null,
+            logger: null);
+
+        Assert.AreEqual(McpErrorCode.InvalidParams, translated.ErrorCode);
+        StringAssert.Contains(translated.Message, "throwing_prompt", StringComparison.Ordinal);
+        StringAssert.Contains(translated.Message, "target", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void TranslateException_JsonExceptionNeverEchoesRawMessage()
+    {
+        var translated = GetPromptErrorFilter.TranslateException(
+            new JsonException(_secretSentinel),
+            "throwing_prompt",
+            reporter: null,
+            logger: null);
+
+        Assert.AreEqual(McpErrorCode.InvalidParams, translated.ErrorCode);
+        Assert.IsFalse(translated.Message.Contains(_secretSentinel, StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void TranslateException_UnexpectedExceptionReportsGetPromptCategoryAndSanitizes()
+    {
+        var sink = new CapturingSink();
+        var reporter = new ServerObservabilityReporter(sink);
+        McpProtocolException translated;
+        string correlationId;
+
+        using (RequestCorrelationContext.Begin())
+        {
+            correlationId = RequestCorrelationContext.Current!;
+            translated = GetPromptErrorFilter.TranslateException(
+                new InvalidOperationException(_secretSentinel, new IOException(_secretSentinel)),
+                "throwing_prompt",
+                reporter,
+                logger: null);
+        }
+
+        Assert.AreEqual(McpErrorCode.InternalError, translated.ErrorCode);
+        StringAssert.Contains(translated.Message, correlationId, StringComparison.Ordinal);
+        Assert.IsFalse(translated.Message.Contains(_secretSentinel, StringComparison.Ordinal));
+        Assert.IsFalse(translated.Message.Contains(
+            nameof(InvalidOperationException), StringComparison.Ordinal));
+
+        Assert.HasCount(1, sink.Events);
+        Assert.AreEqual("GetPrompt", sink.Events.Single().Category);
+        Assert.AreEqual(correlationId, sink.Events.Single().Exception.CorrelationId);
+    }
+
+    [TestMethod]
+    public void CreateErrorMessage_EmitsCorrelationAndRemediationNeverExceptionMessage()
+    {
+        string correlationId;
+        PromptMessage message;
+
+        using (RequestCorrelationContext.Begin())
+        {
+            correlationId = RequestCorrelationContext.Current!;
+            message = PromptMessageBuilder.CreateErrorMessage(
+                "explain_error",
+                new InvalidOperationException(_secretSentinel, new IOException(_secretSentinel)));
+        }
+
+        var text = Assert.IsInstanceOfType<TextContentBlock>(message.Content).Text;
+        StringAssert.Contains(text, "explain_error", StringComparison.Ordinal);
+        StringAssert.Contains(text, correlationId, StringComparison.Ordinal);
+        StringAssert.Contains(text, "Retry once", StringComparison.Ordinal);
+        Assert.IsFalse(text.Contains(_secretSentinel, StringComparison.Ordinal));
+        Assert.IsFalse(text.Contains(nameof(InvalidOperationException), StringComparison.Ordinal));
+        Assert.IsFalse(text.Contains("private/source.cs", StringComparison.Ordinal));
+    }
+
+    private static async Task<InMemoryMcpClientServerHarness> CreateHarnessAsync(
+        string transportName,
+        CapturingSink sink)
+    {
+        var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
+        builder.Services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new Implementation { Name = "roslyn-mcp-test", Version = "1.0.0" };
+            })
+            .WithPrompts<FilterTestPrompts>()
+            .WithRequestFilters(filters =>
+                filters.AddGetPromptFilter(GetPromptErrorFilter.Create));
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        return await InMemoryMcpClientServerHarness.CreateAsync(
+            transportName,
+            clientCapabilities: new ClientCapabilities(),
+            clientHandlers: new McpClientHandlers(),
+            disposalFailureContext: transportName,
+            cancellationToken: CancellationToken.None,
+            protocolVersion: null,
+            serverOptions: options,
+            serverServicesFactory: () => new ServiceCollection()
+                .AddSingleton<IUnexpectedExceptionReporter>(new ServerObservabilityReporter(sink))
+                .BuildServiceProvider(),
+            captureServerMessages: true);
+    }
+
+    private static (JsonElement Error, IReadOnlyList<string> RawMessages) FindSingleNewError(
+        IReadOnlyList<string> rawMessages,
+        int priorMessageCount)
+    {
+        var newMessages = rawMessages.Skip(priorMessageCount).ToArray();
+        var errors = new List<JsonElement>();
+        foreach (var rawMessage in newMessages)
+        {
+            using var document = JsonDocument.Parse(rawMessage);
+            if (document.RootElement.TryGetProperty("error", out var error))
+            {
+                errors.Add(error.Clone());
+            }
+        }
+
+        Assert.HasCount(1, errors, "Expected exactly one JSON-RPC error response.");
+        return (errors[0], newMessages);
+    }
+
+    /// <summary>
+    /// Test-only prompt surface. The production prompt handlers all catch their own exceptions
+    /// (until the <c>prompt-error-catch-retirement-*</c> rows land), so exercising the boundary
+    /// requires prompts whose failures actually reach the filter.
+    /// </summary>
+    [McpServerPromptType]
+    public sealed class FilterTestPrompts
+    {
+        [McpServerPrompt(Name = "throwing_prompt")]
+        [Description("Test prompt whose handler throws a nested secret-bearing exception.")]
+        public static IEnumerable<PromptMessage> ThrowingPrompt(
+            [Description("Required parameter used for the InvalidParams contract test.")] string target) =>
+            throw new InvalidOperationException(
+                _secretSentinel,
+                new IOException(_secretSentinel));
+
+        [McpServerPrompt(Name = "cancelling_prompt")]
+        [Description("Test prompt whose handler surfaces a cooperative cancellation signal.")]
+        public static IEnumerable<PromptMessage> CancellingPrompt() =>
+            throw new OperationCanceledException("cooperative cancellation");
+    }
+
+    private sealed class CapturingSink : IServerObservabilitySink
+    {
+        public List<ServerObservabilityEvent> Events { get; } = [];
+        public bool IsEnabled => true;
+
+        public void Write(ServerObservabilityEvent diagnosticEvent)
+        {
+            Events.Add(diagnosticEvent);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GetPromptErrorFilter` — the single error-handling and observability boundary for every `prompts/get` dispatch, registered via `requestFilters.AddGetPromptFilter(...)` in `Program.cs` alongside the existing list/read-resource/call-tool filters.
- Unexpected prompt exceptions now ride the JSON-RPC error channel as a sanitized `McpProtocolException` / `InternalError` (`-32603`) carrying only a fixed category, summary, remediation, and correlation id — never the raw exception message, type chain, inner exceptions, stack text, or local paths. Server-side diagnostics retain the secret-safe structure (type chain + stack-frame count) under the new `UnexpectedExceptionCategory.GetPrompt` observability category.
- Preserved semantics: `OperationCanceledException` is rethrown untouched (SDK cancellation envelope); SDK `McpProtocolException` (unknown prompt, parameter validation) passes through unchanged; binding-stage `ArgumentException`/`JsonException` keep the `InvalidParams` (`-32602`) contract.
- Closes the live disclosure immediately: `PromptMessageBuilder.CreateErrorMessage` keeps its signature (15 call sites across 4 handler partials compile unchanged) but its body no longer interpolates raw `ex.Message` — it emits the fixed remediation text plus the sanitized correlation id. The catch retirement itself is owned by the follow-on `prompt-error-catch-retirement-*` rows.
- Compatibility note: clients that previously received a *successful* `prompts/get` result describing a failure now receive a JSON-RPC error response (recorded in the changelog fragment).

## Validation

- `mcp__roslyn__compile_check`: 0 errors (Host.Stdio + Tests).
- New `tests/RoslynMcp.Tests/PromptCallErrorFilterTests.cs` (7 tests): wire-level sanitized `-32603` with secret-sentinel absence across the serialized payload, `InvalidParams` preservation (missing required param + unknown prompt name), cancellation propagated untouched by the boundary, `TranslateException` unit shapes, `CreateErrorMessage` sanitization, and `GetPrompt`-category observability sink event with type chain but no message.
- `dotnet test` filtered run: PromptCallErrorFilterTests | PromptSmokeTests | ServerDiscoveryWireTests | ServerObservabilitySinkTests → 43/43 passed.
- `./eng/verify-ai-docs.ps1` + `./eng/verify-changelog-fragments.ps1` → pass. Full `verify-release.ps1` left to the self-hosted CI runner per repo policy (no local duplicate runs).

Closes: prompt-call-error-filter-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)