### PR TITLE
fix(release): manual NuGet publisher gains workflow-parity provenance (manual-nuget-publish-provenance)

### DIFF
--- a/.claude/skills/publish-preflight/SKILL.md
+++ b/.claude/skills/publish-preflight/SKILL.md
@@ -199,6 +199,6 @@ Step 8.7: Registry Readiness      ✓ PASS / ✗ FAIL (N pass / M fail / K warn)
 Overall: READY TO PUBLISH / NOT READY (N issues)
 ```
 
-If all pass, tell the user: "All checks passed. To publish: create a GitHub Release (which triggers the publish-nuget workflow) or run `eng/publish-nuget.ps1` manually."
+If all pass, tell the user: "All checks passed. To publish: create a GitHub Release (which triggers the publish-nuget workflow) or run `eng/publish-nuget.ps1` manually." The manual publisher enforces the same provenance contract as the workflow: it runs the full publish-mode release gate (`verify-release.ps1 -Configuration Release -NoCoverage -RequireConsumedFragments`, ~10-15 min locally), derives the version from `Directory.Build.props` (a supplied `-Version` is an assertion that must match, never an override), packs fresh into `artifacts/publish-nuget/<version>/`, and fails on a nonzero push exit. Validate-and-pack without pushing: `eng/publish-nuget.ps1 -NoPush`.
 
 If any fail, list the failures with remediation steps. Step 8's WARN/INFO never blocks publish — it only changes the wording of the overall summary line.

--- a/changelog.d/manual-nuget-publish-provenance.md
+++ b/changelog.d/manual-nuget-publish-provenance.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the manual NuGet publisher (`eng/publish-nuget.ps1`) now runs the publish-mode release gate, packs a fresh package into an owned staging directory from the canonical six-file version, rejects a mismatched `-Version`, supports validate-only `-NoPush`, and fails on a nonzero `dotnet nuget push` exit instead of printing `Done.` after a failed push.

--- a/eng/publish-nuget.ps1
+++ b/eng/publish-nuget.ps1
@@ -1,12 +1,25 @@
 param(
     [string]$Version,
     [string]$Source = 'https://api.nuget.org/v3/index.json',
-    [string]$PackageId = 'Darylmcd.RoslynMcp'
+    [string]$PackageId = 'Darylmcd.RoslynMcp',
+    [switch]$NoPush
 )
 
-# Publishes the packed Darylmcd.RoslynMcp global tool to nuget.org.
-# Build the package first (creates nupkg\Darylmcd.RoslynMcp.<Version>.nupkg), e.g.:
-#   dotnet publish src/RoslynMcp.Host.Stdio -c Release
+# Publishes the Darylmcd.RoslynMcp global tool to nuget.org with the same
+# provenance guarantees as the publish-nuget workflow
+# (.github/workflows/publish-nuget.yml):
+#   1. The full publish-mode release gate runs first (verify-release.ps1:
+#      version drift across the six canonical version files, build, tests,
+#      publish smoke, consumed changelog fragments, breaking-version bump).
+#      Expect ~10-15 minutes locally — the same cost the CI path pays.
+#   2. The version is derived from the canonical Directory.Build.props.
+#      A supplied -Version is an ASSERTION that must match; it never overrides.
+#   3. The package is packed fresh into an owned staging directory
+#      (artifacts/publish-nuget/<version>/, recreated per run) — a stale
+#      package left in nupkg/ can never be selected.
+#   4. -NoPush validates and packs only (dry run), then exits 0.
+#   5. A nonzero push exit fails the script; `Done.` prints
+#      only on a verified-successful push.
 #
 # Authentication: API key from https://www.nuget.org/account/apikeys (Push scope).
 #   $env:NUGET_API_KEY = '<secret>'
@@ -22,40 +35,77 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
-# Manual publishing has the same release-note contract as the tag/release
-# workflow: every fragment must already be consumed, and any breaking section
-# must advance the major version before a package can be selected or pushed.
-$global:LASTEXITCODE = 0
-& (Join-Path $PSScriptRoot 'verify-breaking-version-bump.ps1') `
-    -RepoRoot $repoRoot `
-    -RequireConsumedFragments
-$breakingGateExitCode = $global:LASTEXITCODE
-if ($breakingGateExitCode -ne 0) {
-    throw "Breaking version validation failed with exit code $breakingGateExitCode."
-}
-
-if (-not $Version) {
-    [xml]$props = Get-Content (Join-Path $repoRoot 'Directory.Build.props')
-    $Version = @($props.Project.PropertyGroup | ForEach-Object { $_.Version } | Where-Object { $_ })[0]
-    if (-not $Version) {
-        throw 'Could not read Version from Directory.Build.props'
-    }
-}
-
-$packagePath = Join-Path $repoRoot "nupkg\$PackageId.$Version.nupkg"
-if (-not (Test-Path $packagePath)) {
-    throw "Package not found: $packagePath`nBuild it with: dotnet publish src/RoslynMcp.Host.Stdio -c Release"
-}
-
+# Fail fast on a missing key before spending ~10-15 minutes in the release gate.
 $apiKey = $env:NUGET_API_KEY
-if ([string]::IsNullOrWhiteSpace($apiKey)) {
+if (-not $NoPush -and [string]::IsNullOrWhiteSpace($apiKey)) {
     throw @"
 NUGET_API_KEY is not set. Create a key at https://www.nuget.org/account/apikeys then:
   `$env:NUGET_API_KEY = '<your-key>'
   ./eng/publish-nuget.ps1
+Or run a validate-and-pack-only dry run: ./eng/publish-nuget.ps1 -NoPush
 "@
 }
 
+# Manual publishing has the same release contract as the tag/release workflow:
+# run the full publish-mode release gate before anything is packed or pushed.
+# PowerShell does not honor $ErrorActionPreference = 'Stop' for a child
+# script's nonzero `exit`, so reset the global native-exit state and capture it
+# immediately after the child returns.
+$global:LASTEXITCODE = 0
+& (Join-Path $PSScriptRoot 'verify-release.ps1') `
+    -Configuration Release `
+    -NoCoverage `
+    -RequireConsumedFragments
+$releaseGateExitCode = $global:LASTEXITCODE
+if ($releaseGateExitCode -ne 0) {
+    throw "Release validation failed with exit code $releaseGateExitCode."
+}
+
+# The publishable version is ALWAYS the canonical Directory.Build.props value
+# (verify-release.ps1 has already proven the other five version files agree).
+# A caller-supplied -Version is a cross-check, never an override.
+[xml]$props = Get-Content (Join-Path $repoRoot 'Directory.Build.props')
+$canonicalVersion = @($props.Project.PropertyGroup | ForEach-Object { $_.Version } | Where-Object { $_ })[0]
+if (-not $canonicalVersion) {
+    throw 'Could not read Version from Directory.Build.props'
+}
+if ($Version -and $Version -ne $canonicalVersion) {
+    throw "-Version $Version disagrees with the canonical Directory.Build.props version $canonicalVersion. The parameter is an assertion, not an override; fix the checkout (or drop the parameter) instead of publishing an off-checkout version."
+}
+$Version = $canonicalVersion
+
+# Pack fresh into an owned staging root so a stale artifact from an earlier
+# release can never be selected. Never reuse the shared nupkg/ directory.
+$stagingRoot = Join-Path $repoRoot 'artifacts' 'publish-nuget' $Version
+if (Test-Path $stagingRoot) {
+    Remove-Item -LiteralPath $stagingRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $stagingRoot | Out-Null
+
+Write-Host "Packing $PackageId $Version into $stagingRoot ..."
+$global:LASTEXITCODE = 0
+dotnet pack (Join-Path $repoRoot 'src/RoslynMcp.Host.Stdio/RoslynMcp.Host.Stdio.csproj') `
+    -c Release `
+    -o $stagingRoot
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet pack failed with exit code $LASTEXITCODE."
+}
+
+$packagePath = Join-Path $stagingRoot "$PackageId.$Version.nupkg"
+if (-not (Test-Path $packagePath)) {
+    $produced = @(Get-ChildItem -Path $stagingRoot -Filter '*.nupkg' | ForEach-Object { $_.Name }) -join ', '
+    throw "Fresh pack did not produce the expected $PackageId.$Version.nupkg in $stagingRoot (found: $produced)."
+}
+
+if ($NoPush) {
+    Write-Host "Validate-only run complete (-NoPush): packed $packagePath; nothing was pushed."
+    exit 0
+}
+
 Write-Host "Pushing $packagePath to nuget.org ..."
+$global:LASTEXITCODE = 0
 dotnet nuget push $packagePath --source $Source --api-key $apiKey --skip-duplicate
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet nuget push failed with exit code $LASTEXITCODE."
+}
 Write-Host 'Done.'

--- a/tests/RoslynMcp.Tests/BreakingVersionGateTests.cs
+++ b/tests/RoslynMcp.Tests/BreakingVersionGateTests.cs
@@ -64,17 +64,23 @@ public sealed class BreakingVersionGateTests
         var manualPublisherPath = Path.Combine(repositoryRoot, "eng", "publish-nuget.ps1");
         var manualPublisher = File.ReadAllText(manualPublisherPath);
         var manualGateIndex = manualPublisher.IndexOf(
+            "'verify-release.ps1'",
+            StringComparison.Ordinal);
+        var manualGateFragmentIndex = manualPublisher.IndexOf(
             "-RequireConsumedFragments",
             StringComparison.Ordinal);
-        var manualPackageIndex = manualPublisher.IndexOf("$packagePath =", StringComparison.Ordinal);
+        var manualPackIndex = manualPublisher.IndexOf("dotnet pack", StringComparison.Ordinal);
         var manualPushIndex = manualPublisher.IndexOf("dotnet nuget push", StringComparison.Ordinal);
-        Assert.IsTrue(manualGateIndex >= 0, "The manual publisher must require consumed fragments.");
         Assert.IsTrue(
-            manualPackageIndex > manualGateIndex,
-            "The manual publisher must validate the release contract before selecting a package.");
+            manualGateIndex >= 0,
+            "The manual publisher must run the publish-mode release gate (verify-release.ps1).");
+        Assert.IsTrue(manualGateFragmentIndex >= 0, "The manual publisher must require consumed fragments.");
+        Assert.IsTrue(
+            manualPackIndex > manualGateIndex,
+            "The manual publisher must validate the release contract before packing a package.");
         Assert.IsTrue(
             manualPushIndex > manualGateIndex,
-            "The manual publisher must validate the breaking contract before pushing a package.");
+            "The manual publisher must validate the release contract before pushing a package.");
     }
 
     [TestMethod]
@@ -222,7 +228,7 @@ public sealed class BreakingVersionGateTests
 
     [TestMethod]
     [TestCategory("Process")]
-    public async Task ManualPublisher_StopsBeforePackageSelectionWhenBreakingGateExitsNonzero()
+    public async Task ManualPublisher_StopsBeforePackagingWhenReleaseGateExitsNonzero()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
         var fixtureRoot = Path.Combine(
@@ -240,7 +246,7 @@ public sealed class BreakingVersionGateTests
                 Path.Combine(repositoryRoot, "eng", "publish-nuget.ps1"),
                 Path.Combine(engDirectory, "publish-nuget.ps1"));
             File.WriteAllText(
-                Path.Combine(engDirectory, "verify-breaking-version-bump.ps1"),
+                Path.Combine(engDirectory, "verify-release.ps1"),
                 "exit 37\n");
             File.WriteAllText(
                 Path.Combine(packageDirectory, "Darylmcd.RoslynMcp.9.9.9.nupkg"),
@@ -278,10 +284,13 @@ public sealed class BreakingVersionGateTests
 
             var output = await stdoutTask + await stderrTask;
             Assert.AreNotEqual(0, process.ExitCode, output);
-            StringAssert.Contains(output, "Breaking version validation failed with exit code 37.");
+            StringAssert.Contains(output, "Release validation failed with exit code 37.");
+            Assert.IsFalse(
+                output.Contains("Packing ", StringComparison.Ordinal),
+                "The publisher continued to packaging after the release gate failed.");
             Assert.IsFalse(
                 output.Contains("Pushing ", StringComparison.Ordinal),
-                "The publisher continued to package selection after the release gate failed.");
+                "The publisher continued to pushing after the release gate failed.");
         }
         finally
         {

--- a/tests/RoslynMcp.Tests/ManualNuGetPublishContractTests.cs
+++ b/tests/RoslynMcp.Tests/ManualNuGetPublishContractTests.cs
@@ -1,0 +1,329 @@
+using System.Diagnostics;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Process-level contract tests for the manual NuGet publisher
+/// (<c>eng/publish-nuget.ps1</c>). Each test copies the real script into a
+/// sandbox fixture, stubs its child dependencies (<c>verify-release.ps1</c>
+/// and the <c>dotnet</c> CLI), and drives it end-to-end through
+/// <c>pwsh -NoProfile -File</c> to pin the provenance guarantees:
+/// gate-before-pack ordering, canonical-version assertion, fresh-pack staging
+/// (a stale <c>nupkg/</c> artifact is never selected), <c>-NoPush</c> dry-run
+/// behavior, safe push-argument construction, and push-failure propagation.
+/// </summary>
+[TestClass]
+public sealed class ManualNuGetPublishContractTests
+{
+    private const string PackageFileName = "Darylmcd.RoslynMcp.9.9.9.nupkg";
+    private const string FixtureApiKey = "fixture-not-a-secret-key";
+    private const string GateInvokedMarker = "release-gate-invoked";
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task MissingApiKey_FailsFastBeforeReleaseGate()
+    {
+        using var fixture = PublisherFixture.Create();
+        var result = await fixture.RunAsync(apiKey: null);
+
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(result.Output, "NUGET_API_KEY");
+        Assert.IsFalse(
+            result.Output.Contains(GateInvokedMarker, StringComparison.Ordinal),
+            "A missing API key must fail before the ~10-15 minute release gate runs.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task ReleaseGateFailure_AbortsBeforeAnyDotnetInvocation()
+    {
+        using var fixture = PublisherFixture.Create(gateExitCode: 37);
+        var result = await fixture.RunAsync();
+
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(result.Output, "Release validation failed with exit code 37.");
+        Assert.IsFalse(result.Output.Contains("Done.", StringComparison.Ordinal), result.Output);
+        Assert.AreEqual(
+            0,
+            fixture.DotnetInvocations.Count,
+            "No dotnet pack/push may run after the release gate fails.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task NoPush_PacksFreshIntoStagingAndNeverPushes()
+    {
+        using var fixture = PublisherFixture.Create();
+        var result = await fixture.RunAsync(noPush: true);
+
+        Assert.AreEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(result.Output, "Validate-only run complete (-NoPush)");
+        Assert.IsFalse(result.Output.Contains("Done.", StringComparison.Ordinal), result.Output);
+
+        var packInvocation = fixture.DotnetInvocations.SingleOrDefault(
+            line => line.StartsWith("pack ", StringComparison.Ordinal));
+        Assert.IsNotNull(packInvocation, "A -NoPush run must still pack the package.");
+        StringAssert.Contains(
+            packInvocation,
+            Path.Combine("artifacts", "publish-nuget", "9.9.9"),
+            "The pack output must be the owned per-version staging directory.");
+        Assert.IsFalse(
+            fixture.DotnetInvocations.Any(
+                line => line.StartsWith("nuget push", StringComparison.Ordinal)),
+            "-NoPush must never invoke dotnet nuget push.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task Push_UsesFreshlyPackedStagingArtifactNotTheStaleNupkgDirectory()
+    {
+        using var fixture = PublisherFixture.Create();
+        var result = await fixture.RunAsync();
+
+        Assert.AreEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(result.Output, "Done.");
+
+        var pushInvocation = fixture.DotnetInvocations.Single(
+            line => line.StartsWith("nuget push", StringComparison.Ordinal));
+        StringAssert.Contains(
+            pushInvocation,
+            Path.Combine("artifacts", "publish-nuget", "9.9.9", PackageFileName),
+            "The pushed package must be the freshly packed staging artifact.");
+        Assert.IsFalse(
+            pushInvocation.Contains(
+                Path.Combine("nupkg", PackageFileName),
+                StringComparison.Ordinal),
+            "A pre-existing package in nupkg/ must never be selected for push.");
+        StringAssert.Contains(pushInvocation, "--source");
+        StringAssert.Contains(pushInvocation, "--api-key");
+        StringAssert.Contains(pushInvocation, "--skip-duplicate");
+        Assert.IsFalse(
+            result.Output.Contains(FixtureApiKey, StringComparison.Ordinal),
+            "The API key value must never be echoed to stdout/stderr.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task PushFailure_PropagatesNonzeroExitAndSuppressesDone()
+    {
+        using var fixture = PublisherFixture.Create(pushExitCode: 41);
+        var result = await fixture.RunAsync();
+
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(
+            PowerShellOutputNormalizer.Normalize(result.Output),
+            "dotnet nuget push failed with exit code 41.");
+        Assert.IsFalse(
+            result.Output.Contains("Done.", StringComparison.Ordinal),
+            "A failed push must never report Done.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VersionParameter_IsAnAssertionThatRejectsMismatch()
+    {
+        using var fixture = PublisherFixture.Create();
+        var result = await fixture.RunAsync(versionArgument: "1.2.3");
+
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(
+            PowerShellOutputNormalizer.Normalize(result.Output),
+            "disagrees with the canonical Directory.Build.props version 9.9.9");
+        Assert.IsFalse(
+            fixture.DotnetInvocations.Any(
+                line => line.StartsWith("pack ", StringComparison.Ordinal)),
+            "A mismatched -Version must abort before packing.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task PackProducingWrongFileName_FailsTheIdentityAssertion()
+    {
+        using var fixture = PublisherFixture.Create(
+            packedFileName: "Darylmcd.RoslynMcp.0.0.1.nupkg");
+        var result = await fixture.RunAsync(noPush: true);
+
+        Assert.AreNotEqual(0, result.ExitCode, result.Output);
+        StringAssert.Contains(
+            PowerShellOutputNormalizer.Normalize(result.Output),
+            "did not produce the expected Darylmcd.RoslynMcp.9.9.9.nupkg");
+        Assert.IsFalse(
+            fixture.DotnetInvocations.Any(
+                line => line.StartsWith("nuget push", StringComparison.Ordinal)),
+            "A failed package-identity assertion must abort before push.");
+    }
+
+    private sealed class PublisherFixture : IDisposable
+    {
+        private PublisherFixture(string root, string binDirectory, string scriptPath)
+        {
+            Root = root;
+            BinDirectory = binDirectory;
+            ScriptPath = scriptPath;
+        }
+
+        private string Root { get; }
+
+        private string BinDirectory { get; }
+
+        private string ScriptPath { get; }
+
+        private string InvocationLogPath => Path.Combine(BinDirectory, "dotnet-invocations.log");
+
+        public IReadOnlyList<string> DotnetInvocations =>
+            File.Exists(InvocationLogPath)
+                ? File.ReadAllLines(InvocationLogPath)
+                : Array.Empty<string>();
+
+        public static PublisherFixture Create(
+            int gateExitCode = 0,
+            int pushExitCode = 0,
+            string packedFileName = PackageFileName)
+        {
+            var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+            var root = Path.Combine(
+                TestTempRoot.Current,
+                nameof(ManualNuGetPublishContractTests),
+                Guid.NewGuid().ToString("N"));
+            var engDirectory = Path.Combine(root, "eng");
+            var binDirectory = Path.Combine(root, "bin");
+            var stalePackageDirectory = Path.Combine(root, "nupkg");
+            Directory.CreateDirectory(engDirectory);
+            Directory.CreateDirectory(binDirectory);
+            Directory.CreateDirectory(stalePackageDirectory);
+
+            var scriptPath = Path.Combine(engDirectory, "publish-nuget.ps1");
+            File.Copy(Path.Combine(repositoryRoot, "eng", "publish-nuget.ps1"), scriptPath);
+
+            // Stub release gate: prints a marker (so fail-fast tests can prove it
+            // never ran) then exits with the configured code.
+            File.WriteAllText(
+                Path.Combine(engDirectory, "verify-release.ps1"),
+                $"Write-Host '{GateInvokedMarker}'\nexit {gateExitCode}\n");
+
+            // Canonical version source the script derives from.
+            File.WriteAllText(
+                Path.Combine(root, "Directory.Build.props"),
+                """
+                <Project>
+                  <PropertyGroup>
+                    <Version>9.9.9</Version>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            // Stale decoy that the legacy script would have pushed verbatim.
+            File.WriteAllText(
+                Path.Combine(stalePackageDirectory, PackageFileName),
+                "stale package from an earlier release");
+
+            // dotnet stub: logs every invocation to a capture file (never stdout,
+            // so the api key cannot leak into the process output under test),
+            // materializes the configured .nupkg on pack, and honors the
+            // configured push exit code.
+            File.WriteAllText(
+                Path.Combine(binDirectory, "dotnet-stub.ps1"),
+                $$"""
+                Set-StrictMode -Version Latest
+                Add-Content -Path (Join-Path $PSScriptRoot 'dotnet-invocations.log') -Value ($args -join ' ')
+                if ($args.Count -ge 1 -and $args[0] -eq 'pack') {
+                    $outIndex = [Array]::IndexOf($args, '-o')
+                    if ($outIndex -ge 0 -and ($outIndex + 1) -lt $args.Count) {
+                        $outDirectory = $args[$outIndex + 1]
+                        New-Item -ItemType Directory -Force -Path $outDirectory | Out-Null
+                        Set-Content -Path (Join-Path $outDirectory '{{packedFileName}}') -Value 'stub package'
+                    }
+                    exit 0
+                }
+                if ($args.Count -ge 2 -and $args[0] -eq 'nuget' -and $args[1] -eq 'push') {
+                    exit {{pushExitCode}}
+                }
+                exit 0
+                """);
+
+            if (OperatingSystem.IsWindows())
+            {
+                File.WriteAllText(
+                    Path.Combine(binDirectory, "dotnet.cmd"),
+                    "@echo off\r\npwsh -NoProfile -File \"%~dp0dotnet-stub.ps1\" %*\r\nexit /b %ERRORLEVEL%\r\n");
+            }
+            else
+            {
+                var shimPath = Path.Combine(binDirectory, "dotnet");
+                File.WriteAllText(
+                    shimPath,
+                    "#!/bin/sh\nexec pwsh -NoProfile -File \"$(dirname \"$0\")/dotnet-stub.ps1\" \"$@\"\n");
+                File.SetUnixFileMode(
+                    shimPath,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+            }
+
+            return new PublisherFixture(root, binDirectory, scriptPath);
+        }
+
+        public async Task<PublisherResult> RunAsync(
+            string? apiKey = FixtureApiKey,
+            bool noPush = false,
+            string? versionArgument = null)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Root,
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(ScriptPath);
+            if (noPush)
+            {
+                startInfo.ArgumentList.Add("-NoPush");
+            }
+
+            if (versionArgument is not null)
+            {
+                startInfo.ArgumentList.Add("-Version");
+                startInfo.ArgumentList.Add(versionArgument);
+            }
+
+            // Prepend the stub bin so `dotnet` resolves to the fixture shim.
+            var pathVariableName = OperatingSystem.IsWindows() ? "Path" : "PATH";
+            startInfo.Environment[pathVariableName] =
+                BinDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable("PATH");
+            if (apiKey is not null)
+            {
+                startInfo.Environment["NUGET_API_KEY"] = apiKey;
+            }
+            else
+            {
+                startInfo.Environment.Remove("NUGET_API_KEY");
+            }
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Could not start the manual publisher fixture.");
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            try
+            {
+                await process.WaitForExitAsync(timeout.Token);
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                process.Kill(entireProcessTree: true);
+                throw new TimeoutException("Manual publisher fixture did not exit within 60 seconds.");
+            }
+
+            return new PublisherResult(process.ExitCode, await stdoutTask + await stderrTask);
+        }
+
+        public void Dispose() => TestFixtureFileSystem.DeleteDirectoryIfExists(Root);
+    }
+
+    private sealed record PublisherResult(int ExitCode, string Output);
+}


### PR DESCRIPTION
## Summary

Rewrites `eng/publish-nuget.ps1` to mirror the provenance guarantees of `.github/workflows/publish-nuget.yml`:

- Runs the full publish-mode release gate (`verify-release.ps1 -Configuration Release -NoCoverage -RequireConsumedFragments`) before anything is packed or pushed, replacing the standalone breaking-version-bump check (the gate runs it transitively along with version-drift, build, test, and publish smoke).
- Derives the version from the canonical `Directory.Build.props` unconditionally; a supplied `-Version` is an assertion that must match, never an override.
- Packs fresh into an owned per-version staging directory (`artifacts/publish-nuget/<version>/`, recreated per run) and asserts exact `<PackageId>.<Version>.nupkg` identity — a stale package left in `nupkg/` can never be selected.
- Adds `-NoPush` (validate-and-pack-only dry run mirroring the workflow's `dry_run` input).
- Checks `$LASTEXITCODE` after `dotnet pack` and `dotnet nuget push`; `Done.` prints only on a verified-successful push (previously a rejected push reported success).
- API key stays env-var-only, never echoed; missing-key failure now happens before the ~10-15 min gate.

## Tests

- New `ManualNuGetPublishContractTests` (7 process tests): gate-failure abort, missing-key fail-fast, fresh-pack staging vs stale `nupkg/` decoy, `-NoPush` dry run, push-argument construction without key leakage, push-failure propagation, `-Version` mismatch rejection, wrong-filename identity assertion.
- `BreakingVersionGateTests` re-pointed at the new gate/pack markers; its manual-publisher process fixture now stubs `verify-release.ps1`.

## Validation

- `dotnet test --filter "FullyQualifiedName~ManualNuGetPublishContractTests|FullyQualifiedName~BreakingVersionGateTests"` — 10/10 passed (Release).
- `eng/verify-ai-docs.ps1` — passed.
- Full `verify-release.ps1` runs on CI (self-hosted runner; per standing note, not duplicated locally).

Closes: manual-nuget-publish-provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)