### PR TITLE
chore(host): trim server/discovery tool descriptions to capability statements (method-description-diet-server-surface)

### DIFF
--- a/changelog.d/method-description-diet-server-surface.md
+++ b/changelog.d/method-description-diet-server-surface.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Trimmed method-level tool descriptions for the server/discovery surface (`server_info`, `server_heartbeat`, `recommend_workflow`, `suggest_refactorings`, `get_prompt_text`) to <=200-char capability statements, relocating the connection state-machine, prompts-tier note, and usage guidance to XML remarks. Cuts the `tools/list` payload for these 5 tools from 2,826 characters to 979 with no capability statement or discriminating trigger dropped.

--- a/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs
@@ -42,10 +42,16 @@ public static class PromptShimTools
 
     internal static int PromptIndexBuildCount => Volatile.Read(ref _promptIndexBuildCount);
 
+    /// <remarks>
+    /// Example <c>promptName</c> values: <c>explain_error</c>, <c>refactor_and_validate</c>.
+    /// Enumerate the full set with <c>list_prompts</c> on the resources channel or by reading
+    /// <c>roslyn://server/catalog</c>. The response shape is
+    /// <c>{ messages: [{role, text}], promptName, parameterCount }</c>.
+    /// </remarks>
     [McpServerTool(Name = "get_prompt_text", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("prompts", "experimental", true, false,
         "Render any registered MCP prompt as plain text. Pass the prompt name plus a JSON object of the prompt's parameters; returns { messages: [{role, text}], promptName, parameterCount }."),
-     Description("Render any registered MCP prompt as plain text via the regular tool channel. Useful for clients that cannot invoke prompts via prompts/get directly. Pass `promptName` (e.g. \"explain_error\", \"refactor_and_validate\") and a `parametersJson` object containing the prompt's named parameters. Returns the rendered message list as JSON.")]
+     Description("Render any registered MCP prompt as plain text via the tool channel, for clients that cannot use the prompts/get channel. Pass `promptName` plus a `parametersJson` object; returns messages as JSON.")]
     public static async Task<string> GetPromptText(
         IServiceProvider services,
         [Description("The name of the prompt as registered with [McpServerPrompt(Name = \"...\")]. Use list_prompts on the resources channel or read roslyn://server/catalog for the full list.")] string promptName,

--- a/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs
@@ -76,11 +76,34 @@ public static class ServerTools
             PreviousRecycleReason: previous?.RecycleReason);
     }
 
+    /// <remarks>
+    /// <para>
+    /// <c>workspaceCount</c> reflects sessions at call time and may briefly lag if invoked in
+    /// parallel with — or immediately after — <c>workspace_load</c>; <c>workspace_list</c> is
+    /// the authoritative session enumeration.
+    /// </para>
+    /// <para>
+    /// Prompts tier note: the response carries <c>prompts.stable</c> and
+    /// <c>prompts.experimental</c> from the live catalog. All currently-exposed prompts are
+    /// experimental until promoted, so <c>stable=0</c> alongside a nonzero experimental count
+    /// is expected — it is NOT a missing-surface bug.
+    /// </para>
+    /// <para>
+    /// The <c>connection</c> subfield (state / loadedWorkspaceCount / stdioPid /
+    /// serverStartedAt) distinguishes transport-reachable from workspace-loaded before calling
+    /// workspace-scoped tools; <c>server_heartbeat</c> returns that block alone. The
+    /// idle/ready/degraded state machine — including the guidance that prompts meaning "server
+    /// responsive" should gate on <c>state in {idle, ready}</c> rather than
+    /// <c>state==ready</c> — is documented canonically on
+    /// <see cref="BuildConnection(IWorkspaceManager, ServerProcessMetadata)"/>; do not restate
+    /// it here.
+    /// </para>
+    /// </remarks>
     [McpServerTool(Name = "server_info", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false,
         UseStructuredContent = true, OutputSchemaType = typeof(ServerInfoDto)),
      McpToolMetadata("server", "stable", true, false,
         "Inspect server capabilities, versions, and support tiers."),
-     Description("Get server version, capabilities, runtime information, and loaded workspace count. workspaceCount reflects sessions at call time and may briefly lag if invoked in parallel with or immediately after workspace_load; use workspace_list for authoritative session enumeration. Prompts tier note: the response carries prompts.stable and prompts.experimental from the live catalog; all currently-exposed prompts are experimental until promoted, so stable=0 with a nonzero experimental count is expected — it is NOT a missing-surface bug. Connection readiness: the response includes a `connection` subfield with state=idle|ready|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt — use this (or the lighter `server_heartbeat` tool) to distinguish transport-reachable from workspace-loaded before calling workspace-scoped tools. State machine: `idle` = transport up but no workspace loaded (terminal pre-load state; server does NOT auto-advance — call `workspace_load` to transition to `ready`). `ready` = at least one workspace loaded; workspace-scoped tools will resolve. `degraded` = reserved for future use (not emitted today). Prompts that previously gated on `state==ready` to mean 'server responsive' should gate on `state in {idle, ready}`; prompts that genuinely require a loaded workspace should continue to gate on `state==ready`.")]
+     Description("Server version, capabilities, runtime, and workspace count plus a `connection` readiness block (state=idle|ready|degraded). workspace_list is authoritative for sessions; server_heartbeat is cheaper.")]
     public static Task<CallToolResult> GetServerInfo(
         IWorkspaceManager workspace,
         ILatestVersionProvider versionChecker,
@@ -289,11 +312,20 @@ public static class ServerTools
     /// startup — calling <c>server_info</c> on every poll needlessly ships ~2 KB of
     /// catalog summary each time.
     /// </summary>
+    /// <remarks>
+    /// Returns <c>state=idle|ready|degraded</c> plus <c>loadedWorkspaceCount</c>,
+    /// <c>stdioPid</c>, and <c>serverStartedAt</c> — no version, catalog, or update metadata.
+    /// The idle/ready/degraded state machine is documented canonically on
+    /// <see cref="BuildConnection(IWorkspaceManager, ServerProcessMetadata)"/>. Poll this to
+    /// observe "at least one workspace loaded" before calling workspace-scoped tools, but
+    /// never poll waiting for <c>idle</c> to transition off on its own: pre-load is a terminal
+    /// state and only a <c>workspace_load</c> call advances it to <c>ready</c>.
+    /// </remarks>
     [McpServerTool(Name = "server_heartbeat", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false,
         UseStructuredContent = true, OutputSchemaType = typeof(ServerHeartbeatDto)),
      McpToolMetadata("server", "stable", true, false,
         "Lightweight connection readiness probe — returns state/loadedWorkspaceCount/stdioPid/serverStartedAt without the full server_info payload."),
-     Description("Return the connection readiness block only — state=idle|ready|degraded, loadedWorkspaceCount, stdioPid, and serverStartedAt. Cheaper than server_info (no version, catalog, or update metadata). State machine: `idle` = transport up but no workspace loaded (terminal pre-load state; server does NOT auto-advance — call `workspace_load` to transition to `ready`). `ready` = at least one workspace loaded; workspace-scoped tools will resolve. `degraded` = reserved for future use (not emitted today). Use this to poll for 'at least one workspace loaded' before calling workspace-scoped tools; do NOT poll waiting for `idle` to transition off its own — a `workspace_load` call is required.")]
+     Description("Connection readiness block only (state/loadedWorkspaceCount/stdioPid/serverStartedAt); cheaper than server_info. Do not poll waiting for `idle` to self-advance — a workspace_load call is required.")]
     public static Task<CallToolResult> GetServerHeartbeat(
         IWorkspaceManager workspace,
         ServerProcessMetadata processMetadata)

--- a/src/RoslynMcp.Host.Stdio/Tools/SuggestionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SuggestionTools.cs
@@ -8,10 +8,17 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class SuggestionTools
 {
+    /// <remarks>
+    /// Suggestions are ranked across three independent signals — complexity metrics, LCOM4
+    /// cohesion analysis, and unused-symbol detection — and each entry carries a severity, a
+    /// human-readable description, the target symbol's location, and the recommended tool
+    /// sequence to act on it. Use <c>limit</c> to cap the returned set and <c>projectName</c>
+    /// to scope the sweep to a single project.
+    /// </remarks>
     [McpServerTool(Name = "suggest_refactorings", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
     [McpToolMetadata("advanced-analysis", "stable", true, false,
         "Analyze the workspace and return ranked refactoring suggestions based on complexity, cohesion (LCOM4), and unused symbol detection. Each suggestion includes severity, target, and recommended tool sequence.")]
-    [Description("Analyze the workspace and return ranked refactoring suggestions based on complexity metrics, cohesion analysis (LCOM4), and unused symbol detection. Each suggestion includes severity, description, target symbol location, and a recommended tool sequence.")]
+    [Description("Return ranked workspace refactoring suggestions from complexity metrics, cohesion (LCOM4), and unused-symbol detection; each carries severity, target location, and a recommended tool sequence.")]
     public static Task<string> SuggestRefactorings(
         IWorkspaceExecutionGate gate,
         IRefactoringSuggestionService suggestionService,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs
@@ -8,10 +8,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class WorkflowRecommendationTools
 {
+    /// <remarks>
+    /// Intended as the discovery front door: call this when the task is known but the tool
+    /// sequence is not, instead of reading the full catalog. <c>requiredWorkspaceState</c>
+    /// tells the caller whether a <c>workspace_load</c> must precede the recommended hops, and
+    /// <c>avoid</c> names the tools that look plausible for the task but are the wrong fit.
+    /// </remarks>
     [McpServerTool(Name = "recommend_workflow", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("orchestration", "experimental", true, false,
         "Recommend first-hop Roslyn MCP tools for a natural-language task."),
-     Description("Recommend a compact first-hop workflow for a task. Returns primaryTools, followUpTools, avoid, why, and requiredWorkspaceState so agents can choose focused Roslyn tools without reading the full catalog.")]
+     Description("Recommend a compact first-hop workflow for a task. Returns primaryTools, followUpTools, avoid, why, and requiredWorkspaceState so agents pick focused Roslyn tools without reading the full catalog.")]
     public static Task<string> RecommendWorkflow(
         [Description("Natural-language task, e.g. 'find callers', 'outline this file', 'compile sanity', 'run related tests', or 'rename this symbol'.")] string task,
         [Description("Optional absolute file path relevant to the task.")] string? filePath = null,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
@@ -1,0 +1,111 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-description diet across the server/discovery surface
+/// (<c>server_info</c>, <c>server_heartbeat</c>, <c>recommend_workflow</c>,
+/// <c>suggest_refactorings</c>, <c>get_prompt_text</c>). Deliberately narrower than
+/// <see cref="SurfaceCatalogTests"/>'s assembly-wide 2,000-char guard: that constant stays
+/// owned by the global ratchet, while these four types are held to a ~200-char capability
+/// statement with operational detail living in XML remarks.
+/// </summary>
+[TestClass]
+public sealed class MethodDescriptionDietServerSurfaceTests
+{
+    /// <summary>Per-tool ceiling for a capability statement in this slice.</summary>
+    private const int MaxDescriptionCharacters = 200;
+
+    /// <summary>
+    /// Aggregate ceiling for the slice, per the initiative spec. Measured 2,826 chars across
+    /// 5 tools before the diet and 979 after. <see cref="MaxDescriptionCharacters"/> is a
+    /// per-tool CEILING, not a target, so the aggregate is not bounded below by 5 x 200; this
+    /// constant is the measured post-diet total plus a small drafting headroom.
+    /// </summary>
+    private const int MaxAggregateDescriptionCharacters = 1_050;
+
+    private static readonly Type[] SliceToolTypes =
+    [
+        typeof(ServerTools),
+        typeof(WorkflowRecommendationTools),
+        typeof(SuggestionTools),
+        typeof(PromptShimTools),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreCapabilityStatements()
+    {
+        var violations = EnumerateSliceTools()
+            .Where(entry => entry.Description.Length > MaxDescriptionCharacters)
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Method [Description] for these tools must be <= {MaxDescriptionCharacters} characters " +
+            "(what it does plus the one discriminating trigger); move operational detail to XML " +
+            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayUnderAggregateBudget()
+    {
+        var entries = EnumerateSliceTools().ToArray();
+        var total = entries.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            entries.Length > 0,
+            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
+
+        Assert.IsTrue(
+            total <= MaxAggregateDescriptionCharacters,
+            $"Aggregate method-description budget for the slice is " +
+            $"{MaxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
+    }
+
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
+    {
+        // The two clauses most at risk of being dropped rather than relocated.
+        AssertDescriptionContains(
+            "server_heartbeat",
+            "Do not poll waiting for `idle` to self-advance");
+        AssertDescriptionContains(
+            "server_info",
+            "workspace_list is authoritative");
+
+        // Remaining per-tool discriminators.
+        AssertDescriptionContains("server_heartbeat", "cheaper than server_info");
+        AssertDescriptionContains("suggest_refactorings", "LCOM4");
+        AssertDescriptionContains("get_prompt_text", "prompts/get");
+        AssertDescriptionContains("recommend_workflow", "requiredWorkspaceState");
+    }
+
+    private static void AssertDescriptionContains(string toolName, string expected)
+    {
+        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
+
+        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
+        StringAssert.Contains(
+            entry.Description,
+            expected,
+            $"Trimming '{toolName}' dropped its discriminating trigger.");
+    }
+
+    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
+        => SliceToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null && entry.Description is not null)
+            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+}

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
@@ -17,17 +17,17 @@ namespace RoslynMcp.Tests;
 public sealed class MethodDescriptionDietServerSurfaceTests
 {
     /// <summary>Per-tool ceiling for a capability statement in this slice.</summary>
-    private const int MaxDescriptionCharacters = 200;
+    private const int _maxDescriptionCharacters = 200;
 
     /// <summary>
     /// Aggregate ceiling for the slice, per the initiative spec. Measured 2,826 chars across
-    /// 5 tools before the diet and 979 after. <see cref="MaxDescriptionCharacters"/> is a
+    /// 5 tools before the diet and 979 after. <see cref="_maxDescriptionCharacters"/> is a
     /// per-tool CEILING, not a target, so the aggregate is not bounded below by 5 x 200; this
     /// constant is the measured post-diet total plus a small drafting headroom.
     /// </summary>
-    private const int MaxAggregateDescriptionCharacters = 1_050;
+    private const int _maxAggregateDescriptionCharacters = 1_050;
 
-    private static readonly Type[] SliceToolTypes =
+    private static readonly Type[] _sliceToolTypes =
     [
         typeof(ServerTools),
         typeof(WorkflowRecommendationTools),
@@ -39,7 +39,7 @@ public sealed class MethodDescriptionDietServerSurfaceTests
     public void SliceToolDescriptions_AreCapabilityStatements()
     {
         var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > MaxDescriptionCharacters)
+            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
             .OrderBy(entry => entry.Name, StringComparer.Ordinal)
             .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
             .ToArray();
@@ -47,7 +47,7 @@ public sealed class MethodDescriptionDietServerSurfaceTests
         Assert.AreEqual(
             0,
             violations.Length,
-            $"Method [Description] for these tools must be <= {MaxDescriptionCharacters} characters " +
+            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
             "(what it does plus the one discriminating trigger); move operational detail to XML " +
             "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
     }
@@ -63,9 +63,9 @@ public sealed class MethodDescriptionDietServerSurfaceTests
             "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
 
         Assert.IsTrue(
-            total <= MaxAggregateDescriptionCharacters,
+            total <= _maxAggregateDescriptionCharacters,
             $"Aggregate method-description budget for the slice is " +
-            $"{MaxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
+            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public sealed class MethodDescriptionDietServerSurfaceTests
     }
 
     private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => SliceToolTypes
+        => _sliceToolTypes
             .SelectMany(type => type.GetMethods(
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
             .Select(method => new


### PR DESCRIPTION
## Summary

Phase-A child of the `method-description-diet` split, covering the server/discovery surface: trims method-level `[Description]` metadata on the five `[McpServerTool]` methods in `ServerTools.cs`, `WorkflowRecommendationTools.cs`, `SuggestionTools.cs`, and `PromptShimTools.cs` so each advertises a <=200-char capability statement instead of a paragraph of operational guidance.

Slice aggregate: **2,826 -> 979 chars across 5 tools**, max per-tool 200 (was 1,349).

| Tool | Before | After |
|---|---:|---:|
| `server_info` | 1,349 | 198 |
| `server_heartbeat` | 689 | 196 |
| `get_prompt_text` | 333 | 197 |
| `suggest_refactorings` | 253 | 192 |
| `recommend_workflow` | 202 | 196 |

Root cause was duplication, not density: the idle/ready/degraded state machine was written out three times — canonically in the XML `<summary>` on `BuildConnection`, then verbatim again in both tool `[Description]`s — and `suggest_refactorings`'s `[Description]` was a near-verbatim restatement of its own `McpToolMetadata` summary two lines above. Only the `[Description]` copy is billed on every `tools/list`.

## Changes

- `src/RoslynMcp.Host.Stdio/Tools/ServerTools.cs` — `server_info` and `server_heartbeat` trimmed; the `workspaceCount` lag caveat, the prompts-tier `stable=0` note, and the `connection` subfield guidance moved to new XML `<remarks>`, which now cross-reference the canonical state-machine copy on `BuildConnection` instead of writing a third one. `GetServerHeartbeat`'s existing `<summary>` was appended to, not overwritten.
- `src/RoslynMcp.Host.Stdio/Tools/SuggestionTools.cs` — `suggest_refactorings` trimmed; per-entry payload shape and the `limit` / `projectName` scoping notes moved to `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/PromptShimTools.cs` — `get_prompt_text` trimmed; example prompt names, the enumeration route, and the response shape moved to `<remarks>`.
- `src/RoslynMcp.Host.Stdio/Tools/WorkflowRecommendationTools.cs` — `recommend_workflow` trimmed 202 -> 196 with its `primaryTools`/`followUpTools`/`avoid`/`why`/`requiredWorkspaceState` field list intact; discovery-front-door framing moved to `<remarks>`.
- `tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs` — new slice-scoped ratchet modeled on `MethodDescriptionDietScaffoldingMutationTests`: per-tool <=200, aggregate <=1,050 (measured 979, constant set from the real post-diet total plus headroom — not `5 x 200`), plus explicit assertions that each tool kept its discriminating trigger, including the two at-risk clauses.
- `changelog.d/method-description-diet-server-surface.md` — Maintenance fragment.

## At-risk clauses explicitly pinned

Both are asserted by `TrimmedDescriptions_KeepTheirDiscriminatingTriggers`, so a future trim cannot silently drop them:

- `server_heartbeat`: "Do not poll waiting for `idle` to self-advance — a workspace_load call is required."
- `server_info`: "workspace_list is authoritative for sessions".

## Deliberately untouched

- `McpToolMetadata(...)` summary strings — `SurfaceCatalogTests` asserts summary parity against the catalog partials, so editing one would drag the `ServerSurfaceCatalog` hotspot in as a fifth production file. Zero catalog ripple here.
- Parameter-level `[Description]`s — owned by the sibling `param-description-dedupe-*` initiatives.
- The canonical state-machine `<summary>` on `BuildConnection` (`ServerTools.cs:22-52`) — the new `<remarks>` cross-reference it rather than restating it.
- The assembly-wide 2,000-char constant at `SurfaceCatalogTests.cs:287` — stays owned by whichever slice lands the global ratchet.

## Note on the slice-assignment count

The parent row's slice assignment said 9 `[McpServerTool]` methods across these four files; the live count is 5. Budget and ratchet were re-derived from the live count.

## Validation

- `dotnet build tests/RoslynMcp.Tests -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet test --filter MethodDescriptionDietServerSurfaceTests|SurfaceCatalogTests|ServerHeartbeatTests|ServerDiscoveryWireTests|PromptShimToolsTests|PromptSmokeTests` — 68 passed, 0 failed.
- `eng/verify-ai-docs.ps1` — passed.
- Full `eng/verify-release.ps1` deferred to the self-hosted CI runner (per standing guidance not to duplicate the runner's work locally).

Closes: (none — parent row `method-description-diet` stays open; ~40 `Tools/*.cs` remain across this and sibling clusters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
