### PR TITLE
maintenance: service ModelContextProtocol 2.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="2.1.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <!-- Ships the RS* release-tracking rules used by ServerSurfaceCatalogAnalyzer.
          Keep aligned with the Microsoft.CodeAnalysis.CSharp family to avoid NU1605. -->

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -18,7 +18,7 @@ Roslyn-Backed MCP Server uses the following open-source packages. Versions come 
 | Microsoft.Extensions.Http | 10.0.11 | MIT | https://github.com/dotnet/runtime |
 | Microsoft.Extensions.Logging | 10.0.11 | MIT | https://github.com/dotnet/runtime |
 | Microsoft.Extensions.Logging.Console | 10.0.11 | MIT | https://github.com/dotnet/runtime |
-| ModelContextProtocol | 2.1.0 | Apache-2.0 | https://github.com/modelcontextprotocol/csharp-sdk |
+| ModelContextProtocol | 2.2.0 | Apache-2.0 | https://github.com/modelcontextprotocol/csharp-sdk |
 | Nito.AsyncEx | 5.1.2 | MIT | https://github.com/StephenCleary/AsyncEx |
 | System.Security.Cryptography.Xml | 10.0.11 | MIT | https://github.com/dotnet/runtime |
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-24T21:36:27Z
+**updated_at:** 2026-08-24T23:01:31Z
 
 ## Agent contract
 
@@ -183,6 +183,8 @@
 | `workspace-fixture-load-amortization-wave-3` | Low | — | Amortize repeated isolated loads in scaffolding and cross-project refactoring tests with deterministic per-case state restoration. [type: test performance] [source: 2026-08-24 TRX hotspot audit] | S | items/workspace-fixture-load-amortization-wave-3.md |
 | `isolated-workspace-restore-helper-deduplication` | Low | — | **Share isolated-workspace restore** — centralize cancellation-aware restore execution and complete failure diagnostics across both duplicate suites. [type: test infrastructure] [source: 2026-08-24 adjacent review] | S | items/isolated-workspace-restore-helper-deduplication.md |
 | `workspace-readiness-fixture-ready-state-isolation` | Low | — | **Automate readiness order proof** — keep isolated scenarios and add a bounded repeated runner that executes the class in deliberately different orders. [type: test correctness] [source: 2026-08-24 dependency review] | S | items/workspace-readiness-fixture-ready-state-isolation.md |
+| `dependency-gate-process-tests-runner-adoption` | Low | powershell-script-test-runner-foundation | Adopt shared process runner in dependency gate tests — replace duplicated PowerShell launch, timeout, process-tree termination, root-reap, and output-drain plumbing without weakening fail-closed assertions. [type: test-refactor] [source: 2026-08-24 loaded-machine gate failure] | S | items/dependency-gate-process-tests-runner-adoption.md |
+| `mstest-cooperative-timeout-token-flow` | Low | — | Make cooperative test timeouts cancel owned work — flow MSTest cancellation through the third-party notice verifier and elicitation coordinator so hung work cannot outlive the advertised ceiling. [type: test-correctness] [source: 2026-08-24 adjacent review] | S | items/mstest-cooperative-timeout-token-flow.md |
 
 ## Defer
 

--- a/ai_docs/items/dependency-gate-process-tests-runner-adoption.md
+++ b/ai_docs/items/dependency-gate-process-tests-runner-adoption.md
@@ -1,0 +1,20 @@
+# dependency-gate-process-tests-runner-adoption — Share dependency-gate process fixtures
+
+**row:** `dependency-gate-process-tests-runner-adoption` · **pri:** `Low` · **size:** `S` · **deps:** `powershell-script-test-runner-foundation`
+
+## Anchors
+
+- `tests/RoslynMcp.Tests/NuGetAuditGateTests.cs`
+- `tests/RoslynMcp.Tests/PackageFamilyContractTests.cs`
+
+## Acceptance
+
+- [ ] Replace both private PowerShell process launchers, timeout/tree-reap helpers, and result records with the shared `PwshScriptRunner`.
+- [ ] Preserve argument boundaries, isolated child environments, concurrent stdout/stderr draining, the 60-second contention-tolerant process bound, and full timeout diagnostics.
+- [ ] Preserve every fail-closed audit, package-family, and upgrade-matrix assertion.
+- [ ] One source scan proves neither anchored file retains private `ProcessStartInfo`, process-tree cleanup, or duplicate result plumbing.
+
+## Evidence
+
+The unsharded Windows gate on 2026-08-24 ran with 24 class workers while another local workload contended for the machine. Three prior full runs completed each dependency-gate subprocess in about 0.3–0.6 seconds; the contended run stretched the same cases to 3–28 seconds and tripped the former 20-second NuGet-audit bound. The immediate hardening keeps these isolated classes parallel while making timeout cleanup deterministic. Both files still duplicate the process machinery already tracked by `powershell-script-test-runner-foundation`; this dependent row bounds their later migration to two test consumers.
+2026-08-24 review clarification: Kill(entireProcessTree: true) requests descendant termination, but Process.WaitForExitAsync proves only the root exited. The shared runner must retain a bounded root wait and redirected-stream drain and must not claim that root reaping independently proves every descendant exited.

--- a/ai_docs/items/mstest-cooperative-timeout-token-flow.md
+++ b/ai_docs/items/mstest-cooperative-timeout-token-flow.md
@@ -1,0 +1,19 @@
+# mstest-cooperative-timeout-token-flow — Make cooperative timeouts cancel owned test work
+
+**row:** `mstest-cooperative-timeout-token-flow` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `tests/RoslynMcp.Tests/ThirdPartyNoticeDriftTests.cs`
+- `tests/RoslynMcp.Tests/StructuredCallElicitationCoordinatorTests.cs`
+
+## Acceptance
+
+- [ ] Flow `TestContext.CancellationToken` through each operation guarded by `Timeout(..., CooperativeCancellation = true)`; do not rely on the attribute alone to stop work.
+- [ ] On cancellation, bound and await every owned process, redirected stream, pending elicitation handler, and harness teardown path before fixture disposal.
+- [ ] Preserve the notice verifier's parity assertions and the coordinator's success, cancellation, and slot-release contracts.
+- [ ] One short-deadline regression matrix forces cancellation at both boundaries and proves each test returns without an owned process or pending handler.
+
+## Evidence
+
+Review on 2026-08-24 found both classes declare cooperative MSTest timeouts but never observe MSTest's token. A hung child verifier or elicitation harness can therefore outlive the advertised test ceiling and contaminate later tests. This is separate from the dependency-gate timeout hardening because it touches different process and in-memory ownership boundaries.

--- a/ai_docs/items/output-schema-generation-authority.md
+++ b/ai_docs/items/output-schema-generation-authority.md
@@ -21,3 +21,4 @@
 
 - SDK 2.1 generates a schema from `McpServerToolAttribute.OutputSchemaType`, then `SurfaceRegistrationPolicy` overwrites it from `ToolOutputSchemaIndex`; fixed schemas can drift even though variant unions require a deliberate custom contract.
 2026-08-20 adjacent review: JsonDefaults now includes custom public-projection converters and ToolOutputSchemaIndex clones those serializer options. .NET 10 JsonSchemaExporter can emit boolean true for a custom-converted type, erasing its DTO shape. Extend this row's fixed-versus-union matrix with BuildResultDto/TestRunResultDto projection parity or separate schema-export options before either type gains an advertised structured schema.
+2026-08-24 SDK 2.2 servicing review: the SDK-generated output-schema behavior above is unchanged; treat 2.2.0 as the current pin for implementation and regression evidence.

--- a/ai_docs/items/stdio-shutdown-flush-transport-ownership.md
+++ b/ai_docs/items/stdio-shutdown-flush-transport-ownership.md
@@ -21,3 +21,4 @@
 - SDK 2.1 stdio transport constructs its own `BufferedStream(Console.OpenStandardOutput())` and flushes that stream after each send.
 - Current production shutdown code flushes `Console.Out` instead, while tests explicitly admit they do not exercise a real process or transport.
 - The current transport-disconnect catch writes `ex.Message` directly to stderr; removal of the ineffective flusher must not preserve that separate disclosure.
+2026-08-24 SDK 2.2 servicing review: the stdio transport ownership and per-send flush behavior above are unchanged; acceptance now targets the pinned SDK 2.2.0 assemblies.

--- a/ai_docs/references/mcp-server-best-practices.md
+++ b/ai_docs/references/mcp-server-best-practices.md
@@ -33,7 +33,7 @@ Concretely: if a caller omits a required parameter or supplies an unknown parame
 
 ## 2. .NET SDK native pattern: request filters
 
-This repo pins `ModelContextProtocol` 2.1.0. The SDK exposes a first-class decorator/middleware pipeline for each MCP method:
+This repo pins `ModelContextProtocol` 2.2.0. The SDK exposes a first-class decorator/middleware pipeline for each MCP method:
 
 - Entrypoint: `IMcpServerBuilder.WithRequestFilters(Action<IMcpRequestFilterBuilder>)`
 - Tool-call slot: `IMcpRequestFilterBuilder.AddCallToolFilter(McpRequestFilter<CallToolRequestParams, CallToolResult>)`
@@ -64,7 +64,7 @@ Canonical example from the [Microsoft SDK filters docs](https://csharp.sdk.model
 
 ### 2.1 Filters see pre-binding exceptions (as of SDK 0.4.0-preview.3+)
 
-The SDK originally swallowed reflection-binding exceptions inside the invocation wrapper, returning a bare `"An error occurred invoking '<tool>'."` string. That defect is tracked in [csharp-sdk#820](https://github.com/modelcontextprotocol/csharp-sdk/issues/820) and [csharp-sdk#830](https://github.com/modelcontextprotocol/csharp-sdk/issues/830), and fixed in [PR #844 "Propagate tool call exceptions through filters"](https://github.com/modelcontextprotocol/csharp-sdk/pull/844) (shipped 0.4.0-preview.3 and retained in 2.1.0). Filters observe:
+The SDK originally swallowed reflection-binding exceptions inside the invocation wrapper, returning a bare `"An error occurred invoking '<tool>'."` string. That defect is tracked in [csharp-sdk#820](https://github.com/modelcontextprotocol/csharp-sdk/issues/820) and [csharp-sdk#830](https://github.com/modelcontextprotocol/csharp-sdk/issues/830), and fixed in [PR #844 "Propagate tool call exceptions through filters"](https://github.com/modelcontextprotocol/csharp-sdk/pull/844) (shipped 0.4.0-preview.3 and retained through 2.2.0). Filters observe:
 
 - `ArgumentException` / `ArgumentNullException` from parameter binding (missing or unknown required argument)
 - `JsonException` from `arguments` deserialization
@@ -93,7 +93,7 @@ Don't invent middleware; use the filter slots the SDK provides (`AddCallToolFilt
 | Metrics / `_meta` injection | The same filter (cross-cutting, not per-tool) | Prevents per-tool duplication; guarantees coverage |
 | Validation of domain inputs (file paths, symbol handles, etc.) | Inside the tool body, throwing typed exceptions that the filter classifies | Keeps business logic local; the filter provides the envelope |
 
-**Anti-pattern:** wrapping tool bodies with `ToolErrorHandler.ExecuteAsync(...)` as the primary error boundary. This is the pre-filter legacy pattern that misses pre-binding failures entirely. New tools must not adopt it; existing usages should migrate to the filter.
+**Anti-pattern:** wrapping tool bodies with `ToolErrorHandler.ExecuteAsync(...)` as the primary error boundary. This is the pre-filter legacy pattern that misses pre-binding failures entirely. All legacy usages have been retired; do not reintroduce it.
 
 ---
 
@@ -142,7 +142,7 @@ Stdio-transport MCP servers **must not** write to stdout except framed JSON-RPC 
 - **Every public parameter must carry `[Description(...)]`.** Agents introspect these via `ToolSearch` / `tools/list`; undocumented parameters lead to the exact failure mode that triggered this doc's creation.
 - **Prefer required non-nullable types over optional-with-sentinel-null** for parameters the tool truly cannot proceed without. The filter will surface a clean `InvalidArgument` envelope naming the parameter when it's missing.
 - **Read-only annotations** (`[McpServerTool(ReadOnly = true)]`) matter — clients gate what a tool can do based on these. Get them right.
-- **DI-register services against the interface that tool methods inject**, not only the concrete type. [`di-register-latest-version-provider`](../backlog.md) recorded the failure mode: if the SDK's parameter binder can't resolve a service-typed parameter, it leaks that parameter into the tool schema as a required user-supplied argument.
+- **DI-register services against the interface that tool methods inject**, not only the concrete type. If the SDK's parameter binder can't resolve a service-typed parameter, it leaks that parameter into the tool schema as a required user-supplied argument.
 
 ---
 
@@ -157,7 +157,7 @@ This section is the live log of decisions derived from the above principles. Upd
 | `ClassifyError` handles pre-binding failures in BOTH shapes: wrapped in `TargetInvocationException` / `InvalidOperationException` AND raw-unwrapped as the SDK filter pipeline delivers them | § 4.1 | [`ToolErrorHandler.TryClassifyBindingLike`](../../src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs) — single helper invoked against both the inner exception (wrapped) and the exception itself (unwrapped). Resolves [csharp-sdk#830](https://github.com/modelcontextprotocol/csharp-sdk/issues/830) for this repo's filter path. Regression coverage: [`ToolErrorHandlerParameterValidationTests`](../../tests/RoslynMcp.Tests/ToolErrorHandlerParameterValidationTests.cs), [`StructuredCallToolFilterTests.BuildErrorResult_MissingRequiredParameter_*`](../../tests/RoslynMcp.Tests/StructuredCallToolFilterTests.cs). |
 | `_meta` block on every response with gate-metrics snapshot | § 5 | The filter opens the [`AmbientGateMetrics`](../../src/RoslynMcp.Core/Services/AmbientGateMetrics.cs) scope on entry and injects the snapshot via [`ToolErrorHandler.InjectMetaIfPossible`](../../src/RoslynMcp.Host.Stdio/Tools/ToolErrorHandler.cs) on both success (into the first `TextContentBlock` of the returned `CallToolResult`) and error (into the envelope text). Array-rooted responses pass through unchanged — see `StructuredCallToolFilter.InjectMetaIntoContent`. |
 | Stdio transport writes framed JSON-RPC only; operational and opt-in structured diagnostics use stderr | § 4.4, § 5 | [Program.cs](../../src/RoslynMcp.Host.Stdio/Program.cs), [`ServerObservability`](../../src/RoslynMcp.Host.Stdio/Diagnostics/ServerObservability.cs), [`McpLoggingLifecycleWireTests`](../../tests/RoslynMcp.Tests/McpLoggingLifecycleWireTests.cs) |
-| Services registered against interface + concrete type for SDK binder compatibility | § 6 | [Program.cs:47-49](../../src/RoslynMcp.Host.Stdio/Program.cs) with `di-register-latest-version-provider` comment |
+| Services registered against interface + concrete type for SDK binder compatibility | § 6 | [`ServiceCollectionExtensions.AddRoslynMcpHostServices`](../../src/RoslynMcp.Host.Stdio/ServiceCollectionExtensions.cs) bridges `NuGetVersionChecker` to `ILatestVersionProvider`; [`ServiceCollectionExtensionsTests`](../../tests/RoslynMcp.Tests/ServiceCollectionExtensionsTests.cs) and [`ToolDiResolutionTests`](../../tests/RoslynMcp.Tests/ToolDiResolutionTests.cs) guard the composition root. |
 
 ---
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -18,7 +18,7 @@ Per-PR-per-file fragments are merge-safe by construction: no two PRs ever touch 
 ## File shape
 
 - **Filename:** `<backlog-row-id>.md` — kebab-case, matches the backlog row the change closes. If a single PR closes multiple rows, pick one id as the filename; cite all closed rows in the bullet body.
-- **Format:** YAML frontmatter carrying the CHANGELOG category; body is a single bullet in the shipping `**<Category>:**` prose style.
+- **Format:** YAML frontmatter carrying the CHANGELOG category; body is exactly one nonblank bullet line in the shipping `**<Category>:**` prose style. Keep the complete entry on that line.
 
 Example fragment, filename `changelog.d/release-cut-atomic-skill-bump-ship-tag-reinstall.md`:
 
@@ -55,6 +55,7 @@ Malformed fragments fail the bump skill loudly — no silent skip. Failure modes
 - Missing `category` key in frontmatter.
 - Unknown category value (not one of the five listed above).
 - Empty body (frontmatter-only file).
+- More than one nonblank body line, including a wrapped continuation or a second bullet.
 - Filename is not lowercase kebab-case.
 - The bold category prefix on the first body bullet does not exactly match the
   YAML `category` value.

--- a/changelog.d/dependency-gate-process-timeout-hardening.md
+++ b/changelog.d/dependency-gate-process-timeout-hardening.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Made the NuGet-audit and package-family PowerShell contract tests tolerate loaded Windows process-start latency without serialization, observe MSTest cancellation, and bound process-tree termination, root-process reaping, and redirected-output draining before fixture deletion; changelog validation now also rejects extra body lines instead of silently accepting a second category bullet.

--- a/changelog.d/modelcontextprotocol-2-2-servicing.md
+++ b/changelog.d/modelcontextprotocol-2-2-servicing.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Updated the MCP C# SDK from 2.1.0 to 2.2.0 after a dedicated release, API, license, and dual-era wire review. RoslynMcp remains stdio-only; the SDK's new hybrid HTTP session mode is not adopted, the malformed HTTP-header decoder correction does not change stdio frames, and clients require no migration. ADR 0006 records the disposition.

--- a/changelog.d/routine-dependency-servicing.md
+++ b/changelog.d/routine-dependency-servicing.md
@@ -2,4 +2,4 @@
 category: Maintenance
 ---
 
-- **Maintenance:** Updated the .NET 10 Extensions servicing family to 10.0.11, Microsoft.Extensions.TimeProvider.Testing to 10.9.0, Microsoft.NET.Test.Sdk to 18.9.0, Microsoft.CodeAnalysis.NetAnalyzers and Microsoft.SourceLink.GitHub to 10.0.400, and System.Security.Cryptography.Xml to 10.0.11; ModelContextProtocol remains on 2.1.0 for dedicated contract review.
+- **Maintenance:** Updated the .NET 10 Extensions servicing family to 10.0.11, Microsoft.Extensions.TimeProvider.Testing to 10.9.0, Microsoft.NET.Test.Sdk to 18.9.0, Microsoft.CodeAnalysis.NetAnalyzers and Microsoft.SourceLink.GitHub to 10.0.400, and System.Security.Cryptography.Xml to 10.0.11. The contract-sensitive ModelContextProtocol pin was intentionally excluded from this routine servicing group.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ Human-facing documentation for the Roslyn-Backed MCP Server.
 | `decisions/0001-locationdto-nested-field-migration.md` | ADR: additive nested `Location` field on `SymbolDto`/`DiagnosticDto`/`TypeUsageDto`, legacy-flat-field deprecation window, and the bounded producer/consumer migration stages |
 | `decisions/0002-configured-sanctioned-root-boundary.md` | ADR: server-owned sanctioned-root security boundary, canonical path resolution, and migration from client Roots authority |
 | `decisions/0003-sdk-2x-wire-compatibility.md` | ADR: SDK 1.4.1→2.1.0 lineage, dual-protocol wire contract, correction classification, and consumer migration |
+| `decisions/0004-public-command-diagnostic-path-projection.md` | ADR: secret-safe public projection of child-process diagnostic paths across Windows, UNC, and POSIX forms |
+| `decisions/0005-stable-profile-preview-apply-closure.md` | ADR: stable-profile preview/apply closure, registration invariants, and token redemption |
+| `decisions/0006-modelcontextprotocol-2-2-servicing.md` | ADR: ModelContextProtocol 2.1.0→2.2.0 servicing, stdio-only scope, and non-breaking compatibility disposition |
 
 ## Claude Code Plugin
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # MCP Client Compatibility Matrix
 
-The Roslyn-Backed MCP server uses the standard MCP stdio transport and explicitly supports the protocol eras recorded in [ADR 0003](decisions/0003-sdk-2x-wire-compatibility.md). A client must support both stdio and one of those protocol contracts; this matrix records the install paths actually exercised plus known gotchas. PRs welcome to flip rows from *Likely* to *Tested* with evidence.
+The Roslyn-Backed MCP server uses the standard MCP stdio transport and explicitly supports the protocol eras recorded in [ADR 0003](decisions/0003-sdk-2x-wire-compatibility.md). [ADR 0006](decisions/0006-modelcontextprotocol-2-2-servicing.md) records the non-breaking SDK 2.2 servicing review and confirms that the separate ASP.NET Core hybrid-session feature is not part of this stdio product. A client must support both stdio and one of those protocol contracts; this matrix records the install paths actually exercised plus known gotchas. PRs welcome to flip rows from *Likely* to *Tested* with evidence.
 
 ## Status legend
 

--- a/docs/decisions/0006-modelcontextprotocol-2-2-servicing.md
+++ b/docs/decisions/0006-modelcontextprotocol-2-2-servicing.md
@@ -1,0 +1,77 @@
+# ADR 0006 — ModelContextProtocol 2.2 servicing
+
+- **Status:** Accepted (2026-08-24)
+- **Deciders:** repository maintainers
+- **Scope:** `ModelContextProtocol` 2.1.0 to 2.2.0 servicing and the public RoslynMcp transport/wire contract
+- **Supersedes:** nothing; extends ADR 0003
+- **Superseded by:** nothing
+
+## Context
+
+RoslynMcp pins the main `ModelContextProtocol` package and publishes a local stdio server. It does
+not reference `ModelContextProtocol.AspNetCore`, and remote HTTP hosting remains deferred by
+`http-streamable-host-project`.
+
+The official 2.2.0 release adds `HttpServerSessionMode` to the separate ASP.NET Core package so
+2025-11-25 stateful clients and 2026-07-28 stateless clients can share one HTTP endpoint. Its Core
+runtime correction adds a minimum wrapper-length check to `McpHeaderEncoder.DecodeValue`, so a
+degenerate `=?base64?=` header value no longer throws during substring extraction. RoslynMcp does
+not call `McpHeaderEncoder`; stdio traffic has no MCP HTTP parameter headers.
+
+The restored 2.2.0 package retains its Apache-2.0 license, target frameworks, and dependency shape.
+The net10 XML member inventories for both `ModelContextProtocol` and `ModelContextProtocol.Core`
+contain the same member identifiers as 2.1.0. Those source and API observations narrow the review,
+but do not replace integration evidence against RoslynMcp's registered surface and both supported
+protocol eras.
+
+## Decision
+
+1. Pin `ModelContextProtocol` 2.2.0.
+2. Retain the stdio-only product boundary. Do not add `ModelContextProtocol.AspNetCore`, an HTTP
+   endpoint, or `HttpServerSessionMode` as part of this servicing update.
+3. Retain ADR 0003's supported protocol eras and negotiation rules:
+   - initialization-based sessions through 2025-11-25;
+   - discovery/request-scoped 2026-07-28 sessions.
+4. Classify the update as non-breaking maintenance. Tool, prompt, resource, schema, result, error,
+   elicitation, sampling, logging, and cache contracts do not intentionally change.
+5. Require refreshed third-party notices, raw-wire coverage for both eras, surface registration and
+   schema tests, the complete local release gate, and the hosted `validate` aggregate before merge.
+
+## Public-change classification
+
+| Concern | Classification | RoslynMcp disposition | Consumer migration |
+|---|---|---|---|
+| SDK package pin | Maintenance | Adopt 2.2.0 after complete validation. | None. |
+| Hybrid stateful/stateless HTTP serving | Not adopted | The feature lives in the unreferenced ASP.NET Core package; RoslynMcp remains stdio-only. | None. |
+| Degenerate MCP HTTP-header decoding | Upstream bug fix | The corrected Core helper is not called by RoslynMcp and does not alter stdio frames. | None. |
+| Supported protocol eras | No change | Preserve ADR 0003's 2025-11-25 and 2026-07-28 contracts. | None. |
+
+## Consumer migration
+
+None. Existing clients continue using the stdio transport and the protocol-era behavior recorded in
+ADR 0003. This update does not add an HTTP endpoint, alter discovery or initialization, or change a
+RoslynMcp request or response contract.
+
+## Consequences
+
+- The direct SDK pin, notice inventory, and current-version documentation move to 2.2.0 together.
+- Historical 1.4.1→2.1.0 evidence in ADR 0003 and existing regressions remains unchanged.
+- HTTP hosting still requires a separate product decision and implementation.
+- A later SDK release receives its own release-note, API, dependency, license, and wire review rather
+  than inheriting this disposition.
+
+## Validation
+
+- Restore the exact package and verify its nuspec identity and Apache-2.0 license.
+- Run all dual-era raw-wire suites.
+- Run tool, prompt, and resource registration and schema suites.
+- Run `just ci`.
+- Require the hosted `validate` aggregate, including Windows, Linux, and exact-SDK-floor jobs.
+
+## References
+
+- [ADR 0003 — MCP SDK 2.x wire compatibility](0003-sdk-2x-wire-compatibility.md)
+- [ModelContextProtocol 2.2.0 release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.2.0)
+- [ModelContextProtocol 2.1.0...2.2.0 source comparison](https://github.com/modelcontextprotocol/csharp-sdk/compare/v2.1.0...v2.2.0)
+- [ModelContextProtocol 2.2.0 on NuGet](https://www.nuget.org/packages/ModelContextProtocol/2.2.0)
+- [RoslynMcp release policy](../release-policy.md)

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -42,6 +42,10 @@ A release is production-ready when all of the following are true:
 - [ADR 0003](decisions/0003-sdk-2x-wire-compatibility.md) records the direct
   `ModelContextProtocol` 1.4.1→2.1.0 adoption, evaluated intervening releases, dual-era wire
   decisions, breaking-correction migrations, and the distinction between SDK and RoslynMcp versions.
+- [ADR 0006](decisions/0006-modelcontextprotocol-2-2-servicing.md) records the
+  `ModelContextProtocol` 2.1.0→2.2.0 servicing review, confirms that the separate ASP.NET Core
+  hybrid-session feature is outside this stdio product, and retains both supported protocol eras
+  without a consumer migration.
 - Future SDK major upgrades must add or supersede an ADR before release. The record must include the
   exact package lineage, supported protocol eras, public-change classification, raw-wire evidence,
   and consumer migration for each breaking correction.

--- a/docs/stdio-client-integration.md
+++ b/docs/stdio-client-integration.md
@@ -9,7 +9,7 @@ If you're using Claude Code (via the `/plugin install roslyn-mcp@roslyn-mcp-mark
 - **Transport:** NDJSON (newline-delimited JSON) on stdin/stdout. Each message is a single JSON object followed by `\n`. **Do not** use LSP-style `Content-Length:` framing — the server ignores headers and treats the first non-JSON byte as a parse error.
 - **Stderr** is for operational logging. Do not parse it as protocol traffic.
 - **Spec:** [Model Context Protocol](https://modelcontextprotocol.io). The server implements the stdio transport; the public MCP SDKs speak it natively.
-- **Protocol eras:** MCP SDK 2.1 serves modern `2026-07-28` requests and initialize-capable `2025-11-25` and earlier clients. Prefer an official SDK so discovery and fallback remain correct.
+- **Protocol eras:** MCP SDK 2.2 serves modern `2026-07-28` requests and initialize-capable `2025-11-25` and earlier clients. Prefer an official SDK so discovery and fallback remain correct.
 
 ## Connection bootstrap
 

--- a/docs/upgrade-matrix.md
+++ b/docs/upgrade-matrix.md
@@ -3,7 +3,8 @@
 This document maps **upgrade axes** for Roslyn-Backed MCP: what moves together, where it is pinned, and what to run after a change. Values below reflect the repository as of **2026-08-24**; when you bump a row, refresh the “Current” cells in the same PR.
 
 Related: [Release policy](release-policy.md) (product version and gates),
-[SDK 2.x wire-compatibility decision](decisions/0003-sdk-2x-wire-compatibility.md), and
+[SDK 2.x wire-compatibility decision](decisions/0003-sdk-2x-wire-compatibility.md),
+[SDK 2.2 servicing decision](decisions/0006-modelcontextprotocol-2-2-servicing.md), and
 [CI policy](../CI_POLICY.md) (merge validation).
 
 ---
@@ -26,7 +27,7 @@ The previous `10.0.100` minimum was not executable: its compiler loads Roslyn 5.
 
 | Package id | Current | Where pinned | Coupling / routing |
 |------------|---------|--------------|--------------------|
-| `ModelContextProtocol` | `2.1.0` | `Directory.Packages.props` | Contract-sensitive; dedicated PR, release-note/ADR review, notices, and raw-wire matrices |
+| `ModelContextProtocol` | `2.2.0` | `Directory.Packages.props` | Contract-sensitive; dedicated PR, release-note/ADR review, notices, and raw-wire matrices |
 | `Microsoft.CodeAnalysis.CSharp` | `5.9.0` | `Directory.Packages.props` | Roslyn API family; move together |
 | `Microsoft.CodeAnalysis.Analyzers` | `5.9.0` | `Directory.Packages.props` | Roslyn API family; move together |
 | `Microsoft.CodeAnalysis.CSharp.Workspaces` | `5.9.0` | `Directory.Packages.props` | Roslyn API family; move together |
@@ -73,13 +74,15 @@ The previous `10.0.100` minimum was not executable: its compiler loads Roslyn 5.
 
 ## 4. MCP SDK wire contract
 
-The repository adopted MCP SDK 2.1 directly from 1.4.1. The evaluated official sequence is
-2.0.0-preview.1, preview.2, preview.3, rc.1, rc.2, 2.0.0, and 2.1.0; there is no SDK
-2.0.1 or 3.x in that lineage. RoslynMcp product 2.x/3.x versions are independent. SDK 2.1 serves
-both protocol eras: modern `2026-07-28` requests use `server/discover` plus request-scoped metadata,
-while initialize-capable clients negotiate a down-level revision. The exact public contract and
-remaining compatibility migrations are recorded in
-[ADR 0003](decisions/0003-sdk-2x-wire-compatibility.md).
+The repository adopted MCP SDK 2.1 directly from 1.4.1, then advanced to 2.2.0 through a dedicated
+servicing review. The evaluated official sequence is 2.0.0-preview.1, preview.2, preview.3, rc.1,
+rc.2, 2.0.0, 2.1.0, and 2.2.0; there is no SDK 2.0.1 or 3.x in that lineage. RoslynMcp product
+2.x/3.x versions are independent. SDK 2.2 preserves both protocol eras: modern `2026-07-28`
+requests use `server/discover` plus request-scoped metadata, while initialize-capable clients
+negotiate a down-level revision. The wire contract is recorded in
+[ADR 0003](decisions/0003-sdk-2x-wire-compatibility.md); the non-breaking 2.2 servicing
+disposition is recorded in
+[ADR 0006](decisions/0006-modelcontextprotocol-2-2-servicing.md).
 
 Protocol logging is retired: the server advertises `logging: false`, emits no
 `notifications/message`, and keeps operational output on stderr. Secret-safe structured unexpected-
@@ -114,7 +117,7 @@ Automated check: `eng/verify-version-drift.ps1` (invoked from `eng/verify-releas
 | `global.json` SDK | Adjust `Microsoft.CodeAnalysis.NetAnalyzers` to the matching band if Microsoft publishes one; update the exact `sdk-floor` lane; run `verify-release.ps1`. |
 | Any `Microsoft.CodeAnalysis.*` (Roslyn API) version | Bump **all** rows in section 2 together; run full tests; watch MSBuild workspace integration. |
 | `Microsoft.Build.*` or `Microsoft.Build.Locator` | Keep all four compile-family pins equal; full `verify-release.ps1`; exact-floor lane; exercise solution load + `build_workspace` / `test_run` paths. |
-| `ModelContextProtocol` | Review every official release since the pin; update/supersede ADR 0003; run raw-wire matrices for every supported protocol era; check tool/prompt/resource registration and schemas. |
+| `ModelContextProtocol` | Review every official release since the pin; add an ADR disposition that preserves or explicitly supersedes the current wire decision; run raw-wire matrices for every supported protocol era; check tool/prompt/resource registration and schemas. |
 | `Microsoft.Extensions.*` | Host startup, logging, and shutdown; no special Roslyn coupling. |
 | Product version only | All seven version files + `eng/verify-version-drift.ps1`. |
 

--- a/eng/verify-changelog-fragments.ps1
+++ b/eng/verify-changelog-fragments.ps1
@@ -203,7 +203,13 @@ foreach ($file in $fragments) {
         continue
     }
 
-    $firstBodyLine = @($bodyLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })[0].Trim()
+    $nonBlankBodyLines = @($bodyLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($nonBlankBodyLines.Count -ne 1) {
+        $errors.Add("$($file.Name): body must contain exactly one nonblank bullet line")
+        continue
+    }
+
+    $firstBodyLine = $nonBlankBodyLines[0].Trim()
     $expectedPrefix = "- **$category`:**"
     if (-not $firstBodyLine.StartsWith($expectedPrefix, [System.StringComparison]::Ordinal)) {
         $errors.Add(

--- a/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/ElicitationChoicePrompt.cs
@@ -195,7 +195,7 @@ internal static class ElicitationChoicePrompt
         }
         catch (InvalidOperationException ex)
         {
-            // ModelContextProtocol.Core 2.1's ElicitAsync XML contract declares only
+            // The SDK's public ElicitAsync XML contract declares only
             // InvalidOperationException (unsupported) and McpException (request/client error)
             // beyond caller-precondition failures. IOException/ObjectDisposedException are not
             // declared transport outcomes and intentionally remain hard failures. Keep this

--- a/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
@@ -31,7 +31,7 @@ internal enum RequestScopedInputOutcome
 
 /// <summary>
 /// The single request-scoped boundary through which the <c>tools/call</c> recovery pipeline asks
-/// the user for input, portable across both SDK 2.1 session modes (SEP-2322 MRTR on the
+/// the user for input, portable across both supported SDK session modes (SEP-2322 MRTR on the
 /// <c>2026-07-28</c> revision, and the <c>2025-11-25</c>-and-earlier initialize-handshake
 /// sessions).
 ///

--- a/src/RoslynMcp.Host.Stdio/ProtocolCompatibility/RequestProtocolFeatureGate.cs
+++ b/src/RoslynMcp.Host.Stdio/ProtocolCompatibility/RequestProtocolFeatureGate.cs
@@ -17,7 +17,7 @@ internal static class RequestProtocolFeatureGate
 
         var protocolVersion = context.JsonRpcRequest.Context?.ProtocolVersion
             ?? context.Server.NegotiatedProtocolVersion;
-        // MCP revision identifiers are ISO-8601 dates. Mirror the SDK 2.1 gate exactly; its
+        // MCP revision identifiers are ISO-8601 dates. Mirror the SDK's gate exactly; its
         // McpProtocolVersions helper is internal and therefore unavailable to server filters.
         return !string.IsNullOrEmpty(protocolVersion)
             && StringComparer.Ordinal.Compare(protocolVersion, July2026ProtocolVersion) >= 0;

--- a/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
+++ b/src/RoslynMcp.Roslyn/Helpers/DotnetOutputParser.cs
@@ -24,9 +24,8 @@ internal static partial class DotnetOutputParser
     // with the failure count and per-failure text size.
     //
     // Measured ceiling (see RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling in
-    // TestRunFailureEnvelopeTests): neither this repo nor the pinned ModelContextProtocol 2.1.0
-    // SDK declares ANY response-size constant — verified by grep over src/ and by symbol search
-    // over the shipped SDK assemblies. There is no protocol-level ceiling to point at; the real
+    // TestRunFailureEnvelopeTests): a source and restored-assembly audit found no repository or
+    // SDK response-size constant. There is no protocol-level ceiling to point at; the real
     // ceiling is the consuming client's context budget. So the caps below are sized against that
     // budget rather than a protocol constant: with both halves of the fix in place, a worst-case
     // page (25 failures, every Message/StackTrace at the caps) measures 56,923 chars of indented

--- a/tests/RoslynMcp.Tests/ChangelogFragmentRequirementTests.cs
+++ b/tests/RoslynMcp.Tests/ChangelogFragmentRequirementTests.cs
@@ -94,9 +94,11 @@ public sealed class ChangelogFragmentRequirementTests
             try
             {
                 var result = await RunVerifierAsync(fixtureRoot);
-                var diagnostic = $"{testCase.Name}: stdout={result.StdOut} stderr={result.StdErr}";
+                var allOutput = PowerShellOutputNormalizer.Normalize(
+                    result.StdOut + Environment.NewLine + result.StdErr);
+                var diagnostic = $"{testCase.Name}: output={allOutput}";
                 Assert.AreEqual(testCase.ExpectedExitCode, result.ExitCode, diagnostic);
-                StringAssert.Contains(result.StdOut + result.StdErr, testCase.ExpectedText, diagnostic);
+                StringAssert.Contains(allOutput, testCase.ExpectedText, diagnostic);
             }
             finally
             {
@@ -139,6 +141,12 @@ public sealed class ChangelogFragmentRequirementTests
                 1,
                 "repeats a leading category"),
             new GrammarCase(
+                "multiple body bullets",
+                "fixture-entry.md",
+                Fragment("Maintenance", "- **Maintenance:** Fixture servicing.\n- **Fixed:** Unrelated correction."),
+                1,
+                "exactly one nonblank bullet line"),
+            new GrammarCase(
                 "empty body",
                 "fixture-entry.md",
                 "---\ncategory: Fixed\n---\n",
@@ -167,9 +175,11 @@ public sealed class ChangelogFragmentRequirementTests
                     Path.Combine(fixtureRoot, "changelog.d", testCase.FileName),
                     testCase.Contents);
                 var result = await RunVerifierAsync(fixtureRoot);
-                var diagnostic = $"{testCase.Name}: stdout={result.StdOut} stderr={result.StdErr}";
+                var allOutput = PowerShellOutputNormalizer.Normalize(
+                    result.StdOut + Environment.NewLine + result.StdErr);
+                var diagnostic = $"{testCase.Name}: output={allOutput}";
                 Assert.AreEqual(testCase.ExpectedExitCode, result.ExitCode, diagnostic);
-                StringAssert.Contains(result.StdOut + result.StdErr, testCase.ExpectedText, diagnostic);
+                StringAssert.Contains(allOutput, testCase.ExpectedText, diagnostic);
             }
             finally
             {

--- a/tests/RoslynMcp.Tests/NuGetAuditGateTests.cs
+++ b/tests/RoslynMcp.Tests/NuGetAuditGateTests.cs
@@ -5,6 +5,12 @@ namespace RoslynMcp.Tests;
 [TestClass]
 public sealed class NuGetAuditGateTests
 {
+    private const int ProcessTimeoutSeconds = 60;
+    private const int CleanupTimeoutSeconds = 15;
+    private const int TestTimeoutMilliseconds = 90_000;
+
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     public void LocalAndHostedGates_UseSharedFailClosedRestoreAudit()
     {
@@ -31,7 +37,7 @@ public sealed class NuGetAuditGateTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task DefaultSolutionPath_ResolvesFromRepository_WhenCallerWorkingDirectoryIsUnrelated()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -66,7 +72,7 @@ public sealed class NuGetAuditGateTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task AbsoluteSolutionPath_IsPreservedAtDotnetBoundary()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -104,7 +110,7 @@ public sealed class NuGetAuditGateTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task DotnetAuditFailure_PropagatesAfterUsingFailClosedArguments()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -143,7 +149,7 @@ public sealed class NuGetAuditGateTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task MissingRelativeSolution_FailsBeforeDotnetAndIgnoresCallerDirectory()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -177,7 +183,7 @@ public sealed class NuGetAuditGateTests
         }
     }
 
-    private static async Task<ProcessResult> RunAuditScriptAsync(
+    private async Task<ProcessResult> RunAuditScriptAsync(
         string repositoryRoot,
         string workingDirectory,
         string fakeBin,
@@ -209,18 +215,71 @@ public sealed class NuGetAuditGateTests
             ?? throw new InvalidOperationException("Failed to start NuGet audit verifier.");
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(ProcessTimeoutSeconds));
+        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            timeout.Token,
+            TestContext.CancellationToken);
         try
         {
-            await process.WaitForExitAsync(timeout.Token);
+            await process.WaitForExitAsync(waitCancellation.Token);
+            var capturedOutput = await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(waitCancellation.Token);
+            return new(process.ExitCode, capturedOutput[0], capturedOutput[1]);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception) when (timeout.IsCancellationRequested)
         {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException("NuGet audit verifier timed out after 20 seconds.");
+            var output = await RequestTerminationAndDrainAsync(
+                process,
+                stdoutTask,
+                stderrTask,
+                "NuGet audit verifier");
+            throw new TimeoutException(
+                $"NuGet audit verifier timed out after {ProcessTimeoutSeconds} seconds. Output:{Environment.NewLine}{output}",
+                exception);
+        }
+        catch (OperationCanceledException) when (TestContext.CancellationToken.IsCancellationRequested)
+        {
+            await RequestTerminationAndDrainAsync(
+                process,
+                stdoutTask,
+                stderrTask,
+                "NuGet audit verifier");
+            throw;
+        }
+    }
+
+    private static async Task<string> RequestTerminationAndDrainAsync(
+        Process process,
+        Task<string> stdoutTask,
+        Task<string> stderrTask,
+        string description)
+    {
+        if (!process.HasExited)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException) when (process.HasExited)
+            {
+                // The process exited between the state check and the kill request.
+            }
         }
 
-        return new(process.ExitCode, await stdoutTask, await stderrTask);
+        using var cleanupTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(CleanupTimeoutSeconds));
+        try
+        {
+            await process.WaitForExitAsync(cleanupTimeout.Token);
+            var capturedOutput = await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cleanupTimeout.Token);
+            return PowerShellOutputNormalizer.Normalize(
+                capturedOutput[0] + Environment.NewLine + capturedOutput[1]);
+        }
+        catch (OperationCanceledException exception) when (cleanupTimeout.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"{description} did not exit and close redirected streams within " +
+                $"{CleanupTimeoutSeconds} seconds after process-tree termination was requested.",
+                exception);
+        }
     }
 
     private sealed record ProcessResult(int ExitCode, string StdOut, string StdErr)

--- a/tests/RoslynMcp.Tests/PackageFamilyContractTests.cs
+++ b/tests/RoslynMcp.Tests/PackageFamilyContractTests.cs
@@ -6,9 +6,15 @@ namespace RoslynMcp.Tests;
 [TestClass]
 public sealed class PackageFamilyContractTests
 {
+    private const int ProcessTimeoutSeconds = 60;
+    private const int CleanupTimeoutSeconds = 15;
+    private const int TestTimeoutMilliseconds = 90_000;
+
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task PackageFamilyGate_RejectsSplitMicrosoftBuildPinsBeforeRestore()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -45,7 +51,7 @@ public sealed class PackageFamilyContractTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task UpgradeMatrixGate_RejectsNonProtocolPackageDriftWithBothVersions()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -91,7 +97,7 @@ public sealed class PackageFamilyContractTests
     [DataRow("malformed-matrix", "malformed central-package row")]
     [DataRow("malformed-central", "without a non-empty Include and Version")]
     [DataRow("extra", "no matching")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task UpgradeMatrixGate_FailsClosedForInvalidBijection(
         string fixtureKind,
         string expectedDiagnostic)
@@ -144,7 +150,7 @@ public sealed class PackageFamilyContractTests
 
     [TestMethod]
     [TestCategory("Process")]
-    [Timeout(30_000, CooperativeCancellation = true)]
+    [Timeout(TestTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task UpgradeMatrixGate_AcceptsExactMinimalBijection()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -302,7 +308,7 @@ public sealed class PackageFamilyContractTests
     private static string MatrixRow(string packageId, string version) =>
         $"| `{packageId}` | `{version}` | `Directory.Packages.props` | fixture |";
 
-    private static async Task<PowerShellResult> RunPowerShellAsync(
+    private async Task<PowerShellResult> RunPowerShellAsync(
         string repositoryRoot,
         string workingDirectory,
         string scriptName,
@@ -330,20 +336,67 @@ public sealed class PackageFamilyContractTests
             ?? throw new InvalidOperationException($"Failed to start '{scriptName}'.");
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(ProcessTimeoutSeconds));
+        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            timeout.Token,
+            TestContext.CancellationToken);
         try
         {
-            await process.WaitForExitAsync(timeout.Token);
+            await process.WaitForExitAsync(waitCancellation.Token);
+            var capturedOutput = await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(waitCancellation.Token);
+            return new(process.ExitCode, capturedOutput[0], capturedOutput[1]);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception) when (timeout.IsCancellationRequested)
         {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException($"'{scriptName}' timed out after 20 seconds.");
+            var output = await RequestTerminationAndDrainAsync(
+                process,
+                stdoutTask,
+                stderrTask,
+                scriptName);
+            throw new TimeoutException(
+                $"'{scriptName}' timed out after {ProcessTimeoutSeconds} seconds. Output:{Environment.NewLine}{output}",
+                exception);
+        }
+        catch (OperationCanceledException) when (TestContext.CancellationToken.IsCancellationRequested)
+        {
+            await RequestTerminationAndDrainAsync(process, stdoutTask, stderrTask, scriptName);
+            throw;
+        }
+    }
+
+    private static async Task<string> RequestTerminationAndDrainAsync(
+        Process process,
+        Task<string> stdoutTask,
+        Task<string> stderrTask,
+        string description)
+    {
+        if (!process.HasExited)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException) when (process.HasExited)
+            {
+                // The process exited between the state check and the kill request.
+            }
         }
 
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
-        return new(process.ExitCode, stdout, stderr);
+        using var cleanupTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(CleanupTimeoutSeconds));
+        try
+        {
+            await process.WaitForExitAsync(cleanupTimeout.Token);
+            var capturedOutput = await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cleanupTimeout.Token);
+            return PowerShellOutputNormalizer.Normalize(
+                capturedOutput[0] + Environment.NewLine + capturedOutput[1]);
+        }
+        catch (OperationCanceledException exception) when (cleanupTimeout.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"{description} did not exit and close redirected streams within " +
+                $"{CleanupTimeoutSeconds} seconds after process-tree termination was requested.",
+                exception);
+        }
     }
 
     private sealed record PowerShellResult(int ExitCode, string StdOut, string StdErr)

--- a/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
@@ -310,9 +310,9 @@ public sealed class TestRunFailureEnvelopeTests
     // a payload that grew linearly with the failure count.
     //
     // Cap investigation (the row's acceptance criterion — measured, not assumed): there is NO
-    // response-size constant anywhere to guard against. `rg` over src/ finds no
-    // MaximumResponseSize/MaxResponseSize/ResponseSizeLimit/OutputSizeLimit, and a symbol sweep
-    // over the pinned ModelContextProtocol 2.1.0 assemblies finds no
+    // response-size constant anywhere to guard against. A source audit found no
+    // MaximumResponseSize/MaxResponseSize/ResponseSizeLimit/OutputSizeLimit, and a restored-
+    // assembly symbol audit found no
     // MaxMessageSize/MaximumMessageSize/MaxResponseSize/SizeLimit either. The MCP protocol
     // imposes no ceiling; the real ceiling is the consuming client's context budget. The tests
     // below therefore MEASURE the serialized payload rather than comparing it to a constant, and
@@ -448,8 +448,8 @@ public sealed class TestRunFailureEnvelopeTests
     public async Task RunTests_WorstCasePayload_StaysWithinTheMeasuredCeiling()
     {
         // Acceptance criterion for test-run-failures-pagination-truncation: no MCP/SDK/in-repo
-        // response-size constant exists (verified by grep over src/ and a symbol sweep over the
-        // pinned ModelContextProtocol 2.1.0 assemblies), so the guard has to be an explicitly
+        // response-size constant exists (verified by a source and symbol audit over the restored
+        // ModelContextProtocol assemblies), so the guard has to be an explicitly
         // MEASURED budget rather than a comparison against a protocol constant.
         //
         // This drives the true worst case at the shipped defaults: every returned failure carries

--- a/tests/RoslynMcp.Tests/WorkspacePathMrtrWireTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspacePathMrtrWireTests.cs
@@ -19,7 +19,7 @@ namespace RoslynMcp.Tests;
 
 /// <summary>
 /// Raw-wire contract for the <c>mcp-mrtr-dispatch-contract</c> initiative: server-driven input
-/// through <see cref="RequestScopedInputAdapter"/> must be portable across both SDK 2.1 session
+/// through <see cref="RequestScopedInputAdapter"/> must be portable across both supported SDK session
 /// eras. Mirrors the dual-protocol harness pattern of
 /// <see cref="ProtocolVersionResultShapeWireTests"/> (negotiated <c>2025-11-25</c> vs
 /// <c>2026-07-28</c>, asserting against <c>harness.RawServerMessages</c>). Pins:


### PR DESCRIPTION
## Summary
- pin ModelContextProtocol and ModelContextProtocol.Core to 2.2.0 and regenerate third-party attribution
- record the non-breaking stdio-only disposition in ADR 0006 and refresh dual-era compatibility documentation
- harden dependency-gate subprocess tests for loaded Windows runners and make changelog fragments fail closed on extra body lines
- record bounded follow-ups for duplicated PowerShell runners and ineffective cooperative timeout token flow

## Compatibility
- no HTTP host or hybrid HTTP session mode is added
- the 2025-11-25 and 2026-07-28 stdio protocol-era contracts remain unchanged
- no consumer migration is required

## Verification
- `just ci`: 2,557 passed, 7 expected skips, 0 failed; 17m01s
- dependency-gate process classes: 150/150 across 10 consecutive runs
- exact 2.2.0 NuGet packages: signature, SHA-512, license, dependency shape, and XML member inventory verified
- restored release artifact resolves ModelContextProtocol 2.2.0 and ModelContextProtocol.Core 2.2.0