### PR TITLE
fix(eng): assert prefix-agnostic tool references in shipped skills

### DIFF
--- a/changelog.d/shipped-skills-prefix-genericity-guard-assertion.md
+++ b/changelog.d/shipped-skills-prefix-genericity-guard-assertion.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the shipped-skill genericity gate now enforces prefix-agnostic tool references. `eng/verify-skills-are-generic.ps1` fails on a bare `mcp__roslyn__` literal used inside a "call it / verify it appears in your tool surface" instruction (the canonical note's explicit *examples, not an allowed list* prefixes remain permitted), and asserts the resolve-once-then-pin precheck block stays byte-identical wherever it appears, in both its section and inline-blockquote canonical forms. Files still carrying the pre-fix note are tracked in an enumerated, shrink-ratcheted allowlist rather than silently exempted.

--- a/eng/banned-skill-markers.json
+++ b/eng/banned-skill-markers.json
@@ -13,5 +13,60 @@
   "stripPatterns": [
     "https?://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+;=%-]+",
     "<(?:audited-repo-root|Roslyn-Backed-MCP-root)>/[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+;=%-]*"
+  ],
+  "prefixAgnostic": {
+    "imperativePatterns": [
+      "(?i)\\b(?:before|after|when)\\s+(?:running|issuing|making|calling)\\s+any\\s+\\x60?mcp__[A-Za-z0-9_-]*roslyn[A-Za-z0-9_-]*__",
+      "(?i)(?:^|[\\s(\\[>*_-])(?:call|run|invoke|execute|issue)\\s+\\x60mcp__[A-Za-z0-9_-]*roslyn[A-Za-z0-9_-]*__[a-z_]+\\x60",
+      "(?i)verif(?:y|ies|ying)\\b[^.]*\\x60mcp__[A-Za-z0-9_-]*roslyn[A-Za-z0-9_-]*__[a-z_]+\\x60[^.]*(?:appears|is present|tool surface)"
+    ],
+    "exemptSpans": [
+      "examples, not an allowed list",
+      "never hard-code it",
+      "The prefix does not matter",
+      "under whichever prefix",
+      "whichever prefix your (?:own )?(?:client|tool surface)",
+      "is \\*\\*not\\*\\* grounds to halt",
+      "never itself grounds to halt"
+    ],
+    "residualUnsweptAllowlist": [
+      "skills/semantic-find/SKILL.md",
+      "skills/test-coverage/SKILL.md",
+      "skills/trace-flow/SKILL.md",
+      "skills/version-bump/SKILL.md",
+      "skills/workspace-health/SKILL.md"
+    ]
+  },
+  "canonicalPrecheckBlocks": [
+    {
+      "id": "connectivity-precheck-section",
+      "anchorPattern": "^## Connectivity precheck\\s*$",
+      "terminatorPattern": "^## ",
+      "text": [
+        "## Connectivity precheck",
+        "",
+        "Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.",
+        "",
+        "> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.",
+        "",
+        "1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.",
+        "2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.",
+        "3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.",
+        "4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `\"ready\"` (`initializing`, `degraded`, absent):",
+        "",
+        "   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: \"ready\"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: \"ready\"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).",
+        "",
+        "5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.",
+        ""
+      ]
+    },
+    {
+      "id": "tool-prefix-inline-blockquote",
+      "anchorPattern": "^> \\*\\*Tool prefix — resolve it once from `server",
+      "terminatorPattern": null,
+      "text": [
+        "> **Tool prefix — resolve it once from `server_info`, then pin it.** Your MCP client prepends a prefix derived from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key (a custom `.mcp.json` key, a forked plugin name). Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt. Resolve the prefix **once**, at the first gate, then pin it. **(1) Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so there may be more than one candidate and some may belong to other servers entirely. **(2) Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding. **(3) Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill — including its phase sub-files (`workspace_load`, `find_references`, `get_symbol_outline`, …) — under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn. Every gate in this skill — including its phase sub-files — halts only when **no** tool ending in `server_info` returns a Roslyn-shaped response."
+      ]
+    }
   ]
 }

--- a/eng/verify-skills-are-generic.ps1
+++ b/eng/verify-skills-are-generic.ps1
@@ -62,6 +62,108 @@ foreach ($file in $skillFiles) {
     }
 }
 
+# ---------------------------------------------------------------------------
+# Prefix-agnostic assertion (additive pass — the banned-pattern loop above is
+# unchanged so the in-process echo test's literal substrings stay green).
+#
+# The server's MCP tool prefix is CLIENT-ASSIGNED: the same tool surfaces as
+# `mcp__roslyn__server_info` on a self-hosted entry and as
+# `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace install. A
+# shipped skill must therefore never instruct the agent to CALL or VERIFY a
+# bare prefixed literal. Citing those prefixes as illustrative examples is
+# fine — `exemptSpans` neutralizes any line carrying the disclaimer.
+# ---------------------------------------------------------------------------
+$prefixPolicy = $policy.prefixAgnostic
+if ($null -eq $prefixPolicy) {
+    throw "Genericity policy is missing prefixAgnostic: $policyPath"
+}
+$imperativePatterns = @($prefixPolicy.imperativePatterns)
+$exemptSpans = @($prefixPolicy.exemptSpans)
+$residualUnsweptAllowlist = @($prefixPolicy.residualUnsweptAllowlist)
+$canonicalBlocks = @($policy.canonicalPrecheckBlocks)
+if ($imperativePatterns.Count -eq 0 -or $exemptSpans.Count -eq 0 -or $canonicalBlocks.Count -eq 0) {
+    throw "Genericity policy is missing prefixAgnostic.imperativePatterns, prefixAgnostic.exemptSpans, or canonicalPrecheckBlocks: $policyPath"
+}
+
+# The allowlist is a SHRINKING amnesty for files not yet swept onto the
+# canonical note. Assert every entry still exists so it cannot rot into a
+# permanent exemption pointing at deleted paths.
+$allowedSet = @{}
+foreach ($allowed in $residualUnsweptAllowlist) {
+    $allowedSet[$allowed.ToLowerInvariant()] = $true
+    if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot $allowed) -PathType Leaf)) {
+        $issues.Add("eng/banned-skill-markers.json: residualUnsweptAllowlist entry '$allowed' no longer exists -- drop the stale entry.")
+    }
+}
+
+function Get-RelativeSkillPath {
+    param([string]$FullName, [string]$Root)
+    return ($FullName.Substring($Root.Length + 1) -replace '\\', '/')
+}
+
+function Assert-PrefixAgnostic {
+    foreach ($file in $skillFiles) {
+        $rel = Get-RelativeSkillPath -FullName $file.FullName -Root $RepoRoot
+        if ($allowedSet.ContainsKey($rel.ToLowerInvariant())) { continue }
+        $lines = @(Get-Content -LiteralPath $file.FullName)
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $line = $lines[$i]
+            $exempt = $false
+            foreach ($span in $exemptSpans) {
+                if ($line -match $span) { $exempt = $true; break }
+            }
+            if ($exempt) { continue }
+            foreach ($pattern in $imperativePatterns) {
+                if ($line -match $pattern) {
+                    $issues.Add("${rel}:$($i + 1): bare roslyn prefix inside a tool-surface imperative -> $line")
+                    break
+                }
+            }
+        }
+    }
+}
+
+function Assert-CanonicalBlockIdentity {
+    foreach ($file in $skillFiles) {
+        $rel = Get-RelativeSkillPath -FullName $file.FullName -Root $RepoRoot
+        if ($allowedSet.ContainsKey($rel.ToLowerInvariant())) { continue }
+        $lines = @(Get-Content -LiteralPath $file.FullName)
+        foreach ($block in $canonicalBlocks) {
+            $canonical = @($block.text)
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                if ($lines[$i] -notmatch $block.anchorPattern) { continue }
+
+                $extracted = New-Object System.Collections.Generic.List[string]
+                if ([string]::IsNullOrEmpty($block.terminatorPattern)) {
+                    $extracted.Add($lines[$i])
+                } else {
+                    for ($j = $i; $j -lt $lines.Count; $j++) {
+                        if ($j -gt $i -and $lines[$j] -match $block.terminatorPattern) { break }
+                        $extracted.Add($lines[$j])
+                    }
+                }
+
+                # The canonical text must be the byte-identical LEADING slice of the
+                # block. Per-skill trailing prose AFTER it is allowed (e.g. the
+                # workspace-health skill's "a failing precheck is itself the answer").
+                if ($extracted.Count -lt $canonical.Count) {
+                    $issues.Add("${rel}:$($i + 1): canonical block '$($block.id)' is truncated ($($extracted.Count) lines, expected at least $($canonical.Count)).")
+                    continue
+                }
+                for ($k = 0; $k -lt $canonical.Count; $k++) {
+                    if (-not [string]::Equals($extracted[$k], $canonical[$k], [System.StringComparison]::Ordinal)) {
+                        $issues.Add("${rel}:$($i + 1 + $k): canonical block '$($block.id)' drifted from eng/banned-skill-markers.json -> $($extracted[$k])")
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
+Assert-PrefixAgnostic
+Assert-CanonicalBlockIdentity
+
 if ($issues.Count -gt 0) {
     Write-Host ""
     Write-Host "Shipped skills under ./skills/ must be generic (not coupled to this repo)." -ForegroundColor Red

--- a/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
@@ -1,0 +1,360 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynMcp.Tests.Support;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// Build-only echo of the prefix-agnostic half of <c>eng/verify-skills-are-generic.ps1</c>.
+/// The PowerShell gate is canonical; this mirrors it so a contributor without <c>pwsh</c> still
+/// catches drift via <c>dotnet test</c>.
+///
+/// Contract enforced here:
+///   1. The shipped policy (<c>eng/banned-skill-markers.json</c>) carries a populated
+///      <c>prefixAgnostic</c> section and at least the two canonical precheck block forms.
+///   2. The imperative rule fires on the pre-fix note's shapes — "Before running any
+///      <c>mcp__roslyn__*</c> tool call", "Call <c>mcp__roslyn__server_info</c>", "Run
+///      <c>mcp__roslyn__server_heartbeat</c>" — because the MCP tool prefix is CLIENT-ASSIGNED
+///      and a shipped skill must never instruct the agent to call a hard-coded literal.
+///   3. The rule does NOT fire on the canonical note's own illustrative prefixes, which carry the
+///      "examples, not an allowed list" disclaimer. That false positive would make the whole
+///      assertion unshippable.
+///   4. Every canonical precheck block on disk is byte-identical to the policy text, with
+///      per-skill trailing prose after it allowed (the workspace-health case).
+///   5. <c>residualUnsweptAllowlist</c> is a SHRINKING amnesty — every entry exists on disk, and
+///      the count never exceeds the ratchet recorded when the assertion landed.
+/// </summary>
+[TestClass]
+public sealed class SkillPrefixGenericityTests
+{
+    /// <summary>
+    /// Shrink ratchet. Five shipped skills still carried the pre-fix bare-prefix precheck when this
+    /// gate landed (<c>semantic-find</c>, <c>test-coverage</c>, <c>trace-flow</c>,
+    /// <c>version-bump</c>, <c>workspace-health</c>). The allowlist may only ever get SMALLER —
+    /// lowering this constant as the sweep batches land is the intended edit; raising it is not.
+    /// </summary>
+    private const int ResidualUnsweptRatchet = 5;
+
+    [TestMethod]
+    public void PrefixAgnosticPolicy_IsPopulated()
+    {
+        var policy = LoadPolicy();
+
+        Assert.IsNotNull(policy.PrefixAgnostic, "eng/banned-skill-markers.json is missing prefixAgnostic.");
+        Assert.IsNotEmpty(policy.PrefixAgnostic.ImperativePatterns);
+        Assert.IsNotEmpty(policy.PrefixAgnostic.ExemptSpans);
+        Assert.IsNotNull(policy.CanonicalPrecheckBlocks);
+
+        var ids = policy.CanonicalPrecheckBlocks.Select(b => b.Id).ToList();
+        CollectionAssert.Contains(ids, "connectivity-precheck-section");
+        CollectionAssert.Contains(ids, "tool-prefix-inline-blockquote");
+
+        foreach (var block in policy.CanonicalPrecheckBlocks)
+        {
+            Assert.IsNotEmpty(block.Text, $"Canonical block '{block.Id}' has no text.");
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(block.AnchorPattern),
+                $"Canonical block '{block.Id}' has no anchorPattern.");
+        }
+    }
+
+    [TestMethod]
+    [DataRow("Before running any `mcp__roslyn__*` tool call, probe the server once:")]
+    [DataRow("1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: \"ready\"`.")]
+    [DataRow("Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill.")]
+    [DataRow("2. Invoke `mcp__plugin_roslyn-mcp_roslyn__workspace_load` before anything else.")]
+    [DataRow("Verify `mcp__roslyn__server_info` appears in your tool surface before proceeding.")]
+    public void ImperativeRule_FiresOnHardCodedPrefixInstructions(string line)
+    {
+        Assert.IsTrue(
+            MatchesImperativeRule(line),
+            $"Expected the prefix-agnostic rule to flag a hard-coded prefix imperative: {line}");
+    }
+
+    [TestMethod]
+    [DataRow("> **The prefix is client-assigned — never hard-code it.** … the same tool surfaces as `mcp__roslyn__server_info` on a dev-build entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace install. Those two are **examples, not an allowed list** — every prefix is valid.")]
+    [DataRow("The prefix does not matter — your client assigns it, so it may be `mcp__roslyn__…` or anything else.")]
+    [DataRow("Resolve once by suffix and then pin the prefix: a missing `mcp__roslyn__`-prefixed literal is **not** grounds to halt.")]
+    [DataRow("1. Scan your current tool surface for every tool whose name ends in `server_info`.")]
+    public void ImperativeRule_DoesNotFireOnIllustrativePrefixes(string line)
+    {
+        Assert.IsFalse(
+            MatchesImperativeRule(line),
+            $"The prefix-agnostic rule must not flag an illustrative/disclaimed prefix: {line}");
+    }
+
+    [TestMethod]
+    public void ImperativeRule_ClearsEveryShippedSkillOutsideTheAllowlist()
+    {
+        var policy = LoadPolicy();
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var allowed = AllowlistSet(policy);
+        var offenders = new List<string>();
+
+        foreach (var (relative, lines) in EnumerateShippedSkillFiles(repoRoot, policy))
+        {
+            if (allowed.Contains(relative))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (MatchesImperativeRule(lines[i], policy))
+                {
+                    offenders.Add($"{relative}:{i + 1}: {lines[i]}");
+                }
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            offenders.Count,
+            $"Shipped skills must not hard-code an MCP tool prefix inside a call/verify instruction:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, offenders));
+    }
+
+    [TestMethod]
+    public void CanonicalPrecheckBlocks_AreByteIdenticalWhereverTheyAppear()
+    {
+        var policy = LoadPolicy();
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var allowed = AllowlistSet(policy);
+        var drift = new List<string>();
+        var matched = 0;
+
+        foreach (var (relative, lines) in EnumerateShippedSkillFiles(repoRoot, policy))
+        {
+            if (allowed.Contains(relative))
+            {
+                continue;
+            }
+
+            foreach (var block in policy.CanonicalPrecheckBlocks)
+            {
+                var anchor = new Regex(block.AnchorPattern);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    if (!anchor.IsMatch(lines[i]))
+                    {
+                        continue;
+                    }
+
+                    matched++;
+                    var extracted = Extract(lines, i, block.TerminatorPattern);
+                    if (extracted.Count < block.Text.Length)
+                    {
+                        drift.Add($"{relative}:{i + 1}: block '{block.Id}' truncated to {extracted.Count} lines (expected >= {block.Text.Length}).");
+                        continue;
+                    }
+
+                    for (var k = 0; k < block.Text.Length; k++)
+                    {
+                        if (!string.Equals(extracted[k], block.Text[k], StringComparison.Ordinal))
+                        {
+                            drift.Add($"{relative}:{i + 1 + k}: block '{block.Id}' drifted -> {extracted[k]}");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.IsTrue(matched > 0, "No shipped skill matched any canonical precheck anchor — the identity assertion is vacuous.");
+        Assert.AreEqual(
+            0,
+            drift.Count,
+            $"Canonical precheck blocks drifted from eng/banned-skill-markers.json:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, drift));
+    }
+
+    [TestMethod]
+    public void CanonicalBlockIdentity_DetectsASingleCharacterMutation()
+    {
+        var policy = LoadPolicy();
+        var block = policy.CanonicalPrecheckBlocks.Single(b => b.Id == "connectivity-precheck-section");
+        var mutated = (string[])block.Text.Clone();
+        mutated[2] = mutated[2].Replace("**once**", "**Once**", StringComparison.Ordinal);
+
+        Assert.AreNotEqual(
+            block.Text[2],
+            mutated[2],
+            "Fixture setup failed — the mutation did not change the line.");
+        Assert.IsFalse(
+            block.Text.SequenceEqual(mutated, StringComparer.Ordinal),
+            "A one-character drift inside the canonical block must not compare equal.");
+    }
+
+    [TestMethod]
+    public void CanonicalBlockIdentity_AllowsPerSkillTrailingProse()
+    {
+        var policy = LoadPolicy();
+        var block = policy.CanonicalPrecheckBlocks.Single(b => b.Id == "connectivity-precheck-section");
+        var withTrailer = block.Text
+            .Concat(["Note: this skill reports server status, so a failing precheck is itself the answer.", string.Empty])
+            .ToArray();
+
+        // The gate compares the canonical text as the LEADING slice, so appended per-skill prose
+        // must still pass while the canonical portion stays byte-identical.
+        var extracted = Extract(withTrailer, 0, terminatorPattern: null);
+        Assert.HasCount(1, extracted, "Fixture setup failed — a null terminator must extract exactly one line.");
+
+        Assert.IsTrue(
+            withTrailer.Length > block.Text.Length,
+            "Fixture setup failed — no trailer was appended.");
+        for (var k = 0; k < block.Text.Length; k++)
+        {
+            Assert.AreEqual(
+                block.Text[k],
+                withTrailer[k],
+                $"Line {k} of the canonical block diverged under a per-skill trailer.");
+        }
+    }
+
+    [TestMethod]
+    public void ResidualUnsweptAllowlist_OnlyShrinksAndEveryEntryExists()
+    {
+        var policy = LoadPolicy();
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var allowlist = policy.PrefixAgnostic.ResidualUnsweptAllowlist;
+
+        Assert.IsTrue(
+            allowlist.Length <= ResidualUnsweptRatchet,
+            $"residualUnsweptAllowlist grew to {allowlist.Length}; the ratchet is {ResidualUnsweptRatchet}. "
+                + "The allowlist is a shrinking amnesty — sweep the skill onto the canonical note instead of adding an entry.");
+
+        foreach (var entry in allowlist)
+        {
+            Assert.IsTrue(
+                File.Exists(Path.Combine(repoRoot, entry.Replace('/', Path.DirectorySeparatorChar))),
+                $"residualUnsweptAllowlist entry '{entry}' no longer exists — drop the stale entry rather than banking permanent amnesty.");
+        }
+    }
+
+    [TestMethod]
+    public void PowerShellGate_ConsumesThePrefixAgnosticPolicy()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repoRoot, "eng", "verify-skills-are-generic.ps1"));
+
+        StringAssert.Contains(script, "$policy.prefixAgnostic");
+        StringAssert.Contains(script, "$policy.canonicalPrecheckBlocks");
+        StringAssert.Contains(script, "Assert-PrefixAgnostic");
+        StringAssert.Contains(script, "Assert-CanonicalBlockIdentity");
+        StringAssert.Contains(script, "residualUnsweptAllowlist");
+    }
+
+    private static List<string> Extract(string[] lines, int start, string? terminatorPattern)
+    {
+        var extracted = new List<string>();
+        if (string.IsNullOrEmpty(terminatorPattern))
+        {
+            extracted.Add(lines[start]);
+            return extracted;
+        }
+
+        var terminator = new Regex(terminatorPattern);
+        for (var j = start; j < lines.Length; j++)
+        {
+            if (j > start && terminator.IsMatch(lines[j]))
+            {
+                break;
+            }
+
+            extracted.Add(lines[j]);
+        }
+
+        return extracted;
+    }
+
+    private static IEnumerable<(string Relative, string[] Lines)> EnumerateShippedSkillFiles(
+        string repoRoot,
+        GenericityPolicy policy)
+    {
+        var skillsDir = Path.Combine(repoRoot, "skills");
+        if (!Directory.Exists(skillsDir))
+        {
+            yield break;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(skillsDir, policy.FilePattern, SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(repoRoot, path).Replace('\\', '/');
+            yield return (relative, File.ReadAllLines(path));
+        }
+    }
+
+    private static HashSet<string> AllowlistSet(GenericityPolicy policy) =>
+        new(policy.PrefixAgnostic.ResidualUnsweptAllowlist, StringComparer.OrdinalIgnoreCase);
+
+    private static bool MatchesImperativeRule(string line) => MatchesImperativeRule(line, LoadPolicy());
+
+    private static bool MatchesImperativeRule(string line, GenericityPolicy policy)
+    {
+        foreach (var span in policy.PrefixAgnostic.ExemptSpans)
+        {
+            if (Regex.IsMatch(line, span))
+            {
+                return false;
+            }
+        }
+
+        return policy.PrefixAgnostic.ImperativePatterns.Any(pattern => Regex.IsMatch(line, pattern));
+    }
+
+    private static GenericityPolicy LoadPolicy()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var policyPath = Path.Combine(repoRoot, "eng", "banned-skill-markers.json");
+        var policy = JsonSerializer.Deserialize<GenericityPolicy>(
+            File.ReadAllText(policyPath),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return policy ?? throw new AssertFailedException($"Could not deserialize {policyPath}.");
+    }
+
+    /// <summary>
+    /// Local DTO. The sibling <c>McpServerSurfaceTestSkillTests</c> declares a private
+    /// three-property record for the banned-pattern half of the same file; this one models the
+    /// prefix-agnostic half without widening that type.
+    /// </summary>
+    private sealed record GenericityPolicy
+    {
+        [JsonPropertyName("filePattern")]
+        public string FilePattern { get; init; } = "*.md";
+
+        [JsonPropertyName("prefixAgnostic")]
+        public PrefixAgnosticPolicy PrefixAgnostic { get; init; } = new();
+
+        [JsonPropertyName("canonicalPrecheckBlocks")]
+        public CanonicalBlock[] CanonicalPrecheckBlocks { get; init; } = [];
+    }
+
+    private sealed record PrefixAgnosticPolicy
+    {
+        [JsonPropertyName("imperativePatterns")]
+        public string[] ImperativePatterns { get; init; } = [];
+
+        [JsonPropertyName("exemptSpans")]
+        public string[] ExemptSpans { get; init; } = [];
+
+        [JsonPropertyName("residualUnsweptAllowlist")]
+        public string[] ResidualUnsweptAllowlist { get; init; } = [];
+    }
+
+    private sealed record CanonicalBlock
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
+
+        [JsonPropertyName("anchorPattern")]
+        public string AnchorPattern { get; init; } = string.Empty;
+
+        [JsonPropertyName("terminatorPattern")]
+        public string? TerminatorPattern { get; init; }
+
+        [JsonPropertyName("text")]
+        public string[] Text { get; init; } = [];
+    }
+}


### PR DESCRIPTION
## Summary

The MCP tool prefix is **client-assigned** — the same tool surfaces as `mcp__roslyn__server_info` on a self-hosted entry and as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install. A shipped skill must therefore never instruct the agent to *call* or *verify* a hard-coded prefixed literal. `eng/verify-skills-are-generic.ps1` was a pure line-wise banned-regex scanner with no notion of that shape, so acceptance bullets 3 and 4 of `shipped-skills-hardcode-bare-roslyn-tool-prefix` were unshipped.

Two additive passes now run over the same `$skillFiles` set and feed the existing `$issues` / exit-1 block (the banned-pattern loop is untouched, so the in-process echo test's literal substrings stay green):

- **`Assert-PrefixAgnostic`** — flags a bare `mcp__…roslyn…__<tool>` literal on a line that also carries a call/verify imperative. Lines carrying the *examples, not an allowed list* disclaimer are exempt, so the canonical resolve-once-then-pin note itself passes.
- **`Assert-CanonicalBlockIdentity`** — asserts the precheck block is byte-identical (ordinal) to the policy text in **both** canonical forms: the `## Connectivity precheck` section (12 skills) and the inline `> **Tool prefix …` blockquote (4 `mcp-server-surface-test` files). Per-skill trailing prose **after** the canonical slice is allowed (the `workspace-health` case).

Files still carrying the pre-fix note are tracked in an **enumerated, shrink-ratcheted** `residualUnsweptAllowlist` rather than silently exempted; the gate also fails if an allowlist entry no longer exists, so the list cannot rot into permanent amnesty.

## Validation (all run this session)

| Check | Result |
|---|---|
| `pwsh -File ./eng/verify-skills-are-generic.ps1` | exit 0 — 38 .md files checked |
| Append `Call \`mcp__roslyn__server_info\`` to a non-allowlisted swept file | exit 1, `skills/analyze/SKILL.md:128: bare roslyn prefix inside a tool-surface imperative` |
| One-char mutation inside a section-form canonical block | exit 1, `connectivity-precheck-section' drifted` |
| One-char mutation inside a blockquote-form canonical block | exit 1, `tool-prefix-inline-blockquote' drifted` |
| Delete one canonical line | exit 1, `is truncated (14 lines, expected at least 15)` |
| Canonical note's own example prefixes (`skills/analyze/SKILL.md:25,32`, `mcp-server-surface-test/SKILL.md:17,22,172`, `README.md:14`, `refactor{,-loop}/SKILL.md`) | no false positives |
| Simulated batch-c sweep of `workspace-health` (canonical + per-skill trailer, de-allowlisted) | exit 0 |
| Bogus allowlist entry | exit 1, `no longer exists -- drop the stale entry` |
| `dotnet test --filter FullyQualifiedName~RoslynMcp.Tests.Skills` | 97/97 passed (new `SkillPrefixGenericityTests` + existing `McpServerSurfaceTestSkillTests`) |
| `dotnet test --filter FullyQualifiedName~VerifyRelease` | 7/7 passed |
| `pwsh -File ./eng/verify-ai-docs.ps1` | passed |

Full `verify-release.ps1 -Configuration Release` intentionally deferred to the self-hosted runner rather than duplicated locally.

## Directive #5 re-derivation vs. the plan

The plan's Diagnosis (written pre-sweep) predicted 13 unswept files; against live `main` at `c3e1ac4` the sibling batch-a/batch-b sweeps have already landed, so **5** remain (`semantic-find`, `test-coverage`, `trace-flow`, `version-bump`, `workspace-health`) — exactly the residual set the plan's Risks section forecast. `residualUnsweptAllowlist` enumerates those 5 and `SkillPrefixGenericityTests.ResidualUnsweptRatchet` pins the count at 5, downward-only.

One real defect found and fixed during validation: the first draft's literal class `[A-Za-z0-9_]` could not match the hyphenated marketplace prefix `mcp__plugin_roslyn-mcp_roslyn__…`, so the rule would have missed exactly the form it exists to catch. The class now admits `-`, with a regression `[DataRow]` for it.

## Follow-on required

The parent backlog row **`shipped-skills-hardcode-bare-roslyn-tool-prefix` must stay open** — acceptance bullet 4 is not met while those 5 skills sit behind the allowlist. A batch-c row to sweep them (and empty the allowlist) needs filing, or the amnesty becomes permanent.

Closes: (none — parent row `shipped-skills-hardcode-bare-roslyn-tool-prefix` stays open by design)

shims-added: 0
