### PR TITLE
maintenance(tools): trim refactoring-core tool descriptions

### DIFF
--- a/changelog.d/method-description-diet-refactoring-core.md
+++ b/changelog.d/method-description-diet-refactoring-core.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Trimmed method-level `[Description]` text on the refactoring-core tools (`extract_method_preview`, `extract_method_apply`, `extract_shared_expression_to_helper_preview`, `change_signature_preview`, `parameter_object_preview`, `get_syntax_tree`) to ~200-char capability statements, cutting ~1,800 chars (~450 tokens) from every `tools/list` response. Refusal reasons and budget semantics were not lost — they remain in the tools' runtime error messages and parameter descriptions. Added a slice-scoped description-length regression.

--- a/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
@@ -19,7 +19,7 @@ public static class ChangeSignatureTools
     [McpServerTool(Name = "change_signature_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview adding/removing/renaming/reordering a method parameter with all callsites updated atomically."),
-     Description("Preview a change to a method's signature: add, remove, rename, or reorder parameters. The declaration AND every callsite are rewritten in one preview token. For 'add', supply Name + ParameterType + DefaultValue. For 'remove', supply Name OR Position. For 'rename', supply Name (current) + NewName. For 'reorder', supply NewOrder as a comma-separated permutation of parameter names or 0-based indices (e.g. 'b,a,c' or '1,0,2'); positional callsites are reordered, all-named callsites are left as-is, mixed callsites are refused.")]
+     Description("Preview adding, removing, renaming, or reordering a method's parameters: the declaration and every callsite are rewritten under one preview token. Supply op plus its name/newName/parameterType/newOrder arguments.")]
     public static Task<string> PreviewChangeSignature(
         IWorkspaceExecutionGate gate,
         IChangeSignatureService changeSignatureService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -19,7 +19,7 @@ public static class ExtractMethodTools
     [McpServerTool(Name = "extract_method_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
     [McpToolMetadata("refactoring", "stable", true, false,
         "Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values.")]
-    [Description("Preview extracting selected statements into a new method. Uses data-flow analysis to infer parameters and return values. Selection must cover complete statements in the same block without return statements.")]
+    [Description("Preview extracting selected statements into a new method, inferring parameters and return values by data flow. Selection must cover complete statements in one block, with no return statements.")]
     public static Task<string> PreviewExtractMethod(
         IWorkspaceExecutionGate gate,
         IExtractMethodService extractMethodService,
@@ -58,7 +58,7 @@ public static class ExtractMethodTools
     [McpServerTool(Name = "extract_shared_expression_to_helper_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
     [McpToolMetadata("refactoring", "experimental", true, false,
         "Preview extracting a shared sub-expression into a synthesized private static helper and rewriting every structurally-identical call site in the scope.")]
-    [Description("Preview extracting a shared sub-expression at an example span into a synthesized static helper, then rewriting every structurally-identical call site in the example's containing type (or entire project when allowCrossFile=true). Refuses when the expression has fewer than 2 occurrences, when a candidate site's free-variable semantic types differ from the example, or when allowCrossFile=false and a hit resides in a different containing type. Complements extract_method_preview (statement-block, single-function) by handling the N-function shape.")]
+    [Description("Preview extracting a shared sub-expression into a static helper, rewriting every identical site in the containing type (or project when allowCrossFile=true). Handles the N-function shape extract_method_preview does not.")]
     public static Task<string> PreviewExtractSharedExpressionToHelper(
         IWorkspaceExecutionGate gate,
         IExtractMethodService extractMethodService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -58,7 +58,7 @@ public static class ExtractMethodTools
     [McpServerTool(Name = "extract_shared_expression_to_helper_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
     [McpToolMetadata("refactoring", "experimental", true, false,
         "Preview extracting a shared sub-expression into a synthesized private static helper and rewriting every structurally-identical call site in the scope.")]
-    [Description("Preview extracting a shared sub-expression into a static helper, rewriting every identical site in the containing type (or project when allowCrossFile=true). Handles the N-function shape extract_method_preview does not.")]
+    [Description("Preview rewriting an N-function shared sub-expression into static-helper calls, unlike extract_method_preview. Refuses on occurrences < 2, mixed free-variable types, or cross-type hits when allowCrossFile=false.")]
     public static Task<string> PreviewExtractSharedExpressionToHelper(
         IWorkspaceExecutionGate gate,
         IExtractMethodService extractMethodService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
@@ -19,7 +19,7 @@ public static class ParameterObjectTools
     [McpServerTool(Name = "parameter_object_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview grouping N parameters of a method into a positional sealed record DTO with all callsites updated atomically."),
-     Description("Preview replacing N parameters of a method with a single record DTO. Synthesizes a `public sealed record NewType(...)` (or `internal` when same-project + non-public containing type) and rewrites every call site so grouped arguments flow through `new NewType(...)`. Refuses (does not partially proceed) for: default-value omissions at any call site, ref/out/in/params parameters, the extension-method `this` receiver, local-function targets, non-ordinary target kinds (constructors, destructors, property/event accessors, operators, conversions), overrides and virtual/abstract dispatch roots, implicit or explicit interface implementations, extern/PInvoke declarations, partial method definition/implementation pairs, and cross-project call sites where the caller project does not already reference the DTO project. Redeem the returned preview token via apply_with_verify. v1 always emits a positional record; class/struct generation is out of scope.")]
+     Description("Preview grouping N parameters of a method into a positional sealed record and rewriting every call site through `new NewType(...)`. Refuses with a reason rather than partially proceeding; redeem via apply_with_verify.")]
     public static Task<string> PreviewParameterObject(
         IWorkspaceExecutionGate gate,
         IParameterObjectService parameterObjectService,

--- a/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
@@ -14,7 +14,7 @@ public static class SyntaxTools
     [McpServerTool(Name = "get_syntax_tree", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("syntax", "stable", true, false,
         "Return a structured syntax tree for a document or range."),
-     Description("Get the syntax tree (AST) for a source file or a specific line range. Returns a hierarchical tree of syntax nodes with their kinds and positions. THREE INDEPENDENT BUDGETS apply: maxOutputChars (LEAF TEXT only — does not bound structural JSON), maxNodes (total node count), maxTotalBytes (estimated total response size). The walker stops at the first cap hit and emits a TruncationNotice. Use maxTotalBytes to enforce the MCP cap regardless of leaf-text vs structural distribution — addresses the §3 stress test repro where maxOutputChars=20000 produced 229 KB on EncodingHelper.cs because structural JSON dominated.")]
+     Description("Get the hierarchical syntax tree (AST) for a file or line range, with node kinds and positions. Three budgets cap it (maxOutputChars, maxNodes, maxTotalBytes); output stops at the first cap and emits a TruncationNotice.")]
     public static Task<string> GetSyntaxTree(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/tests/RoslynMcp.Tests/RefactoringCoreDescriptionBudgetTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringCoreDescriptionBudgetTests.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the refactoring-core tool surface: these six method-level
+/// [Description] strings are capability statements, not guidance essays. Refusal reasons
+/// live in the services' runtime error messages and budget semantics live in the
+/// parameter [Description]s, so the method text must stay short.
+/// </summary>
+[TestClass]
+public sealed class RefactoringCoreDescriptionBudgetTests
+{
+    private const int MaxDescriptionCharacters = 220;
+
+    private static readonly string[] RatchetedToolNames =
+    [
+        "change_signature_preview",
+        "extract_method_apply",
+        "extract_method_preview",
+        "extract_shared_expression_to_helper_preview",
+        "get_syntax_tree",
+        "parameter_object_preview",
+    ];
+
+    [TestMethod]
+    public void RefactoringCoreToolDescriptions_AreNonEmptyAndWithinSliceBudget()
+    {
+        var descriptions = typeof(ServerTools).Assembly.GetTypes()
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool?.Name is not null)
+            .GroupBy(entry => entry.Tool!.Name!, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First().Description?.Description, StringComparer.Ordinal);
+
+        var violations = new List<string>();
+        foreach (var toolName in RatchetedToolNames)
+        {
+            if (!descriptions.TryGetValue(toolName, out var description))
+            {
+                violations.Add($"{toolName}: no [McpServerTool] method found");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                violations.Add($"{toolName}: description is missing or empty");
+                continue;
+            }
+
+            if (description.Length > MaxDescriptionCharacters)
+            {
+                violations.Add($"{toolName}: {description.Length} chars");
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            violations.Count,
+            $"Refactoring-core tool descriptions must be non-empty and <= {MaxDescriptionCharacters} characters. " +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+}


### PR DESCRIPTION
## Summary

Slice 8 of the `method-description-diet` sweep — the refactoring-core tool surface.

Rewrites the method-level `[Description]` text on 5 tools into <= 220-char capability statements (`extract_method_apply` was already compliant at 56 chars and is byte-identical):

| Tool | Before | After |
|---|---|---|
| `extract_method_preview` | 206 | 192 |
| `extract_method_apply` | 56 | 56 (unchanged) |
| `extract_shared_expression_to_helper_preview` | 547 | 219 |
| `change_signature_preview` | 527 | 212 |
| `parameter_object_preview` | 950 | 217 |
| `get_syntax_tree` | 616 | 219 |
| **total** | **2,902** | **1,115** |

Net ~1,800 chars (~450 tokens) off every `tools/list` response.

## No guidance was lost

- `parameter_object_preview`'s refusal catalogue is already emitted as actionable runtime errors by `ParameterObjectService` (`EnforceTargetMethodContractRefusals`, `EnforceParameterShapeRefusals`, ~15 `"parameter_object_preview refuses: ..."` messages).
- `get_syntax_tree`'s three-budget essay is duplicated verbatim in the `maxOutputChars` / `maxNodes` / `maxTotalBytes` **parameter** `[Description]`s, which this PR does not touch.
- Each rewritten string keeps its discriminating trigger — notably the `extract_method_preview` (single-function statement block) vs `extract_shared_expression_to_helper_preview` (N-function shared sub-expression) contrast.

## Negative space

No `McpToolMetadata(..., summary)` argument, no `ServerSurfaceCatalog.*` entry, and no parameter `[Description]` is edited, so the RMCP001/RMCP002 catalog-tracking analyzers and the sibling param-dedupe slices stay untouched.

## Regression

New `tests/RoslynMcp.Tests/RefactoringCoreDescriptionBudgetTests.cs` — slice-scoped ratchet asserting the six named tools' descriptions are non-empty and <= 220 chars. `SurfaceCatalogTests.cs` is deliberately NOT edited (its global 2,000-char ceiling is claimed by the sibling `method-description-diet-symbol-analysis` slice).

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-changelog-fragments.ps1` — passed.
- `RefactoringCoreDescriptionBudgetTests` + `SurfaceCatalogTests` — 22/22 passed.
- Behavior filter (`ChangeSignature|ParameterObject|ExtractSharedExpression|SyntaxTree|ExtractMethod`) — 105 passed, 3 failed. **All 3 failures reproduce byte-identically on the untouched base commit** (`ExtractMethod_PreviewAndApply_CompilationSucceeds`, `ExtractMethod_ReassignsExistingLocal_EmitsAssignmentNotVarDecl`, `ExtractSharedExpression_ApplyAfterPreview_CompilationSucceeds`) — verified by stashing this PR's changes and re-running. Pre-existing, unrelated to this text-only change.

Closes: none — child slice of `method-description-diet`; the parent row stays open (this covers 4 of ~54 `Tools/*.cs` files).
