### PR TITLE
refactor(tools): trim workspace/validation tool descriptions (method-description-diet-workspace-validation)

### DIFF
--- a/changelog.d/method-description-diet-workspace-validation.md
+++ b/changelog.d/method-description-diet-workspace-validation.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** trimmed method-level tool descriptions for the workspace, validation, validation-bundle, and compile-check tool groups to ~150-250-char capability statements (22 tools, ~11.7k chars down to ~4.3k), relocating operational guidance to in-source XML remarks and cutting the `tools/list` payload accordingly. Added a slice-scoped description-length regression test.

--- a/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CompileCheckTools.cs
@@ -18,10 +18,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class CompileCheckTools
 {
+    /// <remarks>
+    /// <para>The emitValidation option performs a real PE emit (not metadata-only) and is typically 50-100x slower than GetDiagnostics-only on large solutions, BUT only when the workspace has its NuGet packages restored - on a workspace with unresolved metadata references the emit phase short-circuits and the wall-clock cost matches GetDiagnostics. If you observe identical timing between emitValidation=true and emitValidation=false, run dotnet restore on the workspace first.</para>
+    /// <para>Use offset/limit to page through large diagnostic sets.</para>
+    /// <para>When file/files resolve to documents owned by one project, compilation is scoped to that project; unresolved or multi-project file filters fall back to the requested project scope or the full solution and surface the fallback in restoreHint. The response also carries structured requestedScope/actualScope fields (one of files, project, or solution) so widening can be detected programmatically - requestedScope != actualScope means the supplied file scope was not honoured - without parsing restoreHint prose.</para>
+    /// </remarks>
     [McpServerTool(Name = "compile_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "stable", true, false,
         "Fast in-memory compilation check without invoking dotnet build."),
-     Description("Fast in-memory compilation check using the Roslyn Compilation API — validates compilability without invoking dotnet build. Much faster for quick feedback loops during code generation. Note: only reports compiler diagnostics (CS*); analyzer diagnostics (CA*, IDE*) are excluded — use project_diagnostics for those. The emitValidation option performs a real PE emit (not metadata-only) and is typically 50–100× slower than GetDiagnostics-only on large solutions, BUT only when the workspace has its NuGet packages restored — on a workspace with unresolved metadata references the emit phase short-circuits and the wall-clock cost matches GetDiagnostics. If you observe identical timing between emitValidation=true and emitValidation=false, run dotnet restore on the workspace first. Results are paginated — use offset/limit to page through large diagnostic sets. When file/files resolve to documents owned by one project, compilation is scoped to that project; unresolved or multi-project file filters fall back to the requested project scope or full solution and surface the fallback in restoreHint. The response also carries structured requestedScope/actualScope fields (one of files, project, or solution) so that widening can be detected programmatically — requestedScope != actualScope means the supplied file scope was not honoured — without parsing restoreHint prose.")]
+     Description("Fast in-memory compilation check using the Roslyn Compilation API - validates compilability without invoking dotnet build. Reports compiler diagnostics (CS*) only; use project_diagnostics for analyzer (CA*, IDE*) diagnostics. Results are paginated.")]
     public static Task<string> CompileCheck(
         IWorkspaceExecutionGate gate,
         ICompileCheckService compileCheckService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -13,10 +13,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ValidationBundleTools
 {
+    /// <remarks>
+    /// <para>overallStatus is one of clean | compile-error | analyzer-error | test-failure | test-zero-run | timeout.</para>
+    /// <para>test-zero-run indicates runTests=true but the discovered filter matched zero tests - re-run test_run standalone against the surfaced filter; the zero-match is almost always a working-directory/filter-resolution race, not a real pass.</para>
+    /// <para>timeout indicates a validation phase exceeded the 25-second internal cap; the response carries compileResult.cancelled=true plus a warnings entry naming the phase and is safe to retry.</para>
+    /// <para>Pass summary=true on multi-project solutions where the default response (per-diagnostic detail plus per-test rows) exceeds the MCP cap. Pass responseFormat="markdown" for a compact summary table; the verdict is preserved across both shapes.</para>
+    /// </remarks>
     [McpServerTool(Name = "validate_workspace", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
         "Composite post-edit validation: compile_check + project_diagnostics (errors) + test_related_files (+ optional test_run)."),
-     Description("One-call post-edit validation bundle. Runs an in-memory compile_check, harvests Error-severity compiler+analyzer diagnostics, discovers tests related to the changed file set, and (when runTests=true) executes those tests. Returns an aggregate envelope with overallStatus = clean | compile-error | analyzer-error | test-failure | test-zero-run | timeout. `test-zero-run` indicates runTests=true but the discovered filter matched zero tests — re-run `test_run` standalone against the surfaced filter; the zero-match is almost always a working-directory/filter-resolution race, not a real pass. `timeout` indicates a validation phase exceeded the 25-second internal cap; the response carries `compileResult.cancelled=true` plus a `warnings` entry naming the phase and is safe to retry. Pass `summary=true` on multi-project solutions where the default response (per-diagnostic detail + per-test rows) exceeds the MCP cap (Jellyfin: 135 KB). Pass `responseFormat=\"markdown\"` for a compact ~30-line summary table when the JSON envelope is overkill — verdict (overallStatus) is preserved across both shapes.")]
+     Description("One-call post-edit validation bundle over an explicit changed-file set: in-memory compile_check, Error-severity compiler and analyzer diagnostics, related-test discovery, and optional test_run. Returns an aggregate overallStatus envelope.")]
     public static Task<string> ValidateWorkspace(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
@@ -34,10 +40,15 @@ public static class ValidationBundleTools
             return RenderValidationResponse(dto, responseFormat);
         }, ct);
 
+    /// <remarks>
+    /// <para>Falls back to full-workspace scope and surfaces the fallback via the Warnings field when git is unavailable (not on PATH, solution outside a git repo, git exited non-zero).</para>
+    /// <para>overallStatus is one of clean | compile-error | analyzer-error | test-failure | test-zero-run | git-status-unknown | timeout.</para>
+    /// <para>git-status-unknown is unique to this tool: it fires when the git status scope-collection itself timed out, so a would-be clean verdict was computed over an untrustworthy fallback scope rather than the real working tree - retry, or raise ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS if git status is slow on this repo.</para>
+    /// </remarks>
     [McpServerTool(Name = "validate_recent_git_changes", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
         "post-edit-validate-workspace-scoped-to-touched-files: auto-scoped validation companion that derives changedFilePaths from git status --porcelain, falls back to full-workspace scope with a warning when git is unavailable or the solution is outside a git repo."),
-     Description("Post-edit validation bundle that auto-derives the changed-file set from `git status --porcelain` in the solution directory, eliminating the manual path-enumeration step. Internally forwards to validate_workspace with the derived list. Falls back to full-workspace scope and surfaces the fallback via the Warnings field when git is unavailable (not on PATH, solution outside a git repo, git exited non-zero). Prefer this over validate_workspace when you have uncommitted edits and want the bundle scoped to the touched-file set. Returns an aggregate envelope with overallStatus = clean | compile-error | analyzer-error | test-failure | test-zero-run | git-status-unknown | timeout. `git-status-unknown` is unique to this tool: it fires when the `git status` scope-collection itself timed out, so a would-be `clean` verdict was computed over an untrustworthy fallback scope rather than the real working tree — retry, or raise `ROSLYNMCP_GIT_STATUS_TIMEOUT_SECONDS` if `git status` is slow on this repo (scope defaulted to full-workspace because the touched-file set could not be determined).")]
+     Description("Post-edit validation bundle that auto-derives the changed-file set from `git status --porcelain` and forwards to validate_workspace. Prefer this over validate_workspace when you have uncommitted edits and want touched-file scope.")]
     public static Task<string> ValidateRecentGitChanges(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
@@ -51,10 +62,14 @@ public static class ValidationBundleTools
             c => validationService.ValidateRecentGitChangesAsync(workspaceId, runTests, c, summary),
             ct);
 
+    /// <remarks>
+    /// <para>The fork is created under .roslynmcp/forks beneath the workspace root and loaded as its own workspace.</para>
+    /// <para>retention values: drop-on-success (default), drop-on-failure, drop-always, keep.</para>
+    /// </remarks>
     [McpServerTool(Name = "workspace_fork_apply", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("validation", "experimental", false, false,
         "Fork a loaded workspace, replay a preview token into the fork, validate it, and retain/drop the fork by policy."),
-     Description("Experimental validation-bundle tool. Creates a server-owned fork under <workspace>/.roslynmcp/forks, replays an existing preview token into that fork without mutating the source workspace, loads the fork as a workspace, runs validate_workspace, and retains or deletes the fork according to retention. retention values: drop-on-success (default), drop-on-failure, drop-always, keep.")]
+     Description("Experimental: fork a loaded workspace, replay an existing preview token into the fork without mutating the source workspace, run validate_workspace against the fork, then retain or delete the fork per the retention policy.")]
     public static Task<string> WorkspaceForkApply(
         IWorkspaceExecutionGate gate,
         IWorkspaceForkApplyService forkApplyService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationTools.cs
@@ -84,7 +84,10 @@ public static class ValidationTools
         }, ct);
     }
 
-    [McpServerTool(Name = "test_discover", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Discover tests from test projects in the loaded workspace. Results are paginated to keep responses within MCP context budgets — large suites should be filtered with projectName and/or nameFilter. The response includes returnedCount/totalCount/hasMore so you can tell when more pages exist.")]
+    /// <remarks>
+    /// <para>Use returnedCount/totalCount/hasMore to tell when more pages exist.</para>
+    /// </remarks>
+    [McpServerTool(Name = "test_discover", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Discover tests from test projects in the loaded workspace. Results are paginated to stay within MCP context budgets - filter large suites with projectName and/or nameFilter. The response includes returnedCount/totalCount/hasMore.")]
     [McpToolMetadata("validation", "stable", true, false,
         "Discover tests in the loaded workspace.")]
     public static Task<string> DiscoverTests(
@@ -188,7 +191,12 @@ public static class ValidationTools
         }, ct);
     }
 
-    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured test results. When the run cannot produce TRX output (MSBuild file lock, build failure, timeout, unknown exit) the result carries a populated FailureEnvelope with ErrorKind ('FileLock'|'BuildFailure'|'Timeout'|'Unknown'), IsRetryable, Summary, and tails of StdOut/StdErr — instead of throwing a bare invocation error. Windows note: MSB3027/MSB3021 file-lock failures typically mean another testhost.exe (IDE test runner, background build) is holding the test assembly; the envelope classifies these as retryable so callers can close the conflicting runner and retry without touching source. The `failures` array is paginated (failuresOffset/failuresLimit, default limit 25) and each entry's Message/StackTrace is head-truncated to 500/1500 chars with a trailing '... [truncated]' marker — a broad/unfiltered run over a large suite would otherwise produce an unbounded payload. Aggregate total/passed/failed/skipped always reflect the full run; failuresTotal/hasMoreFailures tell you when more failure detail exists.")]
+    /// <remarks>
+    /// <para>FailureEnvelope carries ErrorKind (FileLock | BuildFailure | Timeout | Unknown), IsRetryable, Summary, and tails of StdOut/StdErr.</para>
+    /// <para>Windows note: MSB3027/MSB3021 file-lock failures typically mean another testhost.exe (IDE test runner, background build) is holding the test assembly; the envelope classifies these as retryable so callers can close the conflicting runner and retry without touching source.</para>
+    /// <para>The failures array is paginated via failuresOffset/failuresLimit (default limit 25) and each entry Message/StackTrace is head-truncated to 500/1500 chars with a trailing "... [truncated]" marker - a broad, unfiltered run over a large suite would otherwise produce an unbounded payload. Aggregate total/passed/failed/skipped always reflect the full run; failuresTotal/hasMoreFailures tell you when more failure detail exists.</para>
+    /// </remarks>
+    [McpServerTool(Name = "test_run", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Run dotnet test for the loaded workspace or a specific test project and return structured results. When TRX output cannot be produced the result carries a classified FailureEnvelope instead of throwing; the failures array is paginated.")]
     [McpToolMetadata("validation", "stable", false, false,
         "Run dotnet test for the workspace or a selected project.")]
     public static Task<string> RunTests(
@@ -374,7 +382,11 @@ public static class ValidationTools
         }, ct);
     }
 
-    [McpServerTool(Name = "test_related", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find likely related tests for a symbol by source location or symbol handle. Three mutually-exclusive locator modes: (1) symbolHandle alone — pass the stable handle returned by other semantic tools; (2) metadataName alone — pass a fully-qualified metadata name such as Namespace.TypeName; (3) source-location — pass filePath, line, AND column all together (all three are required when using this mode). Two-pass match: (1) heuristic name overlap (substring of the symbol name in test methods/classes — fast, catches the common case), plus (2) reference sweep via SymbolFinder.FindReferencesAsync over the symbol + its overrides/implementations (covers interface-dispatch tests that don't mention the interface name). An empty result set usually means: (a) the symbol's simple name doesn't appear in any test method/class name AND no test file references the symbol (or any implementation) by position, (b) the target symbol is a local/anonymous construct that isn't reachable by name. For file-based impact, use `test_related_files` instead.")]
+    /// <remarks>
+    /// <para>Two-pass match: (1) heuristic name overlap (substring of the symbol name in test methods/classes - fast, catches the common case), plus (2) a reference sweep via SymbolFinder.FindReferencesAsync over the symbol and its overrides/implementations (covers interface-dispatch tests that do not mention the interface name).</para>
+    /// <para>An empty result set usually means: (a) the symbol simple name does not appear in any test method/class name AND no test file references the symbol (or any implementation) by position, or (b) the target symbol is a local/anonymous construct that is not reachable by name.</para>
+    /// </remarks>
+    [McpServerTool(Name = "test_related", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Find likely related tests for a symbol via three mutually-exclusive locators: symbolHandle alone, metadataName alone, or filePath plus line plus column together. For file-based impact use test_related_files instead.")]
     [McpToolMetadata("validation", "stable", true, false,
         "Find tests related to a symbol.")]
     public static Task<string> FindRelatedTests(

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -25,7 +25,14 @@ public static class WorkspaceTools
     private const int _maxSupportBundleDriftCap = 100;
     private static readonly TimeSpan s_processDrainTimeout = TimeSpan.FromSeconds(10);
 
-    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj file into the workspace for semantic analysis. Returns a lean summary by default — pass verbose=true for the full per-project tree (large solutions can produce ~30 KB or more). Idempotent by path: if the same solution/project file is already loaded in this host process, workspace_load returns the EXISTING WorkspaceId instead of creating a new one — no extra workspace slot is consumed. Set autoRestore=true to run dotnet restore and one follow-up reload when the loaded status reports restoreRequired=true. Set prewarm=true to immediately run the workspace_warm compilation/semantic-model prewarm after a successful load or auto-restore reload; set prewarm=false to opt out. When prewarm is omitted, workspace_load automatically prewarms solutions with more than 50 projects. The response includes a prewarm result block only when warming ran. DocumentCount note: the per-project DocumentCount often exceeds the <Compile> item count (from evaluate_msbuild_items) by about 3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit <Compile> items. Sessions persist for the lifetime of the stdio host process — there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 16) forced an eviction. When a previously valid workspaceId returns 'Workspace was not found', call workspace_load again rather than treating it as an error. Pass evictPolicy=lru to silently evict the least-recently-used idle workspace when the cap is reached instead of receiving a hard error.")]
+    /// <remarks>
+    /// <para>Set autoRestore=true to run dotnet restore plus one follow-up reload when the loaded status reports restoreRequired=true.</para>
+    /// <para>Set prewarm=true to run the workspace_warm compilation/semantic-model prewarm after a successful load or auto-restore reload; set prewarm=false to opt out. When prewarm is omitted, solutions with more than 50 projects are prewarmed automatically. The response includes a prewarm result block only when warming ran.</para>
+    /// <para>DocumentCount note: the per-project DocumentCount often exceeds the Compile item count reported by evaluate_msbuild_items by about 3, because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that Roslyn includes in the document set but MSBuild does not list as explicit Compile items.</para>
+    /// <para>Sessions persist for the lifetime of the stdio host process - there is NO inactivity TTL. A workspace can become unreachable if (a) the host process restarts (Cursor/Claude Code may relaunch the MCP server transparently between conversations), (b) workspace_close is called, or (c) the concurrent-workspace cap (ROSLYNMCP_MAX_WORKSPACES, default 16) forced an eviction. When a previously valid workspaceId returns "Workspace was not found", call workspace_load again rather than treating it as an error.</para>
+    /// <para>Pass evictPolicy=lru to silently evict the least-recently-used idle workspace when the cap is reached instead of receiving a hard error.</para>
+    /// </remarks>
+    [McpServerTool(Name = "workspace_load", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false), Description("Load a .sln, .slnx, or .csproj into a Roslyn workspace session for semantic analysis. Idempotent by path: loading an already-loaded file returns the existing workspaceId. Returns a lean summary; pass verbose=true for the full project tree.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Load a .sln, .slnx, or .csproj into a named Roslyn workspace session.")]
     public static Task<string> LoadWorkspace(
@@ -90,7 +97,10 @@ public static class WorkspaceTools
         }, ct);
     }
 
-    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload the currently loaded workspace to pick up file changes. Set autoRestore=true to run dotnet restore and one follow-up reload when the reloaded status reports restoreRequired=true. Pass verbose=false for a compact readiness/version/count projection; the default verbose=true preserves the full project tree.")]
+    /// <remarks>
+    /// <para>Pass verbose=false for a compact readiness/version/count projection; the default verbose=true preserves the full project tree.</para>
+    /// </remarks>
+    [McpServerTool(Name = "workspace_reload", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false), Description("Reload a loaded workspace from disk to pick up file changes. Set autoRestore=true to run dotnet restore plus one follow-up reload when the reloaded status reports restoreRequired=true.")]
     [McpToolMetadata("workspace", "stable", false, false,
         "Reload an existing workspace session from disk.")]
     public static Task<string> ReloadWorkspace(
@@ -113,7 +123,10 @@ public static class WorkspaceTools
             }, outerCt), ct);
     }
 
-    [McpServerTool(Name = "workspace_close", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false), Description("Close and dispose a loaded workspace session, freeing all resources. Set drainProcesses=true to run `dotnet build-server shutdown` AND terminate any detached test-runner processes (testhost / vstest.console) whose executable lives under the loaded path's directory, after session removal — this releases MSBuild build-server and test-host file-system locks on Windows, which is required before `git worktree remove` in sweep teardown sequences.")]
+    /// <remarks>
+    /// <para>drainProcesses=true runs `dotnet build-server shutdown` AND terminates any detached test-runner processes (testhost / vstest.console) whose executable lives under the loaded path directory, after session removal. On Windows this is what releases the MSBuild build-server and test-host file-system locks.</para>
+    /// </remarks>
+    [McpServerTool(Name = "workspace_close", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false), Description("Close and dispose a loaded workspace session, freeing all resources. Set drainProcesses=true to also release MSBuild build-server and test-host file locks - required before `git worktree remove` in sweep teardown sequences.")]
     [McpToolMetadata("workspace", "stable", false, true,
         "Close a loaded workspace session and release resources.")]
     public static Task<string> CloseWorkspace(
@@ -364,11 +377,11 @@ public static class WorkspaceTools
         return Task.FromResult(StructuredToolResult.Create(payload));
     }
 
+    /// <remarks>
+    /// <para>Pass verbose=true for the full per-project tree and workspace diagnostics.</para>
+    /// </remarks>
     [McpServerTool(Name = "workspace_status", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false,
-        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceStatusSummaryDto)), Description(
-        "Cheap health check after workspace_load — call this first before compile_check or heavy tools. " +
-        "Default (verbose=false) returns summary JSON: isReady, isStale, workspaceErrorCount, restoreHint, solutionFileName, counts. " +
-        "Pass verbose=true for the full per-project tree and workspace diagnostics.")]
+        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceStatusSummaryDto)), Description("Cheap health check after workspace_load - call this first before compile_check or heavy tools. Default (verbose=false) returns summary JSON: isReady, isStale, workspaceErrorCount, restoreHint, solutionFileName, counts.")]
     [McpToolMetadata("workspace", "stable", true, false,
         "Inspect status, diagnostics, and stale-state information for a workspace.")]
     public static Task<CallToolResult> GetWorkspaceStatus(
@@ -399,12 +412,12 @@ public static class WorkspaceTools
         CancellationToken ct = default) =>
         GetWorkspaceStatus(gate, workspace, workspaceId, verbose: false, ct);
 
+    /// <remarks>
+    /// <para>Uses existing read-side workspace probes only; it does not run tests or dotnet build by default.</para>
+    /// <para>If workspaceId is omitted and exactly one workspace is loaded, that workspace is used; if none or multiple are loaded, the response explains the next action.</para>
+    /// </remarks>
     [McpServerTool(Name = "workspace_readiness_report", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false,
-        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceReadinessReportDto)), Description(
-        "First-run/onboarding readiness report for a loaded workspace, distinct from the incident-focused workspace_support_bundle. " +
-        "Uses existing read-side workspace probes only; it does not run tests or dotnet build by default. " +
-        "Returns one compact verdict: ready, restore-needed, build-needed, or analyzer-limited, plus limitations and next recommended workflows. " +
-        "If workspaceId is omitted and exactly one workspace is loaded, that workspace is used; if none or multiple are loaded, the response explains the next action.")]
+        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceReadinessReportDto)), Description("First-run/onboarding readiness report for a loaded workspace, distinct from the incident-focused workspace_support_bundle. Returns one verdict - ready, restore-needed, build-needed, or analyzer-limited - plus limitations and next workflows.")]
     [McpToolMetadata("workspace", "stable", true, false,
         "First-run workspace readiness report with verdict, limitations, and next workflows.")]
     public static Task<CallToolResult> GetWorkspaceReadinessReport(
@@ -474,11 +487,12 @@ public static class WorkspaceTools
         }, ct);
     }
 
+    /// <remarks>
+    /// <para>Also reports the loaded path and workspace/surface version. Does not include source snippets.</para>
+    /// <para>If workspaceId is omitted and exactly one workspace is loaded, that workspace is used; if none or multiple are loaded, the response explains the next action.</para>
+    /// </remarks>
     [McpServerTool(Name = "workspace_support_bundle", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false,
-        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceSupportBundleDto)), Description(
-        "Incident-diagnosis bundle for an existing workspace session, distinct from first-run readiness reporting. " +
-        "Composes loaded path, readiness summary, drift status, capped change ledger, workspace/surface version, diagnostics totals, and next-action hints. " +
-        "Does not include source snippets. If workspaceId is omitted and exactly one workspace is loaded, that workspace is used; if none or multiple are loaded, the response explains the next action.")]
+        UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceSupportBundleDto)), Description("Incident-diagnosis bundle for an existing workspace session, distinct from the first-run workspace_readiness_report. Composes readiness, drift status, a capped change ledger, versions, diagnostics totals, and next-action hints.")]
     [McpToolMetadata("workspace", "stable", true, false,
         "Incident support bundle: readiness, drift, changes, versions, diagnostics totals, and recovery hints without source snippets.")]
     public static Task<CallToolResult> GetWorkspaceSupportBundle(
@@ -578,7 +592,11 @@ public static class WorkspaceTools
             c => workspace.GetSourceGeneratedDocumentsAsync(workspaceId, projectName, c),
             ct);
 
-    [McpServerTool(Name = "get_source_text", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Read source text of a document in the loaded workspace. By default returns the full file. Pass startLine/endLine (1-based, inclusive) to slice. Output is capped at maxChars (default 65536); set Truncated=true marker indicates the response was clipped — re-request a narrower line range. Always returns RequestedStartLine/RequestedEndLine, ReturnedStartLine/ReturnedEndLine, TotalLineCount so callers can verify the slice.")]
+    /// <remarks>
+    /// <para>maxChars defaults to 65536; a Truncated=true marker indicates the response was clipped - re-request a narrower line range.</para>
+    /// <para>The response always returns RequestedStartLine/RequestedEndLine, ReturnedStartLine/ReturnedEndLine, and TotalLineCount so callers can verify the slice.</para>
+    /// </remarks>
+    [McpServerTool(Name = "get_source_text", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false), Description("Read source text of a document as the loaded Roslyn workspace currently sees it (may differ from disk until reload). Returns the full file by default; pass startLine/endLine (1-based, inclusive) to slice. Output is capped at maxChars.")]
     [McpToolMetadata("workspace", "stable", true, false,
         "Read source text as the Roslyn workspace currently sees it (may differ from disk if workspace hasn't been reloaded).")]
     public static Task<string> GetSourceText(

--- a/tests/RoslynMcp.Tests/ToolDescriptionDietWorkspaceValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDescriptionDietWorkspaceValidationTests.cs
@@ -1,0 +1,95 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-level tool-description diet applied to the workspace,
+/// validation, validation-bundle, and compile-check tool groups. The global 2,000-character
+/// client-truncation ceiling in <c>SurfaceCatalogTests</c> stays untouched; this class holds the
+/// tighter per-slice budget so a future edit cannot silently regrow the <c>tools/list</c> payload.
+/// </summary>
+/// <remarks>
+/// <para>Mirrors the reflection harness of
+/// <c>SurfaceCatalogTests.AllMcpToolMethodDescriptions_AreWithinClientLimit</c>, but enumerates an
+/// explicit declaring-type set instead of the whole assembly so sibling diet slices stay
+/// independent and do not collide in this file.</para>
+/// <para>Only METHOD-level <c>[Description]</c> attributes are in scope. Parameter-level
+/// descriptions and the <c>[McpToolMetadata]</c> summaries the surface catalog mirrors are
+/// deliberately excluded.</para>
+/// </remarks>
+[TestClass]
+public sealed class ToolDescriptionDietWorkspaceValidationTests
+{
+    private const int MaxPerToolDescriptionCharacters = 250;
+    private const int MaxSweptSetTotalCharacters = 4_600;
+
+    private static readonly Type[] s_sweptToolTypes =
+    [
+        typeof(WorkspaceTools),
+        typeof(ValidationTools),
+        typeof(ValidationBundleTools),
+        typeof(CompileCheckTools),
+    ];
+
+    private static (string Name, string Description)[] SweptToolDescriptions() =>
+        s_sweptToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null)
+            .OrderBy(entry => entry.Tool!.Name, StringComparer.Ordinal)
+            .Select(entry => (
+                Name: entry.Tool!.Name ?? "(unnamed)",
+                Description: entry.Description?.Description ?? string.Empty))
+            .ToArray();
+
+    [TestMethod]
+    public void SweptToolDescriptions_AreWithinPerToolBudget()
+    {
+        var violations = SweptToolDescriptions()
+            .Where(entry => entry.Description.Length > MaxPerToolDescriptionCharacters)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Swept tool descriptions must be <= {MaxPerToolDescriptionCharacters} characters. " +
+            "Move operational guidance into XML <remarks> on the same method instead of the wire " +
+            "description. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SweptToolDescriptions_TotalIsWithinSliceBudget()
+    {
+        var swept = SweptToolDescriptions();
+        var total = swept.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            total <= MaxSweptSetTotalCharacters,
+            $"Swept-set method description total is {total} chars across {swept.Length} tools, " +
+            $"over the {MaxSweptSetTotalCharacters}-char slice budget.");
+    }
+
+    [TestMethod]
+    public void SweptTools_AllHaveNonEmptyDescription()
+    {
+        var missing = SweptToolDescriptions()
+            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
+            .Select(entry => entry.Name)
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            missing.Length,
+            "Every swept tool must keep a non-empty method-level description so clients can " +
+            "discriminate it from sibling tools. Missing:\n  " + string.Join("\n  ", missing));
+    }
+}


### PR DESCRIPTION
Slice 2 of 4 of the `method-description-diet` parent row: workspace, validation, validation-bundle, and compile-check tool groups.

## What changed

- Rewrote the method-level `[Description]` on all 22 `[McpServerTool]` methods in `WorkspaceTools.cs`, `ValidationTools.cs`, `ValidationBundleTools.cs`, and `CompileCheckTools.cs` down to a single capability statement plus the discriminator against sibling tools.
- Relocated the surviving operational guidance to `///` XML `<remarks>` on the same methods — preserved for maintainers, zero wire cost on `tools/list`.
- Added `tests/RoslynMcp.Tests/ToolDescriptionDietWorkspaceValidationTests.cs`, a slice-scoped reflection ratchet: per-tool `<= 250` chars, swept-set total `<= 4,600` chars, and every swept tool keeps a non-empty description.

### Before / after (swept-set method `[Description]` chars)

| | Tools | Total chars | Max |
|---|---|---|---|
| Before | 22 | 11,732 | 1,828 (`workspace_load`) |
| After | 22 | 4,298 | 248 (`compile_check`) |

Per file: `WorkspaceTools` 4,904 -> 2,267 · `ValidationTools` 2,863 -> 1,094 · `ValidationBundleTools` 2,578 -> 689 · `CompileCheckTools` 1,387 -> 248.

### Discriminators deliberately preserved

- `workspace_health` — "Alias for workspace_status with verbose=false".
- `workspace_close` — the drain-locks clause ("required before `git worktree remove` in sweep teardown").
- `workspace_readiness_report` (first-run) vs `workspace_support_bundle` (incident).
- `validate_workspace` (explicit changed-file set) vs `validate_recent_git_changes` (auto-derived from `git status --porcelain`).

### Deliberately NOT touched

- Parameter-level `[Description]`s (read by `AllArrayTypedToolParameters_...` and the doc gates).
- `[McpToolMetadata]` summaries — that is what the surface-catalog drift test compares.
- The global `maxDescriptionCharacters = 2_000` ceiling in `SurfaceCatalogTests.cs` — the parent row ratchets it once all slices land.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter` over `ToolDescriptionDietWorkspaceValidationTests | SurfaceCatalogTests | CatalogDestructiveWarningTests | ReadmeSurfaceCountTests` — 31/31 passed.
- `./eng/verify-ai-docs.ps1` — passed.

Closes: (none — partial slice; parent row `method-description-diet` stays open for the remaining Tools files)
