### PR TITLE
chore(backlog): file breaking-fragment major-escalation guard row

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-08-27T14:20:19Z
+**updated_at:** 2026-08-28T14:17:12Z
 
 ## Agent contract
 
@@ -80,6 +80,7 @@
 | `preview-token-apply-route-binding-remaining-families` | Medium | — | **Bind the remaining apply families to preview-token kinds** — 5 of ~20 `ApplyByTokenAsync` routes declare an expectedKind; the rest keep pre-binding behavior. Centralize the kind→route map while binding. [type: refactor] [source: PR #1354 follow-on] | L | items/preview-token-apply-route-binding-remaining-families.md |
 | `fixall-producer-kind-round-trip-coverage` | Medium | — | **Assert `fix_all_preview` mints `PreviewKind.FixAll`** — the producer half of the fix_all_apply binding is unasserted; blocked on the fixture not copying `.editorconfig` and FixAllService passing no AnalyzerOptions. [type: test] [source: 2026-08-26 backlog-sweep spec review] | S | items/fixall-producer-kind-round-trip-coverage.md |
 | `tool-description-slice-test-harness-consolidation` | Medium | — | **Share the per-slice description-budget test harness** — each diet/dedupe slice copies a ~98-line reflection harness (33 differing lines of 98 measured); five cold reviews flagged it independently. Split per slice-family before planning. [type: refactor] [source: 2026-08-26 backlog-sweep code review] | L | items/tool-description-slice-test-harness-consolidation.md |
+| `breaking-fragment-major-escalation-unconfirmed` | Medium | — | **Breaking fragment silently escalates to major** — make `verify-breaking-version-bump.ps1` echo the fragment filename + body, and WARN on a lone breaking member of a non-breaking family, instead of permitting a major on a bare `Write-Host`. [type: bug] [source: 2026-08-28 release-cut] | S | items/breaking-fragment-major-escalation-unconfirmed.md |
 
 ## Low
 

--- a/ai_docs/items/breaking-fragment-major-escalation-unconfirmed.md
+++ b/ai_docs/items/breaking-fragment-major-escalation-unconfirmed.md
@@ -1,0 +1,40 @@
+# breaking-fragment-major-escalation-unconfirmed — Breaking fragment silently escalates to major
+
+**row:** `breaking-fragment-major-escalation-unconfirmed` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `eng/verify-breaking-version-bump.ps1:85-101` — asymmetric breaking-fragment handling
+- `tests/RoslynMcp.Tests/ChangelogFragmentRequirementTests.cs` — existing fragment-contract tests
+- `.claude/skills/release-cut/SKILL.md` — Step 1 preflight (optional surfacing site)
+
+## Acceptance
+
+- [ ] A pending `Changed — BREAKING` fragment on a `major` bump is surfaced as a distinct, operator-visible confirmation — not a lone `Write-Host` line buried in verify output.
+- [ ] The verifier reports the breaking fragment's **filename and body** at the escalation point, so the operator can judge the break without opening the file.
+- [ ] Consistency heuristic: when a breaking fragment shares a filename stem/family with sibling fragments that are uniformly non-breaking, the verifier emits a WARN naming those siblings.
+- [ ] Failing→passing test covers: single breaking fragment among non-breaking siblings ⇒ WARN emitted; breaking fragment with no siblings ⇒ no WARN.
+- [ ] Existing breaking→major refusal on patch/minor is unchanged (no regression to the blocking arm).
+
+## Evidence
+
+- 2026-08-28 `/release-cut` preflight: `changelog.d/preview-token-route-binding-bulk-family.md` carried `Changed — BREAKING` while its four siblings from the same route-binding initiative (`preview-token-apply-route-binding`, `-extraction-family`, `-fileops-fixall`, `-multifile-codeaction`) were all `Fixed`, and its shipping commit `dce5488d` was `fix(host):`. The mis-classification would have forced 4.0.0 → 5.0.0 on a published package. Caught only by a human reading a category tally; no gate flagged it. Corrected in PR #1390.
+
+## Context
+
+`eng/verify-breaking-version-bump.ps1` handles the breaking→major rule asymmetrically:
+
+| Bump | Breaking fragment present | Behavior |
+|---|---|---|
+| patch / minor | yes | `Write-Error` + `exit 1` — loud refusal |
+| major | yes | `Write-Host "Breaking fragments permit requested major bump"` — silent permit |
+
+The blocking arm is well covered. The permitting arm is the hole: a category that is merely *spelled* correctly is accepted as *warranted*. `verify-changelog-fragments.ps1:27` validates the category against a five-value allowlist and nothing else, so a single mis-typed `category:` line escalates a published package by a full major version with no confirmation step.
+
+Directive #4 puts this repo in contract-care mode (published as `roslyn-mcp@roslyn-mcp-marketplace`). A spurious major burns a version number and signals a break to consumers that never occurred — the inverse error (a real break shipped as minor) is already gated, this one is not.
+
+## Notes
+
+- Scope is the *permitting* arm only. Do not weaken the patch/minor refusal.
+- The sibling-family heuristic is advisory (WARN, not error) — a genuinely-breaking lone member of an otherwise-safe family is legitimate and must stay shippable.
+- Cheaper alternative if the heuristic proves noisy: drop it and keep only the explicit filename+body echo at the escalation point.


### PR DESCRIPTION
Files one Medium/S backlog row: `breaking-fragment-major-escalation-unconfirmed`.

## The gap

`eng/verify-breaking-version-bump.ps1` handles the breaking→major rule asymmetrically:

| Bump | Breaking fragment present | Behavior |
|---|---|---|
| patch / minor | yes | `Write-Error` + `exit 1` — loud refusal |
| major | yes | `Write-Host "Breaking fragments permit requested major bump"` — silent permit |

The blocking arm is well covered. The permitting arm is the hole: `verify-changelog-fragments.ps1:27` validates a category against a five-value allowlist and nothing else, so a category that is merely *spelled* correctly is accepted as *warranted*. One mis-typed `category:` line escalates a published package by a full major version with no confirmation step.

## How it surfaced

2026-08-28 `/release-cut` preflight. `changelog.d/preview-token-route-binding-bulk-family.md` carried `Changed — BREAKING` while its four siblings from the same route-binding initiative were all `Fixed`, and its shipping commit dce5488d was `fix(host):`. It would have forced 4.0.0 → **5.0.0**. Caught only by a human reading a category tally — no gate flagged it. Fragment corrected in #1390; this row tracks the missing guard.

Directive #4 puts this repo in contract-care mode. The inverse error — a real break shipped as minor — is already gated; this one is not.

## Proposed fix (in the row)

Echo the breaking fragment's filename + body at the escalation point, and WARN (advisory, not error) when a breaking fragment is the lone non-`Fixed` member of an otherwise uniform sibling family. Patch/minor refusal arm unchanged.

Backlog-only change — `ai_docs/**` is exempt from the fragment requirement.
`backlog-lint`: 0 ERROR, 0 WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)