### PR TITLE
fix(host): bind the extraction/move apply routes to their producer families (preview-token-route-binding-extraction-family)

### DIFF
--- a/changelog.d/preview-token-route-binding-extraction-family.md
+++ b/changelog.d/preview-token-route-binding-extraction-family.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the four extraction/move apply routes (`extract_method_apply`, `extract_interface_apply`, `extract_type_apply`, `move_type_to_file_apply`) now bind to their producer families and reject a preview token minted by a different `*_preview` before any workspace mutation, with an error naming the token's real producer and the route it should be redeemed through. Adds the matching `PreviewKind` members plus the missing `extract_interface_preview` → `extract_interface_apply` catalog pairing, so the mismatch message stays factual instead of falling back to the generic `apply_with_verify` advice. Tokens with unrecorded provenance still redeem unchanged, and `apply_with_verify` remains producer-agnostic by design.

--- a/src/RoslynMcp.Core/Models/PreviewKind.cs
+++ b/src/RoslynMcp.Core/Models/PreviewKind.cs
@@ -58,4 +58,16 @@ public enum PreviewKind
 
     /// <summary>A solution-wide fix-all preview.</summary>
     FixAll,
+
+    /// <summary>A single-block extract-method preview.</summary>
+    ExtractMethod,
+
+    /// <summary>A same-project interface-extraction preview.</summary>
+    ExtractInterface,
+
+    /// <summary>A type-extraction preview.</summary>
+    ExtractType,
+
+    /// <summary>A move-type-to-its-own-file preview.</summary>
+    MoveTypeToFile,
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ServerSurfaceCatalog.cs
@@ -72,6 +72,13 @@ public static partial class ServerSurfaceCatalog
             // the exhaustiveness pin requires every concrete PreviewKind to resolve through it.
             ["preview_multi_file_edit"] = "preview_multi_file_edit_apply",
             ["fix_all_preview"] = "fix_all_apply",
+            // preview-token-route-binding-extraction-family: this pairing was MISSING while its
+            // three extraction/move siblings (extract_method, extract_type, move_type_to_file)
+            // were present, so TryGetCompatibleApplyRoute reported no pairing for a route that
+            // has one — letting tier selection surface extract_interface_preview in a tier that
+            // excludes extract_interface_apply. Also a gate-forced companion for the
+            // PreviewKind.ExtractInterface member added in the same change.
+            ["extract_interface_preview"] = "extract_interface_apply",
         };
 
     public static IReadOnlyList<SurfaceEntry> Tools => s_allTools.Value;

--- a/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ExtractMethodTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
 
@@ -53,7 +54,10 @@ public static class ExtractMethodTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_method_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.ExtractMethod);
 
     [McpServerTool(Name = "extract_shared_expression_to_helper_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
     [McpToolMetadata("refactoring", "experimental", true, false,

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -52,5 +53,8 @@ public static class InterfaceExtractionTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_interface_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.ExtractInterface);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -217,6 +217,10 @@ internal static class ToolDispatch
             [PreviewKind.FileMove] = "move_file_preview",
             [PreviewKind.CodeAction] = "preview_code_action",
             [PreviewKind.FixAll] = "fix_all_preview",
+            [PreviewKind.ExtractMethod] = "extract_method_preview",
+            [PreviewKind.ExtractInterface] = "extract_interface_preview",
+            [PreviewKind.ExtractType] = "extract_type_preview",
+            [PreviewKind.MoveTypeToFile] = "move_type_to_file_preview",
         };
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeExtractionTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -57,5 +58,8 @@ public static class TypeExtractionTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "extract_type_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.ExtractType);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/TypeMoveTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Catalog;
@@ -56,7 +57,10 @@ public static class TypeMoveTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "move_type_to_file_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.MoveTypeToFile);
 
     [McpServerTool(Name = "change_type_namespace_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,

--- a/tests/RoslynMcp.Tests/ExtractionApplyRouteBindingTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractionApplyRouteBindingTests.cs
@@ -1,0 +1,248 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// preview-token-route-binding-extraction-family: route-level coverage for the four
+/// extraction/move apply tools — <c>extract_method_apply</c>, <c>extract_interface_apply</c>,
+/// <c>extract_type_apply</c>, and <c>move_type_to_file_apply</c> — which now declare an
+/// <see cref="PreviewKind"/> producer family through
+/// <see cref="ToolDispatch.ApplyByTokenAsync{TDto}(IWorkspaceExecutionGate, IPreviewStore, string, Func{CancellationToken, Task{TDto}}, CancellationToken, PreviewKind)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests exercise the SHIM methods, not <see cref="ToolDispatch"/> directly, so the binding
+/// itself (the <c>expectedKind:</c> argument on each call site) is what is pinned. A regression
+/// that drops the argument compiles green — the parameter is optional — and would only be caught
+/// here.
+/// </para>
+/// <para>
+/// The fakes are deliberately local duplicates of the ones nested inside <c>ToolDispatchTests</c>:
+/// those are <c>private</c> nested types, and widening them into a shared fixture would couple two
+/// unrelated test files for four small stubs.
+/// </para>
+/// </remarks>
+[TestClass]
+public sealed class ExtractionApplyRouteBindingTests
+{
+    /// <summary>
+    /// A wrong-family token (minted by <c>rename_preview</c>) must be refused by every one of the
+    /// four bound routes BEFORE the refactoring service is reached, with a message naming both the
+    /// token's real apply route and the route it was wrongly redeemed through.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractionApplyRoutes_ForeignFamilyToken_RefuseBeforeServiceCall()
+    {
+        (string RouteName, Func<IWorkspaceExecutionGate, IRefactoringService, IPreviewStore, Task<string>> Invoke)[] routes =
+        [
+            ("extract_method_apply",
+                (gate, svc, store) => ExtractMethodTools.ApplyExtractMethod(gate, svc, store, "tok-xroute", CancellationToken.None)),
+            ("extract_interface_apply",
+                (gate, svc, store) => InterfaceExtractionTools.ApplyExtractInterface(gate, svc, store, "tok-xroute", CancellationToken.None)),
+            ("extract_type_apply",
+                (gate, svc, store) => TypeExtractionTools.ApplyExtractType(gate, svc, store, "tok-xroute", CancellationToken.None)),
+            ("move_type_to_file_apply",
+                (gate, svc, store) => TypeMoveTools.ApplyMoveTypeToFile(gate, svc, store, "tok-xroute", CancellationToken.None)),
+        ];
+
+        foreach (var (routeName, invoke) in routes)
+        {
+            var gate = new FakeGate();
+            var service = new ThrowingRefactoringService();
+            var store = new FakePreviewStore(token: "tok-xroute", workspaceId: "ws-xr")
+            {
+                Kind = PreviewKind.SymbolRename,
+            };
+
+            var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => invoke(gate, service, store));
+
+            StringAssert.Contains(ex.Message, "rename_apply",
+                $"{routeName} must name the token's real apply route so the caller can recover.");
+            StringAssert.Contains(ex.Message, routeName,
+                $"{routeName} must name the route that refused the token.");
+            Assert.AreEqual(0, service.ApplyCallCount,
+                $"{routeName} must refuse the foreign token BEFORE the refactoring service runs.");
+            Assert.AreEqual(1, gate.WriteCallCount,
+                $"{routeName} runs its provenance guard INSIDE the write gate.");
+        }
+    }
+
+    /// <summary>
+    /// The permissive arm: a token whose producer recorded no provenance
+    /// (<see cref="PreviewKind.Unspecified"/> — the state of every extraction producer today) must
+    /// still redeem on a bound route. Binding the routes must not break untagged producers.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractionApplyRoutes_UnspecifiedProvenanceToken_StillRedeems()
+    {
+        Func<IWorkspaceExecutionGate, IRefactoringService, IPreviewStore, Task<string>>[] routes =
+        [
+            (gate, svc, store) => ExtractMethodTools.ApplyExtractMethod(gate, svc, store, "tok-untagged", CancellationToken.None),
+            (gate, svc, store) => InterfaceExtractionTools.ApplyExtractInterface(gate, svc, store, "tok-untagged", CancellationToken.None),
+            (gate, svc, store) => TypeExtractionTools.ApplyExtractType(gate, svc, store, "tok-untagged", CancellationToken.None),
+            (gate, svc, store) => TypeMoveTools.ApplyMoveTypeToFile(gate, svc, store, "tok-untagged", CancellationToken.None),
+        ];
+
+        foreach (var invoke in routes)
+        {
+            var gate = new FakeGate();
+            var service = new RecordingRefactoringService();
+            var store = new FakePreviewStore(token: "tok-untagged", workspaceId: "ws-ut");
+
+            var json = await invoke(gate, service, store);
+
+            Assert.AreEqual(1, service.ApplyCallCount,
+                "An untagged token is permissive by the PreviewKind contract and must still apply.");
+            StringAssert.Contains(json, "A.cs", "The route must serialize the service's result.");
+        }
+    }
+
+    /// <summary>
+    /// Same-family redemption is unaffected — a token tagged with the route's own kind applies.
+    /// </summary>
+    [TestMethod]
+    public async Task ExtractMethodApply_MatchingProvenanceToken_Redeems()
+    {
+        var gate = new FakeGate();
+        var service = new RecordingRefactoringService();
+        var store = new FakePreviewStore(token: "tok-em", workspaceId: "ws-em")
+        {
+            Kind = PreviewKind.ExtractMethod,
+        };
+
+        _ = await ExtractMethodTools.ApplyExtractMethod(gate, service, store, "tok-em", CancellationToken.None);
+
+        Assert.AreEqual(1, service.ApplyCallCount, "A same-family token must redeem unchanged.");
+    }
+
+    /// <summary>Records apply invocations and returns a canned success DTO.</summary>
+    private class RecordingRefactoringService : IRefactoringService
+    {
+        public int ApplyCallCount { get; private set; }
+
+        public virtual Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct)
+        {
+            ApplyCallCount++;
+            return Task.FromResult(new ApplyResultDto(true, new[] { "A.cs" }, null));
+        }
+
+        public virtual Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, bool force, CancellationToken ct)
+            => ApplyRefactoringAsync(previewToken, toolName, ct);
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewRenameAsync(string workspaceId, SymbolLocator locator, string newName, bool summary, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewOrganizeUsingsAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatDocumentAsync(string workspaceId, string filePath, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewFormatRangeAsync(string workspaceId, string filePath, int startLine, int startColumn, int endLine, int endColumn, CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewCodeFixAsync(string workspaceId, string diagnosticId, string filePath, int line, int column, string? fixId, CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Fails loudly if the provenance guard lets a foreign token through — the apply must never be
+    /// reached, so reaching it is itself the failure signal (belt-and-braces alongside the
+    /// <c>ApplyCallCount</c> assertion, which would otherwise only fire after the mutation ran).
+    /// </summary>
+    private sealed class ThrowingRefactoringService : RecordingRefactoringService
+    {
+        public override Task<ApplyResultDto> ApplyRefactoringAsync(string previewToken, string toolName, CancellationToken ct)
+        {
+            _ = base.ApplyRefactoringAsync(previewToken, toolName, ct);
+            // NotSupportedException on purpose: the guard throws InvalidOperationException, so a
+            // distinct type keeps ThrowsExactlyAsync<InvalidOperationException> from passing on a
+            // guard that never fired.
+            throw new NotSupportedException(
+                $"The provenance guard must refuse the token before `{toolName}` reaches the service.");
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IWorkspaceExecutionGate"/> stand-in recording which verb ran. Mirrors the
+    /// private fake nested in <c>ToolDispatchTests</c>.
+    /// </summary>
+    private sealed class FakeGate : IWorkspaceExecutionGate
+    {
+        public int WriteCallCount { get; private set; }
+
+        public async Task<T> RunReadAsync<T>(string workspaceId, Func<CancellationToken, Task<T>> action, CancellationToken ct)
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            return await action(linked.Token).ConfigureAwait(false);
+        }
+
+        public async Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true)
+        {
+            _ = applyStalenessPolicy;
+            WriteCallCount++;
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            return await action(linked.Token).ConfigureAwait(false);
+        }
+
+        public Task<T> RunLoadGateAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken ct)
+            => throw new NotSupportedException("Extraction apply routes must not route through RunLoadGateAsync.");
+
+        public void RemoveGate(string workspaceId)
+            => throw new NotSupportedException("Extraction apply routes must not call RemoveGate.");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IPreviewStore"/> stand-in exposing only the peek surface the apply path
+    /// consumes. Mirrors the private fake nested in <c>ToolDispatchTests</c>.
+    /// </summary>
+    private sealed class FakePreviewStore : IPreviewStore
+    {
+        private readonly string _token;
+        private readonly string _workspaceId;
+
+        public FakePreviewStore(string token, string workspaceId)
+        {
+            _token = token;
+            _workspaceId = workspaceId;
+        }
+
+        public PreviewKind Kind { get; init; } = PreviewKind.Unspecified;
+
+        public string? PeekWorkspaceId(string token) => token == _token ? _workspaceId : null;
+
+        public IReadOnlyList<string>? PeekChangedPaths(string token) => null;
+
+        public PreviewKind PeekKind(string token) => token == _token ? Kind : PreviewKind.Unspecified;
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description)
+            => throw new NotSupportedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, bool diffTruncated)
+            => throw new NotSupportedException();
+
+        public string Store(string workspaceId, Solution modifiedSolution, int workspaceVersion, string description, IReadOnlyList<FileChangeDto> changes)
+            => throw new NotSupportedException();
+
+        public (string WorkspaceId, Solution OriginalSolution, Solution ModifiedSolution, int WorkspaceVersion, string Description, bool DiffTruncated)? Retrieve(string token)
+            => throw new NotSupportedException();
+
+        public void Invalidate(string token) => throw new NotSupportedException();
+
+        public void InvalidateAll(string? workspaceId = null) => throw new NotSupportedException();
+
+        public void InvalidateOnVersionBump(string workspaceId, int newWorkspaceVersion) => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/ToolDispatchTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDispatchTests.cs
@@ -210,6 +210,10 @@ public sealed class ToolDispatchTests
             (PreviewKind.FileMove, "move_file_preview", "move_file_apply"),
             (PreviewKind.CodeAction, "preview_code_action", "apply_code_action"),
             (PreviewKind.FixAll, "fix_all_preview", "fix_all_apply"),
+            (PreviewKind.ExtractMethod, "extract_method_preview", "extract_method_apply"),
+            (PreviewKind.ExtractInterface, "extract_interface_preview", "extract_interface_apply"),
+            (PreviewKind.ExtractType, "extract_type_preview", "extract_type_apply"),
+            (PreviewKind.MoveTypeToFile, "move_type_to_file_preview", "move_type_to_file_apply"),
         ];
 
         foreach (var (kind, previewTool, applyRoute) in expected)


### PR DESCRIPTION
## What

Binds the four extraction/move apply routes to their preview-token producer families, so a token minted by a different `*_preview` is refused **before** any workspace mutation:

| Route | `expectedKind` |
|---|---|
| `extract_method_apply` | `PreviewKind.ExtractMethod` |
| `extract_interface_apply` | `PreviewKind.ExtractInterface` |
| `extract_type_apply` | `PreviewKind.ExtractType` |
| `move_type_to_file_apply` | `PreviewKind.MoveTypeToFile` |

Child 3 of 5 of `preview-token-apply-route-binding-remaining-families`.

## How

1. `PreviewKind.cs` — appends four concrete members (append-only; no renumbering, the enum is persisted in `PreviewStore` entries).
2. `ToolDispatch._previewToolsByKind` — four kind → `*_preview` rows in the map centralized by `preview-token-route-map-centralization`. Gate-forced companion: order 1's exhaustiveness pin (`PreviewKindRouteMap_EveryConcreteKind_ResolvesPreviewToolAndApplyRoute`) reds without them.
3. `ServerSurfaceCatalog.PreviewApplyRoutes` — adds the **missing** `extract_interface_preview` → `extract_interface_apply` pairing. This was a live bug independent of the binding: its three siblings (`extract_method`, `extract_type`, `move_type_to_file`) were all present, so `TryGetCompatibleApplyRoute` reported "no pairing" for a route that has one, and tier selection could surface `extract_interface_preview` in a tier excluding `extract_interface_apply`. `ToolDispatch.ApplyRouteFor` derives its apply-route half from this dictionary, so it is also a gate-forced companion.
4. The four `*Tools.cs` shims — one `expectedKind:` argument each, mirroring `RefactoringTools.cs:51-60` (no `applyRoute:` — order 1 removed that parameter).

**Rule 3 arithmetic — gate-forced-companion exemption:** 4 base + 3 additional (`PreviewKind.cs`, `ToolDispatch.cs`, `ServerSurfaceCatalog.cs`) = **7 ≤ 7**. Gates: the C# compiler (CS0117 on an undeclared member) and order 1's exhaustiveness + content pin tests. `ServerSurfaceCatalog.cs` is an addenda-listed hotspot — this PR is the wave's catalog-touching initiative.

## Out of scope (deliberate)

- **Producer-side tagging** of `ExtractMethodService` / `InterfaceExtractionService` / `TypeExtractionService` / `TypeMoveService` — all four still call the no-kind `Store` overload. Untagged producers stay permissive by the enum's documented contract, so these bindings are correct today (they refuse foreign-family tokens) and become symmetric when tagging lands. Follow-on row filed at reconcile.
- `extract_shared_expression_to_helper_preview` and `change_type_namespace_preview` — same files, no named apply route, deliberately unbound.
- `apply_with_verify` remains producer-agnostic by design.

## Tests

New `tests/RoslynMcp.Tests/ExtractionApplyRouteBindingTests.cs` (MSTest; local fakes, since `ToolDispatchTests`' are private nested types). It exercises the **shim methods**, not `ToolDispatch` directly — dropping an `expectedKind:` argument compiles green because the parameter is optional, so this file is the only thing that catches that regression.

- foreign-family token (`rename_preview` provenance) refused on all four routes, message names both `rename_apply` and the invoked route, service never reached, guard runs inside the write gate
- `Unspecified` provenance still redeems on all four routes (permissive arm)
- matching provenance redeems unchanged

`ToolDispatchTests.PreviewKindRouteMap_EachKind_ResolvesItsOwnProducerPair` content pin extended with the four new rows, as that test's own failure message instructs.

## Validation

- `dotnet build RoslynMcp.slnx -c Debug` — 0 warnings, 0 errors
- `dotnet test --filter "ExtractionApplyRouteBinding|ToolDispatchTests|PreviewStoreTests"` — 35/35 passed
- `dotnet test --filter "Catalog|Surface|Tier|Snapshot"` — 175/175 passed
- `eng/verify-changed-format.ps1` — 9 changed C# files, **0 new findings**, 10 tracked baseline findings
- `eng/verify-changelog-fragments.ps1`, `eng/verify-ai-docs.ps1` — passed

Full `verify-release.ps1` is left to the self-hosted runner rather than duplicated locally.

## Bad code observed, not fixed here

`ServerSurfaceCatalog.PreviewApplyRoutes` is a **fourth** encoding of preview→apply knowledge (alongside the `PreviewKind` enum, `_previewToolsByKind`, and the per-tool `ApplyRefactoringAsync` route strings). Order 1 collapsed two of the hops; the remaining duplication is worth a consolidation row.

Closes:
(none — partial slice; the row `preview-token-apply-route-binding-remaining-families` closes with child 5, `preview-token-route-binding-bulk-family`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
