### PR TITLE
Upgrade Roslyn packages to 5.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="ModelContextProtocol" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <!-- Ships the RS* release-tracking rules used by ServerSurfaceCatalogAnalyzer.
-         Must match the 5.6.x Microsoft.CodeAnalysis.CSharp family — 4.x trips NU1605. -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Features" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
+         Keep aligned with the Microsoft.CodeAnalysis.CSharp family to avoid NU1605. -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Features" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
@@ -30,15 +30,16 @@
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <!-- Analyzer-testing infrastructure for ServerSurfaceCatalogAnalyzer (RMCP001/RMCP002).
-         The harness consumes the centrally-pinned Microsoft.CodeAnalysis.* 5.6.0 family so
+         The harness consumes the centrally-pinned Microsoft.CodeAnalysis.* 5.9.0 family so
          analyzer tests and production analysis share the same Roslyn workspace ABI. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <!-- Transitive pin: the analyzer-testing harness drags in NuGet.Frameworks; pin an
          explicit version so Microsoft.Build.Locator's MSBL001 check stays satisfied
          (see the PackageReference in RoslynMcp.Tests.csproj for ExcludeAssets details). -->
     <PackageVersion Include="NuGet.Frameworks" Version="6.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
+    <!-- Independently versioned package; do not align mechanically with the compiler family. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,12 +8,12 @@ Roslyn-Backed MCP Server uses the following open-source packages. Versions come 
 |---|---:|---|---|
 | DiffPlex | 1.9.0 | Apache-2.0 | https://github.com/mmanela/diffplex |
 | Microsoft.Build.Locator | 1.11.2 | MIT | https://github.com/microsoft/MSBuildLocator |
-| Microsoft.CodeAnalysis.CSharp | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
-| Microsoft.CodeAnalysis.CSharp.Features | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
-| Microsoft.CodeAnalysis.CSharp.Scripting | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
-| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
-| Microsoft.CodeAnalysis.Features | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
-| Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.6.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp.Features | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp.Scripting | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.Features | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
+| Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.9.0 | MIT | https://github.com/dotnet/roslyn |
 | Microsoft.Extensions.Hosting | 10.0.10 | MIT | https://github.com/dotnet/runtime |
 | Microsoft.Extensions.Http | 10.0.10 | MIT | https://github.com/dotnet/runtime |
 | Microsoft.Extensions.Logging | 10.0.10 | MIT | https://github.com/dotnet/runtime |
@@ -30,7 +30,7 @@ Roslyn-Backed MCP Server uses the following open-source packages. Versions come 
 | Microsoft.Build.Framework | 17.14.28 | MIT | https://github.com/dotnet/msbuild |
 | Microsoft.Build.Tasks.Core | 17.14.28 | MIT | https://github.com/dotnet/msbuild |
 | Microsoft.Build.Utilities.Core | 17.14.28 | MIT | https://github.com/dotnet/msbuild |
-| Microsoft.CodeAnalysis.Analyzers | 5.6.0 | MIT | https://github.com/dotnet/roslyn-analyzers |
+| Microsoft.CodeAnalysis.Analyzers | 5.9.0 | MIT | https://github.com/dotnet/roslyn-analyzers |
 | Microsoft.CodeAnalysis.BannedApiAnalyzers | 5.6.0 | MIT | https://github.com/dotnet/roslyn-analyzers |
 | Microsoft.CodeAnalysis.NetAnalyzers | 10.0.302 | MIT | https://github.com/dotnet/sdk |
 | Microsoft.SourceLink.GitHub | 10.0.301 | MIT | https://github.com/dotnet/sourcelink |

--- a/changelog.d/roslyn-5-9-package-family-upgrade.md
+++ b/changelog.d/roslyn-5-9-package-family-upgrade.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** upgraded the coordinated Microsoft.CodeAnalysis compiler, workspace, feature, scripting, and analyzer package family from 5.6.0 to 5.9.0 while retaining the independently versioned Banned API analyzer at its latest 5.6.0 release.


### PR DESCRIPTION
## Summary

- upgrade the coordinated Microsoft.CodeAnalysis compiler, workspace, features, scripting, and analyzer package family from 5.6.0 to 5.9.0
- retain the independently versioned Banned API analyzer at 5.6.0
- regenerate third-party notices and add a release-cut changelog fragment

## Validation

- `just ci` (2,468 passed, 0 failed, 6 skipped; Release build 0 warnings/errors; NuGet audit clean)
- focused analyzer, diagnostics, workspace, and real-host wire tests (50 passed)
- resolved dependency graph confirms the coordinated Roslyn runtime packages at 5.9.0
- built `Microsoft.CodeAnalysis.CSharp.dll` reports assembly version 5.9.0.0
- changelog fragment and third-party notice verification passed
