### PR TITLE
fix(host): bind the scaffolding apply routes to their producer family (preview-token-route-binding-orchestration-family)

### DIFF
--- a/changelog.d/preview-token-route-binding-orchestration-family.md
+++ b/changelog.d/preview-token-route-binding-orchestration-family.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Preview-token provenance enforcement on the scaffolding apply routes. `scaffold_type_apply` and `scaffold_test_apply` now declare `PreviewKind.FileCreate` as their compatible producer set, so a rename, format, code-fix, or extraction token redeemed through a scaffold apply route is refused with an actionable message naming the correct route, before any workspace mutation. Untagged tokens — including the ones `scaffold_test_batch_preview` mints — stay permissive. `apply_composite_preview` and `apply_project_mutation` remain unbound: their preview stores do not implement `IPreviewStore` and expose no provenance peek.

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -95,7 +95,10 @@ public static class ScaffoldingTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "scaffold_type_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.FileCreate);
 
     /// <remarks>
     /// When <c>referenceTestFile</c> is provided — or the test project contains a sibling
@@ -238,7 +241,10 @@ public static class ScaffoldingTools
             previewStore,
             previewToken,
             c => refactoringService.ApplyRefactoringAsync(previewToken, "scaffold_test_apply", c),
-            ct);
+            ct,
+            // preview-token-apply-route-provenance: bind this route to its producer family so a
+            // token minted by a different *_preview is refused before any workspace mutation.
+            expectedKind: PreviewKind.FileCreate);
 
     /// <remarks>
     /// Distinct from <c>scaffold_test_preview</c>, which adds a single method-focused test to an

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Diagnostics;
+using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Services;
 using RoslynMcp.Tests.TestInfrastructure;
 
@@ -71,6 +72,78 @@ public sealed class ScaffoldingIntegrationTests : IsolatedWorkspaceTestBase
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "namespace SampleLib.Generated");
         StringAssert.Contains(contents, "class Bird");
+    }
+
+    /// <summary>
+    /// preview-token-route-binding-orchestration-family: <c>scaffold_type_preview</c> mints through
+    /// <c>IFileOperationService.PreviewCreateFileAsync</c>, which records
+    /// <see cref="PreviewKind.FileCreate"/>. Same-family redemption through the newly bound
+    /// <c>scaffold_type_apply</c> shim must be unaffected.
+    /// </summary>
+    [TestMethod]
+    public async Task Scaffold_Type_Preview_Token_Carries_FileCreate_Provenance_And_Redeems()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var targetFilePath = workspace.GetPath("SampleLib", "Generated", "Bird.cs");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTypeAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTypeDto("SampleLib", "Bird", "class", "SampleLib.Generated"),
+            CancellationToken.None);
+
+        Assert.AreEqual(PreviewKind.FileCreate, PreviewStore.PeekKind(preview.PreviewToken),
+            "scaffold_type_preview delegates to PreviewCreateFileAsync, so its token must record the "
+            + "file-creation producer family.");
+
+        var json = await ScaffoldingTools.ApplyScaffoldType(
+            WorkspaceExecutionGate,
+            RefactoringService,
+            PreviewStore,
+            preview.PreviewToken,
+            CancellationToken.None);
+
+        StringAssert.Contains(json, "\"success\": true", "Same-family redemption must still apply cleanly.");
+        Assert.IsTrue(File.Exists(targetFilePath), "Binding the route must not break the happy path.");
+    }
+
+    /// <summary>
+    /// preview-token-route-binding-orchestration-family: the fail-closed arm. A token minted by
+    /// <c>rename_preview</c> (<see cref="PreviewKind.SymbolRename"/>) redeemed through
+    /// <c>scaffold_type_apply</c> / <c>scaffold_test_apply</c> must be refused with a message naming
+    /// <c>rename_apply</c> as the correct route, and must leave the workspace untouched.
+    /// </summary>
+    [TestMethod]
+    [DataRow("scaffold_type_apply")]
+    [DataRow("scaffold_test_apply")]
+    public async Task Scaffold_Apply_Routes_Refuse_ForeignFamily_Rename_Token(string route)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogPath = workspace.GetPath("SampleLib", "Dog.cs");
+        var originalContents = await File.ReadAllTextAsync(dogPath, CancellationToken.None);
+
+        var document = WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId)
+            .Projects.SelectMany(project => project.Documents)
+            .First(candidate => candidate.Name == "Dog.cs");
+        var renamePreview = await RefactoringService.PreviewRenameAsync(
+            workspace.WorkspaceId,
+            SymbolLocator.BySource(document.FilePath!, 5, 6),
+            "Doggo",
+            CancellationToken.None);
+
+        Assert.AreEqual(PreviewKind.SymbolRename, PreviewStore.PeekKind(renamePreview.PreviewToken));
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => route switch
+        {
+            "scaffold_type_apply" => ScaffoldingTools.ApplyScaffoldType(
+                WorkspaceExecutionGate, RefactoringService, PreviewStore, renamePreview.PreviewToken, CancellationToken.None),
+            _ => ScaffoldingTools.ApplyScaffoldTest(
+                WorkspaceExecutionGate, RefactoringService, PreviewStore, renamePreview.PreviewToken, CancellationToken.None),
+        });
+
+        StringAssert.Contains(ex.Message, "rename_apply",
+            $"{route} must name the token's real apply route so the caller can recover.");
+        Assert.AreEqual(originalContents, await File.ReadAllTextAsync(dogPath, CancellationToken.None),
+            $"{route} must refuse the foreign token BEFORE any workspace mutation.");
     }
 
     [TestMethod]
@@ -965,6 +1038,43 @@ public class PlaywrightFlowTests
 
         StringAssert.Contains(dogContents, "Speak_Needs_Test");
         StringAssert.Contains(animalServiceContents, "GetAllAnimals_Needs_Test");
+    }
+
+    /// <summary>
+    /// preview-token-route-binding-orchestration-family: the permissive arm.
+    /// <c>scaffold_test_batch_preview</c> aggregates its own solution snapshot rather than
+    /// delegating to <c>PreviewCreateFileAsync</c>, so its token stays
+    /// <see cref="PreviewKind.Unspecified"/>. There is no <c>scaffold_test_batch_apply</c> route —
+    /// batch tokens are redeemed through <c>scaffold_test_apply</c>, which is now bound — so the
+    /// untagged-is-permissive contract is what keeps that flow working.
+    /// </summary>
+    [TestMethod]
+    public async Task Scaffold_Test_Batch_Token_Is_Untagged_And_Still_Redeems_Through_Scaffold_Test_Apply()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var dogPath = workspace.GetPath("SampleLib.Tests", "DogGeneratedTests.cs");
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestBatchAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestBatchDto(
+                "SampleLib.Tests",
+                [new ScaffoldTestBatchTargetDto("Dog", "Speak")],
+                "auto"),
+            CancellationToken.None);
+
+        Assert.AreEqual(PreviewKind.Unspecified, PreviewStore.PeekKind(preview.PreviewToken),
+            "The batch scaffolder mints its own aggregate token and records no provenance.");
+
+        var json = await ScaffoldingTools.ApplyScaffoldTest(
+            WorkspaceExecutionGate,
+            RefactoringService,
+            PreviewStore,
+            preview.PreviewToken,
+            CancellationToken.None);
+
+        StringAssert.Contains(json, "\"success\": true");
+        Assert.IsTrue(File.Exists(dogPath),
+            "An untagged token must stay redeemable through a bound apply route.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## What

Binds the two remaining scaffolding `*_apply` routes to the producer family that mints their tokens: `scaffold_type_apply` and `scaffold_test_apply`.

Before this change both called `ToolDispatch.ApplyByTokenAsync` without an `expectedKind`, so `RequireCompatibleProducer` returned early and a token minted by ANY preview family (rename, format, code-fix, extraction, …) redeemed through them.

## How

Consumer side only — one file, two call sites in `src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs`, each gaining `expectedKind: PreviewKind.FileCreate` plus the standard two-line provenance comment.

No producer edit was needed. `scaffold_type_preview` (`TypeScaffolder.cs:44`), `scaffold_test_preview` (`SingleTestScaffolder.cs:100`), and `scaffold_first_test_file_preview` (`BatchTestScaffolder.cs:341`) all mint through `IFileOperationService.PreviewCreateFileAsync`, which **already** records `PreviewKind.FileCreate` — merged sibling PR #1375 tagged it. No `applyRoute:` argument: that parameter no longer exists after the route-map centralization landed. No edits to `ToolDispatch.cs`, `PreviewKind.cs`, or `ServerSurfaceCatalog.cs` — the `FileCreate` member and both companion map entries are already present, so order 1's exhaustiveness pin needs nothing new.

### Deviation from the plan stanza — recorded, not silent

The stanza's Approach steps 1–3 (add the `FileCreate` enum member, tag `FileOperationService.cs:53`, add the kind→tool map row) and its test case (d) were all re-derived against live `main` and found **already shipped** by siblings `preview-token-route-binding-editing-substrate` (#1371) and `preview-token-route-binding-fileops-fixall` (#1375). Re-implementing step 2 on the frozen sweep base produced a genuine line-level conflict with `main`, so the branch was fast-forwarded to `main` and only the un-shipped step 4 was applied. Production files touched: **1** (stanza declared 4).

## Behavior change

A caller that today redeems, say, a `rename_preview` token through `scaffold_type_apply` starts receiving an `InvalidOperationException` envelope inside the write gate but before boundary revalidation and before any mutation. Intended.

Permissive paths are preserved. `scaffold_test_batch_preview` mints its own aggregate token via `BatchTestScaffolder.CreateBatchScaffoldPreviewAsync` (`Store` without a kind → `Unspecified`), and there is no `scaffold_test_batch_apply` route — batch tokens are redeemed through `scaffold_test_apply`. The untagged-is-permissive contract keeps that flow working; a regression test pins it.

## Honest limitation

`FileCreate` is **family**-granular by construction: `create_file_preview`, `scaffold_type_preview`, `scaffold_test_preview`, and `scaffold_first_test_file_preview` share one producer method, so a `create_file_preview` token still redeems through `scaffold_type_apply` and vice-versa. That is a strict improvement over today (a rename or code-fix token currently redeems through either), but it is not per-tool provenance. Per-tool granularity would require splitting that producer and is explicitly not attempted here.

Relatedly, the refusal message's "not `<route>`" clause is derived from `expectedKind` via the centralized map, so it names `create_file_apply` (the family's canonical apply route) rather than the literally-invoked `scaffold_type_apply`. The actionable half — the token's real producer and the route it *should* go through — is correct.

## Residue — still unbound

`apply_composite_preview` (`OrchestrationTools.cs:104`) and `apply_project_mutation` (`ProjectMutationTools.cs:242`) remain unbound and are out of scope. They call the **delegate-peek** `ApplyByTokenAsync` overload, which has no `expectedKind` parameter and never calls `RequireCompatibleProducer`; their stores (`ICompositePreviewStore`, `IProjectMutationPreviewStore`) do not derive from `IPreviewStore` and expose no `PeekKind`. Binding them requires widening that overload plus adding a kind peek to two store contracts and their implementations plus tagging two producers.

## Tests

`tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs`, 4 new cases driving the **real** shims with the real gate, real `PreviewStore`, and a real isolated workspace (not fakes):

- `Scaffold_Type_Preview_Token_Carries_FileCreate_Provenance_And_Redeems` — producer half plus same-family happy path through `ScaffoldingTools.ApplyScaffoldType`.
- `Scaffold_Apply_Routes_Refuse_ForeignFamily_Rename_Token` (`[DataRow]` × 2) — a real `rename_preview` token is refused by both routes, the message names `rename_apply`, and `Dog.cs` is byte-identical afterwards (no mutation).
- `Scaffold_Test_Batch_Token_Is_Untagged_And_Still_Redeems_Through_Scaffold_Test_Apply` — the permissive arm.

Local verification: `dotnet build -c Release` clean; 110 tests green across `ScaffoldingIntegrationTests`, `ToolDispatchTests` (incl. the exhaustiveness pin), `PreviewStoreTests`, `PreviewRouteBinding*Tests`, `ExtractionApplyRouteBindingTests`, `PreviewTokenCrossCouplingTests`, `FileOperationIntegrationTests`, `BuildTestToolsShimTests`. `eng/verify-changed-format.ps1`, `eng/verify-changelog-fragments.ps1`, and `eng/verify-ai-docs.ps1` all pass.

Closes: preview-token-apply-route-binding-remaining-families (PARTIAL — orchestration-family child; the row stays OPEN for the composite/project-mutation residue above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
