### PR TITLE
feat(eng): gate formatter debt introduced on changed C# files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
           }
           ./eng/verify-release.ps1 @parameters
 
+      - name: Verify changed-file formatting
+        if: github.event_name == 'pull_request' && matrix.leg.artifact_owner == true && needs.route.outputs.docs_only != 'true'
+        shell: pwsh
+        run: ./eng/verify-changed-format.ps1 -BaseRef origin/${{ github.base_ref }} -NoRestore
+
       - name: Verify release build (dispatch / schedule)
         if: github.event_name != 'pull_request'
         shell: pwsh

--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -53,6 +53,7 @@ The router emits typed leg fields. Keep their concerns separate:
 | Exact declared SDK floor | Concurrent `sdk-floor` job on code PRs, dispatch, and schedule; exact version assertion + restore/build + representative MSBuildWorkspace load |
 | Publish/hash | Artifact-owning non-doc leg |
 | Fail-closed NuGet vulnerability audit | Artifact-owning non-doc leg |
+| Changed-file formatter gate | Artifact-owning non-doc pull-request leg; new findings on touched files fail, tracked baseline debt is reported not suppressed |
 | `host-stdio-publish`, `release-manifests` | Artifact-owning non-doc leg; 14 days |
 | Per-leg timing summary + TRX (`test-results-<leg>`) | Every pull-request/test leg, generated/uploaded with `always()`; 14 days |
 | Cobertura + HTML `code-coverage` | Dispatch/schedule artifact owner; 30 days |
@@ -106,10 +107,11 @@ Combine filters with `&` (AND) or `|` (OR) per `dotnet test` syntax.
 |---|---|
 | AI-doc changes | `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` |
 | Required PR-equivalent gate | `just ci` |
+| Formatter debt on touched C# files | `pwsh -NoProfile -File ./eng/verify-changed-format.ps1` |
 | Informational coverage/live-network gate | `just full` |
 | One release shard | `pwsh -NoProfile -File ./eng/verify-release.ps1 -NoCoverage -ExcludeNetworkTests -TestShardIndex <zero-based> -TestShardCount <count>` |
 
-`just ci` composes docs, shipped skills, unsharded PR-equivalent release validation, and the vulnerability audit. Local validation remains unsharded so one command proves the complete suite.
+`just ci` composes docs, shipped skills, the changed-file formatter gate, unsharded PR-equivalent release validation, and the vulnerability audit. Local validation remains unsharded so one command proves the complete suite.
 
 ## Merge Gating Expectations
 

--- a/changelog.d/format-changed-file-gate.md
+++ b/changelog.d/format-changed-file-gate.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `eng/verify-changed-format.ps1`, a changed-file formatter gate wired into the CI `validate` leg and `just ci`. New `IMPORTS`, `IDE1006`, `WHITESPACE`, and `FINALNEWLINE` violations on files a pull request touches now fail the build, while the tracked repository formatter baseline stays explicitly reported rather than suppressed.

--- a/eng/verify-changed-format.ps1
+++ b/eng/verify-changed-format.ps1
@@ -1,0 +1,303 @@
+<#
+.SYNOPSIS
+Changed-file formatter gate: fail the build on formatter debt a pull request introduces.
+
+.DESCRIPTION
+The repository carries a large, explicitly tracked formatter baseline (see
+`eng/format-baseline.json`, produced by `eng/generate-format-baseline.ps1`). A whole-repo
+`dotnet format --verify-no-changes` gate cannot be enabled while that debt exists — it would
+red every pull request. This script gates the only thing a pull request is responsible for:
+the files it actually touches, minus the debt those files already carried.
+
+Algorithm:
+  1. Resolve the changed set with `git diff --name-only --diff-filter=ACMR <BaseRef>...HEAD`,
+     filtered to `*.cs` files that still exist on disk. An empty set exits 0 immediately.
+  2. Run `dotnet format <solution> --verify-no-changes --no-restore` scoped to that set and
+     parse every reported diagnostic.
+  3. Bucket the findings per (file, diagnostic id) and compare the observed count against the
+     count the tracked baseline records for that same pair.
+       * observed <= baseline  -> PRE-EXISTING. Reported as explicitly tracked debt, not a failure.
+       * observed >  baseline  -> NEW. Fails the gate.
+     Counting (rather than merely testing for presence) is what closes the concealment hole: a
+     file that already carries one baseline `IDE1006` cannot smuggle in a second one.
+
+Scoping contract:
+  Findings are filtered to the changed set in PowerShell regardless of what `--include` does.
+  `--include` is still passed as an optimization (verified empirically to scope both the report
+  and the exit code), but correctness never depends on it. When the changed set is large enough
+  that `--include` would risk the operating-system command-line limit, the argument is dropped
+  and the solution-wide scan is narrowed by the same PowerShell filter.
+
+Rename contract:
+  `--diff-filter=ACMR` includes renames, and the baseline is keyed by path. A file moved to a new
+  path therefore reports its inherited debt as NEW. That is deliberate: a rename is the natural
+  moment to repair a file's formatter debt, and the alternative (following renames) would let debt
+  travel silently forever. Repair the file, or regenerate the baseline in the same pull request.
+
+Fail-closed contract:
+  `dotnet format` silently skips projects whose references did not load, which would shrink the
+  report to nothing and pass the gate. The truncation marker is treated as fatal, and the script
+  restores first unless `-NoRestore` says the caller already did.
+
+.PARAMETER BaseRef
+Git ref the pull request is measured against. Defaults to `origin/main`.
+
+.PARAMETER BaselinePath
+Tracked formatter baseline inventory. Relative paths resolve against the repository root.
+
+.PARAMETER SolutionPath
+Solution or project `dotnet format` runs against. Relative paths resolve against the repository root.
+
+.PARAMETER NoRestore
+Skip the `dotnet restore` precondition. Only safe when the caller already restored this tree.
+
+.PARAMETER Quiet
+Suppress the per-file informational listing. Failures and the terminal summary are always printed.
+#>
+param(
+    [string]$BaseRef = "origin/main",
+
+    [string]$BaselinePath = "eng/format-baseline.json",
+
+    [string]$SolutionPath = "RoslynMcp.slnx",
+
+    [switch]$NoRestore,
+
+    [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Beyond this many characters of `--include` payload the argument is dropped and the
+# PowerShell-side filter alone scopes the result. Keeps the gate correct on rename-heavy or
+# very wide pull requests instead of failing on a command line the OS refuses to launch.
+$includeArgumentBudget = 20000
+$truncationMarker = "Required references did not load"
+$gatedDiagnosticIds = @("FINALNEWLINE", "IDE1006", "IMPORTS", "WHITESPACE")
+
+function Resolve-RepositoryRoot {
+    $global:LASTEXITCODE = 0
+    $root = (& git rev-parse --show-toplevel 2>&1 | Select-Object -First 1)
+    if ($global:LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) {
+        throw "verify-changed-format must run inside a git working tree; 'git rev-parse --show-toplevel' failed: $root"
+    }
+
+    return [System.IO.Path]::GetFullPath($root.Trim())
+}
+
+function Resolve-AgainstRoot {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Root
+    )
+
+    if ([System.IO.Path]::IsPathFullyQualified($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path -Path $Root -ChildPath $Path))
+}
+
+function ConvertTo-RepositoryRelativePath {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Root
+    )
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    $prefix = $Root.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $full.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    return $full.Substring($prefix.Length).Replace("\", "/")
+}
+
+$repositoryRoot = Resolve-RepositoryRoot
+$resolvedSolutionPath = Resolve-AgainstRoot -Path $SolutionPath -Root $repositoryRoot
+if (-not [System.IO.File]::Exists($resolvedSolutionPath)) {
+    throw "Formatter gate solution does not exist: '$resolvedSolutionPath'."
+}
+
+$resolvedBaselinePath = Resolve-AgainstRoot -Path $BaselinePath -Root $repositoryRoot
+if (-not [System.IO.File]::Exists($resolvedBaselinePath)) {
+    throw "Formatter baseline inventory does not exist: '$resolvedBaselinePath'. Generate it with eng/generate-format-baseline.ps1."
+}
+
+# Baseline shape: { files: [ { path, countsByDiagnosticId: { <id>: <count> } } ] }.
+# Flattened to "<path>|<id>" -> count so a lookup miss is unambiguously "no tracked debt".
+$baselineDocument = Get-Content -LiteralPath $resolvedBaselinePath -Raw | ConvertFrom-Json
+$baselineCounts = @{}
+foreach ($entry in @($baselineDocument.files)) {
+    $entryPath = [string]$entry.path
+    foreach ($property in $entry.countsByDiagnosticId.PSObject.Properties) {
+        $baselineCounts["$entryPath|$($property.Name)"] = [int]$property.Value
+    }
+}
+
+Push-Location -LiteralPath $repositoryRoot
+try {
+    $global:LASTEXITCODE = 0
+    $diffOutput = @(& git diff --name-only --diff-filter=ACMR "$BaseRef...HEAD" -- "*.cs" 2>&1 | ForEach-Object { $_.ToString() })
+    if ($global:LASTEXITCODE -ne 0) {
+        throw "Unable to diff against '$BaseRef'. Fetch the base ref (CI uses fetch-depth: 0) before running the formatter gate.`n$($diffOutput -join [System.Environment]::NewLine)"
+    }
+
+    $changedFiles = [string[]]@(
+        $diffOutput |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { $_.Trim().Replace("\", "/") } |
+            Where-Object { [System.IO.File]::Exists((Join-Path -Path $repositoryRoot -ChildPath $_)) } |
+            Sort-Object -Unique
+    )
+
+    if ($changedFiles.Count -eq 0) {
+        Write-Host "Changed-file formatter gate: no changed C# files against '$BaseRef'; nothing to verify."
+        exit 0
+    }
+
+    if (-not $Quiet) {
+        Write-Host "Changed-file formatter gate: verifying $($changedFiles.Count) changed C# file(s) against '$BaseRef'."
+    }
+
+    if (-not $NoRestore) {
+        $global:LASTEXITCODE = 0
+        $restoreOutput = @(& dotnet restore $resolvedSolutionPath 2>&1 | ForEach-Object { $_.ToString() })
+        if ($global:LASTEXITCODE -ne 0) {
+            throw "dotnet restore failed with exit code $($global:LASTEXITCODE):`n$($restoreOutput -join [System.Environment]::NewLine)"
+        }
+    }
+
+    $formatArguments = [System.Collections.Generic.List[string]]::new()
+    $formatArguments.Add("format")
+    $formatArguments.Add($resolvedSolutionPath)
+    $formatArguments.Add("--verify-no-changes")
+    $formatArguments.Add("--no-restore")
+
+    $includePayloadLength = ($changedFiles | Measure-Object -Property Length -Sum).Sum + $changedFiles.Count
+    if ($includePayloadLength -le $includeArgumentBudget) {
+        $formatArguments.Add("--include")
+        foreach ($changedFile in $changedFiles) {
+            $formatArguments.Add($changedFile)
+        }
+    }
+    elseif (-not $Quiet) {
+        Write-Host "Changed-file formatter gate: changed set too wide for --include; scanning the solution and filtering to the changed set."
+    }
+
+    $global:LASTEXITCODE = 0
+    $formatOutput = @(& dotnet @formatArguments 2>&1 | ForEach-Object { $_.ToString() })
+    $formatExitCode = $global:LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+if ($formatExitCode -ne 0 -and $formatExitCode -ne 2) {
+    throw "dotnet format exited with unexpected code $formatExitCode.`n$($formatOutput -join [System.Environment]::NewLine)"
+}
+
+$truncated = @($formatOutput | Where-Object { $_ -like "*$truncationMarker*" })
+if ($truncated.Count -gt 0) {
+    throw "dotnet format produced a truncated report (unrestored projects were skipped), so the gate cannot prove the changed files are clean: $($truncated[0])"
+}
+
+# Same diagnostic grammar the baseline generator parses, so the gate and the inventory can never
+# disagree about what counts as a finding.
+$diagnosticPattern = '^(?<path>.+?)\((?<line>\d+),(?<column>\d+)\): (?<severity>error|warning) (?<id>[A-Za-z0-9_]+): (?<message>.*?)(?: \[(?<project>[^\]]+)\])?$'
+$changedFileSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$changedFiles, [System.StringComparer]::OrdinalIgnoreCase)
+$findingKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$observedCounts = @{}
+$observedMessages = @{}
+
+foreach ($line in $formatOutput) {
+    $match = [regex]::Match($line, $diagnosticPattern)
+    if (-not $match.Success) {
+        continue
+    }
+
+    $relativePath = ConvertTo-RepositoryRelativePath -Path $match.Groups["path"].Value -Root $repositoryRoot
+    if ($null -eq $relativePath -or -not $changedFileSet.Contains($relativePath)) {
+        continue
+    }
+
+    $diagnosticId = $match.Groups["id"].Value
+    # A file owned by more than one project is reported once per owning project; de-duplicate on
+    # position so multi-targeted projects cannot inflate the count past the baseline and red the gate.
+    $key = "$relativePath|$diagnosticId|$($match.Groups['line'].Value)|$($match.Groups['column'].Value)"
+    if (-not $findingKeys.Add($key)) {
+        continue
+    }
+
+    $bucket = "$relativePath|$diagnosticId"
+    if (-not $observedCounts.ContainsKey($bucket)) {
+        $observedCounts[$bucket] = 0
+        $observedMessages[$bucket] = [System.Collections.Generic.List[string]]::new()
+    }
+
+    $observedCounts[$bucket] = $observedCounts[$bucket] + 1
+    $observedMessages[$bucket].Add("$relativePath($($match.Groups['line'].Value),$($match.Groups['column'].Value)): $diagnosticId`: $($match.Groups['message'].Value)")
+}
+
+$ordinal = [System.StringComparer]::Ordinal
+$sortedBuckets = [string[]]@($observedCounts.Keys)
+[System.Array]::Sort($sortedBuckets, $ordinal)
+
+$newFindings = [System.Collections.Generic.List[string]]::new()
+$trackedFindings = [System.Collections.Generic.List[string]]::new()
+$newFindingCount = 0
+$trackedFindingCount = 0
+
+foreach ($bucket in $sortedBuckets) {
+    $observed = $observedCounts[$bucket]
+    $baseline = if ($baselineCounts.ContainsKey($bucket)) { $baselineCounts[$bucket] } else { 0 }
+    $tracked = [System.Math]::Min($observed, $baseline)
+    $introduced = $observed - $baseline
+
+    $parts = $bucket.Split("|")
+    $bucketPath = $parts[0]
+    $bucketId = $parts[1]
+
+    if ($tracked -gt 0) {
+        $trackedFindingCount += $tracked
+        $trackedFindings.Add("  tracked debt: $bucketPath - $bucketId x$tracked (baseline $baseline)")
+    }
+
+    if ($introduced -gt 0) {
+        $newFindingCount += $introduced
+        $newFindings.Add("  NEW: $bucketPath - $bucketId x$introduced (observed $observed, baseline $baseline)")
+        # Every observed position is listed. The baseline records counts, not positions, so the
+        # gate can prove how many findings are new but never which ones — printing only a "sample"
+        # would point at an arbitrary occurrence and send the reader to the wrong line.
+        foreach ($observedMessage in $observedMessages[$bucket]) {
+            $newFindings.Add("       $observedMessage")
+        }
+    }
+}
+
+if ($trackedFindings.Count -gt 0 -and -not $Quiet) {
+    Write-Host "Changed-file formatter gate: $trackedFindingCount pre-existing finding(s) on changed files are recorded in '$BaselinePath' and are reported, not suppressed."
+    foreach ($tracked in $trackedFindings) {
+        Write-Host $tracked
+    }
+}
+
+if ($newFindings.Count -gt 0) {
+    $message = [System.Collections.Generic.List[string]]::new()
+    $message.Add("Changed-file formatter gate FAILED: $newFindingCount formatter finding(s) introduced on files this change touches.")
+    foreach ($finding in $newFindings) {
+        $message.Add($finding)
+    }
+
+    $message.Add("Gated diagnostics: $($gatedDiagnosticIds -join ', '). Fix them with 'dotnet format $SolutionPath --include <file>'.")
+    $message.Add("A renamed file inherits no baseline entry by design; repair it, or regenerate eng/format-baseline.json in this change.")
+    # [Console]::Error rather than Write-Error: under `pwsh -File` the host renders an error record
+    # with ANSI escapes and re-wraps it, which destroys the per-finding line structure this message
+    # exists to convey.
+    [Console]::Error.WriteLine($message -join [System.Environment]::NewLine)
+    exit 1
+}
+
+Write-Host "Changed-file formatter gate passed: $($changedFiles.Count) changed C# file(s), 0 new finding(s), $trackedFindingCount tracked baseline finding(s)."
+exit 0

--- a/justfile
+++ b/justfile
@@ -52,6 +52,10 @@ verify-version-drift:
 verify-skills:
     pwsh -NoProfile -File ./eng/verify-skills-are-generic.ps1
 
+# Gate formatter debt introduced on the C# files this change touches (baseline debt stays tracked)
+verify-changed-format:
+    pwsh -NoProfile -File ./eng/verify-changed-format.ps1
+
 # MCP registry install-readiness scorecard (writes artifacts/registry-readiness.json)
 verify-registry-readiness:
     pwsh -NoProfile -File ./eng/verify-registry-readiness.ps1
@@ -68,10 +72,10 @@ run:
 validate: build test
 
 # Local equivalent of the required pull-request pipeline (no coverage/live-network canary)
-ci: verify-docs verify-skills verify-release-pr vuln-audit
+ci: verify-docs verify-skills verify-changed-format verify-release-pr vuln-audit
 
 # Everything including coverage and the live-network canary
-full: verify-docs verify-skills verify-release vuln-audit
+full: verify-docs verify-skills verify-changed-format verify-release vuln-audit
 
 # --- Clean ---
 

--- a/tests/RoslynMcp.Tests/CiRunnerParityContractTests.cs
+++ b/tests/RoslynMcp.Tests/CiRunnerParityContractTests.cs
@@ -207,12 +207,25 @@ public sealed class CiRunnerParityContractTests
         StringAssert.Contains(releaseStep, "./eng/verify-release.ps1 @parameters");
         Assert.IsFalse(releaseStep.Contains("--filter", StringComparison.Ordinal));
 
-        StringAssert.Contains(justfile, "ci: verify-docs verify-skills verify-release-pr vuln-audit");
+        StringAssert.Contains(justfile, "ci: verify-docs verify-skills verify-changed-format verify-release-pr vuln-audit");
         StringAssert.Contains(
             justfile,
             "verify-release-pr:\n" +
             "    pwsh -NoProfile -File ./eng/verify-release.ps1 -NoCoverage -ExcludeNetworkTests");
-        StringAssert.Contains(justfile, "full: verify-docs verify-skills verify-release vuln-audit");
+        StringAssert.Contains(justfile, "full: verify-docs verify-skills verify-changed-format verify-release vuln-audit");
+
+        // The changed-file formatter gate is a standalone validate-leg step, deliberately NOT a
+        // verify-release child (that script's child set is a separate hard-listed contract). Local
+        // `just ci` therefore has to invoke it directly or it would run only in CI.
+        var formatStep = GetNamedStepBlock(validate, "Verify changed-file formatting");
+        StringAssert.Contains(
+            formatStep,
+            "if: github.event_name == 'pull_request' && matrix.leg.artifact_owner == true && needs.route.outputs.docs_only != 'true'");
+        StringAssert.Contains(formatStep, "./eng/verify-changed-format.ps1 -BaseRef origin/${{ github.base_ref }} -NoRestore");
+        StringAssert.Contains(
+            justfile,
+            "verify-changed-format:\n" +
+            "    pwsh -NoProfile -File ./eng/verify-changed-format.ps1");
     }
 
     [TestMethod]

--- a/tests/RoslynMcp.Tests/Skills/ChangedFormatGateScriptTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/ChangedFormatGateScriptTests.cs
@@ -1,0 +1,373 @@
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RoslynMcp.Tests.Skills;
+
+/// <summary>
+/// format-changed-file-gate: behavior tests for <c>eng/verify-changed-format.ps1</c>.
+///
+/// The gate exists because the repository carries a large tracked formatter baseline
+/// (<c>eng/format-baseline.json</c>) that makes a whole-repo <c>dotnet format --verify-no-changes</c>
+/// gate impossible. It therefore verifies only the files a change touches, and only the findings
+/// those files did not already carry in the baseline.
+///
+/// HARD INVARIANT: every test seeds an isolated temp git repository under
+/// <see cref="TestTempRoot.Current"/> containing its own project, <c>.editorconfig</c>, and
+/// baseline inventory, then shells the REAL script against it. Nothing here reads or mutates the
+/// production repository. Pattern mirrors <c>AggregatePromotionScorecardsScriptTests.cs</c>.
+///
+/// The tests deliberately drive real <c>dotnet format</c> rather than a stubbed parser: the whole
+/// value of the gate is that the diagnostic ids it classifies are the ids the formatter actually
+/// emits, which a stub would silently stop proving the moment the SDK changed its wording.
+/// </summary>
+[TestClass]
+public sealed class ChangedFormatGateScriptTests
+{
+    // Expressed as properties rather than `private const` / `private static readonly` fields on
+    // purpose: .editorconfig's private_fields naming rule declares `applicable_kinds = field` with no
+    // required modifiers, so it demands a leading underscore on constants too. The repository's real
+    // convention is PascalCase constants, and every such field is tracked debt in eng/format-baseline.json.
+    // A new file must not add to that inventory, and must not rename constants to satisfy a rule the
+    // repository does not actually follow.
+    private static string BaseBranchName => "gate-base";
+
+    private static string ProjectFileName => "Probe.csproj";
+
+    /// <summary>
+    /// A file carrying exactly one <c>IDE1006</c> finding, mirrored by <see cref="BaselineWithOneDirtyIde1006"/>.
+    /// Used as the "already in the inventory" fixture for the tracked-debt and concealment cases.
+    /// </summary>
+    private static string DirtyFileWithOneNamingViolation =>
+        "namespace Probe;\n\npublic sealed class Dirty\n{\n    private int badField;\n\n    public int Value => badField;\n}\n";
+
+    private static string CleanFile =>
+        "namespace Probe;\n\npublic sealed class Clean\n{\n    public int Value => 1;\n}\n";
+
+    private static string BaselineWithOneDirtyIde1006 => """
+        {
+          "schemaVersion": 1,
+          "command": "dotnet format Probe.csproj --verify-no-changes --no-restore",
+          "diagnosticIds": [ "IDE1006" ],
+          "totals": {
+            "findingCount": 1,
+            "fileCount": 1,
+            "countsByDiagnosticId": { "IDE1006": 1 }
+          },
+          "files": [
+            {
+              "path": "Dirty.cs",
+              "findingCount": 1,
+              "diagnosticIds": [ "IDE1006" ],
+              "countsByDiagnosticId": { "IDE1006": 1 }
+            }
+          ]
+        }
+        """;
+
+    private static string EmptyBaseline => """
+        {
+          "schemaVersion": 1,
+          "command": "dotnet format Probe.csproj --verify-no-changes --no-restore",
+          "diagnosticIds": [],
+          "totals": { "findingCount": 0, "fileCount": 0, "countsByDiagnosticId": {} },
+          "files": []
+        }
+        """;
+
+    private string _repositoryDirectory = string.Empty;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _repositoryDirectory = Path.Combine(TestTempRoot.Current, "ChangedFormatGate", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_repositoryDirectory);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestFixtureFileSystem.DeleteDirectoryIfExists(_repositoryDirectory);
+    }
+
+    [TestMethod]
+    public void Script_FileExistsAtDocumentedPath()
+    {
+        var scriptPath = ResolveScriptPath();
+        Assert.IsTrue(
+            File.Exists(scriptPath),
+            $"verify-changed-format.ps1 was not found at the documented path '{scriptPath}'. " +
+            "CI_POLICY.md, the justfile `verify-changed-format` recipe, and the ci.yml validate leg " +
+            "all reference this exact path; without the file every one of them is a dead reference.");
+    }
+
+    [TestMethod]
+    public void Gate_NoChangedCSharpFiles_PassesWithAnExplicitNoOp()
+    {
+        SeedBaseCommit(EmptyBaseline, ("Clean.cs", CleanFile));
+
+        // A commit that touches no C# file at all. The gate must say so explicitly rather than
+        // silently reporting success, so a misconfigured base ref cannot look like a green run.
+        WriteRepositoryFile("README.md", "# probe\n");
+        CommitAll("docs only");
+
+        var result = RunGate();
+
+        Assert.AreEqual(0, result.ExitCode, Describe("A change with no C# files must pass", result));
+        StringAssert.Contains(
+            result.StdOut,
+            "no changed C# files",
+            Describe("The no-op path must be reported explicitly", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileIsClean_Passes()
+    {
+        SeedBaseCommit(EmptyBaseline, ("Clean.cs", CleanFile));
+
+        WriteRepositoryFile("Clean.cs", "namespace Probe;\n\npublic sealed class Clean\n{\n    public int Value => 42;\n}\n");
+        CommitAll("clean edit");
+
+        var result = RunGate();
+
+        Assert.AreEqual(0, result.ExitCode, Describe("A formatter-clean changed file must pass", result));
+        StringAssert.Contains(result.StdOut, "0 new finding(s)", Describe("The pass summary must report zero new findings", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileIntroducesUnsortedUsings_FailsWithAnImportsFinding()
+    {
+        SeedBaseCommit(EmptyBaseline, ("Clean.cs", CleanFile));
+
+        // `System.Text` before `System` violates dotnet_sort_system_directives_first -> IMPORTS.
+        WriteRepositoryFile(
+            "Clean.cs",
+            "using System.Text;\nusing System;\n\nnamespace Probe;\n\npublic sealed class Clean\n{\n" +
+            "    public int Value => new StringBuilder().Length + Console.In.GetHashCode();\n}\n");
+        CommitAll("unsorted usings");
+
+        var result = RunGate();
+
+        Assert.AreEqual(1, result.ExitCode, Describe("A newly introduced IMPORTS finding must fail the gate", result));
+        StringAssert.Contains(result.StdErr, "Clean.cs", Describe("The failure must name the offending file", result));
+        StringAssert.Contains(result.StdErr, "IMPORTS", Describe("The failure must name the diagnostic id", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileIntroducesNamingViolation_FailsWithAnIde1006Finding()
+    {
+        SeedBaseCommit(EmptyBaseline, ("Clean.cs", CleanFile));
+
+        // A private field without the required `_` prefix -> IDE1006.
+        WriteRepositoryFile(
+            "Clean.cs",
+            "namespace Probe;\n\npublic sealed class Clean\n{\n    private int newlyBadField;\n\n" +
+            "    public int Value => newlyBadField;\n}\n");
+        CommitAll("naming violation");
+
+        var result = RunGate();
+
+        Assert.AreEqual(1, result.ExitCode, Describe("A newly introduced IDE1006 finding must fail the gate", result));
+        StringAssert.Contains(result.StdErr, "Clean.cs", Describe("The failure must name the offending file", result));
+        StringAssert.Contains(result.StdErr, "IDE1006", Describe("The failure must name the diagnostic id", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileIsMissingItsFinalNewline_FailsWithAFinalNewlineFinding()
+    {
+        SeedBaseCommit(EmptyBaseline, ("Clean.cs", CleanFile));
+
+        WriteRepositoryFile("Clean.cs", "namespace Probe;\n\npublic sealed class Clean\n{\n    public int Value => 7;\n}");
+        CommitAll("missing final newline");
+
+        var result = RunGate();
+
+        Assert.AreEqual(1, result.ExitCode, Describe("A missing final newline must fail the gate", result));
+        StringAssert.Contains(result.StdErr, "Clean.cs", Describe("The failure must name the offending file", result));
+        StringAssert.Contains(result.StdErr, "FINALNEWLINE", Describe("The failure must name the diagnostic id", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileCarriesOnlyInventoriedDebt_PassesAndReportsItAsTrackedRatherThanSuppressed()
+    {
+        SeedBaseCommit(
+            BaselineWithOneDirtyIde1006,
+            ("Dirty.cs", DirtyFileWithOneNamingViolation),
+            ("Clean.cs", CleanFile));
+
+        // Touch the inventoried file without adding any new formatter debt: its single baseline
+        // IDE1006 travels along unchanged. That is tracked debt, not a regression.
+        WriteRepositoryFile(
+            "Dirty.cs",
+            "namespace Probe;\n\npublic sealed class Dirty\n{\n    private int badField;\n\n" +
+            "    public int Value => badField;\n\n    public int Doubled => Value * 2;\n}\n");
+        CommitAll("edit an inventoried file without adding debt");
+
+        var result = RunGate();
+
+        Assert.AreEqual(0, result.ExitCode, Describe("Inventoried debt on a changed file must not fail the gate", result));
+        StringAssert.Contains(
+            result.StdOut,
+            "tracked debt: Dirty.cs - IDE1006 x1",
+            Describe("Baseline debt must be reported, not silently suppressed", result));
+        StringAssert.Contains(result.StdOut, "0 new finding(s)", Describe("No new findings were introduced", result));
+    }
+
+    [TestMethod]
+    public void Gate_ChangedFileCarriesBaselineDebtPlusOneNewViolation_StillFails()
+    {
+        // The concealment case. `Dirty.cs` is in the inventory with ONE IDE1006. If the gate
+        // classified findings by mere presence in the baseline, a second, freshly introduced
+        // IDE1006 in the same file would be masked by the first and ship silently. The gate
+        // compares COUNTS, so observed(2) > baseline(1) is a failure.
+        SeedBaseCommit(
+            BaselineWithOneDirtyIde1006,
+            ("Dirty.cs", DirtyFileWithOneNamingViolation),
+            ("Clean.cs", CleanFile));
+
+        WriteRepositoryFile(
+            "Dirty.cs",
+            "namespace Probe;\n\npublic sealed class Dirty\n{\n    private int badField;\n    private int smuggledField;\n\n" +
+            "    public int Value => badField + smuggledField;\n}\n");
+        CommitAll("smuggle a second naming violation into an inventoried file");
+
+        var result = RunGate();
+
+        Assert.AreEqual(
+            1,
+            result.ExitCode,
+            Describe("A baseline entry must not mask a newly introduced finding in the same file", result));
+        StringAssert.Contains(
+            result.StdErr,
+            "NEW: Dirty.cs - IDE1006 x1 (observed 2, baseline 1)",
+            Describe("The failure must show the observed-vs-baseline count that proves concealment", result));
+    }
+
+    private static string ResolveScriptPath()
+    {
+        var repoRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return Path.Combine(repoRoot, "eng", "verify-changed-format.ps1");
+    }
+
+    /// <summary>
+    /// Builds the synthetic repository (project, editorconfig, baseline, seed sources), commits it,
+    /// and parks <see cref="BaseBranchName"/> on that commit so later commits are the "changed set".
+    /// </summary>
+    private void SeedBaseCommit(string baselineJson, params (string Name, string Content)[] sourceFiles)
+    {
+        WriteRepositoryFile(
+            ProjectFileName,
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n");
+
+        // `root = true` stops inheritance from anything above the temp directory, and the rules
+        // below are the exact ones the production .editorconfig uses for the gated diagnostics.
+        WriteRepositoryFile(
+            ".editorconfig",
+            "root = true\n\n[*]\nindent_style = space\nindent_size = 4\nend_of_line = lf\n" +
+            "trim_trailing_whitespace = true\ninsert_final_newline = true\n\n[*.cs]\n" +
+            "dotnet_sort_system_directives_first = true\ndotnet_separate_import_directive_groups = false\n" +
+            "dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning\n" +
+            "dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields\n" +
+            "dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_underscore\n" +
+            "dotnet_naming_symbols.private_fields.applicable_kinds = field\n" +
+            "dotnet_naming_symbols.private_fields.applicable_accessibilities = private\n" +
+            "dotnet_naming_style.camel_case_underscore.required_prefix = _\n" +
+            "dotnet_naming_style.camel_case_underscore.capitalization = camel_case\n");
+
+        // `* -text` disables git's newline translation, so a checked-out fixture file is byte-identical
+        // to what the test wrote and cannot acquire CRLF-shaped formatter findings the test never intended.
+        WriteRepositoryFile(".gitattributes", "* -text\n");
+        WriteRepositoryFile(".gitignore", "bin/\nobj/\n");
+        WriteRepositoryFile(Path.Combine("eng", "format-baseline.json"), baselineJson);
+
+        foreach (var (name, content) in sourceFiles)
+        {
+            WriteRepositoryFile(name, content);
+        }
+
+        RunGit("init", "--quiet", "--initial-branch=main", ".");
+        CommitAll("base");
+        RunGit("branch", BaseBranchName);
+    }
+
+    private void WriteRepositoryFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_repositoryDirectory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+    }
+
+    private void CommitAll(string message)
+    {
+        RunGit("add", "--all");
+        RunGit("-c", "user.email=gate@test.invalid", "-c", "user.name=gate-test", "commit", "--quiet", "--message", message);
+    }
+
+    private void RunGit(params string[] arguments)
+    {
+        var result = RunProcess("git", _repositoryDirectory, arguments);
+        Assert.AreEqual(
+            0,
+            result.ExitCode,
+            $"git {string.Join(' ', arguments)} failed in the fixture repository. stdout={result.StdOut} stderr={result.StdErr}");
+    }
+
+    private ProcessResult RunGate()
+    {
+        var scriptPath = ResolveScriptPath();
+        Assert.IsTrue(File.Exists(scriptPath), $"verify-changed-format.ps1 was not found at '{scriptPath}'.");
+
+        return RunProcess(
+            OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh",
+            _repositoryDirectory,
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            scriptPath,
+            "-BaseRef",
+            BaseBranchName,
+            "-SolutionPath",
+            ProjectFileName);
+    }
+
+    private static ProcessResult RunProcess(string fileName, string workingDirectory, params string[] arguments)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            psi.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(milliseconds: 300_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException(
+                $"'{fileName} {string.Join(' ', arguments)}' timed out after 300s.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            stdoutTask.GetAwaiter().GetResult(),
+            stderrTask.GetAwaiter().GetResult());
+    }
+
+    private static string Describe(string expectation, ProcessResult result) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{expectation}. exit={result.ExitCode}\n--- stdout ---\n{result.StdOut}\n--- stderr ---\n{result.StdErr}");
+
+    private sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);
+}


### PR DESCRIPTION
Adds a changed-file formatter gate. The repository carries 418 tracked formatter findings across 232 files (`eng/format-baseline.json`), so a whole-repo `dotnet format --verify-no-changes` gate is impossible — it would red every PR. This gate holds only the C# files a pull request touches, minus the debt those files already carried.

## What it does

`eng/verify-changed-format.ps1`:

1. Resolves the changed set with `git diff --name-only --diff-filter=ACMR <BaseRef>...HEAD`, filtered to `*.cs`. Empty set exits 0 with an explicit no-op line.
2. Runs `dotnet format <solution> --verify-no-changes --no-restore` scoped to that set.
3. Buckets findings per (file, diagnostic id) and compares the observed count against the count the tracked baseline records for the same pair.
   - `observed <= baseline` → pre-existing; reported as explicitly tracked debt, not a failure.
   - `observed > baseline` → new; fails the gate.

Comparing **counts** rather than mere presence is what closes the concealment hole: a file already carrying one baseline `IDE1006` cannot smuggle in a second one.

## Wiring

- `.github/workflows/ci.yml` — new `validate`-leg step `Verify changed-file formatting`, gated to the artifact-owning non-doc pull-request leg. `fetch-depth: 0` was already in place, so the base ref is present; `-NoRestore` is safe because the preceding release step restores.
- `justfile` — new `verify-changed-format` recipe, appended to the `ci:` and `full:` aggregates so `just ci` keeps its documented PR-equivalence.
- `CI_POLICY.md` — rows in `## Required Checks And Artifacts` and `## Local Validation`.

Deliberately **not** wired into `eng/verify-release.ps1`: that script's child-script set is a separate hard-listed contract (`VerifyReleaseChildScriptTests`, `eng/guard-release-managed-files.ps1`), and joining it would force two more files into scope for no behavioral gain.

## Verification

- `tests/RoslynMcp.Tests/Skills/ChangedFormatGateScriptTests.cs` — 7 process-level cases, each seeding an isolated temp git repo with its own project, `.editorconfig`, and baseline inventory, then shelling the real script: clean file passes; new `IMPORTS` / `IDE1006` / `FINALNEWLINE` each fail and name the file plus the diagnostic; a changed file carrying only inventoried debt passes with the debt reported; the concealment case (baseline debt **plus** one new violation in the same file) still fails; and a change with no C# files reports the no-op explicitly.
- `tests/RoslynMcp.Tests/CiRunnerParityContractTests.cs` — extended `PullRequestAndLocalCi_UseTheDocumentedReleaseLane` to lock the ci.yml step, the justfile recipe, and both aggregates.
- `--include` scoping verified empirically (it restricts both the report and the exit code), but correctness never depends on it — findings are filtered to the changed set in PowerShell regardless, and `--include` is dropped entirely when the changed set would risk the OS command-line limit.
- Truncation (`Required references did not load`) is fatal, so an unrestored tree cannot pass the gate by reporting nothing.
- `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` passes. `eng/generate-format-baseline.ps1 -Check` passes (inventory unchanged). The gate is green against this PR's own diff.

## Notes

- A renamed file inherits no baseline entry and therefore reports its debt as new. That is deliberate — a rename is the natural moment to repair a file, and following renames would let debt travel silently forever. Documented in the script header and in the failure message.
- The new test file uses static properties rather than `private const` / `private static readonly` fields: `.editorconfig`'s `private_fields` rule sets `applicable_kinds = field` with no required modifiers, so it demands a leading underscore on constants too (306 of the 418 baseline findings are this mis-scoped rule). A new file must not add to that inventory, and renaming constants to `_camelCase` would follow a convention the repository does not actually use. Re-scoping the rule is tracked separately.

Closes: repository-dotnet-format-baseline-partition (acceptance bullets 3 and 4; the row stays open for bullet 2, the bounded repair-slice row factory)
