### PR TITLE
chore(preview): add editing-family preview kinds and route-map substrate (preview-token-route-binding-editing-substrate)

### DIFF
--- a/changelog.d/preview-token-route-binding-editing-substrate.md
+++ b/changelog.d/preview-token-route-binding-editing-substrate.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** added the `PreviewKind` members for the multi-file-edit, file-create, file-delete, file-move, code-action and fix-all producer families, registered all six in the centralized preview-kind to apply-route map (including the two gate-forced `ServerSurfaceCatalog.PreviewApplyRoutes` companions), and declared the kind-carrying `IPreviewStore.Store` overload for the non-`changes` call shape. No runtime behavior change on its own — this is the substrate the remaining apply-route bindings build on.

--- a/src/RoslynMcp.Core/Models/PreviewKind.cs
+++ b/src/RoslynMcp.Core/Models/PreviewKind.cs
@@ -40,4 +40,22 @@ public enum PreviewKind
 
     /// <summary>A diagnostic code-fix preview.</summary>
     CodeFix,
+
+    /// <summary>A batched multi-file text-edit preview.</summary>
+    MultiFileEdit,
+
+    /// <summary>A source-file creation preview.</summary>
+    FileCreate,
+
+    /// <summary>A source-file deletion preview.</summary>
+    FileDelete,
+
+    /// <summary>A source-file move/rename preview.</summary>
+    FileMove,
+
+    /// <summary>A Roslyn code-action preview.</summary>
+    CodeAction,
+
+    /// <summary>A solution-wide fix-all preview.</summary>
+    FixAll,
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -66,6 +66,12 @@ public static partial class ServerSurfaceCatalog
             ["set_conditional_property_preview"] = "apply_project_mutation",
             ["remove_central_package_version_preview"] = "apply_project_mutation",
             ["scaffold_test_preview"] = "scaffold_test_apply",
+            // preview-token-route-binding-editing-substrate: gate-forced companions for the
+            // PreviewKind.MultiFileEdit / PreviewKind.FixAll members added in the same change.
+            // ToolDispatch.ApplyRouteFor derives its apply-route half from this dictionary, and
+            // the exhaustiveness pin requires every concrete PreviewKind to resolve through it.
+            ["preview_multi_file_edit"] = "preview_multi_file_edit_apply",
+            ["fix_all_preview"] = "fix_all_apply",
         };
 
     public static IReadOnlyList<SurfaceEntry> Tools => s_allTools.Value;

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -211,6 +211,12 @@ internal static class ToolDispatch
             [PreviewKind.FormatRange] = "format_range_preview",
             [PreviewKind.OrganizeUsings] = "organize_usings_preview",
             [PreviewKind.CodeFix] = "code_fix_preview",
+            [PreviewKind.MultiFileEdit] = "preview_multi_file_edit",
+            [PreviewKind.FileCreate] = "create_file_preview",
+            [PreviewKind.FileDelete] = "delete_file_preview",
+            [PreviewKind.FileMove] = "move_file_preview",
+            [PreviewKind.CodeAction] = "preview_code_action",
+            [PreviewKind.FixAll] = "fix_all_preview",
         };
 
     /// <summary>

--- a/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
+++ b/src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs
@@ -31,6 +31,31 @@ public interface IPreviewStore
     string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated);
 
     /// <summary>
+    /// <b>preview-token-apply-route-provenance:</b> same as the <paramref name="diffTruncated"/>-shaped
+    /// overload, but additionally records a machine-checkable <paramref name="kind"/> discriminator
+    /// identifying which producer family created the token, so an apply route can verify provenance
+    /// before mutating the workspace.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="changes"/>-shaped sibling below already covers producers that hand the
+    /// store a computed diff; this declaration covers the three producers that pass the truncation
+    /// flag directly (<c>EditService</c>, <c>CodeActionService</c>, <c>FixAllService</c>), which
+    /// could not be tagged at all while the concrete <c>PreviewStore</c> implemented this shape
+    /// without the interface declaring it. Default implementation drops <paramref name="kind"/> and
+    /// delegates to the untagged overload, so existing test fakes (and any out-of-tree
+    /// implementations) keep compiling; only stores that actually persist provenance override it.
+    /// </remarks>
+    /// <param name="kind">The producer family that created this preview.</param>
+    string Store(
+        string workspaceId,
+        Solution modifiedSolution,
+        int workspaceVersion,
+        string description,
+        bool diffTruncated,
+        PreviewKind kind)
+        => Store(workspaceId, modifiedSolution, workspaceVersion, description, diffTruncated);
+
+    /// <summary>
     /// Item #4 — convenience overload: derives the truncated flag from the presence of
     /// <see cref="Helpers.SolutionDiffHelper.TruncatedSentinelFilePath"/> in <paramref name="changes"/>.
     /// </summary>

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
@@ -162,16 +163,71 @@ public sealed class ToolDispatchTests
                 continue;
             }
 
+            // preview-token-route-binding-editing-substrate: assert catalog MEMBERSHIP, not a
+            // `*_preview` / `*_apply` suffix convention. The live surface breaks that convention
+            // (`preview_code_action` / `apply_code_action`, `preview_multi_file_edit`), so a suffix
+            // check would reject correct mappings while still accepting an invented tool name.
             var previewTool = ToolDispatch.PreviewToolFor(kind);
-            StringAssert.EndsWith(previewTool, "_preview",
-                $"PreviewKind.{kind} must map to a real *_preview tool name, not a catch-all phrase.");
+            Assert.IsTrue(
+                ServerSurfaceCatalog.TryGetTool(previewTool, out var previewEntry),
+                $"PreviewKind.{kind} must map to a tool that actually exists in the server surface, " +
+                $"not a catch-all phrase; '{previewTool}' is not a catalog entry.");
+            Assert.IsTrue(previewEntry!.ReadOnly,
+                $"PreviewKind.{kind} must map to the token-ISSUING preview tool, not a mutating route.");
 
             var applyRoute = ToolDispatch.ApplyRouteFor(kind);
-            StringAssert.EndsWith(applyRoute, "_apply",
-                $"PreviewKind.{kind} must resolve to a real *_apply route name.");
+            Assert.IsTrue(
+                ServerSurfaceCatalog.TryGetTool(applyRoute, out var applyEntry),
+                $"PreviewKind.{kind} must resolve to a tool that actually exists in the server " +
+                $"surface; '{applyRoute}' is not a catalog entry.");
+            Assert.IsFalse(applyEntry!.ReadOnly,
+                $"PreviewKind.{kind} must resolve to a mutating apply route.");
             Assert.AreNotEqual("apply_with_verify", applyRoute,
                 $"PreviewKind.{kind} must resolve to its OWN named apply route, not the generic fallback.");
         }
+    }
+
+    /// <summary>
+    /// preview-token-route-binding-editing-substrate: content pin for the centralized map. The
+    /// exhaustiveness test above proves every concrete kind resolves to SOMETHING real; this one
+    /// proves it resolves to the RIGHT thing, so a copy-paste slip between two neighbouring
+    /// producer families fails a test instead of shipping a misleading mismatch message.
+    /// Hand-listed on purpose — a table derived from the map under test would assert nothing.
+    /// </summary>
+    [TestMethod]
+    public void PreviewKindRouteMap_EachKind_ResolvesItsOwnProducerPair()
+    {
+        (PreviewKind Kind, string PreviewTool, string ApplyRoute)[] expected =
+        [
+            (PreviewKind.SymbolRename, "rename_preview", "rename_apply"),
+            (PreviewKind.FormatDocument, "format_document_preview", "format_document_apply"),
+            (PreviewKind.FormatRange, "format_range_preview", "format_range_apply"),
+            (PreviewKind.OrganizeUsings, "organize_usings_preview", "organize_usings_apply"),
+            (PreviewKind.CodeFix, "code_fix_preview", "code_fix_apply"),
+            (PreviewKind.MultiFileEdit, "preview_multi_file_edit", "preview_multi_file_edit_apply"),
+            (PreviewKind.FileCreate, "create_file_preview", "create_file_apply"),
+            (PreviewKind.FileDelete, "delete_file_preview", "delete_file_apply"),
+            (PreviewKind.FileMove, "move_file_preview", "move_file_apply"),
+            (PreviewKind.CodeAction, "preview_code_action", "apply_code_action"),
+            (PreviewKind.FixAll, "fix_all_preview", "fix_all_apply"),
+        ];
+
+        foreach (var (kind, previewTool, applyRoute) in expected)
+        {
+            Assert.AreEqual(previewTool, ToolDispatch.PreviewToolFor(kind),
+                $"PreviewKind.{kind} is mapped to the wrong *_preview producer.");
+            Assert.AreEqual(applyRoute, ToolDispatch.ApplyRouteFor(kind),
+                $"PreviewKind.{kind} resolves to the wrong apply route.");
+        }
+
+        var concreteKinds = Enum.GetValues<PreviewKind>()
+            .Where(static kind => kind != PreviewKind.Unspecified)
+            .ToArray();
+        CollectionAssert.AreEquivalent(
+            concreteKinds,
+            expected.Select(static row => row.Kind).ToArray(),
+            "A new concrete PreviewKind member must be added to this content pin too — otherwise a " +
+            "typo'd map entry ships silently once the exhaustiveness test is satisfied.");
     }
 
     /// <summary>


### PR DESCRIPTION
Closes: preview-token-apply-route-binding-remaining-families (partial — substrate slice only; the row closes with child 5, `preview-token-route-binding-bulk-family`)

Initiative `preview-token-route-binding-editing-substrate` from `ai_docs/plans/20260825T214500Z_backlog-sweep/plan.md` §2.01. Part 1 of 3 of the split from `preview-token-route-binding-editing-family`; branches from a base that already carries order 1 (`preview-token-route-map-centralization`, PR #1354).

No `Fixes #N` lines: the backlog row's `do` cell carries no `[gh #NNN]` reference.

## What this ships

Substrate only. Enum members, map entries and one interface declaration — no producer is tagged and no apply route is bound, so **runtime behavior is unchanged**. That is what makes parts 2 and 3 parallelizable against each other.

- **`src/RoslynMcp.Core/Models/PreviewKind.cs`** — append `MultiFileEdit`, `FileCreate`, `FileDelete`, `FileMove`, `CodeAction`, `FixAll`. Append-only: `Unspecified = 0` remains the load-bearing permissive default and the existing five keep their positional values (consumed by `RefactoringTools.cs:59/94/129/168/209`).
- **`src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs`** — register all six in `_previewToolsByKind` against their `[McpServerTool(Name = …)]`-verified producer tool names.
- **`src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs`** — add the two **gate-forced companions** the map's apply-route hop needs: `preview_multi_file_edit` → `preview_multi_file_edit_apply` and `fix_all_preview` → `fix_all_apply`. The other four preview tools were already keys in `PreviewApplyRoutes`.
- **`src/RoslynMcp.Roslyn/Contracts/IPreviewStore.cs`** — declare `Store(workspaceId, modifiedSolution, workspaceVersion, description, bool diffTruncated, PreviewKind kind)` with a kind-discarding default body. `PreviewStore.cs:94` already implemented this shape but the interface never declared it, so the three `bool`-shaped producers (`EditService.cs:302`, `CodeActionService.cs:152`, `FixAllService.cs:207`) could not be tagged at all. The default body keeps the three in-tree `IPreviewStore` fakes and any out-of-tree implementers compiling.

## Test changes

`tests/RoslynMcp.Tests/ToolDispatchTests.cs`:

- The order-1 exhaustiveness pin asserted a `*_preview` / `*_apply` **suffix convention** that the live tool surface does not follow — `preview_code_action` / `apply_code_action` and `preview_multi_file_edit` all break it. Replaced with **catalog-membership** assertions (`ServerSurfaceCatalog.TryGetTool`) plus a `ReadOnly` direction check. This is strictly stronger: an invented tool name that happened to end in `_preview` used to pass and now fails.
- Added `PreviewKindRouteMap_EachKind_ResolvesItsOwnProducerPair` — a hand-listed content pin over all eleven concrete kinds, with an equivalence check that a future member must be added to the pin too. A copy-paste slip between two neighbouring producer families now fails a test rather than shipping a misleading mismatch message.

## Scope note (Rule 3)

Plan Scope named 3 production files; this ships **4**. `ServerSurfaceCatalog.cs` is the gate-forced companion the plan's own FAMILY CONTRACT predicted — order 1's pin requires every non-`Unspecified` member to resolve through `PreviewApplyRoutes`, and two of the six new preview-tool names were not keys there. Arithmetic: 3 planned + 1 gate-forced = 4, exactly at the Rule 3 cap, below the 7-file companion ceiling. `ServerSurfaceCatalog.cs` is an addenda-listed hotspot (≤1 catalog-touching initiative per wave).

## Validation

- `dotnet build RoslynMcp.slnx -c Debug` — 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- `dotnet build RoslynMcp.slnx -c Release` — 0 warnings, 0 errors.
- `dotnet test --filter "ToolDispatchTests|PreviewStoreTests|StartupDiagnosticsTests"` — 51/51 passed. `PreviewStoreTests` confirms the new interface default body does not shadow `PreviewStore`'s concrete implementation; `StartupDiagnosticsTests` confirms the two new `PreviewApplyRoutes` entries do not disturb the stable-tier preview/apply selection closure (both new pairs are experimental/experimental).
- `dotnet test --filter "Catalog|Surface|ApplyUndoWorkflowServiceTests|ApplyWithVerify|AliasTools"` — 167/167 passed.
- `./eng/verify-ai-docs.ps1` — passed.
- `./eng/verify-changed-format.ps1` — passed, 0 new findings (7 pre-existing IDE1006 baseline findings on `ServerSurfaceCatalog.cs`, unchanged).
- `./eng/verify-changelog-fragments.ps1` — passed.
- Full `./eng/verify-release.ps1 -Configuration Release` is delegated to the self-hosted CI runner on this PR per the standing "don't duplicate the runner locally" rule; Release-config build parity was verified locally instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
