### PR TITLE
maintenance(tools): canonicalize repeated parameter descriptions (edit/file-op/MSBuild/type-move)

### DIFF
--- a/changelog.d/param-description-dedupe-edit-file-ops.md
+++ b/changelog.d/param-description-dedupe-edit-file-ops.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Standardized repeated parameter descriptions (`workspaceId`, file-path, `previewToken`) to one canonical one-liner each across the edit, file-operation, MSBuild, and type-move tools, trimming tools/list schema overhead without touching load-bearing discriminator, format-contract, or preview-token guidance.

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -20,13 +20,13 @@ public static class EditTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         IEditService editService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file to edit")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the file to edit.")] string filePath,
         [Description("Array of text edits. Each edit has startLine, startColumn, endLine, endColumn (1-based), and newText. Example: [{\"startLine\":10,\"startColumn\":5,\"endLine\":10,\"endColumn\":15,\"newText\":\"newValue\"}]. All positions are 1-based inclusive; non-overlapping edits are applied in the order given.")] TextEditDto[] edits,
         CancellationToken ct = default,
         [Description("When false (default), C# files are parsed after edits and lexer/parser errors block the apply. Set true only for intentional intermediate invalid states.")] bool skipSyntaxCheck = false,
-        [Description("When true, run compile_check scoped to the owning project after the edit and attach the result under Verification. Pre-existing errors are filtered out, so only NEW errors appear in the outcome. Default false preserves the original call-site behavior.")] bool verify = false,
-        [Description("When true AND verify surfaces new compile errors, automatically revert the edit through the single-slot undo path this call populated. Single-shot per call - never touches prior-turn edits. Ignored when verify is false. Default false.")] bool autoRevertOnError = false)
+        [Description("When true, run compile_check scoped to the owning project after the edit and attach the result under Verification. Pre-existing errors are filtered out, so only NEW errors appear in the outcome.")] bool verify = false,
+        [Description("When true AND verify surfaces new compile errors, automatically revert the edit through the single-slot undo path this call populated. Single-shot per call - never touches prior-turn edits. Ignored when verify is false.")] bool autoRevertOnError = false)
     {
         return gate.RunWriteAsync(workspaceId, async c =>
         {

--- a/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FileOperationTools.cs
@@ -31,9 +31,9 @@ public static class FileOperationTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         IFileOperationService fileOperationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Project name or project file path within the loaded workspace")] string projectName,
-        [Description("Absolute path to the source file to create")] string filePath,
+        [Description("Absolute path to the file to create.")] string filePath,
         [Description("Initial file contents")] string content,
         CancellationToken ct = default)
     {
@@ -53,7 +53,7 @@ public static class FileOperationTools
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         IPreviewStore previewStore,
-        [Description("The preview token returned by create_file_preview")] string previewToken,
+        [Description("Preview token from create_file_preview.")] string previewToken,
         CancellationToken ct = default)
         => ToolDispatch.ApplyByTokenAsync(
             gate,
@@ -70,8 +70,8 @@ public static class FileOperationTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         IFileOperationService fileOperationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file to delete")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the file to delete.")] string filePath,
         CancellationToken ct = default)
     {
         return gate.RunReadAsync(workspaceId, async c =>
@@ -90,7 +90,7 @@ public static class FileOperationTools
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         IPreviewStore previewStore,
-        [Description("The preview token returned by delete_file_preview")] string previewToken,
+        [Description("Preview token from delete_file_preview.")] string previewToken,
         CancellationToken ct = default)
         => ToolDispatch.ApplyByTokenAsync(
             gate,
@@ -107,9 +107,9 @@ public static class FileOperationTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         IFileOperationService fileOperationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the existing source file")] string sourceFilePath,
-        [Description("Absolute path to the destination source file")] string targetFilePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file.")] string sourceFilePath,
+        [Description("Absolute path to the destination file.")] string targetFilePath,
         [Description("Optional: destination project name or project file path; defaults to the source project")] string? destinationProjectName = null,
         [Description("When true, updates the namespace declaration in the moved file to match the destination folder")] bool updateNamespace = false,
         CancellationToken ct = default)
@@ -134,7 +134,7 @@ public static class FileOperationTools
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         IPreviewStore previewStore,
-        [Description("The preview token returned by move_file_preview")] string previewToken,
+        [Description("Preview token from move_file_preview.")] string previewToken,
         CancellationToken ct = default)
         => ToolDispatch.ApplyByTokenAsync(
             gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
@@ -20,7 +20,7 @@ public static class MSBuildTools
     public static Task<string> EvaluateMsbuildProperty(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Project name as loaded in the workspace")] string projectName,
         [Description("Property name (e.g. TargetFramework)")] string propertyName,
         CancellationToken ct = default)
@@ -37,7 +37,7 @@ public static class MSBuildTools
     public static Task<string> EvaluateMsbuildItems(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Project name as loaded in the workspace")] string projectName,
         [Description("Item type (e.g. Compile, PackageReference)")] string itemType,
         CancellationToken ct = default)
@@ -54,7 +54,7 @@ public static class MSBuildTools
     public static Task<string> GetMsbuildProperties(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Project name as loaded in the workspace")] string projectName,
         [Description("Optional: case-insensitive substring filter applied to property names (e.g., 'Nullable', 'Target')")] string? propertyNameFilter = null,
         [Description("Optional: explicit allowlist of property names to return. Pass as a native JSON array, not a JSON-encoded string. Example: [\"Nullable\", \"TargetFramework\"]. Takes precedence over propertyNameFilter when supplied.")] string[]? includedNames = null,

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -27,8 +27,8 @@ public static class TypeMoveTools
         McpServer server,
         IWorkspaceExecutionGate gate,
         ITypeMoveService typeMoveService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file containing the type")] string sourceFilePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file containing the type.")] string sourceFilePath,
         [Description("Name of the type to move")] string typeName,
         [Description("Optional: target file path. If omitted, defaults to {TypeName}.cs in the same directory")] string? targetFilePath = null,
         CancellationToken ct = default)
@@ -49,7 +49,7 @@ public static class TypeMoveTools
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
         IPreviewStore previewStore,
-        [Description("The preview token returned by move_type_to_file_preview")] string previewToken,
+        [Description("Preview token from move_type_to_file_preview.")] string previewToken,
         CancellationToken ct = default)
         => ToolDispatch.ApplyByTokenAsync(
             gate,
@@ -65,7 +65,7 @@ public static class TypeMoveTools
     public static Task<string> PreviewChangeTypeNamespace(
         IWorkspaceExecutionGate gate,
         INamespaceRelocationService relocationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Name of the type to relocate (must be unique within fromNamespace)")] string typeName,
         [Description("Fully-qualified namespace currently containing the type")] string fromNamespace,
         [Description("Fully-qualified destination namespace inside the same project")] string toNamespace,

--- a/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the parameter-description canonicalization sweep.
+/// </summary>
+/// <remarks>
+/// Scope is deliberately limited to the four tool types swept by
+/// <c>param-description-dedupe-edit-file-ops</c>. The remaining <c>Tools/*.cs</c> files are still
+/// unswept, so a repo-wide assertion would red CI; later slices widen <see cref="SweptToolTypes"/>.
+/// </remarks>
+[TestClass]
+public sealed class ParameterDescriptionCanonicalizationTests
+{
+    private static readonly Type[] SweptToolTypes =
+    [
+        typeof(EditTools),
+        typeof(FileOperationTools),
+        typeof(MSBuildTools),
+        typeof(TypeMoveTools),
+    ];
+
+    private const string CanonicalWorkspaceId = "Workspace session id from workspace_load.";
+
+    private static readonly Regex CanonicalPreviewToken =
+        new(@"^Preview token from [a-z0-9_]+_preview\.$", RegexOptions.Compiled);
+
+    private static readonly Regex CanonicalPath =
+        new(@"^Absolute path to the .+\.$", RegexOptions.Compiled);
+
+    /// <summary>(type name, parameter name) -> substring the description must still contain.</summary>
+    private static readonly (string Type, string Parameter, string Keyword)[] LoadBearingContracts =
+    [
+        (nameof(EditTools), "edits", "1-based"),
+        (nameof(EditTools), "verify", "compile_check"),
+        (nameof(EditTools), "autoRevertOnError", "Ignored when verify is false"),
+        (nameof(MSBuildTools), "includedNames", "native JSON array"),
+    ];
+
+    private static IEnumerable<(Type Type, MethodInfo Method, ParameterInfo Parameter, string Description)> SweptToolParameters()
+    {
+        foreach (var type in SweptToolTypes)
+        {
+            var methods = type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+            foreach (var method in methods)
+            {
+                if (method.GetCustomAttribute<McpServerToolAttribute>() is null)
+                {
+                    continue;
+                }
+
+                foreach (var parameter in method.GetParameters())
+                {
+                    var description = parameter.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
+                    if (description is not null)
+                    {
+                        yield return (type, method, parameter, description);
+                    }
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SweptTools_BoilerplateParameterDescriptions_UseCanonicalForm()
+    {
+        var violations = new List<string>();
+
+        foreach (var (type, method, parameter, description) in SweptToolParameters())
+        {
+            var site = $"{type.Name}.{method.Name}({parameter.Name})";
+
+            switch (parameter.Name)
+            {
+                case "workspaceId" when !string.Equals(description, CanonicalWorkspaceId, StringComparison.Ordinal):
+                    violations.Add($"{site}: expected \"{CanonicalWorkspaceId}\", got \"{description}\"");
+                    break;
+                case "previewToken" when !CanonicalPreviewToken.IsMatch(description):
+                    violations.Add($"{site}: expected \"Preview token from <tool>_preview.\", got \"{description}\"");
+                    break;
+                // Optional path parameters (e.g. TypeMoveTools.targetFilePath) keep their
+                // "Optional: ... defaults to ..." form — the defaulting rule is a discriminator,
+                // not boilerplate, so only required path parameters carry the canonical one-liner.
+                case "filePath" or "sourceFilePath" or "targetFilePath"
+                    when !parameter.IsOptional && !CanonicalPath.IsMatch(description):
+                    violations.Add($"{site}: expected \"Absolute path to the <role>.\", got \"{description}\"");
+                    break;
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            violations.Count,
+            "Boilerplate parameter descriptions on the swept tool types must use the canonical form:\n  "
+            + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SweptTools_LoadBearingParameterDescriptions_RetainTheirContractKeyword()
+    {
+        var parameters = SweptToolParameters().ToArray();
+        var violations = new List<string>();
+
+        foreach (var (typeName, parameterName, keyword) in LoadBearingContracts)
+        {
+            var matches = parameters
+                .Where(entry => entry.Type.Name == typeName && entry.Parameter.Name == parameterName)
+                .ToArray();
+
+            if (matches.Length == 0)
+            {
+                violations.Add($"{typeName}.{parameterName}: no [Description]-carrying tool parameter found");
+                continue;
+            }
+
+            foreach (var match in matches)
+            {
+                if (!match.Description.Contains(keyword, StringComparison.Ordinal))
+                {
+                    violations.Add(
+                        $"{typeName}.{match.Method.Name}({parameterName}): must still document \"{keyword}\"");
+                }
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            violations.Count,
+            "Load-bearing parameter descriptions must not be trimmed past their contract:\n  "
+            + string.Join("\n  ", violations));
+    }
+}


### PR DESCRIPTION
## Summary

Slice `param-description-dedupe-edit-file-ops` of the `param-description-dedupe` backlog row. Text-only change to parameter `[Description]` attributes on four tool types — no signatures, defaults, or behavior touched.

- `workspaceId` -> `"Workspace session id from workspace_load."` (9 sites across all four files)
- path params -> `Absolute path to the <role>.`, keeping the role discriminator (edit / create / delete / source / destination / source-containing-the-type)
- `previewToken` -> `"Preview token from <producer>_preview."`, producer name retained (load-bearing under the preview-token carve-out)
- trimmed two pure restatement tails in `EditTools` (`verify`'s "Default false preserves the original call-site behavior.", `autoRevertOnError`'s trailing "Default false.")

**Deliberately NOT unified:** `projectName`. Verified both resolvers — MSBuild goes through `ProjectFilterHelper.FilterProjects`, which matches `p.Name` only (a project *file path* genuinely fails there); FileOperation goes through `FileOperationService.ResolveProject`, which matches `Name` OR `FilePath`. The two strings are discriminators, so they stay distinct.

**Load-bearing text preserved:** the 1-based-inclusive contract + JSON example on `edits`, the `compile_check`/new-errors-only clause on `verify`, the "Ignored when verify is false" clause on `autoRevertOnError`, and the native-JSON-array + precedence clauses on `includedNames`.

## Acceptance evidence

Slice parameter-description budget (script over `^\s*\[Description("…")\]\s*<ident>`):

| File | Params | Before | After |
|---|---|---|---|
| EditTools.cs | 6 | 1,035 | 939 |
| FileOperationTools.cs | 14 | 754 | 644 |
| MSBuildTools.cs | 10 | 685 | 631 |
| TypeMoveTools.cs | 10 | 643 | 598 |
| **TOTAL** | **40** | **3,117** | **2,812** (-305, -9.8%) |

Param count is unchanged by design — this trims boilerplate, not surface.

## New ratchet

`tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs` — reflection ratchet mirroring the `SurfaceCatalogTests` method-level pattern. Scoped to the four swept types only; a repo-wide assertion would red CI against the ~50 unswept `Tools/*.cs` files. Asserts (a) the boilerplate params use the canonical form and (b) the four load-bearing params still carry their contract keyword. Optional path params (e.g. `TypeMoveTools.targetFilePath`) are exempt from the path rule — their "defaults to {TypeName}.cs" clause is a discriminator.

## Validation

- `dotnet build tests/RoslynMcp.Tests` — clean (0 warnings, 0 errors)
- `dotnet test --filter "ParameterDescriptionCanonicalizationTests|SurfaceCatalogTests|ExpandedSurfaceIntegrationTests"` — 56/56 passed
- `src/RoslynMcp.Host.Stdio/Catalog/Snapshots/catalog-v2.3.1.json` deliberately untouched (frozen historical diff baseline); the catalog drift gate compares Category/SupportTier/ReadOnly/Destructive/Summary only, none of which changed.
- Full `verify-release.ps1` runs on the self-hosted CI runner.

Closes: none — parent row `param-description-dedupe` stays open for the remaining ~50 `Tools/*.cs` files.
