### PR TITLE
Fix workspace observability contracts

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-23T16:08:13Z
+**updated_at:** 2026-08-23T17:48:40Z
 
 ## Agent contract
 

--- a/ai_docs/items/tool-surface-pagination-or-tool-sets.md
+++ b/ai_docs/items/tool-surface-pagination-or-tool-sets.md
@@ -23,3 +23,10 @@
 173 tools is approaching small-model discovery saturation, but current evidence points to a routing/steering problem more than a raw-count problem. Now that `recommend_workflow` exists, wait for fresh post-router evidence before adding tool-set catalog resources (for example `roslyn://server/catalog/tool-sets` and `roslyn://server/catalog/tools/{toolSet}/{offset}/{limit}`) that expose bounded subsets such as `navigation`, `refactoring`, `validation`, and `analysis` without hiding tools from clients that can handle the full surface.
 
 **Weaker evidence — N until small-model discovery friction is reported after the router lands externally.**
+
+## 2026-08-23 Codex session evidence
+
+- Roslyn tools were absent from the initially materialized declarations, and the agent incorrectly reported the documented server unavailable before querying the deferred catalog.
+- Codex's deferred catalog exposed the complete Roslyn surface; server-info, workspace load, compilation, semantic analysis, catalog parity, and workspace cleanup then succeeded.
+- This is post-router external discovery-friction evidence, but it is confounded: the Codex session contract already documented deferred discovery, so the immediate failure was probe noncompliance rather than proof that raw tool count alone caused saturation.
+- Use this evidence when re-evaluating the row; do not create a duplicate discovery row or change default tool visibility without client-safety evidence.

--- a/changelog.d/workspace-observability-contracts.md
+++ b/changelog.d/workspace-observability-contracts.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** workspace lifecycle observability now isolates Git status from ambient repository overrides, avoids cold support-bundle analyzer passes, keeps informational diagnostics non-blocking, reports nested gate holds as one wall-clock interval, and offers an opt-in compact `workspace_reload` response while preserving its default shape. Closes `validate-recent-git-status-windows-timeout`, `workspace-support-bundle-cold-diagnostics-budget`, `workspace-support-bundle-info-only-verdict`, `workspace-gate-metrics-nested-hold-accounting`, and `workspace-reload-compact-response`.

--- a/src/RoslynMcp.Core/Models/GateMetricsDto.cs
+++ b/src/RoslynMcp.Core/Models/GateMetricsDto.cs
@@ -13,7 +13,7 @@ namespace RoslynMcp.Core.Models;
 /// (e.g. workspace-independent tools like <c>analyze_snippet</c>).
 /// </param>
 /// <param name="QueuedMs">Total milliseconds spent waiting in the rate limiter, global throttle, and per-workspace lock queues before the action ran.</param>
-/// <param name="HeldMs">Total milliseconds the per-workspace lock (or load gate) was held while the action executed.</param>
+/// <param name="HeldMs">Wall-clock milliseconds covered by one or more held workspace/load gates. Nested or concurrent gate holds are counted once, so this value does not exceed request elapsed time.</param>
 /// <param name="HeartbeatCount">For long-running operations that emit progress heartbeats, the number of heartbeats observed. <see langword="null"/> when the tool does not emit progress.</param>
 /// <param name="ElapsedMs">Total wall-clock milliseconds the tool action took, including queue + lock-hold + service work. Lets concurrency audits compute speedup ratios from inside the agent loop without external instrumentation.</param>
 /// <param name="StaleAction">

--- a/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
+++ b/src/RoslynMcp.Core/Services/AmbientGateMetrics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using RoslynMcp.Core.Models;
 
 namespace RoslynMcp.Core.Services;
@@ -53,6 +54,10 @@ public static class AmbientGateMetrics
 /// </summary>
 public sealed class GateMetricsBuilder
 {
+    private readonly object _gateTimingSync = new();
+    private int _activeGateDepth;
+    private long _gateHoldStartedAt;
+
     public string? GateMode { get; set; }
     public long QueuedMs { get; set; }
     public long HeldMs { get; set; }
@@ -124,6 +129,51 @@ public sealed class GateMetricsBuilder
     /// <c>auto-loaded</c>. <see langword="null"/> otherwise.
     /// </summary>
     public long? AutoLoadElapsedMs { get; set; }
+
+    /// <summary>
+    /// Starts a balanced gate-hold interval. Nested intervals contribute one wall-clock span.
+    /// </summary>
+    public IDisposable TrackGate(string gateMode, long queuedMs)
+    {
+        lock (_gateTimingSync)
+        {
+            GateMode ??= gateMode;
+            QueuedMs += queuedMs;
+            if (_activeGateDepth++ == 0)
+            {
+                _gateHoldStartedAt = Stopwatch.GetTimestamp();
+            }
+        }
+
+        return new GateTimingScope(this);
+    }
+
+    private void ExitGate()
+    {
+        lock (_gateTimingSync)
+        {
+            if (_activeGateDepth <= 0)
+            {
+                throw new InvalidOperationException("Gate timing exit did not have a matching entry.");
+            }
+
+            if (--_activeGateDepth == 0)
+            {
+                HeldMs += (long)Stopwatch.GetElapsedTime(_gateHoldStartedAt).TotalMilliseconds;
+                _gateHoldStartedAt = 0;
+            }
+        }
+    }
+
+    private sealed class GateTimingScope(GateMetricsBuilder owner) : IDisposable
+    {
+        private GateMetricsBuilder? _owner = owner;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _owner, null)?.ExitGate();
+        }
+    }
 
     public GateMetricsDto ToDto() => new(GateMode, QueuedMs, HeldMs, HeartbeatCount, ElapsedMs, StaleAction, StaleReloadMs, RetriedAfterReload, CacheHit, ReloadConfirmedNotFound, AutoResolution, AutoLoadElapsedMs);
 }

--- a/src/RoslynMcp.Core/Services/IDiagnosticService.cs
+++ b/src/RoslynMcp.Core/Services/IDiagnosticService.cs
@@ -20,6 +20,24 @@ public interface IDiagnosticService
         string workspaceId, string? projectFilter, string? fileFilter, string? severityFilter, string? diagnosticIdFilter, CancellationToken ct);
 
     /// <summary>
+    /// Tries to read already-computed full-workspace diagnostic totals without starting a
+    /// compilation or analyzer pass. Incident and readiness surfaces use this cache-only path so
+    /// a cold diagnostic probe cannot monopolize the workspace read gate.
+    /// </summary>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="diagnostics">
+    /// A current-version full-workspace result when available; otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns><see langword="true"/> only when current cached totals were returned.</returns>
+    bool TryGetCachedWorkspaceDiagnostics(
+        string workspaceId,
+        out DiagnosticsResultDto? diagnostics)
+    {
+        diagnostics = null;
+        return false;
+    }
+
+    /// <summary>
     /// Returns detailed information for a specific diagnostic at a source location, including available code fixes.
     /// Returns <see langword="null"/> if no matching diagnostic is found.
     /// </summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceSupportBundleBuilder.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceSupportBundleBuilder.cs
@@ -17,7 +17,7 @@ internal static class WorkspaceSupportBundleBuilder
         IReadOnlyList<WorkspaceStatusSummaryDto> loadedWorkspaces,
         WorkspaceStatusSummaryDto readiness,
         WorkspaceDriftResult drift,
-        DiagnosticsResultDto diagnostics,
+        DiagnosticsResultDto? diagnostics,
         IReadOnlyList<WorkspaceChangeDto> changes,
         int changeCap,
         int driftCap)
@@ -41,13 +41,15 @@ internal static class WorkspaceSupportBundleBuilder
                 ServerVersion: ResolveServerVersion(),
                 CatalogVersion: ServerSurfaceCatalog.CatalogVersion));
 
-        var diagnosticTotals = new WorkspaceSupportDiagnosticsTotalsDto(
-            TotalErrors: diagnostics.TotalErrors,
-            TotalWarnings: diagnostics.TotalWarnings,
-            TotalInfo: diagnostics.TotalInfo,
-            CompilerErrors: diagnostics.CompilerErrors,
-            AnalyzerErrors: diagnostics.AnalyzerErrors,
-            WorkspaceErrors: diagnostics.WorkspaceErrors);
+        var diagnosticTotals = diagnostics is null
+            ? null
+            : new WorkspaceSupportDiagnosticsTotalsDto(
+                TotalErrors: diagnostics.TotalErrors,
+                TotalWarnings: diagnostics.TotalWarnings,
+                TotalInfo: diagnostics.TotalInfo,
+                CompilerErrors: diagnostics.CompilerErrors,
+                AnalyzerErrors: diagnostics.AnalyzerErrors,
+                WorkspaceErrors: diagnostics.WorkspaceErrors);
 
         var ledger = new WorkspaceSupportChangeLedgerDto(
             TotalChanges: changes.Count,
@@ -127,7 +129,7 @@ internal static class WorkspaceSupportBundleBuilder
     private static IReadOnlyList<string> BuildSupportBundleNextActions(
         WorkspaceStatusSummaryDto readiness,
         WorkspaceDriftResult drift,
-        WorkspaceSupportDiagnosticsTotalsDto diagnostics,
+        WorkspaceSupportDiagnosticsTotalsDto? diagnostics,
         WorkspaceSupportChangeLedgerDto ledger)
     {
         var actions = new List<string>();
@@ -151,7 +153,11 @@ internal static class WorkspaceSupportBundleBuilder
             actions.Add(readiness.RestoreHint);
         }
 
-        if (diagnostics.TotalErrors > 0)
+        if (diagnostics is null)
+        {
+            actions.Add("Diagnostic totals are not cached for this workspace version; run project_diagnostics when current totals are required.");
+        }
+        else if (diagnostics.TotalErrors > 0)
         {
             actions.Add("Run compile_check or project_diagnostics to inspect the error diagnostics.");
         }
@@ -180,7 +186,7 @@ internal static class WorkspaceSupportBundleBuilder
     private static string ResolveSupportBundleStatus(
         WorkspaceStatusSummaryDto readiness,
         WorkspaceDriftResult drift,
-        WorkspaceSupportDiagnosticsTotalsDto diagnostics,
+        WorkspaceSupportDiagnosticsTotalsDto? diagnostics,
         WorkspaceSupportChangeLedgerDto ledger)
     {
         if (drift.Stale || readiness.IsStale)
@@ -188,7 +194,17 @@ internal static class WorkspaceSupportBundleBuilder
             return "stale";
         }
 
-        if (!readiness.IsReady || diagnostics.TotalErrors > 0 || diagnostics.TotalWarnings > 0 || diagnostics.TotalInfo > 0)
+        if (!readiness.IsReady)
+        {
+            return "attention-needed";
+        }
+
+        if (diagnostics is null)
+        {
+            return "diagnostics-limited";
+        }
+
+        if (diagnostics.TotalErrors > 0 || diagnostics.TotalWarnings > 0)
         {
             return "attention-needed";
         }

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -90,7 +90,7 @@ public static class WorkspaceTools
         }, ct);
     }
 
-    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes. Set autoRestore=true to run dotnet restore and one follow-up reload when the reloaded status reports restoreRequired=true.")]
+    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes. Set autoRestore=true to run dotnet restore and one follow-up reload when the reloaded status reports restoreRequired=true. Pass verbose=false for a compact readiness/version/count projection; the default verbose=true preserves the full project tree.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Reload an existing workspace session from disk.")]
     public static Task<string> ReloadWorkspace(
@@ -99,6 +99,7 @@ public static class WorkspaceTools
         IDotnetCommandRunner commandRunner,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
         [Description("When true and the reloaded status reports restoreRequired=true, run `dotnet restore` on the loaded target and reload once before returning.")] bool autoRestore = false,
+        [Description("When true (default), preserve the full per-project response. Pass false for readiness, version, and aggregate counts without the project tree.")] bool verbose = true,
         CancellationToken ct = default)
     {
         // Reload acquires both the global load gate AND the per-workspace write lock so that
@@ -108,7 +109,7 @@ public static class WorkspaceTools
             {
                 var status = await workspace.ReloadAsync(workspaceId, innerCt).ConfigureAwait(false);
                 status = await RestoreAndReloadIfRequiredAsync(commandRunner, workspace, status, autoRestore, innerCt).ConfigureAwait(false);
-                return JsonSerializer.Serialize(status, JsonDefaults.Indented);
+                return SerializeWorkspaceLoadResult(status, verbose, prewarmResult: null);
             }, outerCt), ct);
     }
 
@@ -527,13 +528,9 @@ public static class WorkspaceTools
             var status = await workspace.GetStatusAsync(resolvedWorkspaceId, c).ConfigureAwait(false);
             var readiness = WorkspaceStatusSummaryDto.From(status);
             var drift = await driftService.CheckDriftAsync(resolvedWorkspaceId, c).ConfigureAwait(false);
-            var diagnostics = await diagnosticService.GetDiagnosticsAsync(
+            diagnosticService.TryGetCachedWorkspaceDiagnostics(
                 resolvedWorkspaceId,
-                projectFilter: null,
-                fileFilter: null,
-                severityFilter: "Warning",
-                diagnosticIdFilter: null,
-                c).ConfigureAwait(false);
+                out var diagnostics);
             var changes = changeTracker.GetChanges(resolvedWorkspaceId);
 
             var bundle = WorkspaceSupportBundleBuilder.Create(

--- a/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DiagnosticService.cs
@@ -64,6 +64,34 @@ public sealed class DiagnosticService : IDiagnosticService
         _diagnosticCache.TryRemove(workspaceId, out _);
     }
 
+    public bool TryGetCachedWorkspaceDiagnostics(
+        string workspaceId,
+        out DiagnosticsResultDto? diagnostics)
+    {
+        diagnostics = null;
+        var version = _workspace.GetCurrentVersion(workspaceId);
+        if (!_resultCache.TryGetValue(workspaceId, out var entry) || entry.Version != version)
+        {
+            return false;
+        }
+
+        foreach (var cached in entry.Results)
+        {
+            var key = cached.Key;
+            // Severity changes the returned rows but not aggregate totals. The support-bundle
+            // cache-only path consumes totals, so any current full-workspace severity entry is valid.
+            if (key.ProjectFilter is null
+                && key.FileFilter is null
+                && key.DiagnosticIdFilter is null)
+            {
+                diagnostics = cached.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public async Task<DiagnosticsResultDto> GetDiagnosticsAsync(
         string workspaceId, string? projectFilter, string? fileFilter, string? severityFilter, string? diagnosticIdFilter, CancellationToken ct)
     {

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceExecutionGate.cs
@@ -508,22 +508,9 @@ public sealed class WorkspaceExecutionGate : IWorkspaceExecutionGate, IDisposabl
     {
         queueStopwatch.Stop();
         var queuedMs = queueStopwatch.ElapsedMilliseconds;
-        var holdStopwatch = Stopwatch.StartNew();
-        try
-        {
-            return await body().ConfigureAwait(false);
-        }
-        finally
-        {
-            holdStopwatch.Stop();
-            var metrics = AmbientGateMetrics.Current;
-            if (metrics is not null)
-            {
-                metrics.GateMode ??= gateMode;
-                metrics.QueuedMs += queuedMs;
-                metrics.HeldMs += holdStopwatch.ElapsedMilliseconds;
-            }
-        }
+        var metrics = AmbientGateMetrics.Current;
+        using var gateTiming = metrics?.TrackGate(gateMode, queuedMs);
+        return await body().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceValidationService.cs
@@ -691,7 +691,6 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
             startInfo = new ProcessStartInfo
             {
                 FileName = "git",
-                WorkingDirectory = solutionDirectory,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -699,6 +698,11 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
                 StandardOutputEncoding = Encoding.UTF8,
                 StandardErrorEncoding = Encoding.UTF8,
             };
+            RemoveAmbientGitRepositoryOverrides(startInfo);
+            startInfo.Environment["GIT_OPTIONAL_LOCKS"] = "0";
+            startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+            startInfo.ArgumentList.Add("-C");
+            startInfo.ArgumentList.Add(solutionDirectory);
             startInfo.ArgumentList.Add("status");
             startInfo.ArgumentList.Add("--porcelain=v1");
             startInfo.ArgumentList.Add("-z");
@@ -770,6 +774,24 @@ public sealed class WorkspaceValidationService : IWorkspaceValidationService
         }
 
         return (ParseGitPorcelainZ(stdout, solutionDirectory), Array.Empty<string>(), false);
+    }
+
+    private static void RemoveAmbientGitRepositoryOverrides(ProcessStartInfo startInfo)
+    {
+        string[] repositoryOverrides =
+        [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_COMMON_DIR",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        ];
+
+        foreach (var variable in repositoryOverrides)
+        {
+            startInfo.Environment.Remove(variable);
+        }
     }
 
     internal WorkspaceValidationFailureDetail CreateUnexpectedFailure(

--- a/tests/RoslynMcp.Tests/DiagnosticServiceFilterTotalsTests.cs
+++ b/tests/RoslynMcp.Tests/DiagnosticServiceFilterTotalsTests.cs
@@ -99,6 +99,23 @@ public sealed class DiagnosticServiceFilterTotalsTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task TryGetCachedWorkspaceDiagnostics_ReturnsCurrentFullWorkspaceTotalsWithoutAnalyzerPass()
+    {
+        var analyzed = await DiagnosticService.GetDiagnosticsAsync(
+            WorkspaceId, projectFilter: null, fileFilter: null, severityFilter: "Error",
+            diagnosticIdFilter: null, CancellationToken.None);
+
+        var cacheHit = DiagnosticService.TryGetCachedWorkspaceDiagnostics(WorkspaceId, out var cached);
+
+        Assert.IsTrue(cacheHit);
+        Assert.IsNotNull(cached);
+        Assert.AreEqual(analyzed.TotalErrors, cached.TotalErrors);
+        Assert.AreEqual(analyzed.TotalWarnings, cached.TotalWarnings);
+        Assert.AreEqual(analyzed.TotalInfo, cached.TotalInfo,
+            "The cache-only support-bundle path must reuse current full-workspace totals.");
+    }
+
+    [TestMethod]
     public async Task ProjectDiagnostics_TotalDiagnosticsIsInvariantUnderSeverityFilter()
     {
         // BUG fix (project-diagnostics-totaldiagnostics-collapses-under-severity-filter):

--- a/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
+++ b/tests/RoslynMcp.Tests/ValidateRecentGitChangesTests.cs
@@ -99,6 +99,44 @@ public sealed class ValidateRecentGitChangesTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task ValidateRecentGitChangesAsync_AmbientRepositoryOverrides_DoNotEscapeSolutionScope()
+    {
+        if (!IsGitAvailable())
+        {
+            Assert.Inconclusive($"git unavailable — cannot run the process-environment test. {_gitUnavailableReason}");
+            return;
+        }
+
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        InitializeGitRepo(workspace.RootPath);
+        GitFixtureRunner.StageAndCommitAll(workspace.RootPath);
+        var touchedFile = workspace.GetPath("SampleLib", "AnimalService.cs");
+        await File.AppendAllTextAsync(touchedFile, $"{Environment.NewLine}// ambient git override {Guid.NewGuid():N}{Environment.NewLine}");
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var priorGitDir = Environment.GetEnvironmentVariable("GIT_DIR");
+        var priorGitWorkTree = Environment.GetEnvironmentVariable("GIT_WORK_TREE");
+        try
+        {
+            Environment.SetEnvironmentVariable("GIT_DIR", workspace.GetPath("missing-git-dir"));
+            Environment.SetEnvironmentVariable("GIT_WORK_TREE", workspace.GetPath("missing-work-tree"));
+
+            var result = await _validationService.ValidateRecentGitChangesAsync(
+                workspace.WorkspaceId, runTests: false, CancellationToken.None);
+
+            Assert.AreEqual(0, result.Warnings.Count,
+                $"Git scoping must ignore ambient repository overrides; got [{string.Join("; ", result.Warnings)}].");
+            Assert.AreEqual(1, result.ChangedFilePaths.Count);
+            Assert.AreEqual(Path.GetFullPath(touchedFile), Path.GetFullPath(result.ChangedFilePaths[0]));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GIT_DIR", priorGitDir);
+            Environment.SetEnvironmentVariable("GIT_WORK_TREE", priorGitWorkTree);
+        }
+    }
+
+    [TestMethod]
     public async Task ValidateRecentGitChangesAsync_SlowValidationPhase_ReturnsRetryableTimeoutWithGitScope()
     {
         if (!IsGitAvailable())

--- a/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceExecutionGateTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Time.Testing;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
@@ -16,6 +17,31 @@ public class WorkspaceExecutionGateTests
         return new WorkspaceExecutionGate(
             new ExecutionGateOptions(),
             manager ?? new FakeGateWorkspaceManager());
+    }
+
+    [TestMethod]
+    public async Task NestedLoadAndWorkspaceGates_ReportOneWallClockHoldInterval()
+    {
+        var gate = CreateGate();
+        using var scope = AmbientGateMetrics.BeginRequest();
+        var stopwatch = Stopwatch.StartNew();
+
+        await gate.RunLoadGateAsync(outerCt =>
+            gate.RunWriteAsync(WorkspaceA, async innerCt =>
+            {
+                await Task.Delay(75, innerCt);
+                return 0;
+            }, outerCt), CancellationToken.None);
+
+        stopwatch.Stop();
+        AmbientGateMetrics.Current!.ElapsedMs = stopwatch.ElapsedMilliseconds;
+        var metrics = AmbientGateMetrics.Snapshot();
+
+        Assert.IsNotNull(metrics);
+        Assert.IsTrue(metrics.HeldMs >= 50,
+            $"The nested gate interval should include the inner work; heldMs={metrics.HeldMs}.");
+        Assert.IsTrue(metrics.HeldMs <= metrics.ElapsedMs,
+            $"Nested gate holds must not be double-counted; heldMs={metrics.HeldMs}, elapsedMs={metrics.ElapsedMs}.");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/WorkspaceSupportBundleTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceSupportBundleTests.cs
@@ -202,7 +202,7 @@ public sealed class WorkspaceSupportBundleTests
     }
 
     [TestMethod]
-    public async Task WorkspaceSupportBundle_InfoOnlyDiagnostics_ReturnsAttentionNeededWithAction()
+    public async Task WorkspaceSupportBundle_InfoOnlyDiagnostics_RemainsCleanWithOptionalAction()
     {
         var status = CreateStatus(isReady: true);
         var diagnostics = new DiagnosticsResultDto(
@@ -224,10 +224,34 @@ public sealed class WorkspaceSupportBundleTests
             new FakeDiagnosticService(diagnostics));
 
         using var doc = JsonDocument.Parse(json.TextPayload());
-        Assert.AreEqual("attention-needed", doc.RootElement.GetProperty("status").GetString());
+        Assert.AreEqual("clean", doc.RootElement.GetProperty("status").GetString());
+        Assert.AreEqual(3, doc.RootElement.GetProperty("diagnosticsTotals").GetProperty("totalInfo").GetInt32());
         StringAssert.Contains(
             string.Join(" ", doc.RootElement.GetProperty("nextActions").EnumerateArray().Select(a => a.GetString())),
             "Info");
+    }
+
+    [TestMethod]
+    public async Task WorkspaceSupportBundle_ColdDiagnostics_ReturnsExplicitLimitationWithoutStartingAnalyzerPass()
+    {
+        var status = CreateStatus(isReady: true);
+        var diagnosticService = new CacheMissDiagnosticService();
+
+        var json = await WorkspaceTools.GetWorkspaceSupportBundle(
+            new FakeGate(),
+            new FakeWorkspaceManager([status]),
+            new FakeDriftService(new WorkspaceDriftResult(false, [], "noop")),
+            new FakeChangeTracker([]),
+            diagnosticService);
+
+        using var doc = JsonDocument.Parse(json.TextPayload());
+        Assert.AreEqual("diagnostics-limited", doc.RootElement.GetProperty("status").GetString());
+        Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("diagnosticsTotals").ValueKind);
+        StringAssert.Contains(
+            string.Join(" ", doc.RootElement.GetProperty("nextActions").EnumerateArray().Select(a => a.GetString())),
+            "not cached");
+        Assert.AreEqual(0, diagnosticService.AnalyzerPassCount,
+            "A support bundle cache miss must not start a cold analyzer pass while the read gate is held.");
     }
 
     private static WorkspaceStatusDto CreateStatus(bool isReady, bool isStale = false, string workspaceId = "ws-1")
@@ -337,6 +361,14 @@ public sealed class WorkspaceSupportBundleTests
 
     private sealed class FakeDiagnosticService(DiagnosticsResultDto result) : IDiagnosticService
     {
+        public bool TryGetCachedWorkspaceDiagnostics(
+            string workspaceId,
+            out DiagnosticsResultDto? diagnostics)
+        {
+            diagnostics = result;
+            return true;
+        }
+
         public Task<DiagnosticsResultDto> GetDiagnosticsAsync(
             string workspaceId,
             string? projectFilter,
@@ -345,6 +377,41 @@ public sealed class WorkspaceSupportBundleTests
             string? diagnosticIdFilter,
             CancellationToken ct) =>
             Task.FromResult(result);
+
+        public Task<DiagnosticDetailsDto?> GetDiagnosticDetailsAsync(
+            string workspaceId,
+            string diagnosticId,
+            string filePath,
+            int line,
+            int column,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class CacheMissDiagnosticService : IDiagnosticService
+    {
+        public int AnalyzerPassCount { get; private set; }
+
+        public bool TryGetCachedWorkspaceDiagnostics(
+            string workspaceId,
+            out DiagnosticsResultDto? diagnostics)
+        {
+            diagnostics = null;
+            return false;
+        }
+
+        public Task<DiagnosticsResultDto> GetDiagnosticsAsync(
+            string workspaceId,
+            string? projectFilter,
+            string? fileFilter,
+            string? severityFilter,
+            string? diagnosticIdFilter,
+            CancellationToken ct)
+        {
+            AnalyzerPassCount++;
+            return Task.FromException<DiagnosticsResultDto>(
+                new AssertFailedException("Cold analyzer pass must not start from workspace_support_bundle."));
+        }
 
         public Task<DiagnosticDetailsDto?> GetDiagnosticDetailsAsync(
             string workspaceId,

--- a/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceToolsIntegrationTests.cs
@@ -86,6 +86,44 @@ public sealed class WorkspaceToolsIntegrationTests : SharedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task WorkspaceTools_ReloadWorkspace_DefaultPreservesFullProjectResponse()
+    {
+        var json = await WorkspaceTools.ReloadWorkspace(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            DotnetCommandRunner,
+            WorkspaceId,
+            autoRestore: false,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        var projects = doc.RootElement.GetProperty("projects");
+        Assert.IsTrue(projects.GetArrayLength() >= 1);
+        Assert.IsTrue(projects.EnumerateArray().All(project =>
+            !string.IsNullOrWhiteSpace(project.GetProperty("outputType").GetString())),
+            "Full reload responses must preserve per-project OutputType metadata.");
+    }
+
+    [TestMethod]
+    public async Task WorkspaceTools_ReloadWorkspace_VerboseFalseReturnsCompactSummary()
+    {
+        var json = await WorkspaceTools.ReloadWorkspace(
+            WorkspaceExecutionGate,
+            WorkspaceManager,
+            DotnetCommandRunner,
+            WorkspaceId,
+            autoRestore: false,
+            verbose: false,
+            ct: CancellationToken.None);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.IsFalse(doc.RootElement.TryGetProperty("projects", out _));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("workspaceVersion", out _));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("projectCount", out _));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("workspaceDiagnosticCount", out _));
+    }
+
+    [TestMethod]
     public async Task WorkspaceTools_ListWorkspaces_Default_Is_Summary()
     {
         var json = await WorkspaceTools.ListWorkspaces(WorkspaceManager, verbose: false);


### PR DESCRIPTION
## Summary

- isolate recent-change Git status from ambient repository overrides and keep the real-process timeout boundary
- make support bundles cache-only for diagnostics, fail closed on cache misses, and keep info-only results non-blocking
- report nested workspace gate holds as one wall-clock interval and add opt-in compact reload responses
- close five validated backlog rows and preserve external deferred-tool discovery evidence

## Validation

- `just ci` (2,468 passed, 0 failed, 6 skipped; Release build 0 warnings/errors; NuGet audit clean)
- focused workspace observability suites (77 passed across Git, support-bundle, gate, reload, and diagnostics-cache coverage)
- Roslyn `compile_check` (5 projects, 0 diagnostics)
- Roslyn `format_check` (796 documents, 0 violations)
- backlog lint (0 errors, 0 warnings)
- changelog fragment verification
