### PR TITLE
fix(roslyn): lease analyzer shadow loaders per workspace load (analyzer-shadow-loader-lifecycle)

### DIFF
--- a/changelog.d/analyzer-shadow-loader-lifecycle.md
+++ b/changelog.d/analyzer-shadow-loader-lifecycle.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** analyzer shadow-copy loaders are now leased per workspace load — each load gets its own collectible `AssemblyLoadContext` and uniquely-keyed shadow root that workspace close, reload, and host shutdown reclaim exactly once. Long-running hosts no longer accumulate hundreds of orphaned analyzer shadow trees (hundreds of MB) until process exit. Analyzers keep on-disk shadow copies, so `Assembly.Location` and adjacent-resource/native-dependency behavior are unchanged.

--- a/src/RoslynMcp.Roslyn/Helpers/AnalyzerReferenceIsolation.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/AnalyzerReferenceIsolation.cs
@@ -11,29 +11,59 @@ namespace RoslynMcp.Roslyn.Helpers;
 
 internal static class AnalyzerReferenceIsolation
 {
+    /// <summary>Directory name under the OS temp path shared by all workspaces (each lease gets its own subtree).</summary>
+    internal const string ShadowRootDirectoryName = "RoslynMcpAnalyzerShadow";
+
+    /// <summary>
+    /// A lease root older than this is assumed abandoned (a crashed or killed host) and is
+    /// eligible for sweeping. Deliberately long: a live lease in ANOTHER process may be older,
+    /// but its loaded shadow assemblies keep the files locked so deletion fails harmlessly.
+    /// Mirrors the abandoned-run reaper discipline in <c>TestTempRoot</c>.
+    /// </summary>
+    private static readonly TimeSpan StaleLeaseAge = TimeSpan.FromDays(1);
+
     private static readonly FieldInfo? AssemblyLoaderField = typeof(AnalyzerFileReference)
         .GetField("_assemblyLoader", BindingFlags.Instance | BindingFlags.NonPublic);
 
     private static readonly FieldInfo? LazyAssemblyField = typeof(AnalyzerFileReference)
         .GetField("_lazyAssembly", BindingFlags.Instance | BindingFlags.NonPublic);
 
-    public static int RetargetFileReferencesToShadowLoader(
+    /// <summary>Once-per-process gate for the background abandoned-root sweep.</summary>
+    private static int s_sweepStarted;
+
+    /// <summary>
+    /// Retargets every file-based analyzer reference in <paramref name="solution"/> onto a
+    /// shadow-copy loader whose <see cref="AssemblyLoadContext"/>s and on-disk shadow root are
+    /// owned by the returned lease. Disposing the lease unloads the (collectible) load contexts
+    /// and best-effort deletes the lease's shadow directory, so workspace close / reload / host
+    /// shutdown reclaim both the memory and the disk space (analyzer-shadow-loader-lifecycle;
+    /// previously the loaders and their non-collectible contexts were dropped on the floor and
+    /// hundreds of orphaned shadow trees accumulated until process exit).
+    /// The shadow root is keyed per-LEASE (<c>%TEMP%/RoslynMcpAnalyzerShadow/&lt;workspaceId&gt;/&lt;leaseId&gt;</c>),
+    /// not per-workspace, so disposing an old lease after a reload can never race the new
+    /// lease's files. On the non-Windows and reflection-unavailable early returns an empty
+    /// no-op lease is returned so callers never need null checks.
+    /// </summary>
+    public static AnalyzerShadowLoaderLease RetargetFileReferencesToShadowLoader(
         Solution solution,
         string workspaceId,
         ILogger logger)
     {
         if (!OperatingSystem.IsWindows())
         {
-            return 0;
+            return AnalyzerShadowLoaderLease.CreateEmpty();
         }
 
         if (AssemblyLoaderField is null)
         {
             logger.LogWarning("Could not locate AnalyzerFileReference loader field; analyzer references will use Roslyn's default loader.");
-            return 0;
+            return AnalyzerShadowLoaderLease.CreateEmpty();
         }
 
-        var shadowRoot = Path.Combine(Path.GetTempPath(), "RoslynMcpAnalyzerShadow", workspaceId);
+        StartAbandonedRootSweepOnce(logger);
+
+        var leaseId = Guid.NewGuid().ToString("N");
+        var shadowRoot = Path.Combine(Path.GetTempPath(), ShadowRootDirectoryName, workspaceId, leaseId);
         var loaders = new Dictionary<string, ShadowCopyAnalyzerAssemblyLoader>(StringComparer.OrdinalIgnoreCase);
         var retargeted = 0;
 
@@ -65,7 +95,120 @@ internal static class AnalyzerReferenceIsolation
             }
         }
 
-        return retargeted;
+        return new AnalyzerShadowLoaderLease(shadowRoot, [.. loaders.Values], retargeted, logger);
+    }
+
+    /// <summary>
+    /// Best-effort removal of shadow roots abandoned by earlier crashed or pre-fix hosts, so
+    /// per-lease disposal does not leave historical leaks in place forever. Only lease
+    /// directories older than <see cref="StaleLeaseAge"/> that are not owned by a live lease in
+    /// this process are candidates; a live lease in another process keeps its shadow assemblies
+    /// locked, so its deletion fails harmlessly. The shared parent and per-workspace parents of
+    /// live leases are never deleted.
+    /// </summary>
+    internal static void SweepAbandonedRoots(ILogger logger)
+    {
+        var sharedParent = Path.Combine(Path.GetTempPath(), ShadowRootDirectoryName);
+        if (!Directory.Exists(sharedParent))
+        {
+            return;
+        }
+
+        var utcNow = DateTime.UtcNow;
+        foreach (var workspaceDirectory in EnumerateDirectoriesSafe(sharedParent))
+        {
+            foreach (var leaseDirectory in EnumerateDirectoriesSafe(workspaceDirectory))
+            {
+                if (AnalyzerShadowLoaderLease.IsLiveRoot(leaseDirectory))
+                {
+                    continue;
+                }
+
+                if (!IsStale(leaseDirectory, utcNow))
+                {
+                    continue;
+                }
+
+                // A live lease in another process holds file locks on its loaded shadow copies;
+                // losing to that lock (or to a concurrent sweeper) is harmless — the next sweep retries.
+                try
+                {
+                    Directory.Delete(leaseDirectory, recursive: true);
+                    logger.LogDebug("Swept abandoned analyzer shadow root {ShadowRoot}", leaseDirectory);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                }
+            }
+
+            // Best-effort removal of a now-empty per-workspace parent. Never the shared parent.
+            try
+            {
+                if (!Directory.EnumerateFileSystemEntries(workspaceDirectory).Any())
+                {
+                    Directory.Delete(workspaceDirectory);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+            {
+            }
+        }
+    }
+
+    private static void StartAbandonedRootSweepOnce(ILogger logger)
+    {
+        if (Interlocked.Exchange(ref s_sweepStarted, 1) != 0)
+        {
+            return;
+        }
+
+        // Off the load path: sweeping hundreds of stale directories from pre-fix runs can take
+        // seconds, and workspace load latency must not pay for historical leaks.
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                SweepAbandonedRoots(logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Abandoned analyzer shadow root sweep failed.");
+            }
+        });
+    }
+
+    private static IEnumerable<string> EnumerateDirectoriesSafe(string parent)
+    {
+        try
+        {
+            return Directory.EnumerateDirectories(parent).ToList();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+        {
+            return [];
+        }
+    }
+
+    private static bool IsStale(string directory, DateTime utcNow)
+    {
+        try
+        {
+            // Newest of create/write time: shadow copies are written lazily after the root is
+            // created, so a recently-populated root must not look abandoned.
+            var lastActivityUtc = Directory.GetLastWriteTimeUtc(directory);
+            var createdUtc = Directory.GetCreationTimeUtc(directory);
+            if (createdUtc > lastActivityUtc)
+            {
+                lastActivityUtc = createdUtc;
+            }
+
+            return utcNow - lastActivityUtc > StaleLeaseAge;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Cannot establish age — treat as live rather than risk deleting a running host's lease.
+            return false;
+        }
     }
 
     private static bool TryGetExistingFullPath(string? path, out string fullPath)
@@ -87,13 +230,131 @@ internal static class AnalyzerReferenceIsolation
         }
     }
 
-    private sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+    /// <summary>
+    /// Owns one workspace load's shadow-copy loaders: the collectible
+    /// <see cref="AssemblyLoadContext"/>s they created and the uniquely-keyed on-disk shadow
+    /// root they copy into. <see cref="Dispose"/> is idempotent (eviction, explicit close, and
+    /// host shutdown can all reach the same session): it unloads every context — containing any
+    /// failure so a third-party analyzer's leaked root can never fault workspace close — then
+    /// best-effort deletes the lease root with a bounded GC-assisted retry (ALC unload is
+    /// asynchronous; mapped shadow files stay locked until collection completes). A root that
+    /// remains undeletable is logged at Debug and left for <see cref="SweepAbandonedRoots"/>.
+    /// </summary>
+    public sealed class AnalyzerShadowLoaderLease : IDisposable
+    {
+        private const int MaxDeleteAttempts = 4;
+
+        /// <summary>Roots of leases still alive in THIS process; the sweeper never touches them.</summary>
+        private static readonly ConcurrentDictionary<string, byte> s_liveRoots = new(StringComparer.OrdinalIgnoreCase);
+
+        private IReadOnlyList<ShadowCopyAnalyzerAssemblyLoader> _loaders;
+        private readonly ILogger? _logger;
+        private int _disposed;
+
+        internal AnalyzerShadowLoaderLease(
+            string? shadowRoot,
+            IReadOnlyList<ShadowCopyAnalyzerAssemblyLoader> loaders,
+            int retargetedReferenceCount,
+            ILogger? logger)
+        {
+            ShadowRoot = shadowRoot;
+            _loaders = loaders;
+            RetargetedReferenceCount = retargetedReferenceCount;
+            _logger = logger;
+
+            if (shadowRoot is not null)
+            {
+                s_liveRoots[shadowRoot] = 0;
+            }
+        }
+
+        /// <summary>Number of analyzer references retargeted onto this lease's loaders.</summary>
+        public int RetargetedReferenceCount { get; }
+
+        /// <summary>This lease's unique shadow directory, or null for the no-op empty lease.</summary>
+        public string? ShadowRoot { get; }
+
+        /// <summary>No-op lease for the platforms/configurations where isolation cannot run.</summary>
+        public static AnalyzerShadowLoaderLease CreateEmpty() => new(null, [], 0, null);
+
+        internal static bool IsLiveRoot(string directory) => s_liveRoots.ContainsKey(directory);
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            foreach (var loader in _loaders)
+            {
+                loader.UnloadAndRelease();
+            }
+
+            // Drop the loader references BEFORE the GC-assisted delete retries: the loaders'
+            // cached Assembly instances strongly root their collectible contexts, and this
+            // lease (alive on the disposing stack) roots the loaders — without this release
+            // the retry loop's collections could never complete the unload.
+            _loaders = [];
+
+            if (ShadowRoot is null)
+            {
+                return;
+            }
+
+            s_liveRoots.TryRemove(ShadowRoot, out _);
+            TryDeleteShadowRoot();
+        }
+
+        private void TryDeleteShadowRoot()
+        {
+            for (var attempt = 1; attempt <= MaxDeleteAttempts; attempt++)
+            {
+                if (attempt > 1)
+                {
+                    // AssemblyLoadContext.Unload is asynchronous: the memory-mapped shadow
+                    // assemblies stay locked until the collectible context is actually
+                    // collected. Nudge the GC between bounded attempts.
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                }
+
+                try
+                {
+                    if (Directory.Exists(ShadowRoot))
+                    {
+                        Directory.Delete(ShadowRoot, recursive: true);
+                    }
+
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    if (attempt == MaxDeleteAttempts)
+                    {
+                        _logger?.LogDebug(
+                            ex,
+                            "Analyzer shadow root {ShadowRoot} is still locked after unload; leaving it for the abandoned-root sweeper.",
+                            ShadowRoot);
+                    }
+                }
+            }
+        }
+    }
+
+    internal sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
     {
         private readonly string _shadowRoot;
         private readonly ILogger _logger;
         private readonly ConcurrentDictionary<string, string> _dependenciesByName = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, Assembly> _assembliesByIdentity = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string> _shadowCopiesByIdentity = new(StringComparer.OrdinalIgnoreCase);
+
+        // Every context ever constructed, including GetOrAdd race losers, so the owning lease
+        // can unload them all. ALC unload only ever completes via GC, so tracking a loser here
+        // costs nothing beyond what the race already leaked pre-fix.
+        private readonly ConcurrentBag<ShadowAnalyzerLoadContext> _contexts = [];
 
         private ShadowCopyAnalyzerAssemblyLoader(string shadowRoot, ILogger logger)
         {
@@ -106,6 +367,35 @@ internal static class AnalyzerReferenceIsolation
             var loader = new ShadowCopyAnalyzerAssemblyLoader(shadowRoot, logger);
             loader.RegisterAnalyzerDirectory(analyzerPath);
             return loader;
+        }
+
+        /// <summary>
+        /// Initiates unload of every load context this loader created and releases the cached
+        /// <see cref="Assembly"/>/context references that would otherwise keep the collectible
+        /// contexts strongly rooted (an <see cref="Assembly"/> roots its load context, so a
+        /// loader that keeps its cache can never actually be collected). Unload is contained
+        /// per-context: a third-party analyzer that leaked a rooted reference must degrade to
+        /// "context never collects" (the sweeper reclaims the disk later), never fault
+        /// workspace close.
+        /// </summary>
+        public void UnloadAndRelease()
+        {
+            foreach (var context in _contexts)
+            {
+                try
+                {
+                    context.Unload();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to unload analyzer shadow load context under {ShadowRoot}", _shadowRoot);
+                }
+            }
+
+            _contexts.Clear();
+            _assembliesByIdentity.Clear();
+            _shadowCopiesByIdentity.Clear();
+            _dependenciesByName.Clear();
         }
 
         public void AddDependencyLocation(string fullPath)
@@ -134,6 +424,7 @@ internal static class AnalyzerReferenceIsolation
             return _assembliesByIdentity.GetOrAdd(identity, _ =>
             {
                 var context = new ShadowAnalyzerLoadContext(this);
+                _contexts.Add(context);
                 return context.LoadFromAssemblyPath(ShadowCopy(normalized));
             });
         }
@@ -242,8 +533,13 @@ internal static class AnalyzerReferenceIsolation
         {
             private readonly ShadowCopyAnalyzerAssemblyLoader _loader;
 
+            // Collectible so the owning lease's Dispose can actually unload analyzer assemblies
+            // on workspace close/reload. Collectibility does NOT change Assembly.Location:
+            // loading stays LoadFromAssemblyPath over an on-disk shadow copy, preserving
+            // adjacent-resource and native-dependency probing (the LoadFromStream shortcut is
+            // deliberately not taken — see ValidationIntegrationTests' Location assertion).
             public ShadowAnalyzerLoadContext(ShadowCopyAnalyzerAssemblyLoader loader)
-                : base(isCollectible: false)
+                : base(isCollectible: true)
             {
                 _loader = loader;
             }

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceManager.cs
@@ -925,8 +925,10 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         // success pattern, readers always see EITHER the prior loaded workspace OR the fully
         // initialized new workspace; the disposed object is never observable.
         MSBuildWorkspace? newWorkspace = null;
+        Helpers.AnalyzerReferenceIsolation.AnalyzerShadowLoaderLease? newLease = null;
         var diagnosticsSink = new WorkspaceDiagnosticsSink(MaxDiagnosticsPerWorkspace);
         var oldWorkspace = session.Workspace;
+        var oldLease = session.AnalyzerLease;
         var swapped = false;
         try
         {
@@ -976,7 +978,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // loader self-disposes on failure before returning, so the manager only handles
             // disposal of post-loader-success state (strip-analyzers, project-statuses,
             // cache-write failures).
-            newWorkspace = await _sessionLoader.CreateAndOpenAsync(
+            (newWorkspace, newLease) = await _sessionLoader.CreateAndOpenAsync(
                 session.WorkspaceId,
                 path,
                 globalProperties,
@@ -1025,6 +1027,7 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
             // the new workspace is fully loaded so concurrent readers never observe a mid-reload
             // session (disposed workspace, empty project list, or mismatched LoadedPath).
             session.Workspace = newWorkspace;
+            session.AnalyzerLease = newLease;
             session.WorkspaceDiagnostics = diagnosticsSink.Queue;
             session.ProjectStatuses = projectStatuses;
             session.LoadedPath = path;
@@ -1050,18 +1053,27 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         {
             if (swapped)
             {
-                // Successful swap: oldWorkspace was captured before the swap and is no longer
-                // referenced by the session. Safe to dispose.
+                // Successful swap: oldWorkspace/oldLease were captured before the swap and are
+                // no longer referenced by the session. Safe to dispose — lease after workspace
+                // so Roslyn has released the old analyzer references first.
                 oldWorkspace?.Dispose();
+                // Null before disposing the lease: this async frame's local would otherwise
+                // keep the old solution graph (and its loaded analyzer assemblies) rooted
+                // while the lease's GC-assisted delete retries run.
+                oldWorkspace = null;
+                oldLease?.Dispose();
             }
             else
             {
                 // Load failed mid-way after the loader returned: dispose the half-initialized
-                // new workspace and leave the session's prior state untouched. Readers
-                // continue to see the previous valid workspace rather than a broken one (or
-                // null). If the loader itself threw, it already disposed `newWorkspace` is
-                // null here so this is a no-op — the autoreload-cascade invariant holds.
+                // new workspace (and its analyzer shadow lease) and leave the session's prior
+                // state untouched. Readers continue to see the previous valid workspace rather
+                // than a broken one (or null). If the loader itself threw, it already disposed
+                // both — `newWorkspace`/`newLease` are null here so this is a no-op — the
+                // autoreload-cascade invariant holds.
                 newWorkspace?.Dispose();
+                newWorkspace = null;
+                newLease?.Dispose();
             }
             session.LoadLock.Release();
         }
@@ -1248,6 +1260,15 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         public ConcurrentQueue<DiagnosticDto> WorkspaceDiagnostics { get; set; } = new();
         public ImmutableArray<ProjectStatusDto> ProjectStatuses { get; set; } = ImmutableArray<ProjectStatusDto>.Empty;
         public MSBuildWorkspace? Workspace { get; set; }
+
+        /// <summary>
+        /// analyzer-shadow-loader-lifecycle: owns the per-load analyzer shadow-copy loaders'
+        /// collectible load contexts + on-disk shadow root. Swapped atomically alongside
+        /// <see cref="Workspace"/> and released exactly once — by <see cref="Dispose"/> (close,
+        /// eviction, host shutdown) or by the reload swap's old-lease disposal.
+        /// </summary>
+        public Helpers.AnalyzerReferenceIsolation.AnalyzerShadowLoaderLease? AnalyzerLease { get; set; }
+
         public string? LoadedPath { get; set; }
         public bool RestoreRequired { get; set; }
         public bool BuildRequired { get; set; }
@@ -1262,6 +1283,14 @@ public sealed class WorkspaceManager : IWorkspaceManager, IDisposable
         public void Dispose()
         {
             Workspace?.Dispose();
+            // Lease after workspace so Roslyn has released the analyzer references before the
+            // load contexts are unloaded and the shadow root is deleted; the Workspace field is
+            // nulled first so this frame's session reference does not keep the solution graph
+            // (and through it the loaded analyzer assemblies) rooted while the lease's
+            // GC-assisted delete retries run. Lease disposal is idempotent, so the
+            // eviction/close/host-shutdown paths can all reach here safely.
+            Workspace = null;
+            AnalyzerLease?.Dispose();
             LoadLock.Dispose();
         }
     }

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceSessionLoader.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceSessionLoader.cs
@@ -23,13 +23,16 @@ namespace RoslynMcp.Roslyn.Services;
 internal class WorkspaceSessionLoader
 {
     /// <summary>
-    /// Creates a new <see cref="MSBuildWorkspace"/>, attaches the diagnostics sink, and opens
-    /// the supplied solution or project path. The caller owns disposal of the returned
-    /// workspace on both success (transferred to the session) and failure (the manager's
-    /// finally block disposes the partial workspace if this method throws after returning a
-    /// reference, but the throw-before-return case is the loader's responsibility).
+    /// Creates a new <see cref="MSBuildWorkspace"/>, attaches the diagnostics sink, opens
+    /// the supplied solution or project path, and retargets file-based analyzer references
+    /// onto per-lease shadow-copy loaders. The caller owns disposal of the returned workspace
+    /// AND analyzer-shadow lease on both success (transferred to the session) and failure
+    /// (the manager's finally block disposes the partial workspace/lease if this method throws
+    /// after returning, but the throw-before-return case is the loader's responsibility). The
+    /// lease is never null: platforms/configurations where isolation cannot run get a no-op
+    /// empty lease (analyzer-shadow-loader-lifecycle).
     /// </summary>
-    public virtual async Task<MSBuildWorkspace> CreateAndOpenAsync(
+    public virtual async Task<(MSBuildWorkspace Workspace, AnalyzerReferenceIsolation.AnalyzerShadowLoaderLease Lease)> CreateAndOpenAsync(
         string workspaceId,
         string path,
         IDictionary<string, string>? globalProperties,
@@ -47,6 +50,7 @@ internal class WorkspaceSessionLoader
         var workspace = (globalProperties is { Count: > 0 })
             ? MSBuildWorkspace.Create(globalProperties)
             : MSBuildWorkspace.Create();
+        AnalyzerReferenceIsolation.AnalyzerShadowLoaderLease? analyzerLease = null;
         try
         {
             if (globalProperties is { Count: > 0 })
@@ -74,25 +78,28 @@ internal class WorkspaceSessionLoader
                 throw new ArgumentException($"Path must end with .sln, .slnx, or .csproj: {path}");
             }
 
-            var isolatedAnalyzerReferences = AnalyzerReferenceIsolation.RetargetFileReferencesToShadowLoader(
+            analyzerLease = AnalyzerReferenceIsolation.RetargetFileReferencesToShadowLoader(
                 workspace.CurrentSolution,
                 workspaceId,
                 logger);
-            if (isolatedAnalyzerReferences > 0)
+            if (analyzerLease.RetargetedReferenceCount > 0)
             {
                 logger.LogInformation(
                     "Workspace {WorkspaceId}: retargeted {Count} analyzer reference(s) to shadow-copy loaders.",
                     workspaceId,
-                    isolatedAnalyzerReferences);
+                    analyzerLease.RetargetedReferenceCount);
             }
 
-            return workspace;
+            return (workspace, analyzerLease);
         }
         catch
         {
-            // Partial-load failure: dispose the half-initialized workspace before propagating
-            // so the caller does not have to track ownership of a return-value-not-yet-handed-out.
+            // Partial-load failure: dispose the half-initialized workspace (and any analyzer
+            // shadow lease created before the throw — lease after workspace, so Roslyn has
+            // released the analyzer references first) before propagating, so the caller does
+            // not have to track ownership of a return-value-not-yet-handed-out.
             workspace.Dispose();
+            analyzerLease?.Dispose();
             throw;
         }
     }

--- a/tests/RoslynMcp.Tests/AnalyzerShadowLoaderLifecycleTests.cs
+++ b/tests/RoslynMcp.Tests/AnalyzerShadowLoaderLifecycleTests.cs
@@ -1,0 +1,254 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn;
+using RoslynMcp.Roslyn.Helpers;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Regression guard for <c>analyzer-shadow-loader-lifecycle</c>: analyzer shadow-copy loaders
+/// are leased per workspace load — each load gets its own collectible
+/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> and uniquely-keyed shadow root under
+/// <c>%TEMP%/RoslynMcpAnalyzerShadow/&lt;workspaceId&gt;/&lt;leaseId&gt;</c> that workspace
+/// close and reload reclaim. Pre-fix, the loaders' non-collectible contexts were dropped on the
+/// floor and every load leaked one shadow tree until process exit (245–272 orphaned trees /
+/// ~600 MB per full Release test run).
+///
+/// <para>
+/// ALC unload is asynchronous (mapped shadow files stay locked until the collectible context is
+/// collected), so reclamation is asserted with a bounded GC-assisted retry rather than a
+/// synchronous check — pre-fix the contexts are non-collectible and the files stay locked
+/// forever, so the retry loop times out and the assertion still fails deterministically.
+/// </para>
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class AnalyzerShadowLoaderLifecycleTests
+{
+    private static readonly TimeSpan ReclamationTimeout = TimeSpan.FromSeconds(30);
+
+    private static string ShadowSharedParent =>
+        Path.Combine(Path.GetTempPath(), AnalyzerReferenceIsolation.ShadowRootDirectoryName);
+
+    [TestMethod]
+    public void Retarget_LeasesAreUniquelyKeyedPerLoad_AndDisposeIsIdempotent()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        // Two retargets for the SAME workspace id must produce distinct shadow roots — the
+        // per-lease key is what makes disposing an old lease after a reload safe against the
+        // new lease's files.
+        using var adhoc = new AdhocWorkspace();
+        var project = adhoc.AddProject("LeaseProbe", LanguageNames.CSharp);
+        var analyzerPath = typeof(WorkspaceSessionLoader).Assembly.Location;
+        var reference = new AnalyzerFileReference(analyzerPath, StubAnalyzerAssemblyLoader.Instance);
+        var solution = project.Solution.AddAnalyzerReference(project.Id, reference);
+
+        var lease1 = AnalyzerReferenceIsolation.RetargetFileReferencesToShadowLoader(
+            solution, "lease-unit-probe", NullLogger.Instance);
+        var lease2 = AnalyzerReferenceIsolation.RetargetFileReferencesToShadowLoader(
+            solution, "lease-unit-probe", NullLogger.Instance);
+
+        Assert.AreEqual(1, lease1.RetargetedReferenceCount);
+        Assert.IsNotNull(lease1.ShadowRoot);
+        Assert.IsNotNull(lease2.ShadowRoot);
+        StringAssert.Contains(lease1.ShadowRoot, "lease-unit-probe");
+        Assert.AreNotEqual(lease1.ShadowRoot, lease2.ShadowRoot,
+            "Each lease must own a uniquely-keyed shadow root; a per-workspace key would let old-lease deletion race a reload's new files.");
+
+        // Idempotent release: eviction, explicit close, and host shutdown can all reach the
+        // same session, so double-dispose must be a safe no-op (including on a lease whose
+        // root never materialized because no analyzer was actually loaded).
+        lease1.Dispose();
+        lease1.Dispose();
+        lease2.Dispose();
+        lease2.Dispose();
+    }
+
+    [TestMethod]
+    public async Task WorkspaceCloseAndReload_ReclaimAnalyzerShadowRoots()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var solutionPath = Path.Combine(repoRoot, "RoslynMcp.slnx");
+
+        // Mirror ValidationIntegrationTests' host-config detection: MSBuildWorkspace defaults
+        // to Configuration=Debug evaluation; on Release-only checkouts (CI runners) the
+        // analyzer ProjectReference would resolve to a nonexistent Debug TargetPath and the
+        // AnalyzerFileReference would be dropped before the lease could shadow-copy anything.
+        var configuration = AppContext.BaseDirectory.Contains(
+            Path.DirectorySeparatorChar + "Release" + Path.DirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase) ? "Release" : "Debug";
+        var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Configuration"] = configuration,
+        };
+
+        MsBuildInitializer.EnsureInitialized();
+        using var manager = new WorkspaceManager(
+            NullLogger<WorkspaceManager>.Instance,
+            new PreviewStore(),
+            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 4 },
+            cacheStore: null,
+            sessionLoader: new WorkspaceSessionLoader());
+
+        var status = await manager.LoadAsync(solutionPath, globalProperties, CancellationToken.None);
+        Assert.IsTrue(status.IsLoaded, "Repository solution must load before exercising the lease lifecycle.");
+        var workspaceDirectory = Path.Combine(ShadowSharedParent, status.WorkspaceId);
+
+        // (b) Force the shadow assemblies to actually load: retargeting alone creates loaders
+        // lazily, and the lease's on-disk root only materializes on the first shadow copy.
+        var firstContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId);
+        var leaseDirsAfterLoad = ListLeaseDirectories(workspaceDirectory);
+        Assert.AreEqual(1, leaseDirsAfterLoad.Count,
+            $"Exactly one live shadow root expected after load; saw [{string.Join(", ", leaseDirsAfterLoad)}].");
+
+        // (e) Reload: the old lease's root must be reclaimed while the new lease's root
+        // survives — no second leaked tree.
+        await manager.ReloadAsync(status.WorkspaceId, CancellationToken.None);
+        var secondContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId);
+        var leaseDirsAfterReload = ListLeaseDirectories(workspaceDirectory);
+        var newLeaseDirs = leaseDirsAfterReload.Except(leaseDirsAfterLoad, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.AreEqual(1, newLeaseDirs.Count,
+            $"Reload must materialize exactly one NEW shadow root; saw [{string.Join(", ", newLeaseDirs)}].");
+        Assert.IsTrue(
+            await WaitForReclamationOnCleanStackAsync(workspaceDirectory, surviving: newLeaseDirs[0]),
+            "The pre-reload lease's shadow root was still locked after the bounded wait — the old load context did not unload.");
+        Assert.IsTrue(Directory.Exists(newLeaseDirs[0]),
+            "The reloaded workspace's own shadow root must survive old-lease reclamation.");
+
+        // (c)+(d) Close: every remaining shadow root for this workspace must be reclaimed.
+        Assert.IsTrue(manager.Close(status.WorkspaceId));
+        var (closeReclaimed, closeError) = await WaitForReclamationWithErrorOnCleanStackAsync(workspaceDirectory, surviving: null);
+        Assert.IsTrue(
+            closeReclaimed,
+            $"The workspace's shadow roots were still locked after close + bounded wait — the load contexts did not unload. Last error: {closeError}; firstContextAlive={firstContextRef.IsAlive}; secondContextAlive={secondContextRef.IsAlive}; allContexts=[{string.Join(", ", System.Runtime.Loader.AssemblyLoadContext.All.Select(c => c.GetType().Name))}]");
+    }
+
+    /// <summary>
+    /// Loads the server-surface catalog analyzer through the session's shadow loader and
+    /// asserts the compatibility witness: shadow-copied analyzers keep a real on-disk
+    /// <see cref="System.Reflection.Assembly.Location"/> (path-loaded, never stream-loaded).
+    /// Deliberately a separate method so the test body holds no reference that would root the
+    /// pre-reload <see cref="Solution"/> graph and keep its collectible context alive.
+    /// </summary>
+    private static WeakReference ForceAnalyzerLoad(WorkspaceManager manager, string workspaceId)
+    {
+        var solution = manager.GetCurrentSolution(workspaceId);
+        var hostProject = solution.Projects.First(project => project.Name == "RoslynMcp.Host.Stdio");
+        var analyzerReference = hostProject.AnalyzerReferences
+            .OfType<AnalyzerFileReference>()
+            .FirstOrDefault(reference =>
+                reference.FullPath?.Contains("ServerSurfaceCatalogAnalyzer", StringComparison.OrdinalIgnoreCase) == true);
+        Assert.IsNotNull(analyzerReference, "Expected Host.Stdio to carry the server-surface catalog analyzer reference.");
+
+        var analyzer = analyzerReference.GetAnalyzers(hostProject.Language)
+            .FirstOrDefault(candidate => candidate.GetType().Name == "ServerSurfaceCatalogAnalyzer");
+        Assert.IsNotNull(analyzer, "Expected the shadow-copy loader to preserve analyzer discovery.");
+        Assert.IsFalse(string.IsNullOrEmpty(analyzer.GetType().Assembly.Location),
+            "Shadow-copied analyzers must keep an on-disk Assembly.Location (collectible ALC must not imply stream loading).");
+        return new WeakReference(System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(analyzer.GetType().Assembly));
+    }
+
+    private static List<string> ListLeaseDirectories(string workspaceDirectory) =>
+        Directory.Exists(workspaceDirectory)
+            ? Directory.EnumerateDirectories(workspaceDirectory).ToList()
+            : [];
+
+    /// <summary>
+    /// Bounded GC-assisted wait for shadow-root reclamation. A lease directory that survives
+    /// its lease's Dispose retry budget is only reclaimable once the collectible context has
+    /// actually been collected, so the poll loop nudges the GC and retries the delete itself —
+    /// with pre-fix non-collectible contexts the files stay locked and this times out.
+    ///
+    /// <para>
+    /// The wait MUST run on a clean stack (hence <see cref="Task.Run(Action)"/>): the manager's
+    /// load/reload awaits complete with inline continuations, so the test method resumes ON TOP
+    /// of the not-yet-unwound <c>MSBuildWorkspace.OpenSolutionAsync</c> /
+    /// <c>LoadIntoSessionAsync</c> frames. Those live frames' stack slots pin the just-loaded
+    /// <see cref="Solution"/> graph — and through <c>AnalyzerFileReference._lazyAssembly</c> the
+    /// analyzer <see cref="Assembly"/> and its collectible context — for as long as the test
+    /// thread sits in the poll loop, so an in-place wait deadlocks against its own stack
+    /// (diagnosed via SOS <c>gcroot</c>: the only root of the leaked context was the test
+    /// thread's own <c>OpenSolutionAsync.MoveNext</c> continuation frames).
+    /// </para>
+    /// </summary>
+    private static async Task<bool> WaitForReclamationOnCleanStackAsync(string workspaceDirectory, string? surviving)
+    {
+        var (reclaimed, _) = await WaitForReclamationWithErrorOnCleanStackAsync(workspaceDirectory, surviving).ConfigureAwait(false);
+        return reclaimed;
+    }
+
+    private static Task<(bool Reclaimed, string LastError)> WaitForReclamationWithErrorOnCleanStackAsync(
+        string workspaceDirectory, string? surviving) =>
+        Task.Run(() =>
+        {
+            var reclaimed = WaitForReclamation(workspaceDirectory, surviving, out var lastError);
+            return (reclaimed, lastError);
+        });
+
+    private static bool WaitForReclamation(string workspaceDirectory, string? surviving, out string lastError)
+    {
+        lastError = "(none)";
+        var deadline = DateTime.UtcNow + ReclamationTimeout;
+        while (true)
+        {
+            var remaining = ListLeaseDirectories(workspaceDirectory)
+                .Where(directory => !string.Equals(directory, surviving, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (remaining.Count == 0)
+            {
+                return true;
+            }
+
+            if (DateTime.UtcNow > deadline)
+            {
+                return false;
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            foreach (var directory in remaining)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // Still locked — the context has not been collected yet; retry until deadline.
+                    lastError = ex.GetType().Name + ": " + ex.Message;
+                }
+            }
+
+            Thread.Sleep(250);
+        }
+    }
+
+    private sealed class StubAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+    {
+        public static StubAnalyzerAssemblyLoader Instance { get; } = new();
+
+        public void AddDependencyLocation(string fullPath)
+        {
+        }
+
+        public Assembly LoadFromPath(string fullPath) =>
+            throw new InvalidOperationException(
+                "The stub loader must have been replaced by shadow-loader retargeting before any load.");
+    }
+}

--- a/tests/RoslynMcp.Tests/AnalyzerShadowLoaderLifecycleTests.cs
+++ b/tests/RoslynMcp.Tests/AnalyzerShadowLoaderLifecycleTests.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Analyzers.ServerSurfaceCatalog;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn;
 using RoslynMcp.Roslyn.Helpers;
@@ -80,82 +82,124 @@ public sealed class AnalyzerShadowLoaderLifecycleTests
             return;
         }
 
+        // The fixture is deliberately SELF-CONTAINED: an isolated copy of the sample solution
+        // plus an <Analyzer/> item pointing at the analyzer assembly the TEST HOST already
+        // loaded. Depending on this repo's own build graph instead (Host.Stdio's
+        // OutputItemType="Analyzer" ProjectReference) made the fixture environment-sensitive —
+        // the analyzer's TargetPath is configuration-dependent, and
+        // AnalyzerReferenceIsolation skips any reference whose file is missing, so on a clean
+        // machine the setup collapsed before any lifetime behavior was exercised.
         var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
-        var solutionPath = Path.Combine(repoRoot, "RoslynMcp.slnx");
+        var solutionPath = TestFixtureFileSystem.CreateSampleSolutionCopy(
+            repoRoot, Path.Combine(repoRoot, "samples", "SampleSolution", "SampleSolution.slnx"));
+        var copiedRoot = Path.GetDirectoryName(solutionPath)!;
 
-        // Mirror ValidationIntegrationTests' host-config detection: MSBuildWorkspace defaults
-        // to Configuration=Debug evaluation; on Release-only checkouts (CI runners) the
-        // analyzer ProjectReference would resolve to a nonexistent Debug TargetPath and the
-        // AnalyzerFileReference would be dropped before the lease could shadow-copy anything.
-        var configuration = AppContext.BaseDirectory.Contains(
-            Path.DirectorySeparatorChar + "Release" + Path.DirectorySeparatorChar,
-            StringComparison.OrdinalIgnoreCase) ? "Release" : "Debug";
-        var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        try
         {
-            ["Configuration"] = configuration,
-        };
+            var analyzerAssemblyPath = InjectFixtureAnalyzer(copiedRoot);
 
-        MsBuildInitializer.EnsureInitialized();
-        using var manager = new WorkspaceManager(
-            NullLogger<WorkspaceManager>.Instance,
-            new PreviewStore(),
-            new FileWatcherService(NullLogger<FileWatcherService>.Instance),
-            new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 4 },
-            cacheStore: null,
-            sessionLoader: new WorkspaceSessionLoader());
+            MsBuildInitializer.EnsureInitialized();
+            using var manager = new WorkspaceManager(
+                NullLogger<WorkspaceManager>.Instance,
+                new PreviewStore(),
+                new FileWatcherService(NullLogger<FileWatcherService>.Instance),
+                new WorkspaceManagerOptions { MaxConcurrentWorkspaces = 4 },
+                cacheStore: null,
+                sessionLoader: new WorkspaceSessionLoader());
 
-        var status = await manager.LoadAsync(solutionPath, globalProperties, CancellationToken.None);
-        Assert.IsTrue(status.IsLoaded, "Repository solution must load before exercising the lease lifecycle.");
-        var workspaceDirectory = Path.Combine(ShadowSharedParent, status.WorkspaceId);
+            var status = await manager.LoadAsync(solutionPath, CancellationToken.None);
+            Assert.IsTrue(status.IsLoaded, "Fixture solution must load before exercising the lease lifecycle.");
+            var workspaceDirectory = Path.Combine(ShadowSharedParent, status.WorkspaceId);
 
-        // (b) Force the shadow assemblies to actually load: retargeting alone creates loaders
-        // lazily, and the lease's on-disk root only materializes on the first shadow copy.
-        var firstContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId);
-        var leaseDirsAfterLoad = ListLeaseDirectories(workspaceDirectory);
-        Assert.AreEqual(1, leaseDirsAfterLoad.Count,
-            $"Exactly one live shadow root expected after load; saw [{string.Join(", ", leaseDirsAfterLoad)}].");
+            // (b) Force the shadow assemblies to actually load: retargeting alone creates loaders
+            // lazily, and the lease's on-disk root only materializes on the first shadow copy.
+            var firstContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId, analyzerAssemblyPath);
+            var leaseDirsAfterLoad = ListLeaseDirectories(workspaceDirectory);
+            Assert.AreEqual(1, leaseDirsAfterLoad.Count,
+                $"Exactly one live shadow root expected after load; saw [{string.Join(", ", leaseDirsAfterLoad)}].");
 
-        // (e) Reload: the old lease's root must be reclaimed while the new lease's root
-        // survives — no second leaked tree.
-        await manager.ReloadAsync(status.WorkspaceId, CancellationToken.None);
-        var secondContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId);
-        var leaseDirsAfterReload = ListLeaseDirectories(workspaceDirectory);
-        var newLeaseDirs = leaseDirsAfterReload.Except(leaseDirsAfterLoad, StringComparer.OrdinalIgnoreCase).ToList();
-        Assert.AreEqual(1, newLeaseDirs.Count,
-            $"Reload must materialize exactly one NEW shadow root; saw [{string.Join(", ", newLeaseDirs)}].");
-        Assert.IsTrue(
-            await WaitForReclamationOnCleanStackAsync(workspaceDirectory, surviving: newLeaseDirs[0]),
-            "The pre-reload lease's shadow root was still locked after the bounded wait — the old load context did not unload.");
-        Assert.IsTrue(Directory.Exists(newLeaseDirs[0]),
-            "The reloaded workspace's own shadow root must survive old-lease reclamation.");
+            // (e) Reload: the old lease's root must be reclaimed while the new lease's root
+            // survives — no second leaked tree.
+            await manager.ReloadAsync(status.WorkspaceId, CancellationToken.None);
+            var secondContextRef = ForceAnalyzerLoad(manager, status.WorkspaceId, analyzerAssemblyPath);
+            var leaseDirsAfterReload = ListLeaseDirectories(workspaceDirectory);
+            var newLeaseDirs = leaseDirsAfterReload.Except(leaseDirsAfterLoad, StringComparer.OrdinalIgnoreCase).ToList();
+            Assert.AreEqual(1, newLeaseDirs.Count,
+                $"Reload must materialize exactly one NEW shadow root; saw [{string.Join(", ", newLeaseDirs)}].");
+            Assert.IsTrue(
+                await WaitForReclamationOnCleanStackAsync(workspaceDirectory, surviving: newLeaseDirs[0]),
+                "The pre-reload lease's shadow root was still locked after the bounded wait — the old load context did not unload.");
+            Assert.IsTrue(Directory.Exists(newLeaseDirs[0]),
+                "The reloaded workspace's own shadow root must survive old-lease reclamation.");
 
-        // (c)+(d) Close: every remaining shadow root for this workspace must be reclaimed.
-        Assert.IsTrue(manager.Close(status.WorkspaceId));
-        var (closeReclaimed, closeError) = await WaitForReclamationWithErrorOnCleanStackAsync(workspaceDirectory, surviving: null);
-        Assert.IsTrue(
-            closeReclaimed,
-            $"The workspace's shadow roots were still locked after close + bounded wait — the load contexts did not unload. Last error: {closeError}; firstContextAlive={firstContextRef.IsAlive}; secondContextAlive={secondContextRef.IsAlive}; allContexts=[{string.Join(", ", System.Runtime.Loader.AssemblyLoadContext.All.Select(c => c.GetType().Name))}]");
+            // (c)+(d) Close: every remaining shadow root for this workspace must be reclaimed.
+            Assert.IsTrue(manager.Close(status.WorkspaceId));
+            var (closeReclaimed, closeError) = await WaitForReclamationWithErrorOnCleanStackAsync(workspaceDirectory, surviving: null);
+            Assert.IsTrue(
+                closeReclaimed,
+                $"The workspace's shadow roots were still locked after close + bounded wait — the load contexts did not unload. Last error: {closeError}; firstContextAlive={firstContextRef.IsAlive}; secondContextAlive={secondContextRef.IsAlive}; allContexts=[{string.Join(", ", System.Runtime.Loader.AssemblyLoadContext.All.Select(c => c.GetType().Name))}]");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(copiedRoot);
+        }
     }
 
     /// <summary>
-    /// Loads the server-surface catalog analyzer through the session's shadow loader and
-    /// asserts the compatibility witness: shadow-copied analyzers keep a real on-disk
+    /// Makes the analyzer's presence a GUARANTEED precondition rather than an assumption:
+    /// the copied <c>SampleLib</c> project gets an explicit <c>&lt;Analyzer/&gt;</c> item
+    /// pointing at <see cref="ServerSurfaceCatalogAnalyzer"/>'s own assembly — the file the
+    /// running test host loaded this very type from, so it exists on any machine that can run
+    /// this test at all (the tests project carries a plain ProjectReference to the analyzer,
+    /// so MSBuild copies it next to the test assembly in every configuration). No build-graph
+    /// probing, no configuration guessing, no dependence on prior build output.
+    /// </summary>
+    /// <returns>The absolute path of the analyzer assembly wired into the fixture.</returns>
+    private static string InjectFixtureAnalyzer(string copiedRoot)
+    {
+        var analyzerAssemblyPath = typeof(ServerSurfaceCatalogAnalyzer).Assembly.Location;
+        Assert.IsFalse(string.IsNullOrEmpty(analyzerAssemblyPath),
+            "Fixture precondition: the analyzer assembly must be path-loaded so it can be wired into the sample project.");
+        Assert.IsTrue(File.Exists(analyzerAssemblyPath),
+            $"Fixture precondition: analyzer assembly '{analyzerAssemblyPath}' must exist on disk.");
+
+        var projectPath = Path.Combine(copiedRoot, "SampleLib", "SampleLib.csproj");
+        Assert.IsTrue(File.Exists(projectPath),
+            $"Fixture precondition: copied sample project '{projectPath}' must exist.");
+
+        var project = XDocument.Load(projectPath);
+        project.Root!.Add(new XElement("ItemGroup",
+            new XElement("Analyzer", new XAttribute("Include", analyzerAssemblyPath))));
+        project.Save(projectPath);
+
+        return analyzerAssemblyPath;
+    }
+
+    /// <summary>
+    /// Loads the fixture analyzer through the session's shadow loader and asserts the
+    /// compatibility witness: shadow-copied analyzers keep a real on-disk
     /// <see cref="System.Reflection.Assembly.Location"/> (path-loaded, never stream-loaded).
     /// Deliberately a separate method so the test body holds no reference that would root the
     /// pre-reload <see cref="Solution"/> graph and keep its collectible context alive.
     /// </summary>
-    private static WeakReference ForceAnalyzerLoad(WorkspaceManager manager, string workspaceId)
+    private static WeakReference ForceAnalyzerLoad(
+        WorkspaceManager manager, string workspaceId, string analyzerAssemblyPath)
     {
+        var analyzerFileName = Path.GetFileName(analyzerAssemblyPath);
         var solution = manager.GetCurrentSolution(workspaceId);
-        var hostProject = solution.Projects.First(project => project.Name == "RoslynMcp.Host.Stdio");
-        var analyzerReference = hostProject.AnalyzerReferences
+        var fixtureProject = solution.Projects.First(project => project.Name == "SampleLib");
+        var analyzerReference = fixtureProject.AnalyzerReferences
             .OfType<AnalyzerFileReference>()
             .FirstOrDefault(reference =>
-                reference.FullPath?.Contains("ServerSurfaceCatalogAnalyzer", StringComparison.OrdinalIgnoreCase) == true);
-        Assert.IsNotNull(analyzerReference, "Expected Host.Stdio to carry the server-surface catalog analyzer reference.");
+                string.Equals(Path.GetFileName(reference.FullPath), analyzerFileName, StringComparison.OrdinalIgnoreCase));
 
-        var analyzer = analyzerReference.GetAnalyzers(hostProject.Language)
-            .FirstOrDefault(candidate => candidate.GetType().Name == "ServerSurfaceCatalogAnalyzer");
+        // Distinguishes a broken FIXTURE (analyzer never reached the loaded project) from a
+        // genuine reclamation failure, which is asserted further down the test body.
+        Assert.IsNotNull(analyzerReference,
+            $"Fixture precondition failed (this is NOT a reclamation failure): the loaded SampleLib project must carry the injected analyzer reference '{analyzerFileName}'. Analyzer references seen: [{string.Join(", ", fixtureProject.AnalyzerReferences.Select(reference => reference.Display ?? reference.Id.ToString()))}].");
+
+        var analyzer = analyzerReference.GetAnalyzers(fixtureProject.Language)
+            .FirstOrDefault(candidate => candidate.GetType().Name == nameof(ServerSurfaceCatalogAnalyzer));
         Assert.IsNotNull(analyzer, "Expected the shadow-copy loader to preserve analyzer discovery.");
         Assert.IsFalse(string.IsNullOrEmpty(analyzer.GetType().Assembly.Location),
             "Shadow-copied analyzers must keep an on-disk Assembly.Location (collectible ALC must not imply stream loading).");

--- a/tests/RoslynMcp.Tests/UnresolvedAnalyzerReferenceStripperTests.cs
+++ b/tests/RoslynMcp.Tests/UnresolvedAnalyzerReferenceStripperTests.cs
@@ -37,13 +37,15 @@ public sealed class UnresolvedAnalyzerReferenceStripperTests : IsolatedWorkspace
         MsBuildInitializer.EnsureInitialized();
         var loader = new WorkspaceSessionLoader();
         var diagnosticsSink = new WorkspaceDiagnosticsSink(200);
-        using var msbuildWorkspace = await loader.CreateAndOpenAsync(
+        var (msbuildWorkspace, analyzerLease) = await loader.CreateAndOpenAsync(
             "test-workspace-unresolved",
             workspace.SolutionPath,
             globalProperties: null,
             diagnosticsSink,
             NullLogger.Instance,
             CancellationToken.None);
+        using var _ = msbuildWorkspace;
+        using var __ = analyzerLease;
 
         var sampleLibBefore = msbuildWorkspace.CurrentSolution.Projects.First(p => p.Name == "SampleLib");
         Assert.IsTrue(
@@ -83,13 +85,15 @@ public sealed class UnresolvedAnalyzerReferenceStripperTests : IsolatedWorkspace
         MsBuildInitializer.EnsureInitialized();
         var loader = new WorkspaceSessionLoader();
         var diagnosticsSink = new WorkspaceDiagnosticsSink(200);
-        using var msbuildWorkspace = await loader.CreateAndOpenAsync(
+        var (msbuildWorkspace, analyzerLease) = await loader.CreateAndOpenAsync(
             "test-workspace-clean",
             workspace.SolutionPath,
             globalProperties: null,
             diagnosticsSink,
             NullLogger.Instance,
             CancellationToken.None);
+        using var _ = msbuildWorkspace;
+        using var __ = analyzerLease;
 
         var diagnosticsQueue = new ConcurrentQueue<DiagnosticDto>();
         var stripper = new UnresolvedAnalyzerReferenceStripper();

--- a/tests/RoslynMcp.Tests/WorkspaceSessionLoaderFailureTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceSessionLoaderFailureTests.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
 using RoslynMcp.Roslyn.Services;
 using RoslynMcp.Tests.Helpers;
 
@@ -72,7 +73,7 @@ public sealed class WorkspaceSessionLoaderFailureTests
     {
         public int CallCount { get; private set; }
 
-        public override async Task<MSBuildWorkspace> CreateAndOpenAsync(
+        public override async Task<(MSBuildWorkspace Workspace, AnalyzerReferenceIsolation.AnalyzerShadowLoaderLease Lease)> CreateAndOpenAsync(
             string workspaceId,
             string path,
             IDictionary<string, string>? globalProperties,


### PR DESCRIPTION
## Summary

- Introduces `AnalyzerShadowLoaderLease` in `AnalyzerReferenceIsolation`: each workspace load owns its shadow-copy loaders, their now-**collectible** `AssemblyLoadContext`s, and a uniquely-keyed shadow root (`%TEMP%/RoslynMcpAnalyzerShadow/<workspaceId>/<leaseId>`), so old-lease deletion after a reload can never race the new lease's files. Non-Windows / reflection-unavailable paths return a no-op empty lease.
- `WorkspaceSessionLoader.CreateAndOpenAsync` now returns `(MSBuildWorkspace, AnalyzerShadowLoaderLease)`; the throw-before-return catch disposes the lease alongside the workspace.
- `WorkspaceManager.WorkspaceSession` carries the lease and releases it exactly once (idempotent) after `Workspace?.Dispose()` — covering close, LRU eviction, host `Dispose`, and both reload-swap arms (old lease on success, new lease on failure). Assigned inside the existing atomic-swap block, preserving the `autoreload-cascade-stdio-host-crash` invariant.
- Lease `Dispose` unloads every context with per-context failure containment, then best-effort deletes the lease root with a bounded GC-assisted retry; a once-per-process background `SweepAbandonedRoots` reaps roots abandoned by crashed or pre-fix hosts (never the shared parent, never a live lease).
- Analyzers stay **path-loaded** from on-disk shadow copies — `Assembly.Location` and adjacent-resource/native probing behavior are unchanged (`ValidationIntegrationTests` loader-type + Location assertions pass unmodified as the compatibility witness).

## Prior-attempt diagnosis

The interrupted `wip/analyzer-shadow-loader-lifecycle` attempt failed its own acceptance test (second context never unloaded). SOS `gcroot` on a live dump showed the only root was the **test thread's own stack**: the manager's awaits completed with inline continuations, so the test resumed on top of not-yet-unwound `MSBuildWorkspace.OpenSolutionAsync` / `LoadIntoSessionAsync` frames whose stack slots pinned the just-loaded `Solution` graph (→ `AnalyzerFileReference._lazyAssembly` → analyzer assembly → collectible ALC) for the whole in-place poll loop. Production disposal is unaffected; the test now runs its reclamation waits on a clean stack via `Task.Run`, and reclamation completes in seconds.

## Validation

- New `AnalyzerShadowLoaderLifecycleTests` (Windows-gated, `[DoNotParallelize]`): per-lease unique shadow roots, idempotent double-dispose, and the full load → force-analyzer-load → reload (old root reclaimed, new root survives) → close (all roots reclaimed) lifecycle, with `Assembly.Location` non-empty asserted through the shadow loader.
- Targeted runs green: `AnalyzerShadowLoaderLifecycleTests` + `ValidationIntegrationTests` + `WorkspaceSessionLoaderFailureTests` + `UnresolvedAnalyzerReferenceStripperTests` (12/12). One transient failure in an early witness run did not reproduce across two subsequent clean runs (concurrent sibling-executor test activity on this box).
- `eng/verify-ai-docs.ps1` + `eng/verify-changelog-fragments.ps1` pass. Full `verify-release.ps1` left to CI per the no-local-duplicate-runner policy.

Closes: analyzer-shadow-loader-lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)