### PR TITLE
chore(deps): ignore MSBuild 18.x until Locator MSBL001 is satisfied

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,3 +75,26 @@ updates:
           # MCP SDK updates require a dedicated ADR/wire/notices review and
           # therefore must never share the routine servicing PR.
           - "ModelContextProtocol"
+
+    # MSBuild 18.x is blocked, not merely unreviewed. Bumping the
+    # msbuild-compile-family to 18.x drags Microsoft.NET.StringTools 18.x in
+    # transitively, and Microsoft.Build.Locator 1.11.2 then fails the build with
+    # MSBL001 because StringTools carries no ExcludeAssets="runtime"
+    # PrivateAssets="all" of its own (the four Microsoft.Build.* refs in
+    # RoslynMcp.Roslyn.csproj already have it; StringTools is unpinned).
+    # PR #1330 was closed on this basis.
+    #
+    # Lift this ignore only when BOTH hold:
+    #   1. Microsoft.NET.StringTools is centrally pinned in
+    #      Directory.Packages.props and referenced with ExcludeAssets="runtime"
+    #      PrivateAssets="all", matching the existing Microsoft.Build.* refs; and
+    #   2. a green sdk-floor leg proves MSBL001 is satisfied at the 10.0.400 floor.
+    ignore:
+      - dependency-name: "Microsoft.Build"
+        versions: [">=18.0.0"]
+      - dependency-name: "Microsoft.Build.Framework"
+        versions: [">=18.0.0"]
+      - dependency-name: "Microsoft.Build.Tasks.Core"
+        versions: [">=18.0.0"]
+      - dependency-name: "Microsoft.Build.Utilities.Core"
+        versions: [">=18.0.0"]

--- a/changelog.d/dependabot-ignore-msbuild-18-locator-msbl001.md
+++ b/changelog.d/dependabot-ignore-msbuild-18-locator-msbl001.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Dependabot no longer proposes MSBuild 18.x. Bumping the `msbuild-compile-family` group to 18.x pulls `Microsoft.NET.StringTools` 18.x transitively, which fails the build with `MSBL001` under `Microsoft.Build.Locator` 1.11.2 because that package carries no `ExcludeAssets="runtime" PrivateAssets="all"` of its own. `.github/dependabot.yml` now ignores `>=18.0.0` for the four `Microsoft.Build.*` pins, with the two conditions required to lift it recorded inline. Closes PR #1330.


### PR DESCRIPTION
Closes out Dependabot PR #1330 with a standing, in-repo ignore.

## Why #1330 is not mergeable

Every leg failed — not a flake, not a rebase issue:

```
error MSBL001: A PackageReference to the package 'Microsoft.NET.StringTools'
at version '18.9.6' is present in this project without ExcludeAssets="runtime"
and PrivateAssets="all" set. This can cause errors at run-time due to MSBuild
assembly-loading. [src/RoslynMcp.Roslyn/RoslynMcp.Roslyn.csproj]
```

The four `Microsoft.Build.*` references in `RoslynMcp.Roslyn.csproj` already carry `ExcludeAssets="runtime" PrivateAssets="all"`. `Microsoft.NET.StringTools` is pulled in transitively and is **not pinned anywhere in the repo** — at MSBuild 17.14.28 it resolves to a version `Microsoft.Build.Locator` 1.11.2 tolerates; at 18.x it trips the guard.

Secondary defect: the bump landed **split** — `Microsoft.Build.Framework`, `Tasks.Core`, and `Utilities.Core` moved to 18.9.6 while `Microsoft.Build` itself stayed at 17.14.28 — despite the `msbuild-compile-family` group existing to prevent exactly that shape (the comment there cites PR #1327 as prior art).

## What this does

Adds an `ignore` block to the nuget entry in `.github/dependabot.yml` pinning the four `Microsoft.Build.*` packages below 18.0.0. This is a **blocked** upgrade rather than an unreviewed one, so it gets a version-range ignore with the lift conditions recorded inline rather than a close-and-forget:

> Lift this ignore only when BOTH hold:
> 1. `Microsoft.NET.StringTools` is centrally pinned in `Directory.Packages.props` and referenced with `ExcludeAssets="runtime" PrivateAssets="all"`, matching the existing `Microsoft.Build.*` refs; and
> 2. a green `sdk-floor` leg proves MSBL001 is satisfied at the 10.0.400 floor.

Chose a version-range ignore over `@dependabot ignore this major version` so the rule and its rationale live in the repo where the next reader finds them, instead of in Dependabot's private state.

YAML validated: 5 groups intact, 4 ignore entries at the update-entry level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)