### PR TITLE
fix(security): redact raw Roslyn exception text from flow-analysis failures (analysis-flow-error-detail-redaction)

### DIFF
--- a/changelog.d/analysis-flow-error-detail-redaction.md
+++ b/changelog.d/analysis-flow-error-detail-redaction.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `analyze_data_flow`, `analyze_control_flow`, and `extract_method_preview` no longer publish raw Roslyn exception text in their failure messages. Failures now carry the operation, the requested line range, the actionable remediation guidance, and a correlation ID via the shared `PublicExceptionDetailPolicy` projection; full exception detail stays in the server-only diagnostic sink. Error message text for these three failure paths changed.

--- a/src/RoslynMcp.Core/Services/IUnexpectedExceptionReporter.cs
+++ b/src/RoslynMcp.Core/Services/IUnexpectedExceptionReporter.cs
@@ -16,6 +16,7 @@ public enum UnexpectedExceptionCategory
     FixAll,
     WorkspaceReadiness,
     GetPrompt,
+    FlowAnalysis,
 }
 
 /// <summary>

--- a/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
+++ b/src/RoslynMcp.Roslyn/Services/ExtractMethodService.cs
@@ -18,15 +18,18 @@ public sealed class ExtractMethodService : IExtractMethodService
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
     private readonly ILogger<ExtractMethodService> _logger;
+    private readonly IUnexpectedExceptionReporter? _exceptionReporter;
 
     public ExtractMethodService(
         IWorkspaceManager workspace,
         IPreviewStore previewStore,
-        ILogger<ExtractMethodService> logger)
+        ILogger<ExtractMethodService> logger,
+        IUnexpectedExceptionReporter? exceptionReporter = null)
     {
         _workspace = workspace;
         _previewStore = previewStore;
         _logger = logger;
+        _exceptionReporter = exceptionReporter;
     }
 
     public async Task<RefactoringPreviewDto> PreviewExtractMethodAsync(
@@ -49,7 +52,9 @@ public sealed class ExtractMethodService : IExtractMethodService
             FindEnclosingMethodAndStatements(root, selectionSpan);
 
         var (parameters, flowsOut, variablesDeclaredInRegion, isStatic) =
-            AnalyzeFlowAndInferSignature(semanticModel, statementsInSelection, enclosingMember);
+            AnalyzeFlowAndInferSignature(
+                semanticModel, statementsInSelection, enclosingMember,
+                _exceptionReporter, startLine, endLine);
 
         var (newMethod, callStatement) =
             BuildMethodAndCallSite(methodName, parameters, flowsOut, variablesDeclaredInRegion, isStatic, statementsInSelection);
@@ -138,7 +143,10 @@ public sealed class ExtractMethodService : IExtractMethodService
         AnalyzeFlowAndInferSignature(
             SemanticModel semanticModel,
             List<StatementSyntax> statementsInSelection,
-            MemberDeclarationSyntax enclosingMember)
+            MemberDeclarationSyntax enclosingMember,
+            IUnexpectedExceptionReporter? exceptionReporter,
+            int startLine,
+            int endLine)
     {
         var firstStatement = statementsInSelection[0];
         var lastStatement = statementsInSelection[^1];
@@ -150,9 +158,12 @@ public sealed class ExtractMethodService : IExtractMethodService
         }
         catch (ArgumentException ex)
         {
+            // analysis-flow-error-detail-redaction: never publish raw Roslyn exception text
+            // in the client-visible failure message; route through the shared secret-safe
+            // projection and keep the original exception server-side as InnerException.
             throw new InvalidOperationException(
-                $"Data flow analysis failed: {ex.Message}. " +
-                "Ensure the selection covers complete statements within a single block.", ex);
+                FlowAnalysisFailurePolicy.CreateFailureMessage(
+                    exceptionReporter, ex, "Extract-method data flow analysis", startLine, endLine), ex);
         }
 
         if (dataFlow is null || !dataFlow.Succeeded)

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisFailurePolicy.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisFailurePolicy.cs
@@ -1,0 +1,31 @@
+using RoslynMcp.Core.Services;
+
+namespace RoslynMcp.Roslyn.Services;
+
+/// <summary>
+/// Creates one shared secret-safe failure message for recovered flow-analysis errors.
+/// The raw Roslyn exception text (message, data, source paths, stack text) is never copied
+/// into the client-visible message; full detail stays in the server-only diagnostic sink
+/// keyed by the correlation ID.
+/// </summary>
+internal static class FlowAnalysisFailurePolicy
+{
+    internal const string Remediation =
+        "Try widening the range to a complete expression-bodied member or to statements " +
+        "within a single block (avoid spanning try/catch/finally boundaries).";
+
+    public static string CreateFailureMessage(
+        IUnexpectedExceptionReporter? exceptionReporter,
+        Exception exception,
+        string operation,
+        int startLine,
+        int endLine)
+    {
+        var detail = UnexpectedExceptionReporting.Report(
+            exceptionReporter,
+            exception,
+            UnexpectedExceptionCategory.FlowAnalysis).Public;
+        return $"{operation} failed for lines {startLine}-{endLine}. " +
+            $"{Remediation} correlationId={detail.CorrelationId}";
+    }
+}

--- a/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
+++ b/src/RoslynMcp.Roslyn/Services/FlowAnalysisService.cs
@@ -8,10 +8,14 @@ namespace RoslynMcp.Roslyn.Services;
 public sealed class FlowAnalysisService : IFlowAnalysisService
 {
     private readonly IWorkspaceManager _workspace;
+    private readonly IUnexpectedExceptionReporter? _exceptionReporter;
 
-    public FlowAnalysisService(IWorkspaceManager workspace)
+    public FlowAnalysisService(
+        IWorkspaceManager workspace,
+        IUnexpectedExceptionReporter? exceptionReporter = null)
     {
         _workspace = workspace;
+        _exceptionReporter = exceptionReporter;
     }
 
     public async Task<DataFlowAnalysisDto> AnalyzeDataFlowAsync(
@@ -33,9 +37,12 @@ public sealed class FlowAnalysisService : IFlowAnalysisService
         }
         catch (ArgumentException ex)
         {
+            // analysis-flow-error-detail-redaction: never publish raw Roslyn exception text
+            // in the client-visible failure message; route through the shared secret-safe
+            // projection and keep the original exception server-side as InnerException.
             throw new InvalidOperationException(
-                $"Data flow analysis failed for lines {startLine}-{endLine}: {ex.Message}. " +
-                "Try widening the range to a complete expression-bodied member or to statements within a single block (avoid spanning try/catch/finally boundaries).", ex);
+                FlowAnalysisFailurePolicy.CreateFailureMessage(
+                    _exceptionReporter, ex, "Data flow analysis", startLine, endLine), ex);
         }
 
         return new DataFlowAnalysisDto(
@@ -88,9 +95,10 @@ public sealed class FlowAnalysisService : IFlowAnalysisService
         }
         catch (ArgumentException ex)
         {
+            // analysis-flow-error-detail-redaction: see the data-flow catch above.
             throw new InvalidOperationException(
-                $"Control flow analysis failed for lines {startLine}-{endLine}: {ex.Message}. " +
-                "Try widening the range to a complete expression-bodied member or to statements within a single block (avoid spanning try/catch/finally boundaries).", ex);
+                FlowAnalysisFailurePolicy.CreateFailureMessage(
+                    _exceptionReporter, ex, "Control flow analysis", startLine, endLine), ex);
         }
 
         var entryPoints = result.EntryPoints

--- a/tests/RoslynMcp.Tests/AnalysisFlowFailureRedactionTests.cs
+++ b/tests/RoslynMcp.Tests/AnalysisFlowFailureRedactionTests.cs
@@ -1,0 +1,96 @@
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// analysis-flow-error-detail-redaction: the flow-analysis failure paths in
+/// <see cref="FlowAnalysisService"/> and <see cref="ExtractMethodService"/> must never publish
+/// raw Roslyn exception text in their client-visible messages. All three catch sites route
+/// through <see cref="FlowAnalysisFailurePolicy.CreateFailureMessage"/>, so the redaction
+/// contract is asserted directly against the shared policy (the Roslyn analysis APIs offer no
+/// injectable seam to force an <see cref="ArgumentException"/> with attacker-controlled text
+/// through the live services). Healthy-path DTO behavior is covered by
+/// <c>FlowAnalysisServiceTests</c> and <c>ExtractMethodServiceTests</c>, which are unchanged.
+/// </summary>
+[TestClass]
+public sealed class AnalysisFlowFailureRedactionTests
+{
+    private const string Sentinel = "SENTINEL-SECRET-9F3A";
+
+    [TestMethod]
+    [DataRow("Data flow analysis")]
+    [DataRow("Control flow analysis")]
+    [DataRow("Extract-method data flow analysis")]
+    public void CreateFailureMessage_RedactsExceptionTextAndCarriesContract(string operation)
+    {
+        var reporter = new RecordingUnexpectedExceptionReporter();
+        var roslynException = new ArgumentException(
+            $"statementOrExpression at C:/secret/path/{Sentinel}.cs is not valid");
+
+        var message = FlowAnalysisFailurePolicy.CreateFailureMessage(
+            reporter, roslynException, operation, startLine: 12, endLine: 34);
+
+        Assert.IsFalse(message.Contains(Sentinel, StringComparison.Ordinal),
+            $"The raw Roslyn exception text must not leak into the published message: {message}");
+        Assert.IsFalse(message.Contains(roslynException.Message, StringComparison.Ordinal),
+            "No portion of the raw exception message may be republished verbatim.");
+        StringAssert.Contains(message, operation, StringComparison.Ordinal);
+        StringAssert.Contains(message, "lines 12-34", StringComparison.Ordinal);
+        StringAssert.Contains(message, FlowAnalysisFailurePolicy.Remediation, StringComparison.Ordinal);
+        StringAssert.Contains(message, "correlationId=", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void CreateFailureMessage_ReportsToServerSinkWithFlowAnalysisCategory()
+    {
+        var reporter = new RecordingUnexpectedExceptionReporter();
+        var roslynException = new ArgumentException(Sentinel);
+
+        _ = FlowAnalysisFailurePolicy.CreateFailureMessage(
+            reporter, roslynException, "Data flow analysis", startLine: 1, endLine: 2);
+
+        Assert.HasCount(1, reporter.Reports);
+        Assert.AreSame(roslynException, reporter.Reports[0].Exception,
+            "The original exception must reach the server-only diagnostic sink.");
+        Assert.AreEqual(UnexpectedExceptionCategory.FlowAnalysis, reporter.Reports[0].Category);
+        CollectionAssert.Contains(
+            reporter.LastDetails!.Server.ExceptionTypes.ToList(),
+            "System.ArgumentException",
+            "The server-only projection must retain the exception type topology.");
+    }
+
+    [TestMethod]
+    public void CreateFailureMessage_NullReporter_FallsBackToUnavailableCorrelationId()
+    {
+        var message = FlowAnalysisFailurePolicy.CreateFailureMessage(
+            exceptionReporter: null,
+            new ArgumentException(Sentinel),
+            "Control flow analysis",
+            startLine: 3,
+            endLine: 3);
+
+        Assert.IsFalse(message.Contains(Sentinel, StringComparison.Ordinal));
+        StringAssert.Contains(message, "correlationId=unavailable", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Recording <see cref="IUnexpectedExceptionReporter"/> double: captures each report and
+    /// delegates the projection to the shared <see cref="PublicExceptionDetailPolicy"/>.
+    /// </summary>
+    private sealed class RecordingUnexpectedExceptionReporter : IUnexpectedExceptionReporter
+    {
+        public List<(Exception Exception, UnexpectedExceptionCategory Category)> Reports { get; } = [];
+
+        public UnexpectedExceptionDetails? LastDetails { get; private set; }
+
+        public UnexpectedExceptionDetails ReportUnexpected(
+            Exception exception,
+            UnexpectedExceptionCategory category)
+        {
+            Reports.Add((exception, category));
+            LastDetails = PublicExceptionDetailPolicy.ProjectUnexpected(exception, correlationId: null);
+            return LastDetails;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `analyze_data_flow`, `analyze_control_flow`, and `extract_method_preview` interpolated raw Roslyn `ArgumentException.Message` into client-visible failure strings (the `InvalidOperationException` takes the expected-error path in `StructuredCallToolFilter`, so the compiler-exception text was published verbatim in the tools/call error envelope).
- Added `FlowAnalysisFailurePolicy.CreateFailureMessage` (mirrors `ScaffoldingReadFailurePolicy`) built on the shared `UnexpectedExceptionReporting` / `PublicExceptionDetailPolicy` projection: messages now carry the operation name, the requested line range, the actionable remediation sentence, and `correlationId=<id>` — never `ex.Message`, paths, data, or stack text. The original exception stays as `InnerException` for server-side chaining, and full detail reaches the server-only diagnostic sink under the new `UnexpectedExceptionCategory.FlowAnalysis`.
- `FlowAnalysisService` and `ExtractMethodService` gained an optional `IUnexpectedExceptionReporter? exceptionReporter = null` ctor parameter (already `TryAddSingleton`-registered — no DI edit; existing direct constructions still compile).
- New table-driven `AnalysisFlowFailureRedactionTests`: sentinel-secret redaction, contract fields (operation / line range / remediation / `correlationId=`), FlowAnalysis category reporting to the server sink, and null-reporter `correlationId=unavailable` fallback.

## Validation

- `dotnet build` clean; targeted run: 13/13 passing (`AnalysisFlowFailureRedactionTests` + `FlowAnalysisServiceTests`); `ExtractMethod*` suites 26/28 — the 2 failures (`ExtractMethod_PreviewAndApply_CompilationSucceeds`, `ExtractMethod_ReassignsExistingLocal_EmitsAssignmentNotVarDecl`) reproduce identically at clean baseRef inside the worktree (isolated sample-solution restore cannot resolve MSTest packages from a `.worktrees` path) — pre-existing environmental, not this diff; they pass in the primary checkout at the same commit.
- Full `verify-release.ps1` gate deferred to CI (self-hosted runner active; standing rule not to duplicate locally).

Note (plan deviation, documented): the plan's sentinel test drove the sentinel through the live service paths; Roslyn's `AnalyzeDataFlow`/`AnalyzeControlFlow` offer no injectable seam to force an `ArgumentException` with controlled text, so the redaction contract is asserted directly against the shared policy that all three catch sites route through.

Closes: analysis-flow-error-detail-redaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)