### PR TITLE
refactor(tools): trim symbol/analysis tool descriptions to capability statements

### DIFF
--- a/changelog.d/method-description-diet-symbol-analysis.md
+++ b/changelog.d/method-description-diet-symbol-analysis.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** Trimmed method-level tool descriptions for the symbol and analysis tool surface (`symbol_search`, `find_references`, `find_overrides`, `get_completions`, `semantic_grep`, `semantic_search`, `find_duplicated_methods`, `project_diagnostics`, and 32 more) to ~200-char capability statements, removing prose that duplicated each tool's published `outputSchema` and its own parameter descriptions. Cuts ~14.7k characters (~3.7k tokens) from every `tools/list` response; each tool keeps its discriminating trigger for tool-search discovery.

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -14,7 +14,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_unused_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find likely unused symbols."),
-     Description("Find symbols (types, methods, properties, fields) with zero references across the solution — helps identify dead code. Each hit includes Confidence: high (private/internal), medium (public API), low (enum members, record/serialization-shaped properties, interface members — often false positives). By default skips convention-invoked shapes (EF ModelSnapshots, xUnit/NUnit/MSTest fixtures, ASP.NET middleware, SignalR Hubs, FluentValidation validators, Razor PageModels) — set excludeConventionInvoked=false to include them.")]
+     Description("Find symbols with zero solution-wide references — likely dead code. Each hit carries Confidence: high (private/internal), medium (public API), low (enum/interface members). Convention-invoked shapes are skipped by default.")]
     public static Task<string> FindUnusedSymbols(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
@@ -52,13 +52,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_di_registrations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Inspect DI registration patterns in source."),
-     Description("Scan the solution for dependency injection registrations (AddSingleton, AddScoped, AddTransient) and return the service-to-implementation mappings. " +
-        "Paginated via offset/limit (default limit=100) to bound response size on large DI graphs — callers on solutions with > limit registrations " +
-        "should iterate by increasing offset until hasMore=false. totalCount counts ALL registrations in the queried scope; the paged registrations slice " +
-        "contains only the [offset, offset+limit) window. Pass showLifetimeOverrides=true to additionally emit per-service-type override chains (winning lifetime, " +
-        "lifetime-mismatch flag, dead-registration count) — opt-in to keep the default payload shape stable; pagination applies identically to the registrations list " +
-        "in this mode while overrideChains remains unpaged (use summary=true if the override-chain list also needs paging). " +
-        "Pass summary=true for large graphs to return aggregate counts plus a bounded page of override-chain summaries instead of full registrations/overrideChains.")]
+     Description("Scan the solution for DI registrations (AddSingleton/AddScoped/AddTransient) and return the service-to-implementation mappings. Pass showLifetimeOverrides=true for per-service override chains and lifetime-mismatch flags.")]
     public static Task<string> GetDiRegistrations(
         IWorkspaceExecutionGate gate,
         IDiRegistrationService diRegistrationService,
@@ -171,7 +165,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_complexity_metrics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Compute cyclomatic complexity and related metrics."),
-     Description("Calculate cyclomatic complexity, lines of code, nesting depth, parameter count, and an approximate maintainability index (0–100, higher is better) for methods in the workspace")]
+     Description("Calculate cyclomatic complexity, lines of code, nesting depth, parameter count, and an approximate maintainability index (0-100, higher is better) for methods in the workspace.")]
     public static Task<string> GetComplexityMetrics(
         IWorkspaceExecutionGate gate,
         ICodeMetricsService codeMetricsService,
@@ -194,12 +188,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_reflection_usages", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find reflection-heavy call sites."),
-     Description("Find all reflection API usage in the solution (typeof, Type.GetMethod, Activator.CreateInstance, Assembly.Load, etc.). " +
-        "Paginated via offset/limit (default limit=200) to bound response size on reflection-heavy solutions — " +
-        "callers on solutions with > limit hits should iterate by increasing offset until hasMore=false. " +
-        "totalCount counts ALL reflection sites in the queried scope; the paged usagesByKind slice contains only " +
-        "the [offset, offset+limit) window. Pass summary=true for the per-UsageKind counts only (no item arrays) — " +
-        "a compact aggregate shape for large solutions where the default paginated response still exceeds the MCP cap.")]
+     Description("Find reflection API usage across the solution (typeof, Type.GetMethod, Activator.CreateInstance, Assembly.Load, etc.), bucketed by UsageKind — the call sites that make rename and dead-code removal unsafe.")]
     public static Task<string> FindReflectionUsages(
         IWorkspaceExecutionGate gate,
         ICodePatternAnalyzer codePatternAnalyzer,
@@ -265,7 +254,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_namespace_dependencies", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Build namespace dependency graphs."),
-     Description("Get the namespace dependency graph and detect circular namespace dependencies in the solution")]
+     Description("Get the namespace dependency graph for the solution and detect circular namespace dependencies.")]
     public static Task<string> GetNamespaceDependencies(
         IWorkspaceExecutionGate gate,
         INamespaceDependencyService namespaceDependencyService,
@@ -308,7 +297,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "get_nuget_dependencies", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Inspect NuGet package references and versions."),
-     Description("List all NuGet package references across projects in the workspace, including which projects use each package. Pass `summary=true` to collapse the response to per-package counts + distinct version count — required on multi-project solutions where the default response exceeds the MCP cap (Jellyfin's 40-project graph: ~102 KB).")]
+     Description("List every NuGet package reference across workspace projects, including which projects use each package. Use summary=true on multi-project solutions to collapse to per-package counts and distinct version counts.")]
     public static Task<string> GetNuGetDependencies(
         IWorkspaceExecutionGate gate,
         INuGetDependencyService nuGetDependencyService,
@@ -324,7 +313,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_dead_locals", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Find method-local variables whose only write is not followed by any read."),
-     Description("Find method-local variables whose only write is not followed by any read — the class of waste IDE0059 (\"Unnecessary assignment of a value\") covers when the diagnostic is at default severity. Walks every method-like body (methods, constructors, accessors, local functions) and runs SemanticModel.AnalyzeDataFlow once per body, collecting ILocalSymbols that appear in WrittenInside but not in ReadInside. Conservative exclusions: discards (`_`), `foreach` iteration variables, `using`/`await using` resource locals, `catch (Exception ex)` exception locals, pattern-matching designations (`is T x`, `var p`), tuple-deconstruction designations (`var (_, b) = Foo()`), and `out var` declarations at call sites are NOT flagged — those shapes routinely require a name even when the value is unused, and IDE0059 separately suggests the `out _` rewrite. `const` locals are also skipped (removing them changes nameof shape).")]
+     Description("Find method-local variables written but never read — the IDE0059 waste class — via per-body data-flow analysis. Discards, foreach/using/catch locals, pattern and tuple designations, `out var`, and consts are not flagged.")]
     public static Task<string> FindDeadLocals(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
@@ -350,7 +339,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_dead_fields", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Find source-declared fields that are never read, never written, or never either."),
-     Description("Find source-declared fields whose in-solution usage is incomplete: `never-read`, `never-written`, or `never-either`. Classification uses Roslyn reference finding plus declaration initializers (which count as writes). Skips enum members, constants, compiler-generated backing fields, field-like event storage, and generated files. By default excludes public/protected fields because external consumers may legitimately read or write them; set `includePublic=true` to include that surface. Optional `usageKind` filter accepts `never-read`, `never-written`, or `never-either`. Each hit also includes `removalBlockedBy` (non-null list of `Kind@Path:Line:Col` markers, e.g. `ConstructorWrite@...`, when residual references exist) and `safelyRemovable` (false when `remove_dead_code_preview` would refuse with \"still has references\" — typically DI-captured fields written only in the constructor). Skip chaining `remove_dead_code_preview` on hits where `safelyRemovable=false`.")]
+     Description("Find source-declared fields never read, never written, or neither. Public/protected fields need includePublic=true. Each hit reports removalBlockedBy and safelyRemovable — skip remove_dead_code_preview when that is false.")]
     public static Task<string> FindDeadFields(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
@@ -380,7 +369,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicate_helpers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Flag private/internal helper methods whose body duplicates a reachable BCL/NuGet symbol."),
-      Description("Find private/internal static helpers (on `static class` hosts) whose body is a single ≤ 2-statement delegation to a method declared in a non-source assembly (BCL or referenced NuGet) — the \"reinvented `string.IsNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull`\" pattern that `find_unused_symbols` misses because the helper IS used locally. Conservative: expression-bodied forwarders and `{ return Target(...); }` bodies return Confidence=high; a single null-guard followed by the delegation returns Confidence=medium. By default, thin forwarders into common hosting, service-registration, and HTTP extension APIs are omitted as framework glue rather than redundant primitives. Set `excludeFrameworkWrappers=false` to include those. Any body that calls the solution's own code (same-solution assembly), or does more than a pure re-wrap, is not flagged. Intentionally distinct from `find_duplicated_methods` (which buckets internal-to-internal structural duplicates); this tool targets internal-vs-referenced-library duplicates.")]
+      Description("Find private/internal static helpers whose body just re-wraps a BCL or NuGet method — the reinvented ArgumentNullException.ThrowIfNull pattern. Contrast find_duplicated_methods, which buckets internal-to-internal duplicates.")]
     public static Task<string> FindDuplicateHelpers(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,
@@ -408,7 +397,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicated_methods", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find clusters of near-duplicate method bodies by AST-normalized hash."),
-     Description("Find clusters of method bodies whose AST-normalized structure is identical (or very close) — surfaces internal copy-paste that should be extracted to a shared helper. Normalization strips trivia, renames locals/parameters to ordinal placeholders, and compares the canonical SyntaxKind sequence, so cosmetic differences (formatting, local names, parameter names) don't affect bucketing. Overloads with identical bodies cluster; overloads with different bodies do not (bucketing is by body-shape, not method name). Auto-generated files (.g.cs, .Designer.cs, obj/), abstract declarations, partial methods without bodies, and by default single-delegation [McpServerTool] wrapper shims are excluded. Tune `minLines` up to reduce noise (default 10); narrow `projectFilter` for large solutions. `similarityThreshold` gates exact-structural matches only in the current implementation — near-miss bucketing is reserved for a future iteration, so any value in [0,1] behaves the same as 1.0. Response shape: { count, groups, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. find_duplicated_code). Set `summary=true` for a compact payload that omits each group's per-member `Methods` array (file paths + line spans), keeping only { normalizedHash, memberCount, similarity, lineCount, clusterKind } per cluster — use this on large solutions where the full member lists exceed the MCP output cap.")]
+     Description("Find clusters of method bodies whose AST-normalized structure matches — internal copy-paste to extract into a shared helper. Bucketing is by body shape, not method name, so identical overloads cluster and differing ones do not.")]
     public static Task<string> FindDuplicatedMethods(
         IWorkspaceExecutionGate gate,
         IDuplicateMethodDetectorService duplicateMethodDetectorService,
@@ -489,7 +478,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_duplicated_code", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Alias for find_duplicated_methods (cross-MCP-server name compatibility)."),
-     Description("Alias for `find_duplicated_methods` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical find_duplicated_methods response envelope ({ count, groups, deprecation }) with deprecation.canonicalName populated. Note: the python-refactor server has only one duplicate-detection tool while this server has two — `find_duplicated_methods` (clusters of internal copy-paste, picked here as the broader match) and `find_duplicate_helpers` (private/internal helpers that re-wrap a BCL/NuGet symbol). Call those canonicals directly when you need the targeted shape. Set `summary=true` for a compact payload that omits each group's per-member `Methods` array, keeping only per-cluster metadata — use this on large solutions where the full member lists exceed the MCP output cap.")]
+     Description("Alias for find_duplicated_methods (cross-MCP-server name compatibility with python-refactor). For BCL/NuGet re-wraps use find_duplicate_helpers instead; call the canonicals directly when you need the targeted shape.")]
     public static Task<string> FindDuplicatedCode(
         IWorkspaceExecutionGate gate,
         IDuplicateMethodDetectorService duplicateMethodDetectorService,
@@ -519,7 +508,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "semantic_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Run semantic search over symbols and declarations."),
-     Description("Search for symbols by semantic criteria. NOTE: this tool does NOT use embedding-based similarity or vector search — matching is done via structured Roslyn predicate parsing (symbol kind, modifiers, return types, etc.) with a token-substring fallback for queries that do not parse to a structured predicate. Supports natural language queries like 'async methods returning Task<bool>', 'classes implementing IDisposable', 'methods with more than 5 parameters', 'static methods', 'virtual properties', 'generic classes', etc. async gotcha: the 'async' keyword maps to Roslyn's IMethodSymbol.IsAsync which REQUIRES the 'async' modifier on the declaration — a Task<T>-returning method that uses Task.FromResult(...) without 'async' is NOT matched. Query 'methods returning Task<bool>' without 'async' to match all Task-returning methods. Verbose-query fallback: long natural-language queries that fail structured parsing decompose into stopword-filtered tokens and match any symbol name containing a token; the response Debug payload shows the parsed tokens, applied predicates, and fallback strategy (structured/name-substring/token-or-match/none) so callers can see why a query matched or missed.")]
+     Description("Search symbols by structured Roslyn predicates parsed from natural language ('async methods returning Task<bool>', 'classes implementing IDisposable') — not embeddings or vector search. 'async' requires the literal async modifier.")]
     public static Task<string> SemanticSearch(
         IWorkspaceExecutionGate gate,
         ICodePatternAnalyzer codePatternAnalyzer,

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalysisTools.cs
@@ -19,12 +19,7 @@ public static class AnalysisTools
         Analyzer,
     }
 
-    [McpServerTool(Name = "project_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
-        "Get diagnostics for the workspace (compiler CS*, analyzers CA*/IDE*, and workspace load issues). " +
-        "Contrast with compile_check (CS-only). Totals totalErrors/totalWarnings/totalInfo count the full queried scope and ignore the severity filter; " +
-        "the severity parameter only narrows which rows are collected (default minimum severity is Info when omitted — Hidden is still excluded). " +
-        "Use offset/limit to page; limit defaults to 200 to cap payload size. When hasMore is true, increase offset or narrow project/file filters. " +
-        "Large solutions can take tens of seconds — prefer projectName or file filters.")]
+    [McpServerTool(Name = "project_diagnostics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get workspace diagnostics — compiler CS*, analyzers CA*/IDE*, and workspace load issues. Contrast compile_check, which is CS-only. Large solutions take tens of seconds, so prefer a projectName or file filter.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Return compiler diagnostics for a workspace.")]
     public static Task<string> GetProjectDiagnostics(
@@ -135,19 +130,7 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "diagnostic_details", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
-        "Get detailed information and available code fix options for a specific diagnostic occurrence. " +
-        "supportedFixes is populated from CodeFixProvider instances loaded via the CodeFixProviderRegistry " +
-        "(static IDE Features providers + per-project analyzer references). " +
-        "IMPORTANT LIMITATION: CA-series rules (e.g. CA1826, CA1848) from Microsoft.CodeAnalysis.NetAnalyzers " +
-        "ship with code-fix providers but those providers require Roslyn workspace services injected via constructor " +
-        "and cannot be instantiated by static reflection alone — supportedFixes will therefore always be empty for " +
-        "CA-series diagnostics. Use get_code_actions + preview_code_action to apply fixes for CA rules at a specific " +
-        "document location; those tools go through the live Roslyn workspace and surface the full fix menu. " +
-        "supportedFixes is reliable for CS* compiler diagnostics and IDE* Roslyn-IDE rules. " +
-        "When supportedFixes is empty for any diagnostic, guidanceMessage points to the get_code_actions fallback. " +
-        "Position parameters accept either `line`/`column` or the `startLine`/`startColumn` naming used by other positional tools " +
-        "(find_references, goto_definition, get_code_actions, …); supply exactly one pair.")]
+    [McpServerTool(Name = "diagnostic_details", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get details and available code fixes for one diagnostic occurrence. supportedFixes is reliable for CS* and IDE* rules but is always empty for CA-series NetAnalyzers rules — use get_code_actions + preview_code_action there.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Inspect one diagnostic occurrence in detail.")]
     public static Task<string> GetDiagnosticDetails(
@@ -240,7 +223,7 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "callers_callees", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find direct callers and callees of the symbol resolved at the exact line/column (or symbolHandle). Resolution uses the token at that position — e.g. a caret on a field name inside a method resolves the field, not the enclosing method. Place the caret on the method name to analyze the method.")]
+    [McpServerTool(Name = "callers_callees", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find direct callers and callees of the symbol at the exact position or symbolHandle. Resolution uses the token at that position — a caret on a field inside a method resolves the field, so place it on the method name.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Find direct callers and callees for a method.")]
     public static Task<string> GetCallersCallees(
@@ -284,7 +267,7 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "impact_analysis", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Analyze the impact of changing a symbol: find all references, affected declarations, and affected projects. References and declarations are paginated server-side (FLAG-3D) — use referencesOffset/referencesLimit/declarationsLimit. Total counts and hasMore flags are always returned. Pass summary=true to drop the per-reference and per-declaration arrays and keep only counts (10-100x smaller payload on broad-impact symbols).")]
+    [McpServerTool(Name = "impact_analysis", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Analyze the blast radius of changing a symbol: references, affected declarations, and affected projects in one call. Pass summary=true on broad-impact symbols to keep only counts (10-100x smaller than the full arrays).")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Estimate the impact of changing a symbol.")]
     public static Task<string> AnalyzeImpact(
@@ -343,7 +326,7 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_type_mutations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Heavy analysis: find all mutating members of a type (settable properties, methods that write instance state) and their external callers, classified as construction-phase vs post-construction callers")]
+    [McpServerTool(Name = "find_type_mutations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Heavy analysis: find every mutating member of a type (settable properties, methods writing instance state) and their external callers, classified as construction-phase vs post-construction.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Identify mutating members of a type and who calls them.")]
     public static Task<string> FindTypeMutations(
@@ -379,7 +362,7 @@ public static class AnalysisTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_type_usages", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all usages of a type across the solution, classified by role: MethodReturnType, MethodParameter, PropertyType, LocalVariable, FieldType, GenericArgument, BaseType, Cast, TypeCheck, ObjectCreation, or Other")]
+    [McpServerTool(Name = "find_type_usages", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all usages of a type across the solution, each classified by role: MethodReturnType, MethodParameter, PropertyType, LocalVariable, FieldType, GenericArgument, BaseType, Cast, TypeCheck, ObjectCreation, or Other.")]
     [McpToolMetadata("analysis", "stable", true, false,
         "Classify usages of a type across the solution.")]
     public static Task<string> FindTypeUsages(
@@ -427,13 +410,7 @@ public static class AnalysisTools
     /// </summary>
     private const int SemanticGrepHardCap = 500;
 
-    [McpServerTool(Name = "semantic_grep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
-        "Token-aware regex search over the loaded C# workspace. Applies a .NET regular expression to individual syntax tokens and comment trivia so callers can avoid plain-text false positives in strings or comments. " +
-        "Scopes: `identifiers` (identifier tokens), `strings` (string, interpolated-text, raw, char, and UTF-8 literal tokens), `comments` (single-line, multi-line, and documentation trivia), or `all` (their union). " +
-        "Patterns use System.Text.RegularExpressions, not ripgrep/PCRE syntax; each token is matched independently. Under `identifiers`, member access is split into separate tokens (`Task.Run` becomes `Task`, `.`, `Run`), so `Task\\.Run` cannot match—search the component identifiers separately. " +
-        "Per-document regex evaluation is capped at 2 seconds; timed-out tokens are skipped, so simplify expensive patterns if results appear incomplete. Optional `projectName` restricts the walk by Project.Name. " +
-        "Collection is hard-capped at 500 hits per call. Results are paginated with offset/limit; iterate until hasMore=false. totalCount covers collected hits only, up to that hard cap, so narrow `pattern` or `projectName` when the ceiling is reached. " +
-        "Response shape: { count, totalCount, hasMore, offset, limit, items: [{ filePath, line, column, tokenKind, snippet }] } sorted by ascending file/line/column.")]
+    [McpServerTool(Name = "semantic_grep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Token-aware regex search over the loaded C# workspace, scoped to identifiers / strings / comments / all — no plain-text false positives. Patterns are .NET regex, not ripgrep; identifiers split on member access, so `Task\\.Run` never matches.")]
     [McpToolMetadata("analysis", "experimental", true, false,
         "Token-aware regex search over C# code (identifier / string / comment scopes).")]
     public static Task<string> SemanticGrep(

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolTools.cs
@@ -20,7 +20,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class SymbolTools
 {
 
-    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search for symbols (types, methods, properties, fields) by name pattern across the loaded workspace. Matching is substring (case-insensitive) — pass a bare fragment like 'Animal' to find 'AnimalService', 'IAnimal', 'CatAnimal', etc. Wildcards (*, ?) and regex metacharacters are NOT interpreted; they are matched literally. Pass `summary=true` to drop expensive per-symbol fields (documentation, parameters, baseTypes, interfaces, modifiers, returnType) for broad queries — useful when the default payload exceeds the MCP cap (~171 KB observed at limit=100 without summary). When a query matches more than one symbol the calling agent receives the full paginated candidate list directly by default; pass `allowElicitation=true` to instead ask for a request-scoped operator choice on form-capable clients. Response shape: { count, totalCount, hasMore, offset, limit, summary, symbols }.")]
+    [McpServerTool(Name = "symbol_search", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Search workspace symbols (types, methods, properties, fields) by case-insensitive substring — 'Animal' matches 'AnimalService'. Wildcards and regex metacharacters are matched literally, not interpreted. Use summary=true for broad queries.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Search symbols by name across the workspace.")]
     public static Task<string> SearchSymbols(
@@ -153,7 +153,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "symbol_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get detailed information about a symbol at a specific file location. Default resolution is strict — a caret on whitespace adjacent to an identifier returns NotFound. Pass allowAdjacent=true to restore the pre-v1.19.1 lenient behavior where the resolver walks to the adjacent token.")]
+    [McpServerTool(Name = "symbol_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get detailed information about the symbol at a file position. Resolution is strict — a caret on whitespace next to an identifier returns NotFound; pass allowAdjacent=true for the lenient walk to the neighbouring token.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Inspect the symbol at a source location.")]
     public static Task<string> GetSymbolInfo(
@@ -183,7 +183,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "go_to_definition", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the definition location(s) of a symbol at the given position. When a metadataName resolves to multiple candidates the calling agent receives the structured candidate list directly by default; pass allowElicitation=true to instead ask for a request-scoped operator choice on form-capable clients.")]
+    [McpServerTool(Name = "go_to_definition", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the definition location(s) of the symbol at a position or metadataName. Use find_implementations instead when the symbol is an interface or abstract member and you want the concrete declarations.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Navigate to the symbol definition.")]
     public static Task<string> GoToDefinition(
@@ -253,7 +253,7 @@ public static class SymbolTools
         return "No definition found for the symbol at the specified location";
     }
 
-    [McpServerTool(Name = "find_references", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all references to a symbol at the given position across the entire solution. Response shape: { count, totalCount, hasMore, offset, limit, items } where items is the paged LocationDto list. Pass `summary=true` to drop per-ref preview text — useful for high-fan-out symbols where the default payload exceeds the MCP cap (Jellyfin's IUserManager: 154 KB on 233 refs). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the result to references hosted in the listed project(s) — matches semantic_grep's filter semantics. When a metadataName resolves to multiple candidates the calling agent receives the structured candidate list directly by default; pass allowElicitation=true to instead ask for a request-scoped operator choice on form-capable clients.")]
+    [McpServerTool(Name = "find_references", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find every reference to a symbol across the solution. Use summary=true on high-fan-out symbols to drop preview text, and projectFilter to restrict to named projects; for many symbols at once use find_references_bulk.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find references to a symbol. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated).")]
     public static Task<string> FindReferences(
@@ -316,7 +316,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_implementations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all implementations of an interface or abstract member at the given position. Response shape: { count, items }. By default, source-generator-emitted partial declarations (e.g. Logging.g.cs, RegexGenerator.g.cs) are deduped against the user-authored partial so each implementation appears exactly once; pass includeGeneratedPartials=true to restore the raw per-declaration list. IMPORTANT: when using filePath/line/column, the column must point at the symbol identifier token (e.g., the interface name 'IMyService'), not the start of the line — otherwise no symbol can be resolved and the result is empty. For interface lookups, prefer metadataName (fully qualified) when you do not have an exact cursor position.")]
+    [McpServerTool(Name = "find_implementations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find implementations of an interface or abstract member. The column must point at the identifier token (e.g. 'IMyService'), not the line start; prefer metadataName without an exact cursor. Generator partials are deduped by default.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find implementations of an interface or abstract member.")]
     public static Task<string> FindImplementations(
@@ -370,7 +370,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all symbol declarations (types, methods, properties, fields) in a document as a hierarchical tree. Accepts either filePath OR a symbol locator (symbolHandle / metadataName) — mirroring the flexibility of symbol_info. Response shape: { count, symbols, deprecation } — deprecation is null on the canonical tool and populated on aliases (e.g. get_symbol_outline).")]
+    [McpServerTool(Name = "document_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get all declarations in a document (types, methods, properties, fields) as a hierarchical tree. Accepts filePath OR a symbol locator (symbolHandle / metadataName), like symbol_info. Alias: get_symbol_outline.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "List declared symbols in a document.")]
     public static Task<string> GetDocumentSymbols(
@@ -436,7 +436,7 @@ public static class SymbolTools
     // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
     // (Jedi) tool name `get_symbol_outline`. Delegates to the canonical `document_symbols`
     // implementation and surfaces the migration path inline via the `deprecation` envelope.
-    [McpServerTool(Name = "get_symbol_outline", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Alias for `document_symbols` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical document_symbols response envelope ({ count, symbols, deprecation }) with deprecation.canonicalName populated. Prefer `document_symbols` directly in new code.")]
+    [McpServerTool(Name = "get_symbol_outline", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Alias for document_symbols (cross-MCP-server name compatibility with python-refactor). Returns the canonical document_symbols envelope with deprecation.canonicalName populated. Prefer document_symbols in new code.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Alias for document_symbols (cross-MCP-server name compatibility).")]
     public static Task<string> GetSymbolOutline(
@@ -461,7 +461,7 @@ public static class SymbolTools
             ct);
     }
 
-    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find true virtual/abstract overrides for a member — only symbols actually marked `override` of a virtual or abstract declaration. Sibling interface implementations (e.g. independent IDisposable.Dispose impls across a solution) are NOT included here; query member_hierarchy and read the siblingInterfaceImplementations bucket for that. Response shape: { count, items } in the normal path, or { count: 0, items: [], hint } when the post-promotion symbol is a corlib virtual (System.Object.ToString / Equals / GetHashCode, System.IDisposable.Dispose, etc.) — the unbounded solution-wide enumeration is suppressed and the hint explains why. Each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Auto-promotes to the virtual/interface root: override chains, explicit interface implementations, and implicit interface implementations are normalized before the search so callers can anchor at the implementation or declaration site and get the same result set. Metadata-boundary members (e.g. IEquatable<T>.Equals) surface with FilePath=null so the count matches member_hierarchy.overrides.")]
+    [McpServerTool(Name = "find_overrides", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find true virtual/abstract overrides of a member — only symbols actually marked `override`. Sibling interface implementations are NOT included; use member_hierarchy for those. Auto-promotes to the virtual/interface root before searching.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find overrides of a virtual or abstract member.")]
     public static Task<string> FindOverrides(
@@ -508,7 +508,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_base_members", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find base or implemented members for an override or implementation. Response shape: { count, items }; each item is a SymbolDto (Name, FullyQualifiedName, FilePath, StartLine, etc.). Metadata-boundary bases (e.g. IEquatable<T>.Equals from corlib) surface with FilePath=null so count matches member_hierarchy.")]
+    [McpServerTool(Name = "find_base_members", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find the base or implemented members behind an override or implementation. Metadata-boundary bases (e.g. IEquatable<T>.Equals from corlib) surface with FilePath=null so counts match member_hierarchy.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find base or implemented members.")]
     public static Task<string> FindBaseMembers(
@@ -530,7 +530,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "member_hierarchy", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get a summary of base members, true virtual/abstract overrides, and sibling interface implementations for a symbol. Response buckets: `baseMembers` (the base chain), `overrides` (members actually marked `override` of a virtual/abstract declaration — matches find_overrides), `siblingInterfaceImplementations` (every concrete type whose member fulfills the same interface contract — e.g. independent IDisposable.Dispose impls across a solution).")]
+    [McpServerTool(Name = "member_hierarchy", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Summarize a member's base chain, its true `override` members, and its sibling interface implementations (other concrete types fulfilling the same contract) — the superset of find_overrides and find_base_members.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Summarize base, override, and sibling interface implementation relationships for a member.")]
     public static Task<string> GetMemberHierarchy(
@@ -557,7 +557,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get display signature, parameters, return type, and documentation for the symbol resolved at the exact line/column (or handle/metadata name). When the caret lands on a method's return-type token (or a property's type token), the result is auto-promoted to the enclosing member by default — disable with preferDeclaringMember=false to inspect the type token directly.")]
+    [McpServerTool(Name = "symbol_signature_help", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get the display signature, parameters, return type, and documentation for the symbol at a position or locator. A caret on a return-type or property-type token auto-promotes to the enclosing member unless preferDeclaringMember=false.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Return symbol signature and documentation.")]
     public static Task<string> GetSignatureHelp(
@@ -585,7 +585,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_overloads", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Enumerate every overload of a member by type + name, including BCL/NuGet methods not authored in workspace source (symbol_search can't find those). Response: { count, items } of SignatureHelpDto.")]
+    [McpServerTool(Name = "find_overloads", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Enumerate every overload of a member by type + name, including BCL/NuGet methods with no workspace source — the case symbol_search cannot reach.")]
     [McpToolMetadata("symbols", "experimental", true, false,
         "Enumerate all overloads of a member by type + name.")]
     public static Task<string> FindOverloads(
@@ -606,7 +606,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "symbol_relationships", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get a combined summary of definitions, references, implementations, base members, and overrides. Auto-promotes a caret on a member's type token to the enclosing member by default (see preferDeclaringMember).")]
+    [McpServerTool(Name = "symbol_relationships", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Combined summary of a symbol's definitions, references, implementations, base members, and overrides in one call. A caret on a member's type token auto-promotes to the enclosing member (see preferDeclaringMember).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Combine definition, reference, base, and implementation relationships.")]
     public static Task<string> GetSymbolRelationships(
@@ -659,11 +659,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_references_bulk", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description(
-        "Find references for multiple symbols in one call (max 50). Returns { count, results } where each result has key, referenceCount, references, truncated, and optional error. " +
-        "Parameter name must be `symbols` (array of objects). Do NOT pass symbolHandles or a JSON string array. " +
-        "Each element must set exactly one of: symbolHandle, metadataName, or filePath+line+column. " +
-        "Pass `summary=true` to drop per-ref preview text and `maxItemsPerSymbol=N` to cap each symbol's reference list so the aggregate envelope stays under the MCP payload cap (overflowed at 120 KB without bounds).")]
+    [McpServerTool(Name = "find_references_bulk", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find references for up to 50 symbols in one call. Each element of `symbols` must set exactly one of symbolHandle, metadataName, or filePath+line+column — do not pass symbolHandles or a JSON string array.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Resolve references for multiple symbols in one request.")]
     public static Task<string> FindReferencesBulk(
@@ -735,7 +731,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_type_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("File-granularity rollup of consumers for a named type. Returns one entry per source file that references the type, with a deduped list of usage `kinds` (using | ctor | inherit | field | local | other) and the total `count` of reference sites in that file. Removes the Grep fallback for 'which files touch this type' workflows. Pass typeName as a fully qualified metadata name (e.g. 'SampleLib.IAnimal' or 'System.Collections.Generic.List`1') or a short type name when unambiguous; generic arity uses backtick notation. Response shape: { count, items: [{ filePath, kinds, count }] } sorted by descending site count then ascending file path.")]
+    [McpServerTool(Name = "find_type_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("File-granularity rollup of which source files reference a named type, with deduped usage kinds and a per-file site count — the 'which files touch this type' question. Contrast find_type_usages, which classifies individual sites.")]
     [McpToolMetadata("symbols", "experimental", true, false,
         "Roll up reference sites per file for a named type, classified by usage kind.")]
     public static Task<string> FindTypeConsumers(
@@ -753,7 +749,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "find_property_writes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find all locations where a property is assigned to (written). Each write carries a WriteKind bucket: ObjectInitializer (safe for init), Assignment (post-construction), OutRef (passed by out/ref), or PrimaryConstructorBind (the property is a positional-record primary-ctor parameter and the site is a `new T(value)` construction that binds this positional slot — find-property-writes-positional-record-silent-zero).")]
+    [McpServerTool(Name = "find_property_writes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find every location where a property is assigned. Each write carries a WriteKind bucket: ObjectInitializer, Assignment, OutRef, or PrimaryConstructorBind (a positional-record slot bound by a `new T(value)` construction).")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Find property write sites and classify object-initializer writes.")]
     public static Task<string> FindPropertyWrites(
@@ -800,7 +796,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "probe_position", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("position-probe-for-test-fixture-authoring: return the raw lexical + containing-symbol state at a source position without applying the lenient adjacent-identifier fallback used by symbol resolvers. Intended for test-fixture authoring — a caret on whitespace returns tokenKind='Whitespace' + leadingTriviaBefore=true instead of silently resolving to the next identifier. Response shape: { filePath, line, column, tokenKind, syntaxKind, tokenText, containingSymbol, containingSymbolKind, leadingTriviaBefore }.")]
+    [McpServerTool(Name = "probe_position", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Return the raw lexical and containing-symbol state at a source position without the lenient adjacent-identifier fallback other resolvers apply — a caret on whitespace reports Whitespace. Intended for test-fixture authoring.")]
     [McpToolMetadata("symbols", "experimental", true, false,
         "Probe the raw lexical token and containing symbol at a source position.")]
     public static Task<string> ProbePosition(
@@ -867,7 +863,7 @@ public static class SymbolTools
         }, ct);
     }
 
-    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense/code completion suggestions at a given position in a source file. Pass the member/token position where completions are expected, not the literal dot column; use probe_position first when uncertain. Use filterText for case-insensitive prefix narrowing and maxItems for paging (UX-007). To get instance-member candidates at a member-access position (e.g. right after typing `foo.`), pass triggerCharacter='.' — without it Roslyn returns only the position's general accessible-type set and method-tier candidates are NOT emitted, so the in-scope ranking has nothing to promote. The response IsIncomplete flag indicates that the filtered list is longer than maxItems — raise maxItems or refine filterText to see the rest. InlineDescription may be empty when Roslyn does not supply inline text for an item.")]
+    [McpServerTool(Name = "get_completions", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Get IntelliSense completions at a position. Pass the member/token position where completions are expected, not the literal dot column; use probe_position when uncertain. Pass triggerCharacter='.' for instance-member candidates.")]
     [McpToolMetadata("symbols", "stable", true, false,
         "Return IntelliSense-style completion items at the member/token position, not the literal dot column; use probe_position when uncertain.")]
     public static Task<string> GetCompletions(

--- a/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
+++ b/tests/RoslynMcp.Tests/SurfaceCatalogTests.cs
@@ -309,6 +309,54 @@ public sealed class SurfaceCatalogTests
     }
 
     [TestMethod]
+    public void DietedToolMethodDescriptions_StayWithinSliceCeiling()
+    {
+        // Slice ratchet for method-description-diet. Each slice adds its declaring types here
+        // once its descriptions are compressed to ~200-char capability statements.
+        const int maxPerToolCharacters = 250;
+        const int maxAggregateCharacters = 9_500;
+
+        var dietedTypes = new[]
+        {
+            typeof(SymbolTools),
+            typeof(AdvancedAnalysisTools),
+            typeof(AnalysisTools),
+        };
+
+        var entries = dietedTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null && entry.Description is not null)
+            .Select(entry => new { Name = entry.Tool!.Name!, Text = entry.Description!.Description })
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.IsTrue(entries.Length > 0, "Expected dieted tool types to declare [McpServerTool] methods.");
+
+        var violations = entries
+            .Where(entry => entry.Text.Length > maxPerToolCharacters)
+            .Select(entry => $"{entry.Name}: {entry.Text.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Dieted tool descriptions must stay <= {maxPerToolCharacters} characters. Violations:\n  "
+            + string.Join("\n  ", violations));
+
+        var aggregate = entries.Sum(entry => entry.Text.Length);
+        Assert.IsTrue(
+            aggregate <= maxAggregateCharacters,
+            $"Aggregate dieted tool description length was {aggregate} characters "
+            + $"across {entries.Length} tools; ceiling is {maxAggregateCharacters}.");
+    }
+
+    [TestMethod]
     public void GetCompletions_DescriptionAndCatalogGuideMemberAccessPositioning()
     {
         var method = typeof(SymbolTools).GetMethod(


### PR DESCRIPTION
## Summary

Slice 1 of 4 of the `method-description-diet` backlog row. Rewrites the 40 method-level `[Description]` strings on `SymbolTools`, `AdvancedAnalysisTools`, and `AnalysisTools` into ~200-char capability statements of the form "what it does — discriminating trigger vs sibling tools".

Removed only text that was already published elsewhere:

1. `Response shape: { ... }` sentences that restate the tool's own `outputSchema` (served via `ToolOutputSchemaIndex`).
2. Per-parameter tuning / pagination prose that restates the parameter-level `[Description]`s sitting a few lines below in the same signature — those parameter descriptions are untouched, so the information stays in place.

Every sibling-tool discriminator and correctness caveat was kept, compressed: `project_diagnostics` vs `compile_check` (CS-only), `semantic_grep`'s .NET-regex-not-ripgrep dialect and identifier-token splitting, `find_duplicated_methods` body-shape-not-name bucketing, `find_overrides` vs `member_hierarchy`, `find_duplicate_helpers` vs `find_duplicated_methods`, and the `get_completions` positioning gate.

**Measured:** aggregate method-`[Description]` length across the three types drops **22,894 → 8,212 chars** (~14.7k chars / ~3.7k tokens off every `tools/list` response). Per-tool max is now 250 chars, down from 1,422.

## Ratchet

Adds `SurfaceCatalogTests.DietedToolMethodDescriptions_StayWithinSliceCeiling`: every `[McpServerTool]` method on the three named types must be <= 250 chars, aggregate <= 9,500. The three declaring types are named explicitly so the remaining slices extend the array as they land. The global 2,000-char `AllMcpToolMethodDescriptions_AreWithinClientLimit` test and its constant are untouched.

## Not touched

No `[McpToolMetadata]` summary (catalog drift assertions), no parameter-level `[Description]`, no `Catalog/**`, no other `Tools/*.cs`. Verified the diff contains only method-`Description` literal lines.

## Validation

- `dotnet build` of the full solution + test project: clean, 0 warnings, 0 errors.
- `dotnet test --filter SurfaceCatalogTests|ReadmeSurfaceCountTests|CatalogDestructiveWarningTests`: 29/29 passed — including the new ratchet, the global client-limit test, `GetCompletions_DescriptionAndCatalogGuideMemberAccessPositioning`, and the `[McpToolMetadata]`/`ServerSurfaceCatalog` drift assertions.
- `./eng/verify-ai-docs.ps1`: passed.
- `./eng/verify-release.ps1 -Configuration Release` runs on the self-hosted runner via this PR.

Closes: method-description-diet (partial — slice 1 of 4; row remains open for the other three slices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
