### PR TITLE
fix(ci): close two pre-existing Actions script injections in publish-nuget.yml

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -147,9 +147,16 @@ jobs:
       - name: Resolve package version
         id: ver
         shell: bash
+        # Context values arrive as environment variables, never interpolated into the
+        # run: body — github.event.release.tag_name is named by whoever cuts the release,
+        # and substituting it as source text lets a crafted tag close the quote and run
+        # commands. Quoting is not a mitigation: ${{ }} is replaced before any shell parses.
+        env:
+          PUBLISH_EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            v="${{ github.event.release.tag_name }}"
+          if [ "$PUBLISH_EVENT_NAME" = "release" ]; then
+            v="$PUBLISH_RELEASE_TAG"
           else
             v="${GITHUB_REF_NAME}"
           fi
@@ -162,9 +169,13 @@ jobs:
         # and checking for the `mcp-name` marker. The flat-container README endpoint
         # returns 200 only once NuGet has finished validating + indexing the package.
         shell: bash
+        # PUBLISH_VERSION derives from the release tag, so it is transitively
+        # attacker-influenced and must not be interpolated into this run: body either.
+        env:
+          PUBLISH_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           id="darylmcd.roslynmcp"   # flat-container ids are lowercased
-          ver="${{ steps.ver.outputs.version }}"
+          ver="$PUBLISH_VERSION"
           url="https://api.nuget.org/v3-flatcontainer/${id}/${ver}/readme"
           echo "Polling $url"
           for i in $(seq 1 80); do

--- a/changelog.d/publish-workflow-preexisting-script-injection.md
+++ b/changelog.d/publish-workflow-preexisting-script-injection.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Closed two GitHub Actions script-injection sites in `.github/workflows/publish-nuget.yml`. The `Resolve package version` step interpolated `${{ github.event.release.tag_name }}`, and the nuget.org readme poll interpolated `${{ steps.ver.outputs.version }}` (derived from that same tag), directly into `run:` bodies in jobs holding `NUGET_API_KEY`. Because `${{ }}` is substituted into the workflow source before any shell parses it, a release tag containing a quote could close the string and execute arbitrary commands — quoting the expansion is not a mitigation. Both now bind through `env:` and are read as `$NAME`. A new `PublishWorkflow_NeverInterpolatesContextIntoRunBodies` regression lock walks every `run:` body and fails on any `${{ }}` expression. Closes `publish-workflow-preexisting-script-injection`.

--- a/tests/RoslynMcp.Tests/PublishVersionContextTests.cs
+++ b/tests/RoslynMcp.Tests/PublishVersionContextTests.cs
@@ -177,6 +177,75 @@ public sealed class PublishVersionContextTests
             "The gate must read its context from environment variables.");
     }
 
+    [TestMethod]
+    public void PublishWorkflow_NeverInterpolatesContextIntoRunBodies()
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var workflowPath = Path.Combine(repositoryRoot, ".github", "workflows", "publish-nuget.yml");
+        var lines = File.ReadAllLines(workflowPath);
+
+        var offenders = new List<string>();
+        var runBodyIndent = -1;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var indent = line.Length - line.TrimStart().Length;
+            var trimmed = line.TrimStart();
+
+            if (runBodyIndent >= 0)
+            {
+                // A run: | block body continues while lines are blank or indented deeper
+                // than the `run:` key itself.
+                if (trimmed.Length == 0)
+                {
+                    continue;
+                }
+
+                if (indent > runBodyIndent)
+                {
+                    if (line.Contains("${{", StringComparison.Ordinal))
+                    {
+                        offenders.Add($"{workflowPath}:{i + 1}: {trimmed}");
+                    }
+
+                    continue;
+                }
+
+                runBodyIndent = -1;
+            }
+
+            if (!trimmed.StartsWith("run:", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var inline = trimmed["run:".Length..].Trim();
+            if (inline is "|" or ">" or "|-" or ">-" or "")
+            {
+                runBodyIndent = indent;
+                continue;
+            }
+
+            if (line.Contains("${{", StringComparison.Ordinal))
+            {
+                offenders.Add($"{workflowPath}:{i + 1}: {trimmed}");
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            offenders.Count,
+            "GitHub Actions script injection: ${{ }} expressions must never be interpolated "
+                + "into a run: body — they are substituted as source text before the shell parses "
+                + "them, so attacker-influenced values (github.event.release.tag_name, "
+                + "github.ref_name, PR titles/branches) can break out and execute commands in a "
+                + "job holding NUGET_API_KEY. Bind them via env: and read $env:NAME / $NAME "
+                + "instead. Offending lines:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
+    }
+
     private static async Task<ProcessResult> RunAsync(
         string repoRoot,
         string eventName,


### PR DESCRIPTION
Closes `publish-workflow-preexisting-script-injection` (High).

## The vulnerability

Two steps interpolated attacker-influenced text directly into a `run:` body, in jobs that hold `NUGET_API_KEY`:

| Step | Expression | Control |
|---|---|---|
| `Resolve package version` | `v="${{ github.event.release.tag_name }}"` | Named by whoever cuts the release |
| nuget.org readme poll | `ver="${{ steps.ver.outputs.version }}"` | Derived from that same tag — transitively controlled |

`${{ }}` is substituted into the workflow **source** before any shell parses it. A release tag containing a quote closes the string literal and the remainder executes. **Quoting the expansion is not a mitigation** — that misconception is what produced the original finding.

Both now bind through `env:` and are read as `$NAME`, so the value arrives as data rather than as source text.

## Regression lock

`PublishWorkflow_NeverInterpolatesContextIntoRunBodies` walks every `run:` body in the workflow and fails on any `${{ }}` expression, naming the offending file:line and explaining why quoting does not help.

This lock is not decoration: **it is what found the second site.** The readme-poll instance was invisible to inspection because `steps.ver.outputs.version` doesn't look attacker-controlled until you trace it back to the tag.

## Provenance

Both sites predate sweep `20260819T180531Z`. They were fixed inline during initiative `publish-tag-version-parity` (PR #1287), then deliberately reverted out of it: spec-compliance review ruled them reducible scope creep, since they are independently revertable rather than gate-forced, and a test added in the same diff cannot bootstrap its own exemption. Split out here per Directives #3 and #6.

## Validation

`./eng/verify-release.ps1 -Configuration Release -NoCoverage` — **2193 passed, 0 failed** (exit code captured directly, not through a pipe).

Injection payloads verified inert against the provenance script: `-ReleaseTag "v3.0.2'; whoami; '"` yields exit 1 and the malformed-tag rejection, with no execution.