### PR TITLE
fix(scaffolding): redact project-parse fallback diagnostics

### DIFF
--- a/changelog.d/scaffolding-project-parse-diagnostic-redaction.md
+++ b/changelog.d/scaffolding-project-parse-diagnostic-redaction.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Scaffolding project-file parse fallbacks no longer log raw exception objects or absolute project paths. Test-framework detection and test-project validation now emit a secret-safe diagnostic (redacted project identity, deterministic outcome, correlation ID) through the shared unexpected-exception projection, while keeping the existing `mstest` default and allow-through behavior.

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingReadFailurePolicy.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingReadFailurePolicy.cs
@@ -17,4 +17,26 @@ internal static class ScaffoldingReadFailurePolicy
         return $"Could not read the {affectedInput}; scaffolded without pattern inference. " +
             $"correlationId={detail.CorrelationId}";
     }
+
+    /// <summary>
+    /// Secret-safe diagnostic for a recovered project-file parse failure. Carries only the
+    /// redacted project identity (file name, never the full path), the deterministic outcome
+    /// text, and the correlation ID from the shared unexpected-exception projection.
+    /// </summary>
+    public static string CreateProjectParseDiagnostic(
+        IUnexpectedExceptionReporter? exceptionReporter,
+        Exception exception,
+        string? projectFilePath,
+        string outcome)
+    {
+        var detail = UnexpectedExceptionReporting.Report(
+            exceptionReporter,
+            exception,
+            UnexpectedExceptionCategory.Scaffolding).Public;
+        var projectFileName = string.IsNullOrWhiteSpace(projectFilePath)
+            ? "unknown"
+            : Path.GetFileName(projectFilePath);
+        return $"Failed to parse project file '{projectFileName}'; {outcome}. " +
+            $"correlationId={detail.CorrelationId}";
+    }
 }

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingService.cs
@@ -92,7 +92,10 @@ public sealed partial class ScaffoldingService : IScaffoldingService
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "Failed to parse project file '{ProjectFilePath}' while detecting test framework; defaulting to mstest.", projectFilePath);
+            _logger?.LogWarning(
+                "{ScaffoldingParseDiagnostic}",
+                ScaffoldingReadFailurePolicy.CreateProjectParseDiagnostic(
+                    _exceptionReporter, ex, projectFilePath, "defaulting to mstest"));
         }
 
         return "mstest";
@@ -137,7 +140,10 @@ public sealed partial class ScaffoldingService : IScaffoldingService
         catch (Exception ex)
         {
             // If we can't parse the project file, allow and let downstream handle it.
-            _logger?.LogWarning(ex, "Failed to parse project file '{ProjectFilePath}' while validating test project; allowing operation to proceed.", project.FilePath);
+            _logger?.LogWarning(
+                "{ScaffoldingParseDiagnostic}",
+                ScaffoldingReadFailurePolicy.CreateProjectParseDiagnostic(
+                    _exceptionReporter, ex, project.FilePath, "allowing operation to proceed"));
         }
     }
 

--- a/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingFirstTestFileTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
@@ -404,13 +405,14 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
     // capturing logger and the shared static ScaffoldingService is built with a NullLogger.
 
     [TestMethod]
-    public void DetectTestFramework_MalformedProjectFile_LogsWarning_AndDefaultsToMsTest()
+    public void DetectTestFramework_MalformedProjectFile_LogsRedactedWarning_AndDefaultsToMsTest()
     {
         var malformedPath = WriteMalformedProjectFile();
         try
         {
             var logger = new CaptureLogger<ScaffoldingService>();
-            var service = new ScaffoldingService(null!, null!, null!, logger);
+            var reporter = new RecordingUnexpectedExceptionReporter();
+            var service = new ScaffoldingService(null!, null!, null!, logger, reporter);
 
             var method = typeof(ScaffoldingService).GetMethod(
                 "DetectTestFrameworkFromProjectFile",
@@ -419,11 +421,7 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
 
             Assert.AreEqual("mstest", result,
                 "A malformed project file must still default to mstest (behavior unchanged).");
-            var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
-            Assert.IsNotNull(warning,
-                "A malformed project file must now emit a Warning log instead of being silently swallowed.");
-            StringAssert.Contains(warning!.Message, malformedPath);
-            Assert.IsNotNull(warning.Exception, "The underlying parse exception must be attached to the log entry.");
+            AssertRedactedParseWarning(logger, reporter, malformedPath, "defaulting to mstest");
         }
         finally
         {
@@ -432,13 +430,14 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
-    public void ValidateIsTestProject_MalformedProjectFile_LogsWarning_AndAllowsThrough()
+    public void ValidateIsTestProject_MalformedProjectFile_LogsRedactedWarning_AndAllowsThrough()
     {
         var malformedPath = WriteMalformedProjectFile();
         try
         {
             var logger = new CaptureLogger<ScaffoldingService>();
-            var service = new ScaffoldingService(null!, null!, null!, logger);
+            var reporter = new RecordingUnexpectedExceptionReporter();
+            var service = new ScaffoldingService(null!, null!, null!, logger, reporter);
 
             var project = new ProjectStatusDto(
                 Name: "Malformed",
@@ -457,15 +456,67 @@ public sealed class ScaffoldingFirstTestFileTests : IsolatedWorkspaceTestBase
             // Must NOT throw — a parse failure allows the operation through (behavior unchanged).
             method.Invoke(service, [project]);
 
-            var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
-            Assert.IsNotNull(warning,
-                "A malformed project file must now emit a Warning log instead of being silently swallowed.");
-            StringAssert.Contains(warning!.Message, malformedPath);
-            Assert.IsNotNull(warning.Exception, "The underlying parse exception must be attached to the log entry.");
+            AssertRedactedParseWarning(logger, reporter, malformedPath, "allowing operation to proceed");
         }
         finally
         {
             File.Delete(malformedPath);
+        }
+    }
+
+    /// <summary>
+    /// Shared assertion body for the two malformed-project redaction tests: exactly one
+    /// Warning, no attached exception object, no absolute path or raw exception message in
+    /// the log text, a correlationId token, and a server-side projection that retains the
+    /// XmlException type topology under the Scaffolding category.
+    /// </summary>
+    private static void AssertRedactedParseWarning(
+        CaptureLogger<ScaffoldingService> logger,
+        RecordingUnexpectedExceptionReporter reporter,
+        string malformedPath,
+        string expectedOutcome)
+    {
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning);
+        Assert.IsNotNull(warning,
+            "A malformed project file must emit exactly one Warning log entry.");
+        Assert.IsNull(warning!.Exception,
+            "The raw exception object must NOT be attached to the log entry (PublicExceptionDetailPolicy).");
+        Assert.IsFalse(warning.Message.Contains(malformedPath, StringComparison.Ordinal),
+            $"The log message must not disclose the absolute project path. Message: {warning.Message}");
+        StringAssert.Contains(warning.Message, Path.GetFileName(malformedPath),
+            "The redacted project identity (bare file name) keeps the diagnostic actionable.");
+        StringAssert.Contains(warning.Message, expectedOutcome);
+        StringAssert.Contains(warning.Message, "correlationId=");
+
+        Assert.AreEqual(1, reporter.Reports.Count,
+            "The parse failure must be reported once through the unexpected-exception sink.");
+        var (exception, category) = reporter.Reports[0];
+        Assert.AreEqual(UnexpectedExceptionCategory.Scaffolding, category);
+        Assert.IsFalse(warning.Message.Contains(exception.Message, StringComparison.Ordinal),
+            "The raw parse exception message must not leak into the log text.");
+        CollectionAssert.Contains(
+            reporter.LastDetails!.Server.ExceptionTypes.ToList(),
+            "System.Xml.XmlException",
+            "The server-only projection must retain the benign exception type topology.");
+    }
+
+    /// <summary>
+    /// Recording <see cref="IUnexpectedExceptionReporter"/> double: captures each report and
+    /// delegates the projection to the shared <see cref="PublicExceptionDetailPolicy"/>.
+    /// </summary>
+    private sealed class RecordingUnexpectedExceptionReporter : IUnexpectedExceptionReporter
+    {
+        public List<(Exception Exception, UnexpectedExceptionCategory Category)> Reports { get; } = [];
+
+        public UnexpectedExceptionDetails? LastDetails { get; private set; }
+
+        public UnexpectedExceptionDetails ReportUnexpected(
+            Exception exception,
+            UnexpectedExceptionCategory category)
+        {
+            Reports.Add((exception, category));
+            LastDetails = PublicExceptionDetailPolicy.ProjectUnexpected(exception, correlationId: null);
+            return LastDetails;
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `ScaffoldingReadFailurePolicy.CreateProjectParseDiagnostic` — a secret-safe factory that reports the parse exception through the shared unexpected-exception projection (`UnexpectedExceptionReporting.Report`, `Scaffolding` category) and returns a message carrying only the redacted project identity (bare file name, `unknown` when absent), the deterministic outcome text, and a `correlationId`.
- Replace both `_logger?.LogWarning(ex, "...'{ProjectFilePath}'...")` project-parse fallbacks in `ScaffoldingService` (`DetectTestFrameworkFromProjectFile`, `ValidateIsTestProject`) with the redacted diagnostic — no raw exception object, no absolute project path. Control flow is byte-identical: `mstest` default and allow-through validation are unchanged, and the `InvalidOperationException` rethrow stays ahead of the general catch.
- Invert the two malformed-project tests that previously pinned the disclosure: they now assert exactly one Warning with `Exception == null`, no absolute path or raw exception message in the log text, a `correlationId=` token, and (via a recording `IUnexpectedExceptionReporter`) the `Scaffolding` category with `System.Xml.XmlException` retained in the server-only type topology.

## Validation

- `mcp__roslyn__compile_check`: 0 errors across all 5 projects.
- `mcp__roslyn__test_run --filter ScaffoldingFirstTestFileTests`: 9/9 passed.
- `mcp__roslyn__test_run --filter PublicExceptionDetailPolicyTests`: 3/3 passed.
- `./eng/verify-ai-docs.ps1`: passed. Full `verify-release.ps1` parity left to the self-hosted CI runner per standing policy.

Closes: scaffolding-project-parse-diagnostic-redaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)