### PR TITLE
chore(tools): dedupe validation/signature parameter descriptions (param-description-dedupe-validation-signature)

### DIFF
--- a/changelog.d/param-description-dedupe-validation-signature.md
+++ b/changelog.d/param-description-dedupe-validation-signature.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Parameter-description dedupe — validation/signature cluster (`param-description-dedupe-validation-signature`): standardized the `workspaceId`, required-path, and `previewToken` boilerplate across `validate_workspace`, `validate_recent_git_changes`, `workspace_fork_apply`, `move_type_to_project_preview`, `extract_interface_cross_project_preview`, `dependency_inversion_preview`, `change_signature_preview`, and `parameter_object_preview` onto the canonical one-liners, and dropped duplicated version-archaeology text from the two `summary` parameters. Discriminating guidance (`op`/`newOrder`/`retention`/`metadataName` contracts, the `native JSON array` encoding hints, and the fork tool's "source workspace" qualifier) is unchanged. `ParameterDescriptionCanonicalizationTests` now ratchets these four tool types so the phrasing cannot drift back.

--- a/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ChangeSignatureTools.cs
@@ -23,7 +23,7 @@ public static class ChangeSignatureTools
     public static Task<string> PreviewChangeSignature(
         IWorkspaceExecutionGate gate,
         IChangeSignatureService changeSignatureService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Operation: 'add', 'remove', 'rename', or 'reorder'.")] string op,
         [Description("Optional: absolute path to the source file containing the method declaration")] string? filePath = null,
         [Description("Optional: 1-based line number of the method declaration")] int? line = null,

--- a/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/CrossProjectRefactoringTools.cs
@@ -22,8 +22,8 @@ public static class CrossProjectRefactoringTools
     public static Task<string> PreviewMoveTypeToProject(
         IWorkspaceExecutionGate gate,
         ICrossProjectRefactoringService crossProjectRefactoringService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file containing the type")] string sourceFilePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file containing the type.")] string sourceFilePath,
         [Description("Name of the type declaration to move")] string typeName,
         [Description("Target project name or project file path")] string targetProjectName,
         [Description("Optional: explicit namespace for the moved type. When null and preserveNamespace is false, uses the target project's default namespace.")] string? targetNamespace = null,
@@ -49,8 +49,8 @@ public static class CrossProjectRefactoringTools
     public static Task<string> PreviewExtractInterface(
         IWorkspaceExecutionGate gate,
         ICrossProjectRefactoringService crossProjectRefactoringService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file containing the type")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file containing the type.")] string filePath,
         [Description("Name of the type declaration to extract from")] string typeName,
         [Description("Optional: interface name. Defaults to I + type name")] string? interfaceName = null,
         [Description("Optional: target project name or project file path")] string? targetProjectName = null,
@@ -74,8 +74,8 @@ public static class CrossProjectRefactoringTools
     public static Task<string> PreviewDependencyInversion(
         IWorkspaceExecutionGate gate,
         ICrossProjectRefactoringService crossProjectRefactoringService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("Absolute path to the source file containing the concrete type")] string filePath,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
+        [Description("Absolute path to the source file containing the concrete type.")] string filePath,
         [Description("Name of the concrete type to invert dependencies around")] string typeName,
         [Description("Target project name or project file path for the extracted interface")] string interfaceProjectName,
         [Description("Optional: interface name. Defaults to I + type name")] string? interfaceName = null,

--- a/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ParameterObjectTools.cs
@@ -23,7 +23,7 @@ public static class ParameterObjectTools
     public static Task<string> PreviewParameterObject(
         IWorkspaceExecutionGate gate,
         IParameterObjectService parameterObjectService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Names of method parameters to group, in the order they should appear on the new record's primary constructor. Must contain at least two entries.")] string[] parameterNames,
         [Description("PascalCase name of the new record type (e.g. 'OrderRequest').")] string newTypeName,
         [Description("Optional: absolute path to the source file containing the method declaration")] string? filePath = null,

--- a/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ValidationBundleTools.cs
@@ -26,10 +26,10 @@ public static class ValidationBundleTools
     public static Task<string> ValidateWorkspace(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("Optional: explicit list of changed file paths. Pass as a native JSON array of absolute file paths, not a JSON-encoded string. Example: [\"/abs/path/a.cs\", \"/abs/path/b.cs\"]. When omitted, the change tracker's session-wide change set is used. Empty list means no test discovery.")] string[]? changedFilePaths = null,
         [Description("When true, runs the discovered related tests via dotnet test --filter. Default: false (discovery only).")] bool runTests = false,
-        [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default false preserves the v1.18 shape.")] bool summary = false,
+        [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default: false.")] bool summary = false,
         [Description("Response shape: \"json\" (default) returns the indented JSON envelope; \"markdown\" returns a compact summary table built from the same DTO so the verdict is identical across shapes. Case-insensitive.")] string? responseFormat = null,
         CancellationToken ct = default) =>
         gate.RunReadAsync(workspaceId, async c =>
@@ -52,9 +52,9 @@ public static class ValidationBundleTools
     public static Task<string> ValidateRecentGitChanges(
         IWorkspaceExecutionGate gate,
         IWorkspaceValidationService validationService,
-        [Description("The workspace session identifier returned by workspace_load")] string workspaceId,
+        [Description("Workspace session id from workspace_load.")] string workspaceId,
         [Description("When true, runs the discovered related tests via dotnet test --filter. Default: false (discovery only).")] bool runTests = false,
-        [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default false preserves the full response shape.")] bool summary = false,
+        [Description("When true, drops the per-diagnostic ErrorDiagnostics list and per-test DiscoveredTests list to keep the response under the MCP cap on large solutions. OverallStatus + counts still surface the verdict. Default: false.")] bool summary = false,
         CancellationToken ct = default) =>
         ToolDispatch.ReadByWorkspaceIdAsync(
             gate,
@@ -73,8 +73,8 @@ public static class ValidationBundleTools
     public static Task<string> WorkspaceForkApply(
         IWorkspaceExecutionGate gate,
         IWorkspaceForkApplyService forkApplyService,
-        [Description("The source workspace session identifier returned by workspace_load")] string workspaceId,
-        [Description("The preview token returned by an *_preview tool for the source workspace")] string previewToken,
+        [Description("Source workspace session id from workspace_load.")] string workspaceId,
+        [Description("Preview token from any *_preview tool.")] string previewToken,
         [Description("Fork retention policy: drop-on-success, drop-on-failure, drop-always, or keep. Default: drop-on-success.")] string retention = "drop-on-success",
         [Description("When true, runs related tests discovered by validate_workspace. If testFilter is supplied, runs that explicit filter instead.")] bool runTests = false,
         [Description("Optional explicit dotnet test filter to run against the fork when runTests=true.")] string? testFilter = null,

--- a/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
@@ -10,9 +10,11 @@ namespace RoslynMcp.Tests;
 /// Slice-scoped ratchet for the parameter-description canonicalization sweep.
 /// </summary>
 /// <remarks>
-/// Scope is deliberately limited to the four tool types swept by
-/// <c>param-description-dedupe-edit-file-ops</c>. The remaining <c>Tools/*.cs</c> files are still
-/// unswept, so a repo-wide assertion would red CI; later slices widen <see cref="SweptToolTypes"/>.
+/// Scope is deliberately limited to the tool types swept so far —
+/// <c>param-description-dedupe-edit-file-ops</c> (the first four) plus
+/// <c>param-description-dedupe-validation-signature</c> (the last four). The remaining
+/// <c>Tools/*.cs</c> files are still unswept, so a repo-wide assertion would red CI; later
+/// slices widen <see cref="SweptToolTypes"/>.
 /// </remarks>
 [TestClass]
 public sealed class ParameterDescriptionCanonicalizationTests
@@ -23,12 +25,42 @@ public sealed class ParameterDescriptionCanonicalizationTests
         typeof(FileOperationTools),
         typeof(MSBuildTools),
         typeof(TypeMoveTools),
+        typeof(ValidationBundleTools),
+        typeof(CrossProjectRefactoringTools),
+        typeof(ChangeSignatureTools),
+        typeof(ParameterObjectTools),
     ];
 
     private const string CanonicalWorkspaceId = "Workspace session id from workspace_load.";
 
+    /// <summary>
+    /// (type name, method name, parameter name) triples whose <c>workspaceId</c> description is
+    /// deliberately non-canonical because it carries call-accuracy information the canonical
+    /// one-liner would lose. Mirrors <c>LoadBearingFilePathExceptions</c> in
+    /// <see cref="ParamDescriptionCanonicalFormCodeActionSuppressionTests"/>, but keyed by
+    /// type/method because this ratchet enumerates <see cref="Type"/> rather than tool name,
+    /// and each entry pins its exact allowed text so an exemption is a second canonical form
+    /// rather than an unguarded hole.
+    /// </summary>
+    private static readonly Dictionary<(string Type, string Method, string Parameter), string> _loadBearingWorkspaceIdExceptions =
+        new()
+        {
+            // workspace_fork_apply juggles TWO workspaces; "Source" is the disambiguator.
+            [(nameof(ValidationBundleTools), nameof(ValidationBundleTools.WorkspaceForkApply), "workspaceId")] =
+                "Source workspace session id from workspace_load.",
+        };
+
+    /// <summary>
+    /// The exact <c>workspaceId</c> description a site must carry: the canonical one-liner, or the
+    /// pinned text when the site is a declared load-bearing exception.
+    /// </summary>
+    private static string ExpectedWorkspaceId(string typeName, string methodName, string parameterName) =>
+        _loadBearingWorkspaceIdExceptions.TryGetValue((typeName, methodName, parameterName), out var exempted)
+            ? exempted
+            : CanonicalWorkspaceId;
+
     private static readonly Regex CanonicalPreviewToken =
-        new(@"^Preview token from [a-z0-9_]+_preview\.$", RegexOptions.Compiled);
+        new(@"^Preview token from (?:[a-z0-9_]+_preview\.|any \*_preview tool\.)$", RegexOptions.Compiled);
 
     private static readonly Regex CanonicalPath =
         new(@"^Absolute path to the .+\.$", RegexOptions.Compiled);
@@ -40,6 +72,11 @@ public sealed class ParameterDescriptionCanonicalizationTests
         (nameof(EditTools), "verify", "compile_check"),
         (nameof(EditTools), "autoRevertOnError", "Ignored when verify is false"),
         (nameof(MSBuildTools), "includedNames", "native JSON array"),
+        (nameof(ValidationBundleTools), "changedFilePaths", "native JSON array"),
+        (nameof(ValidationBundleTools), "retention", "drop-on-success"),
+        (nameof(ParameterObjectTools), "dtoFolders", "native JSON array"),
+        (nameof(ChangeSignatureTools), "metadataName", "NOT accepted"),
+        (nameof(ChangeSignatureTools), "newOrder", "exactly once"),
     ];
 
     private static IEnumerable<(Type Type, MethodInfo Method, ParameterInfo Parameter, string Description)> SweptToolParameters()
@@ -79,11 +116,18 @@ public sealed class ParameterDescriptionCanonicalizationTests
 
             switch (parameter.Name)
             {
-                case "workspaceId" when !string.Equals(description, CanonicalWorkspaceId, StringComparison.Ordinal):
-                    violations.Add($"{site}: expected \"{CanonicalWorkspaceId}\", got \"{description}\"");
+                case "workspaceId" when !string.Equals(
+                    description,
+                    ExpectedWorkspaceId(type.Name, method.Name, parameter.Name),
+                    StringComparison.Ordinal):
+                    violations.Add(
+                        $"{site}: expected \"{ExpectedWorkspaceId(type.Name, method.Name, parameter.Name)}\", "
+                        + $"got \"{description}\"");
                     break;
                 case "previewToken" when !CanonicalPreviewToken.IsMatch(description):
-                    violations.Add($"{site}: expected \"Preview token from <tool>_preview.\", got \"{description}\"");
+                    violations.Add(
+                        $"{site}: expected \"Preview token from <tool>_preview.\" or "
+                        + $"\"Preview token from any *_preview tool.\", got \"{description}\"");
                     break;
                 // Optional path parameters (e.g. TypeMoveTools.targetFilePath) keep their
                 // "Optional: ... defaults to ..." form — the defaulting rule is a discriminator,


### PR DESCRIPTION
## Summary

Parameter-description dedupe for the validation/signature cluster (initiative `param-description-dedupe-validation-signature`, plan `ai_docs/plans/20260825T214500Z_backlog-sweep/plan.md` §15).

Standardizes the repeated `workspaceId` / required-path / `previewToken` boilerplate on the four cluster tool types and drops the version-archaeology tails from the two duplicated `summary` essays. Discriminating guidance is untouched.

### Canonical-form decision

Two mutually exclusive "canonical" forms shipped in the same sweep: PR #1349's short form (`ParameterDescriptionCanonicalizationTests`) and PR #1350's long form (`ParamDescriptionCanonicalFormCodeActionSuppressionTests`). This slice adopts **#1349's short form** — it is the only one that actually reduces characters. The #1350 types are untouched, so both ratchets stay green side by side. Repo-wide unification remains open (see Follow-ups).

### Production changes

| File | Change |
|---|---|
| `ValidationBundleTools.cs` | 2 plain `workspaceId` → canonical; fork tool's `workspaceId` → `Source workspace session id from workspace_load.`; `previewToken` → `Preview token from any *_preview tool.`; both `summary` tails → `Default: false.` |
| `CrossProjectRefactoringTools.cs` | 3 `workspaceId` → canonical; 3 required path params gain the trailing period `#1349`'s `CanonicalPath` regex requires |
| `ChangeSignatureTools.cs` | 1 `workspaceId` → canonical |
| `ParameterObjectTools.cs` | 1 `workspaceId` → canonical |

The two OPTIONAL `filePath` params (`ChangeSignatureTools`, `ParameterObjectTools`) keep their `"Optional: …"` form — `#1349`'s guard deliberately exempts optional path params because the defaulting rule is a discriminator.

**Not trimmed (verified load-bearing):** `op`, `newOrder`, `parameterType`, `defaultValue`, `position`, `retention`, `dtoProjectName`, `metadataName`, and the two `native JSON array` encoding hints pinned by `SurfaceCatalogTests.cs:551-568`.

### Measured char delta

Script over `^\s+\[Description("…")\]\s+<ident>` parameter attributes across the four files:

| | params | chars | avg |
|---|---|---|---|
| before | 55 | 5,338 | 97 |
| after | 55 | 5,105 | 93 |
| delta | 0 | **-233 (-4.4%)** | -4 |

Note: below the plan's ~10-15% estimate. The plan's Approach enumerates exactly four mechanical edits (7 `workspaceId`, 3 required paths, 1 `previewToken`, 2 `summary` tails); everything else in this cluster is discriminator-dense and the plan's Risks field explicitly forbids trimming it (PR #1348 lesson). The delta is what that edit set actually yields, not a shortfall in execution.

### Test surface

No third per-slice ratchet class. `ParameterDescriptionCanonicalizationTests` is widened exactly as its own remarks invite:

- Four types added to `SweptToolTypes`.
- `_loadBearingWorkspaceIdExceptions` — keyed by (type, method, parameter) since this ratchet enumerates `Type` rather than tool name. Each entry **pins its exact allowed text** rather than merely exempting the site, so an exemption is a second canonical form, not an unguarded hole.
- `CanonicalPreviewToken` widened with an alternation for the any-tool form (`workspace_fork_apply` accepts a token from ANY preview tool, so the single-tool shape is wrong there).
- Five `LoadBearingContracts` entries pin `changedFilePaths`/`dtoFolders` → `native JSON array`, `metadataName` → `NOT accepted`, `newOrder` → `exactly once`, `retention` → `drop-on-success`.

Both new guard arms were mutation-tested this session: reverting `previewToken` to its old text and demoting the fork tool's `workspaceId` to the plain canonical form each produced the expected named violation.

### Validation

- `dotnet build RoslynMcp.slnx -c Debug` — 0 warnings, 0 errors.
- `dotnet test --filter ParameterDescriptionCanonicalizationTests|ParamDescriptionCanonicalFormCodeActionSuppressionTests|SurfaceCatalogTests|ToolDescriptionDietWorkspaceValidationTests|RefactoringCoreDescriptionBudgetTests` — 30/30 passed.
- Full `RoslynMcp.Tests` suite — 2650 passed / 7 skipped / 4 failed. All four failures are **not** from this change: `ExtractMethod_PreviewAndApply_CompilationSucceeds`, `ExtractMethod_ReassignsExistingLocal_EmitsAssignmentNotVarDecl` and `ExtractSharedExpression_ApplyAfterPreview_CompilationSucceeds` reproduce byte-identically at the base commit `e1addf5f` (verified this session by checking out the base tree, rebuilding and re-running the same filter); `GetLatestVersion_WhileFetchInFlight_RecordsPendingStatus` is a timing flake that passes in isolation.
- `eng/verify-ai-docs.ps1` — passed.
- `eng/verify-changelog-fragments.ps1` — passed.
- `eng/verify-changed-format.ps1` — passed (0 new findings; 6 tracked baseline findings reported).

### Follow-ups observed (Directive #3, out of scope)

1. The two conflicting canonical parameter-description forms still need repo-wide unification before the per-slice ratchets can collapse into one `ToolParameterIndex`-driven guard.
2. `CrossProjectRefactoringTools.PreviewMoveTypeToProject` places `CancellationToken ct = default` BEFORE the described `preserveNamespace` parameter — CA1068-shaped, and it puts an optional described param after the token in the emitted schema order.
3. `ParameterDescriptionCanonicalizationTests` carries 5 tracked `IDE1006` baseline findings (private static fields missing the `_` prefix the repo `.editorconfig` requires). The new field in this PR follows the `.editorconfig`, so the file is now mixed-style until that debt is repaired.

Closes: none — partial slice; parent backlog row `param-description-dedupe` stays OPEN (~42 `Tools/*.cs` remain).
