### PR TITLE
feat(preview): add PreviewKind provenance discriminator to the preview-token store

### DIFF
--- a/changelog.d/preview-token-apply-route-provenance.md
+++ b/changelog.d/preview-token-apply-route-provenance.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Producer/workflow discriminator (`PreviewKind`) on the shared preview-token store. Each preview token can now record which producer created it, surfaced non-consumingly via `IPreviewStore.PeekKind`, so apply routes can verify token provenance before mutating the workspace. The discriminator is optional-with-default (`PreviewKind.Unspecified` = permissive), so existing preview producers and out-of-tree `IPreviewStore` implementations are unaffected; `RefactoringService`'s rename / format-document / format-range / organize-usings / code-fix previews are tagged as the first real producers. Route enforcement follows in a companion change.

--- a/src/RoslynMcp.Core/Models/PreviewKind.cs
+++ b/src/RoslynMcp.Core/Models/PreviewKind.cs
@@ -1,0 +1,43 @@
+namespace RoslynMcp.Core.Models;
+
+/// <summary>
+/// <b>preview-token-apply-route-provenance:</b> machine-checkable discriminator recording which
+/// producer family created a preview token, so an apply route can verify a token's provenance
+/// before mutating the workspace instead of redeeming any token that reaches the shared store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Semantics are permissive-by-default so producers can be tagged incrementally without a flag
+/// day: <see cref="Unspecified"/> means "no provenance recorded" and MUST be accepted by every
+/// apply route. A concrete member is enforceable — a route that knows which kind it consumes may
+/// reject a token whose kind is concrete and different.
+/// </para>
+/// <para>
+/// This type lives in <c>RoslynMcp.Core.Models</c> (dependency-free, already referenced by both
+/// <c>RoslynMcp.Roslyn</c> and <c>RoslynMcp.Host.Stdio</c>) so host-side apply routes can consume
+/// it without a new project reference.
+/// </para>
+/// </remarks>
+public enum PreviewKind
+{
+    /// <summary>
+    /// No provenance recorded. Permissive: every apply route accepts a token with this kind.
+    /// This is the default for producers that have not yet been tagged.
+    /// </summary>
+    Unspecified = 0,
+
+    /// <summary>A symbol rename preview.</summary>
+    SymbolRename,
+
+    /// <summary>A whole-document formatting preview.</summary>
+    FormatDocument,
+
+    /// <summary>A range-scoped formatting preview.</summary>
+    FormatRange,
+
+    /// <summary>An organize-usings / import-cleanup preview.</summary>
+    OrganizeUsings,
+
+    /// <summary>A diagnostic code-fix preview.</summary>
+    CodeFix,
+}

--- a/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
@@ -42,6 +42,28 @@ public interface IPreviewStore
         IReadOnlyList<FileChangeDto> changes);
 
     /// <summary>
+    /// <b>preview-token-apply-route-provenance:</b> same as the <paramref name="changes"/>-shaped
+    /// overload, but additionally records a machine-checkable <paramref name="kind"/> discriminator
+    /// identifying which producer family created the token, so an apply route can verify provenance
+    /// before mutating the workspace.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation drops <paramref name="kind"/> and delegates to the untagged overload,
+    /// so existing test fakes (and any out-of-tree implementations) keep compiling; only stores that
+    /// actually persist provenance override it. Producers that do not pass a kind are recorded as
+    /// <see cref="PreviewKind.Unspecified"/>, which every apply route must accept.
+    /// </remarks>
+    /// <param name="kind">The producer family that created this preview.</param>
+    string Store(
+        string workspaceId,
+        Solution modifiedSolution,
+        int workspaceVersion,
+        string description,
+        IReadOnlyList<FileChangeDto> changes,
+        PreviewKind kind)
+        => Store(workspaceId, modifiedSolution, workspaceVersion, description, changes);
+
+    /// <summary>
     /// Retrieves the stored solution pair for the given token, or <see langword="null"/>
     /// if the token is expired or not found.
     /// </summary>
@@ -117,4 +139,20 @@ public interface IPreviewStore
     /// snapshot pair override it.
     /// </remarks>
     IReadOnlyList<string>? PeekChangedPaths(string token) => null;
+
+    /// <summary>
+    /// <b>preview-token-apply-route-provenance:</b> returns the producer family that created the
+    /// stored preview, without consuming or TTL-refreshing the entry. Returns
+    /// <see cref="PreviewKind.Unspecified"/> when the token is expired/not found, when the producer
+    /// did not record a kind, or when the store does not track provenance — callers treat
+    /// <see cref="PreviewKind.Unspecified"/> as "permissive, no provenance claim", never as proof of
+    /// a mismatch.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation returns <see cref="PreviewKind.Unspecified"/> so existing test fakes
+    /// (and any out-of-tree implementations) keep compiling; only stores that actually persist
+    /// provenance override it. Mirrors the non-consuming contract of
+    /// <see cref="PeekChangedPaths(string)"/>.
+    /// </remarks>
+    PreviewKind PeekKind(string token) => PreviewKind.Unspecified;
 }

--- a/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Services/PreviewStore.cs
@@ -85,7 +85,14 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
     /// so <c>Solution.Workspace.CurrentSolution</c> at Store time IS the original.
     /// </remarks>
     public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated)
-        => Store(workspaceId, modifiedSolution.Workspace.CurrentSolution, modifiedSolution, workspaceVersion, description, diffTruncated);
+        => Store(workspaceId, modifiedSolution, workspaceVersion, description, diffTruncated, PreviewKind.Unspecified);
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: as above, but records the producer family that
+    /// created the preview so an apply route can verify provenance before mutating.
+    /// </summary>
+    public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated, PreviewKind kind)
+        => Store(workspaceId, modifiedSolution.Workspace.CurrentSolution, modifiedSolution, workspaceVersion, description, diffTruncated, kind);
 
     /// <summary>
     /// preview-token-cross-coupling-bundle: explicit-original-solution overload. Use this
@@ -99,6 +106,20 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         int workspaceVersion,
         string description,
         bool diffTruncated)
+        => Store(workspaceId, originalSolution, modifiedSolution, workspaceVersion, description, diffTruncated, PreviewKind.Unspecified);
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: explicit-original-solution overload that also records
+    /// the producer family. All other <c>Store</c> overloads funnel here.
+    /// </summary>
+    public string Store(
+        string workspaceId,
+        Solution originalSolution,
+        Solution modifiedSolution,
+        int workspaceVersion,
+        string description,
+        bool diffTruncated,
+        PreviewKind kind)
         => StoreEntry(new PreviewEntry(
             workspaceId,
             originalSolution,
@@ -110,6 +131,7 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
             MaxRedeemableVersion: workspaceVersion + _maxVersionSpan,
             description,
             diffTruncated,
+            kind,
             DateTime.UtcNow));
 
     /// <summary>
@@ -123,12 +145,26 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         int workspaceVersion,
         string description,
         IReadOnlyList<FileChangeDto> changes)
+        => Store(workspaceId, modifiedSolution, workspaceVersion, description, changes, PreviewKind.Unspecified);
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: as above, but records the producer family that
+    /// created the preview. This is the overload in-tree producers should call.
+    /// </summary>
+    public string Store(
+        string workspaceId,
+        Solution modifiedSolution,
+        int workspaceVersion,
+        string description,
+        IReadOnlyList<FileChangeDto> changes,
+        PreviewKind kind)
         => Store(
             workspaceId,
             modifiedSolution,
             workspaceVersion,
             description,
-            diffTruncated: ContainsTruncatedSentinel(changes));
+            diffTruncated: ContainsTruncatedSentinel(changes),
+            kind);
 
     private static bool ContainsTruncatedSentinel(IReadOnlyList<FileChangeDto> changes)
     {
@@ -216,6 +252,19 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         return paths;
     }
 
+    /// <summary>
+    /// <b>preview-token-apply-route-provenance:</b> returns the producer family recorded at Store
+    /// time, or <see cref="PreviewKind.Unspecified"/> when the token is expired/not found or the
+    /// producer did not tag it. Uses the non-consuming
+    /// <see cref="BoundedStore{TEntry}.RetrieveEntry"/> lookup, so a subsequent <see cref="Retrieve"/>
+    /// by the redeeming service still succeeds and the entry's TTL is not refreshed.
+    /// </summary>
+    public PreviewKind PeekKind(string token)
+    {
+        var entry = RetrieveEntry(token);
+        return entry?.Kind ?? PreviewKind.Unspecified;
+    }
+
     private static void AddDocumentPath(List<string> paths, Document? document)
     {
         if (document?.FilePath is { Length: > 0 } filePath
@@ -246,5 +295,9 @@ public sealed class PreviewStore : BoundedStore<PreviewStore.PreviewEntry>, IPre
         int MaxRedeemableVersion,
         string Description,
         bool DiffTruncated,
+        // preview-token-apply-route-provenance: producer family recorded at Store time; surfaced
+        // non-consumingly via PeekKind so apply routes can verify token provenance.
+        // PreviewKind.Unspecified means "untagged producer" and stays permissive.
+        PreviewKind Kind,
         DateTime CreatedAt) : IBoundedStoreEntry;
 }

--- a/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
+++ b/src/RoslynMcp.Roslyn/Services/RefactoringService.cs
@@ -88,7 +88,7 @@ public sealed class RefactoringService : IRefactoringService
         }
 
         var description = $"Rename '{symbol.Name}' to '{newName}'";
-        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes, PreviewKind.SymbolRename);
 
         // Register a post-apply rename hint so ApplyRefactoringAsync can rotate the handle
         // and return ApplyResult.MutatedSymbol with the new name. Declaration position is
@@ -487,7 +487,7 @@ public sealed class RefactoringService : IRefactoringService
 
         var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
         var description = $"Organize usings in '{Path.GetFileName(filePath)}'";
-        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes, PreviewKind.OrganizeUsings);
 
         return new RefactoringPreviewDto(token, description, changes, null);
     }
@@ -507,7 +507,7 @@ public sealed class RefactoringService : IRefactoringService
 
         var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
         var description = $"Format document '{Path.GetFileName(filePath)}'";
-        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes, PreviewKind.FormatDocument);
 
         return new RefactoringPreviewDto(token, description, changes, null);
     }
@@ -588,7 +588,7 @@ public sealed class RefactoringService : IRefactoringService
 
         var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
         var description = $"Format range in '{Path.GetFileName(filePath)}' (lines {startLine}-{endLine})";
-        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes, PreviewKind.FormatRange);
 
         return new RefactoringPreviewDto(token, description, changes, null);
     }
@@ -638,7 +638,7 @@ public sealed class RefactoringService : IRefactoringService
                     var diff = await SolutionDiffHelper.ComputeChangesAsync(solution, newSol, ct).ConfigureAwait(false);
                     var actionId = registeredAction.EquivalenceKey ?? registeredAction.Title ?? provider.GetType().Name;
                     var desc = $"Apply code fix '{actionId}' for {diagnosticId} in '{Path.GetFileName(filePath)}'";
-                    var tk = _previewStore.Store(workspaceId, newSol, _workspace.GetCurrentVersion(workspaceId), desc);
+                    var tk = _previewStore.Store(workspaceId, newSol, _workspace.GetCurrentVersion(workspaceId), desc, diff, PreviewKind.CodeFix);
                     return new RefactoringPreviewDto(tk, desc, diff, null);
                 }
             }
@@ -691,7 +691,7 @@ public sealed class RefactoringService : IRefactoringService
         var newSolution = document.WithSyntaxRoot(newRoot).Project.Solution;
         var changes = await SolutionDiffHelper.ComputeChangesAsync(solution, newSolution, ct).ConfigureAwait(false);
         var description = $"Apply code fix '{normalizedFixId}' for CS8019 in '{Path.GetFileName(document.FilePath)}'";
-        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes);
+        var token = _previewStore.Store(workspaceId, newSolution, _workspace.GetCurrentVersion(workspaceId), description, changes, PreviewKind.CodeFix);
 
         return new RefactoringPreviewDto(token, description, changes, null);
     }

--- a/tests/RoslynMcp.Tests/PreviewStoreTests.cs
+++ b/tests/RoslynMcp.Tests/PreviewStoreTests.cs
@@ -1,3 +1,4 @@
+using RoslynMcp.Core.Models;
 using RoslynMcp.Roslyn.Services;
 using Microsoft.CodeAnalysis;
 
@@ -212,5 +213,80 @@ public class PreviewStoreTests
 
         Assert.ThrowsExactly<ArgumentNullException>(() => _store.InvalidateOnVersionBump(null!, 1));
         Assert.ThrowsExactly<ArgumentException>(() => _store.InvalidateOnVersionBump(string.Empty, 1));
+    }
+
+    [TestMethod]
+    public void Store_Without_Kind_Defaults_To_Unspecified()
+    {
+        // preview-token-apply-route-provenance: untagged producers stay permissive.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+
+        var token = _store.Store("workspace-1", solution, 1, "test");
+
+        Assert.AreEqual(PreviewKind.Unspecified, _store.PeekKind(token));
+    }
+
+    [TestMethod]
+    public void Store_With_Kind_Roundtrips_Through_PeekKind()
+    {
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+
+        var token = _store.Store(
+            "workspace-1",
+            solution,
+            1,
+            "test",
+            Array.Empty<FileChangeDto>(),
+            PreviewKind.SymbolRename);
+
+        Assert.AreEqual(PreviewKind.SymbolRename, _store.PeekKind(token));
+    }
+
+    [TestMethod]
+    public void PeekKind_Does_Not_Consume_Entry_Or_Refresh_Ttl()
+    {
+        // Mirrors the non-consuming PeekChangedPaths contract: the redeeming service must
+        // still be able to Retrieve after a provenance check.
+        using var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+
+        var token = _store.Store(
+            "workspace-1",
+            solution,
+            1,
+            "test",
+            Array.Empty<FileChangeDto>(),
+            PreviewKind.FormatDocument);
+
+        Assert.AreEqual(PreviewKind.FormatDocument, _store.PeekKind(token));
+        Assert.AreEqual(PreviewKind.FormatDocument, _store.PeekKind(token));
+
+        var result = _store.Retrieve(token);
+        Assert.IsNotNull(result, "PeekKind must not consume the entry");
+        Assert.AreEqual("test", result.Value.Description);
+    }
+
+    [TestMethod]
+    public void PeekKind_On_Unknown_Or_Expired_Token_Returns_Unspecified()
+    {
+        Assert.AreEqual(PreviewKind.Unspecified, _store.PeekKind("no-such-token"));
+
+        // BoundedStore coerces a non-positive ttl to the 5-minute default, so use a real
+        // (tiny) window and let it elapse.
+        var expiring = new PreviewStore(maxEntries: 20, ttl: TimeSpan.FromMilliseconds(1));
+        using var workspace = new AdhocWorkspace();
+        var token = expiring.Store(
+            "workspace-1",
+            workspace.CurrentSolution,
+            1,
+            "test",
+            Array.Empty<FileChangeDto>(),
+            PreviewKind.CodeFix);
+
+        Thread.Sleep(30);
+
+        Assert.AreEqual(PreviewKind.Unspecified, expiring.PeekKind(token));
     }
 }


### PR DESCRIPTION
## What

Adds a machine-checkable producer/workflow discriminator (`PreviewKind`) to the shared preview-token store, so an apply route can verify a token's provenance before mutating the workspace. Today the store's entry record carries no field an apply route could branch on — only free-text `Description` prose — so any apply route that can reach the shared store can redeem any token. This slice creates the contract; route enforcement follows in the companion change.

## Changes

- **`src/RoslynMcp.Core/Models/PreviewKind.cs`** (new) — enum discriminator: `Unspecified`, `SymbolRename`, `FormatDocument`, `FormatRange`, `OrganizeUsings`, `CodeFix`. Placed in `Core.Models` because it is dependency-free and already referenced by both `RoslynMcp.Roslyn` and `RoslynMcp.Host.Stdio`, so host-side apply routes can consume it without a new project reference.
- **`src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs`** — one new kind-tagged `Store` overload and a non-consuming `PreviewKind PeekKind(string token)`, both declared as **default interface members** mirroring the existing `PeekChangedPaths` pattern.
- **`src/RoslynMcp.Roslyn/Services/PreviewStore.cs`** — `PreviewEntry` gains a positional `Kind` field between `DiffTruncated` and `CreatedAt`; all `Store` overloads funnel into one explicit-original implementation; `PeekKind` reads via the non-consuming `RetrieveEntry` lookup so the TTL is not refreshed and a subsequent `Retrieve` by the redeeming service still succeeds. `InvalidateOnVersionBump` and the pinned `MaxRedeemableVersion` range are untouched.
- **`src/RoslynMcp.Roslyn/Services/RefactoringService.cs`** — tags its six producer call sites (rename, organize-usings, format-document, format-range, and both code-fix paths) as the first real producers, so the companion route-binding change has a non-`Unspecified` kind to enforce against on day one.
- **`tests/RoslynMcp.Tests/PreviewStoreTests.cs`** — four new tests: default-to-`Unspecified`, kind round-trip through `PeekKind`, `PeekKind` is non-consuming (a subsequent `Retrieve` still succeeds), and unknown/expired token returns `Unspecified`.

## No-break design (the load-bearing constraint)

23 production files call `_previewStore.Store(` and 3 test fakes implement `IPreviewStore`. The optional-overload + default-interface-member design holds **all 26 of those files at zero edits** — a required `kind` parameter, a widened `Retrieve` tuple, or a non-default interface member would each re-open a 26-file fanout. `PreviewKind.Unspecified` is permissive (every apply route must accept it), so the remaining 22 producer files can be tagged incrementally without a flag day.

## Validation

- `dotnet build RoslynMcp.slnx` — clean, 0 warnings / 0 errors, with **zero** edits to the 23 producers or the 3 fakes.
- Targeted regression suites green: `PreviewStore`, `PreviewToken*` (cross-coupling, stale-across-auto-reload), `TruncatedPreviewApplyGate`, `PreviewApplyBoundaryRevalidation`, `ApplyUndoWorkflowService`, `ToolDispatch` — 60/60 passed.
- Producer-side suites green: `Refactoring`, `CodeFix`, `Format`, `Rename`, `OrganizeUsings` — 105/105 passed.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1 -Configuration Release` — 2591 passed / 1 failed. The single failure is `EvaluateAsync_InfiniteScript_TerminatesWorkerAndRecoversCapacity` (C# script-worker isolation, shipped in #1337), which touches none of the files in this PR and **passes in isolation in Release** on this same worktree. It is a load-sensitive flake: the test's 1-second script timeout fires before the worker-termination path under heavy parallel load. See the note below.

## Follow-on (not fixed here)

`EvaluateAsync_InfiniteScript_TerminatesWorkerAndRecoversCapacity` asserts on the message `"worker process was terminated"` but observes `"Script execution timed out after 1 seconds..."` when the machine is loaded — the 1s script timeout races the worker-kill path. Deserves a backlog row to make the assertion (or the timing) load-independent rather than wall-clock dependent.

Closes: (none — parent backlog row `preview-token-apply-route-provenance` stays OPEN; it is child 1 of 2 and is closed by sibling `preview-token-apply-route-binding`)
Relates-to: `preview-token-apply-route-provenance`
