### PR TITLE
chore(tools): trim diagnostics/security tool descriptions to capability statements

### DIFF
--- a/changelog.d/method-description-diet-diagnostics-security.md
+++ b/changelog.d/method-description-diet-diagnostics-security.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Trimmed method-level tool descriptions for the exception-flow, security, snippet-analysis, and analyzer-info tool groups to ~200-char capability statements, moving operational detail to XML remarks. Cuts the `tools/list` payload for these 6 tools from 3,130 to 1,079 characters with no capability statement or discriminating trigger dropped.

--- a/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AnalyzerInfoTools.cs
@@ -9,13 +9,17 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class AnalyzerInfoTools
 {
+    /// <remarks>
+    /// Response JSON: <c>analyzerCount</c> = total distinct analyzer assemblies (unpaged);
+    /// <c>totalRules</c> = sum of rules across all assemblies — use this for the total rule count
+    /// without paging the full list; <c>returnedRules</c> = rules in this page;
+    /// <c>returnedAnalyzerCount</c> = distinct assemblies that contributed at least one rule in
+    /// this page; <c>hasMore</c> = true when <c>offset + returnedRules &lt; totalRules</c>.
+    /// </remarks>
     [McpServerTool(Name = "list_analyzers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
         "List all loaded analyzers and their diagnostic rules."),
-     Description(
-        "List all loaded Roslyn analyzers and their supported diagnostic rules. Use to understand what analysis coverage exists and which diagnostic IDs are available for code_fix_preview or fix_all_preview. " +
-        "Response JSON: analyzerCount = total distinct analyzer assemblies (unpaged); totalRules = sum of rules across all assemblies — use this for total rule count without paging the full list; offset/limit paginate the flattened rule list (not whole analyzers). " +
-        "returnedRules = rules in this page; returnedAnalyzerCount = distinct assemblies that contributed at least one rule in this page; hasMore = true when offset + returnedRules < totalRules.")]
+     Description("List loaded Roslyn analyzers and their rules — which diagnostic IDs are available for code_fix_preview or fix_all_preview. offset/limit paginate the flattened rule list, not whole analyzers.")]
     public static Task<string> ListAnalyzers(
         IWorkspaceExecutionGate gate,
         IAnalyzerInfoService analyzerInfoService,

--- a/src/RoslynMcp.Host.Stdio/Tools/ExceptionFlowTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExceptionFlowTools.cs
@@ -16,10 +16,23 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ExceptionFlowTools
 {
+    /// <remarks>
+    /// Catch sites whose declared type is assignable from the input carry the containing method,
+    /// a body excerpt (with the <c>when</c> filter prepended when present), and a
+    /// <c>rethrowAsTypeMetadataName</c> annotation when the body wraps the exception in
+    /// <c>throw new X(...)</c> of a different type. Catch sites are ranked type-specific
+    /// (exact-match) first so a broad <c>catch (Exception)</c> never displaces a precise handler
+    /// when results are truncated; untyped <c>catch { }</c> clauses are treated as catching
+    /// <c>System.Exception</c>. Throw sites whose thrown type is assignable to the input carry
+    /// the containing method, an <c>isUnhandledAtBoundary</c> flag (syntactic — true when the
+    /// throw is not lexically inside a <c>catch</c>), and an excerpt. <c>countOmitted</c> reports
+    /// how many catch+throw sites were dropped past <c>maxResults</c>. Pair handling and
+    /// origination sites for an exception-classification refactor.
+    /// </remarks>
     [McpServerTool(Name = "trace_exception_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "experimental", true, false,
         "Trace catch clauses that handle a given exception type."),
-     Description("Return both `catch` clauses (handling sites) and `throw new T(...)` sites (origination sites) across the workspace related to the input exception type. Catch sites whose declared type is assignable from the input carry the containing method, a body excerpt (with the `when` filter prepended when present), and a `rethrowAsTypeMetadataName` annotation when the body wraps the exception in `throw new X(...)` of a different type; catch sites are ranked type-specific (exact-match) first so a broad `catch (Exception)` never displaces a precise handler when results are truncated. Throw sites whose thrown type is assignable to the input carry the containing method, an `isUnhandledAtBoundary` flag (syntactic — true when the throw is not lexically inside a `catch`), and an excerpt. `countOmitted` reports how many catch+throw sites were dropped past `maxResults`. Untyped `catch { }` clauses are treated as catching `System.Exception`. Pair handling and origination sites for an exception-classification refactor.")]
+     Description("Return both `catch` handling sites and `throw new` origination sites for an exception type across the workspace. Use when `find_references` gives usage sites, not handling sites.")]
     public static Task<string> TraceExceptionFlow(
         IWorkspaceExecutionGate gate,
         IExceptionFlowService exceptionFlowService,

--- a/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SecurityTools.cs
@@ -49,10 +49,18 @@ public static class SecurityTools
             c => securityService.GetAnalyzerStatusAsync(workspaceId, c),
             ct);
 
+    /// <remarks>
+    /// Returns affected packages with severity, advisory links, and project locations, sourced
+    /// from the NuGet vulnerability database via <c>dotnet list package</c>. The response
+    /// includes <c>IncludesTransitive</c>: when false, results match direct references only —
+    /// pass <c>includeTransitive=true</c> (and the CLI transitive flags) when you need full
+    /// transitive CVE coverage. The underlying CLI call needs a .NET 8+ SDK with JSON output
+    /// support.
+    /// </remarks>
     [McpServerTool(Name = "nuget_vulnerability_scan", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("security", "stable", true, false,
         "Scan NuGet references for known CVEs using dotnet list package --vulnerable."),
-     Description("Scan NuGet package references for known security vulnerabilities (CVEs) using the NuGet vulnerability database via dotnet list package. Returns affected packages with severity, advisory links, and project locations. Response includes IncludesTransitive: when false, results match direct references only — use includeTransitive=true (and CLI transitive flags) when you need full transitive CVE coverage. Requires .NET 8+ SDK with JSON output support.")]
+     Description("Scan NuGet references for known CVEs via `dotnet list package`. Default includeTransitive=false returns direct references only; pass true for transitive coverage. Requires .NET 8+ SDK.")]
     public static Task<string> ScanNuGetVulnerabilities(
         IWorkspaceExecutionGate gate,
         INuGetDependencyService nuGetDependencyService,

--- a/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SnippetAnalysisTools.cs
@@ -9,10 +9,19 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class SnippetAnalysisTools
 {
+    /// <remarks>
+    /// The <c>kind</c> parameter selects the wrapper the snippet is compiled inside:
+    /// <c>expression</c> (single expression), <c>statements</c> (void method body — use this for
+    /// code without a return value), <c>returnExpression</c> (<c>object?</c>-returning method
+    /// body — use this when you need <c>return &lt;value&gt;;</c>), <c>members</c> (class members),
+    /// and <c>program</c> (full compilation unit, the default). Diagnostic line <i>and</i> column
+    /// numbers are 1-based and relative to the user-supplied code (wrapper offsets are subtracted
+    /// server-side, UX-001 + FLAG-C), so positions always point inside the original snippet.
+    /// </remarks>
     [McpServerTool(Name = "analyze_snippet", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
         "Analyze a C# code snippet in an ephemeral workspace without loading a solution."),
-     Description("Analyze a C# code snippet for compilation errors and declared symbols without loading a full solution. Uses an ephemeral workspace for quick validation of code fragments, diffs, or pasted code. Kinds: 'expression' (single expression), 'statements' (void method body — use this for code without a return value), 'returnExpression' (object?-returning method body — use this when you need 'return <value>;'), 'members' (class members), 'program' (full compilation unit, default). Diagnostic line *and* column numbers are 1-based and relative to the user-supplied code (wrapper offsets are subtracted server-side, UX-001 + FLAG-C), so positions always point inside the original snippet.")]
+     Description("Analyze a C# snippet for compilation errors and declared symbols in an ephemeral workspace — no solution load. Use for fragments, diffs, or pasted code; `kind` selects the wrapper.")]
     public static async Task<string> AnalyzeSnippet(
         ISnippetAnalysisService snippetAnalysisService,
         [Description("The C# code to analyze")] string code,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietDiagnosticsSecurityTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietDiagnosticsSecurityTests.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-description diet across the exception-flow, security,
+/// snippet-analysis, and analyzer-info tool groups. Deliberately narrower than
+/// <see cref="SurfaceCatalogTests"/>'s assembly-wide 2,000-char guard: that constant stays owned
+/// by the global ratchet, while these four types are held to a ~200-char capability statement
+/// with operational detail living in XML remarks.
+/// </summary>
+[TestClass]
+public sealed class MethodDescriptionDietDiagnosticsSecurityTests
+{
+    /// <summary>Per-tool ceiling for a capability statement in this slice.</summary>
+    private const int _maxDescriptionCharacters = 200;
+
+    /// <summary>
+    /// Aggregate ceiling for the slice. Measured 3,130 chars across 6 tools before the diet and
+    /// 1,079 after (trace_exception_flow 1,012 -> 178, analyze_snippet 682 -> 180,
+    /// list_analyzers 640 -> 190, nuget_vulnerability_scan 449 -> 184; security_diagnostics 175
+    /// and security_analyzer_status 172 already complied and were left byte-identical).
+    /// <see cref="_maxDescriptionCharacters"/> is a per-tool CEILING, not a target, so the
+    /// aggregate is not bounded below by 6 x 200 — this constant is the measured post-diet total
+    /// plus modest headroom.
+    /// </summary>
+    private const int _maxAggregateDescriptionCharacters = 1_150;
+
+    private static readonly Type[] _sliceToolTypes =
+    [
+        typeof(ExceptionFlowTools),
+        typeof(SecurityTools),
+        typeof(SnippetAnalysisTools),
+        typeof(AnalyzerInfoTools),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreCapabilityStatements()
+    {
+        var violations = EnumerateSliceTools()
+            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
+            "(what it does plus the one discriminating trigger); move operational detail to XML " +
+            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayUnderAggregateBudget()
+    {
+        var entries = EnumerateSliceTools().ToArray();
+        var total = entries.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            entries.Length > 0,
+            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
+
+        Assert.IsTrue(
+            total <= _maxAggregateDescriptionCharacters,
+            $"Aggregate method-description budget for the slice is " +
+            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
+    }
+
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
+    {
+        // trace_exception_flow: both handling AND origination sites, and the find_references contrast.
+        AssertDescriptionContains("trace_exception_flow", "`throw new` origination sites");
+        AssertDescriptionContains("trace_exception_flow", "usage sites, not handling sites");
+
+        // nuget_vulnerability_scan: direct-vs-transitive default and the SDK floor.
+        AssertDescriptionContains("nuget_vulnerability_scan", "includeTransitive=false returns direct references only");
+        AssertDescriptionContains("nuget_vulnerability_scan", ".NET 8+ SDK");
+
+        // analyze_snippet: ephemeral workspace with no solution load, and the kind-selects-wrapper pointer.
+        AssertDescriptionContains("analyze_snippet", "ephemeral workspace");
+        AssertDescriptionContains("analyze_snippet", "`kind` selects the wrapper");
+
+        // list_analyzers: the code-fix discovery use case and the flattened-rule pagination unit.
+        AssertDescriptionContains("list_analyzers", "code_fix_preview or fix_all_preview");
+        AssertDescriptionContains("list_analyzers", "flattened rule list, not whole analyzers");
+    }
+
+    private static void AssertDescriptionContains(string toolName, string expected)
+    {
+        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
+
+        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
+        StringAssert.Contains(
+            entry.Description,
+            expected,
+            $"Trimming '{toolName}' dropped its discriminating trigger.");
+    }
+
+    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
+        => _sliceToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null && entry.Description is not null)
+            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+}


### PR DESCRIPTION
Per-cluster child of the `method-description-diet` parent row — the exception-flow / security / snippet-analysis / analyzer-info cluster.

## What changed

Four method-level `[Description]` attributes trimmed to <=200-char capability statements, with the displaced operational detail relocated verbatim-in-substance to an XML `<remarks>` block above the attribute list (the shipped #1345 `MultiFileEditTools` pattern).

| Tool | Before | After |
|---|---|---|
| `trace_exception_flow` | 1,012 | 178 |
| `analyze_snippet` | 682 | 180 |
| `list_analyzers` | 640 | 190 |
| `nuget_vulnerability_scan` | 449 | 184 |
| `security_diagnostics` | 175 | 175 (untouched) |
| `security_analyzer_status` | 172 | 172 (untouched) |
| **Aggregate** | **3,130** | **1,079** |

`security_diagnostics` and `security_analyzer_status` already complied and are byte-identical. No `McpToolMetadata` summary and no `ServerSurfaceCatalog` entry is touched, so `SurfaceCatalogTests`' metadata-drift assertion is unaffected.

## Discriminating triggers retained (PR #1348 lesson — condense, never drop)

- `trace_exception_flow` — still states it returns BOTH `catch` handling sites AND `throw new` origination sites, and that `find_references` returns usage sites, not handling sites.
- `nuget_vulnerability_scan` — keeps the `includeTransitive=false` -> direct-references-only default and the .NET 8+ SDK requirement.
- `analyze_snippet` — keeps "ephemeral workspace, no solution load" plus the pointer that `kind` selects the wrapper. The 1-based line/column (UX-001 + FLAG-C) contract moved to `<remarks>`, not deleted; behaviour stays pinned by `AuditFixesTests`.
- `list_analyzers` — keeps the `code_fix_preview` / `fix_all_preview` diagnostic-ID discovery use case and the "offset/limit paginate the flattened rule list, not whole analyzers" pagination discriminator.

## Tests

New slice-scoped ratchet `tests/RoslynMcp.Tests/MethodDescriptionDietDiagnosticsSecurityTests.cs`: per-tool ceiling 200, an aggregate ceiling budgeted from the MEASURED post-diet total (1,079, constant 1,150) rather than `toolCount x 200` (PR #1345 lesson), and `TrimmedDescriptions_KeepTheirDiscriminatingTriggers` asserting the four retained triggers above.

Deliberately does NOT extend `SurfaceCatalogTests.DietedToolMethodDescriptions_StayWithinSliceCeiling` — four sibling diet initiatives run in this same sweep and that shared list is a guaranteed merge conflict; the filed consolidation follow-on owns unifying the per-slice classes.

## Validation

- `dotnet test --filter "MethodDescriptionDiet|SurfaceCatalogTests|AuditFixesTests|PromptSmokeTests|SecurityDiagnosticIntegrationTests"` — 90/90 passed.
- `./eng/verify-changed-format.ps1` — passed (5 changed C# files, 0 new findings, 3 pre-existing baseline IMPORTS entries reported).
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-changelog-fragments.ps1` — passed.

Full `verify-release.ps1` is left to the self-hosted CI runner rather than duplicated locally.

Closes: (none — parent row `method-description-diet` stays open; ~36 `Tools/*.cs` files remain unswept)

Initiative: `method-description-diet-diagnostics-security`
