### PR TITLE
fix(skills): close the shipped-skills prefix amnesty (shipped-skills-prefix-batch-c2)

### DIFF
--- a/changelog.d/shipped-skills-prefix-batch-c2.md
+++ b/changelog.d/shipped-skills-prefix-batch-c2.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the shipped `version-bump` and `workspace-health` skills now resolve the Roslyn MCP tool prefix once from a `server_info` response shape and pin it, instead of instructing a hard-coded `mcp__roslyn__` literal — marketplace-plugin installs (which surface `mcp__plugin_roslyn-mcp_roslyn__*`) no longer halt on a prefix they never expose. This completes the shipped-skills sweep: `residualUnsweptAllowlist` in `eng/banned-skill-markers.json` is now empty and its shrink ratchet is pinned at 0, so `eng/verify-skills-are-generic.ps1` enforces the prefix-agnostic rule and canonical-block byte-identity across every shipped skill with zero amnesty.

--- a/eng/banned-skill-markers.json
+++ b/eng/banned-skill-markers.json
@@ -29,10 +29,7 @@
       "is \\*\\*not\\*\\* grounds to halt",
       "never itself grounds to halt"
     ],
-    "residualUnsweptAllowlist": [
-      "skills/version-bump/SKILL.md",
-      "skills/workspace-health/SKILL.md"
-    ]
+    "residualUnsweptAllowlist": []
   },
   "canonicalPrecheckBlocks": [
     {

--- a/skills/version-bump/SKILL.md
+++ b/skills/version-bump/SKILL.md
@@ -22,14 +22,18 @@ Use **`server_info`**, resource **`roslyn://server/catalog`**, or MCP prompt **`
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 ## Workflow
 

--- a/skills/workspace-health/SKILL.md
+++ b/skills/workspace-health/SKILL.md
@@ -26,14 +26,18 @@ If the client does not support elicitation, or if the user declines the prompt, 
 
 ## Connectivity precheck
 
-Before running any `mcp__roslyn__*` tool call, probe the server once:
+Before running any Roslyn MCP tool call, resolve the server's tool prefix **once**, then pin it.
 
-1. Call `mcp__roslyn__server_info` — confirm the response includes `connection.state: "ready"`.
-2. If the call fails OR `connection.state` is `initializing` / `degraded` / absent, bail with this message to the user and stop the skill:
+> **The prefix is client-assigned — never hard-code it.** Your MCP client derives it from the registration path it loaded the server under, so the same tool surfaces as `mcp__roslyn__server_info` on a dev-build/self-hosted entry, as `mcp__plugin_roslyn-mcp_roslyn__server_info` on the marketplace-plugin install, and under a different prefix again for any other registration key. Those two are **examples, not an allowed list** — every prefix is valid, and a missing specific prefix literal is never itself grounds to halt.
 
-   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server. Run `mcp__roslyn__server_heartbeat` to confirm connection state, then re-run this skill once the server reports `connection.state: "ready"`. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+1. **Scan** your current tool surface for **every** tool whose name ends in `server_info`. `server_info` is a common MCP tool name, so expect more than one candidate and expect some to belong to other servers entirely.
+2. **Identify** the Roslyn one by its **response shape**, never by its prefix: a Roslyn `server_info` response carries `connection.state`, `catalogVersion`, and `surface.*`. A candidate that returns anything else is simply *not this server* — that is **not** a halt condition, so try each remaining candidate before deciding.
+3. **Pin** the winning candidate's prefix and resolve **every** later bare tool name in this skill under **that one pinned prefix only**. Never re-resolve a later bare name by suffix across the whole surface: another MCP server may expose the same bare name (a Python/Jedi server has its own `find_references` and `get_symbol_outline`), and matching it would silently attribute another server's results to Roslyn.
+4. Bail — report the message below to the user and stop the skill — only if **no** candidate returns a Roslyn-shaped response, or the pinned server reports `connection.state` as anything other than `"ready"` (`initializing`, `degraded`, absent):
 
-3. If `connection.state` is `"ready"`, proceed with the rest of the workflow. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
+   > **Roslyn MCP is not connected.** This skill requires an active Roslyn MCP server: some tool whose name **ends in** `server_info` must be callable, return a Roslyn-shaped response (`connection.state`, `catalogVersion`, `surface.*`), and report `connection.state: "ready"`. The prefix does not matter — your client assigns it from the registration path, so it may be `mcp__roslyn__…`, `mcp__plugin_roslyn-mcp_roslyn__…`, or anything else. Start the server (for example `dotnet tool run roslynmcp`, or ensure the plugin's stdio entry is active in your client config), then re-run this skill once the Roslyn `server_info` tool reports `connection.state: "ready"` under whichever prefix your tool surface exposes. See the [Connection-state signals reference](https://github.com/darylmcd/Roslyn-Backed-MCP/blob/main/ai_docs/runtime.md#connection-state-signals) for the canonical probes (`server_info` / `server_heartbeat`).
+
+5. Otherwise proceed with the rest of the workflow, issuing every tool call under the pinned prefix. The `server_info` call above also satisfies any server-version / capability-discovery needs — do not repeat it.
 
 Note: this skill's purpose is to report server/workspace status, so a failing precheck is itself the answer. Surface the failure as the final output (see *Refusal conditions* below) rather than silently aborting.
 

--- a/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
+++ b/tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs
@@ -32,11 +32,13 @@ public sealed class SkillPrefixGenericityTests
     /// <summary>
     /// Shrink ratchet. Five shipped skills still carried the pre-fix bare-prefix precheck when this
     /// gate landed (<c>semantic-find</c>, <c>test-coverage</c>, <c>trace-flow</c>,
-    /// <c>version-bump</c>, <c>workspace-health</c>). Batch c1 swept the first three, leaving
-    /// <c>version-bump</c> and <c>workspace-health</c>. The allowlist may only ever get SMALLER —
-    /// lowering this constant as the sweep batches land is the intended edit; raising it is not.
+    /// <c>version-bump</c>, <c>workspace-health</c>). Batch c1 swept the first three and batch c2
+    /// swept the last two, so the amnesty is now CLOSED: <c>residualUnsweptAllowlist</c> is empty
+    /// and every shipped skill is subject to the prefix-agnostic rule with zero exemptions. The
+    /// allowlist may only ever get SMALLER — this constant is pinned at 0 and raising it is not an
+    /// allowed edit; a new unswept skill must be swept, not re-amnestied.
     /// </summary>
-    private const int ResidualUnsweptRatchet = 2;
+    private const int ResidualUnsweptRatchet = 0;
 
     [TestMethod]
     public void PrefixAgnosticPolicy_IsPopulated()


### PR DESCRIPTION
Closes: shipped-skills-hardcode-bare-roslyn-tool-prefix

Final batch of the shipped-skills prefix-agnostic sweep. Replaces the pre-fix
bare-prefix connectivity precheck in the last two allowlisted shipped skills and
closes the amnesty outright.

## Changes

- `skills/version-bump/SKILL.md` — `## Connectivity precheck` replaced wholesale with the canonical prefix-agnostic block.
- `skills/workspace-health/SKILL.md` — same replacement; the per-skill trailer note ("this skill's purpose is to report server/workspace status…") is retained, which `Assert-CanonicalBlockIdentity` permits because it compares only the leading slice of the anchor-to-`^## ` span.
- `eng/banned-skill-markers.json` — `prefixAgnostic.residualUnsweptAllowlist` emptied to `[]`. The **key is retained deliberately**: `eng/verify-skills-are-generic.ps1:82` coerces it with `@(...)`, and a missing key yields `@($null)` whose `.ToLowerInvariant()` throws under `$ErrorActionPreference = "Stop"`, crashing the gate instead of passing it.
- `tests/RoslynMcp.Tests/Skills/SkillPrefixGenericityTests.cs` — `ResidualUnsweptRatchet` lowered `2` → `0`; doc comment records the amnesty as closed.

Both skill blocks were copied byte-for-byte from the SSOT array
`canonicalPrecheckBlocks[0].text` (shipped copy: `skills/exception-audit/SKILL.md`),
not retyped. `eng/verify-skills-are-generic.ps1` is unchanged — it already
tolerates an empty allowlist.

## Why

The MCP tool prefix is client-assigned. A marketplace-plugin consumer surfaces
`mcp__plugin_roslyn-mcp_roslyn__*` and would halt on the hard-coded
`mcp__roslyn__*` literal it never exposes.

## Validation

- `pwsh -NoProfile -File ./eng/verify-skills-are-generic.ps1` → exit 0, "Shipped skills under ./skills/ are generic (38 .md files checked)" — both files are now gate-covered with zero amnesty.
- `dotnet test --filter "FullyQualifiedName~SkillPrefixGenericityTests"` → 16/16 passed at ratchet 0.
- `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` → exit 0.
- Byte-identity: the 15-line `## Connectivity precheck` span in `version-bump`, `workspace-health`, and `exception-audit` all hash to `fc014c84…`.
- Negative check: `rg -c "mcp__[A-Za-z0-9_-]*roslyn[A-Za-z0-9_-]*__"` reports exactly `2` per file (the canonical block's two disclaimed illustrative prefixes).
- `## Workflow` still follows the trailer note in `workspace-health`.

Full `eng/verify-release.ps1` parity is left to CI on this PR — the self-hosted
runner on this box serializes validate jobs, so it was not duplicated locally.
