### PR TITLE
chore(tools): trim method descriptions on test + impact tools (method-description-diet-test-tooling)

### DIFF
--- a/changelog.d/method-description-diet-test-tooling.md
+++ b/changelog.d/method-description-diet-test-tooling.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Trimmed method-level `[Description]` text on the test-and-impact tools (`test_coverage`, `get_test_coverage_map`, `test_reference_map`, `symbol_impact_sweep`, `preview_record_field_addition`) to ~200-char capability statements, cutting ~1,000 chars (~250 tokens) from every `tools/list` response. Response-field roll-calls, payload-size advice, and pagination detail moved to XML `<remarks>` and were already stated on the parameter descriptions — no capability or discriminating trigger was dropped. Added a slice-scoped description-length regression.

--- a/src/RoslynMcp.Host.Stdio/Tools/ImpactSweepTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ImpactSweepTools.cs
@@ -14,10 +14,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ImpactSweepTools
 {
+    /// <remarks>
+    /// Pass <c>summary=true</c> (drops per-reference preview text) and/or
+    /// <c>maxItemsPerCategory</c> (caps each list) for high-fan-out symbols where the default
+    /// response exceeds the MCP cap — Jellyfin's 1452-reference <c>BaseItem</c> emits ~886 KB.
+    /// </remarks>
     [McpServerTool(Name = "symbol_impact_sweep", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "experimental", true, false,
         "Sweep downstream impact of a symbol change: references + switch-exhaustiveness diagnostics + mapper-suffix callsites."),
-     Description("Sweep downstream impact of a symbol change: references, non-exhaustive switches (CS8509/CS8524/IDE0072), and mapper/converter-suffix callsites. Returns suggested-tasks list. Pass `summary=true` (drops per-ref preview text) and/or `maxItemsPerCategory` (caps each list) for high-fan-out symbols where the default response exceeds the MCP cap (Jellyfin's 1452-ref BaseItem: ~886 KB).")]
+     Description("Sweep downstream impact of a symbol change: references, non-exhaustive switches (CS8509/CS8524/IDE0072), and mapper/converter-suffix callsites. Returns a suggested-tasks list.")]
     public static Task<string> SweepSymbolImpact(
         IWorkspaceExecutionGate gate,
         IImpactSweepService impactSweepService,

--- a/src/RoslynMcp.Host.Stdio/Tools/RecordImpactTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RecordImpactTools.cs
@@ -15,10 +15,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class RecordImpactTools
 {
+    /// <remarks>
+    /// Construction sites carry rewritten argument lists, deconstruction sites carry rewritten
+    /// patterns, and property-pattern sites are flagged when exhaustive-in-spirit but missing the
+    /// new field. Test files that merely mention the record are reported separately.
+    /// </remarks>
     [McpServerTool(Name = "preview_record_field_addition", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("analysis", "experimental", true, false,
         "Pre-flight audit: every site impacted by adding a positional field to a record."),
-     Description("Pre-flight audit for adding a positional field to a record. Returns positional construction sites (with rewritten arg lists), deconstruction sites (with rewritten patterns), property-pattern sites (flagged when exhaustive-in-spirit but missing the new field), `with`-expression sites, and test files that mention the record. Catches the breaking-change shapes the C# compiler does NOT flag: pattern coverage, deconstruction shape, with-expression assumptions.")]
+     Description("Pre-flight audit for adding a positional field to a record: construction, deconstruction, property-pattern, and `with`-expression sites. Catches breaking shapes the C# compiler does NOT flag.")]
     public static Task<string> PreviewRecordFieldAddition(
         IWorkspaceExecutionGate gate,
         IRecordFieldAdditionService recordFieldAdditionService,

--- a/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs
@@ -13,10 +13,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class TestCoverageTools
 {
 
+    /// <remarks>
+    /// Response shape is the <see cref="TestCoverageResultDto"/> fields (success, error,
+    /// lineCoveragePercent, branchCoveragePercent, modules, failureEnvelope) with an additional
+    /// top-level <c>deprecation</c> field — null on this canonical tool, populated on aliases
+    /// (e.g. <c>get_test_coverage_map</c>).
+    /// </remarks>
     [McpServerTool(Name = "test_coverage", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("validation", "stable", false, false,
         "Run coverage collection for test execution."),
-     Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires coverlet.collector NuGet package in test projects. Response shape is the TestCoverageResultDto fields (success, error, lineCoveragePercent, branchCoveragePercent, modules, failureEnvelope) with an additional top-level `deprecation` field — null on the canonical tool, populated on aliases (e.g. get_test_coverage_map).")]
+     Description("Run tests with code coverage collection and return coverage metrics per module and class. Requires the coverlet.collector NuGet package in test projects.")]
     public static Task<string> RunTestCoverage(
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,
@@ -222,10 +228,14 @@ public static class TestCoverageTools
     // roslyn-mcp-sister-tool-name-aliases: thin alias for callers carrying the python-refactor
     // (Jedi) tool name `get_test_coverage_map`. Delegates to the canonical `test_coverage`
     // implementation and surfaces the migration path inline via the `deprecation` envelope.
+    /// <remarks>
+    /// Returns the canonical <c>test_coverage</c> response envelope with
+    /// <c>deprecation.canonicalName</c> populated.
+    /// </remarks>
     [McpServerTool(Name = "get_test_coverage_map", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("validation", "stable", false, false,
         "Alias for test_coverage (cross-MCP-server name compatibility)."),
-     Description("Alias for `test_coverage` (cross-MCP-server name compatibility — matches the python-refactor tool name). Returns the canonical test_coverage response envelope with deprecation.canonicalName populated. Prefer `test_coverage` directly in new code.")]
+     Description("Alias for `test_coverage` (cross-MCP-server name compatibility — matches the python-refactor tool name). Prefer `test_coverage` directly in new code.")]
     public static Task<string> GetTestCoverageMap(
         IWorkspaceExecutionGate gate,
         IWorkspaceManager workspace,

--- a/src/RoslynMcp.Host.Stdio/Tools/TestReferenceMapTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TestReferenceMapTools.cs
@@ -14,10 +14,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class TestReferenceMapTools
 {
+    /// <remarks>
+    /// Responses paginate via <c>offset</c>/<c>limit</c>; <c>projectName</c> scopes both the
+    /// productive-symbol collection (when the name matches a productive project) and the test
+    /// scan (when it matches a test project).
+    /// </remarks>
     [McpServerTool(Name = "test_reference_map", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "experimental", true, false,
         "Statically map source symbols to test references; returns covered/uncovered symbol lists and a coverage percentage. Supports offset/limit pagination and projectName scoping."),
-     Description("Map productive source symbols to the test methods that reference them statically. Useful for identifying untested public/internal APIs without running tests. Responses paginate via offset/limit; projectName scopes both the productive-symbol collection (when the name matches a productive project) and the test scan (when it matches a test project).")]
+     Description("Map productive source symbols to the test methods that reference them statically, without running tests — identifies untested public/internal APIs.")]
     public static Task<string> BuildTestReferenceMap(
         IWorkspaceExecutionGate gate,
         ITestReferenceMapService testReferenceMapService,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietTestToolingTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietTestToolingTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-description diet across the test-coverage,
+/// test-reference-map, symbol-impact-sweep, and record-impact tool groups.
+/// Deliberately narrower than <see cref="SurfaceCatalogTests"/>'s assembly-wide 2,000-char
+/// guard: that constant stays owned by the global ratchet, while these four types are held
+/// to a ~200-char capability statement with operational detail living in XML remarks.
+/// </summary>
+[TestClass]
+public sealed class MethodDescriptionDietTestToolingTests
+{
+    /// <summary>Per-tool ceiling for a capability statement in this slice.</summary>
+    private const int _maxDescriptionCharacters = 200;
+
+    /// <summary>
+    /// Aggregate ceiling for the slice. Measured 1,850 chars across 5 tools before the diet and
+    /// 815 after. <see cref="_maxDescriptionCharacters"/> is a per-tool CEILING, not a target: a
+    /// 5 x 200 = 1,000 constant would silently license ~185 chars of un-dieted text, so this
+    /// bound is the measured post-diet total plus ~9 percent headroom.
+    /// </summary>
+    private const int _maxAggregateDescriptionCharacters = 890;
+
+    private static readonly Type[] _sliceToolTypes =
+    [
+        typeof(TestCoverageTools),
+        typeof(TestReferenceMapTools),
+        typeof(ImpactSweepTools),
+        typeof(RecordImpactTools),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreCapabilityStatements()
+    {
+        var violations = EnumerateSliceTools()
+            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
+            "(what it does plus the one discriminating trigger); move operational detail to XML " +
+            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayUnderAggregateBudget()
+    {
+        var entries = EnumerateSliceTools().ToArray();
+        var total = entries.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            entries.Length > 0,
+            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
+
+        Assert.IsTrue(
+            total <= _maxAggregateDescriptionCharacters,
+            $"Aggregate method-description budget for the slice is " +
+            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
+    }
+
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
+    {
+        // Runtime coverage collection — the discriminator against test_run and test_reference_map.
+        AssertDescriptionContains("test_coverage", "Run tests with code coverage collection");
+        AssertDescriptionContains("test_coverage", "coverlet.collector");
+
+        // The alias exists only to state its identity and point at the canonical tool.
+        AssertDescriptionContains("get_test_coverage_map", "Alias for `test_coverage`");
+        AssertDescriptionContains("get_test_coverage_map", "Prefer `test_coverage`");
+
+        // Static-vs-runtime is the only thing separating this from test_coverage in tool search.
+        AssertDescriptionContains("test_reference_map", "statically, without running tests");
+
+        // The three result buckets.
+        AssertDescriptionContains("symbol_impact_sweep", "references");
+        AssertDescriptionContains("symbol_impact_sweep", "CS8509/CS8524/IDE0072");
+        AssertDescriptionContains("symbol_impact_sweep", "mapper/converter-suffix callsites");
+
+        // Trigger plus the site categories the response buckets by.
+        AssertDescriptionContains(
+            "preview_record_field_addition",
+            "adding a positional field to a record");
+        AssertDescriptionContains(
+            "preview_record_field_addition",
+            "construction, deconstruction, property-pattern, and `with`-expression sites");
+        AssertDescriptionContains("preview_record_field_addition", "does NOT flag");
+    }
+
+    private static void AssertDescriptionContains(string toolName, string expected)
+    {
+        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
+
+        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
+        StringAssert.Contains(
+            entry.Description,
+            expected,
+            $"Trimming '{toolName}' dropped its discriminating trigger.");
+    }
+
+    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
+        => _sliceToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null && entry.Description is not null)
+            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+}


### PR DESCRIPTION
## Summary

Slice 11 of the `method-description-diet` sweep. Trims the five method-level `[Description]` strings on the test-and-impact tool group to <=200-char capability statements and relocates the operational detail (response-field roll-calls, pagination scoping, payload-size advice) into XML `<remarks>` on the same methods. Net effect is ~1,035 fewer chars (~250 tokens) in every `tools/list` response.

Closes: none — this is a per-cluster slice of the `method-description-diet` backlog row; ~36 `Tools/*.cs` files remain unswept, so the row stays open.

## Linked issue

N/A — no `[gh #NNN]` reference on the `method-description-diet` backlog row.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/TestCoverageTools.cs` — trimmed `test_coverage` and `get_test_coverage_map`; `TestCoverageResultDto` field roll-call and the `deprecation`-envelope mechanics moved to `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/TestReferenceMapTools.cs` — trimmed `test_reference_map`; the `offset`/`limit` pagination and `projectName` dual-scoping paragraph moved to `<remarks>` (both were already stated verbatim on the parameters' own descriptions).
- `src/RoslynMcp.Host.Stdio/Tools/ImpactSweepTools.cs` — trimmed `symbol_impact_sweep`; the `summary`/`maxItemsPerCategory` advice and the Jellyfin `BaseItem` payload-size anecdote moved to `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/RecordImpactTools.cs` — trimmed `preview_record_field_addition`; the per-category rewrite detail moved to `<remarks>`.
- `tests/RoslynMcp.Tests/MethodDescriptionDietTestToolingTests.cs` (new) — slice-scoped ratchet: per-tool 200-char ceiling, aggregate ceiling **derived from the measured post-diet total** (890, deliberately not `5 x 200 = 1000`), and 11 discriminator-retention asserts.
- `changelog.d/method-description-diet-test-tooling.md` (new) — `category: Maintenance` fragment.

Deliberately untouched: every `McpToolMetadata(...)` summary on these four files (the pinned `Catalog/Snapshots/catalog-v2.3.1.json` mirrors those, not the method descriptions), `SurfaceCatalogTests.cs`'s `dietedTypes` array, and every other `*Tools.cs` (owned by sibling slices).

## Measured evidence (method-level `[Description]` char counts)

| tool | before | after | delta |
|---|---:|---:|---:|
| `test_coverage` | 417 | 153 | -264 |
| `get_test_coverage_map` | 245 | 149 | -96 |
| `test_reference_map` | 348 | 147 | -201 |
| `symbol_impact_sweep` | 381 | 175 | -206 |
| `preview_record_field_addition` | 459 | 191 | -268 |
| **aggregate** | **1,850** | **815** | **-1,035** |

No capability or discriminating trigger was dropped (PR #1348 lesson). Retained and asserted in the new test: `test_coverage` keeps "Run tests with code coverage collection" + "coverlet.collector"; `get_test_coverage_map` keeps its alias identity and the "Prefer `test_coverage`" pointer; `test_reference_map` keeps "statically, without running tests" (its only discriminator against `test_coverage` in capability search); `symbol_impact_sweep` keeps all three result buckets including `CS8509/CS8524/IDE0072`; `preview_record_field_addition` keeps the trigger, the four site categories, and "does NOT flag".

## Test plan

- [x] Added or updated unit/integration tests covering the change
- [x] `dotnet build RoslynMcp.slnx` succeeds (0 warnings, warnings-as-errors on)
- [x] `dotnet test` passes on the targeted filter set — 99 passed / 0 failed, covering `MethodDescriptionDiet*`, `SurfaceCatalogTests` (assembly-wide 2,000-char guard + `McpToolMetadata` drift), `PromptSmokeTests`, `ToolDescriptionDiet*`, `RefactoringCoreDescriptionBudget*`, and the TestCoverage / TestReferenceMap / ImpactSweep / RecordField service suites
- [x] `./eng/verify-changed-format.ps1` — passed, 0 new findings (3 pre-existing baselined `IMPORTS` findings reported, not suppressed)
- [x] `./eng/verify-changelog-fragments.ps1` — passed
- [x] `./eng/verify-ai-docs.ps1` — passed

Full `verify-release.ps1 -Configuration Release` is left to the self-hosted CI runner rather than duplicated locally.

## Checklist

- [x] Followed the existing code style and project layering
- [x] No new compiler warnings
- [x] Public API changes are intentional and documented — description text only; no signature, DTO, or catalog-summary change

## Backlog (maintainer-only)

- Closes backlog row: N/A — slice of `method-description-diet`; row stays open.
- Follow-on recommended (out of scope here, per the plan's Directive-#3 flag): a `method-description-diet-ratchet-consolidation` row. Four slice-scoped ratchet classes now exist with three different per-tool caps (200 / 220 / 250) plus the assembly-wide 2,000 guard; `ai_docs/items/method-description-diet.md:42` claims that consolidation was "filed separately" but no such row exists in `ai_docs/backlog.md`.
- Also observed while working (Directive #3): `.editorconfig:41-49` applies the `_`-prefix `private_fields_should_be_camel_case` rule to `private const` and `private static readonly` fields, forcing `_maxDescriptionCharacters` naming on compile-time constants. Existing test files carry this as baselined formatter debt; new files must adopt the unconventional naming to pass `verify-changed-format.ps1`.
