### PR TITLE
chore(tools): canonicalize workspace-ops param descriptions + assembly-wide ratchet (param-description-dedupe-workspace-ops)

### DIFF
--- a/changelog.d/param-description-dedupe-workspace-ops.md
+++ b/changelog.d/param-description-dedupe-workspace-ops.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Standardized `workspaceId` and `filePath` parameter descriptions on the workspace-warm, workspace-drift, undo, and editorconfig tool surfaces to the canonical short form, and replaced the per-slice canonicalization guards with an assembly-wide ratchet that rejects any third phrasing and monotonically lowers the legacy-form ceiling. Load-bearing parameter guidance (JSON-array format contracts, `workspace_changes` sequence semantics, editorconfig key/value examples, optional-`workspaceId` auto-resolution contracts) is unchanged.

--- a/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/EditorConfigTools.cs
@@ -23,8 +23,8 @@ public static class EditorConfigTools
     public static Task<string> GetEditorConfigOptions(
         IWorkspaceExecutionGate gate,
         IEditorConfigService editorConfigService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file to inspect")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file to inspect.")] string filePath,
         CancellationToken ct = default)
         => ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
@@ -39,8 +39,8 @@ public static class EditorConfigTools
     public static Task<string> SetEditorConfigOption(
         IWorkspaceExecutionGate gate,
         IEditorConfigService editorConfigService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to a C# source file whose .editorconfig should be updated")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the C# source file whose .editorconfig should be updated.")] string filePath,
         [Description("EditorConfig key (e.g. dotnet_diagnostic.CA1000.severity)")] string key,
         [Description("Value (e.g. warning, suggestion, silent, none)")] string value,
         CancellationToken ct = default)

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -17,7 +17,7 @@ public static class UndoTools
     public static Task<string> RevertLastApply(
         IWorkspaceExecutionGate gate,
         IUndoService undoService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(workspaceId))
@@ -67,7 +67,7 @@ public static class UndoTools
     public static Task<string> RevertApplyBySequence(
         IWorkspaceExecutionGate gate,
         IApplyUndoWorkflowService workflowService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("The sequence number reported by workspace_changes for the apply you want to revert")] int sequenceNumber,
         CancellationToken ct = default)
     {

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
@@ -30,7 +30,7 @@ public static class WorkspaceDriftTool
     public static Task<CallToolResult> WorkspaceDriftCheck(
         IWorkspaceExecutionGate gate,
         IWorkspaceDriftService driftService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         CancellationToken ct = default)
         => gate.RunReadAsync(
             workspaceId,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
@@ -30,7 +30,7 @@ public static class WorkspaceWarmTools
     public static Task<string> WorkspaceWarm(
         IWorkspaceExecutionGate gate,
         IWorkspaceWarmService warmService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Optional: project names to warm. Pass as a native JSON array, not a JSON-encoded string. Example: [\"MyProject.Core\", \"MyProject.Tests\"]. Case-insensitive; unknown names are silently skipped. Omit or pass an empty array to warm every project in the solution.")] string[]? projects = null,
         IProgress<ProgressNotificationValue>? progress = null,
         CancellationToken ct = default)

--- a/tests/RoslynMcp.Tests/ToolParameterCanonicalFormTests.cs
+++ b/tests/RoslynMcp.Tests/ToolParameterCanonicalFormTests.cs
@@ -1,0 +1,204 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using RoslynMcp.Host.Stdio.Tools;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Assembly-wide ratchet for the <c>param-description-dedupe</c> sweep.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Supersedes the per-slice <c>Type[]</c> guards (<see cref="ParameterDescriptionCanonicalizationTests"/>
+/// and <see cref="ParamDescriptionCanonicalFormCodeActionSuppressionTests"/>), which could only see the
+/// types their own slice swept and therefore could not stop a THIRD phrasing appearing in an unswept file.
+/// This class walks every <c>[McpServerTool]</c> method in the Host.Stdio assembly instead.
+/// </para>
+/// <para>
+/// PRs #1349 and #1350 shipped two mutually incompatible "canonical" forms in the same sweep.
+/// <see cref="_canonicalWorkspaceId"/> (#1349's short form) is THE canon going forward — it is the only
+/// one of the two that actually cuts characters. <see cref="_legacyWorkspaceId"/> (#1350's long form, and
+/// the pre-existing repo-wide boilerplate) is tolerated only while unswept files remain, and only under a
+/// monotonically-decreasing ceiling. A third phrasing is rejected outright.
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class ToolParameterCanonicalFormTests
+{
+    /// <summary>PR #1349's short form — the canonical target for every <c>workspaceId</c> parameter.</summary>
+    private const string _canonicalWorkspaceId = "Workspace session id from workspace_load.";
+
+    /// <summary>PR #1350's long form — the legacy boilerplate later slices must retire.</summary>
+    private const string _legacyWorkspaceId = "The workspace session identifier returned by workspace_load";
+
+    /// <summary>
+    /// Reflection-observed count of <c>workspaceId</c> parameters still on <see cref="_legacyWorkspaceId"/>
+    /// after the <c>param-description-dedupe-workspace-ops</c> slice. This is a RATCHET: each later slice
+    /// lowers it and never raises it. The comparison is <c>&lt;=</c> so sibling slices landing in either
+    /// order cannot red this test.
+    /// </summary>
+    private const int _legacyWorkspaceIdCeiling = 122;
+
+    /// <summary>
+    /// (tool name, parameter name) pairs whose description is deliberately neither form because it
+    /// carries call-accuracy information both one-liners would lose. Mirrors the
+    /// <c>set_diagnostic_severity</c>/<c>filePath</c> exception in
+    /// <see cref="ParamDescriptionCanonicalFormCodeActionSuppressionTests"/>.
+    /// </summary>
+    /// <remarks>
+    /// This list is a closed set on purpose. Adding to it is a deliberate act that says "this tool's
+    /// <c>workspaceId</c> genuinely needs more than the one-liner" — it is NOT the escape hatch for
+    /// drift. Everything not listed here must be one of the two known forms.
+    /// </remarks>
+    private static readonly HashSet<(string ToolName, string ParamName)> _loadBearingWorkspaceIdExceptions =
+    [
+        // Two-workspace tool: "source" distinguishes the workspace being forked FROM the fork.
+        ("workspace_fork_apply", "workspaceId"),
+
+        // Read-path tools whose workspaceId is OPTIONAL: the description documents the
+        // omit-when-exactly-one-workspace auto-resolution contract enforced by the read-path
+        // middleware. Dropping that to the one-liner would make the parameter look required.
+        ("compile_check", "workspaceId"),
+        ("go_to_definition", "workspaceId"),
+        ("find_references", "workspaceId"),
+        ("document_symbols", "workspaceId"),
+        ("workspace_readiness_report", "workspaceId"),
+        ("workspace_support_bundle", "workspaceId"),
+    ];
+
+    /// <summary>
+    /// Tool types already swept onto <see cref="_canonicalWorkspaceId"/>: PR #1349's four
+    /// (<c>param-description-dedupe-edit-file-ops</c>) plus this slice's four
+    /// (<c>param-description-dedupe-workspace-ops</c>). These may carry ONLY the short form.
+    /// </summary>
+    private static readonly HashSet<string> _canonicalizedToolTypes =
+    [
+        nameof(EditTools),
+        nameof(FileOperationTools),
+        nameof(MSBuildTools),
+        nameof(TypeMoveTools),
+        nameof(WorkspaceWarmTools),
+        nameof(WorkspaceDriftTool),
+        nameof(UndoTools),
+        nameof(EditorConfigTools),
+    ];
+
+    [TestMethod]
+    public void EveryWorkspaceIdDescription_IsOneOfTheTwoKnownForms()
+    {
+        var failures = new List<string>();
+        var observed = 0;
+
+        foreach (var entry in EnumerateToolParameters())
+        {
+            if (entry.Parameter.Name != "workspaceId") continue;
+            if (_loadBearingWorkspaceIdExceptions.Contains((entry.ToolName, "workspaceId"))) continue;
+
+            observed++;
+            if (string.Equals(entry.Description, _canonicalWorkspaceId, StringComparison.Ordinal)) continue;
+            if (string.Equals(entry.Description, _legacyWorkspaceId, StringComparison.Ordinal)) continue;
+
+            failures.Add(
+                $"{entry.DeclaringTypeName}.{entry.MethodName} (tool {entry.ToolName}): got \"{entry.Description}\".");
+        }
+
+        Assert.IsTrue(observed > 0, "No 'workspaceId' tool parameters discovered — the assembly walk broke.");
+        Assert.AreEqual(
+            0,
+            failures.Count,
+            "A 'workspaceId' parameter description must be exactly one of:\n"
+            + $"  canonical (target): \"{_canonicalWorkspaceId}\"\n"
+            + $"  legacy (being retired): \"{_legacyWorkspaceId}\"\n"
+            + "Do not invent a third phrasing — see backlog row param-description-dedupe. Offenders:\n  "
+            + string.Join("\n  ", failures));
+    }
+
+    [TestMethod]
+    public void LegacyWorkspaceIdSites_DoNotExceedTheRatchetCeiling()
+    {
+        var legacySites = EnumerateToolParameters()
+            .Where(entry => entry.Parameter.Name == "workspaceId")
+            .Where(entry => !_loadBearingWorkspaceIdExceptions.Contains((entry.ToolName, "workspaceId")))
+            .Where(entry => string.Equals(entry.Description, _legacyWorkspaceId, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.IsTrue(
+            legacySites.Length <= _legacyWorkspaceIdCeiling,
+            $"Legacy-form 'workspaceId' descriptions rose to {legacySites.Length}, above the ratchet ceiling "
+            + $"of {_legacyWorkspaceIdCeiling}. New tools must use \"{_canonicalWorkspaceId}\"; a slice that "
+            + "retires legacy sites should LOWER _legacyWorkspaceIdCeiling to the new observed count.");
+    }
+
+    [TestMethod]
+    public void CanonicalizedToolTypes_UseOnlyTheShortForm()
+    {
+        var failures = new List<string>();
+        var observed = 0;
+
+        foreach (var entry in EnumerateToolParameters())
+        {
+            if (entry.Parameter.Name != "workspaceId") continue;
+            if (!_canonicalizedToolTypes.Contains(entry.DeclaringTypeName)) continue;
+
+            observed++;
+            if (string.Equals(entry.Description, _canonicalWorkspaceId, StringComparison.Ordinal)) continue;
+
+            failures.Add(
+                $"{entry.DeclaringTypeName}.{entry.MethodName} (tool {entry.ToolName}): got \"{entry.Description}\".");
+        }
+
+        Assert.IsTrue(
+            observed > 0,
+            "No 'workspaceId' parameters discovered on the already-canonicalized tool types — "
+            + "_canonicalizedToolTypes is stale or the assembly walk broke.");
+        Assert.AreEqual(
+            0,
+            failures.Count,
+            $"Already-canonicalized tool types must carry exactly \"{_canonicalWorkspaceId}\":\n  "
+            + string.Join("\n  ", failures));
+    }
+
+    /// <summary>
+    /// Walks every <c>[McpServerTool]</c>-attributed method in the Host.Stdio assembly, mirroring the
+    /// discovery walk in <c>ToolParameterIndex.BuildIndex</c>, and yields each caller-supplied parameter
+    /// that carries a <see cref="DescriptionAttribute"/>.
+    /// </summary>
+    private static IEnumerable<ToolParameterEntry> EnumerateToolParameters()
+    {
+        // Anchor on a known tool-host type so we walk the same assembly MCP discovery walks.
+        var assembly = typeof(AnalysisTools).Assembly;
+
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var method in type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            {
+                var serverTool = method.GetCustomAttribute<McpServerToolAttribute>();
+                if (serverTool is null) continue;
+
+                // Inherited methods surface once per declaring type; keep the declaring type authoritative.
+                if (method.DeclaringType != type) continue;
+
+                var toolName = serverTool.Name ?? method.Name;
+
+                foreach (var parameter in method.GetParameters())
+                {
+                    var description = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description;
+                    if (description is null) continue;
+
+                    yield return new ToolParameterEntry(
+                        type.Name, method.Name, toolName, parameter, description);
+                }
+            }
+        }
+    }
+
+    private readonly record struct ToolParameterEntry(
+        string DeclaringTypeName,
+        string MethodName,
+        string ToolName,
+        ParameterInfo Parameter,
+        string Description);
+}


### PR DESCRIPTION
## Summary

Slice `param-description-dedupe-workspace-ops` of the `param-description-dedupe` sweep.

Rewrites the 6 `workspaceId` and 2 `filePath` parameter descriptions on the workspace-warm, workspace-drift, undo, and editorconfig tool surfaces onto the canonical short form, and replaces the per-slice canonicalization guards with an assembly-wide ratchet.

## The canon fork (load-bearing decision)

PRs #1349 and #1350 shipped **two mutually incompatible "canonical" forms in the same sweep**:

| PR | Form | Live sites |
|---|---|---|
| #1349 | `Workspace session id from workspace_load.` | 9 across 4 types |
| #1350 | `The workspace session identifier returned by workspace_load` | ~122 across ~40 types |

This PR adopts **#1349's short form as THE canon**. #1350's form *is* the pre-existing repo-wide boilerplate the row set out to replace, so pinning it entrenches a 0% character cut against a row whose acceptance demands ~40%.

## The generalized ratchet

New `tests/RoslynMcp.Tests/ToolParameterCanonicalFormTests.cs` replaces the per-slice `Type[]` pattern with an assembly-wide reflection walk over every `[McpServerTool]` method in Host.Stdio (mirroring `ToolParameterIndex.BuildIndex`). Three assertions:

- **(a)** every `workspaceId` description is exactly one of the two known forms — a third phrasing fails *anywhere* in the assembly, closing the drift hole the per-slice type lists structurally could not see.
- **(b)** legacy-form sites are capped by `_legacyWorkspaceIdCeiling` (pinned to the reflection-observed post-edit count, 122). Monotone: later slices lower it, never raise it. Deliberately `<=` so sibling param-cluster slices landing in either order cannot red each other.
- **(c)** the eight already-canonicalized tool types (#1349's four + this slice's four) carry ONLY the short form.

Both existing per-slice guards are left untouched and green.

## Load-bearing exceptions the plan had not accounted for

Assertion (a) immediately surfaced **seven** genuinely load-bearing `workspaceId` descriptions — the plan's handoff notes predicted only one:

- `workspace_fork_apply` — "source" distinguishes the workspace being forked FROM the fork (two-workspace tool).
- `compile_check`, `go_to_definition`, `find_references`, `document_symbols`, `workspace_readiness_report`, `workspace_support_bundle` — all have an **optional** `workspaceId` whose description documents the omit-when-exactly-one-workspace auto-resolution contract enforced by the read-path middleware. Collapsing these to the one-liner would make the parameter read as required.

These are recorded as named `(toolName, paramName)` exceptions — not rewritten, and not papered over by loosening the assertion to a regex.

## Untouched (deliberately)

`WorkspaceWarmTools.projects` (native-JSON-array format contract), `UndoTools.sequenceNumber` (`workspace_changes` discriminator), `EditorConfigTools.key`/`value` (worked examples). The two `filePath` rewrites keep their disambiguators.

## Validation

- `ToolParameterCanonicalFormTests`, `ParameterDescriptionCanonicalizationTests`, `ParamDescriptionCanonicalFormCodeActionSuppressionTests`, `SurfaceCatalogTests`, `StructuredContentWireContractTests`, `FormatterBaselineContractTests` — 35/35 green.
- Ratchet proven to bite: temporarily reverting one edit pushed legacy to 123 and red both (b) and (c); restored.
- `dotnet format --verify-no-changes` clean on the new file (the three IMPORTS violations on the edited production files are pre-existing baseline entries; only string literals were changed).
- `./eng/verify-ai-docs.ps1` passed.
- `./eng/verify-release.ps1 -Configuration Release`: full Release suite **Failed: 0, Passed: 2655, Skipped: 7**. The script's non-zero exit came from a Coverlet in-proc coverage-collector `AccessViolationException` during test-session *teardown*, after every test had already completed — an artifact of running 9 concurrent sweep worktrees on this box, not of this change. CI on the self-hosted runner is the authority.

## Scope

Production files: 4 (exactly at the Rule 3 cap). Test files added: 1. Shims added: 0.

## Backlog

Closes: (none — partial slice; parent row `param-description-dedupe` stays OPEN, ~40 `Tools/*.cs` still unswept)
Initiative: `param-description-dedupe-workspace-ops`
Partial-progress row: `param-description-dedupe`

Follow-ups for the orchestrator to file:
1. Re-canonicalize #1350's four tool types (`CodeActionTools`, `SuppressionTools`, `SymbolRefactorTools`, `BulkRefactoringTools`) onto the short form and retire the now-duplicated guard.
2. Remove the Host.Stdio param-description copy from `src/RoslynMcp.Core/Services/ISymbolRefactorService.cs` (Core layer holding a tool-surface description string).
3. Promote the assembly walk into `ToolParameterIndex` as a first-class enumerator (deferred here — would have been a 5th production file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
