### PR TITLE
maintenance(tools): canonicalize filePath param descriptions and lock drift

### DIFF
--- a/changelog.d/param-description-dedupe-code-action-suppression.md
+++ b/changelog.d/param-description-dedupe-code-action-suppression.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Standardized parameter descriptions across the code-action, suppression, symbol-refactor, and bulk-refactoring tool surfaces to canonical one-liners, and added a reflection-driven contract test that locks the canonical `workspaceId` / `filePath` forms (with an explicit allow-list for load-bearing exceptions such as `set_diagnostic_severity.filePath`) so phrasing drift cannot re-accumulate.

--- a/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
@@ -67,7 +67,7 @@ public static class SuppressionTools
         IWorkspaceExecutionGate gate,
         ISuppressionService suppressionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the C# source file to inspect")] string filePath,
+        [Description("Absolute path to the source file")] string filePath,
         [Description("1-based line number that should be covered (the diagnostic fire site)")] int line,
         [Description("Diagnostic id whose suppression to check (e.g. CA2025)")] string diagnosticId,
         CancellationToken ct = default)
@@ -87,7 +87,7 @@ public static class SuppressionTools
         IWorkspaceExecutionGate gate,
         IPinnedSuppressionWriteService suppressionService,
         [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the C# source file to modify")] string filePath,
+        [Description("Absolute path to the source file")] string filePath,
         [Description("1-based line number that must be covered after the widen (the diagnostic fire site)")] int line,
         [Description("Diagnostic id whose 'restore' is being moved (e.g. CA2025)")] string diagnosticId,
         CancellationToken ct = default)

--- a/tests/RoslynMcp.Tests/ParamDescriptionCanonicalFormCodeActionSuppressionTests.cs
+++ b/tests/RoslynMcp.Tests/ParamDescriptionCanonicalFormCodeActionSuppressionTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// param-description-dedupe-code-action-suppression: locks the canonical one-liner forms for
+/// <c>workspaceId</c> and <c>filePath</c> parameters across the code-action, suppression,
+/// symbol-refactor, and bulk-refactoring tool surfaces so phrasing drift cannot re-accumulate.
+/// Scoped to exactly the four in-scope types — NOT assembly-wide.
+/// </summary>
+[TestClass]
+public sealed class ParamDescriptionCanonicalFormCodeActionSuppressionTests
+{
+    private const string CanonicalWorkspaceIdDescription =
+        "The workspace session identifier returned by workspace_load";
+
+    private const string CanonicalFilePathDescription = "Absolute path to the source file";
+
+    /// <summary>
+    /// (tool, param) pairs whose description is deliberately non-canonical because it carries
+    /// call-accuracy information the canonical one-liner would lose.
+    /// </summary>
+    private static readonly HashSet<(string ToolName, string ParamName)> LoadBearingFilePathExceptions =
+    [
+        // Explains WHICH .editorconfig the server mutates — a real disambiguator.
+        ("set_diagnostic_severity", "filePath"),
+    ];
+
+    private static readonly Type[] InScopeTypes =
+    [
+        typeof(CodeActionTools),
+        typeof(SuppressionTools),
+        typeof(SymbolRefactorTools),
+        typeof(BulkRefactoringTools),
+    ];
+
+    [TestMethod]
+    public void InScopeTools_WorkspaceIdAndFilePathDescriptions_UseCanonicalForms()
+    {
+        var failures = new List<string>();
+        var workspaceIdCount = 0;
+        var filePathCount = 0;
+        var paramCount = 0;
+
+        foreach (var (toolName, param) in EnumerateToolParameters())
+        {
+            paramCount++;
+            var description = param.GetCustomAttribute<DescriptionAttribute>()?.Description ?? string.Empty;
+
+            switch (param.Name)
+            {
+                case "workspaceId":
+                    workspaceIdCount++;
+                    if (!string.Equals(description, CanonicalWorkspaceIdDescription, StringComparison.Ordinal))
+                        failures.Add($"({toolName}, workspaceId): expected \"{CanonicalWorkspaceIdDescription}\" but got \"{description}\".");
+                    break;
+
+                // Exactly "filePath" — not filePaths, sourceFilePath, hostRegistrationFile, etc.
+                case "filePath":
+                    if (LoadBearingFilePathExceptions.Contains((toolName, "filePath"))) break;
+                    filePathCount++;
+                    if (!string.Equals(description, CanonicalFilePathDescription, StringComparison.Ordinal))
+                        failures.Add($"({toolName}, filePath): expected \"{CanonicalFilePathDescription}\" but got \"{description}\".");
+                    break;
+            }
+        }
+
+        Assert.IsTrue(paramCount > 0,
+            "No tool parameters discovered on the in-scope types — reflection walk or tool registration changed.");
+        Assert.IsTrue(workspaceIdCount > 0, "No 'workspaceId' parameters discovered on the in-scope types.");
+        Assert.IsTrue(filePathCount > 0, "No non-exempt 'filePath' parameters discovered on the in-scope types.");
+        Assert.AreEqual(0, failures.Count,
+            "Non-canonical parameter descriptions:\n  " + string.Join("\n  ", failures));
+    }
+
+    [TestMethod]
+    public void InScopeTools_EveryParameter_CarriesNonEmptyDescription()
+    {
+        var failures = new List<string>();
+        var paramCount = 0;
+
+        foreach (var (toolName, param) in EnumerateToolParameters())
+        {
+            paramCount++;
+            var description = param.GetCustomAttribute<DescriptionAttribute>()?.Description;
+            if (string.IsNullOrWhiteSpace(description))
+                failures.Add($"({toolName}, {param.Name}): [Description] is missing or empty.");
+        }
+
+        Assert.IsTrue(paramCount > 0,
+            "No tool parameters discovered on the in-scope types — reflection walk or tool registration changed.");
+        Assert.AreEqual(0, failures.Count,
+            "Tool parameters without a [Description]:\n  " + string.Join("\n  ", failures));
+    }
+
+    private static IEnumerable<(string ToolName, ParameterInfo Parameter)> EnumerateToolParameters()
+    {
+        foreach (var method in InScopeTypes
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)))
+        {
+            var serverTool = method.GetCustomAttribute<McpServerToolAttribute>();
+            if (serverTool is null) continue;
+
+            var toolName = serverTool.Name ?? method.Name;
+            foreach (var param in method.GetParameters())
+            {
+                if (!IsSchemaParameter(param)) continue;
+                yield return (toolName, param);
+            }
+        }
+    }
+
+    /// <summary>
+    /// True for parameters that surface in the tool's JSON input schema. Excludes the
+    /// DI-injected host services (<see cref="McpServer"/> and service interfaces) and the
+    /// trailing <see cref="CancellationToken"/>, none of which carry a [Description].
+    /// </summary>
+    private static bool IsSchemaParameter(ParameterInfo param)
+    {
+        var type = param.ParameterType;
+        if (type == typeof(CancellationToken)) return false;
+        if (type == typeof(McpServer)) return false;
+        if (type.IsInterface) return false;
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Initiative `param-description-dedupe-code-action-suppression` (child 2 of 2 of the pre-split `param-description-dedupe` parent).

- **`SuppressionTools.cs`** — collapsed the two divergent `filePath` `[Description]` variants (`"Absolute path to the C# source file to inspect"` on `verify_pragma_suppresses`, `"...to modify"` on `pragma_scope_widen`) to the canonical `"Absolute path to the source file"` already used by `add_pragma_suppression` and both `CodeActionTools` tools. The `to inspect` / `to modify` suffixes carried zero call-accuracy information — the tools' own `ReadOnly` / `Destructive` annotations already state that.
- **New contract test** `tests/RoslynMcp.Tests/ParamDescriptionCanonicalFormCodeActionSuppressionTests.cs` — reflection walk scoped to exactly `CodeActionTools`, `SuppressionTools`, `SymbolRefactorTools`, `BulkRefactoringTools`. Asserts every `workspaceId` param description equals the canonical workspace one-liner, every `filePath` param equals the canonical path one-liner (allow-listing `set_diagnostic_severity.filePath`, whose description names *which* `.editorconfig` gets mutated), and that every schema parameter carries a non-empty `[Description]`.

`CodeActionTools.cs`, `SymbolRefactorTools.cs`, and `BulkRefactoringTools.cs` were audited and net **zero** text edits — they already carried the canonical forms. Their in-scope value is the new drift-lock coverage.

### Deliberately untouched

- `CodeActionTools.cs:83` / `BulkRefactoringTools.cs:47` preview-token producer-route strings — live contract for the sibling `preview-token-*` initiatives.
- `SuppressionTools.cs:27` `set_diagnostic_severity.filePath` — load-bearing disambiguator, explicitly allow-listed in the test.
- `ISuppressionService.cs` / `ISymbolRefactorService.cs` XML `<param>` doc comments — not `[Description]` attributes, no gate coupling.

### Honest scope note

The parent row's `~40%` char-reduction target is an aggregate over 54 files. This slice's raw text saving is ~40 chars, because `workspaceId` was already byte-identically canonical across all 12 occurrences in these 4 files. The real deliverable is the machine-checked drift-lock.

## Validation

- Red-then-green evidence: temporarily reverted `SuppressionTools.cs:70` → new test **failed** (1/2); restored → **passed**.
- `dotnet test --filter ParamDescriptionCanonicalFormCodeActionSuppressionTests|SurfaceCatalogTests` → 23/23 passed.
- `./eng/verify-ai-docs.ps1` → passed.
- Full `./eng/verify-release.ps1 -Configuration Release` deferred to the self-hosted CI runner rather than duplicated locally (standing no-duplicate-local-run directive; the box is currently running several parallel sweep executors).

Closes: none — parent row `param-description-dedupe` stays OPEN for the remaining ~46 Tools files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
