### PR TITLE
chore(changelog): reclassify bulk-family route-binding fragment as Fixed

### DIFF
--- a/changelog.d/preview-token-route-binding-bulk-family.md
+++ b/changelog.d/preview-token-route-binding-bulk-family.md
@@ -1,5 +1,5 @@
 ---
-category: Changed — BREAKING
+category: Fixed
 ---
 
-- **Changed — BREAKING:** `bulk_replace_type_apply` and `remove_dead_code_apply` now refuse a preview token minted by a different producer family, before any workspace mutation, instead of applying it. A caller that redeemed a foreign token through either route — which previously succeeded — now receives an error naming the token's real producer and the route that should have been used.
+- **Fixed:** `bulk_replace_type_apply` and `remove_dead_code_apply` now refuse a preview token minted by a different producer family, before any workspace mutation, instead of applying it. A caller that redeemed a foreign token through either route — which previously succeeded — now receives an error naming the token's real producer and the route that should have been used.


### PR DESCRIPTION
## Why

`changelog.d/preview-token-route-binding-bulk-family.md` was categorized `Changed — BREAKING`. Its four siblings from the same initiative are all `Fixed`:

| Fragment | Category |
|---|---|
| `preview-token-apply-route-binding` | Fixed |
| `preview-token-route-binding-extraction-family` | Fixed |
| `preview-token-route-binding-fileops-fixall` | Fixed |
| `preview-token-route-binding-multifile-codeaction` | Fixed |
| `preview-token-route-binding-bulk-family` | **Changed — BREAKING** ← outlier |

All five describe the same change in near-identical wording: bind an apply route to its producer family, refuse a foreign token before any workspace mutation, name the token's real producer. The shipping commit also disagrees with the fragment — dce5488d is `fix(host): bind bulk-replace and dead-code apply routes to their preview kinds`.

Substantively it is a fix: the removed behavior is redeeming a token minted by a *different* refactoring, i.e. applying edits the caller never previewed. That is the defect the initiative closes, not a contract anyone depended on deliberately.

## Impact

`eng/verify-release.ps1 -RequireConsumedFragments` enforces breaking→major. Left uncorrected, this single fragment forces 4.0.0 → **5.0.0** on a published package instead of 4.1.0. Caught during a `/release-cut` preflight, which was aborted rather than cutting the spurious major.

## Change

Category and bold body prefix both flipped to `Fixed` (the validator requires they match). No source changes.

`eng/verify-changelog-fragments.ps1` → passed (51 current; 1 changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)