### PR TITLE
refactor(workspace): extract get_source_text validation and projection

### DIFF
--- a/changelog.d/workspace-source-text-projection-extraction.md
+++ b/changelog.d/workspace-source-text-projection-extraction.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Extracted `get_source_text` request validation and wire projection into `SourceTextRequestProjection`, reducing `WorkspaceTools.GetSourceText` to endpoint orchestration. No change to the tool's parameter schema, error envelopes, line counts, clamp behavior, or truncation marker.

--- a/src/RoslynMcp.Host.Stdio/Tools/SourceTextRequestProjection.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SourceTextRequestProjection.cs
@@ -1,0 +1,88 @@
+using RoslynMcp.Roslyn.Helpers;
+
+namespace RoslynMcp.Host.Stdio.Tools;
+
+/// <summary>
+/// The wire shape returned by <c>get_source_text</c>. Property names are PascalCase because
+/// <see cref="JsonDefaults.Indented"/> applies <see cref="System.Text.Json.JsonNamingPolicy.CamelCase"/>,
+/// which emits the same camelCase keys the tool has always produced.
+/// </summary>
+internal sealed record SourceTextProjection(
+    string FilePath,
+    int TotalLineCount,
+    int RequestedStartLine,
+    int RequestedEndLine,
+    int ReturnedStartLine,
+    int ReturnedEndLine,
+    bool Truncated,
+    string Text);
+
+/// <summary>
+/// Request validation and wire projection for <c>get_source_text</c>, kept out of the tool
+/// endpoint so <c>WorkspaceTools.GetSourceText</c> stays pure orchestration. Line slicing and
+/// line counting stay delegated to <see cref="SourceTextSlicer"/>, which the
+/// <c>roslyn://workspace/{id}/file/.../lines/{N-M}</c> resource surface shares.
+/// </summary>
+internal static class SourceTextRequestProjection
+{
+    /// <summary>
+    /// Validates the caller-supplied bounds that can be checked before the document is read.
+    /// Throws <see cref="ArgumentException"/> with the historically stable paramNames.
+    /// </summary>
+    public static void ValidateRequest(int maxChars, int? startLine, int? endLine)
+    {
+        if (maxChars <= 0)
+            throw new ArgumentException($"maxChars must be greater than 0 (got {maxChars}).", nameof(maxChars));
+        if (startLine is < 1)
+            throw new ArgumentException($"startLine must be >= 1 (got {startLine.Value}).", nameof(startLine));
+        if (endLine is < 1)
+            throw new ArgumentException($"endLine must be >= 1 (got {endLine.Value}).", nameof(endLine));
+        if (startLine.HasValue && endLine.HasValue && startLine.Value > endLine.Value)
+            throw new ArgumentException(
+                $"startLine ({startLine.Value}) must be <= endLine ({endLine.Value}).",
+                nameof(startLine));
+    }
+
+    /// <summary>
+    /// Counts lines, rejects a start line past EOF, clamps the end line to the file end,
+    /// slices, and applies the character cap with the truncation marker.
+    /// </summary>
+    public static SourceTextProjection Project(string filePath, string text, int? startLine, int? endLine, int maxChars)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(text);
+
+        var totalLineCount = SourceTextSlicer.CountLines(text);
+        var requestedStart = startLine ?? 1;
+        var requestedEnd = endLine ?? totalLineCount;
+
+        if (requestedStart > totalLineCount)
+            throw new ArgumentException(
+                $"startLine ({requestedStart}) is past the end of the file ({totalLineCount} lines).",
+                nameof(startLine));
+
+        // Clamp endLine to the file end so callers asking for "lines 100..1000" on a
+        // 200-line file get lines 100..200 instead of an error.
+        var returnedEnd = Math.Min(requestedEnd, totalLineCount);
+        var returnedStart = requestedStart;
+
+        var slice = SourceTextSlicer.SliceLines(text, returnedStart, returnedEnd);
+
+        var truncated = false;
+        if (slice.Length > maxChars)
+        {
+            slice = slice.Substring(0, maxChars) + $"\n[TRUNCATED at {maxChars} characters — re-request a narrower line range to see the rest]";
+            truncated = true;
+        }
+
+        return new SourceTextProjection(
+            filePath,
+            totalLineCount,
+            requestedStart,
+            requestedEnd,
+            returnedStart,
+            returnedEnd,
+            truncated,
+            slice);
+    }
+}

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs
@@ -611,54 +611,13 @@ public static class WorkspaceTools
     {
         return gate.RunReadAsync(workspaceId, async c =>
         {
-            if (maxChars <= 0)
-                throw new ArgumentException($"maxChars must be greater than 0 (got {maxChars}).", nameof(maxChars));
-            if (startLine is < 1)
-                throw new ArgumentException($"startLine must be >= 1 (got {startLine.Value}).", nameof(startLine));
-            if (endLine is < 1)
-                throw new ArgumentException($"endLine must be >= 1 (got {endLine.Value}).", nameof(endLine));
-            if (startLine.HasValue && endLine.HasValue && startLine.Value > endLine.Value)
-                throw new ArgumentException(
-                    $"startLine ({startLine.Value}) must be <= endLine ({endLine.Value}).",
-                    nameof(startLine));
+            SourceTextRequestProjection.ValidateRequest(maxChars, startLine, endLine);
 
             var text = await workspace.GetSourceTextAsync(workspaceId, filePath, c);
             if (text is null) throw new KeyNotFoundException($"Document not found: {filePath}");
 
-            var totalLineCount = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.CountLines(text);
-            var requestedStart = startLine ?? 1;
-            var requestedEnd = endLine ?? totalLineCount;
-
-            if (requestedStart > totalLineCount)
-                throw new ArgumentException(
-                    $"startLine ({requestedStart}) is past the end of the file ({totalLineCount} lines).",
-                    nameof(startLine));
-
-            // Clamp endLine to the file end so callers asking for "lines 100..1000" on a
-            // 200-line file get lines 100..200 instead of an error.
-            var returnedEnd = Math.Min(requestedEnd, totalLineCount);
-            var returnedStart = requestedStart;
-
-            var slice = RoslynMcp.Roslyn.Helpers.SourceTextSlicer.SliceLines(text, returnedStart, returnedEnd);
-
-            var truncated = false;
-            if (slice.Length > maxChars)
-            {
-                slice = slice.Substring(0, maxChars) + $"\n[TRUNCATED at {maxChars} characters — re-request a narrower line range to see the rest]";
-                truncated = true;
-            }
-
-            return JsonSerializer.Serialize(new
-            {
-                filePath,
-                totalLineCount,
-                requestedStartLine = requestedStart,
-                requestedEndLine = requestedEnd,
-                returnedStartLine = returnedStart,
-                returnedEndLine = returnedEnd,
-                truncated,
-                text = slice
-            }, JsonDefaults.Indented);
+            var projection = SourceTextRequestProjection.Project(filePath, text, startLine, endLine, maxChars);
+            return JsonSerializer.Serialize(projection, JsonDefaults.Indented);
         }, ct);
     }
 

--- a/tests/RoslynMcp.Tests/SourceTextRequestProjectionTests.cs
+++ b/tests/RoslynMcp.Tests/SourceTextRequestProjectionTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using RoslynMcp.Host.Stdio;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Behaviour-preservation gate for the <c>get_source_text</c> validation + projection helper
+/// extracted out of <c>WorkspaceTools.GetSourceText</c>. Asserts the exact exception paramNames,
+/// clamp semantics, truncation marker literal, and camelCase wire keys the tool has always emitted.
+/// </summary>
+[TestClass]
+public sealed class SourceTextRequestProjectionTests
+{
+    private const string _truncationMarkerFormat =
+        "\n[TRUNCATED at {0} characters \u2014 re-request a narrower line range to see the rest]";
+
+    [TestMethod]
+    public void ValidateRequest_NonPositiveMaxChars_ThrowsNamingMaxChars()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => SourceTextRequestProjection.ValidateRequest(0, null, null));
+
+        Assert.AreEqual("maxChars", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "maxChars must be greater than 0 (got 0).");
+    }
+
+    [TestMethod]
+    public void ValidateRequest_ZeroStartLine_ThrowsNamingStartLine()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => SourceTextRequestProjection.ValidateRequest(100, 0, null));
+
+        Assert.AreEqual("startLine", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "startLine must be >= 1 (got 0).");
+    }
+
+    [TestMethod]
+    public void ValidateRequest_ZeroEndLine_ThrowsNamingEndLine()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => SourceTextRequestProjection.ValidateRequest(100, null, 0));
+
+        Assert.AreEqual("endLine", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "endLine must be >= 1 (got 0).");
+    }
+
+    [TestMethod]
+    public void ValidateRequest_InvertedRange_ThrowsNamingStartLine()
+    {
+        // The historical paramName for the inverted-range throw is startLine, not endLine.
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => SourceTextRequestProjection.ValidateRequest(100, 5, 2));
+
+        Assert.AreEqual("startLine", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "startLine (5) must be <= endLine (2).");
+    }
+
+    [TestMethod]
+    [DataRow(1, null)]
+    [DataRow(1, 1)]
+    [DataRow(2, 10)]
+    public void ValidateRequest_ValidBounds_DoesNotThrow(int startLine, int? endLine)
+        => SourceTextRequestProjection.ValidateRequest(65536, startLine, endLine);
+
+    [TestMethod]
+    public void Project_StartLinePastEndOfFile_ThrowsNamingStartLine()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => SourceTextRequestProjection.Project("C:/repo/A.cs", "a\nb\nc", 9, null, 65536));
+
+        Assert.AreEqual("startLine", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "startLine (9) is past the end of the file (3 lines).");
+    }
+
+    [TestMethod]
+    public void Project_EndLineBeyondFile_ClampsToTotalLineCount()
+    {
+        var projection = SourceTextRequestProjection.Project("C:/repo/A.cs", "a\nb\nc", 2, 1000, 65536);
+
+        Assert.AreEqual(3, projection.TotalLineCount);
+        Assert.AreEqual(2, projection.RequestedStartLine);
+        Assert.AreEqual(1000, projection.RequestedEndLine);
+        Assert.AreEqual(2, projection.ReturnedStartLine);
+        Assert.AreEqual(3, projection.ReturnedEndLine);
+        Assert.AreEqual("b\nc", projection.Text);
+        Assert.IsFalse(projection.Truncated);
+    }
+
+    [TestMethod]
+    public void Project_EmptyText_CountsOneLineAndReturnsEmptySlice()
+    {
+        var projection = SourceTextRequestProjection.Project("C:/repo/Empty.cs", string.Empty, null, null, 65536);
+
+        Assert.AreEqual(1, projection.TotalLineCount);
+        Assert.AreEqual(1, projection.RequestedStartLine);
+        Assert.AreEqual(1, projection.RequestedEndLine);
+        Assert.AreEqual(1, projection.ReturnedEndLine);
+        Assert.AreEqual(string.Empty, projection.Text);
+        Assert.IsFalse(projection.Truncated);
+    }
+
+    [TestMethod]
+    public void Project_TrailingNewline_DoesNotDoubleCountFinalLine()
+    {
+        var projection = SourceTextRequestProjection.Project("C:/repo/A.cs", "a\nb\n", null, null, 65536);
+
+        Assert.AreEqual(2, projection.TotalLineCount);
+        Assert.AreEqual(2, projection.ReturnedEndLine);
+        Assert.AreEqual("a\nb\n", projection.Text);
+    }
+
+    [TestMethod]
+    public void Project_SliceExactlyAtCap_IsNotTruncated()
+    {
+        var text = new string('x', 32);
+
+        var projection = SourceTextRequestProjection.Project("C:/repo/A.cs", text, null, null, 32);
+
+        Assert.IsFalse(projection.Truncated);
+        Assert.AreEqual(32, projection.Text.Length);
+        Assert.AreEqual(text, projection.Text);
+        StringAssert.DoesNotMatch(projection.Text, new System.Text.RegularExpressions.Regex(@"\[TRUNCATED"));
+    }
+
+    [TestMethod]
+    public void Project_SliceOverCap_TruncatesWithVerbatimMarker()
+    {
+        var text = new string('x', 40);
+        const int maxChars = 32;
+
+        var projection = SourceTextRequestProjection.Project("C:/repo/A.cs", text, null, null, maxChars);
+
+        Assert.IsTrue(projection.Truncated);
+        var expectedMarker = string.Format(
+            System.Globalization.CultureInfo.InvariantCulture, _truncationMarkerFormat, maxChars);
+        Assert.AreEqual(new string('x', maxChars) + expectedMarker, projection.Text);
+        StringAssert.EndsWith(projection.Text, expectedMarker);
+    }
+
+    [TestMethod]
+    public void Project_SerializedWithJsonDefaults_EmitsHistoricalCamelCaseKeys()
+    {
+        var projection = SourceTextRequestProjection.Project("C:/repo/A.cs", "a\nb\nc", 1, 2, 65536);
+
+        var json = JsonSerializer.Serialize(projection, JsonDefaults.Indented);
+        using var document = JsonDocument.Parse(json);
+        var keys = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                "filePath",
+                "totalLineCount",
+                "requestedStartLine",
+                "requestedEndLine",
+                "returnedStartLine",
+                "returnedEndLine",
+                "truncated",
+                "text",
+            },
+            keys);
+        Assert.AreEqual("C:/repo/A.cs", document.RootElement.GetProperty("filePath").GetString());
+        Assert.AreEqual("a\nb\n", document.RootElement.GetProperty("text").GetString());
+    }
+}


### PR DESCRIPTION
## Summary

Reduces `WorkspaceTools.GetSourceText` to endpoint orchestration by extracting its request validation and wire projection into a new `internal static` helper, `SourceTextRequestProjection`, mirroring the existing `TestRunPublicProjection` pattern in the same folder.

The tool method previously mixed four responsibilities in one `gate.RunReadAsync` lambda: argument validation, post-read bounds validation, clamping/slicing/truncation, and wire projection of an 8-field anonymous object. It is now: validate → read → null-check → project → serialize.

## Changes

- **`src/RoslynMcp.Host.Stdio/Tools/SourceTextRequestProjection.cs`** (new)
  - `ValidateRequest(maxChars, startLine, endLine)` — the pre-read bounds throws, verbatim. Preserves the historical `ArgumentException` paramNames, including the inverted-range throw naming `startLine` (not `endLine`).
  - `Project(filePath, text, startLine, endLine, maxChars)` — line counting, the past-EOF throw, the end-line clamp, `SourceTextSlicer.SliceLines` delegation, and the byte-identical truncation marker.
  - `SourceTextProjection` record — PascalCase properties serialize to the identical camelCase wire keys under `JsonDefaults.Indented`'s `JsonNamingPolicy.CamelCase`.
- **`src/RoslynMcp.Host.Stdio/Tools/WorkspaceTools.cs`** — `GetSourceText` body reduced to orchestration. Attributes, `[Description]` strings, and the parameter list are untouched.
- **`tests/RoslynMcp.Tests/SourceTextRequestProjectionTests.cs`** (new) — 11 MSTest cases covering invalid bounds (type + paramName + message), start-past-EOF, end clamping, empty text, trailing-newline line counting, exact-cap vs over-cap truncation with the full marker literal asserted, and the camelCase wire-key ordering.

## Behaviour preservation

No change to the tool's parameter schema, error envelopes, line counts, clamp behavior, or truncation marker. Slicing is still delegated to `SourceTextSlicer` — not re-implemented. The truncation marker was byte-compared (`od -c`) against the pre-change literal, em dash included.

## Validation

- `compile_check` across the solution: 0 errors, 0 warnings.
- `dotnet build -c Release`: succeeded, 0 warnings, 0 errors.
- `test_run --filter "SourceTextRequestProjectionTests|WorkspaceToolsIntegrationTests|WorkspaceReloadedNotFoundConflationTests"`: **38/38 passed**. The pre-existing integration and conflation suites are unmodified — they are the real behaviour-preservation gate.
- `./eng/verify-ai-docs.ps1`: passed.
- `./eng/verify-changelog-fragments.ps1`: passed.
- `./eng/verify-release.ps1 -Configuration Release` could not be run locally (blocked by the sandbox permission classifier); the Release build, the targeted suites, and the doc/changelog gates were run individually instead, and CI runs the full gate on this PR.

Closes: workspace-source-text-projection-extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
