### PR TITLE
fix(semantic-grep): redact regex-parser detail from invalid-pattern errors

### DIFF
--- a/changelog.d/semantic-grep-pattern-error-detail-redaction.md
+++ b/changelog.d/semantic-grep-pattern-error-detail-redaction.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `semantic_grep` invalid-pattern failures no longer carry raw .NET regex-parser text or the submitted pattern in the thrown message or debug log, and the public `InvalidArgument` envelope now returns stable, actionable regex-correction guidance instead of the generic parameter fallback. Error-message text is not a stability contract; the response shape, category, `paramName`, and `schemaHint` are unchanged.

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs
@@ -513,6 +513,20 @@ internal static class ToolErrorHandler
             return "Workspace auto-discovery found multiple candidates. Call workspace_load with an explicit solution or project path.";
         }
 
+        // semantic-grep-pattern-error-detail-redaction: SemanticGrepService throws a fixed
+        // input-free sentinel when the caller's regex fails to parse (the raw .NET parser
+        // message embeds the submitted pattern, which may itself be a secret). Guard on BOTH
+        // ParamName and the sentinel substring so other tools' 'pattern' parameters (e.g.
+        // RestructureService's non-empty check) keep the generic fallback below.
+        if (string.Equals(exception.ParamName, "pattern", StringComparison.Ordinal) &&
+            rawMessage.Contains("not a valid .NET regular expression", StringComparison.Ordinal))
+        {
+            return "Parameter 'pattern' is not a valid .NET regular expression. Patterns use " +
+                "System.Text.RegularExpressions syntax, not ripgrep/PCRE. Check for unbalanced " +
+                "parentheses or brackets, invalid quantifier ranges, and unescaped metacharacters, " +
+                "then retry with a corrected pattern.";
+        }
+
         if (rawMessage.Contains("Unsupported catalog diff", StringComparison.Ordinal))
         {
             return "Unsupported catalog diff. Request one of the version pairs advertised by the catalog resource.";

--- a/src/RoslynMcp.Roslyn/Services/SemanticGrepService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SemanticGrepService.cs
@@ -19,6 +19,14 @@ public sealed class SemanticGrepService : ISemanticGrepService
     /// <summary>Hard cap on per-pattern regex evaluation time per document, in milliseconds.</summary>
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
 
+    /// <summary>
+    /// semantic-grep-pattern-error-detail-redaction: fixed, input-free message thrown when the
+    /// caller's regex fails to parse. MUST stay free of the pattern text and the .NET parser
+    /// message — <c>ToolErrorHandler.BuildSafeArgumentMessage</c> keys its regex-guidance arm
+    /// on this exact substring (plus <c>ParamName == "pattern"</c>).
+    /// </summary>
+    public const string InvalidRegexSentinel = "The 'pattern' argument is not a valid .NET regular expression.";
+
     public const string ScopeIdentifiers = "identifiers";
     public const string ScopeStrings = "strings";
     public const string ScopeComments = "comments";
@@ -46,7 +54,9 @@ public sealed class SemanticGrepService : ISemanticGrepService
         int limit,
         CancellationToken ct)
     {
-        _logger.LogDebug("SemanticGrepService.SearchAsync: workspaceId={WorkspaceId} scope={Scope} pattern={Pattern} projectFilter={ProjectFilter} limit={Limit}", workspaceId, scope, pattern, projectFilter, limit);
+        // semantic-grep-pattern-error-detail-redaction: never log the caller's raw pattern —
+        // it can embed searched-for secrets. Length is enough to correlate a request.
+        _logger.LogDebug("SemanticGrepService.SearchAsync: workspaceId={WorkspaceId} scope={Scope} patternLength={PatternLength} projectFilter={ProjectFilter} limit={Limit}", workspaceId, scope, pattern?.Length ?? 0, projectFilter, limit);
         if (string.IsNullOrEmpty(pattern))
         {
             throw new ArgumentException("pattern must be non-empty.", nameof(pattern));
@@ -69,7 +79,11 @@ public sealed class SemanticGrepService : ISemanticGrepService
         }
         catch (ArgumentException ex)
         {
-            throw new ArgumentException($"Invalid regex pattern: {ex.Message}", nameof(pattern), ex);
+            // semantic-grep-pattern-error-detail-redaction: the .NET parser message embeds the
+            // caller's raw pattern text (e.g. "Invalid pattern '(?<secret' at offset 8"), which
+            // can carry the very secret the caller is grepping for. Throw a fixed, input-free
+            // sentinel instead; ex stays as InnerException for server-side diagnostics only.
+            throw new ArgumentException(InvalidRegexSentinel, nameof(pattern), ex);
         }
 
         var includeIdentifiers = scope is ScopeAll || string.Equals(scope, ScopeIdentifiers, StringComparison.OrdinalIgnoreCase);

--- a/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
+++ b/tests/RoslynMcp.Tests/SemanticGrepServiceTests.cs
@@ -123,6 +123,96 @@ public sealed class SemanticGrepServiceTests : SharedWorkspaceTestBase
                 WorkspaceId, "(unclosed", "identifiers", projectFilter: null, limit: 10, CancellationToken.None));
     }
 
+    // ----- Pattern redaction tests (semantic-grep-pattern-error-detail-redaction) -----
+    //
+    // The .NET regex parser's ArgumentException message embeds the caller's raw pattern text
+    // (e.g. "Invalid pattern '(?<secret' at offset 8"). Since semantic_grep is routinely used
+    // to hunt for secrets, the pattern itself can be a secret — so neither the thrown message
+    // nor the public InvalidArgument envelope may carry the submitted pattern or any parser
+    // fragment. The parser detail is preserved server-side only, as InnerException.
+    //
+    // NOTE: the catastrophic-backtracking-shaped pattern `(a+)+$` is deliberately NOT in this
+    // table — it is a VALID .NET regex (pathological only at match time, which RegexTimeout
+    // bounds), so the Regex constructor does not throw for it.
+
+    /// <summary>
+    /// Leak probe used by the redaction assertions below. Kept as a single helper so
+    /// <see cref="SemanticGrep_LeakProbe_DetectsDeliberateLeak"/> can prove it is falsifiable.
+    /// </summary>
+    private static bool MessageLeaks(string message, string pattern) =>
+        message.Contains(pattern, StringComparison.Ordinal) ||
+        message.Contains("Invalid pattern", StringComparison.OrdinalIgnoreCase) ||
+        message.Contains("at offset", StringComparison.OrdinalIgnoreCase) ||
+        message.Contains("parsing", StringComparison.OrdinalIgnoreCase);
+
+    [TestMethod]
+    public void SemanticGrep_LeakProbe_DetectsDeliberateLeak()
+    {
+        // Falsifiability proof: the probe MUST match the pre-fix leaking shape. A redaction
+        // assertion that cannot detect a genuine leak is dead weight.
+        const string leakingMessage = "Invalid regex pattern: Invalid pattern '(?<secret' at offset 8. Incomplete group name.";
+        Assert.IsTrue(MessageLeaks(leakingMessage, "(?<secret"),
+            "Leak probe failed to detect a deliberately-leaking message — the redaction assertions below would be dead.");
+    }
+
+    [TestMethod]
+    [DataRow("(unclosed")]
+    [DataRow("[a-")]
+    [DataRow("a{2,1}")]
+    [DataRow("(?<name")]
+    public async Task SemanticGrep_InvalidRegex_PublicEnvelopeRedactsPatternAndCarriesGuidance(string pattern)
+    {
+        ArgumentException thrown;
+        try
+        {
+            await SemanticGrepService.SearchAsync(
+                WorkspaceId, pattern, "identifiers", projectFilter: null, limit: 10, CancellationToken.None);
+            Assert.Fail($"Expected ArgumentException for pattern '{pattern}'.");
+            return;
+        }
+        catch (ArgumentException ex)
+        {
+            thrown = ex;
+        }
+
+        // Thrown message: fixed sentinel, no pattern text, no parser fragment. Parser detail
+        // survives server-side as InnerException only.
+        Assert.IsFalse(MessageLeaks(thrown.Message, pattern),
+            $"Thrown message leaked pattern or parser text: {thrown.Message}");
+        Assert.AreEqual("pattern", thrown.ParamName);
+        Assert.IsNotNull(thrown.InnerException, "Parser detail must be preserved as InnerException for server-side diagnostics.");
+
+        // Public envelope via the real classifier path.
+        var envelopeJson = ToolErrorHandler.ClassifyAndFormat(thrown, "semantic_grep");
+        using var envelope = JsonDocument.Parse(envelopeJson);
+        var root = envelope.RootElement;
+
+        Assert.AreEqual("InvalidArgument", root.GetProperty("category").GetString());
+        var message = root.GetProperty("message").GetString()!;
+        Assert.IsFalse(MessageLeaks(message, pattern),
+            $"Public envelope message leaked pattern or parser text: {message}");
+        StringAssert.Contains(message, "not a valid .NET regular expression",
+            "Public envelope must carry regex-specific correction guidance, not the generic parameter fallback.");
+        StringAssert.Contains(message, "System.Text.RegularExpressions",
+            "Guidance must name the regex dialect so callers stop retrying ripgrep/PCRE syntax.");
+    }
+
+    [TestMethod]
+    public void SemanticGrep_OtherPatternParameters_KeepGenericFallback()
+    {
+        // The regex-guidance arm is keyed on BOTH ParamName == "pattern" AND the sentinel
+        // substring — a different tool's 'pattern' parameter (e.g. RestructureService's
+        // non-empty check) must NOT pick up regex guidance.
+        var other = new ArgumentException("pattern must be non-empty.", "pattern");
+        var envelopeJson = ToolErrorHandler.ClassifyAndFormat(other, "restructure_preview");
+        using var envelope = JsonDocument.Parse(envelopeJson);
+        var message = envelope.RootElement.GetProperty("message").GetString()!;
+
+        Assert.IsFalse(message.Contains("regular expression", StringComparison.OrdinalIgnoreCase),
+            $"Non-regex 'pattern' failures must keep the generic fallback; got: {message}");
+        StringAssert.Contains(message, "Parameter 'pattern' is invalid");
+    }
+
     // ----- Pagination envelope tests (PR for compact-semantic-grep-pagination, gh #760 split) -----
     //
     // These tests exercise the wrapper layer in AnalysisTools.SemanticGrep, not the service.


### PR DESCRIPTION
## Summary

- `SemanticGrepService`: the invalid-regex `ArgumentException` now throws a fixed, input-free sentinel ("The 'pattern' argument is not a valid .NET regular expression.") instead of wrapping the .NET parser message, which embeds the caller's raw pattern (e.g. `Invalid pattern '(?<secret' at offset 8`) — a secret-bearing input when semantic_grep is used to hunt for secrets. Parser detail is preserved server-side as `InnerException` only.
- `SemanticGrepService`: the Debug log no longer emits the raw pattern; it logs `patternLength` instead.
- `ToolErrorHandler.BuildSafeArgumentMessage`: new arm keyed on `ParamName == "pattern"` AND the sentinel substring returns stable regex-correction guidance (names the `System.Text.RegularExpressions` dialect, common syntax faults) instead of the generic parameter fallback. Other tools' `pattern` parameters (e.g. RestructureService's non-empty check) keep the generic fallback — pinned by test.
- Tests: table-driven redaction regression over `(unclosed`, `[a-`, `a{2,1}`, `(?<name)` driving the real `ToolErrorHandler.ClassifyAndFormat` path, with a falsifiability proof that the leak probe detects the pre-fix leaking message shape. Note: the plan's `(a+)+$` case is a VALID .NET regex (pathological only at match time, bounded by `RegexTimeout`), so it is deliberately excluded from the invalid-pattern table.

Envelope shape, category, `paramName`, and `schemaHint` are unchanged; error-message text is not a stability contract.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Targeted: `SemanticGrepServiceTests` + `ToolErrorHandlerParameterValidationTests` — 23 passed; the 6 new redaction tests confirmed individually.
- `./eng/verify-release.ps1 -Configuration Release` — 2234/2240 passed; single failure `AnalyzerShadowLoaderLifecycleTests.WorkspaceCloseAndReload_ReclaimAnalyzerShadowRoots` (ALC-unload timing test, untouched by this diff, machine under concurrent sibling-executor load) passes in isolation on re-run.
- `./eng/verify-ai-docs.ps1` — passed.

Closes: semantic-grep-pattern-error-detail-redaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)