### PR TITLE
fix(skills): resolve Roslyn MCP prefix once in semantic-find, test-coverage, trace-flow (shipped-skills-prefix-batch-c1)

### DIFF
--- a/changelog.d/shipped-skills-prefix-batch-c1.md
+++ b/changelog.d/shipped-skills-prefix-batch-c1.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Shipped skills `semantic-find`, `test-coverage`, and `trace-flow` now resolve the Roslyn MCP tool prefix once at runtime and pin it, instead of instructing agents to call a hard-coded `mcp__roslyn__` literal — marketplace-plugin installs no longer hit a false connectivity halt. Their residual-unswept amnesty entries were removed from the genericity guard's allowlist, and the shrink ratchet tightened from 5 to 2.

--- a/eng/banned-skill-markers.json
+++ b/eng/banned-skill-markers.json
@@ -30,9 +30,6 @@
       "never itself grounds to halt"
     ],
     "residualUnsweptAllowlist": [
-      "skills/semantic-find/SKILL.md",
-      "skills/test-coverage/SKILL.md",
-      "skills/trace-flow/SKILL.md",
       "skills/version-bump/SKILL.md",
       "skills/workspace-health/SKILL.md"
     ]

--- a/skills/semantic-find/SKILL.md
+++ b/skills/semantic-find/SKILL.md
@@ -28,14 +28,18 @@ Use **`server_info`**, resource **`roslyn://server/catalog`**, or MCP prompt **`
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -20,14 +20,18 @@ Use **`discover_capabilities`** (`testing` / `all`) or MCP prompt **`review_test
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/skills/trace-flow/SKILL.md
+++ b/skills/trace-flow/SKILL.md
@@ -33,14 +33,18 @@ Use **`server_info`**, resource **`roslyn://server/catalog`**, or MCP prompt **`
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
@@ -32,10 +32,11 @@ public sealed class SkillPrefixGenericityTests
     /// <summary>
     /// Shrink ratchet. Five shipped skills still carried the pre-fix bare-prefix precheck when this
     /// gate landed (<c>semantic-find</c>, <c>test-coverage</c>, <c>trace-flow</c>,
-    /// <c>version-bump</c>, <c>workspace-health</c>). The allowlist may only ever get SMALLER —
+    /// <c>version-bump</c>, <c>workspace-health</c>). Batch c1 swept the first three, leaving
+    /// <c>version-bump</c> and <c>workspace-health</c>. The allowlist may only ever get SMALLER —
     /// lowering this constant as the sweep batches land is the intended edit; raising it is not.
     /// </summary>
-    private const int ResidualUnsweptRatchet = 5;
+    private const int ResidualUnsweptRatchet = 2;
 
     [TestMethod]
     public void PrefixAgnosticPolicy_IsPopulated()


### PR DESCRIPTION
## What

Batch c1 of the shipped-skills prefix sweep. Three shipped skills still carried the pre-fix bare-prefix connectivity precheck — an 11-line block instructing agents to call the hard-coded literal `mcp__roslyn__server_info` / `mcp__roslyn__server_heartbeat`. On a marketplace-plugin install the prefix is `mcp__plugin_roslyn-mcp_roslyn__`, so the literal is absent and the skill halts with a false "Roslyn MCP is not connected".

- `skills/semantic-find/SKILL.md`, `skills/test-coverage/SKILL.md`, `skills/trace-flow/SKILL.md` — legacy block replaced with the canonical resolve-once-then-pin block, copied programmatically from `eng/banned-skill-markers.json` `canonicalPrecheckBlocks[0].text` (never retyped; `Assert-CanonicalBlockIdentity` compares Ordinal).
- `eng/banned-skill-markers.json` — the three files removed from `prefixAgnostic.residualUnsweptAllowlist`, leaving exactly `skills/version-bump/SKILL.md` and `skills/workspace-health/SKILL.md` for batch c2.
- `tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs` — `ResidualUnsweptRatchet` lowered 5 → 2 with an updated doc-comment, so the three freed amnesty slots cannot be silently refilled.

## Validation

- `./eng/verify-skills-are-generic.ps1` → exit 0, "Shipped skills under ./skills/ are generic (38 .md files checked)."
- `./eng/verify-ai-docs.ps1` → "AI docs validation passed."
- `dotnet test --filter "FullyQualifiedName~SkillPrefixGenericityTests"` → 16/16 passed.
- Byte-identity spot check: the `## Connectivity precheck` block in all three files hashes identical to the already-swept exemplar `skills/review/SKILL.md` (`fc014c844195fee3…`).
- `residualUnsweptAllowlist` confirmed to contain exactly the two batch-c2 entries.

## Notes

Does **not** close `shipped-skills-hardcode-bare-roslyn-tool-prefix` — acceptance bullets 3 and 4 require the allowlist to empty, which lands in batch c2. Must merge **before** `shipped-skills-prefix-batch-c2`, which touches the same policy JSON and test file.

Closes: (none — partial progress on `shipped-skills-hardcode-bare-roslyn-tool-prefix`, row stays open pending batch-c2)
