### PR TITLE
fix(resources): complete resources/read protocol-error migration for the server-catalog family (resource-read-protocol-error-semantics-server-catalog)

### DIFF
--- a/changelog.d/resource-read-protocol-error-semantics-server-catalog.md
+++ b/changelog.d/resource-read-protocol-error-semantics-server-catalog.md
@@ -1,0 +1,5 @@
+---
+category: Changed — BREAKING
+---
+
+- **Changed — BREAKING:** server-catalog resources (`roslyn://server/catalog/tools/{offset}/{limit}`, `roslyn://server/catalog/prompts/{offset}/{limit}`, `roslyn://server/catalog-diff/{fromVersion}/{toVersion}`) now report failures over the JSON-RPC error channel, completing the `resources/read` protocol-error migration. Malformed pagination slots and unsupported catalog versions return `-32602` (`InvalidParams`) in both protocol eras; unexpected handler failures return a sanitized `-32603` carrying a correlation id. A caller-supplied non-absolute `filePath` on `source_file` now also classifies as caller fault (`-32602` instead of `-32603`). Error payloads carry only a stable category, remediation text, the requested resource URI, and a correlation id. The dead body-envelope wrappers (`ToolErrorHandler.ExecuteResource`/`ExecuteResourceAsync`) were deleted. **Migration:** clients that parsed `{"error":true,"category":...}` out of the resource body must read the JSON-RPC `error` member instead.

--- a/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
@@ -77,9 +77,12 @@ internal static class ResourceReadResultFilter
     private static McpErrorCode MapErrorCode(string category, bool useInvalidParamsForMissingResource) =>
         category switch
         {
-            "NotFound" or "FileNotFound" or "DirectoryNotFound" or "WorkspaceEvicted" =>
+            ToolErrorHandler.ErrorCategories.NotFound or
+            ToolErrorHandler.ErrorCategories.FileNotFound or
+            ToolErrorHandler.ErrorCategories.DirectoryNotFound or
+            ToolErrorHandler.ErrorCategories.WorkspaceEvicted =>
                 useInvalidParamsForMissingResource ? McpErrorCode.InvalidParams : McpErrorCode.ResourceNotFound,
-            "InvalidArgument" => McpErrorCode.InvalidParams,
+            ToolErrorHandler.ErrorCategories.InvalidArgument => McpErrorCode.InvalidParams,
             _ => McpErrorCode.InternalError,
         };
 

--- a/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
+++ b/src/RoslynMcp.Host.Stdio/Middleware/ResourceReadResultFilter.cs
@@ -69,20 +69,45 @@ internal static class ResourceReadResultFilter
         var cause = ex is McpToolException { InnerException: { } inner } ? inner : ex;
 
         var uri = context.Params?.Uri ?? "<unknown>";
-        var info = ToolErrorHandler.ClassifyError(cause, uri);
+        // Seed the classifier with the ambient per-message correlation id so the unexpected-
+        // failure fallback stamps the REAL id instead of its own "unavailable" sentinel (which,
+        // being non-null, would win the ?? in BuildSanitizedMessage and make the wire id dead).
+        var info = ToolErrorHandler.ClassifyError(cause, uri, RequestCorrelationContext.Current);
         var code = MapErrorCode(info.Category, RequestProtocolFeatureGate.UseInvalidParamsForMissingResource(context));
         return new McpProtocolException(BuildSanitizedMessage(info, uri), code);
     }
 
+    /// <summary>
+    /// Maps EVERY category <see cref="ToolErrorHandler.ClassifyError"/> can emit onto a wire
+    /// code. Each category gets an explicit arm — including the ones that resolve to
+    /// <see cref="McpErrorCode.InternalError"/> — so adding a new category to
+    /// <see cref="ToolErrorHandler.ErrorCategories"/> without deciding its wire code is a
+    /// compile-visible gap rather than a silent server-fault default. The trailing discard arm
+    /// exists only because <c>string</c> switches cannot be exhaustive; it is unreachable for
+    /// any declared category.
+    /// </summary>
     private static McpErrorCode MapErrorCode(string category, bool useInvalidParamsForMissingResource) =>
         category switch
         {
+            // Missing-resource family: era-dependent (-32002 legacy, -32602 from 2026-07-28).
             ToolErrorHandler.ErrorCategories.NotFound or
             ToolErrorHandler.ErrorCategories.FileNotFound or
             ToolErrorHandler.ErrorCategories.DirectoryNotFound or
             ToolErrorHandler.ErrorCategories.WorkspaceEvicted =>
                 useInvalidParamsForMissingResource ? McpErrorCode.InvalidParams : McpErrorCode.ResourceNotFound,
+            // Caller-input fault: always -32602.
             ToolErrorHandler.ErrorCategories.InvalidArgument => McpErrorCode.InvalidParams,
+            // Server-side / transport / lifecycle conditions. The caller's request was
+            // well-formed, so these are server faults (-32603) with a retry hint in the
+            // sanitized remediation text, not InvalidParams.
+            ToolErrorHandler.ErrorCategories.StaleWorkspaceTransition or
+            ToolErrorHandler.ErrorCategories.WorkspaceReloadedDuringCall or
+            ToolErrorHandler.ErrorCategories.PreviewTokenStale or
+            ToolErrorHandler.ErrorCategories.Timeout or
+            ToolErrorHandler.ErrorCategories.Disconnected or
+            ToolErrorHandler.ErrorCategories.RateLimited or
+            ToolErrorHandler.ErrorCategories.InvalidOperation or
+            ToolErrorHandler.ErrorCategories.InternalError => McpErrorCode.InternalError,
             _ => McpErrorCode.InternalError,
         };
 

--- a/src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/ServerResources.cs
@@ -46,7 +46,7 @@ public static class ServerResources
         [Description("0-based start index.")] string offset,
         [Description("Entries per page (1-200).")] string limit)
     {
-        return ToolErrorHandler.ExecuteResource(
+        return ToolErrorHandler.ExecuteResourceScope(
             "roslyn://server/catalog/tools/{offset}/{limit}",
             () =>
             {
@@ -64,7 +64,7 @@ public static class ServerResources
         [Description("0-based start index.")] string offset,
         [Description("Entries per page (1-200).")] string limit)
     {
-        return ToolErrorHandler.ExecuteResource(
+        return ToolErrorHandler.ExecuteResourceScope(
             "roslyn://server/catalog/prompts/{offset}/{limit}",
             () =>
             {
@@ -82,7 +82,7 @@ public static class ServerResources
         [Description("Source version, e.g. v2.3.1 or 2.3.1.")] string fromVersion,
         [Description("Target version, e.g. v2.3.2, 2.3.2, or current.")] string toVersion)
     {
-        return ToolErrorHandler.ExecuteResource(
+        return ToolErrorHandler.ExecuteResourceScope(
             "roslyn://server/catalog-diff/{fromVersion}/{toVersion}",
             () =>
             {

--- a/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
+++ b/src/RoslynMcp.Host.Stdio/Resources/WorkspaceResources.cs
@@ -179,8 +179,13 @@ public static class WorkspaceResources
                 var normalizedPath = NormalizeFilePathForResource(filePath);
                 if (!Path.IsPathFullyQualified(normalizedPath))
                 {
-                    throw new InvalidOperationException(
-                        $"filePath must be an absolute path after decoding. Received: {filePath}");
+                    // ArgumentException (not InvalidOperationException): a non-absolute
+                    // filePath is caller input at fault, so classification must yield
+                    // InvalidArgument -> JSON-RPC InvalidParams (-32602), never the
+                    // InternalError fallback (-32603). Mirrors GetSourceFileLines.
+                    throw new ArgumentException(
+                        $"filePath must be an absolute path after decoding. Received: {filePath}",
+                        nameof(filePath));
                 }
 
                 var text = await workspace.GetSourceTextAsync(workspaceId, normalizedPath, innerCt).ConfigureAwait(false);
@@ -190,7 +195,7 @@ public static class WorkspaceResources
             }, ct).ConfigureAwait(false);
         }
         catch (KeyNotFoundException ex) { throw new McpToolException(source, $"Not found: {ex.Message}", ex); }
-        catch (InvalidOperationException ex) { throw new McpToolException(source, $"Invalid operation: {ex.Message}", ex); }
+        catch (ArgumentException ex) { throw new McpToolException(source, $"Invalid argument: {ex.Message}", ex); }
     }
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
@@ -18,6 +17,23 @@ internal static class MetaSerializer
 
 internal static class ToolErrorHandler
 {
+    /// <summary>
+    /// Shared error-category constants for the categories that participate in wire-level
+    /// decisions. Declared next to the classification table below so
+    /// <c>ResourceReadResultFilter.MapErrorCode</c> consumes the SAME identifiers the
+    /// classifier emits — a renamed or typo'd category breaks the compile instead of
+    /// silently falling through to the <c>InternalError</c> wire code.
+    /// </summary>
+    internal static class ErrorCategories
+    {
+        public const string NotFound = "NotFound";
+        public const string FileNotFound = "FileNotFound";
+        public const string DirectoryNotFound = "DirectoryNotFound";
+        public const string WorkspaceEvicted = "WorkspaceEvicted";
+        public const string InvalidArgument = "InvalidArgument";
+        public const string InternalError = "InternalError";
+    }
+
     private static readonly Dictionary<Type, Func<Exception, string, ErrorInfo>> _errorHandlers = new()
     {
         // autoreload-cascade-stdio-host-crash: wraps a state-read that raced with (or followed)
@@ -33,20 +49,20 @@ internal static class ToolErrorHandler
         // miss; register it BEFORE the base entry so the more-specific category wins.
         [typeof(WorkspaceEvictedException)] = (ex, _) =>
         {
-            return new("WorkspaceEvicted",
+            return new(ErrorCategories.WorkspaceEvicted,
                 "The workspace session is no longer available because it was closed, evicted, or owned by a prior host process. " +
                 "Call workspace_load with the original solution or project path, then retry with the new workspaceId.");
         },
-        [typeof(FileNotFoundException)] = (_, _) => new("FileNotFound",
+        [typeof(FileNotFoundException)] = (_, _) => new(ErrorCategories.FileNotFound,
             "The requested file was not found. Verify the file path is absolute and the file exists on disk. " +
             "If the workspace was recently reloaded, the file may have been removed."),
-        [typeof(DirectoryNotFoundException)] = (_, _) => new("DirectoryNotFound",
+        [typeof(DirectoryNotFoundException)] = (_, _) => new(ErrorCategories.DirectoryNotFound,
             "The requested directory was not found. Verify the directory path is absolute and exists on disk."),
-        [typeof(KeyNotFoundException)] = (ex, _) => new("NotFound", BuildSafeNotFoundMessage(ex.Message)),
+        [typeof(KeyNotFoundException)] = (ex, _) => new(ErrorCategories.NotFound, BuildSafeNotFoundMessage(ex.Message)),
         [typeof(ArgumentException)] = (ex, _) =>
         {
             var argument = (ArgumentException)ex;
-            return new("InvalidArgument",
+            return new(ErrorCategories.InvalidArgument,
                 BuildSafeArgumentMessage(argument),
                 ParamName: argument.ParamName);
         },
@@ -101,13 +117,13 @@ internal static class ToolErrorHandler
     // casts to the typed exception internally to preserve ParamName extraction.
     private static readonly Dictionary<Type, Func<Exception, ErrorInfo>> _bindingLikeHandlers = new()
     {
-        [typeof(System.Text.Json.JsonException)] = _ => new("InvalidArgument",
+        [typeof(System.Text.Json.JsonException)] = _ => new(ErrorCategories.InvalidArgument,
             "Parameter binding failed during JSON deserialization. " +
             "Check that JSON property names match the tool schema exactly (camelCase)."),
         [typeof(ArgumentNullException)] = ex =>
         {
             var nullArgEx = (ArgumentNullException)ex;
-            return new("InvalidArgument",
+            return new(ErrorCategories.InvalidArgument,
                 $"Required parameter '{nullArgEx.ParamName ?? "<unknown>"}' is missing or null. " +
                 "Provide a value for this parameter and retry.",
                 ParamName: nullArgEx.ParamName);
@@ -115,106 +131,31 @@ internal static class ToolErrorHandler
         [typeof(ArgumentOutOfRangeException)] = ex =>
         {
             var rangeEx = (ArgumentOutOfRangeException)ex;
-            return new("InvalidArgument",
+            return new(ErrorCategories.InvalidArgument,
                 BuildSafeArgumentMessage(rangeEx),
                 ParamName: rangeEx.ParamName);
         },
         [typeof(ArgumentException)] = ex =>
         {
             var argEx = (ArgumentException)ex;
-            return new("InvalidArgument",
+            return new(ErrorCategories.InvalidArgument,
                 BuildSafeArgumentMessage(argEx),
                 ParamName: argEx.ParamName);
         },
-        [typeof(FormatException)] = _ => new("InvalidArgument",
+        [typeof(FormatException)] = _ => new(ErrorCategories.InvalidArgument,
             "A parameter value has an invalid format. " +
             "Check that values match the expected format (e.g., integers, booleans, paths)."),
     };
 
     /// <summary>
-    /// Wraps a synchronous resource action with structured error handling, returning the same
-    /// error envelope shape as <see cref="ExecuteAsync"/> so JSON-MIME resources surface a
-    /// well-formed error document with the correct <c>tool</c> field instead of bubbling an
-    /// exception that the framework labels as <c>tool: "unknown"</c>. The <paramref name="source"/>
-    /// is the resource URI (or its template form) that originated the call.
-    /// </summary>
-    public static string ExecuteResource(string source, Func<string> action, ILogger? auditLogger = null)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(source);
-
-        using var metricsScope = AmbientGateMetrics.BeginRequest();
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        try
-        {
-            var result = action();
-            stopwatch.Stop();
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.ElapsedMs = stopwatch.ElapsedMilliseconds;
-            }
-            return InjectMetaIfPossible(result, source);
-        }
-        catch (Exception ex)
-        {
-            stopwatch.Stop();
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.ElapsedMs = stopwatch.ElapsedMilliseconds;
-            }
-            var info = ClassifyError(ex, source);
-            auditLogger?.Log(
-                info.Category == "InternalError" ? LogLevel.Error : LogLevel.Warning,
-                ex, "Resource {Source} failed: {ErrorCategory}", source, info.Category);
-            return InjectMetaIfPossible(FormatErrorResponse(info, source, ex), source);
-        }
-    }
-
-    /// <summary>
-    /// Async variant of <see cref="ExecuteResource"/> for awaitable resource handlers.
-    /// </summary>
-    public static async Task<string> ExecuteResourceAsync(string source, Func<Task<string>> action, ILogger? auditLogger = null)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(source);
-
-        using var metricsScope = AmbientGateMetrics.BeginRequest();
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        try
-        {
-            var result = await action().ConfigureAwait(false);
-            stopwatch.Stop();
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.ElapsedMs = stopwatch.ElapsedMilliseconds;
-            }
-            return InjectMetaIfPossible(result, source);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            stopwatch.Stop();
-            if (AmbientGateMetrics.Current is { } metrics)
-            {
-                metrics.ElapsedMs = stopwatch.ElapsedMilliseconds;
-            }
-            var info = ClassifyError(ex, source);
-            auditLogger?.Log(
-                info.Category == "InternalError" ? LogLevel.Error : LogLevel.Warning,
-                ex, "Resource {Source} failed: {ErrorCategory}", source, info.Category);
-            return InjectMetaIfPossible(FormatErrorResponse(info, source, ex), source);
-        }
-    }
-
-    /// <summary>
-    /// Success-only sibling of <see cref="ExecuteResource"/> for resource handlers whose
-    /// failures travel over the JSON-RPC error channel: keeps the ambient gate-metrics scope
-    /// and success-path <c>_meta</c> injection, but has NO catch arm — every exception
-    /// propagates to <c>ResourceReadResultFilter</c>, which translates it into a protocol
-    /// error (<c>McpProtocolException</c>) instead of a serialized error document in the
-    /// resource body. Elapsed time is recorded in a <see langword="finally"/> so failed
-    /// reads still stamp <c>ElapsedMs</c> on the ambient metrics.
+    /// Success-only scope for resource handlers: failures travel over the JSON-RPC error
+    /// channel. Keeps the ambient gate-metrics scope and success-path <c>_meta</c> injection,
+    /// but has NO catch arm — every exception propagates to <c>ResourceReadResultFilter</c>,
+    /// which translates it into a protocol error (<c>McpProtocolException</c>) instead of a
+    /// serialized error document in the resource body. Elapsed time is stamped on the success
+    /// path only: on failure the ambient <c>AmbientGateMetrics</c> scope disposes before the
+    /// read filter observes the exception and nothing reads the AsyncLocal snapshot again, so
+    /// a failure-path stamp would be write-only.
     /// </summary>
     public static string ExecuteResourceScope(string source, Func<string> action)
     {
@@ -222,18 +163,10 @@ internal static class ToolErrorHandler
 
         using var metricsScope = AmbientGateMetrics.BeginRequest();
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        try
-        {
-            var result = action();
-            // Stamp elapsed BEFORE _meta injection so the success snapshot carries it;
-            // the finally re-stamp is idempotent (Stopwatch freezes on first Stop).
-            RecordElapsed(stopwatch);
-            return InjectMetaIfPossible(result, source);
-        }
-        finally
-        {
-            RecordElapsed(stopwatch);
-        }
+        var result = action();
+        // Stamp elapsed BEFORE _meta injection so the success snapshot carries it.
+        RecordElapsed(stopwatch);
+        return InjectMetaIfPossible(result, source);
     }
 
     /// <summary>
@@ -245,16 +178,9 @@ internal static class ToolErrorHandler
 
         using var metricsScope = AmbientGateMetrics.BeginRequest();
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        try
-        {
-            var result = await action().ConfigureAwait(false);
-            RecordElapsed(stopwatch);
-            return InjectMetaIfPossible(result, source);
-        }
-        finally
-        {
-            RecordElapsed(stopwatch);
-        }
+        var result = await action().ConfigureAwait(false);
+        RecordElapsed(stopwatch);
+        return InjectMetaIfPossible(result, source);
     }
 
     private static void RecordElapsed(System.Diagnostics.Stopwatch stopwatch)
@@ -632,7 +558,7 @@ internal static class ToolErrorHandler
 
     internal static string FormatErrorResponse(ErrorInfo info, string toolName, Exception ex)
     {
-        if (info.Category == "InternalError")
+        if (info.Category == ErrorCategories.InternalError)
         {
             return new JsonObject
             {
@@ -663,7 +589,7 @@ internal static class ToolErrorHandler
         // server_info. Hint is omitted (rather than emitted as null) when the failing
         // parameter cannot be resolved against the tool catalog — keeps the envelope
         // shape stable for downstream parsers that do not expect the field.
-        var schemaHint = info.Category == "InvalidArgument"
+        var schemaHint = info.Category == ErrorCategories.InvalidArgument
             ? BuildSchemaHint(toolName, info.ParamName)
             : null;
 

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -18,11 +18,17 @@ internal static class MetaSerializer
 internal static class ToolErrorHandler
 {
     /// <summary>
-    /// Shared error-category constants for the categories that participate in wire-level
-    /// decisions. Declared next to the classification table below so
-    /// <c>ResourceReadResultFilter.MapErrorCode</c> consumes the SAME identifiers the
-    /// classifier emits — a renamed or typo'd category breaks the compile instead of
-    /// silently falling through to the <c>InternalError</c> wire code.
+    /// The COMPLETE set of error categories this classifier can emit. Every category the
+    /// classification tables (and <see cref="ClassifyError"/>'s post-classification hooks)
+    /// produce is declared here, and <c>ResourceReadResultFilter.MapErrorCode</c> gives each
+    /// one an explicit switch arm. Two consequences, both deliberate:
+    /// <list type="bullet">
+    ///   <item><description>A renamed or typo'd category breaks the compile instead of
+    ///         silently falling through to the <c>InternalError</c> wire code.</description></item>
+    ///   <item><description>A NEWLY ADDED category must be declared here and given an explicit
+    ///         wire-code arm, so "is this a caller fault (-32602) or a server fault (-32603)?"
+    ///         is a compile-visible decision rather than a silent default.</description></item>
+    /// </list>
     /// </summary>
     internal static class ErrorCategories
     {
@@ -32,6 +38,13 @@ internal static class ToolErrorHandler
         public const string WorkspaceEvicted = "WorkspaceEvicted";
         public const string InvalidArgument = "InvalidArgument";
         public const string InternalError = "InternalError";
+        public const string StaleWorkspaceTransition = "StaleWorkspaceTransition";
+        public const string Timeout = "Timeout";
+        public const string PreviewTokenStale = "PreviewTokenStale";
+        public const string Disconnected = "Disconnected";
+        public const string RateLimited = "RateLimited";
+        public const string InvalidOperation = "InvalidOperation";
+        public const string WorkspaceReloadedDuringCall = "WorkspaceReloadedDuringCall";
     }
 
     private static readonly Dictionary<Type, Func<Exception, string, ErrorInfo>> _errorHandlers = new()
@@ -39,7 +52,7 @@ internal static class ToolErrorHandler
         // autoreload-cascade-stdio-host-crash: wraps a state-read that raced with (or followed)
         // an auto-reload transition. Registered BEFORE the generic Exception handlers so the
         // structured category wins over the dictionary walk's InvalidOperation fallback.
-        [typeof(StaleWorkspaceTransitionException)] = (_, _) => new("StaleWorkspaceTransition",
+        [typeof(StaleWorkspaceTransitionException)] = (_, _) => new(ErrorCategories.StaleWorkspaceTransition,
             "Workspace is transitioning between snapshots. Retry the request against the refreshed workspace."),
         // mcp-error-category-workspace-evicted-on-host-recycle: a workspace lookup miss that
         // originated from a host recycle (graceful prior-process exit) or an explicit Close.
@@ -66,7 +79,7 @@ internal static class ToolErrorHandler
                 BuildSafeArgumentMessage(argument),
                 ParamName: argument.ParamName);
         },
-        [typeof(TimeoutException)] = (_, _) => new("Timeout",
+        [typeof(TimeoutException)] = (_, _) => new(ErrorCategories.Timeout,
             "The operation timed out. For build/test operations, increase ROSLYNMCP_BUILD_TIMEOUT_SECONDS or " +
             "ROSLYNMCP_TEST_TIMEOUT_SECONDS. For other operations, increase ROSLYNMCP_REQUEST_TIMEOUT_SECONDS."),
         // preview-token-stale-across-auto-reload: a *_apply call whose paired preview was
@@ -81,7 +94,7 @@ internal static class ToolErrorHandler
         // is intact and the client just needs to re-issue the paired *_preview call.
         [typeof(PreviewTokenStaleException)] = (ex, _) =>
         {
-            return new("PreviewTokenStale",
+            return new(ErrorCategories.PreviewTokenStale,
                 "The preview token has expired because the workspace was reloaded after the preview was created. " +
                 "Re-issue the paired *_preview call.");
         },
@@ -95,14 +108,14 @@ internal static class ToolErrorHandler
         {
             if (ex.Message.Contains("Not connected", StringComparison.OrdinalIgnoreCase))
             {
-                return new("Disconnected",
+                return new(ErrorCategories.Disconnected,
                     "The stdio transport disconnected because the MCP client closed the pipe. " +
                     "Reconnect and call workspace_reload to restore the session.");
             }
 
             return ex.Message.Contains("Rate limit")
-                ? new("RateLimited", "The request rate limit was exceeded. Wait for the current rate-limit window to reset, then retry.")
-                : new("InvalidOperation",
+                ? new(ErrorCategories.RateLimited, "The request rate limit was exceeded. Wait for the current rate-limit window to reset, then retry.")
+                : new(ErrorCategories.InvalidOperation,
                     ShouldSuggestReloadAfterInvalidOperation(ex.Message)
                         ? "The operation is not valid for the current workspace state. Call workspace_reload if the state is stale, then retry."
                         : "The operation is not valid in the current state. Check the tool contract and retry.");
@@ -304,7 +317,7 @@ internal static class ToolErrorHandler
             AmbientGateMetrics.Current?.StaleAction == "auto-reloaded" &&
             AmbientGateMetrics.Current?.ReloadConfirmedNotFound != true)
         {
-            info = new("WorkspaceReloadedDuringCall",
+            info = new(ErrorCategories.WorkspaceReloadedDuringCall,
                 "The workspace was auto-reloaded during this call. The symbol handle " +
                 "or metadata name may target the pre-reload compilation. Re-resolve the symbol " +
                 "(e.g. via symbol_search, symbol_info, or a fresh position-based locator) and retry. " +

--- a/tests/RoslynMcp.Tests/ResourceReadWireContractTests.cs
+++ b/tests/RoslynMcp.Tests/ResourceReadWireContractTests.cs
@@ -1,0 +1,379 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Catalog;
+using RoslynMcp.Host.Stdio.Middleware;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// resource-read-protocol-error-semantics (parts 1 + 2): table-driven raw JSON-RPC
+/// <c>resources/read</c> failure matrix across BOTH resource families (workspace + server
+/// catalog) and BOTH protocol eras (2025-11-25 and 2026-07-28). Pins, at the wire level:
+/// <list type="bullet">
+///   <item>NotFound → <c>-32002</c> (ResourceNotFound) under 2025-11-25 and <c>-32602</c>
+///         (InvalidParams) under 2026-07-28, including the <c>source_file</c>
+///         <c>McpToolException</c> wrapper whose INNER <c>KeyNotFoundException</c> must drive
+///         classification (a regression to the InternalError fallback surfaces as
+///         <c>-32603</c> and fails these rows).</item>
+///   <item>Caller-input faults (malformed <c>lineRange</c>, non-absolute <c>filePath</c>,
+///         malformed pagination slots, unsupported catalog-diff versions) → <c>-32602</c> in
+///         both eras.</item>
+///   <item>An unexpected handler failure → sanitized <c>-32603</c> carrying a correlation id
+///         but no exception type name, stack frame, or absolute server-side path. The
+///         forbidden-path probe compares against the JSON-ESCAPED form of the path — a raw
+///         single-backslash <c>Contains</c> can never match a serialized frame and would be a
+///         dead assertion (see the falsifiability self-check).</item>
+///   <item>Failed reads answer on the JSON-RPC error channel: the response frame carries an
+///         <c>error</c> member and NO <c>result.contents</c> body.</item>
+///   <item>One success row pins that <c>TimeToLive</c>/<c>CacheScope</c> normalization still
+///         applies to migrated endpoints (hints present under 2026-07-28, absent under
+///         2025-11-25).</item>
+/// </list>
+/// </summary>
+[TestClass]
+public sealed class ResourceReadWireContractTests
+{
+    private const string WorkspaceId = "ws-wire";
+    private const string SecretServerPath = @"C:\secret-server\Internals.cs";
+
+    private sealed record FailureCase(
+        string Label,
+        string Uri,
+        int LegacyCode,
+        int July2026Code,
+        string MessageMustContain,
+        string[] ForbiddenLiterals);
+
+    private static readonly FailureCase[] _failureCases =
+    [
+        // Workspace family — source_file wraps its causes in McpToolException; the filter
+        // must classify the INNER KeyNotFoundException (NotFound), not the wrapper
+        // (InternalError fallback → -32603, which fails this row in both eras).
+        new("workspace/source_file NotFound (McpToolException inner KeyNotFoundException)",
+            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CMissing.cs",
+            LegacyCode: -32002,
+            July2026Code: -32602,
+            MessageMustContain: "NotFound",
+            ForbiddenLiterals: ["KeyNotFoundException", "McpToolException"]),
+        new("workspace/source_file_lines malformed lineRange",
+            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CPresent.cs/lines/abc-def",
+            LegacyCode: -32602,
+            July2026Code: -32602,
+            // "param: lineRange" proves the HANDLER's validation fired — an SDK binding
+            // failure also produces InvalidArgument/-32602 but names "param: arguments".
+            MessageMustContain: "param: lineRange",
+            ForbiddenLiterals: ["ArgumentException"]),
+        new("workspace/source_file non-absolute filePath is caller fault (-32602, never -32603)",
+            "roslyn://workspace/" + WorkspaceId + "/file/not-absolute.cs",
+            LegacyCode: -32602,
+            July2026Code: -32602,
+            MessageMustContain: "param: filePath",
+            ForbiddenLiterals: ["ArgumentException", "InvalidOperation"]),
+        new("workspace/source_file unexpected handler failure is sanitized",
+            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CBoom.cs",
+            LegacyCode: -32603,
+            July2026Code: -32603,
+            MessageMustContain: "correlationId",
+            ForbiddenLiterals: ["NotImplementedException", "Internals.cs", "   at "]),
+        // Server-catalog family — the three call sites migrated by part 2.
+        new("catalog/tools page malformed offset slot",
+            "roslyn://server/catalog/tools/abc/50",
+            LegacyCode: -32602,
+            July2026Code: -32602,
+            MessageMustContain: "param: offset",
+            ForbiddenLiterals: ["ArgumentException"]),
+        new("catalog/prompts page malformed limit slot",
+            "roslyn://server/catalog/prompts/0/xyz",
+            LegacyCode: -32602,
+            July2026Code: -32602,
+            MessageMustContain: "param: limit",
+            ForbiddenLiterals: ["ArgumentException"]),
+        new("catalog-diff unsupported version pair",
+            "roslyn://server/catalog-diff/v2.3.0/current",
+            LegacyCode: -32602,
+            July2026Code: -32602,
+            MessageMustContain: "Unsupported catalog diff",
+            // The raw ArgumentException message echoes the pair as 'v2.3.0' -> 'current';
+            // the sanitized remediation must not. (The bare version string still appears in
+            // the echoed *request URI*, which is caller-supplied and allowed.)
+            ForbiddenLiterals: ["ArgumentException", "'v2.3.0' ->"]),
+    ];
+
+    [TestMethod]
+    public async Task ResourceRead_FailureMatrix_AnswersOnErrorChannelWithEraCorrectCodes()
+    {
+        var protocols = new (string? RequestedVersion, string ExpectedVersion, bool SupportsJuly2026Features)[]
+        {
+            ("2025-11-25", "2025-11-25", false),
+            (null, "2026-07-28", true),
+        };
+
+        foreach (var protocol in protocols)
+        {
+            await using var harness = await CreateHarnessAsync(protocol.RequestedVersion, protocol.ExpectedVersion);
+            Assert.AreEqual(protocol.ExpectedVersion, harness.Client.NegotiatedProtocolVersion);
+
+            foreach (var failureCase in _failureCases)
+            {
+                var label = $"[{protocol.ExpectedVersion}] {failureCase.Label}";
+                var before = harness.RawServerMessages.Count;
+
+                McpException? clientError = null;
+                try
+                {
+                    _ = await harness.Client.ReadResourceAsync(
+                        new ReadResourceRequestParams { Uri = failureCase.Uri },
+                        CancellationToken.None);
+                }
+                catch (McpException ex)
+                {
+                    clientError = ex;
+                }
+
+                Assert.IsNotNull(clientError, $"{label}: expected a JSON-RPC protocol error, got a successful result.");
+
+                var rawFrame = FindSingleNewResponseFrame(harness.RawServerMessages, before, label);
+                using var frame = JsonDocument.Parse(rawFrame);
+                var root = frame.RootElement;
+
+                // Failure answers on the error channel: an `error` member and NO `result`
+                // (so no `result.contents` body carrying a serialized error document).
+                Assert.IsTrue(root.TryGetProperty("error", out var error),
+                    $"{label}: response frame carries no `error` member: {rawFrame}");
+                Assert.IsFalse(root.TryGetProperty("result", out _),
+                    $"{label}: failed read must not carry `result` (contents body): {rawFrame}");
+
+                var expectedCode = protocol.SupportsJuly2026Features ? failureCase.July2026Code : failureCase.LegacyCode;
+                Assert.AreEqual(expectedCode, error.GetProperty("code").GetInt32(),
+                    $"{label}: wrong JSON-RPC error code. Frame: {rawFrame}");
+
+                var message = error.GetProperty("message").GetString() ?? string.Empty;
+                StringAssert.Contains(message, failureCase.MessageMustContain, $"{label}: message '{message}'");
+                StringAssert.Contains(message, "correlationId", $"{label}: message must carry a correlation id");
+
+                foreach (var forbidden in failureCase.ForbiddenLiterals)
+                {
+                    Assert.IsFalse(rawFrame.Contains(forbidden, StringComparison.Ordinal),
+                        $"{label}: frame leaks forbidden literal '{forbidden}': {rawFrame}");
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task ResourceRead_UnexpectedFailure_NeverLeaksServerSidePath_EscapedProbeIsFalsifiable()
+    {
+        // A serialized JSON frame escapes backslashes, so a raw single-backslash Contains can
+        // NEVER match even when the path genuinely leaks. Build the probe in the frame's own
+        // encoding and prove it is falsifiable before trusting the negative assertion.
+        var escapedPathProbe = JsonSerializer.Serialize(SecretServerPath).Trim('"');
+        Assert.AreNotEqual(SecretServerPath, escapedPathProbe,
+            "Probe self-check: the JSON-escaped form must differ from the raw path (backslashes escape).");
+        StringAssert.Contains(
+            JsonSerializer.Serialize(new { message = $"boom at {SecretServerPath}" }),
+            escapedPathProbe,
+            "Probe self-check: a deliberately leaked frame MUST match the escaped probe — " +
+            "otherwise the negative assertion below is dead.");
+
+        await using var harness = await CreateHarnessAsync(requestedVersion: null, expectedVersion: "2026-07-28");
+        var before = harness.RawServerMessages.Count;
+
+        await Assert.ThrowsAsync<McpException>(async () =>
+            _ = await harness.Client.ReadResourceAsync(
+                new ReadResourceRequestParams { Uri = "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CBoom.cs" },
+                CancellationToken.None));
+
+        var rawFrame = FindSingleNewResponseFrame(harness.RawServerMessages, before, "sanitized -32603");
+        using var frame = JsonDocument.Parse(rawFrame);
+        Assert.AreEqual(-32603, frame.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.IsFalse(rawFrame.Contains(escapedPathProbe, StringComparison.Ordinal),
+            $"-32603 frame leaks the server-side path (escaped probe matched): {rawFrame}");
+        Assert.IsFalse(rawFrame.Contains("NotImplementedException", StringComparison.Ordinal),
+            $"-32603 frame leaks the exception type name: {rawFrame}");
+    }
+
+    [TestMethod]
+    public async Task ResourceRead_MigratedEndpointSuccess_KeepsCacheHintNormalizationPerEra()
+    {
+        var protocols = new (string? RequestedVersion, string ExpectedVersion, bool SupportsJuly2026Features)[]
+        {
+            ("2025-11-25", "2025-11-25", false),
+            (null, "2026-07-28", true),
+        };
+
+        foreach (var protocol in protocols)
+        {
+            await using var harness = await CreateHarnessAsync(protocol.RequestedVersion, protocol.ExpectedVersion);
+            var before = harness.RawServerMessages.Count;
+
+            var result = await harness.Client.ReadResourceAsync(
+                new ReadResourceRequestParams { Uri = "roslyn://server/catalog/tools/0/5" },
+                CancellationToken.None);
+            Assert.AreEqual(1, result.Contents.Count);
+
+            var rawFrame = FindSingleNewResponseFrame(
+                harness.RawServerMessages, before, $"[{protocol.ExpectedVersion}] tools page success");
+            using var frame = JsonDocument.Parse(rawFrame);
+            var resultElement = frame.RootElement.GetProperty("result");
+            Assert.IsTrue(resultElement.TryGetProperty("contents", out _),
+                $"success frame must carry result.contents: {rawFrame}");
+
+            if (protocol.SupportsJuly2026Features)
+            {
+                Assert.AreEqual(0L, resultElement.GetProperty("ttlMs").GetInt64(),
+                    "2026-07-28 read must stamp ttlMs=0 (immediately stale).");
+                Assert.AreEqual("private", resultElement.GetProperty("cacheScope").GetString());
+            }
+            else
+            {
+                Assert.IsFalse(resultElement.TryGetProperty("ttlMs", out _),
+                    "2025-11-25 read must not carry ttlMs.");
+                Assert.IsFalse(resultElement.TryGetProperty("cacheScope", out _),
+                    "2025-11-25 read must not carry cacheScope.");
+            }
+        }
+    }
+
+    private static async Task<InMemoryMcpClientServerHarness> CreateHarnessAsync(
+        string? requestedVersion, string expectedVersion)
+    {
+        var selection = ToolTierSelection.All;
+        var gate = new PassThroughGate();
+        var manager = new ScriptedWorkspaceManager();
+        var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
+        var hostAssembly = typeof(RoslynMcp.Host.Stdio.HostAssemblyMarker).Assembly;
+        // The fakes must be registered in the HOST builder (used at resource-registration
+        // time, where the SDK decides which handler parameters are DI-injected) AND in the
+        // per-request server services below — with only the request-side registration the
+        // binder treats `gate`/`workspace` as missing caller arguments and every read fails
+        // as InvalidParams before reaching the handler.
+        builder.Services.AddSingleton<IWorkspaceExecutionGate>(gate);
+        builder.Services.AddSingleton<IWorkspaceManager>(manager);
+        builder.Services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new Implementation { Name = "roslyn-mcp-test", Version = "1.0.0" };
+            })
+            .WithToolsFromAssembly(hostAssembly)
+            .WithResourcesFromAssembly(hostAssembly)
+            .WithPromptsFromAssembly(hostAssembly)
+            .WithRequestFilters(filters => filters.AddReadResourceFilter(ResourceReadResultFilter.Create));
+        builder.Services.AddRoslynMcpSurfaceRegistrationPolicy(selection);
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<McpServerOptions>>().Value;
+
+        return await InMemoryMcpClientServerHarness.CreateAsync(
+            transportName: $"resource-read-wire-{expectedVersion}",
+            clientCapabilities: new ClientCapabilities(),
+            clientHandlers: new McpClientHandlers(),
+            disposalFailureContext: $"resource-read-wire-{expectedVersion}",
+            cancellationToken: CancellationToken.None,
+            protocolVersion: requestedVersion,
+            serverOptions: options,
+            serverServicesFactory: () => new ServiceCollection()
+                .AddSingleton(selection)
+                .AddSingleton<IWorkspaceExecutionGate>(gate)
+                .AddSingleton<IWorkspaceManager>(manager)
+                .BuildServiceProvider(),
+            captureServerMessages: true);
+    }
+
+    /// <summary>
+    /// Finds the single JSON-RPC response frame (a top-level object with an <c>id</c> plus a
+    /// <c>result</c> or <c>error</c> member) written by the server after <paramref name="skip"/>.
+    /// </summary>
+    private static string FindSingleNewResponseFrame(IReadOnlyList<string> messages, int skip, string label)
+    {
+        var responses = new List<string>();
+        for (var i = skip; i < messages.Count; i++)
+        {
+            using var document = JsonDocument.Parse(messages[i]);
+            var root = document.RootElement;
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("id", out _) &&
+                (root.TryGetProperty("result", out _) || root.TryGetProperty("error", out _)))
+            {
+                responses.Add(messages[i]);
+            }
+        }
+
+        Assert.AreEqual(1, responses.Count, $"{label}: expected exactly one new response frame.");
+        return responses[0];
+    }
+
+    /// <summary>
+    /// Pass-through read gate: runs the action directly so handler-thrown exceptions reach the
+    /// read filter unmodified. Write/lifecycle verbs throw to fail loudly if a resource handler
+    /// ever routes through them.
+    /// </summary>
+    private sealed class PassThroughGate : IWorkspaceExecutionGate
+    {
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct) =>
+            action(ct);
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true) =>
+            throw new NotSupportedException("Resource reads must not route through RunWriteAsync.");
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct) =>
+            throw new NotSupportedException("Resource reads must not route through RunLoadGateAsync.");
+
+        public void RemoveGate(string workspaceId) =>
+            throw new NotSupportedException("Resource reads must not call RemoveGate.");
+    }
+
+    /// <summary>
+    /// Scripted <see cref="IWorkspaceManager"/> for the wire matrix: <c>GetSourceTextAsync</c>
+    /// resolves by file name — <c>Present.cs</c> returns text, <c>Missing.cs</c> returns
+    /// <see langword="null"/> (handler raises <see cref="KeyNotFoundException"/>), and
+    /// <c>Boom.cs</c> throws an unexpected exception whose message deliberately embeds an
+    /// absolute server-side path that must never reach the wire.
+    /// </summary>
+    private sealed class ScriptedWorkspaceManager : IWorkspaceManager
+    {
+        public event Action<string>? WorkspaceClosed { add { } remove { } }
+        public event Action<string>? WorkspaceReloaded { add { } remove { } }
+
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct)
+        {
+            if (filePath.EndsWith("Boom.cs", StringComparison.Ordinal))
+            {
+                throw new NotImplementedException($"handler blew up at {SecretServerPath} line 42");
+            }
+
+            return Task.FromResult(filePath.EndsWith("Present.cs", StringComparison.Ordinal)
+                ? "// present\nclass C { }\n"
+                : (string?)null);
+        }
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool ContainsWorkspace(string workspaceId) => workspaceId == WorkspaceId;
+        public bool IsStale(string workspaceId) => false;
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => [];
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public int GetCurrentVersion(string workspaceId) => throw new NotSupportedException();
+        public void RestoreVersion(string workspaceId, int version) => throw new NotSupportedException();
+        public Solution GetCurrentSolution(string workspaceId) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+    }
+}

--- a/tests/RoslynMcp.Tests/ResourceReadWireContractTests.cs
+++ b/tests/RoslynMcp.Tests/ResourceReadWireContractTests.cs
@@ -44,7 +44,40 @@ namespace RoslynMcp.Tests;
 public sealed class ResourceReadWireContractTests
 {
     private const string WorkspaceId = "ws-wire";
+
+    /// <summary>
+    /// A server-side path SHAPE that must never reach the wire. Deliberately Windows-shaped on
+    /// every OS: it is a literal embedded in the scripted manager's exception message (never
+    /// resolved against the filesystem), so keeping it constant keeps the leak probe's escaped
+    /// form — and its falsifiability self-check — identical on both CI legs.
+    /// </summary>
     private const string SecretServerPath = @"C:\secret-server\Internals.cs";
+
+    /// <summary>
+    /// Fixture root for the workspace-family rows, derived per-OS. The handlers precondition on
+    /// <see cref="Path.IsPathFullyQualified"/>, and Unix rooting requires a leading <c>/</c> —
+    /// a hardcoded <c>C:\ws\</c> is NOT fully qualified on Linux, so every workspace row would
+    /// short-circuit to InvalidArgument/-32602 before reaching the scripted manager and the
+    /// era-correct codes (-32002 / -32603) would never be exercised on the ubuntu leg.
+    /// </summary>
+    private static readonly string _fixtureRoot = OperatingSystem.IsWindows() ? @"C:\ws\" : "/ws/";
+
+    /// <summary>
+    /// URL-encoded <c>{filePath}</c> segment for a fixture file. Encoding at build time keeps
+    /// the URI legal on both legs (Windows <c>:</c>/<c>\</c> and Unix <c>/</c> are all reserved
+    /// in the segment grammar); the handler's normalizer decodes it back.
+    /// </summary>
+    private static string FileSegment(string fileName) => Uri.EscapeDataString(_fixtureRoot + fileName);
+
+    /// <summary>
+    /// The two negotiated protocol eras every wire assertion runs under. Shared by the failure
+    /// matrix and the success row so a new era is added in exactly one place.
+    /// </summary>
+    private static readonly (string? RequestedVersion, string ExpectedVersion, bool SupportsJuly2026Features)[] _protocolEras =
+    [
+        ("2025-11-25", "2025-11-25", false),
+        (null, "2026-07-28", true),
+    ];
 
     private sealed record FailureCase(
         string Label,
@@ -60,13 +93,13 @@ public sealed class ResourceReadWireContractTests
         // must classify the INNER KeyNotFoundException (NotFound), not the wrapper
         // (InternalError fallback → -32603, which fails this row in both eras).
         new("workspace/source_file NotFound (McpToolException inner KeyNotFoundException)",
-            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CMissing.cs",
+            "roslyn://workspace/" + WorkspaceId + "/file/" + FileSegment("Missing.cs"),
             LegacyCode: -32002,
             July2026Code: -32602,
             MessageMustContain: "NotFound",
             ForbiddenLiterals: ["KeyNotFoundException", "McpToolException"]),
         new("workspace/source_file_lines malformed lineRange",
-            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CPresent.cs/lines/abc-def",
+            "roslyn://workspace/" + WorkspaceId + "/file/" + FileSegment("Present.cs") + "/lines/abc-def",
             LegacyCode: -32602,
             July2026Code: -32602,
             // "param: lineRange" proves the HANDLER's validation fired — an SDK binding
@@ -80,7 +113,7 @@ public sealed class ResourceReadWireContractTests
             MessageMustContain: "param: filePath",
             ForbiddenLiterals: ["ArgumentException", "InvalidOperation"]),
         new("workspace/source_file unexpected handler failure is sanitized",
-            "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CBoom.cs",
+            "roslyn://workspace/" + WorkspaceId + "/file/" + FileSegment("Boom.cs"),
             LegacyCode: -32603,
             July2026Code: -32603,
             MessageMustContain: "correlationId",
@@ -112,13 +145,7 @@ public sealed class ResourceReadWireContractTests
     [TestMethod]
     public async Task ResourceRead_FailureMatrix_AnswersOnErrorChannelWithEraCorrectCodes()
     {
-        var protocols = new (string? RequestedVersion, string ExpectedVersion, bool SupportsJuly2026Features)[]
-        {
-            ("2025-11-25", "2025-11-25", false),
-            (null, "2026-07-28", true),
-        };
-
-        foreach (var protocol in protocols)
+        foreach (var protocol in _protocolEras)
         {
             await using var harness = await CreateHarnessAsync(protocol.RequestedVersion, protocol.ExpectedVersion);
             Assert.AreEqual(protocol.ExpectedVersion, harness.Client.NegotiatedProtocolVersion);
@@ -159,7 +186,7 @@ public sealed class ResourceReadWireContractTests
 
                 var message = error.GetProperty("message").GetString() ?? string.Empty;
                 StringAssert.Contains(message, failureCase.MessageMustContain, $"{label}: message '{message}'");
-                StringAssert.Contains(message, "correlationId", $"{label}: message must carry a correlation id");
+                AssertCarriesRealCorrelationId(message, label);
 
                 foreach (var forbidden in failureCase.ForbiddenLiterals)
                 {
@@ -190,7 +217,7 @@ public sealed class ResourceReadWireContractTests
 
         await Assert.ThrowsAsync<McpException>(async () =>
             _ = await harness.Client.ReadResourceAsync(
-                new ReadResourceRequestParams { Uri = "roslyn://workspace/" + WorkspaceId + "/file/C%3A%5Cws%5CBoom.cs" },
+                new ReadResourceRequestParams { Uri = "roslyn://workspace/" + WorkspaceId + "/file/" + FileSegment("Boom.cs") },
                 CancellationToken.None));
 
         var rawFrame = FindSingleNewResponseFrame(harness.RawServerMessages, before, "sanitized -32603");
@@ -205,13 +232,7 @@ public sealed class ResourceReadWireContractTests
     [TestMethod]
     public async Task ResourceRead_MigratedEndpointSuccess_KeepsCacheHintNormalizationPerEra()
     {
-        var protocols = new (string? RequestedVersion, string ExpectedVersion, bool SupportsJuly2026Features)[]
-        {
-            ("2025-11-25", "2025-11-25", false),
-            (null, "2026-07-28", true),
-        };
-
-        foreach (var protocol in protocols)
+        foreach (var protocol in _protocolEras)
         {
             await using var harness = await CreateHarnessAsync(protocol.RequestedVersion, protocol.ExpectedVersion);
             var before = harness.RawServerMessages.Count;
@@ -267,6 +288,11 @@ public sealed class ResourceReadWireContractTests
             .WithToolsFromAssembly(hostAssembly)
             .WithResourcesFromAssembly(hostAssembly)
             .WithPromptsFromAssembly(hostAssembly)
+            // Production parity (Program.cs): the incoming-message filter is what opens the
+            // per-message RequestCorrelationContext scope. WITHOUT it every sanitized error
+            // frame renders the literal "unavailable", and any assertion that merely looks for
+            // the word "correlationId" passes on the hardcoded label alone — a dead assertion.
+            .WithMessageFilters(filters => filters.AddIncomingFilter(RequestCorrelationMessageFilter.Create))
             .WithRequestFilters(filters => filters.AddReadResourceFilter(ResourceReadResultFilter.Create));
         builder.Services.AddRoslynMcpSurfaceRegistrationPolicy(selection);
         using var host = builder.Build();
@@ -286,6 +312,30 @@ public sealed class ResourceReadWireContractTests
                 .AddSingleton<IWorkspaceManager>(manager)
                 .BuildServiceProvider(),
             captureServerMessages: true);
+    }
+
+    /// <summary>
+    /// Asserts the sanitized error message carries a REAL correlation id — a 32-char lowercase
+    /// hex <c>Guid("N")</c> minted by <c>RequestCorrelationContext.Begin()</c> — and explicitly
+    /// NOT the <c>"unavailable"</c> no-context sentinel. Asserting only that the word
+    /// "correlationId" appears is satisfied by the hardcoded label in the message template and
+    /// can never fail.
+    /// </summary>
+    private static void AssertCarriesRealCorrelationId(string message, string label)
+    {
+        const string marker = "correlationId: ";
+        var start = message.LastIndexOf(marker, StringComparison.Ordinal);
+        Assert.IsTrue(start >= 0, $"{label}: message carries no correlationId field: '{message}'");
+
+        var correlationId = message[(start + marker.Length)..].TrimEnd(')');
+        Assert.AreNotEqual("unavailable", correlationId,
+            $"{label}: correlationId is the no-context sentinel — the per-message correlation " +
+            $"scope never opened, so no real id reached the wire. Message: '{message}'");
+        Assert.AreEqual(32, correlationId.Length,
+            $"{label}: correlationId '{correlationId}' is not a 32-char Guid(\"N\"). Message: '{message}'");
+        Assert.IsTrue(
+            correlationId.All(static c => c is >= '0' and <= '9' or >= 'a' and <= 'f'),
+            $"{label}: correlationId '{correlationId}' is not lowercase hex. Message: '{message}'");
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -216,19 +216,17 @@ public sealed class SurfaceCatalogTests
     }
 
     [TestMethod]
-    public void ServerCatalogVersionDiffResource_UnsupportedPair_ReturnsInvalidArgumentEnvelope()
+    public void ServerCatalogVersionDiffResource_UnsupportedPair_PropagatesArgumentException()
     {
-        var json = ServerResources.GetServerCatalogVersionDiff("v2.3.0", "current");
-        using var document = JsonDocument.Parse(json);
+        // resource-read-protocol-error-semantics-server-catalog: the handler no longer
+        // serializes an error envelope into the contents body — the ArgumentException
+        // propagates to ResourceReadResultFilter, which answers on the JSON-RPC error
+        // channel with InvalidParams (-32602). The wire-level shape is pinned by
+        // ResourceReadWireContractTests; this test pins the handler's propagation contract.
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => ServerResources.GetServerCatalogVersionDiff("v2.3.0", "current"));
 
-        Assert.IsTrue(document.RootElement.GetProperty("error").GetBoolean());
-        Assert.AreEqual("InvalidArgument", document.RootElement.GetProperty("category").GetString());
-        Assert.AreEqual(
-            "roslyn://server/catalog-diff/{fromVersion}/{toVersion}",
-            document.RootElement.GetProperty("tool").GetString());
-        StringAssert.Contains(document.RootElement.GetProperty("message").GetString() ?? string.Empty, "Unsupported catalog diff");
-        Assert.IsFalse((document.RootElement.GetProperty("message").GetString() ?? string.Empty)
-            .Contains("v2.3.0", StringComparison.Ordinal));
+        StringAssert.Contains(ex.Message, "Unsupported catalog diff");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceResourceTests.cs
@@ -145,10 +145,15 @@ public sealed class WorkspaceResourceTests : SharedWorkspaceTestBase
     [TestMethod]
     public async Task GetSourceFile_Resource_Rejects_Relative_Path()
     {
+        // resource-read-protocol-error-semantics-server-catalog: a relative filePath is
+        // caller input at fault, so the wrapped cause is ArgumentException (classified
+        // InvalidArgument -> -32602), not InvalidOperationException (-32603).
         var ex = await Assert.ThrowsExactlyAsync<McpToolException>(() =>
             WorkspaceResources.GetSourceFile(WorkspaceExecutionGate, WorkspaceManager, WorkspaceId, "AnimalService.cs", CancellationToken.None));
-        StringAssert.Contains(ex.Message, "Invalid operation");
+        StringAssert.Contains(ex.Message, "Invalid argument");
         StringAssert.Contains(ex.Message, "absolute path");
+        Assert.IsInstanceOfType<ArgumentException>(ex.InnerException,
+            "inner cause must be ArgumentException so the read filter maps it to InvalidParams");
     }
 
     private static string FindDocumentPath(string name)


### PR DESCRIPTION
## Summary

Part 2 of 2 of the `resources/read` protocol-error migration (part 1: PR #1282), plus the amended acceptance items from part 1's code-quality review.

- Migrate the three server-catalog resources (`server_catalog_tools_page`, `server_catalog_prompts_page`, `server_catalog_version_diff`) from the legacy body-envelope `ToolErrorHandler.ExecuteResource` onto the success-only `ExecuteResourceScope`; failures now answer on the JSON-RPC error channel.
- Delete the now-dead `ToolErrorHandler.ExecuteResource` / `ExecuteResourceAsync` (zero callers after part 1).
- `ResourceReadResultFilter.MapErrorCode` now consumes shared `ToolErrorHandler.ErrorCategories` constants declared next to the classification table â€” no more copied string literals.
- Unexpected read failures surface as a sanitized `-32603` carrying a correlation id, with no exception type name, stack frame, or absolute server path in the payload. The unobservable `ExecuteResourceScope*` `finally { RecordElapsed }` (a write-only AsyncLocal stamp with no reader on the failure path) and its doc claim are removed.

  > **Corrected before merge.** This bullet previously claimed failures are recorded through the `UnexpectedExceptionReporting`/`ServerObservability` seam via a new `UnexpectedExceptionCategory.ReadResource`. That arm was removed during a Step 8b fix cycle: the amendment's item 5 is an either/or, implementing both arms pushed the diff to 5 production files over the Rule 3 cap, and the seam arm shipped with no test — the exact "ships uncovered" defect this initiative exists to close. Only the `finally`-removal arm ships.
- `source_file`'s non-absolute `filePath` now throws `ArgumentException` (caller fault â†’ `-32602`), not `InvalidOperationException` (â†’ `-32603`), mirroring `source_file_lines`.
- NEW `ResourceReadWireContractTests`: table-driven raw JSON-RPC `resources/read` matrix across BOTH resource families and BOTH protocol eras (2025-11-25 / 2026-07-28) â€” NotFound `-32002`/`-32602` by era (pinning the `McpToolException` inner-`KeyNotFoundException` unwrap at the filter), caller-input faults `-32602` in both eras, sanitized `-32603` with a falsifiable JSON-escaped path-leak probe, no `result.contents` on failure, and cache-hint normalization on success.

**BREAKING:** clients that parsed `{"error":true,"category":...}` out of the server-catalog resource bodies must read the JSON-RPC `error` member instead (migration note in the changelog fragment).

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` â€” clean (0 warnings, 0 errors)
- Targeted: `ResourceReadWireContractTests` (3/3), `SurfaceCatalogTests`, `ServerDiscoveryWireTests`, `StaticListResultFilterTests`, `ErrorResponseObservabilityTests`, `Top10V2RegressionTests` (52/52); `ExpandedSurfaceIntegrationTests` + `FetchMcpResourceReadinessTests` + `WorkspaceResourceTests` (48/48 after contract-test update)
- `./eng/verify-ai-docs.ps1` â€” passed
- Full CI-parity gate deferred to the self-hosted runner on this PR (local `verify-release.ps1` runs are prohibited while the runner is active)

Closes: resource-read-protocol-error-semantics

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
