### PR TITLE
feat: add find_overloads tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ which is the fail-closed case above. Rationale and full detail:
 
 ## Live Surface
 
-The current release exposes **173 tools** (113 stable / 60 experimental), **14 resources** (9 stable / 5 experimental), and **20 prompts** (all experimental).
+The current release exposes **174 tools** (113 stable / 61 experimental), **14 resources** (9 stable / 5 experimental), and **20 prompts** (all experimental).
 
 Use the running server for the authoritative live catalog and support tiers:
 

--- a/changelog.d/find-overloads-tool.md
+++ b/changelog.d/find-overloads-tool.md
@@ -1,0 +1,8 @@
+---
+category: Added
+---
+
+- **Added:** `find_overloads` tool — enumerate every overload of a member by type + name via
+  `GetTypeByMetadataName`/`GetMembers`, including methods only reachable through a referenced
+  BCL/NuGet assembly that `symbol_search` cannot find (it only searches workspace source). Ships
+  experimental; extension methods are out of scope for v1.

--- a/samples/SampleSolution/SampleLib/OverloadAccessibilityProbe.cs
+++ b/samples/SampleSolution/SampleLib/OverloadAccessibilityProbe.cs
@@ -1,0 +1,21 @@
+namespace SampleLib;
+
+/// <summary>
+/// Holds a private/protected overload pair on a base type so integration tests can assert
+/// that `find_overloads(includeInherited: true)` excludes inaccessible base members instead of
+/// advertising overloads the caller could never actually invoke on the derived type.
+/// </summary>
+public class OverloadAccessibilityProbeBase
+{
+    private void Probe()
+    {
+    }
+
+    protected void Probe(int value)
+    {
+    }
+}
+
+public sealed class OverloadAccessibilityProbeDerived : OverloadAccessibilityProbeBase
+{
+}

--- a/src/RoslynMcp.Core/Services/ISymbolRelationshipService.cs
+++ b/src/RoslynMcp.Core/Services/ISymbolRelationshipService.cs
@@ -28,4 +28,13 @@ public interface ISymbolRelationshipService
     Task<SignatureHelpDto?> GetSignatureHelpAsync(string workspaceId, SymbolLocator locator, bool preferDeclaringMember, CancellationToken ct);
 
     Task<CallerCalleeDto?> GetCallersCalleesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct);
+
+    /// <summary>
+    /// Enumerates every overload of <paramref name="memberName"/> declared on
+    /// <paramref name="typeMetadataName"/>. Returns null when the type does not resolve;
+    /// an empty list when the type resolves but no method matches the member name.
+    /// </summary>
+    Task<IReadOnlyList<SignatureHelpDto>?> FindOverloadsAsync(
+        string workspaceId, string typeMetadataName, string memberName,
+        bool includeInherited, string? projectName, CancellationToken ct);
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.Symbols.cs
@@ -14,6 +14,7 @@ public static partial class ServerSurfaceCatalog
         Tool("find_base_members", "symbols", "stable", true, false, "Find base or implemented members."),
         Tool("member_hierarchy", "symbols", "stable", true, false, "Summarize base, override, and sibling interface implementation relationships for a member."),
         Tool("symbol_signature_help", "symbols", "stable", true, false, "Return symbol signature and documentation."),
+        Tool("find_overloads", "symbols", "experimental", true, false, "Enumerate all overloads of a member by type + name."),
         Tool("symbol_relationships", "symbols", "stable", true, false, "Combine definition, reference, base, and implementation relationships."),
         Tool("find_references_bulk", "symbols", "stable", true, false, "Resolve references for multiple symbols in one request."),
         Tool("find_property_writes", "symbols", "stable", true, false, "Find property write sites and classify object-initializer writes."),

--- a/src/RoslynMcp.Host.Stdio/README.md
+++ b/src/RoslynMcp.Host.Stdio/README.md
@@ -85,7 +85,7 @@ Any stdio-capable MCP client uses the same command:
 
 ## What's in the box
 
-Catalog `2026.04` ships **173 tools** (113 stable / 60 experimental), **14 resources** (9 stable / 5 experimental), and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
+Catalog `2026.04` ships **174 tools** (113 stable / 61 experimental), **14 resources** (9 stable / 5 experimental), and **20 prompts** (all experimental). Use `server_info` and `roslyn://server/catalog` for the authoritative live surface; the categories below are a quick orientation.
 
 | Family | Highlights |
 |---|---|

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -576,6 +576,27 @@ public static class SymbolTools
         }, ct);
     }
 
+    [McpServerTool(Name = "find_overloads", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Enumerate every overload of a member declared on a type, via GetTypeByMetadataName + GetMembers — works both for methods authored in the workspace's own source and for methods only reachable via a referenced BCL/NuGet assembly (e.g. System.Math.Max), which symbol_search cannot find since it only searches workspace source. Response shape: { count, items }; each item is the same SignatureHelpDto shape symbol_signature_help returns (displaySignature, returnType, parameters, documentation). `documentation` is empty when the referenced assembly ships no sibling .xml doc file — expected, not a bug. Extension methods are OUT OF SCOPE (v1): Enumerable.Select does not appear when querying IEnumerable<T>, since extension methods live on the extending static class, not the extended type — query the static class directly instead (typeMetadataName: 'System.Linq.Enumerable', memberName: 'Select'). includeInherited=false (default) returns only members declared directly on typeMetadataName. includeInherited=true also walks the base-class chain and may list a base declaration and its override side by side (no override-chain dedup here — use member_hierarchy for that).")]
+    [McpToolMetadata("symbols", "experimental", true, false,
+        "Enumerate all overloads of a member by type + name.")]
+    public static Task<string> FindOverloads(
+        IWorkspaceExecutionGate gate,
+        ISymbolRelationshipService symbolRelationshipService,
+        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Fully qualified metadata name of the containing type, e.g. 'System.Math' or 'System.Collections.Generic.List`1' (backtick arity for generics).")] string typeMetadataName,
+        [Description("Bare member name to enumerate overloads of, e.g. 'Max'. No signature needed — this resolves ALL overloads of that name.")] string memberName,
+        [Description("Optional: when true, also walk the base-class chain for additional overloads. Default false (direct-declared members only) to avoid pulling in object.ToString/Equals/GetHashCode noise unasked.")] bool includeInherited = false,
+        [Description("Optional: restrict type resolution to one project by name (case-sensitive), for multi-targeted solutions where the same type could differ across TFMs.")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        return gate.RunReadAsync(workspaceId, async c =>
+        {
+            var results = await symbolRelationshipService.FindOverloadsAsync(workspaceId, typeMetadataName, memberName, includeInherited, projectName, c);
+            if (results is null) throw new KeyNotFoundException($"Type not found: '{typeMetadataName}' (workspace '{workspaceId}').");
+            return JsonSerializer.Serialize(new { count = results.Count, items = results }, JsonDefaults.Indented);
+        }, ct);
+    }
+
     [McpServerTool(Name = "symbol_relationships", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get a combined summary of definitions, references, implementations, base members, and overrides. Auto-promotes a caret on a member's type token to the enclosing member by default (see preferDeclaringMember).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Combine definition, reference, base, and implementation relationships.")]

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -576,7 +576,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_overloads", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Enumerate every overload of a member declared on a type, via GetTypeByMetadataName + GetMembers — works both for methods authored in the workspace's own source and for methods only reachable via a referenced BCL/NuGet assembly (e.g. System.Math.Max), which symbol_search cannot find since it only searches workspace source. Response shape: { count, items }; each item is the same SignatureHelpDto shape symbol_signature_help returns (displaySignature, returnType, parameters, documentation). `documentation` is empty when the referenced assembly ships no sibling .xml doc file — expected, not a bug. Extension methods are OUT OF SCOPE (v1): Enumerable.Select does not appear when querying IEnumerable<T>, since extension methods live on the extending static class, not the extended type — query the static class directly instead (typeMetadataName: 'System.Linq.Enumerable', memberName: 'Select'). includeInherited=false (default) returns only members declared directly on typeMetadataName. includeInherited=true also walks the base-class chain and may list a base declaration and its override side by side (no override-chain dedup here — use member_hierarchy for that).")]
+    [McpServerTool(Name = "find_overloads", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Enumerate every overload of a member by type + name, including BCL/NuGet methods not authored in workspace source (symbol_search can't find those). Response: { count, items } of SignatureHelpDto.")]
     [McpToolMetadata("symbols", "experimental", true, false,
         "Enumerate all overloads of a member by type + name.")]
     public static Task<string> FindOverloads(
@@ -584,8 +584,8 @@ public static class SymbolTools
         ISymbolRelationshipService symbolRelationshipService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("Fully qualified metadata name of the containing type, e.g. 'System.Math' or 'System.Collections.Generic.List`1' (backtick arity for generics).")] string typeMetadataName,
-        [Description("Bare member name to enumerate overloads of, e.g. 'Max'. No signature needed — this resolves ALL overloads of that name.")] string memberName,
-        [Description("Optional: when true, also walk the base-class chain for additional overloads. Default false (direct-declared members only) to avoid pulling in object.ToString/Equals/GetHashCode noise unasked.")] bool includeInherited = false,
+        [Description("Bare member name to enumerate overloads of, e.g. 'Max'. No signature needed — resolves ALL overloads of that name. Extension methods are out of scope — query the extending static class directly instead, e.g. typeMetadataName: 'System.Linq.Enumerable', memberName: 'Select'.")] string memberName,
+        [Description("Optional: when true, also walk the base-class chain for additional overloads. Inaccessible (e.g. private) base members are excluded via Roslyn's own accessibility rules; there is no override-chain dedup — use member_hierarchy for that. Default false (direct-declared members only).")] bool includeInherited = false,
         [Description("Optional: restrict type resolution to one project by name (case-sensitive), for multi-targeted solutions where the same type could differ across TFMs.")] string? projectName = null,
         CancellationToken ct = default)
     {

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -263,6 +263,43 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
             Documentation: dto.Documentation);
     }
 
+    public async Task<IReadOnlyList<SignatureHelpDto>?> FindOverloadsAsync(
+        string workspaceId, string typeMetadataName, string memberName,
+        bool includeInherited, string? projectName, CancellationToken ct)
+    {
+        _logger.LogDebug("SymbolRelationshipService.FindOverloadsAsync: workspaceId={WorkspaceId} typeMetadataName={TypeMetadataName} memberName={MemberName}", workspaceId, typeMetadataName, memberName);
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+
+        INamedTypeSymbol? typeSymbol = null;
+        foreach (var project in solution.Projects)
+        {
+            if (projectName is not null && !string.Equals(project.Name, projectName, StringComparison.Ordinal)) continue;
+            ct.ThrowIfCancellationRequested();
+            var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
+            typeSymbol = compilation?.GetTypeByMetadataName(typeMetadataName);
+            if (typeSymbol is not null) break;
+        }
+        if (typeSymbol is null) return null;
+
+        var methods = typeSymbol.GetMembers(memberName).OfType<IMethodSymbol>().ToList();
+        if (includeInherited)
+        {
+            for (var baseType = typeSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                methods.AddRange(baseType.GetMembers(memberName).OfType<IMethodSymbol>());
+            }
+        }
+
+        return methods.Select(m => new SignatureHelpDto(
+            DisplaySignature: m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+            ReturnType: m.ReturnType.ToDisplayString(),
+            Parameters: m.Parameters
+                .Select(p => $"{p.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)} {p.Name}")
+                .ToList(),
+            Documentation: m.GetDocumentationCommentXml()))
+            .ToList();
+    }
+
     public async Task<CallerCalleeDto?> GetCallersCalleesAsync(string workspaceId, SymbolLocator locator, CancellationToken ct)
     {
         _logger.LogDebug("SymbolRelationshipService.GetCallersCalleesAsync: workspaceId={WorkspaceId} locator={Locator}", workspaceId, locator);

--- a/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
+++ b/src/RoslynMcp.Roslyn/Services/SymbolRelationshipService.cs
@@ -270,23 +270,42 @@ public sealed class SymbolRelationshipService : ISymbolRelationshipService
         _logger.LogDebug("SymbolRelationshipService.FindOverloadsAsync: workspaceId={WorkspaceId} typeMetadataName={TypeMetadataName} memberName={MemberName}", workspaceId, typeMetadataName, memberName);
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
+        if (projectName is not null && !solution.Projects.Any(p => string.Equals(p.Name, projectName, StringComparison.Ordinal)))
+        {
+            throw new ArgumentException(
+                $"projectName '{projectName}' matched 0 projects. Omit projectName or use workspace_status to inspect available project names.",
+                nameof(projectName));
+        }
+
         INamedTypeSymbol? typeSymbol = null;
+        Compilation? resolvedCompilation = null;
         foreach (var project in solution.Projects)
         {
             if (projectName is not null && !string.Equals(project.Name, projectName, StringComparison.Ordinal)) continue;
             ct.ThrowIfCancellationRequested();
             var compilation = await _compilationCache.GetCompilationAsync(workspaceId, project, ct).ConfigureAwait(false);
-            typeSymbol = compilation?.GetTypeByMetadataName(typeMetadataName);
-            if (typeSymbol is not null) break;
+            var candidate = compilation?.GetTypeByMetadataName(typeMetadataName);
+            if (candidate is not null)
+            {
+                typeSymbol = candidate;
+                resolvedCompilation = compilation;
+                break;
+            }
         }
         if (typeSymbol is null) return null;
 
         var methods = typeSymbol.GetMembers(memberName).OfType<IMethodSymbol>().ToList();
         if (includeInherited)
         {
+            // Base-class GetMembers returns every declared member, including private ones that
+            // are not actually inherited/visible to the derived type — filter through Roslyn's own
+            // accessibility rules (evaluated FROM typeSymbol) instead of advertising overloads the
+            // caller could never actually invoke on this type.
             for (var baseType = typeSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
             {
-                methods.AddRange(baseType.GetMembers(memberName).OfType<IMethodSymbol>());
+                methods.AddRange(baseType.GetMembers(memberName)
+                    .OfType<IMethodSymbol>()
+                    .Where(m => resolvedCompilation!.IsSymbolAccessibleWithin(m, typeSymbol)));
             }
         }
 

--- a/tests/RoslynMcp.Tests/FindOverloadsTests.cs
+++ b/tests/RoslynMcp.Tests/FindOverloadsTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Coverage for `find_overloads`: enumerates every overload of a member via
+/// <c>GetTypeByMetadataName</c> + <c>GetMembers</c>, closing the gap where <c>symbol_search</c>
+/// only finds symbols declared in the workspace's own source and <c>symbol_signature_help</c>
+/// resolves a single already-bound call site rather than listing every overload choice.
+/// </summary>
+[DoNotParallelize]
+[TestClass]
+public sealed class FindOverloadsTests : SharedWorkspaceTestBase
+{
+    private static string WorkspaceId { get; set; } = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        InitializeServices();
+        WorkspaceId = await LoadSharedSampleWorkspaceAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task FindOverloads_Resolves_BclMethod_Never_Called_In_Fixture_Source()
+    {
+        // The actual gap being closed: System.Math.Max is never referenced anywhere in
+        // SampleLib/SampleApp source, so symbol_search finds nothing for it — but it's still
+        // reachable via the corlib reference already loaded into the compilation.
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "System.Math",
+            memberName: "Max",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(
+            doc.RootElement.TryGetProperty("error", out _),
+            $"find_overloads should resolve a BCL type/member not declared in the workspace's own source. Got: {json}");
+
+        var count = doc.RootElement.GetProperty("count").GetInt32();
+        Assert.IsTrue(count > 1, $"System.Math.Max has multiple overloads. Got count={count}.");
+
+        var items = doc.RootElement.GetProperty("items");
+        Assert.AreEqual(count, items.GetArrayLength());
+        foreach (var item in items.EnumerateArray())
+        {
+            var displaySignature = item.GetProperty("displaySignature").GetString();
+            Assert.IsFalse(string.IsNullOrWhiteSpace(displaySignature), "Each overload must have a non-empty displaySignature.");
+        }
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_Matches_InFixture_Overload_Count()
+    {
+        // SampleLib.AnimalService.CountAnimals has exactly two overloads declared in the fixture's
+        // own source: (List<IAnimal>) and (IEnumerable<IAnimal>).
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.AnimalService",
+            memberName: "CountAnimals",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(2, doc.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_IncludeInherited_Default_False_Excludes_Base_Members()
+    {
+        // SampleLib.AnimalService does not override ToString, so with includeInherited left at its
+        // default (false), querying "ToString" must return zero direct-declared overloads —
+        // object.ToString is not pulled in unasked.
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.AnimalService",
+            memberName: "ToString",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(0, doc.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_IncludeInherited_True_Walks_Base_Chain()
+    {
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.AnimalService",
+            memberName: "ToString",
+            includeInherited: true,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsTrue(
+            doc.RootElement.GetProperty("count").GetInt32() >= 1,
+            "includeInherited=true should surface object.ToString from the base chain.");
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_Unresolvable_Type_Throws_NotFound()
+    {
+        var ex = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(async () =>
+            await SymbolTools.FindOverloads(
+                WorkspaceExecutionGate,
+                SymbolRelationshipService,
+                WorkspaceId,
+                typeMetadataName: "SampleLib.DefinitelyDoesNotExist__Bogus",
+                memberName: "Max",
+                ct: CancellationToken.None));
+
+        StringAssert.Contains(ex.Message, "SampleLib.DefinitelyDoesNotExist__Bogus",
+            $"Error must echo the offending type name so the caller can correlate. Got: {ex.Message}");
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_Resolvable_Type_Unknown_Member_Returns_Empty_Not_Error()
+    {
+        // A resolvable type with no method by that name is a normal empty result, not a NotFound —
+        // distinct from FindOverloads_Unresolvable_Type_Throws_NotFound above.
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.AnimalService",
+            memberName: "DefinitelyNotAMember__Bogus",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(
+            doc.RootElement.TryGetProperty("error", out _),
+            $"An unknown member name on a resolvable type should be an empty success, not an error. Got: {json}");
+        Assert.AreEqual(0, doc.RootElement.GetProperty("count").GetInt32());
+        Assert.AreEqual(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+}

--- a/tests/RoslynMcp.Tests/FindOverloadsTests.cs
+++ b/tests/RoslynMcp.Tests/FindOverloadsTests.cs
@@ -145,4 +145,75 @@ public sealed class FindOverloadsTests : SharedWorkspaceTestBase
         Assert.AreEqual(0, doc.RootElement.GetProperty("count").GetInt32());
         Assert.AreEqual(0, doc.RootElement.GetProperty("items").GetArrayLength());
     }
+
+    [TestMethod]
+    public async Task FindOverloads_IncludeInherited_Excludes_Inaccessible_Private_Base_Member()
+    {
+        // SampleLib.OverloadAccessibilityProbeBase declares a private Probe() and a protected
+        // Probe(int). GetMembers on the base type returns both regardless of accessibility, but
+        // the private overload is not actually inherited/visible from the derived type — only the
+        // protected one should be advertised.
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.OverloadAccessibilityProbeDerived",
+            memberName: "Probe",
+            includeInherited: true,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(1, doc.RootElement.GetProperty("count").GetInt32(),
+            $"Only the protected Probe(int) overload should be inherited-visible; the private parameterless one must be excluded. Got: {json}");
+
+        var onlyItem = doc.RootElement.GetProperty("items")[0];
+        var parameters = onlyItem.GetProperty("parameters");
+        Assert.AreEqual(1, parameters.GetArrayLength(), "The surviving overload must be the one-parameter protected Probe(int), not the private parameterless one.");
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_ProjectName_Scopes_Successful_Lookup()
+    {
+        // A valid projectName should behave identically to the unscoped lookup for a type that
+        // genuinely lives in that project, proving the scoping path resolves rather than
+        // accidentally excluding everything.
+        var json = await SymbolTools.FindOverloads(
+            WorkspaceExecutionGate,
+            SymbolRelationshipService,
+            WorkspaceId,
+            typeMetadataName: "SampleLib.AnimalService",
+            memberName: "CountAnimals",
+            projectName: "SampleLib",
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(
+            doc.RootElement.TryGetProperty("error", out _),
+            $"A valid projectName scoping the type's own project should succeed. Got: {json}");
+        Assert.AreEqual(2, doc.RootElement.GetProperty("count").GetInt32());
+    }
+
+    [TestMethod]
+    public async Task FindOverloads_ProjectName_UnknownProject_Throws_Distinct_From_TypeNotFound()
+    {
+        // An unresolvable projectName must surface as its own clear failure (mirrors the
+        // "projectName '{0}' matched 0 projects" convention already used by compile_check), not
+        // collapse into the generic "type not found" KeyNotFoundException path — those two
+        // failure causes are not the same thing and callers need to be able to tell them apart.
+        const string bogusProject = "DefinitelyNotAProject__Bogus";
+
+        var ex = await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+            await SymbolTools.FindOverloads(
+                WorkspaceExecutionGate,
+                SymbolRelationshipService,
+                WorkspaceId,
+                typeMetadataName: "SampleLib.AnimalService",
+                memberName: "CountAnimals",
+                projectName: bogusProject,
+                ct: CancellationToken.None));
+
+        Assert.AreEqual("projectName", ex.ParamName);
+        StringAssert.Contains(ex.Message, bogusProject,
+            $"Error must echo the offending project name so the caller can correlate. Got: {ex.Message}");
+    }
 }

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -154,7 +154,7 @@ public sealed class SurfaceCatalogTests
         Assert.AreEqual("e147875", diff.SnapshotSources.From.SourceCommit);
 
         CollectionAssert.AreEquivalent(
-            new[] { "workspace_readiness_report", "workspace_support_bundle" },
+            new[] { "workspace_readiness_report", "workspace_support_bundle", "find_overloads" },
             diff.Tools.Added.Select(entry => entry.Name).ToArray());
         CollectionAssert.Contains(diff.Resources.Added.Select(entry => entry.Name).ToArray(), "server_catalog_version_diff");
 
@@ -181,7 +181,7 @@ public sealed class SurfaceCatalogTests
                 $"{workspaceToolName} changed only its outputSchema (buildRequired added to WorkspaceStatusSummaryDto).");
         }
 
-        Assert.AreEqual(3, diff.Summary.Added);
+        Assert.AreEqual(4, diff.Summary.Added);
         Assert.AreEqual(0, diff.Summary.Removed);
         Assert.AreEqual(0, diff.Summary.Promoted);
         Assert.AreEqual(5, diff.Summary.Changed);
@@ -196,7 +196,7 @@ public sealed class SurfaceCatalogTests
         Assert.IsTrue(document.RootElement.TryGetProperty("fromVersion", out var fromVersion));
         Assert.AreEqual("2.3.1", fromVersion.GetString());
         Assert.IsTrue(document.RootElement.TryGetProperty("summary", out var summary));
-        Assert.AreEqual(3, summary.GetProperty("added").GetInt32());
+        Assert.AreEqual(4, summary.GetProperty("added").GetInt32());
         Assert.IsTrue(document.RootElement.TryGetProperty("tools", out var tools));
         Assert.IsTrue(tools.TryGetProperty("changed", out var changed));
         CollectionAssert.AreEquivalent(


### PR DESCRIPTION
## Summary

Adds `find_overloads`: enumerates every overload of a member by type + member name via `GetTypeByMetadataName`/`GetMembers`, closing the gap where `symbol_search` only finds symbols declared in the workspace's own source (0 results for e.g. `System.Math.Max`) and `symbol_signature_help` resolves a single already-bound call site rather than listing every overload choice.

## Linked issue

No tracked issue — surfaced directly from a prior session's workflow gap.

Fixes N/A

## Changes

- `ISymbolRelationshipService` / `SymbolRelationshipService`: new `FindOverloadsAsync`, resolving the type across `solution.Projects` (optionally scoped by `projectName`), collecting `GetMembers(memberName).OfType<IMethodSymbol>()` (plus the base-class chain when `includeInherited=true`), and projecting each into the existing `SignatureHelpDto` shape.
- `SymbolTools.FindOverloads`: new MCP tool wrapper (`find_overloads`), placed next to `symbol_signature_help`. Ships `experimental` tier — no prior usage/audit history yet.
- `ServerSurfaceCatalog.Symbols.cs`: matching catalog row (analyzer-enforced pairing with the tool attribute).
- `README.md` / `src/RoslynMcp.Host.Stdio/README.md`: tool counts bumped 173→174 total, 60→61 experimental (verified by counting catalog rows directly: 113 stable + 61 experimental = 174).
- `SurfaceCatalogTests.cs`: updated the two tests that pin the "tools added since v2.3.1" version-diff snapshot against the live catalog — `find_overloads` is now a fourth added tool in that diff.
- `changelog.d/find-overloads-tool.md`: new fragment.
- `tests/RoslynMcp.Tests/FindOverloadsTests.cs`: 6 new cases — BCL-only overload set never referenced in fixture source (`System.Math.Max`), in-fixture overload parity (`SampleLib.AnimalService.CountAnimals`), `includeInherited` default-false exclusion and true-inclusion of base members, type-not-found (NotFound envelope), and resolvable-type/unknown-member (empty success, not an error).

## Test plan

- [x] Added unit tests covering the change (see above)
- [x] `dotnet build RoslynMcp.slnx` succeeds (0 warnings, 0 errors)
- [x] `dotnet test RoslynMcp.slnx` passes
- [x] Manually verified the behavior (describe below)

**Manual verification:** built this branch as a local global tool and ran it live via the Roslyn MCP server against this repo's own solution:
- `find_overloads(typeMetadataName: "System.Math", memberName: "Max")` → 11 overloads (one per numeric type), each with a correct `displaySignature`/`parameters`/`returnType` — the literal scenario the tool exists to fix, since `System.Math.Max` is never referenced anywhere in this repo's own source.
- `find_overloads(typeMetadataName: "SampleLib.AnimalService", memberName: "CountAnimals")` (against `SampleSolution.slnx`) → 2 overloads, matching the fixture's `List<IAnimal>`/`IEnumerable<IAnimal>` declarations.
- A bogus type name → a clean structured `NotFound` error envelope, not a crash or silent empty result.

**Full-suite run:** 2298 tests, 7 initial failures on this dev machine, all triaged and none caused by this change — 6 pass when re-run individually (3 were flaky only under the full-suite run's load: `ExtractMethod_PreviewAndApply_CompilationSucceeds`, `ExtractMethod_ReassignsExistingLocal_EmitsAssignmentNotVarDecl`, `ExtractSharedExpression_ApplyAfterPreview_CompilationSucceeds`; 3 needed an unrelated local dev-machine NuGet config fix: `Dependency_Inversion_Rewrites_Constructor_Parameter_In_Transitively_Referencing_Project`, `SelfHostedWorkspace_AnalyzerReference_Loads_From_Shadow_Copy`, `Build_Workspace_Returns_Parsed_Diagnostics_For_Broken_Solution`). The 7th, `SampleSolution_ReadinessReport_ReturnsReadyVerdict`, reproduces identically on unmodified `main` (confirmed via `git stash`) — a stale/never-built `SampleLib.Generators` analyzer output on this machine, unrelated to this change.

## Checklist

- [x] Followed the existing code style and project layering (reused `SignatureHelpDto`, the existing per-project compilation-resolution loop pattern from `TryResolveByQualifiedSignatureAsync`, and the `{ count, items }` response shape from `find_base_members`/`find_overrides`)
- [x] No new compiler warnings (`dotnet build` — 0 warnings)
- [x] Public API change (new tool) is intentional and documented in the tool description, including known v1 scope limits (no extension methods, no override-chain dedup for `includeInherited=true`)

## Backlog (maintainer-only)

- Closes backlog row: N/A — shipped in one pass, no row was ever opened
