### PR TITLE
fix(host): bind preview tokens to compatible apply routes

### DIFF
--- a/changelog.d/preview-token-apply-route-binding.md
+++ b/changelog.d/preview-token-apply-route-binding.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** preview tokens are now bound to compatible apply routes. The five named refactoring apply tools (`rename_apply`, `organize_usings_apply`, `format_document_apply`, `code_fix_apply`, `format_range_apply`) reject a preview token minted by a different producer family BEFORE any workspace mutation, with an error naming the token's actual producer and the apply route it should be redeemed through. `apply_with_verify` stays producer-agnostic by design and now documents that supported set explicitly. Tokens whose producer is unrecorded (untagged producers, out-of-tree stores) still redeem unchanged; apply routes outside the refactoring family are not yet bound.

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -16,13 +16,25 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// (Roslyn layer); this wrapper only resolves the workspace, opens the write gate, and maps the
 /// returned <see cref="ApplyVerifyOutcome"/> onto the tool's JSON wire shape.
 /// </summary>
+/// <remarks>
+/// <b>preview-token-apply-route-provenance:</b> this route is deliberately producer-AGNOSTIC and
+/// therefore does NOT call <c>ToolDispatch.RequireCompatibleProducer</c>. Its supported set is
+/// "every token held by <see cref="IPreviewStore"/>" — the store is the parameter type, so the
+/// admissible set is enforced by construction and any <see cref="RoslynMcp.Core.Models.PreviewKind"/>
+/// is legitimate here; adding a guard that accepts every member would be unreachable code. The
+/// named <c>*_apply</c> routes in <c>RefactoringTools</c> are the ones that bind to a single
+/// producer family. Tokens from <c>ICompositePreviewStore</c> / <c>IProjectMutationPreviewStore</c>
+/// are structurally out of reach and already surface as <see cref="PreviewTokenStaleException"/>
+/// from the <c>PeekWorkspaceId</c> miss below. The tool's <c>[Description]</c> states this set
+/// explicitly so callers do not have to infer it.
+/// </remarks>
 [McpServerToolType]
 public static class ApplyWithVerifyTool
 {
     [McpServerTool(Name = "apply_with_verify", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "experimental", false, true,
         "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),
-     Description("Apply a previously previewed refactoring AND immediately verify the workspace still compiles. When new compile errors appear (relative to the pre-apply baseline), automatically revert via revert_last_apply and return status=\"rolled_back\" with the introduced errors. Otherwise return status=\"applied\". Pass rollbackOnError=false to keep broken state for inspection (returns status=\"applied_with_errors\").")]
+     Description("Apply a previously previewed refactoring AND immediately verify the workspace still compiles. Supported producers: any token from a solution-snapshot *_preview tool (rename/organize_usings/format_document/format_range/code_fix_preview, plus untagged ones such as parameter_object_preview) — unlike the named *_apply routes this one is producer-agnostic and never rejects a token for its producer family. Composite and project-mutation tokens are not redeemable here; use apply_composite_preview / apply_project_mutation. When new compile errors appear (relative to the pre-apply baseline), automatically revert via revert_last_apply and return status=\"rolled_back\" with the introduced errors. Otherwise return status=\"applied\". Pass rollbackOnError=false to keep broken state for inspection (returns status=\"applied_with_errors\").")]
     public static Task<string> ApplyWithVerify(
         IWorkspaceExecutionGate gate,
         IApplyUndoWorkflowService workflowService,

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -52,7 +53,11 @@ public static class RefactoringTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "rename_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.SymbolRename,
+            applyRoute: "rename_apply");
 
     [McpServerTool(Name = "organize_usings_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview organizing using directives in a file: removes unused usings and sorts them")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -83,7 +88,11 @@ public static class RefactoringTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "organize_usings_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.OrganizeUsings,
+            applyRoute: "organize_usings_apply");
 
     [McpServerTool(Name = "format_document_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview formatting a document: applies standard C# formatting rules")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -114,7 +123,11 @@ public static class RefactoringTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "format_document_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.FormatDocument,
+            applyRoute: "format_document_apply");
 
     [McpServerTool(Name = "code_fix_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview a curated code fix for a specific diagnostic occurrence")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -149,7 +162,11 @@ public static class RefactoringTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "code_fix_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.CodeFix,
+            applyRoute: "code_fix_apply");
 
     [McpServerTool(Name = "format_range_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "stable", true, false,
@@ -186,7 +203,11 @@ public static class RefactoringTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "format_range_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.FormatRange,
+            applyRoute: "format_range_apply");
 
     [McpServerTool(Name = "format_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Security;
@@ -18,7 +19,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// <para>
 /// <b>Dispatch shapes</b> — one helper method per workspace-gating pattern:
 /// <list type="bullet">
-///   <item><see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>
+///   <item><see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
 ///     — <c>*_apply</c> tools that receive an opaque preview token; resolves the
 ///     workspaceId via the store's <c>PeekWorkspaceId</c> peek and runs under the
 ///     per-workspace write gate. Also has a delegate-peek overload for preview stores
@@ -99,6 +100,17 @@ internal static class ToolDispatch
     /// can emit a parameter-less lambda identical to the existing hand-written body.
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>
+    /// <param name="expectedKind">
+    /// preview-token-apply-route-provenance: the producer family this route accepts. Defaults to
+    /// <see cref="PreviewKind.Unspecified"/> — "route not bound", no enforcement — so the ~10 apply
+    /// families that have not yet declared a producer set keep their existing behavior without an
+    /// edit. See <see cref="RequireCompatibleProducer"/> for the fail-open/fail-closed semantics.
+    /// </param>
+    /// <param name="applyRoute">
+    /// preview-token-apply-route-provenance: this route's tool name, used only to make the mismatch
+    /// error name the route the caller actually invoked. Falls back to the canonical route for
+    /// <paramref name="expectedKind"/> when omitted.
+    /// </param>
     /// <returns>
     /// The DTO serialized with <see cref="JsonDefaults.Indented"/>.
     /// </returns>
@@ -116,11 +128,18 @@ internal static class ToolDispatch
         IPreviewStore previewStore,
         string previewToken,
         Func<CancellationToken, Task<TDto>> serviceCall,
-        CancellationToken ct)
+        CancellationToken ct,
+        PreviewKind expectedKind = PreviewKind.Unspecified,
+        string? applyRoute = null)
     {
         var wsId = RequirePreviewWorkspaceId(previewStore.PeekWorkspaceId, previewToken);
         return gate.RunWriteAsync(wsId, async c =>
         {
+            // preview-token-apply-route-provenance: refuse a token minted by a different producer
+            // family BEFORE any mutation — and before the boundary revalidation below, so a
+            // wrong-route redemption never reaches RevalidateChangedPathsAsync or TryApplyChanges.
+            RequireCompatibleProducer(previewStore, previewToken, expectedKind, applyRoute);
+
             // preview-apply-token-write-path-toctou: revalidate the preview's write set against
             // the sanctioned-root boundary AT REDEMPTION TIME, under the same write gate that
             // holds until the persistence write. The only boundary check before this ran in the
@@ -131,6 +150,83 @@ internal static class ToolDispatch
             return JsonSerializer.Serialize(result, JsonDefaults.Indented);
         }, ct);
     }
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: binds a redeeming <c>*_apply</c> route to the producer
+    /// family that minted the token, using the non-consuming
+    /// <see cref="IPreviewStore.PeekKind(string)"/> peek. Fails OPEN on unknown provenance and
+    /// CLOSED only on a present-and-incompatible one — mirroring the
+    /// <see cref="IPreviewStore.PeekChangedPaths(string)"/> "null means unknown, skip, never
+    /// verified" convention:
+    /// <list type="bullet">
+    ///   <item><paramref name="expectedKind"/> is <see cref="PreviewKind.Unspecified"/> — the route
+    ///     has not declared a producer set, so no enforcement (the ~10 other
+    ///     <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
+    ///     apply families are still in this state; binding them is a follow-up row).</item>
+    ///   <item>The stored kind is <see cref="PreviewKind.Unspecified"/> — an untagged producer or an
+    ///     out-of-tree store that does not track provenance. Permissive by the enum's own documented
+    ///     contract; every apply route MUST accept it.</item>
+    ///   <item>Both are concrete and differ — throw before mutation.</item>
+    /// </list>
+    /// The guard does not consume or TTL-refresh the entry.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the token's recorded producer is concrete and incompatible with the route. The
+    /// message names BOTH the actual producer's <c>*_preview</c> tool and the <c>*_apply</c> route
+    /// the token should be redeemed through, so the caller can correct the call without guessing.
+    /// Surfaces through <c>ToolErrorHandler</c>'s generic envelope.
+    /// </exception>
+    internal static void RequireCompatibleProducer(
+        IPreviewStore previewStore,
+        string previewToken,
+        PreviewKind expectedKind,
+        string? applyRoute)
+    {
+        if (expectedKind == PreviewKind.Unspecified)
+        {
+            return;
+        }
+
+        var actualKind = previewStore.PeekKind(previewToken);
+        if (actualKind == PreviewKind.Unspecified || actualKind == expectedKind)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Preview token '{previewToken}' was produced by `{PreviewToolFor(actualKind)}`; " +
+            $"redeem it via `{ApplyRouteFor(actualKind)}` (or the generic `apply_with_verify`), " +
+            $"not `{applyRoute ?? ApplyRouteFor(expectedKind)}`, which only accepts " +
+            $"`{PreviewToolFor(expectedKind)}` tokens. No workspace changes were made.");
+    }
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: the <c>*_preview</c> tool name that mints each
+    /// <see cref="PreviewKind"/>, for the actionable half of the mismatch message.
+    /// </summary>
+    private static string PreviewToolFor(PreviewKind kind) => kind switch
+    {
+        PreviewKind.SymbolRename => "rename_preview",
+        PreviewKind.FormatDocument => "format_document_preview",
+        PreviewKind.FormatRange => "format_range_preview",
+        PreviewKind.OrganizeUsings => "organize_usings_preview",
+        PreviewKind.CodeFix => "code_fix_preview",
+        _ => "an untagged *_preview tool",
+    };
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: the named <c>*_apply</c> route bound to each
+    /// <see cref="PreviewKind"/>, for the recovery half of the mismatch message.
+    /// </summary>
+    private static string ApplyRouteFor(PreviewKind kind) => kind switch
+    {
+        PreviewKind.SymbolRename => "rename_apply",
+        PreviewKind.FormatDocument => "format_document_apply",
+        PreviewKind.FormatRange => "format_range_apply",
+        PreviewKind.OrganizeUsings => "organize_usings_apply",
+        PreviewKind.CodeFix => "code_fix_apply",
+        _ => "apply_with_verify",
+    };
 
     /// <summary>
     /// preview-apply-token-write-path-toctou: runs every path in the preview's write set through
@@ -205,7 +301,7 @@ internal static class ToolDispatch
     /// A closure that invokes the service method with the <paramref name="previewToken"/>
     /// and the gate-provided <see cref="CancellationToken"/>. Kept as
     /// <c>Func&lt;CancellationToken, Task&lt;TDto&gt;&gt;</c> for the same reason as the
-    /// primary <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken)"/>
+    /// primary <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
     /// overload: closure capture matches the existing hand-written shim bodies byte-for-byte.
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>

--- a/tests/RoslynMcp.Tests/ApplyUndoWorkflowServiceTests.cs
+++ b/tests/RoslynMcp.Tests/ApplyUndoWorkflowServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Services;
 
@@ -231,6 +232,61 @@ public sealed class ApplyUndoWorkflowServiceTests
         }
     }
 
+    /// <summary>
+    /// preview-token-apply-route-provenance: <c>apply_with_verify</c> is the generic verified
+    /// route and its documented supported set is "every token held by <see cref="IPreviewStore"/>".
+    /// This pins that the tool matches its own <c>[Description]</c>: a token carrying a CONCRETE,
+    /// unrelated producer kind (one that <c>rename_apply</c> would refuse) still redeems here.
+    /// Guards against a future edit copying the named routes' producer binding onto this route.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyWithVerify_IsProducerAgnostic_AcceptsAnyPreviewStoreKind()
+    {
+        var compile = new FakeCompileCheck(CleanCheck(), CleanCheck());
+        var undo = new FakeUndo();
+        var refactoring = new FakeRefactoring { Result = new ApplyResultDto(true, new[] { "A.cs" }, null) };
+        var gate = new PassThroughGate();
+        var store = new FakePreviewStore("ws") { Kind = PreviewKind.CodeFix };
+        var service = Create(compile, undo, refactoring);
+
+        var json = await ApplyWithVerifyTool.ApplyWithVerify(
+            gate,
+            service,
+            store,
+            previewToken: "tok-any-producer",
+            rollbackOnError: true,
+            CancellationToken.None);
+
+        StringAssert.Contains(json, "\"applied\"",
+            "apply_with_verify must accept a token from any IPreviewStore producer family.");
+        Assert.AreEqual(1, gate.WriteCallCount, "The route still runs under the per-workspace write gate.");
+    }
+
+    /// <summary>
+    /// Pass-through <see cref="IWorkspaceExecutionGate"/> so the tool shim can be exercised without
+    /// a live workspace. Load-gate and gate-removal verbs throw: <c>apply_with_verify</c> must not
+    /// route through them.
+    /// </summary>
+    private sealed class PassThroughGate : IWorkspaceExecutionGate
+    {
+        public int WriteCallCount { get; private set; }
+
+        public Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => action(ct);
+
+        public Task<T> RunWriteAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct, bool applyStalenessPolicy = true)
+        {
+            WriteCallCount++;
+            return action(ct);
+        }
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new NotSupportedException("apply_with_verify must not route through RunLoadGateAsync.");
+
+        public void RemoveGate(string workspaceId)
+            => throw new NotSupportedException("apply_with_verify must not call RemoveGate.");
+    }
+
     private sealed class FakeRefactoring : IRefactoringService
     {
         public ApplyResultDto Result = new(true, new[] { "A.cs" }, null);
@@ -291,7 +347,15 @@ public sealed class ApplyUndoWorkflowServiceTests
 
         public FakePreviewStore(string workspaceId) => _workspaceId = workspaceId;
 
+        /// <summary>
+        /// preview-token-apply-route-provenance: producer family the fake reports. The generic
+        /// verified route is producer-agnostic, so a concrete value here must NOT block redemption.
+        /// </summary>
+        public PreviewKind Kind { get; init; } = PreviewKind.Unspecified;
+
         public string? PeekWorkspaceId(string token) => _workspaceId;
+
+        public PreviewKind PeekKind(string token) => Kind;
 
         // Retrieve returns null → project-filter derivation is skipped (full-solution compile).
         public (string WorkspaceId, Solution OriginalSolution, Solution ModifiedSolution, int WorkspaceVersion, string Description, bool DiffTruncated)? Retrieve(string token)

--- a/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterObjectPreviewTests.cs
@@ -1226,6 +1226,73 @@ public sealed class ParameterObjectPreviewTests : TestBase
         }
     }
 
+    /// <summary>
+    /// preview-token-apply-route-provenance: the cross-route regression. A token minted by
+    /// <c>rename_preview</c> (recorded as <see cref="PreviewKind.SymbolRename"/>) must be refused
+    /// by a named apply route bound to a different producer family — here
+    /// <c>format_document_apply</c> — BEFORE any workspace mutation. Asserts the file on disk is
+    /// byte-identical afterwards and that the error names both the actual producer and the route
+    /// the token should be redeemed through.
+    /// </summary>
+    /// <remarks>
+    /// The untagged half of the contract is covered by
+    /// <c>ApplyWithVerify_RedeemsPreviewAndWritesChangesToDisk</c> above: a
+    /// <c>parameter_object_preview</c> token carries <see cref="PreviewKind.Unspecified"/>
+    /// ("no provenance claim") and still redeems unchanged, which is the documented fail-open
+    /// behavior for producers that have not yet been tagged.
+    /// </remarks>
+    [TestMethod]
+    public async Task NamedApplyRoute_RejectsTokenFromAnotherProducer_WithoutMutatingDisk()
+    {
+        var (workspaceId, fixturePath, _) = await SetupSingleProjectFixtureAsync(
+            """
+            namespace SampleLib;
+
+            public class POXRouteFixture
+            {
+                public int Sum(int a, int b, int c) => a + b + c;
+
+                public int Caller() => Sum(1, 2, 3);
+            }
+            """,
+            "POXRouteFixture.cs");
+
+        try
+        {
+            var before = await File.ReadAllTextAsync(fixturePath);
+
+            var rename = await RefactoringService.PreviewRenameAsync(
+                workspaceId,
+                SymbolLocator.BySource(fixturePath, line: 5, column: 16), // 'Sum'
+                "Total",
+                CancellationToken.None);
+            Assert.IsNotNull(rename.PreviewToken, "rename_preview must mint a token for this fixture");
+
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                RefactoringTools.ApplyFormatDocument(
+                    WorkspaceExecutionGate,
+                    RefactoringService,
+                    PreviewStore,
+                    rename.PreviewToken!,
+                    CancellationToken.None));
+
+            StringAssert.Contains(ex.Message, "rename_preview",
+                "error must name the token's actual producer");
+            StringAssert.Contains(ex.Message, "rename_apply",
+                "error must name the apply route the token should be redeemed through");
+            StringAssert.Contains(ex.Message, "format_document_apply",
+                "error must name the route that was wrongly invoked");
+
+            var after = await File.ReadAllTextAsync(fixturePath);
+            Assert.AreEqual(before, after,
+                "A wrong-route redemption must be refused BEFORE any file is written.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+        }
+    }
+
     [TestMethod]
     public async Task ExplicitDtoNamespace_QualifiesDeclarationAndCallsiteReferences()
     {

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -28,6 +28,124 @@ namespace RoslynMcp.Tests;
 [TestClass]
 public sealed class ToolDispatchTests
 {
+    /// <summary>
+    /// preview-token-apply-route-provenance: a token whose recorded producer is concrete and
+    /// different from the route's declared producer must be refused BEFORE the service call runs,
+    /// with a message naming both the actual producer and the route it should be redeemed through.
+    /// Mirrors <see cref="ApplyByTokenAsync_ChangedPathOutsideBoundary_RefusesBeforeServiceCall"/>:
+    /// the guard sits inside the write gate but ahead of every mutation.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByTokenAsync_IncompatibleProducer_RefusesBeforeServiceCall()
+    {
+        var gate = new FakeGate();
+        var serviceCallRan = false;
+        var store = new FakePreviewStore(token: "tok-xroute", workspaceId: "ws-xr")
+        {
+            Kind = PreviewKind.CodeFix,
+        };
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+                gate,
+                store,
+                previewToken: "tok-xroute",
+                serviceCall: _ =>
+                {
+                    serviceCallRan = true;
+                    return Task.FromResult(new FakeResultDto("must-not-run", 0));
+                },
+                ct: CancellationToken.None,
+                expectedKind: PreviewKind.SymbolRename,
+                applyRoute: "rename_apply"));
+
+        Assert.IsFalse(serviceCallRan, "Provenance guard must refuse the apply BEFORE the service call runs.");
+        StringAssert.Contains(ex.Message, "code_fix_preview",
+            "message must name the token's ACTUAL producer so the caller knows what they hold");
+        StringAssert.Contains(ex.Message, "code_fix_apply",
+            "message must name the apply route the token SHOULD be redeemed through");
+        StringAssert.Contains(ex.Message, "rename_apply",
+            "message must name the route that was wrongly invoked");
+    }
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: the happy path — a token whose producer matches the
+    /// route's declared family redeems unchanged. Pins that binding the five named routes did not
+    /// regress their own previews.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByTokenAsync_MatchingProducer_Applies()
+    {
+        var gate = new FakeGate();
+        var store = new FakePreviewStore(token: "tok-match", workspaceId: "ws-m")
+        {
+            Kind = PreviewKind.SymbolRename,
+        };
+
+        var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+            gate,
+            store,
+            previewToken: "tok-match",
+            serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 1)),
+            ct: CancellationToken.None,
+            expectedKind: PreviewKind.SymbolRename,
+            applyRoute: "rename_apply");
+
+        StringAssert.Contains(result, "applied");
+    }
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: the guard fails OPEN on unknown provenance — an
+    /// untagged producer or an out-of-tree store that returns the interface default
+    /// <see cref="PreviewKind.Unspecified"/> still redeems on a bound route. Mirrors the
+    /// null-<c>PeekChangedPaths</c> skip in
+    /// <see cref="ApplyByTokenAsync_NullChangedPathsPeek_SkipsRevalidation_AndApplies"/>.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByTokenAsync_UnspecifiedProducer_SkipsGuard_AndApplies()
+    {
+        var gate = new FakeGate();
+        // Kind left at its default (Unspecified) — the interface-default / legacy-store shape.
+        var store = new FakePreviewStore(token: "tok-untagged", workspaceId: "ws-ut");
+
+        var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+            gate,
+            store,
+            previewToken: "tok-untagged",
+            serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 2)),
+            ct: CancellationToken.None,
+            expectedKind: PreviewKind.SymbolRename,
+            applyRoute: "rename_apply");
+
+        StringAssert.Contains(result, "applied",
+            "An Unspecified producer kind means 'no provenance claim' and must stay permissive.");
+    }
+
+    /// <summary>
+    /// preview-token-apply-route-provenance: an UNBOUND route (the ~10 apply families that have
+    /// not declared a producer set) performs no enforcement — a concrete, unrelated producer kind
+    /// still redeems. Pins the deliberate residue so it is a visible contract, not an accident.
+    /// </summary>
+    [TestMethod]
+    public async Task ApplyByTokenAsync_UnboundRoute_DoesNotEnforceProvenance()
+    {
+        var gate = new FakeGate();
+        var store = new FakePreviewStore(token: "tok-unbound", workspaceId: "ws-ub")
+        {
+            Kind = PreviewKind.FormatRange,
+        };
+
+        var result = await ToolDispatch.ApplyByTokenAsync<FakeResultDto>(
+            gate,
+            store,
+            previewToken: "tok-unbound",
+            serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 3)),
+            ct: CancellationToken.None);
+
+        StringAssert.Contains(result, "applied",
+            "A route that declares no expectedKind must keep its pre-binding behavior.");
+    }
+
     // Distinguishable payload type so the assertions can inspect JSON structure.
     private sealed record FakeResultDto(string Message, int Count);
 
@@ -339,9 +457,18 @@ public sealed class ToolDispatchTests
         /// </summary>
         public IReadOnlyList<string>? ChangedPaths { get; init; }
 
+        /// <summary>
+        /// preview-token-apply-route-provenance: producer family the fake reports for its token.
+        /// Defaults to <see cref="PreviewKind.Unspecified"/>, matching both the interface default
+        /// and an untagged producer.
+        /// </summary>
+        public PreviewKind Kind { get; init; } = PreviewKind.Unspecified;
+
         public string? PeekWorkspaceId(string token) => token == _token ? _workspaceId : null;
 
         public IReadOnlyList<string>? PeekChangedPaths(string token) => token == _token ? ChangedPaths : null;
+
+        public PreviewKind PeekKind(string token) => token == _token ? Kind : PreviewKind.Unspecified;
 
         public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
             => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

Every named `*_apply` route was provenance-blind. The route-name string passed to `ApplyRefactoringAsync` was a response/telemetry label only — never compared against the token's producer — so any `IPreviewStore` token redeemed on any route and mutated the workspace.

This is the **consumer half** of `preview-token-apply-route-provenance`; the `IPreviewStore.PeekKind` / `PreviewKind` discriminator shipped in the sibling slice. `IPreviewStore.cs` / `PreviewStore.cs` are untouched here.

## Changes

- **`ToolDispatch.cs`** — `ApplyByTokenAsync` gains optional `expectedKind` / `applyRoute` parameters and a `RequireCompatibleProducer` guard. The guard runs **inside** the write gate and **ahead of** `RevalidateChangedPathsAsync`, so a wrong-route redemption never reaches boundary revalidation or `TryApplyChanges`. It uses the non-consuming `PeekKind` peek (no TTL refresh) and mirrors the `PeekChangedPaths` null-means-unknown convention: fails **open** on `PreviewKind.Unspecified` (untagged producers, out-of-tree stores), **closed** only on a present-and-incompatible kind. The error names the token's actual `*_preview` producer *and* the `*_apply` route it should be redeemed through.
- **`RefactoringTools.cs`** — `rename_apply`, `organize_usings_apply`, `format_document_apply`, `code_fix_apply`, `format_range_apply` each declare their producer family (one added argument per shim).
- **`ApplyWithVerifyTool.cs`** — the generic verified route is producer-agnostic *by construction* (`IPreviewStore` is the parameter type, so every `PreviewKind` is legitimate); adding a guard that accepts every member would be unreachable code. Its `[Description]` now states the supported set explicitly, and a `<remarks>` block records why this route deliberately does not call the guard.

## Deliberate residue

The new parameter is **optional**. The other ~10 `ApplyByTokenAsync` apply families (BulkRefactoring, CodeAction, DeadCode, ExtractMethod, FileOperation, FixAll, InterfaceExtraction, MultiFileEdit, Orchestration, ProjectMutation, Scaffolding, TypeExtraction, TypeMove) stay unbound and unchanged — making the parameter required would have forced 15 production files into scope. That residue is a follow-up backlog row and is called out in the CHANGELOG fragment so the contract is not read as universal. `ApplyByTokenAsync_UnboundRoute_DoesNotEnforceProvenance` pins it as a visible contract rather than an accident.

## Tests

- `ToolDispatchTests` — incompatible producer refuses **before** the service call (message names actual producer + correct route + wrongly-invoked route); matching producer applies; `Unspecified` producer skips the guard; unbound route does not enforce.
- `ApplyUndoWorkflowServiceTests` — `apply_with_verify` accepts a token carrying a concrete, unrelated `PreviewKind`, pinning that the tool matches its own `[Description]`.
- `ParameterObjectPreviewTests` — cross-route regression: a real `rename_preview` token redeemed via `format_document_apply` throws and the fixture file on disk is byte-identical afterwards.

## Validation

- `dotnet build` (host + tests): 0 warnings, 0 errors.
- Targeted: `ToolDispatchTests`, `ApplyUndoWorkflowServiceTests`, `ApplyWithVerifyCancellationAndScopeTests`, `ParameterObjectPreviewTests`, `PreviewStoreTests` — 114 passed.
- Description/catalog gates: `SurfaceCatalogTests`, `ToolDescriptionDietWorkspaceValidationTests`, `PreviewTokenStale*`, `DiagnosticIdentitySet*`, `PreviewApplyBoundaryRevalidation*` — 50 passed.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-release.ps1` deliberately **not** run locally: the self-hosted runner serves this box, and CI validate is the parity gate.

Closes: preview-token-apply-route-provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
