### PR TITLE
fix(security): revalidate preview-token write set at redemption time (preview-apply-token-write-path-toctou)

### DIFF
--- a/changelog.d/preview-apply-token-write-path-toctou.md
+++ b/changelog.d/preview-apply-token-write-path-toctou.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Fixed:** a time-of-check/time-of-use hole on the preview-token apply path: redeeming a preview token now revalidates every changed document path against the configured sanctioned-root boundary under the write gate, instead of trusting the boundary check performed minutes earlier at preview time. `apply_multi_file_edit` now writes to the canonical link-resolved target returned by path validation rather than to the client-supplied path string.
+- **Fixed:** a time-of-check/time-of-use hole on the preview-token apply path: redeeming a preview token now revalidates every changed document path against the configured sanctioned-root boundary under the write gate, instead of trusting the boundary check performed minutes earlier at preview time. `apply_multi_file_edit` now writes to the canonical link-resolved target returned by path validation rather than to the client-supplied path string. Workspaces admitted via `workspace_load(expandSanctionedRoots: true)` are revalidated against that same one-level-widened boundary, so sibling-worktree applies keep working.

--- a/changelog.d/preview-apply-token-write-path-toctou.md
+++ b/changelog.d/preview-apply-token-write-path-toctou.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** a time-of-check/time-of-use hole on the preview-token apply path: redeeming a preview token now revalidates every changed document path against the configured sanctioned-root boundary under the write gate, instead of trusting the boundary check performed minutes earlier at preview time. `apply_multi_file_edit` now writes to the canonical link-resolved target returned by path validation rather than to the client-supplied path string.

--- a/src/RoslynMcp.Host.Stdio/Security/RootExpansionGrantRegistry.cs
+++ b/src/RoslynMcp.Host.Stdio/Security/RootExpansionGrantRegistry.cs
@@ -1,0 +1,54 @@
+using System.Collections.Concurrent;
+
+namespace RoslynMcp.Host.Stdio.Security;
+
+/// <summary>
+/// <b>preview-apply-token-write-path-toctou:</b> records which loaded workspaces were admitted
+/// under a one-level sanctioned-root expansion (<c>workspace_load(expandSanctionedRoots: true)</c>
+/// combined with the server-owned <see cref="RoslynMcp.Roslyn.Services.SecurityOptions.AllowRootExpansion"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Redemption-time boundary revalidation must re-derive the SAME boundary that admitted the
+/// workspace, never a narrower one. A sibling-worktree workspace loaded under a widened parent has
+/// every document <c>FilePath</c> outside the configured roots proper; without this grant the
+/// revalidation would refuse every <c>*_apply</c> on such a workspace — a functional regression on
+/// a supported load mode, not a security win.
+/// </para>
+/// <para>
+/// The grant is <b>sticky-true until close</b>: <c>workspace_load</c> is idempotent by path, so a
+/// later plain load returning the same <c>WorkspaceId</c> must not silently downgrade a boundary
+/// the workspace's documents already depend on. It never widens anything on its own — the effective
+/// widening still requires the operator's <c>AllowRootExpansion</c>, which
+/// <c>ClientRootPathValidator</c> ANDs in.
+/// </para>
+/// </remarks>
+internal static class RootExpansionGrantRegistry
+{
+    private static readonly ConcurrentDictionary<string, byte> s_grants =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Records that <paramref name="workspaceId"/> was loaded with root expansion requested.</summary>
+    public static void Grant(string workspaceId)
+    {
+        if (!string.IsNullOrEmpty(workspaceId))
+        {
+            s_grants[workspaceId] = 0;
+        }
+    }
+
+    /// <summary>Drops the grant for <paramref name="workspaceId"/>; called when the session closes.</summary>
+    public static void Revoke(string workspaceId)
+    {
+        if (!string.IsNullOrEmpty(workspaceId))
+        {
+            s_grants.TryRemove(workspaceId, out _);
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="workspaceId"/> was admitted under a requested root expansion.
+    /// </summary>
+    public static bool IsGranted(string? workspaceId)
+        => !string.IsNullOrEmpty(workspaceId) && s_grants.ContainsKey(workspaceId);
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MultiFileEditTools.cs
@@ -41,12 +41,21 @@ public static class MultiFileEditTools
         return gate.RunWriteAsync(workspaceId, async c =>
         {
             // Validate ALL paths before snapshotting so a bad path does not leave a stale undo entry.
-            foreach (var fileEdit in fileEdits)
+            // preview-apply-token-write-path-toctou: the validator's contract requires callers that
+            // go on to WRITE to persist to the boundary-canonicalized (fully link-resolved) path it
+            // returns — re-walking the client-supplied string at write time re-resolves every
+            // symlink/junction component, letting a link swapped between validation and write
+            // redirect the bytes outside the boundary. Rewrite each FileEditsDto to the canonical
+            // target instead of discarding the validator's return.
+            var canonicalEdits = new FileEditsDto[fileEdits.Length];
+            for (var i = 0; i < fileEdits.Length; i++)
             {
-                await ClientRootPathValidator.ValidatePathAgainstRootsAsync(server, fileEdit.FilePath, c).ConfigureAwait(false);
+                var canonicalPath = await ClientRootPathValidator
+                    .ValidatePathAgainstRootsAsync(server, fileEdits[i].FilePath, c).ConfigureAwait(false);
+                canonicalEdits[i] = fileEdits[i] with { FilePath = canonicalPath };
             }
 
-            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, fileEdits, "apply_multi_file_edit", c, skipSyntaxCheck, verify, autoRevertOnError).ConfigureAwait(false);
+            var dto = await editService.ApplyMultiFileTextEditsAsync(workspaceId, canonicalEdits, "apply_multi_file_edit", c, skipSyntaxCheck, verify, autoRevertOnError).ConfigureAwait(false);
             return JsonSerializer.Serialize(dto, JsonDefaults.Indented);
         }, ct);
     }

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -78,8 +79,12 @@ internal static class ToolDispatch
     /// Dispatch body for <c>*_apply</c> tools that receive an opaque preview token.
     /// Resolves the workspaceId from the token via
     /// <see cref="IPreviewStore.PeekWorkspaceId"/>, acquires the per-workspace write
-    /// gate, invokes <paramref name="serviceCall"/>, and returns the indented-JSON-
-    /// serialized DTO.
+    /// gate, revalidates the preview's write set against the sanctioned-root boundary
+    /// (<see cref="RevalidateChangedPathsAsync"/> — preview-apply-token-write-path-toctou),
+    /// invokes <paramref name="serviceCall"/>, and returns the indented-JSON-serialized DTO.
+    /// The delegate-peek overload below performs NO such revalidation: its stores
+    /// (<c>ICompositePreviewStore</c>, <c>IProjectMutationPreviewStore</c>) cannot yet
+    /// enumerate their write sets — tracked as a spin-off backlog row.
     /// </summary>
     /// <typeparam name="TDto">The DTO type returned by the underlying service call.</typeparam>
     /// <param name="gate">The workspace execution gate.</param>
@@ -111,7 +116,60 @@ internal static class ToolDispatch
         string previewToken,
         Func<CancellationToken, Task<TDto>> serviceCall,
         CancellationToken ct)
-        => ApplyByTokenAsync(gate, previewStore.PeekWorkspaceId, previewToken, serviceCall, ct);
+    {
+        var wsId = previewStore.PeekWorkspaceId(previewToken)
+            ?? throw new PreviewTokenStaleException(
+                previewToken,
+                $"Preview token '{previewToken}' has expired or was invalidated: the workspace was reloaded after the preview was created, dropping the stored solution snapshot. Re-issue the paired *_preview call against the current workspace.");
+        return gate.RunWriteAsync(wsId, async c =>
+        {
+            // preview-apply-token-write-path-toctou: revalidate the preview's write set against
+            // the sanctioned-root boundary AT REDEMPTION TIME, under the same write gate that
+            // holds until the persistence write. The only boundary check before this ran in the
+            // paired *_preview call — up to a full preview-TTL earlier — leaving the whole TTL as
+            // a validate-to-write window for a symlink/junction swap.
+            await RevalidateChangedPathsAsync(previewStore, previewToken, c).ConfigureAwait(false);
+            var result = await serviceCall(c).ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+        }, ct);
+    }
+
+    /// <summary>
+    /// preview-apply-token-write-path-toctou: runs every path in the preview's write set through
+    /// <see cref="ClientRootPathValidator.ValidatePathAgainstRootsAsync"/> against the host-bound
+    /// <see cref="SecurityOptionsSnapshot"/>. Skips silently — documented as "unknown", never
+    /// "verified" — when either the snapshot is <see langword="null"/> (unbooted host, i.e. unit
+    /// tests; the production host always populates it at startup) or the store cannot enumerate
+    /// the write set (<see cref="IPreviewStore.PeekChangedPaths"/> returned
+    /// <see langword="null"/>). Throws <see cref="ArgumentException"/> when any target falls
+    /// outside the configured boundary, refusing the apply before the service call runs.
+    /// </summary>
+    internal static async Task RevalidateChangedPathsAsync(
+        IPreviewStore previewStore,
+        string previewToken,
+        CancellationToken ct)
+    {
+        var securityOptions = SecurityOptionsSnapshot.Value;
+        if (securityOptions is null)
+        {
+            return;
+        }
+
+        var changedPaths = previewStore.PeekChangedPaths(previewToken);
+        if (changedPaths is null)
+        {
+            return;
+        }
+
+        foreach (var path in changedPaths)
+        {
+            await ClientRootPathValidator.ValidatePathAgainstRootsAsync(
+                server: null,
+                path,
+                ct,
+                securityOptions: securityOptions).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     /// Overload for <c>*_apply</c> tools that use a non-<see cref="IPreviewStore"/> preview

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Security;
 using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -128,7 +129,7 @@ internal static class ToolDispatch
             // holds until the persistence write. The only boundary check before this ran in the
             // paired *_preview call — up to a full preview-TTL earlier — leaving the whole TTL as
             // a validate-to-write window for a symlink/junction swap.
-            await RevalidateChangedPathsAsync(previewStore, previewToken, c).ConfigureAwait(false);
+            await RevalidateChangedPathsAsync(previewStore, previewToken, wsId, c).ConfigureAwait(false);
             var result = await serviceCall(c).ConfigureAwait(false);
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
@@ -143,10 +144,20 @@ internal static class ToolDispatch
     /// the write set (<see cref="IPreviewStore.PeekChangedPaths"/> returned
     /// <see langword="null"/>). Throws <see cref="ArgumentException"/> when any target falls
     /// outside the configured boundary, refusing the apply before the service call runs.
+    /// <para>
+    /// The boundary re-derived here must be the SAME one that admitted the workspace, never a
+    /// narrower one: a workspace loaded with <c>workspace_load(expandSanctionedRoots: true)</c>
+    /// legitimately holds documents under the widened parent root, so
+    /// <see cref="RootExpansionGrantRegistry"/> replays that load-time grant. The widening still
+    /// takes effect only when the operator-owned <see cref="RoslynMcp.Roslyn.Services.SecurityOptions.AllowRootExpansion"/>
+    /// is set — an out-of-boundary path is refused on an expansion-loaded workspace exactly as on
+    /// any other.
+    /// </para>
     /// </summary>
     internal static async Task RevalidateChangedPathsAsync(
         IPreviewStore previewStore,
         string previewToken,
+        string workspaceId,
         CancellationToken ct)
     {
         var securityOptions = SecurityOptionsSnapshot.Value;
@@ -161,13 +172,15 @@ internal static class ToolDispatch
             return;
         }
 
+        var expandSanctionedRoots = RootExpansionGrantRegistry.IsGranted(workspaceId);
         foreach (var path in changedPaths)
         {
             await ClientRootPathValidator.ValidatePathAgainstRootsAsync(
                 server: null,
                 path,
                 ct,
-                securityOptions: securityOptions).ConfigureAwait(false);
+                securityOptions: securityOptions,
+                expandSanctionedRoots: expandSanctionedRoots).ConfigureAwait(false);
         }
     }
 

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -10,6 +10,7 @@ using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Security;
 using RoslynMcp.Roslyn.Contracts;
 
 namespace RoslynMcp.Host.Stdio.Tools;
@@ -62,6 +63,15 @@ public static class WorkspaceTools
             var status = await workspace.LoadAsync(path, evictPolicy, c).ConfigureAwait(false);
             ProgressHelper.ReportStage(progress, 2, totalStages, "checking-restore");
             status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, c).ConfigureAwait(false);
+            if (expandSanctionedRoots)
+            {
+                // preview-apply-token-write-path-toctou: record the load-time expansion grant so a
+                // later *_apply redemption re-derives the SAME boundary that admitted this
+                // workspace. Without it, every document of an expansion-loaded sibling worktree
+                // sits outside the un-widened roots and every apply would be refused.
+                RootExpansionGrantRegistry.Grant(status.WorkspaceId);
+            }
+
             var shouldPrewarm = ShouldPrewarmAfterLoad(prewarm, status);
             var resolvedTotalStages = shouldPrewarm ? 5 : totalStages;
             WorkspaceWarmResult? prewarmResult = null;
@@ -147,6 +157,9 @@ public static class WorkspaceTools
                     }
 
                     var closed = workspace.Close(workspaceId);
+                    // The expansion grant is scoped to the session it was recorded for; drop it
+                    // with the session so a later workspace id reuse cannot inherit it.
+                    RootExpansionGrantRegistry.Revoke(workspaceId);
                     return JsonSerializer.Serialize(new { success = closed, workspaceId }, JsonDefaults.Indented);
                 },
                 outerCt,

--- a/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
@@ -102,4 +102,19 @@ public interface IPreviewStore
     /// or <see langword="null"/> if the token is expired or not found.
     /// </summary>
     string? PeekWorkspaceId(string token);
+
+    /// <summary>
+    /// <b>preview-apply-token-write-path-toctou:</b> returns the file paths of every document the
+    /// stored preview adds, changes, or removes — the write set a redeeming <c>*_apply</c> call
+    /// will persist to disk — without consuming or TTL-refreshing the entry. Returns
+    /// <see langword="null"/> when the token is expired/not found OR when the store cannot
+    /// enumerate the write set ("unknown"); callers performing redemption-time boundary
+    /// revalidation treat <see langword="null"/> as "skip", never as "empty write set verified".
+    /// </summary>
+    /// <remarks>
+    /// Default implementation returns <see langword="null"/> so existing test fakes (and any
+    /// out-of-tree implementations) keep compiling; only stores that actually hold a solution
+    /// snapshot pair override it.
+    /// </remarks>
+    IReadOnlyList<string>? PeekChangedPaths(string token) => null;
 }

--- a/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
@@ -159,6 +159,62 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         return (entry.WorkspaceId, entry.OriginalSolution, entry.ModifiedSolution, entry.WorkspaceVersion, entry.Description, entry.DiffTruncated);
     }
 
+    /// <summary>
+    /// <b>preview-apply-token-write-path-toctou:</b> enumerates the preview's write set — the
+    /// <c>FilePath</c> of every document added, changed, or removed between the stored
+    /// <c>OriginalSolution</c> and <c>ModifiedSolution</c> — so the apply dispatch path can
+    /// revalidate each target against the sanctioned-root boundary at redemption time instead of
+    /// trusting the boundary check performed at preview time (up to a full TTL earlier). Uses the
+    /// non-consuming <see cref="BoundedStore{TEntry}.RetrieveEntry"/> lookup, so a subsequent
+    /// <see cref="Retrieve"/> by the redeeming service still succeeds and the entry's TTL is not
+    /// refreshed.
+    /// </summary>
+    public IReadOnlyList<string>? PeekChangedPaths(string token)
+    {
+        var entry = RetrieveEntry(token);
+        if (entry is null) return null;
+
+        var paths = new List<string>();
+        var changes = entry.ModifiedSolution.GetChanges(entry.OriginalSolution);
+        foreach (var projectChanges in changes.GetProjectChanges())
+        {
+            foreach (var documentId in projectChanges.GetChangedDocuments())
+            {
+                AddDocumentPath(paths, projectChanges.NewProject.GetDocument(documentId));
+            }
+            foreach (var documentId in projectChanges.GetAddedDocuments())
+            {
+                AddDocumentPath(paths, projectChanges.NewProject.GetDocument(documentId));
+            }
+            foreach (var documentId in projectChanges.GetRemovedDocuments())
+            {
+                AddDocumentPath(paths, projectChanges.OldProject.GetDocument(documentId));
+            }
+        }
+
+        // A preview that introduces a whole new project (e.g. scaffold flows) writes every
+        // document of that project; enumerate them too rather than silently under-reporting.
+        foreach (var addedProject in changes.GetAddedProjects())
+        {
+            foreach (var document in addedProject.Documents)
+            {
+                AddDocumentPath(paths, document);
+            }
+        }
+
+        return paths;
+    }
+
+    private static void AddDocumentPath(List<string> paths, Document? document)
+    {
+        if (document?.FilePath is { Length: > 0 } filePath
+            // The truncated-diff sentinel is a synthetic marker, not a real write target.
+            && !string.Equals(filePath, SolutionDiffHelper.TruncatedSentinelFilePath, StringComparison.Ordinal))
+        {
+            paths.Add(filePath);
+        }
+    }
+
     /// <inheritdoc />
     public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion)
     {

--- a/tests/RoslynMcp.Tests/PreviewApplyBoundaryRevalidationTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewApplyBoundaryRevalidationTests.cs
@@ -6,6 +6,7 @@ using ModelContextProtocol.Protocol;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Security;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
 using RoslynMcp.Tests.Helpers;
@@ -22,8 +23,9 @@ namespace RoslynMcp.Tests;
 /// client-supplied path string.
 /// </summary>
 /// <remarks>
-/// [DoNotParallelize]: these tests set the process-global <see cref="SecurityOptionsSnapshot"/>,
-/// which <see cref="ToolDispatch.RevalidateChangedPathsAsync"/> reads on every token apply — a
+/// [DoNotParallelize]: these tests set the process-global <see cref="SecurityOptionsSnapshot"/> and
+/// <see cref="RootExpansionGrantRegistry"/>, both of which
+/// <see cref="ToolDispatch.RevalidateChangedPathsAsync"/> reads on every token apply — a
 /// concurrently-running class redeeming preview tokens would otherwise be validated against this
 /// class's temporary boundary.
 /// </remarks>
@@ -31,6 +33,9 @@ namespace RoslynMcp.Tests;
 [TestClass]
 public sealed class PreviewApplyBoundaryRevalidationTests
 {
+    /// <summary>Workspace id every staged preview in this class is stored under.</summary>
+    private const string WorkspaceId = "ws-toctou";
+
     private sealed record FakeResultDto(string Message);
 
     /// <summary>
@@ -219,6 +224,122 @@ public sealed class PreviewApplyBoundaryRevalidationTests
     }
 
     /// <summary>
+    /// Regression for the boundary-narrowing defect the fix cycle caught: a workspace admitted via
+    /// <c>workspace_load(expandSanctionedRoots: true)</c> legitimately holds every document under
+    /// the WIDENED parent of a configured root (the sibling-worktree load mode). Redemption must
+    /// re-derive that same widened boundary — re-deriving the narrower configured-roots-only
+    /// boundary would permanently refuse every <c>*_apply</c> on such a workspace.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByToken_ExpansionLoadedWorkspace_WriteSetUnderWidenedParent_StillApplies()
+    {
+        var testRoot = Path.Combine(TestTempRoot.Current, "rmcp-toctou-expand-" + Guid.NewGuid().ToString("N"));
+        var widenedParent = Path.Combine(testRoot, "repos");
+        var sanctionedRoot = Path.Combine(widenedParent, "primary");
+        var siblingWorktree = Path.Combine(widenedParent, "worktree");
+        Directory.CreateDirectory(sanctionedRoot);
+        Directory.CreateDirectory(siblingWorktree);
+        var documentPath = Path.Combine(siblingWorktree, "Program.cs");
+        File.WriteAllText(documentPath, "// original");
+
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions
+            {
+                SanctionedRoots = [sanctionedRoot],
+                AllowRootExpansion = true,
+            };
+
+            var (store, token) = StagePreview(documentPath);
+            var gate = new FakeGate();
+
+            // Premise: without the recorded load-time grant the boundary narrows to the configured
+            // root alone and the sibling-worktree write set falls outside it.
+            RootExpansionGrantRegistry.Revoke(WorkspaceId);
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                    gate,
+                    store,
+                    token,
+                    serviceCall: _ => Task.FromResult(new FakeResultDto("must-not-run")),
+                    ct: CancellationToken.None));
+
+            // With the grant replayed, redemption re-derives the SAME boundary that admitted the
+            // workspace and the apply succeeds.
+            RootExpansionGrantRegistry.Grant(WorkspaceId);
+            var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                gate,
+                store,
+                token,
+                serviceCall: _ => Task.FromResult(new FakeResultDto("applied")),
+                ct: CancellationToken.None);
+
+            StringAssert.Contains(result, "applied");
+        }
+        finally
+        {
+            RootExpansionGrantRegistry.Revoke(WorkspaceId);
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+            TestFixtureFileSystem.DeleteDirectoryIfExists(testRoot);
+        }
+    }
+
+    /// <summary>
+    /// The grant must not degrade the check into a no-op: on an expansion-loaded workspace a write
+    /// set that escapes even the WIDENED boundary is still refused at redemption time.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByToken_ExpansionLoadedWorkspace_WriteSetOutsideWidenedParent_RefusesRedemption()
+    {
+        var testRoot = Path.Combine(TestTempRoot.Current, "rmcp-toctou-expand-esc-" + Guid.NewGuid().ToString("N"));
+        var widenedParent = Path.Combine(testRoot, "repos");
+        var sanctionedRoot = Path.Combine(widenedParent, "primary");
+        var outside = Path.Combine(testRoot, "outside");
+        Directory.CreateDirectory(sanctionedRoot);
+        Directory.CreateDirectory(outside);
+        var documentPath = Path.Combine(outside, "Program.cs");
+        File.WriteAllText(documentPath, "// outside target — must never be written");
+
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions
+            {
+                SanctionedRoots = [sanctionedRoot],
+                AllowRootExpansion = true,
+            };
+            RootExpansionGrantRegistry.Grant(WorkspaceId);
+
+            var (store, token) = StagePreview(documentPath);
+            var gate = new FakeGate();
+            var serviceCallRan = false;
+
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                    gate,
+                    store,
+                    token,
+                    serviceCall: _ =>
+                    {
+                        serviceCallRan = true;
+                        return Task.FromResult(new FakeResultDto("must-not-run"));
+                    },
+                    ct: CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "outside the configured sanctioned-root boundary");
+            Assert.IsFalse(serviceCallRan,
+                "The expansion grant widens the boundary by exactly one level — it must not disable the check.");
+        }
+        finally
+        {
+            RootExpansionGrantRegistry.Revoke(WorkspaceId);
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+            TestFixtureFileSystem.DeleteDirectoryIfExists(testRoot);
+        }
+    }
+
+    /// <summary>
     /// Stages a real <see cref="PreviewStore"/> entry whose single changed document carries
     /// <paramref name="documentFilePath"/>, mirroring how every in-tree preview service stores an
     /// original/modified solution pair.
@@ -238,7 +359,7 @@ public sealed class PreviewApplyBoundaryRevalidationTests
         var modified = original.WithDocumentText(document.Id, SourceText.From("// modified"));
 
         var store = new PreviewStore();
-        var token = store.Store("ws-toctou", original, modified, workspaceVersion: 1, "toctou test preview", diffTruncated: false);
+        var token = store.Store(WorkspaceId, original, modified, workspaceVersion: 1, "toctou test preview", diffTruncated: false);
         return (store, token);
     }
 

--- a/tests/RoslynMcp.Tests/PreviewApplyBoundaryRevalidationTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewApplyBoundaryRevalidationTests.cs
@@ -1,0 +1,311 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// preview-apply-token-write-path-toctou: redeeming a preview token must revalidate the preview's
+/// write set against the sanctioned-root boundary AT REDEMPTION TIME (under the write gate),
+/// instead of trusting the boundary check performed at preview time — which could be a full
+/// preview-TTL (default 5 minutes) earlier, leaving the whole TTL as a validate-to-write window
+/// for a symlink/junction swap. Also pins the sibling half of the row: <c>apply_multi_file_edit</c>
+/// must persist to the canonical link-resolved target the validator returned, not to the
+/// client-supplied path string.
+/// </summary>
+/// <remarks>
+/// [DoNotParallelize]: these tests set the process-global <see cref="SecurityOptionsSnapshot"/>,
+/// which <see cref="ToolDispatch.RevalidateChangedPathsAsync"/> reads on every token apply — a
+/// concurrently-running class redeeming preview tokens would otherwise be validated against this
+/// class's temporary boundary.
+/// </remarks>
+[DoNotParallelize]
+[TestClass]
+public sealed class PreviewApplyBoundaryRevalidationTests
+{
+    private sealed record FakeResultDto(string Message);
+
+    /// <summary>
+    /// The link-swap regression this row exists for: the preview's changed document sits inside
+    /// the sanctioned root at preview time; the containing directory link is then re-pointed at
+    /// an out-of-boundary target; redemption must be REFUSED with the boundary
+    /// <see cref="ArgumentException"/> before the service call runs, and no bytes may land
+    /// outside the root.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByToken_LinkSwappedOutOfBoundaryAfterPreview_RefusesRedemption()
+    {
+        var testRoot = Path.Combine(TestTempRoot.Current, "rmcp-toctou-swap-" + Guid.NewGuid().ToString("N"));
+        var sanctionedRoot = Path.Combine(testRoot, "sanctioned");
+        var inside = Path.Combine(sanctionedRoot, "real");
+        var outside = Path.Combine(testRoot, "outside");
+        Directory.CreateDirectory(inside);
+        Directory.CreateDirectory(outside);
+        File.WriteAllText(Path.Combine(inside, "Program.cs"), "// inside target");
+        File.WriteAllText(Path.Combine(outside, "Program.cs"), "// outside target — must never be written");
+
+        var link = Path.Combine(sanctionedRoot, "link");
+        if (!TestFixtureFileSystem.TryCreateDirectoryLink(link, inside))
+        {
+            Assert.Inconclusive("Directory links are unavailable in this test environment.");
+            return;
+        }
+
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions { SanctionedRoots = [sanctionedRoot] };
+
+            var documentPath = Path.Combine(link, "Program.cs");
+            var (store, token) = StagePreview(documentPath);
+
+            // PeekChangedPaths must surface the write set without consuming the entry.
+            var changedPaths = store.PeekChangedPaths(token);
+            Assert.IsNotNull(changedPaths);
+            Assert.AreEqual(1, changedPaths.Count);
+            Assert.AreEqual(documentPath, changedPaths[0]);
+            Assert.IsNotNull(store.Retrieve(token),
+                "PeekChangedPaths must be non-consuming — the redeeming service's Retrieve must still succeed.");
+
+            // The swap: re-point the containing link outside the boundary AFTER the preview
+            // (deterministic stand-in for the race inside the preview-TTL window).
+            Directory.Delete(link);
+            if (!TestFixtureFileSystem.TryCreateDirectoryLink(link, outside))
+            {
+                Assert.Inconclusive("Directory link re-pointing is unavailable in this test environment.");
+                return;
+            }
+
+            var gate = new FakeGate();
+            var serviceCallRan = false;
+
+            var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                    gate,
+                    store,
+                    token,
+                    serviceCall: _ =>
+                    {
+                        serviceCallRan = true;
+                        return Task.FromResult(new FakeResultDto("must-not-run"));
+                    },
+                    ct: CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "outside the configured sanctioned-root boundary");
+            Assert.IsFalse(serviceCallRan,
+                "Redemption-time boundary revalidation must refuse the apply BEFORE the service call runs.");
+            Assert.AreEqual(1, gate.WriteCallCount,
+                "Revalidation must run INSIDE the write gate, holding the same lock as the persistence write.");
+            Assert.AreEqual("// outside target — must never be written",
+                File.ReadAllText(Path.Combine(outside, "Program.cs")),
+                "No bytes may land outside the sanctioned root.");
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+            TestFixtureFileSystem.DeleteDirectoryIfExists(testRoot);
+        }
+    }
+
+    /// <summary>
+    /// Happy path: a preview whose write set stays inside the sanctioned root still redeems
+    /// normally — revalidation must not turn into a false-positive gate.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByToken_WriteSetInsideBoundary_StillApplies()
+    {
+        var testRoot = Path.Combine(TestTempRoot.Current, "rmcp-toctou-happy-" + Guid.NewGuid().ToString("N"));
+        var sanctionedRoot = Path.Combine(testRoot, "sanctioned");
+        Directory.CreateDirectory(sanctionedRoot);
+        var documentPath = Path.Combine(sanctionedRoot, "Program.cs");
+        File.WriteAllText(documentPath, "// original");
+
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions { SanctionedRoots = [sanctionedRoot] };
+
+            var (store, token) = StagePreview(documentPath);
+            var gate = new FakeGate();
+
+            var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                gate,
+                store,
+                token,
+                serviceCall: _ => Task.FromResult(new FakeResultDto("applied")),
+                ct: CancellationToken.None);
+
+            StringAssert.Contains(result, "applied");
+            Assert.AreEqual(1, gate.WriteCallCount);
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+            TestFixtureFileSystem.DeleteDirectoryIfExists(testRoot);
+        }
+    }
+
+    /// <summary>
+    /// Sibling half of the row: <c>apply_multi_file_edit</c> must pass the boundary-canonicalized
+    /// (fully link-resolved) target the validator returned to the edit service — per the
+    /// validator's documented contract ("callers that go on to write MUST persist to this returned
+    /// value") — not the client-supplied path string, whose link components would be re-resolved
+    /// at write time.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyMultiFileEdit_PassesCanonicalLinkResolvedTarget_ToEditService()
+    {
+        var testRoot = Path.Combine(TestTempRoot.Current, "rmcp-toctou-multi-" + Guid.NewGuid().ToString("N"));
+        var sanctionedRoot = Path.Combine(testRoot, "sanctioned");
+        var real = Path.Combine(sanctionedRoot, "real");
+        Directory.CreateDirectory(real);
+        var realFile = Path.Combine(real, "Target.cs");
+        File.WriteAllText(realFile, "// target");
+
+        var link = Path.Combine(sanctionedRoot, "link");
+        try
+        {
+            if (!TestFixtureFileSystem.TryCreateDirectoryLink(link, real))
+            {
+                Assert.Inconclusive("Directory links are unavailable in this test environment.");
+                return;
+            }
+
+            await using var harness = await InMemoryMcpClientServerHarness.CreateAsync(
+                transportName: "toctou-multi-file-edit",
+                clientCapabilities: new ClientCapabilities(),
+                clientHandlers: new McpClientHandlers(),
+                disposalFailureContext: "toctou-multi-file-edit",
+                cancellationToken: CancellationToken.None,
+                serverServicesFactory: () => new ServiceCollection()
+                    .AddSingleton(new SecurityOptions { SanctionedRoots = [sanctionedRoot] })
+                    .BuildServiceProvider());
+
+            var clientSuppliedPath = Path.Combine(link, "Target.cs");
+            var editService = new CapturingEditService();
+
+            await MultiFileEditTools.ApplyMultiFileEdit(
+                harness.Server,
+                new FakeGate(),
+                editService,
+                workspaceId: "ws-multi",
+                fileEdits: [new FileEditsDto(clientSuppliedPath, [new TextEditDto(1, 1, 1, 1, "// edited\n")])],
+                ct: CancellationToken.None);
+
+            Assert.IsNotNull(editService.ReceivedFileEdits);
+            Assert.AreEqual(1, editService.ReceivedFileEdits.Count);
+            var receivedPath = editService.ReceivedFileEdits[0].FilePath;
+            var canonical = ClientRootPathValidator.ResolvePath(clientSuppliedPath);
+            Assert.AreNotEqual(
+                Path.GetFullPath(clientSuppliedPath),
+                canonical,
+                "Test premise: the link must make the client-supplied and canonical paths diverge.");
+            Assert.AreEqual(canonical, receivedPath,
+                "apply_multi_file_edit must hand the edit service the canonical link-resolved target " +
+                "the validator returned, not the client-supplied path string.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(testRoot);
+        }
+    }
+
+    /// <summary>
+    /// Stages a real <see cref="PreviewStore"/> entry whose single changed document carries
+    /// <paramref name="documentFilePath"/>, mirroring how every in-tree preview service stores an
+    /// original/modified solution pair.
+    /// </summary>
+    private static (PreviewStore Store, string Token) StagePreview(string documentFilePath)
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var documentInfo = DocumentInfo.Create(
+            DocumentId.CreateNewId(project.Id),
+            name: Path.GetFileName(documentFilePath),
+            loader: TextLoader.From(TextAndVersion.Create(SourceText.From("// original"), VersionStamp.Create())),
+            filePath: documentFilePath);
+        var document = workspace.AddDocument(documentInfo);
+
+        var original = workspace.CurrentSolution;
+        var modified = original.WithDocumentText(document.Id, SourceText.From("// modified"));
+
+        var store = new PreviewStore();
+        var token = store.Store("ws-toctou", original, modified, workspaceVersion: 1, "toctou test preview", diffTruncated: false);
+        return (store, token);
+    }
+
+    /// <summary>
+    /// Minimal write-gate stand-in mirroring <c>ToolDispatchTests.FakeGate</c>: runs the action
+    /// inline and records the verb so the tests can assert the revalidation happened in-gate.
+    /// </summary>
+    private sealed class FakeGate : IWorkspaceExecutionGate
+    {
+        public int WriteCallCount { get; private set; }
+
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => action(ct);
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true)
+        {
+            WriteCallCount++;
+            return action(ct);
+        }
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public void RemoveGate(string workspaceId)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Captures the <see cref="FileEditsDto"/> batch <c>apply_multi_file_edit</c> forwards, so the
+    /// canonical-target pin can be asserted without a loaded workspace.
+    /// </summary>
+    private sealed class CapturingEditService : IEditService
+    {
+        public IReadOnlyList<FileEditsDto>? ReceivedFileEdits { get; private set; }
+
+        public Task<MultiFileEditResultDto> ApplyMultiFileTextEditsAsync(
+            string workspaceId,
+            IReadOnlyList<FileEditsDto> fileEdits,
+            string toolName,
+            CancellationToken ct,
+            bool skipSyntaxCheck = false,
+            bool verify = false,
+            bool autoRevertOnError = false)
+        {
+            ReceivedFileEdits = fileEdits;
+            var files = fileEdits.Select(f => new FileEditSummaryDto(f.FilePath, f.Edits.Count, null)).ToList();
+            return Task.FromResult(new MultiFileEditResultDto(true, files.Count, files));
+        }
+
+        public Task<TextEditResultDto> ApplyTextEditsAsync(
+            string workspaceId,
+            string filePath,
+            IReadOnlyList<TextEditDto> edits,
+            string toolName,
+            CancellationToken ct,
+            bool skipSyntaxCheck = false,
+            bool verify = false,
+            bool autoRevertOnError = false,
+            string? canonicalWritePath = null)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewMultiFileTextEditsAsync(
+            string workspaceId, IReadOnlyList<FileEditsDto> fileEdits, CancellationToken ct, bool skipSyntaxCheck = false)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/ServerInfoPathBoundaryTests.cs
+++ b/tests/RoslynMcp.Tests/ServerInfoPathBoundaryTests.cs
@@ -143,6 +143,10 @@ public sealed class ServerInfoPathBoundaryTests
     /// camelCase name, so the projection cannot be silently disconnected from the response.
     /// </summary>
     [TestMethod]
+    // preview-apply-token-write-path-toctou: ToolDispatch.ApplyByTokenAsync now reads the
+    // process-global SecurityOptionsSnapshot on every token apply, so a parallel class redeeming
+    // preview tokens would be validated against this test's temporary ["."] boundary.
+    [DoNotParallelize]
     public async Task ServerInfo_CarriesPathBoundary_FromTheStartupSnapshot()
     {
         var previous = SecurityOptionsSnapshot.Value;
@@ -173,6 +177,8 @@ public sealed class ServerInfoPathBoundaryTests
     /// matching the DTO's documented convention that nullable members emit explicit nulls.
     /// </summary>
     [TestMethod]
+    // preview-apply-token-write-path-toctou: see ServerInfo_CarriesPathBoundary_FromTheStartupSnapshot.
+    [DoNotParallelize]
     public async Task ServerInfo_UnbootedHost_EmitsExplicitNullBoundary()
     {
         var previous = SecurityOptionsSnapshot.Value;

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -2,7 +2,9 @@ using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -152,6 +154,126 @@ public sealed class ToolDispatchTests
     }
 
     /// <summary>
+    /// preview-apply-token-write-path-toctou: a store that cannot enumerate the preview's write
+    /// set (<c>PeekChangedPaths</c> returns <see langword="null"/> — the interface default) must
+    /// pass through even when a restrictive boundary snapshot is set: <see langword="null"/>
+    /// means "unknown", and the delegate-peek stores that hit this shape are covered by their
+    /// own spin-off row, not silently blocked here.
+    /// </summary>
+    [TestMethod]
+    [DoNotParallelize] // mutates the process-global SecurityOptionsSnapshot
+    public async Task ApplyByTokenAsync_NullChangedPathsPeek_SkipsRevalidation_AndApplies()
+    {
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions
+            {
+                SanctionedRoots = [Path.Combine(TestTempRoot.Current, "nonexistent-boundary")],
+            };
+            var gate = new FakeGate();
+            var store = new FakePreviewStore(token: "tok-null-peek", workspaceId: "ws-np");
+
+            var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                gate,
+                store,
+                previewToken: "tok-null-peek",
+                serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 1)),
+                ct: CancellationToken.None);
+
+            StringAssert.Contains(result, "applied",
+                "A null PeekChangedPaths (write set unknown) must skip revalidation, not refuse the apply.");
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+        }
+    }
+
+    /// <summary>
+    /// preview-apply-token-write-path-toctou: a <see langword="null"/>
+    /// <see cref="SecurityOptionsSnapshot"/> means "unbooted host" (the unit-test path — the
+    /// production host always populates it at startup, <c>Program.cs</c>). Per the snapshot's own
+    /// documented contract that state is "unknown", NOT "unconfigured", so revalidation is
+    /// skipped rather than fabricating a fail-closed boundary. This test asserts and documents
+    /// the skip so it never silently becomes the production path.
+    /// </summary>
+    [TestMethod]
+    [DoNotParallelize] // mutates the process-global SecurityOptionsSnapshot
+    public async Task ApplyByTokenAsync_NullSecuritySnapshot_SkipsRevalidation_AndApplies()
+    {
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = null;
+            var gate = new FakeGate();
+            var store = new FakePreviewStore(token: "tok-null-snap", workspaceId: "ws-ns")
+            {
+                ChangedPaths = [Path.Combine(TestTempRoot.Current, "anywhere", "outside.cs")],
+            };
+
+            var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                gate,
+                store,
+                previewToken: "tok-null-snap",
+                serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 2)),
+                ct: CancellationToken.None);
+
+            StringAssert.Contains(result, "applied",
+                "A null SecurityOptionsSnapshot (unbooted host) must skip revalidation, not refuse the apply.");
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+        }
+    }
+
+    /// <summary>
+    /// preview-apply-token-write-path-toctou: with a configured boundary AND an enumerable write
+    /// set, a changed path outside the boundary refuses the redemption before the service call
+    /// runs. (The full link-swap scenario lives in
+    /// <c>PreviewApplyBoundaryRevalidationTests</c>; this is the pure-unit pin on the dispatch
+    /// helper's own contract.)
+    /// </summary>
+    [TestMethod]
+    [DoNotParallelize] // mutates the process-global SecurityOptionsSnapshot
+    public async Task ApplyByTokenAsync_ChangedPathOutsideBoundary_RefusesBeforeServiceCall()
+    {
+        var boundary = Path.Combine(TestTempRoot.Current, "tdt-boundary-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(boundary);
+        var previousSnapshot = SecurityOptionsSnapshot.Value;
+        try
+        {
+            SecurityOptionsSnapshot.Value = new SecurityOptions { SanctionedRoots = [boundary] };
+            var gate = new FakeGate();
+            var serviceCallRan = false;
+            var store = new FakePreviewStore(token: "tok-oob", workspaceId: "ws-oob")
+            {
+                ChangedPaths = [Path.Combine(TestTempRoot.Current, "elsewhere", "outside.cs")],
+            };
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+                ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                    gate,
+                    store,
+                    previewToken: "tok-oob",
+                    serviceCall: _ =>
+                    {
+                        serviceCallRan = true;
+                        return Task.FromResult(new FakeResultDto("must-not-run", 0));
+                    },
+                    ct: CancellationToken.None));
+
+            Assert.IsFalse(serviceCallRan, "Revalidation must refuse the apply BEFORE the service call runs.");
+            Assert.AreEqual(1, gate.WriteCallCount, "Revalidation runs INSIDE the write gate.");
+        }
+        finally
+        {
+            SecurityOptionsSnapshot.Value = previousSnapshot;
+        }
+    }
+
+    /// <summary>
     /// Minimal stand-in for <see cref="IWorkspaceExecutionGate"/> that records which verb
     /// was invoked and the workspaceId that was passed. <c>RunLoadGateAsync</c> and
     /// <c>RemoveGate</c> are not exercised by <see cref="ToolDispatch"/> so they throw to
@@ -210,7 +332,16 @@ public sealed class ToolDispatchTests
             _workspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// preview-apply-token-write-path-toctou: write set the fake reports for its token, or
+        /// <see langword="null"/> (the default, matching the interface's default implementation)
+        /// for "unknown".
+        /// </summary>
+        public IReadOnlyList<string>? ChangedPaths { get; init; }
+
         public string? PeekWorkspaceId(string token) => token == _token ? _workspaceId : null;
+
+        public IReadOnlyList<string>? PeekChangedPaths(string token) => token == _token ? ChangedPaths : null;
 
         public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
             => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

Closes the preview/apply-token write-path TOCTOU: the only sanctioned-root boundary check for a token-redeemed write used to run in the paired `*_preview` call, leaving the entire preview TTL (default 5 minutes) as a validate-to-write window for a symlink/junction swap.

- `IPreviewStore.PeekChangedPaths(token)` — new default interface method (`null` = "unknown") so the three existing test fakes compile unchanged; `PreviewStore` implements it by diffing the stored `ModifiedSolution` against `OriginalSolution` (added + changed + removed documents, plus added-project documents), non-consuming and non-TTL-refreshing.
- `ToolDispatch.ApplyByTokenAsync` (primary `IPreviewStore` overload) now revalidates every changed-document path via `ClientRootPathValidator.ValidatePathAgainstRootsAsync` against the host-bound `SecurityOptionsSnapshot`, INSIDE the write gate, before the service call. Null snapshot (unbooted host / unit tests) or null peek skips — documented and test-pinned as "unknown", never "verified". The delegate-peek overload (`apply_composite_preview`, `apply_project_mutation`) is deliberately untouched — spin-off row per plan.
- `MultiFileEditTools.ApplyMultiFileEdit` stops discarding the validator's canonical return: each `FileEditsDto` is rewritten to the boundary-canonicalized (fully link-resolved) target per the validator's documented MUST-persist contract.

## Tests

- NEW `PreviewApplyBoundaryRevalidationTests`: link-swap redemption refusal (no service call, no out-of-boundary bytes, in-gate), happy-path redemption, `apply_multi_file_edit` canonical-target pin, `PeekChangedPaths` non-consumption.
- `ToolDispatchTests`: null-peek and null-snapshot pass-through stay non-breaking; out-of-boundary changed path refuses before the service call.
- `ServerInfoPathBoundaryTests`: the two `SecurityOptionsSnapshot`-mutating tests gain `[DoNotParallelize]` — the snapshot is now read on every token apply, so a parallel class could otherwise be validated against their temporary boundary.

## Validation

- `dotnet build RoslynMcp.slnx -c Release` — 0 warnings / 0 errors.
- Targeted suites green: `PreviewApplyBoundaryRevalidationTests`, `ToolDispatchTests`, `ClientRootPathValidatorTests`, `ServerInfoPathBoundaryTests`, `ApplyUndoWorkflowServiceTests`, `ApplyWithVerifyCancellationAndScopeTests`, `ExpandedSurfaceIntegrationTests` (137 passed, 0 failed).
- `./eng/verify-ai-docs.ps1` — passed.
- Full `verify-release.ps1` deliberately NOT run locally (self-hosted CI runner on this box serializes it; standing instruction not to duplicate) — CI validates on this PR.

Closes: preview-apply-token-write-path-toctou

🤖 Generated with [Claude Code](https://claude.com/claude-code)