### PR TITLE
fix: correct /release-cut Step 3 to the publish-gate verify invocation

### DIFF
--- a/.claude/skills/release-cut/SKILL.md
+++ b/.claude/skills/release-cut/SKILL.md
@@ -80,13 +80,31 @@ If the CHANGELOG.md `## [Unreleased]` section had content, `/bump` moved it unde
 
 ### Step 3: Verify
 
-Run the full CI-equivalent locally:
+Run the publish-gate invocation locally — the same entry point and flags
+`publish-nuget.yml` runs at tag time:
 
 ```
-pwsh -NoProfile -File eng/verify-release.ps1 -Configuration Release
+pwsh -NoProfile -File eng/verify-release.ps1 -Configuration Release -NoCoverage -RequireConsumedFragments
 ```
+
+**The flags are load-bearing — do NOT drop them to the bare form.**
+
+| Flag | Why |
+|---|---|
+| `-NoCoverage` | Coverage is informational per `CI_POLICY.md` and gates nothing. The bare form is the dispatch/schedule coverage path, and it trips the known Coverlet .NET 10 teardown crash (`coverlet-net10-session-end-crash-upgrade`) — an `AccessViolationException` in `CoverletInProcDataCollector.TestSessionEnd` that aborts the run and returns exit 1 *after every test has already passed*. That is a false red on an otherwise green release. |
+| `-RequireConsumedFragments` | Enforces that a consumed breaking section advances the major. Step 3 is the only local gate for the breaking→major rule; without this flag a mis-typed bump reaches Ship unchecked. |
+
+Reference invocations (keep this table in sync with the workflows):
+
+| Gate | Invocation |
+|---|---|
+| PR merge gate (`ci.yml`) | `-Configuration Release -NoCoverage -ExcludeNetworkTests` |
+| Publish gate (`publish-nuget.yml`) | `-Configuration Release -NoCoverage -RequireConsumedFragments` |
+| dispatch / schedule (informational only) | `-Configuration Release` |
 
 Save stdout+stderr to `artifacts/verify-release.log` (tee pattern) so Step 4 Ship has evidence and re-runs can probe the log mtime. If exit code is non-zero: STOP and report the failure. Do NOT proceed to Ship with a red verify.
+
+If the run reports `Failed: 0` yet still exits non-zero, check the tail for a collector crash before treating it as a product failure — see the `-NoCoverage` row above.
 
 Also run `pwsh -NoProfile -File eng/verify-ai-docs.ps1` (fast; covers shipped-skill generality + link check).
 

--- a/changelog.d/release-cut-step3-verify-flag-drift.md
+++ b/changelog.d/release-cut-step3-verify-flag-drift.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** `/release-cut` Step 3 now runs the publish-gate verify invocation (`eng/verify-release.ps1 -Configuration Release -NoCoverage -RequireConsumedFragments`) instead of the bare form. The bare form is the dispatch/schedule informational coverage path: it gates nothing, trips the known Coverlet .NET 10 teardown crash (`coverlet-net10-session-end-crash-upgrade`) that aborts an otherwise-green run with exit 1 after every test has passed, and omitted `-RequireConsumedFragments` so Step 3 never exercised the breaking-to-major rule it is the only local gate for. The step now documents why each flag is load-bearing, carries a reference table of the PR-merge / publish / informational invocations to catch future drift, and tells the operator to suspect a collector crash when a run reports `Failed: 0` yet exits non-zero. Closes `release-cut-step3-verify-flag-drift`.


### PR DESCRIPTION
## Problem

`/release-cut` Step 3 prescribed a bare invocation:

```
pwsh -NoProfile -File eng/verify-release.ps1 -Configuration Release
```

That is the **dispatch/schedule informational coverage path**. It gates nothing, and it matches neither real gate:

| Gate | Invocation |
|---|---|
| PR merge (`ci.yml:286`) | `-NoCoverage -ExcludeNetworkTests` |
| Publish (`publish-nuget.yml:60`) | `-NoCoverage -RequireConsumedFragments` |
| dispatch / schedule | bare — *what Step 3 said* |

Two defects followed:

1. **False red on every release cut.** The bare form collects coverage and trips the known Coverlet .NET 10 teardown crash (`coverlet-net10-session-end-crash-upgrade`) — an `AccessViolationException` in `CoverletInProcDataCollector.TestSessionEnd` that aborts the run and returns exit 1 *after every test has already passed*. Observed on the v4.0.0 cut: `Failed: 0, Passed: 2469`, exit 1.

2. **The breaking→major rule was never checked locally.** Omitting `-RequireConsumedFragments` meant Step 3 skipped it, despite Step 3 being the only local gate for that rule — the one that decides whether a major cut is correct.

## Fix

Step 3 now runs the publish-gate invocation, plus:

- a table explaining why each flag is load-bearing
- a reference table of all three invocations, to catch future drift
- a note to suspect a collector crash when a run reports `Failed: 0` yet exits non-zero

Docs-only change to `.claude/**` (repo-local tooling, out of doc-audit and shipped-skill scope). `eng/verify-ai-docs.ps1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)