### PR TITLE
fix(mcp): route server-driven input through a request-scoped MRTR adapter (mcp-mrtr-dispatch-contract)

### DIFF
--- a/changelog.d/mcp-mrtr-dispatch-contract.md
+++ b/changelog.d/mcp-mrtr-dispatch-contract.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Server-driven input now works on stateless MCP sessions. `InputRequiredException` is rethrown from the `tools/call` filter instead of being converted into an `isError` tool result, and a new request-scoped input adapter (`RequestScopedInputAdapter`) emits `InputRequiredResult` on MRTR-capable clients while consuming only that request's `inputResponses` on retry. Clients negotiating `2025-11-25` keep the existing direct `elicitation/create` behavior.

--- a/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Host.Stdio.Elicitation;
+
+/// <summary>
+/// Sanitized classification of one request-scoped input exchange. The caller maps everything
+/// except <see cref="Accepted"/> to its existing <see langword="null"/> → schema-hint-envelope
+/// fallback; no raw exception text or client payload ever rides on the outcome.
+/// </summary>
+internal enum RequestScopedInputOutcome
+{
+    /// <summary>The client accepted and returned form content.</summary>
+    Accepted,
+
+    /// <summary>The client declined or cancelled the input request.</summary>
+    DeclinedOrCancelled,
+
+    /// <summary>
+    /// The retry request carried an input response that could not be deserialized into an
+    /// <see cref="ElicitResult"/>. Sanitized: the malformed payload is never echoed back.
+    /// </summary>
+    MalformedResponse,
+}
+
+/// <summary>
+/// The single request-scoped boundary through which the <c>tools/call</c> recovery pipeline asks
+/// the user for input, portable across both SDK 2.1 session modes (SEP-2322 MRTR on the
+/// <c>2026-07-28</c> revision, and the <c>2025-11-25</c>-and-earlier initialize-handshake
+/// sessions).
+///
+/// <para><b>Why direct <see cref="McpServer.ElicitAsync"/> is stateful-only while MRTR is
+/// portable:</b> <c>ElicitAsync</c> sends a nested <c>elicitation/create</c> JSON-RPC request to
+/// the client and suspends the in-flight <c>tools/call</c> handler until the response arrives.
+/// That nested-continuation shape requires a stateful session — the same server instance must
+/// stay alive (and the same transport channel open) between the outbound request and the inbound
+/// response. On a stateless session (per-request HTTP under the 2026-07-28 revision) there is no
+/// such continuity, so the direct call has no portable equivalent. MRTR inverts the flow: the
+/// server terminates the initial <c>tools/call</c> with an <see cref="InputRequiredResult"/>
+/// (via <see cref="InputRequiredException"/>), the client resolves the embedded
+/// <see cref="InputRequest"/>s locally, and the client RETRIES the original request carrying
+/// <see cref="RequestParams.InputResponses"/> — every round trip is a self-contained request, so
+/// the flow works identically on stateful and stateless sessions.</para>
+///
+/// <para><b>Request-scoped only:</b> the retry leg reads exclusively
+/// <c>context.Params.InputResponses</c> — the responses the client attached to THIS request.
+/// There is no session or static cache of capabilities or responses; per SEP-2575 the server
+/// must not infer per-request client state from previous requests.</para>
+///
+/// <para><b>Policy-free:</b> the adapter takes a caller-built <see cref="ElicitRequestParams"/>
+/// and owns only the transport-era decision. Which parameters may be elicited
+/// (<c>ElicitationAllowlistPolicy</c>) and what the form asks for (the coordinator's
+/// workspace-path schema) stay with the callers.</para>
+///
+/// <para><b>Cancellation contract:</b> the adapter adds no <c>catch</c> around the legacy
+/// <see cref="McpServer.ElicitAsync"/> leg — <see cref="OperationCanceledException"/> from any
+/// leg propagates unchanged so the filter's cooperative-cancellation rethrow stays intact
+/// (mirroring the <c>when (ex is not OperationCanceledException)</c> guard in
+/// <c>StructuredCallElicitationCoordinator.TryRunRecoveryStepAsync</c>). The only guarded spot
+/// is the retry-leg deserialization, whose failure is classified as
+/// <see cref="RequestScopedInputOutcome.MalformedResponse"/> instead of escaping as an internal
+/// error.</para>
+/// </summary>
+internal static class RequestScopedInputAdapter
+{
+    /// <summary>
+    /// The server-assigned identifier under which the elicitation <see cref="InputRequest"/> is
+    /// published in <see cref="InputRequiredResult.InputRequests"/>, and under which the retry
+    /// request's <see cref="RequestParams.InputResponses"/> is consumed. Deterministic so the
+    /// initial and retry legs of a stateless round trip agree without any server-side state.
+    /// </summary>
+    internal const string ElicitationInputRequestKey = "roslynmcp.elicitation";
+
+    /// <summary>
+    /// Requests user input for <paramref name="request"/> through the era-appropriate mechanism:
+    /// <list type="number">
+    ///   <item><b>Retry leg</b> — when the current request carries an input response keyed
+    ///   <see cref="ElicitationInputRequestKey"/>, consume it (request-scoped only) and classify
+    ///   the outcome without any client round trip.</item>
+    ///   <item><b>MRTR leg</b> — when the client supports MRTR
+    ///   (<see cref="McpServer.IsMrtrSupported"/>), throw <see cref="InputRequiredException"/>
+    ///   so the SDK emits an <see cref="InputRequiredResult"/>; the client retries with the
+    ///   response attached and re-enters via the retry leg.</item>
+    ///   <item><b>Stateful legacy leg</b> — otherwise, fall back to the direct nested
+    ///   <see cref="McpServer.ElicitAsync"/> continuation (initialize-handshake sessions).</item>
+    /// </list>
+    /// </summary>
+    /// <exception cref="InputRequiredException">
+    /// Thrown on the MRTR leg. This is a protocol signal, not a failure — it must reach the SDK
+    /// unswallowed (see the <c>StructuredCallToolFilter</c> rethrow and the
+    /// <c>TryRunRecoveryStepAsync</c> exception filter).
+    /// </exception>
+    internal static async ValueTask<(RequestScopedInputOutcome Outcome, ElicitResult? Result)> RequestInputAsync(
+        RequestContext<CallToolRequestParams> context,
+        ElicitRequestParams request,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Retry leg: the client already answered on a previous round trip of THIS logical
+        // request. Consume only this request's own inputResponses — no session/static cache.
+        if (context.Params?.InputResponses is { } inputResponses &&
+            inputResponses.TryGetValue(ElicitationInputRequestKey, out var inputResponse))
+        {
+            return ClassifyInputResponse(inputResponse, logger);
+        }
+
+        if (context.Server?.IsMrtrSupported is true)
+        {
+            // MRTR leg: terminate this round trip with an input-required protocol signal.
+            throw new InputRequiredException(
+                new Dictionary<string, InputRequest>(StringComparer.Ordinal)
+                {
+                    [ElicitationInputRequestKey] = InputRequest.ForElicitation(request),
+                },
+                requestState: null);
+        }
+
+        // Stateful legacy leg: nested elicitation/create continuation. No catch here —
+        // OperationCanceledException must propagate unchanged, and ordinary SDK failures are
+        // owned by the caller's guarded recovery step.
+        var elicitResult = await context.Server!.ElicitAsync(request, cancellationToken).ConfigureAwait(false);
+        return elicitResult.IsAccepted
+            ? (RequestScopedInputOutcome.Accepted, elicitResult)
+            : (RequestScopedInputOutcome.DeclinedOrCancelled, elicitResult);
+    }
+
+    /// <summary>
+    /// Delegate-shaped projection of <see cref="RequestInputAsync"/> matching the coordinator's
+    /// existing <c>Func&lt;ElicitRequestParams, ValueTask&lt;ElicitResult&gt;&gt;</c> seam.
+    /// Non-accept outcomes surface as a non-accepted <see cref="ElicitResult"/> so the caller's
+    /// decline handling (fall through to the schema-hint envelope) applies uniformly; a
+    /// malformed response maps to a sanitized synthetic cancel result carrying none of the raw
+    /// payload.
+    /// </summary>
+    internal static async ValueTask<ElicitResult> RequestInputAsElicitResultAsync(
+        RequestContext<CallToolRequestParams> context,
+        ElicitRequestParams request,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        var (_, result) = await RequestInputAsync(context, request, logger, cancellationToken).ConfigureAwait(false);
+        return result ?? new ElicitResult { Action = "cancel" };
+    }
+
+    private static (RequestScopedInputOutcome Outcome, ElicitResult? Result) ClassifyInputResponse(
+        InputResponse inputResponse,
+        ILogger? logger)
+    {
+        ElicitResult? result;
+        try
+        {
+            result = inputResponse.Deserialize(InputResponse.ElicitResultJsonTypeInfo);
+        }
+        catch (JsonException)
+        {
+            // Narrow, deliberate: a malformed client payload is a classified outcome, not an
+            // internal error. The payload itself is never logged or echoed (redaction contract).
+            result = null;
+        }
+
+        if (result is null)
+        {
+            logger?.LogWarning(
+                "Retry request carried an input response under '{Key}' that did not deserialize " +
+                "to an ElicitResult; classifying as malformed.", ElicitationInputRequestKey);
+            return (RequestScopedInputOutcome.MalformedResponse, null);
+        }
+
+        return result.IsAccepted
+            ? (RequestScopedInputOutcome.Accepted, result)
+            : (RequestScopedInputOutcome.DeclinedOrCancelled, result);
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs
@@ -8,11 +8,13 @@ namespace RoslynMcp.Host.Stdio.Middleware;
 
 /// <summary>
 /// The elicitation/retry orchestration layer extracted from <see cref="StructuredCallToolFilter"/>.
-/// Owns the <em>how</em> of asking the user for a missing value via MCP <c>elicitation/create</c>
-/// and re-dispatching the original call — the exception-path recovery
+/// Owns the <em>how</em> of asking the user for a missing value and re-dispatching the original
+/// call — the exception-path recovery
 /// (<see cref="TryElicitAndRetryAsync"/>) and the workspaceId-specific recover-load-retry loop
 /// (<see cref="TryRecoverMissingWorkspaceIdAsync"/>). Whether a parameter <em>may</em> be elicited
-/// stays in <see cref="ElicitationAllowlistPolicy"/>; metrics stay in
+/// stays in <see cref="ElicitationAllowlistPolicy"/>; the transport-era decision (MRTR
+/// input-required signal vs direct nested <c>elicitation/create</c>) is delegated to
+/// <see cref="RequestScopedInputAdapter"/>; metrics stay in
 /// <see cref="CallMetricsRecorder"/>; the pre-dispatch auto-resolve/auto-load flow and
 /// error-envelope construction stay in the filter. The shared select-from-N picker is NOT owned
 /// here — its canonical (and only) home is
@@ -43,7 +45,8 @@ internal static class StructuredCallElicitationCoordinator
     /// <c>InvalidArgument</c> for a missing required parameter on a tool whose
     /// (toolName, paramName) pair is on the elicitation allowlist AND the client supports
     /// elicitation, this method asks the user for the missing value via
-    /// <see cref="McpServer.ElicitAsync(ElicitRequestParams, CancellationToken)"/>, patches
+    /// <see cref="RequestScopedInputAdapter.RequestInputAsElicitResultAsync"/> (which picks the
+    /// MRTR or direct-<c>elicitation/create</c> leg per session era), patches
     /// the elicited value into the request's <c>Arguments</c> dictionary, and re-invokes
     /// <paramref name="next"/>. Returns <see langword="null"/> when the recovery does not
     /// apply (any layer of the gate fails) — the caller falls through to
@@ -103,7 +106,8 @@ internal static class StructuredCallElicitationCoordinator
             return await TryRecoverMissingWorkspaceIdAsync(
                 toolName,
                 CopyArguments(context.Params!.Arguments),
-                request => context.Server!.ElicitAsync(request, cancellationToken),
+                request => RequestScopedInputAdapter.RequestInputAsElicitResultAsync(
+                    context, request, logger, cancellationToken),
                 (dispatchToolName, arguments) =>
                     DispatchWithTemporaryArgumentsAsync(context, next, dispatchToolName, arguments, cancellationToken),
                 logger,
@@ -116,7 +120,8 @@ internal static class StructuredCallElicitationCoordinator
         var elicitRequest = BuildWorkspacePathElicitationRequest(toolName, missingParam);
 
         var elicitAttempt = await TryRunRecoveryStepAsync(
-            () => context.Server!.ElicitAsync(elicitRequest, cancellationToken),
+            () => RequestScopedInputAdapter.RequestInputAsElicitResultAsync(
+                context, elicitRequest, logger, cancellationToken),
             elicitEx => logger?.LogWarning(elicitEx,
                 "Elicitation request failed for {Tool}.{Param}; falling back to schemaHint envelope.",
                 toolName, missingParam)).ConfigureAwait(false);
@@ -244,7 +249,11 @@ internal static class StructuredCallElicitationCoordinator
 
     /// <summary>
     /// Executes one recovery await boundary. Ordinary recovery failures fall through to the
-    /// caller's existing envelope; cooperative cancellation always escapes unchanged.
+    /// caller's existing envelope; cooperative cancellation always escapes unchanged, and so
+    /// does the MRTR input-required protocol signal
+    /// (<see cref="InputRequiredException"/>) — swallowing it here would convert
+    /// "this call needs client input" into a terminal schema-hint envelope and make the
+    /// request-scoped adapter's MRTR leg unreachable.
     /// </summary>
     internal static async ValueTask<(bool Succeeded, T? Value)> TryRunRecoveryStepAsync<T>(
         Func<ValueTask<T>> action,
@@ -255,7 +264,7 @@ internal static class StructuredCallElicitationCoordinator
         {
             return (true, await action().ConfigureAwait(false));
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
         {
             onFailure(ex);
             return (false, null);

--- a/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/StructuredCallToolFilter.cs
@@ -70,6 +70,18 @@ namespace RoslynMcp.Host.Stdio.Middleware;
 /// and <see cref="ElicitationAllowlistPolicy"/> for the defense layers.
 /// </para>
 ///
+/// <para><b>MRTR passthrough (SEP-2322, protocol 2026-07-28):</b></para>
+/// <para>
+/// <see cref="ModelContextProtocol.Protocol.InputRequiredException"/> is a protocol signal —
+/// "this call needs client input before it can complete" — not a tool failure. The filter
+/// rethrows it (like cancellation) so the SDK emits an
+/// <see cref="ModelContextProtocol.Protocol.InputRequiredResult"/>; on MRTR-capable sessions
+/// the client resolves the embedded input requests and retries the call carrying
+/// <c>params.inputResponses</c>, which
+/// <see cref="Elicitation.RequestScopedInputAdapter"/> consumes request-scoped. Sessions that
+/// negotiated 2025-11-25 or earlier keep the direct <c>elicitation/create</c> path above.
+/// </para>
+///
 /// <para>
 /// Reference: <c>ai_docs/references/mcp-server-best-practices.md</c>.
 /// </para>
@@ -198,6 +210,16 @@ internal static class StructuredCallToolFilter
                 // Cancellation is a cooperative signal, not a tool error. Let the SDK
                 // translate it into the protocol-level cancellation envelope.
                 logger?.LogWarning("Tool {ToolName} was cancelled", toolName);
+                throw;
+            }
+            catch (InputRequiredException)
+            {
+                // MRTR (SEP-2322): an input-required signal is a protocol result, not a tool
+                // error. Rethrow so the SDK converts it into an InputRequiredResult; converting
+                // it into an isError CallToolResult here would make server-driven input
+                // structurally impossible on MRTR sessions. MUST stay above the general
+                // catch (Exception) below — C# picks the first matching clause.
+                logger?.LogInformation("Tool {ToolName} returned an input-required signal", toolName);
                 throw;
             }
             catch (Exception ex)

--- a/tests/RoslynMcp.Tests/McpMrtrWireContractTests.cs
+++ b/tests/RoslynMcp.Tests/McpMrtrWireContractTests.cs
@@ -1,0 +1,388 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Elicitation;
+using RoslynMcp.Host.Stdio.Middleware;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Raw-wire contract for the <c>mcp-mrtr-dispatch-contract</c> initiative: server-driven input
+/// through <see cref="RequestScopedInputAdapter"/> must be portable across both SDK 2.1 session
+/// eras. Mirrors the dual-protocol harness pattern of
+/// <see cref="ProtocolVersionResultShapeWireTests"/> (negotiated <c>2025-11-25</c> vs
+/// <c>2026-07-28</c>, asserting against <c>harness.RawServerMessages</c>). Pins:
+/// <list type="bullet">
+///   <item><b>MRTR round trip</b> — under <c>2026-07-28</c>, a tool call missing an allowlisted
+///   parameter yields an <c>input_required</c> result on the wire (NOT an <c>isError</c>
+///   envelope, which was defect (1): the filter's <c>catch (Exception)</c> used to swallow
+///   <see cref="InputRequiredException"/>); the SDK client resolves the embedded elicitation and
+///   the retry carrying <c>params.inputResponses</c> completes with a success envelope.</item>
+///   <item><b>Stateful compatibility</b> — under <c>2025-11-25</c>, the direct nested
+///   <c>elicitation/create</c> leg still round-trips and the final result keeps the legacy shape
+///   (no <c>resultType</c> discriminator).</item>
+///   <item><b>Sanitized non-accept outcomes</b> — declined and malformed input responses each
+///   fall through to the existing schema-hint <c>InvalidArgument</c> envelope with no raw
+///   exception text or payload echo.</item>
+///   <item><b>Cancellation</b> — cancelling while the adapter's legacy elicitation leg is in
+///   flight surfaces as protocol cancellation, never as a tool-error envelope.</item>
+/// </list>
+/// </summary>
+[TestClass]
+public sealed class McpMrtrWireContractTests
+{
+    // The fake tool deliberately reuses the workspace_load name so the recovery pipeline's
+    // strict allowlist (workspace_load.path) permits elicitation for the missing parameter.
+    private const string ToolName = "workspace_load";
+    private const string ElicitedPath = "C:/synthetic/solution.slnx";
+
+    // ── (1) MRTR round trip under 2026-07-28 ─────────────────────────────────
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MrtrSession_MissingPath_EmitsInputRequiredResult_ThenRetryCompletes()
+    {
+        var elicitationsHandled = 0;
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: null,
+            elicitationHandler: (_, _) =>
+            {
+                Interlocked.Increment(ref elicitationsHandled);
+                return new ValueTask<ElicitResult>(AcceptedPathResult());
+            });
+        Assert.AreEqual("2026-07-28", harness.Client.NegotiatedProtocolVersion);
+
+        var prior = harness.RawServerMessages.Count;
+        var clientResult = await harness.Client.CallToolAsync(
+            ToolName,
+            cancellationToken: CancellationToken.None);
+
+        Assert.AreEqual(1, elicitationsHandled,
+            "The client must resolve exactly one embedded elicitation input request.");
+        Assert.IsFalse(clientResult.IsError is true,
+            "The retry carrying inputResponses must complete with a success envelope.");
+
+        var results = FindNewResults(harness.RawServerMessages, prior);
+        Assert.HasCount(2, results);
+
+        // Initial call: an input-required protocol result, not a failed tool call.
+        var inputRequired = results[0];
+        Assert.AreEqual("input_required", inputRequired.GetProperty("resultType").GetString(),
+            "The initial tools/call must terminate in an InputRequiredResult on the wire — an " +
+            "isError CallToolResult here means the filter swallowed InputRequiredException.");
+        Assert.IsFalse(inputRequired.TryGetProperty("isError", out _));
+        var inputRequest = inputRequired
+            .GetProperty("inputRequests")
+            .GetProperty(RequestScopedInputAdapter.ElicitationInputRequestKey);
+        Assert.AreEqual("elicitation/create", inputRequest.GetProperty("method").GetString());
+        Assert.IsFalse(inputRequired.TryGetProperty("requestState", out _),
+            "The adapter is stateless per round trip: the client re-sends the original " +
+            "arguments itself, so no opaque continuation state is published.");
+
+        // Retry: success envelope carrying the elicited value.
+        var final = results[1];
+        Assert.IsFalse(final.TryGetProperty("isError", out var finalIsError) && finalIsError.GetBoolean());
+        StringAssert.Contains(final.GetProperty("content")[0].GetProperty("text").GetString(), ElicitedPath);
+
+        // The MRTR leg must not also send the legacy nested server-to-client request.
+        Assert.IsFalse(
+            AnyServerRequest(harness.RawServerMessages, prior, RequestMethods.ElicitationCreate),
+            "Under MRTR the elicitation rides inside the InputRequiredResult; the server must " +
+            "not additionally send a nested elicitation/create request.");
+    }
+
+    // ── (2) stateful compatibility under 2025-11-25 ──────────────────────────
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task LegacySession_MissingPath_UsesDirectElicitation_AndLegacyResultShape()
+    {
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: "2025-11-25",
+            elicitationHandler: (_, _) => new ValueTask<ElicitResult>(AcceptedPathResult()));
+        Assert.AreEqual("2025-11-25", harness.Client.NegotiatedProtocolVersion);
+
+        var prior = harness.RawServerMessages.Count;
+        var clientResult = await harness.Client.CallToolAsync(
+            ToolName,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsFalse(clientResult.IsError is true);
+        Assert.IsTrue(
+            AnyServerRequest(harness.RawServerMessages, prior, RequestMethods.ElicitationCreate),
+            "A 2025-11-25 session must keep the direct nested elicitation/create recovery leg.");
+
+        var results = FindNewResults(harness.RawServerMessages, prior);
+        Assert.HasCount(1, results,
+            "The stateful leg answers the original request in a single wire result — " +
+            "input_required never appears on a legacy session.");
+        var final = results[0];
+        Assert.IsFalse(final.TryGetProperty("resultType", out _),
+            "ApplyProtocolResultShape strips the July 2026 discriminator for legacy sessions.");
+        Assert.IsFalse(final.TryGetProperty("isError", out var isError) && isError.GetBoolean());
+        StringAssert.Contains(final.GetProperty("content")[0].GetProperty("text").GetString(), ElicitedPath);
+    }
+
+    // ── (3) sanitized non-accept outcomes ────────────────────────────────────
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MrtrSession_DeclinedInputResponse_FallsThroughToSanitizedSchemaHintEnvelope()
+    {
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: null,
+            elicitationHandler: (_, _) =>
+                new ValueTask<ElicitResult>(new ElicitResult { Action = "decline" }));
+
+        var prior = harness.RawServerMessages.Count;
+        var clientResult = await harness.Client.CallToolAsync(
+            ToolName,
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsTrue(clientResult.IsError is true,
+            "A declined input response cannot recover the call; the existing InvalidArgument " +
+            "envelope is the contract.");
+
+        var results = FindNewResults(harness.RawServerMessages, prior);
+        Assert.HasCount(2, results,
+            "Initial input_required round trip, then the retry's terminal error envelope.");
+        var final = results[1];
+        Assert.IsTrue(final.GetProperty("isError").GetBoolean());
+        AssertSanitizedInvalidArgumentEnvelope(final);
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task MrtrSession_MalformedInputResponse_FallsThroughToSanitizedSchemaHintEnvelope()
+    {
+        var elicitationsHandled = 0;
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: null,
+            elicitationHandler: (_, _) =>
+            {
+                Interlocked.Increment(ref elicitationsHandled);
+                return new ValueTask<ElicitResult>(AcceptedPathResult());
+            });
+
+        // Hand-craft the retry leg: a tools/call already carrying an inputResponses entry whose
+        // raw value cannot deserialize into an ElicitResult. The SDK client always sends
+        // well-formed responses, so this is the only way to drive the malformed classification
+        // over the real wire.
+        var prior = harness.RawServerMessages.Count;
+        var response = await harness.Client.SendRequestAsync(
+            new JsonRpcRequest
+            {
+                Method = RequestMethods.ToolsCall,
+                Params = new JsonObject
+                {
+                    ["name"] = ToolName,
+                    ["arguments"] = new JsonObject(),
+                    ["inputResponses"] = new JsonObject
+                    {
+                        [RequestScopedInputAdapter.ElicitationInputRequestKey] = JsonValue.Create(42),
+                    },
+                },
+            },
+            CancellationToken.None);
+
+        Assert.AreEqual(0, elicitationsHandled,
+            "A malformed retry response is terminal — the adapter must not restart the flow " +
+            "with another input request.");
+
+        var result = JsonSerializer.SerializeToElement(response.Result);
+        Assert.IsFalse(result.TryGetProperty("resultType", out var resultType)
+                       && resultType.GetString() == "input_required",
+            "A malformed response classifies as a sanitized failure, not a fresh input_required.");
+        Assert.IsTrue(result.GetProperty("isError").GetBoolean());
+        AssertSanitizedInvalidArgumentEnvelope(result);
+        var text = result.GetProperty("content")[0].GetProperty("text").GetString()!;
+        Assert.IsFalse(text.Contains("JsonException", StringComparison.OrdinalIgnoreCase),
+            "Deserialization failure detail must never leak into the envelope.");
+
+        Assert.HasCount(1, FindNewResults(harness.RawServerMessages, prior));
+    }
+
+    // ── (4) cancellation through the adapter's legacy leg ────────────────────
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task LegacySession_CancelledDuringElicitation_SurfacesProtocolCancellation_NotToolError()
+    {
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pendingElicitation =
+            new TaskCompletionSource<ElicitResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: "2025-11-25",
+            elicitationHandler: (_, _) =>
+            {
+                requestReceived.TrySetResult();
+                return new ValueTask<ElicitResult>(pendingElicitation.Task);
+            });
+
+        try
+        {
+            var prior = harness.RawServerMessages.Count;
+            using var cts = new CancellationTokenSource();
+            var call = harness.Client.CallToolAsync(ToolName, cancellationToken: cts.Token);
+
+            // Only cancel once the elicitation genuinely reached the client, so the adapter's
+            // legacy ElicitAsync await is the thing observing cancellation (non-vacuous; same
+            // discipline as SymbolDisambiguationElicitationTests).
+            await requestReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await cts.CancelAsync();
+
+            OperationCanceledException? caught = null;
+            try
+            {
+                var result = await call;
+                Assert.Fail(
+                    "Expected protocol cancellation, but the call completed with " +
+                    $"isError={result.IsError}. A cancelled elicitation must never be " +
+                    "converted into a tool result.");
+            }
+            catch (OperationCanceledException ex)
+            {
+                // The SDK surfaces TaskCanceledException; catch the base class manually.
+                caught = ex;
+            }
+
+            Assert.IsNotNull(caught);
+
+            // Release the (now moot) elicitation and prove the server survived the cancelled
+            // round trip; this also gives a deterministic wire boundary for the assertion below.
+            pendingElicitation.TrySetResult(AcceptedPathResult());
+            var followUp = await harness.Client.CallToolAsync(
+                ToolName,
+                cancellationToken: CancellationToken.None);
+            Assert.IsFalse(followUp.IsError is true,
+                "The server must stay healthy after a cancelled elicitation round trip.");
+
+            foreach (var result in FindNewResults(harness.RawServerMessages, prior))
+            {
+                Assert.IsFalse(
+                    result.TryGetProperty("isError", out var isError) && isError.GetBoolean(),
+                    "Cancellation must reach the SDK as OperationCanceledException — never be " +
+                    $"downgraded to a tool-error envelope. Saw: {result.GetRawText()}");
+            }
+        }
+        finally
+        {
+            // Never leave the client's elicitation handler pending — an unanswered handler
+            // wedges McpClient.DisposeAsync forever (see InMemoryMcpClientServerHarness remarks).
+            pendingElicitation.TrySetResult(new ElicitResult { Action = "cancel" });
+        }
+    }
+
+    // ── plumbing ─────────────────────────────────────────────────────────────
+
+    private static ElicitResult AcceptedPathResult() => new()
+    {
+        Action = "accept",
+        Content = new Dictionary<string, JsonElement>
+        {
+            ["path"] = JsonSerializer.SerializeToElement(ElicitedPath),
+        },
+    };
+
+    private static async Task<InMemoryMcpClientServerHarness> CreateHarnessAsync(
+        string? protocolVersion,
+        Func<ElicitRequestParams?, CancellationToken, ValueTask<ElicitResult>> elicitationHandler)
+    {
+        var services = new ServiceCollection();
+        services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new Implementation
+                {
+                    Name = "mrtr-wire-contract-test",
+                    Version = "1.0.0",
+                };
+            })
+            .WithTools<SyntheticWorkspaceLoadTools>()
+            .WithRequestFilters(static filters =>
+                filters.AddCallToolFilter(StructuredCallToolFilter.Create));
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        return await InMemoryMcpClientServerHarness.CreateAsync(
+            transportName: $"mrtr-wire-{protocolVersion ?? "modern"}",
+            clientCapabilities: new ClientCapabilities { Elicitation = new ElicitationCapability() },
+            clientHandlers: new McpClientHandlers { ElicitationHandler = elicitationHandler },
+            disposalFailureContext: "mrtr-wire-contract",
+            cancellationToken: CancellationToken.None,
+            protocolVersion: protocolVersion,
+            serverOptions: options,
+            serverServicesFactory: () => provider,
+            captureServerMessages: true);
+    }
+
+    private static IReadOnlyList<JsonElement> FindNewResults(
+        IReadOnlyList<string> rawMessages,
+        int priorMessageCount) =>
+        rawMessages
+            .Skip(priorMessageCount)
+            .Select(static rawMessage => JsonNode.Parse(rawMessage))
+            .OfType<JsonObject>()
+            .Where(static message => message["result"] is not null)
+            .Select(static message => JsonSerializer.SerializeToElement(message["result"]))
+            .ToArray();
+
+    private static bool AnyServerRequest(
+        IReadOnlyList<string> rawMessages,
+        int priorMessageCount,
+        string method) =>
+        rawMessages
+            .Skip(priorMessageCount)
+            .Select(static rawMessage => JsonNode.Parse(rawMessage))
+            .OfType<JsonObject>()
+            .Any(message => (string?)message["method"] == method);
+
+    /// <summary>
+    /// The redaction contract shared with <c>tool-error-envelope-sensitive-detail-disclosure</c>:
+    /// the terminal envelope stays the classified <c>InvalidArgument</c> schema-hint shape with
+    /// no exception type names or stack frames.
+    /// </summary>
+    private static void AssertSanitizedInvalidArgumentEnvelope(JsonElement result)
+    {
+        var text = result.GetProperty("content")[0].GetProperty("text").GetString();
+        Assert.IsNotNull(text);
+        StringAssert.Contains(text, "InvalidArgument");
+        Assert.IsFalse(text.Contains("InputRequiredException", StringComparison.Ordinal),
+            "The MRTR protocol signal must never leak into a client-facing envelope.");
+        Assert.IsFalse(text.Contains("   at ", StringComparison.Ordinal),
+            "Stack frames must never leak into a client-facing envelope.");
+    }
+
+    [McpServerToolType]
+    private sealed class SyntheticWorkspaceLoadTools
+    {
+        // The parameter is optional at the binder level and the missing-value failure is thrown
+        // by the handler itself, carrying ParamName = "path". This is the InvalidArgument shape
+        // StructuredCallElicitationCoordinator.TryGetMissingParam documents and handles; the
+        // SDK 2.1.0 reflection binder reports a missing REQUIRED parameter as
+        // ArgumentException(ParamName = "arguments"), which the recovery gate deliberately
+        // does not match (it needs the concrete parameter name to consult the allowlist).
+        [McpServerTool(Name = ToolName)]
+        public static string Load(string? path = null)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(
+                    "The arguments dictionary is missing a value for the required parameter 'path'.",
+                    nameof(path));
+            }
+
+            return JsonSerializer.Serialize(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["workspaceId"] = "ws-synthetic",
+                ["loadedPath"] = path,
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Establishes the SDK 2.1 MRTR dispatch contract (`mcp-mrtr-dispatch-contract`): server-driven input now works on stateless MCP sessions.

- **`StructuredCallToolFilter`** — `InputRequiredException` is rethrown (like cancellation) instead of being swallowed by the general `catch (Exception)` into an `isError` tool result. The clause sits ABOVE the general catch (C# picks the first matching clause).
- **New `RequestScopedInputAdapter`** — single request-scoped boundary for server-driven input: consumes only the current request's `params.inputResponses` on the retry leg (no session/static cache), throws `InputRequiredException` on MRTR-capable clients (`McpServer.IsMrtrSupported`) so the SDK emits `InputRequiredResult`, and falls back to the direct nested `elicitation/create` continuation otherwise. Non-accept outcomes are classified sanitized (declined-or-cancelled / malformed-response); `OperationCanceledException` propagates unchanged.
- **`StructuredCallElicitationCoordinator`** — both raw `context.Server!.ElicitAsync(...)` call sites route through the adapter; `TryRunRecoveryStepAsync`'s guard now also lets `InputRequiredException` escape (swallowing it would make the MRTR leg unreachable).

## Root cause of the prior attempt's 4 test failures

The prior executor's tests drove the missing-parameter failure through the SDK reflection binder, which in SDK 2.1.0 throws `ArgumentException(ParamName = "arguments")` — not the concrete parameter name — so the elicitation-recovery gate (allowlist keyed on the real param name) never fired. The synthetic tool now throws the documented handler-shape (`ArgumentException(paramName: "path")`). Note for follow-on `workspace-path-mrtr-adoption`: this also means real binder failures never elicit in production today — that row already tracks replacing binder-exception parsing.

## Validation

- New `McpMrtrWireContractTests` (5 tests, raw-wire dual-protocol harness): MRTR round trip under `2026-07-28` (`input_required` on the wire, retry with `inputResponses` completes), legacy `2025-11-25` compatibility (nested `elicitation/create`, legacy result shape), declined + malformed `inputResponses` → sanitized schema-hint envelope (no exception text/payload echo), cancellation surfaces as protocol cancellation.
- Existing suites green: `StructuredCallElicitationCoordinatorTests`, `StructuredCallToolFilterElicitationTests`, `ElicitationAllowlistPolicyTests`, `SymbolDisambiguationElicitationTests`, `StructuredContentWireContractTests`, `ProtocolVersionResultShapeWireTests`, `ErrorResponseObservabilityTests`, `Top10V2RegressionTests` (98 tests).
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` clean; `./eng/verify-ai-docs.ps1` passed. Full `verify-release.ps1` left to CI (self-hosted runner discipline).

Closes: mcp-mrtr-dispatch-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)