### PR TITLE
chore(host): trim method descriptions for editing/MSBuild/suppression/symbol-refactor tools (method-description-diet-editing-msbuild)

### DIFF
--- a/changelog.d/method-description-diet-editing-msbuild.md
+++ b/changelog.d/method-description-diet-editing-msbuild.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Trimmed method-level tool descriptions for the direct-edit, MSBuild-evaluation, pragma-suppression, and composite symbol-refactor tool groups to ~200-char capability statements, moving operational detail to XML remarks. Cuts the `tools/list` payload for these 11 tools from 3,770 to 1,770 characters with no capability statement, discriminating trigger, or refusal clause dropped. Advances `method-description-diet`; the row stays open for the remaining unswept `Tools/*.cs` files.

--- a/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditTools.cs
@@ -12,10 +12,19 @@ namespace RoslynMcp.Host.Stdio.Tools;
 public static class EditTools
 {
 
+    /// <remarks>
+    /// Each edit specifies a range (start/end line and column) and the replacement text. The
+    /// workspace is updated in-place and a diff is returned. The undo snapshot is one slot per
+    /// workspace, written once per call. When <c>verify</c> is true, <c>compile_check</c> runs
+    /// scoped to the owning project after the edit and the new-error set is attached as
+    /// Verification (pre-existing errors are filtered out via a pre-vs-post fingerprint diff).
+    /// When <c>autoRevertOnError</c> is true AND new errors appeared, the edit is rolled back
+    /// through the same single-slot undo path this call just populated.
+    /// </remarks>
     [McpServerTool(Name = "apply_text_edit", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("editing", "stable", false, true,
         "Apply direct text edits to a single file; optional verify + auto-revert on new compile errors."),
-     Description("Apply one or more text edits to a source file in the workspace. Each edit specifies a range (start/end line and column) and the replacement text. The workspace is updated in-place and a diff is returned. Revertible via revert_last_apply (one snapshot per call, single-slot per workspace). When verify=true, runs compile_check scoped to the owning project after the edit and attaches the new-error set as Verification (pre-existing errors are filtered out via a pre-vs-post fingerprint diff). When autoRevertOnError=true AND new errors appeared, the edit is rolled back through the same single-slot undo path this call just populated. Prefer a semantic preview/apply Roslyn tool whenever one exists; only fall back to apply_text_edit when no semantic equivalent is available.")]
+     Description("Apply one or more text edits to a source file in the workspace. Revertible via revert_last_apply. Prefer a semantic preview/apply Roslyn tool whenever one exists; fall back here only when none does.")]
     public static Task<string> ApplyTextEdit(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/MSBuildTools.cs
@@ -30,10 +30,16 @@ public static class MSBuildTools
             c => msbuildEvaluation.EvaluatePropertyAsync(workspaceId, projectName, propertyName, c),
             ct);
 
+    /// <remarks>
+    /// DocumentCount discrepancy note: when comparing an <c>evaluate_msbuild_items Compile</c>
+    /// count of N to the DocumentCount reported by <c>workspace_load</c>, the latter may be N+3
+    /// because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that
+    /// are not in the explicit <c>Compile</c> item list.
+    /// </remarks>
     [McpServerTool(Name = "evaluate_msbuild_items", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("project-mutation", "stable", true, false,
         "List MSBuild items of a type with evaluated includes and metadata."),
-     Description("List MSBuild items of a given type (e.g. Compile, PackageReference) with evaluated includes and metadata. DocumentCount discrepancy note: when comparing 'evaluate_msbuild_items Compile' count N to workspace_load's DocumentCount, the latter may be N+3 because the SDK auto-generates implicit-usings, AssemblyInfo, and GlobalUsings files that are not in the explicit <Compile> item list.")]
+     Description("List MSBuild items of a given type (e.g. Compile, PackageReference) with evaluated includes and metadata.")]
     public static Task<string> EvaluateMsbuildItems(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,
@@ -47,10 +53,15 @@ public static class MSBuildTools
             c => msbuildEvaluation.EvaluateItemsAsync(workspaceId, projectName, itemType, c),
             ct);
 
+    /// <remarks>
+    /// The unfiltered set is frequently 60KB+ of mostly internal MSBuild state. The response
+    /// includes <c>totalCount</c>, <c>returnedCount</c>, and <c>appliedFilter</c> so the caller can
+    /// see how much the filter it supplied elided.
+    /// </remarks>
     [McpServerTool(Name = "get_msbuild_properties", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("project-mutation", "stable", true, false,
         "Dump evaluated MSBuild properties for a project."),
-     Description("Dump evaluated MSBuild properties for a project. The full set is large (frequently 60KB+ of mostly internal MSBuild state); always pass a propertyNameFilter substring or an explicit includedNames allowlist unless you really need everything. The response includes totalCount/returnedCount/appliedFilter for visibility.")]
+     Description("Dump evaluated MSBuild properties for a project. The full set is large (frequently 60KB+); always pass a propertyNameFilter substring or an includedNames allowlist unless you need everything.")]
     public static Task<string> GetMsbuildProperties(
         IWorkspaceExecutionGate gate,
         IMsBuildEvaluationService msbuildEvaluation,

--- a/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SuppressionTools.cs
@@ -59,10 +59,15 @@ public static class SuppressionTools
             },
             ct);
 
+    /// <remarks>
+    /// The classic cosmetic-pragma shape is a pair that wraps line 68 while the diagnostic
+    /// actually fires at line 78: the suppression looks present in review but suppresses nothing.
+    /// This tool performs no edits; widen a mis-scoped pair with <c>pragma_scope_widen</c>.
+    /// </remarks>
     [McpServerTool(Name = "verify_pragma_suppresses", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("validation", "stable", true, false,
         "Verify an existing #pragma warning disable/restore pair covers a fire line."),
-     Description("Check whether a '#pragma warning disable/restore' pair for the given diagnostic id actually covers the specified 1-based line. Detects 'cosmetic pragma' bugs where the pragma pair wraps the wrong span (e.g. pair wraps line 68 but the diagnostic actually fires at line 78). Read-only — no edits.")]
+     Description("Check whether a '#pragma warning disable/restore' pair for a diagnostic id actually covers the given 1-based line. Detects 'cosmetic pragma' bugs where the pair wraps the wrong span. Read-only.")]
     public static Task<string> VerifyPragmaSuppresses(
         IWorkspaceExecutionGate gate,
         ISuppressionService suppressionService,
@@ -78,10 +83,17 @@ public static class SuppressionTools
                 workspaceId, filePath, line, diagnosticId, c),
             ct);
 
+    /// <remarks>
+    /// Both refusal conditions exist because relocating the restore across a
+    /// <c>#region</c>/<c>#endregion</c> boundary, or into another
+    /// <c>#pragma warning disable</c> for the same id, would silently change the effective scope
+    /// of other suppressions. When the existing pair already covers the target line the call is an
+    /// idempotent no-op.
+    /// </remarks>
     [McpServerTool(Name = "pragma_scope_widen", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("editing", "stable", false, false,
         "Extend an existing #pragma warning restore past a target line."),
-     Description("Extend a matching '#pragma warning restore &lt;id&gt;' down to cover a previously-uncovered fire site. Refuses the edit when relocating the restore would cross a #region/#endregion boundary or nest into another '#pragma warning disable &lt;id&gt;' for the same id (both would silently change the effective scope of other suppressions). Idempotent no-op when the existing pair already covers the target.")]
+     Description("Extend a matching '#pragma warning restore &lt;id&gt;' to cover an uncovered fire site. Refuses when the move would cross a #region/#endregion boundary or nest into another disable for the same id.")]
     public static Task<string> PragmaScopeWiden(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/SymbolRefactorTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SymbolRefactorTools.cs
@@ -15,10 +15,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class SymbolRefactorTools
 {
+    /// <remarks>
+    /// Each operation is <c>{ kind: 'rename'|'edit'|'restructure', ... }</c>; see
+    /// <see cref="ISymbolRefactorService"/> for the per-kind field shape. Later operations see the
+    /// rewritten state produced by earlier ones, and the accumulated result is stored under a
+    /// single preview token.
+    /// </remarks>
     [McpServerTool(Name = "symbol_refactor_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Composite preview chaining rename + edit + restructure operations into a single token."),
-     Description("Composite preview that chains heterogeneous refactor operations (rename, multi-file edit, structural rewrite) in order. Operations are atomic: a failure in any step aborts the whole preview. Each operation is { kind: 'rename'|'edit'|'restructure', ... }. See ISymbolRefactorService for the per-kind field shape.")]
+     Description("Composite preview chaining heterogeneous refactor operations (rename, multi-file edit, structural rewrite) in order. Atomic: a failure in any step aborts the whole preview.")]
     public static Task<string> PreviewSymbolRefactor(
         IWorkspaceExecutionGate gate,
         ISymbolRefactorService symbolRefactorService,
@@ -31,10 +37,17 @@ public static class SymbolRefactorTools
             c => symbolRefactorService.PreviewAsync(workspaceId, operations ?? [], c),
             ct);
 
+    /// <remarks>
+    /// Composite preset <c>composite-split-service-di-registration</c>, built on
+    /// <c>symbol_refactor_preview</c> primitives. The registration lifetime
+    /// (Transient/Scoped/Singleton) is inferred from the existing registration. When the host
+    /// registration file is null or the registration is missing, the preview falls back to a
+    /// warning rather than crashing.
+    /// </remarks>
     [McpServerTool(Name = "split_service_with_di_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Composite preview splitting a service into partitions + forwarding facade + DI-registration deltas."),
-     Description("Composite preset (composite-split-service-di-registration) built on symbol_refactor_preview primitives: splits a service type into N partition implementations + a forwarding facade, and emits DI-registration deltas (Transient/Scoped/Singleton inferred from the existing registration) in one preview token. When the host registration file is null or the registration is missing, the preview falls back to a warning rather than crashing.")]
+     Description("Composite preview that splits a service type into N partition implementations plus a forwarding facade, and emits DI-registration deltas, under one preview token.")]
     public static Task<string> PreviewSplitServiceWithDi(
         IWorkspaceExecutionGate gate,
         ISymbolRefactorService symbolRefactorService,
@@ -51,10 +64,16 @@ public static class SymbolRefactorTools
                 workspaceId, sourceFilePath, sourceType, partitions ?? [], hostRegistrationFile, c),
             ct);
 
+    /// <remarks>
+    /// Composite preset <c>record-field-add-satellite-member-sync</c>. It inspects the type's
+    /// existing fields, infers the satellite-sync pattern (Clone/Snapshot/With/ToJson/Increment),
+    /// and proposes edits for every mirror site. Redeem the returned <c>previewToken</c> via
+    /// <c>apply_composite_preview</c>.
+    /// </remarks>
     [McpServerTool(Name = "record_field_add_with_satellites_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Composite preview synthesizing coordinated edits for satellite members when a type gains a new field."),
-     Description("Composite preview (record-field-add-satellite-member-sync) that inspects a type's existing fields, infers the satellite-sync pattern (Clone/Snapshot/With/ToJson/Increment), and proposes edits for every mirror site when a new field is added. Pattern inference is conservative: requires ≥2 sibling fields with identical satellite coverage before declaring a pattern — returns an empty preview with `patternDetectionReason` populated otherwise. Redeem the `previewToken` via apply_composite_preview.")]
+     Description("Composite preview proposing satellite edits (Clone/Snapshot/With) when a type gains a field. Requires ≥2 sibling fields with identical satellite coverage, else empty with `patternDetectionReason`.")]
     public static Task<string> PreviewRecordFieldAddWithSatellites(
         IWorkspaceExecutionGate gate,
         ISymbolRefactorService symbolRefactorService,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietEditingMsBuildTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietEditingMsBuildTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for the method-description diet across the direct-edit,
+/// MSBuild-evaluation, pragma-suppression, and composite symbol-refactor tool groups.
+/// Deliberately narrower than <see cref="SurfaceCatalogTests"/>'s assembly-wide 2,000-char
+/// guard: that constant stays owned by the global ratchet, while these four types are held
+/// to a ~200-char capability statement with operational detail living in XML remarks.
+/// </summary>
+[TestClass]
+public sealed class MethodDescriptionDietEditingMsBuildTests
+{
+    /// <summary>Per-tool ceiling for a capability statement in this slice.</summary>
+    private const int _maxDescriptionCharacters = 200;
+
+    /// <summary>
+    /// Aggregate ceiling for the slice, per the initiative spec. Measured 3,770 chars across
+    /// 11 tools before the diet and 1,770 after. <see cref="_maxDescriptionCharacters"/> is a
+    /// per-tool CEILING, not a target: three tools in this slice already stated their capability
+    /// in well under 150 chars, so the aggregate is not bounded below by 11 x 200.
+    /// </summary>
+    private const int _maxAggregateDescriptionCharacters = 1_850;
+
+    private static readonly Type[] _sliceToolTypes =
+    [
+        typeof(EditTools),
+        typeof(MSBuildTools),
+        typeof(SuppressionTools),
+        typeof(SymbolRefactorTools),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreCapabilityStatements()
+    {
+        var violations = EnumerateSliceTools()
+            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
+            "(what it does plus the one discriminating trigger); move operational detail to XML " +
+            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayUnderAggregateBudget()
+    {
+        var entries = EnumerateSliceTools().ToArray();
+        var total = entries.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            entries.Length > 0,
+            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
+
+        Assert.IsTrue(
+            total <= _maxAggregateDescriptionCharacters,
+            $"Aggregate method-description budget for the slice is " +
+            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
+    }
+
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
+    {
+        AssertDescriptionContains(
+            "apply_text_edit",
+            "Prefer a semantic preview/apply Roslyn tool whenever one exists");
+        AssertDescriptionContains(
+            "apply_text_edit",
+            "Revertible via revert_last_apply");
+        AssertDescriptionContains(
+            "pragma_scope_widen",
+            "Refuses when the move would cross a #region/#endregion boundary");
+        AssertDescriptionContains(
+            "verify_pragma_suppresses",
+            "'cosmetic pragma' bugs");
+        AssertDescriptionContains(
+            "verify_pragma_suppresses",
+            "Read-only");
+        AssertDescriptionContains(
+            "record_field_add_with_satellites_preview",
+            "patternDetectionReason");
+        AssertDescriptionContains(
+            "symbol_refactor_preview",
+            "a failure in any step aborts the whole preview");
+        AssertDescriptionContains(
+            "split_service_with_di_preview",
+            "forwarding facade");
+        AssertDescriptionContains(
+            "split_service_with_di_preview",
+            "DI-registration deltas");
+        AssertDescriptionContains(
+            "evaluate_msbuild_items",
+            "(e.g. Compile, PackageReference)");
+        AssertDescriptionContains(
+            "get_msbuild_properties",
+            "always pass a propertyNameFilter substring or an includedNames allowlist");
+    }
+
+    private static void AssertDescriptionContains(string toolName, string expected)
+    {
+        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
+
+        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
+        StringAssert.Contains(
+            entry.Description,
+            expected,
+            $"Trimming '{toolName}' dropped its discriminating trigger.");
+    }
+
+    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
+        => _sliceToolTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null && entry.Description is not null)
+            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+}


### PR DESCRIPTION
Initiative `method-description-diet-editing-msbuild` from the `20260825T214500Z_backlog-sweep` plan.

## What changed

Rewrites the eight over-ceiling method `[Description]` strings across `EditTools`, `MSBuildTools`, `SuppressionTools`, and `SymbolRefactorTools` into <=200-char capability statements, relocating the displaced operational detail into XML `<remarks>` blocks above each attribute list (the shape shipped by PR #1345 and pinned by `MethodDescriptionDietScaffoldingMutationTests`).

| Tool | Before | After |
|---|---:|---:|
| `apply_text_edit` | 774 | 198 |
| `record_field_add_with_satellites_preview` | 496 | 196 |
| `split_service_with_di_preview` | 435 | 162 |
| `pragma_scope_widen` | 402 | 197 |
| `evaluate_msbuild_items` | 385 | 105 |
| `get_msbuild_properties` | 317 | 191 |
| `symbol_refactor_preview` | 311 | 172 |
| `verify_pragma_suppresses` | 294 | 193 |

Three already-compliant tools (`evaluate_msbuild_property` 115, `set_diagnostic_severity` 140, `add_pragma_suppression` 101) were left byte-identical. Measured slice aggregate: **3,770 -> 1,770 chars across 11 tools** (both numbers re-derived from source this session, not inherited from the plan).

## Discriminators retained (condensed, never dropped — PR #1348 lesson)

- `apply_text_edit` — semantic-tool preference + `revert_last_apply` revertibility
- `pragma_scope_widen` — the `#region`/`#endregion` + nested-disable refusal
- `verify_pragma_suppresses` — cosmetic-pragma trigger + read-only marker
- `record_field_add_with_satellites_preview` — >=2-sibling-field conservatism + `patternDetectionReason`
- `symbol_refactor_preview` — atomic abort on any step failure
- `split_service_with_di_preview` — partitions + forwarding facade + DI-registration deltas
- `evaluate_msbuild_items` — item-type examples
- `get_msbuild_properties` — "output is large, pass a filter"

## New ratchet

`tests/RoslynMcp.Tests/MethodDescriptionDietEditingMsBuildTests.cs`, modeled on `MethodDescriptionDietScaffoldingMutationTests`: per-tool 200-char ceiling, aggregate ceiling 1,850 derived from the **measured** post-diet total (not `toolCount x ceiling` — PR #1345 spec-review failure), plus discriminator-retention assertions.

The four types are deliberately NOT added to `SurfaceCatalogTests.DietedToolMethodDescriptions_StayWithinSliceCeiling`: four sibling method-diet initiatives run in this same sweep and would all collide on that one file. Consolidation into a single data-driven ratchet is an already-filed follow-on.

## Negative space

No parameter `[Description]`, no `McpToolMetadata` summary, and no catalog file is touched. `ParameterDescriptionCanonicalizationTests` and the `McpToolMetadata` drift assertion both stay green as proof.

## Validation

- `dotnet test --filter "MethodDescriptionDietEditingMsBuild|SurfaceCatalogTests|ParameterDescriptionCanonicalization"` — 27/27 passed
- `eng/verify-changed-format.ps1 -BaseRef <base>` — 0 new findings, 4 tracked baseline `IMPORTS` findings (pre-existing on the four Tools files)
- `eng/verify-changelog-fragments.ps1` — passed
- `eng/verify-ai-docs.ps1` — passed
- Full `eng/verify-release.ps1 -Configuration Release` runs as PR validation on the self-hosted runner; not duplicated locally.

## Adjacent bad code (flagged, not fixed here)

`tests/RoslynMcp.Tests/SurfaceCatalogTests.cs:317` sets `maxAggregateCharacters = 9_500` for three dieted types — exactly the `toolCount x ceiling` slop PR #1345's cold review rejected. Belongs to the already-filed ratchet-consolidation follow-on.

The new test file's private fields use the repo's `_camelCase` editorconfig naming rule rather than copying the sibling ratchet's baselined `IDE1006` debt — a new file has no baseline entry, so mirroring the sibling verbatim would have introduced three new formatter findings.

Closes: method-description-diet (partial slice — row stays open for the remaining unswept `Tools/*.cs` files)
