### PR TITLE
chore(tools): diet analysis/metrics tool descriptions (method-description-diet-analysis-metrics)

### DIFF
--- a/changelog.d/method-description-diet-analysis-metrics.md
+++ b/changelog.d/method-description-diet-analysis-metrics.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** trimmed method-level tool descriptions for the cohesion, consumer, coupling, and flow analysis tool groups to 150-250-char capability statements (6 tools, ~1.5k chars down to ~1.2k), relocating the `projectFilter` restatement and the `EndPointIsReachable` semantics caveat to in-source XML remarks while keeping every discriminating trigger. Added a slice-scoped description-length regression test.

--- a/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs
@@ -10,10 +10,13 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class ConsumerAnalysisTools
 {
 
+    /// <remarks>
+    /// <para>The optional projectFilter is a case-sensitive Project.Name, comma-separated for multiple projects. It restricts the consumer walk to the listed project(s) and matches semantic_grep's filter semantics; null or empty preserves the unfiltered solution-wide walk.</para>
+    /// </remarks>
     [McpServerTool(Name = "find_consumers", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
         "Find all types that depend on a given type or interface, classified by dependency kind. Accepts an optional projectFilter (case-sensitive Project.Name; comma-separated)."),
-     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument, StaticMemberAccess). Optional `projectFilter` (case-sensitive Project.Name; comma-separated for multi) restricts the consumer walk to the listed project(s) — matches semantic_grep's filter semantics.")]
+     Description("Find all types that depend on a given type or interface, classified by dependency kind (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument, StaticMemberAccess). Optional projectFilter scopes the walk.")]
     public static Task<string> FindConsumers(
         IWorkspaceExecutionGate gate,
         IConsumerAnalysisService consumerAnalysisService,

--- a/src/RoslynMcp.Host.Stdio/Tools/CouplingAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CouplingAnalysisTools.cs
@@ -9,10 +9,13 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class CouplingAnalysisTools
 {
+    /// <remarks>
+    /// <para>AfferentCoupling Ca counts incoming references (types that depend on this type); EfferentCoupling Ce counts outgoing references (types this type depends on). Instability I = Ce / (Ca + Ce) ranges 0 (maximally stable) to 1 (maximally unstable), and drives the stable / balanced / unstable / isolated classification.</para>
+    /// </remarks>
     [McpServerTool(Name = "get_coupling_metrics", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "stable", true, false,
         "Measure per-type afferent/efferent coupling + Martin's instability index."),
-     Description("Compute per-type coupling metrics (Martin): AfferentCoupling Ca (incoming refs), EfferentCoupling Ce (outgoing refs), Instability I = Ce / (Ca + Ce). Classifies types as stable / balanced / unstable / isolated. Companion to get_cohesion_metrics — cohesion looks inward, coupling looks outward.")]
+     Description("Compute per-type Martin coupling metrics: AfferentCoupling Ca, EfferentCoupling Ce, Instability I = Ce/(Ca+Ce). Classifies types stable / balanced / unstable / isolated. Companion to get_cohesion_metrics — cohesion looks inward, coupling outward.")]
     public static Task<string> GetCouplingMetrics(
         IWorkspaceExecutionGate gate,
         ICouplingAnalysisService couplingAnalysisService,

--- a/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs
@@ -38,10 +38,13 @@ public static class FlowAnalysisTools
             },
             ct);
 
+    /// <remarks>
+    /// <para>EndPointIsReachable reports whether execution can fall through the end of the analyzed region without hitting a return or throw. It does NOT report whether the method can complete. The response carries a Warning when return statements exist but EndPointIsReachable is false, because that combination is routinely misread as unreachable code.</para>
+    /// </remarks>
     [McpServerTool(Name = "analyze_control_flow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Analyze control flow: entry/exit points, reachability, return statements."),
-     Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. EndPointIsReachable follows Roslyn semantics (whether execution can fall through the end of the region without return/throw), not whether the method can complete; see Warning when returns exist but EndPointIsReachable is false.")]
+     Description("Analyze control flow through a code region: entry/exit points, reachability, and return statements. EndPointIsReachable uses Roslyn fall-through semantics, not whether the method can complete.")]
     public static Task<string> AnalyzeControlFlow(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/tests/RoslynMcp.Tests/ToolDescriptionDietAnalysisMetricsTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDescriptionDietAnalysisMetricsTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-level tool-description diet applied to the cohesion,
+/// consumer, coupling, and flow analysis tool groups. The global 2,000-character
+/// client-truncation ceiling in <c>SurfaceCatalogTests</c> stays untouched; this class holds the
+/// tighter per-slice budget so a future edit cannot silently regrow the <c>tools/list</c> payload.
+/// </summary>
+/// <remarks>
+/// <para>Mirrors the reflection harness of
+/// <c>SurfaceCatalogTests.AllMcpToolMethodDescriptions_AreWithinClientLimit</c>, but enumerates an
+/// explicit declaring-type set instead of the whole assembly so sibling diet slices stay
+/// independent and do not collide in this file.</para>
+/// <para>Only METHOD-level <c>[Description]</c> attributes are in scope. Parameter-level
+/// descriptions and the <c>[McpToolMetadata]</c> summaries the surface catalog mirrors are
+/// deliberately excluded.</para>
+/// <para>The slice total is derived from measured post-diet content (1,220 characters across the
+/// six swept tools), not from <c>toolCount x perToolCeiling</c>. Re-measure and ratchet the
+/// constant DOWN if a later edit shrinks the real total.</para>
+/// </remarks>
+[TestClass]
+public sealed class ToolDescriptionDietAnalysisMetricsTests
+{
+    private const int _maxPerToolDescriptionCharacters = 250;
+    private const int _maxSweptSetTotalCharacters = 1_300;
+
+    private static readonly Type[] _sweptToolTypes =
+    [
+        typeof(CohesionAnalysisTools),
+        typeof(ConsumerAnalysisTools),
+        typeof(CouplingAnalysisTools),
+        typeof(FlowAnalysisTools),
+    ];
+
+    private static (string Name, string Description)[] SweptToolDescriptions() =>
+        _sweptToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null)
+            .OrderBy(entry => entry.Tool!.Name, StringComparer.Ordinal)
+            .Select(entry => (
+                Name: entry.Tool!.Name ?? "(unnamed)",
+                Description: entry.Description?.Description ?? string.Empty))
+            .ToArray();
+
+    [TestMethod]
+    public void SweptToolDescriptions_AreWithinPerToolBudget()
+    {
+        var violations = SweptToolDescriptions()
+            .Where(entry => entry.Description.Length > _maxPerToolDescriptionCharacters)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Swept tool descriptions must be <= {_maxPerToolDescriptionCharacters} characters. " +
+            "Move operational guidance into XML <remarks> on the same method instead of the wire " +
+            "description. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SweptToolDescriptions_TotalIsWithinSliceBudget()
+    {
+        var swept = SweptToolDescriptions();
+        var total = swept.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            total <= _maxSweptSetTotalCharacters,
+            $"Swept-set method description total is {total} chars across {swept.Length} tools, " +
+            $"over the {_maxSweptSetTotalCharacters}-char slice budget.");
+    }
+
+    [TestMethod]
+    public void SweptTools_AllHaveNonEmptyDescription()
+    {
+        var missing = SweptToolDescriptions()
+            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
+            .Select(entry => entry.Name)
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            missing.Length,
+            "Every swept tool must keep a non-empty method-level description so clients can " +
+            "discriminate it from sibling tools. Missing:\n  " + string.Join("\n  ", missing));
+    }
+}


### PR DESCRIPTION
## Summary

Phase-A child of the `method-description-diet` split: trims method-level `[Description]` metadata for the cohesion, consumer, coupling, and flow analysis tool groups so each MCP tool advertises a capability statement instead of a paragraph of operational guidance.

Slice aggregate: **1,541 -> 1,220 chars across 6 tools**, max per-tool 246 (was 382).

The slice assignment claimed 10 `[McpServerTool]` methods; the live count is **6** — a naive `McpServerTool` grep also matches each file's `[McpServerToolType]` class attribute, inflating the count by one per file.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/ConsumerAnalysisTools.cs` — `find_consumers` 382 -> 243. Kept the full dependency-kind enumeration (Constructor, Field, Parameter, BaseType, LocalVariable, Property, ReturnType, GenericArgument, StaticMemberAccess — the ToolSearch discriminator vs `find_references` / `find_type_usages`) and a one-clause `projectFilter` mention; the case-sensitivity / comma-separated / `semantic_grep`-parity prose was already carried verbatim by the `projectFilter` parameter description and moved to XML `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/CouplingAnalysisTools.cs` — `get_coupling_metrics` 293 -> 246. Kept Ca/Ce/Instability naming, the four classification buckets, and the "companion to `get_cohesion_metrics` — cohesion looks inward, coupling outward" discriminator; the incoming/outgoing gloss and the instability range moved to `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/FlowAnalysisTools.cs` — `analyze_control_flow` 327 -> 192. Kept entry/exit points, reachability, return statements, and a short pointer that `EndPointIsReachable` uses Roslyn fall-through semantics; the full caveat plus the Warning-emission rule moved to `<remarks>`.
- `tests/RoslynMcp.Tests/ToolDescriptionDietAnalysisMetricsTests.cs` — new slice-scoped reflection ratchet over the four declaring types: per-tool <= 250, slice aggregate <= 1,300, plus a non-empty-description assertion.
- `changelog.d/method-description-diet-analysis-metrics.md` — Maintenance fragment.

`get_cohesion_metrics` (182), `find_shared_members` (184) and `analyze_data_flow` (173) were measured this pass, are already inside the 250-char ceiling, and are left byte-identical — rewriting compliant text buys nothing and risks dropping a discriminating clause.

## Budget derivation

`MaxSweptSetTotalCharacters = 1_300` is derived from the **measured** post-edit aggregate of 1,220 plus ~80 chars of headroom. It is explicitly NOT `6 x 250 = 1500`; the ceiling is a bound, not a target.

## Deliberately untouched

- `McpToolMetadata(...)` summary strings — mirrored into `ServerSurfaceCatalog.Analysis.cs` and the pinned `catalog-v2.3.1.json` snapshot and drift-gated by `SurfaceCatalogTests.McpToolMetadata_RequiredOnEveryTool_MatchesCatalogEntry`. Zero catalog/registration ripple from this PR.
- Parameter-level `[Description]`s — owned by the sibling `param-description-dedupe-*` initiatives.
- `SurfaceCatalogTests.cs:319`'s shared dieted-slice array — adding these four types there would collide with the sibling diet slices in this same sweep.
- The `using` blocks in all four files — `eng/format-baseline.json` records pre-existing `IMPORTS` findings for `ConsumerAnalysisTools` and `FlowAnalysisTools`; the baseline count is unmoved.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter "ToolDescriptionDiet|SurfaceCatalogTests|ExpandedSurfaceIntegrationTests"` — 61 passed, 0 failed.
- `eng/verify-changed-format.ps1` — passed: 4 changed C# files, 0 new findings, 2 tracked baseline findings (unchanged).
- `eng/verify-ai-docs.ps1` — passed.
- `eng/verify-changelog-fragments.ps1` — passed.
- Full `eng/verify-release.ps1` deferred to the self-hosted CI runner (per standing guidance not to duplicate the runner's work locally).
- Manual re-measure post-edit: get_cohesion_metrics 182, find_shared_members 184, find_consumers 243, get_coupling_metrics 246, analyze_data_flow 173, analyze_control_flow 192 = **1,220**. Each still names what the tool does and what distinguishes it from its siblings.

Closes: (none — parent row `method-description-diet` stays open; roughly 19 `Tools/*.cs` files remain unswept after this sweep's diet children)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
