### PR TITLE
fix(test): stop ScriptingServiceTests pinning one side of a terminal-shape race

### DIFF
--- a/changelog.d/timing-sensitive-test-assertions-flake-under-load.md
+++ b/changelog.d/timing-sensitive-test-assertions-flake-under-load.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Stopped the scripting-service timeout tests pinning one side of a terminal-shape race — a non-cooperative script may end via the watchdog kill or the cooperative timeout, and either is correct — and gave the unbounded-output test enough wall clock for the IPC-limit path to win its race so its assertion stays strict rather than being loosened.

--- a/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
+++ b/tests/RoslynMcp.Tests/ScriptingServiceTests.cs
@@ -42,9 +42,11 @@ public sealed class ScriptingServiceTests
 
         Assert.IsFalse(result.Success, "A non-cooperative script should hit the hard deadline.");
         Assert.IsFalse(string.IsNullOrEmpty(result.Error), "Expected error message.");
-        StringAssert.Contains(result.Error!, "worker process was terminated");
+        AssertTerminalTimeoutShape(result.Error!);
         Assert.AreEqual(1, result.AppliedScriptTimeoutSeconds);
-        Assert.IsTrue(sw.Elapsed.TotalSeconds < 5, $"Expected sub-5s completion, took {sw.Elapsed.TotalSeconds:F1}s");
+        Assert.IsTrue(
+            sw.Elapsed.TotalSeconds < 30,
+            $"A non-cooperative script must terminate rather than hang; took {sw.Elapsed.TotalSeconds:F1}s");
         Assert.AreEqual(0, service.ActiveEvaluationCount, "The completed request should release its capacity slot.");
 
         Assert.AreEqual(0, service.AbandonedEvaluationCount, "The worker process must be reclaimed before the response returns.");
@@ -61,8 +63,26 @@ public sealed class ScriptingServiceTests
         Assert.AreEqual(0, service.AbandonedEvaluationCount);
     }
 
+    /// <summary>
+    /// A deliberately non-cooperative script has TWO correct terminal shapes and which one wins is
+    /// a load-dependent race: the cooperative script timeout can elapse first, or the watchdog can
+    /// kill the worker first. Pinning either side makes the test flake under parallel-test or CI
+    /// contention (row <c>timing-sensitive-test-assertions-flake-under-load</c>). Assert that the
+    /// failure is one of the two known terminal shapes, not which one won.
+    /// </summary>
+    private static void AssertTerminalTimeoutShape(string error)
+    {
+        var watchdogKill = error.Contains("worker process was terminated", StringComparison.Ordinal);
+        var cooperativeTimeout = error.Contains("timed out after", StringComparison.Ordinal);
+
+        Assert.IsTrue(
+            watchdogKill || cooperativeTimeout,
+            "Expected either the watchdog-kill terminal shape (\"worker process was terminated\") " +
+            $"or the cooperative-timeout terminal shape (\"timed out after\"), but got: {error}");
+    }
+
     [TestMethod]
-    [Timeout(10_000)]
+    [Timeout(60_000)]
     public async Task EvaluateAsync_UnboundedRawOutput_TerminatesAtIpcLimit()
     {
         var service = new ScriptingService(
@@ -76,7 +96,7 @@ public sealed class ScriptingServiceTests
             imports: null,
             CancellationToken.None,
             onProgress: null,
-            timeoutSecondsOverride: 5).ConfigureAwait(false);
+            timeoutSecondsOverride: 30).ConfigureAwait(false);
 
         Assert.IsFalse(result.Success);
         StringAssert.Contains(result.Error ?? string.Empty, "bounded IPC output limit");


### PR DESCRIPTION
Unblocks sweep `20260825T214500Z` initiative `preview-token-route-map-centralization` ([#1362](https://github.com/darylmcd/Roslyn-Backed-MCP/pull/1362)), which failed CI twice on these two tests with a diff that touches only `ToolDispatch.cs` / `RefactoringTools.cs`.

Captured assertion text from run 32909200516:

```
expected substring: "bounded IPC output limit"
actual:             "Script execution timed out after 5 seconds. ..."
```

That is acceptance bullet 2 of open row `timing-sensitive-test-assertions-flake-under-load` verbatim — both tests pin ONE of two legitimate terminal shapes, and which one wins is a load-dependent race.

| Test | Change |
|---|---|
| `EvaluateAsync_InfiniteScript_...` | Accept either terminal shape (watchdog kill **or** cooperative timeout) via `AssertTerminalTimeoutShape`. Counter assertions stay strict — those are the real invariant. Wall-clock SLA 5s → 30s ("terminated rather than hung", not a latency budget). |
| `EvaluateAsync_UnboundedRawOutput_...` | `timeoutSecondsOverride` 5 → 30 so the IPC-limit path can win its race; the `"bounded IPC output limit"` assertion stays **strict** rather than being loosened. `[Timeout]` 10s → 60s bounds the test itself. |

**Partial — the row stays open.** Bullet 1 (`GatedCommandExecutorTests`) and bullet 3 (`CodexChangelogHookTests`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)