### PR TITLE
refactor(host): centralize preview-token kind route map (preview-token-route-map-centralization)

### DIFF
--- a/changelog.d/preview-token-route-map-centralization.md
+++ b/changelog.d/preview-token-route-map-centralization.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Centralized the preview-token `PreviewKind` → (`*_preview` tool, `*_apply` route) mapping in `ToolDispatch`, sourcing the apply-route half from `ServerSurfaceCatalog.PreviewApplyRoutes` instead of a third and fourth hand-maintained copy, and removed the redundant `applyRoute` parameter from `ApplyByTokenAsync`. An unmapped concrete `PreviewKind` now fails loudly at redemption instead of silently reporting the token as coming from "an untagged \*_preview tool" and directing the caller to `apply_with_verify`; a new test pins that every non-`Unspecified` member has a mapping.

--- a/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs
@@ -56,8 +56,7 @@ public static class RefactoringTools
             ct,
             // preview-token-apply-route-provenance: bind this route to its producer family so a
             // token minted by a different *_preview is refused before any workspace mutation.
-            expectedKind: PreviewKind.SymbolRename,
-            applyRoute: "rename_apply");
+            expectedKind: PreviewKind.SymbolRename);
 
     [McpServerTool(Name = "organize_usings_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview organizing using directives in a file: removes unused usings and sorts them")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -91,8 +90,7 @@ public static class RefactoringTools
             ct,
             // preview-token-apply-route-provenance: bind this route to its producer family so a
             // token minted by a different *_preview is refused before any workspace mutation.
-            expectedKind: PreviewKind.OrganizeUsings,
-            applyRoute: "organize_usings_apply");
+            expectedKind: PreviewKind.OrganizeUsings);
 
     [McpServerTool(Name = "format_document_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview formatting a document: applies standard C# formatting rules")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -126,8 +124,7 @@ public static class RefactoringTools
             ct,
             // preview-token-apply-route-provenance: bind this route to its producer family so a
             // token minted by a different *_preview is refused before any workspace mutation.
-            expectedKind: PreviewKind.FormatDocument,
-            applyRoute: "format_document_apply");
+            expectedKind: PreviewKind.FormatDocument);
 
     [McpServerTool(Name = "code_fix_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false), Description("Preview a curated code fix for a specific diagnostic occurrence")]
     [McpToolMetadata("refactoring", "stable", true, false,
@@ -165,8 +162,7 @@ public static class RefactoringTools
             ct,
             // preview-token-apply-route-provenance: bind this route to its producer family so a
             // token minted by a different *_preview is refused before any workspace mutation.
-            expectedKind: PreviewKind.CodeFix,
-            applyRoute: "code_fix_apply");
+            expectedKind: PreviewKind.CodeFix);
 
     [McpServerTool(Name = "format_range_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "stable", true, false,
@@ -206,8 +202,7 @@ public static class RefactoringTools
             ct,
             // preview-token-apply-route-provenance: bind this route to its producer family so a
             // token minted by a different *_preview is refused before any workspace mutation.
-            expectedKind: PreviewKind.FormatRange,
-            applyRoute: "format_range_apply");
+            expectedKind: PreviewKind.FormatRange);
 
     [McpServerTool(Name = "format_check", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Security;
 using RoslynMcp.Roslyn.Contracts;
@@ -19,7 +20,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// <para>
 /// <b>Dispatch shapes</b> — one helper method per workspace-gating pattern:
 /// <list type="bullet">
-///   <item><see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
+///   <item><see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind)"/>
 ///     — <c>*_apply</c> tools that receive an opaque preview token; resolves the
 ///     workspaceId via the store's <c>PeekWorkspaceId</c> peek and runs under the
 ///     per-workspace write gate. Also has a delegate-peek overload for preview stores
@@ -106,11 +107,6 @@ internal static class ToolDispatch
     /// families that have not yet declared a producer set keep their existing behavior without an
     /// edit. See <see cref="RequireCompatibleProducer"/> for the fail-open/fail-closed semantics.
     /// </param>
-    /// <param name="applyRoute">
-    /// preview-token-apply-route-provenance: this route's tool name, used only to make the mismatch
-    /// error name the route the caller actually invoked. Falls back to the canonical route for
-    /// <paramref name="expectedKind"/> when omitted.
-    /// </param>
     /// <returns>
     /// The DTO serialized with <see cref="JsonDefaults.Indented"/>.
     /// </returns>
@@ -129,8 +125,7 @@ internal static class ToolDispatch
         string previewToken,
         Func<CancellationToken, Task<TDto>> serviceCall,
         CancellationToken ct,
-        PreviewKind expectedKind = PreviewKind.Unspecified,
-        string? applyRoute = null)
+        PreviewKind expectedKind = PreviewKind.Unspecified)
     {
         var wsId = RequirePreviewWorkspaceId(previewStore.PeekWorkspaceId, previewToken);
         return gate.RunWriteAsync(wsId, async c =>
@@ -138,7 +133,7 @@ internal static class ToolDispatch
             // preview-token-apply-route-provenance: refuse a token minted by a different producer
             // family BEFORE any mutation — and before the boundary revalidation below, so a
             // wrong-route redemption never reaches RevalidateChangedPathsAsync or TryApplyChanges.
-            RequireCompatibleProducer(previewStore, previewToken, expectedKind, applyRoute);
+            RequireCompatibleProducer(previewStore, previewToken, expectedKind);
 
             // preview-apply-token-write-path-toctou: revalidate the preview's write set against
             // the sanctioned-root boundary AT REDEMPTION TIME, under the same write gate that
@@ -161,7 +156,7 @@ internal static class ToolDispatch
     /// <list type="bullet">
     ///   <item><paramref name="expectedKind"/> is <see cref="PreviewKind.Unspecified"/> — the route
     ///     has not declared a producer set, so no enforcement (the ~10 other
-    ///     <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
+    ///     <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind)"/>
     ///     apply families are still in this state; binding them is a follow-up row).</item>
     ///   <item>The stored kind is <see cref="PreviewKind.Unspecified"/> — an untagged producer or an
     ///     out-of-tree store that does not track provenance. Permissive by the enum's own documented
@@ -179,8 +174,7 @@ internal static class ToolDispatch
     internal static void RequireCompatibleProducer(
         IPreviewStore previewStore,
         string previewToken,
-        PreviewKind expectedKind,
-        string? applyRoute)
+        PreviewKind expectedKind)
     {
         if (expectedKind == PreviewKind.Unspecified)
         {
@@ -196,37 +190,83 @@ internal static class ToolDispatch
         throw new InvalidOperationException(
             $"Preview token '{previewToken}' was produced by `{PreviewToolFor(actualKind)}`; " +
             $"redeem it via `{ApplyRouteFor(actualKind)}` (or the generic `apply_with_verify`), " +
-            $"not `{applyRoute ?? ApplyRouteFor(expectedKind)}`, which only accepts " +
+            $"not `{ApplyRouteFor(expectedKind)}`, which only accepts " +
             $"`{PreviewToolFor(expectedKind)}` tokens. No workspace changes were made.");
     }
 
     /// <summary>
+    /// preview-token-route-map-centralization: THE single kind → <c>*_preview</c> tool-name map.
+    /// The apply-route half is deliberately absent — <see cref="ApplyRouteFor"/> derives it by
+    /// looking the preview-tool name up in <c>ServerSurfaceCatalog.PreviewApplyRoutes</c>,
+    /// which the catalog already maintains for the whole preview surface. Keeping only the
+    /// kind → preview-tool hop here means a route rename is edited in exactly one place.
+    /// <see cref="PreviewKind.Unspecified"/> is intentionally NOT a key: it means "no provenance
+    /// claim" and has no producer tool.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<PreviewKind, string> _previewToolsByKind =
+        new Dictionary<PreviewKind, string>
+        {
+            [PreviewKind.SymbolRename] = "rename_preview",
+            [PreviewKind.FormatDocument] = "format_document_preview",
+            [PreviewKind.FormatRange] = "format_range_preview",
+            [PreviewKind.OrganizeUsings] = "organize_usings_preview",
+            [PreviewKind.CodeFix] = "code_fix_preview",
+        };
+
+    /// <summary>
     /// preview-token-apply-route-provenance: the <c>*_preview</c> tool name that mints each
     /// <see cref="PreviewKind"/>, for the actionable half of the mismatch message.
+    /// <para>
+    /// preview-token-route-map-centralization: fails LOUD on an unmapped kind rather than
+    /// returning a plausible-looking catch-all. Only ever reached with a concrete kind —
+    /// <see cref="RequireCompatibleProducer"/> returns early on
+    /// <see cref="PreviewKind.Unspecified"/> for both the route's and the token's kind, so the
+    /// permissive contract never touches this map.
+    /// </para>
     /// </summary>
-    private static string PreviewToolFor(PreviewKind kind) => kind switch
-    {
-        PreviewKind.SymbolRename => "rename_preview",
-        PreviewKind.FormatDocument => "format_document_preview",
-        PreviewKind.FormatRange => "format_range_preview",
-        PreviewKind.OrganizeUsings => "organize_usings_preview",
-        PreviewKind.CodeFix => "code_fix_preview",
-        _ => "an untagged *_preview tool",
-    };
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="kind"/> has no entry — a new <see cref="PreviewKind"/> member
+    /// was added without its companion map entry.
+    /// </exception>
+    internal static string PreviewToolFor(PreviewKind kind) =>
+        _previewToolsByKind.TryGetValue(kind, out var previewTool)
+            ? previewTool
+            : throw UnmappedPreviewKind(kind, "ToolDispatch._previewToolsByKind (kind → *_preview tool)");
 
     /// <summary>
     /// preview-token-apply-route-provenance: the named <c>*_apply</c> route bound to each
     /// <see cref="PreviewKind"/>, for the recovery half of the mismatch message.
+    /// <para>
+    /// preview-token-route-map-centralization: derived, not re-listed — the kind resolves to its
+    /// <c>*_preview</c> tool via <see cref="PreviewToolFor"/>, and the tool resolves to its apply
+    /// route via <see cref="ServerSurfaceCatalog.TryGetCompatibleApplyRoute"/>. Same-assembly
+    /// internal reach; no visibility change was needed.
+    /// </para>
     /// </summary>
-    private static string ApplyRouteFor(PreviewKind kind) => kind switch
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="kind"/> is unmapped in either hop.
+    /// </exception>
+    internal static string ApplyRouteFor(PreviewKind kind)
     {
-        PreviewKind.SymbolRename => "rename_apply",
-        PreviewKind.FormatDocument => "format_document_apply",
-        PreviewKind.FormatRange => "format_range_apply",
-        PreviewKind.OrganizeUsings => "organize_usings_apply",
-        PreviewKind.CodeFix => "code_fix_apply",
-        _ => "apply_with_verify",
-    };
+        var previewTool = PreviewToolFor(kind);
+        return ServerSurfaceCatalog.TryGetCompatibleApplyRoute(previewTool, out var applyRoute)
+            ? applyRoute
+            : throw UnmappedPreviewKind(
+                kind,
+                $"ServerSurfaceCatalog.PreviewApplyRoutes (no entry for `{previewTool}`)");
+    }
+
+    /// <summary>
+    /// preview-token-route-map-centralization: the fail-loud arm shared by
+    /// <see cref="PreviewToolFor"/> and <see cref="ApplyRouteFor"/>. Names the offending member
+    /// and BOTH map sites so the fix is mechanical.
+    /// </summary>
+    private static InvalidOperationException UnmappedPreviewKind(PreviewKind kind, string missingSite) =>
+        new($"PreviewKind.{kind} has no entry in {missingSite}. Every concrete PreviewKind must be " +
+            "mapped in BOTH ToolDispatch._previewToolsByKind (kind → *_preview tool) and " +
+            "ServerSurfaceCatalog.PreviewApplyRoutes (*_preview tool → *_apply route); add the " +
+            "missing entry rather than letting the preview-token provenance guard report a route " +
+            "the caller cannot use.");
 
     /// <summary>
     /// preview-apply-token-write-path-toctou: runs every path in the preview's write set through
@@ -301,7 +341,7 @@ internal static class ToolDispatch
     /// A closure that invokes the service method with the <paramref name="previewToken"/>
     /// and the gate-provided <see cref="CancellationToken"/>. Kept as
     /// <c>Func&lt;CancellationToken, Task&lt;TDto&gt;&gt;</c> for the same reason as the
-    /// primary <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind, string?)"/>
+    /// primary <see cref="ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind)"/>
     /// overload: closure capture matches the existing hand-written shim bodies byte-for-byte.
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -56,8 +56,7 @@ public sealed class ToolDispatchTests
                     return Task.FromResult(new FakeResultDto("must-not-run", 0));
                 },
                 ct: CancellationToken.None,
-                expectedKind: PreviewKind.SymbolRename,
-                applyRoute: "rename_apply"));
+                expectedKind: PreviewKind.SymbolRename));
 
         Assert.IsFalse(serviceCallRan, "Provenance guard must refuse the apply BEFORE the service call runs.");
         StringAssert.Contains(ex.Message, "code_fix_preview",
@@ -88,8 +87,7 @@ public sealed class ToolDispatchTests
             previewToken: "tok-match",
             serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 1)),
             ct: CancellationToken.None,
-            expectedKind: PreviewKind.SymbolRename,
-            applyRoute: "rename_apply");
+            expectedKind: PreviewKind.SymbolRename);
 
         StringAssert.Contains(result, "applied");
     }
@@ -114,8 +112,7 @@ public sealed class ToolDispatchTests
             previewToken: "tok-untagged",
             serviceCall: _ => Task.FromResult(new FakeResultDto("applied", 2)),
             ct: CancellationToken.None,
-            expectedKind: PreviewKind.SymbolRename,
-            applyRoute: "rename_apply");
+            expectedKind: PreviewKind.SymbolRename);
 
         StringAssert.Contains(result, "applied",
             "An Unspecified producer kind means 'no provenance claim' and must stay permissive.");
@@ -144,6 +141,66 @@ public sealed class ToolDispatchTests
 
         StringAssert.Contains(result, "applied",
             "A route that declares no expectedKind must keep its pre-binding behavior.");
+    }
+
+    /// <summary>
+    /// preview-token-route-map-centralization: exhaustiveness pin. Every concrete
+    /// <see cref="PreviewKind"/> member must resolve to BOTH a <c>*_preview</c> tool name (via
+    /// <c>ToolDispatch._previewToolsByKind</c>) and a named <c>*_apply</c> route (via
+    /// <c>ServerSurfaceCatalog.PreviewApplyRoutes</c>). Adding a member without its two companion
+    /// entries fails HERE, at build time, instead of silently mis-directing a caller at redemption
+    /// time. Enumerated rather than hand-listed so the pin cannot go stale.
+    /// </summary>
+    [TestMethod]
+    public void PreviewKindRouteMap_EveryConcreteKind_ResolvesPreviewToolAndApplyRoute()
+    {
+        foreach (var kind in Enum.GetValues<PreviewKind>())
+        {
+            if (kind == PreviewKind.Unspecified)
+            {
+                // "No provenance claim" — permissive by the enum's own contract, deliberately unmapped.
+                continue;
+            }
+
+            var previewTool = ToolDispatch.PreviewToolFor(kind);
+            StringAssert.EndsWith(previewTool, "_preview",
+                $"PreviewKind.{kind} must map to a real *_preview tool name, not a catch-all phrase.");
+
+            var applyRoute = ToolDispatch.ApplyRouteFor(kind);
+            StringAssert.EndsWith(applyRoute, "_apply",
+                $"PreviewKind.{kind} must resolve to a real *_apply route name.");
+            Assert.AreNotEqual("apply_with_verify", applyRoute,
+                $"PreviewKind.{kind} must resolve to its OWN named apply route, not the generic fallback.");
+        }
+    }
+
+    /// <summary>
+    /// preview-token-route-map-centralization: the fail-loud arm. A concrete-but-unmapped kind
+    /// (simulated with an undefined enum value, so no scratch member has to be added) must throw
+    /// and name both map sites, replacing the old silent
+    /// <c>"an untagged *_preview tool"</c> / <c>"apply_with_verify"</c> catch-alls that told the
+    /// caller something factually wrong.
+    /// </summary>
+    [TestMethod]
+    public void PreviewKindRouteMap_UnmappedConcreteKind_ThrowsInsteadOfReportingACatchAll()
+    {
+        const PreviewKind Unmapped = (PreviewKind)999;
+
+        var previewEx = Assert.ThrowsExactly<InvalidOperationException>(
+            () => ToolDispatch.PreviewToolFor(Unmapped));
+        StringAssert.Contains(previewEx.Message, "999",
+            "the failure must name the unmapped member so the fix is mechanical");
+        StringAssert.Contains(previewEx.Message, "_previewToolsByKind",
+            "the failure must point at the kind → *_preview map site");
+        StringAssert.Contains(previewEx.Message, "PreviewApplyRoutes",
+            "the failure must point at the catalog map site too — both need the new entry");
+
+        var applyEx = Assert.ThrowsExactly<InvalidOperationException>(
+            () => ToolDispatch.ApplyRouteFor(Unmapped));
+        StringAssert.Contains(applyEx.Message, "999",
+            "the apply-route half must fail loud on the same unmapped member");
+        Assert.IsFalse(applyEx.Message.Contains("apply_with_verify", StringComparison.Ordinal),
+            "the generic route must no longer be offered as the answer for an unmapped kind");
     }
 
     // Distinguishable payload type so the assertions can inspect JSON structure.


### PR DESCRIPTION
## What

Collapses the **four** hand-maintained encodings of the `PreviewKind` → (`*_preview` tool, `*_apply` route) relationship into one source of truth.

Before this change the mapping lived in `ToolDispatch.PreviewToolFor`, `ToolDispatch.ApplyRouteFor`, five `applyRoute:` string literals in `RefactoringTools.cs`, and — the fourth site, found during planning and not named in the backlog row — the 24-entry `ServerSurfaceCatalog.PreviewApplyRoutes` dictionary, which already covered all five concrete kinds' preview tools.

Now `ToolDispatch` keeps only the `kind → *_preview` hop in a single map and derives the apply-route half from the catalog via the same-assembly `internal TryGetCompatibleApplyRoute`. No visibility change was needed.

## Why it matters

Both old switches had a silent catch-all. A new concrete `PreviewKind` member added without editing both would fall through to `"an untagged *_preview tool"` / `"apply_with_verify"`, so the redemption guard emitted a factually wrong but actionable-looking message — telling a caller to redeem through a route that does not accept their token.

An unmapped concrete kind now throws, naming the member and **both** map sites, so the fix is mechanical.

`PreviewKind.Unspecified` keeps its documented permissive fall-through: `RequireCompatibleProducer` returns early on `Unspecified` for both the route's and the token's kind, so the fail-loud arm is never reached for it. The two canary tests that pin that contract (`ApplyByTokenAsync_UnspecifiedProducer_SkipsGuard_AndApplies`, `ApplyByTokenAsync_UnboundRoute_DoesNotEnforceProvenance`) are unchanged and still pass.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs` — single `_previewToolsByKind` map; `PreviewToolFor` / `ApplyRouteFor` promoted `private` → `internal` (the project already declares `InternalsVisibleTo("RoslynMcp.Tests")`) and made fail-loud; the redundant `string? applyRoute` parameter deleted from `ApplyByTokenAsync` and `RequireCompatibleProducer`, along with its `<param>` doc and the three `<see cref>` signatures that named it.
- `src/RoslynMcp.Host.Stdio/Tools/RefactoringTools.cs` — five `applyRoute:` literals deleted; each route now binds with `expectedKind:` only. This is the shape the follow-on family-binding initiatives copy.
- `tests/RoslynMcp.Tests/ToolDispatchTests.cs` — three mechanical `applyRoute:` argument deletions, plus two new pins: an exhaustiveness pin iterating `Enum.GetValues<PreviewKind>()` (every non-`Unspecified` member must resolve to both a `*_preview` tool and a named `*_apply` route), and a fail-loud pin driven by an undefined enum value.
- `src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs` is **read only** — not edited.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- Targeted tests: `ToolDispatchTests`, `StartupDiagnosticsTests`, `PreviewApplyBoundaryRevalidationTests`, `PreviewTokenStaleAcrossAutoReloadTests`, `PreviewStoreTests`, `ApplyUndoWorkflowServiceTests`, `ParameterObjectPreviewTests`, `ApplyWithVerify*`, `ServerSurfaceCatalog*` — 153 passed, 0 failed.
- `eng/verify-ai-docs.ps1`, `eng/verify-changelog-fragments.ps1`, `eng/verify-changed-format.ps1` — all pass (0 new formatter findings on the touched files).
- **Negative check performed and reverted:** a scratch concrete `PreviewKind` member was added locally; the exhaustiveness pin failed loudly with the new `InvalidOperationException` naming the member and both map sites, rather than silently emitting `apply_with_verify`.

Closes: none — child 1 of 5 of `preview-token-apply-route-binding-remaining-families`; that row stays open until the four family-binding children land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
