### PR TITLE
docs(update-skill): correct the stale plugin-cache file count

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -27,7 +27,7 @@ pwsh -NoProfile -File eng/update-claude-plugin.ps1
 The script replicates `/plugin marketplace update` + `/plugin install` without going through the client:
 
 - `git pull`s the marketplace clone at `~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/`
-- Re-syncs the plugin cache at `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<new-version>/` from the git-tracked files matching `.claude-plugin/package-allowlist.txt` (consumer-facing only: `skills/**`, `hooks/hooks.json`, the `.claude-plugin/*.json` manifests, `manifest.json`, LICENSE, README, notices, and three `docs/*.md` — 52 files at 4.1.0). A count in the dozens is correct, not a truncated copy; the server itself is fetched by the release-pinned `dnx` launch rather than carried in the cache.
+- Re-syncs the plugin cache at `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<new-version>/` from the git-tracked files matching `.claude-plugin/package-allowlist.txt` — read that file for the authoritative set. It admits consumer-facing files only (skills, `hooks/hooks.json`, the `.claude-plugin/*.json` manifests, `manifest.json`, LICENSE, README, notices, and a few `docs/*.md`), so the copied-file count is tens rather than hundreds. That is not a truncated copy: the server binary is fetched by the release-pinned `dnx` launch instead of being carried in the cache.
 - Prunes stale `<old-version>/` cache directories
 - Updates `installed_plugins.json` + `known_marketplaces.json` with the new version, commit SHA, and UTC timestamp
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -27,7 +27,7 @@ pwsh -NoProfile -File eng/update-claude-plugin.ps1
 The script replicates `/plugin marketplace update` + `/plugin install` without going through the client:
 
 - `git pull`s the marketplace clone at `~/.claude/plugins/marketplaces/roslyn-mcp-marketplace/`
-- Re-syncs the plugin cache at `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<new-version>/` from git-tracked files only (710+ files at 1.29.0)
+- Re-syncs the plugin cache at `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/<new-version>/` from the git-tracked files matching `.claude-plugin/package-allowlist.txt` (consumer-facing only: `skills/**`, `hooks/hooks.json`, the `.claude-plugin/*.json` manifests, `manifest.json`, LICENSE, README, notices, and three `docs/*.md` — 52 files at 4.1.0). A count in the dozens is correct, not a truncated copy; the server itself is fetched by the release-pinned `dnx` launch rather than carried in the cache.
 - Prunes stale `<old-version>/` cache directories
 - Updates `installed_plugins.json` + `known_marketplaces.json` with the new version, commit SHA, and UTC timestamp
 

--- a/changelog.d/update-skill-stale-cache-file-count.md
+++ b/changelog.d/update-skill-stale-cache-file-count.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Fixed:** the maintainer-local `/update` skill described the plugin cache as "710+ files at 1.29.0", a count from before `.claude-plugin/package-allowlist.txt` existed. The refresh now copies only allowlisted consumer-facing files (52 at 4.1.0), so the documented figure read as a truncated cache during a release. It now names the allowlist as the source of truth and states that a count in the dozens is expected.
+- **Fixed:** the maintainer-local `/update` skill pinned a plugin-cache file count to a release ("710+ files at 1.29.0") that predated `.claude-plugin/package-allowlist.txt`, so the documented figure read as a truncated cache during a later release cut. It now points at the allowlist as the authoritative set and describes the magnitude qualitatively, rather than restating a count that goes stale whenever a skill is added or removed.

--- a/changelog.d/update-skill-stale-cache-file-count.md
+++ b/changelog.d/update-skill-stale-cache-file-count.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** the maintainer-local `/update` skill described the plugin cache as "710+ files at 1.29.0", a count from before `.claude-plugin/package-allowlist.txt` existed. The refresh now copies only allowlisted consumer-facing files (52 at 4.1.0), so the documented figure read as a truncated cache during a release. It now names the allowlist as the source of truth and states that a count in the dozens is expected.


### PR DESCRIPTION
One-line doc fix found during the v4.1.0 release cut.

## The drift

`.claude/skills/update/SKILL.md` described the cache re-sync as copying *"710+ files at 1.29.0"*. The v4.1.0 cut copied **52**.

That is not a truncation. The figure predates `.claude-plugin/package-allowlist.txt` (added in 40b79f31), which deliberately restricted the cache to 14 consumer-facing patterns — `skills/**`, `hooks/hooks.json`, the four `.claude-plugin/*.json` manifests, `manifest.json`, LICENSE, README, notices, and three `docs/*.md`. At 1.29.0 no allowlist existed, so the script copied every git-tracked file.

Cross-check: the cache holds **38 skills**, matching `verify-ai-docs.ps1`'s "38 .md files checked". The count is correct.

## Why it's worth fixing

- It sits in **Step 6 of the release-cut path**, read when a maintainer is mid-release and least wants a false alarm. It did exactly that this cut — 52-against-710 prompted a truncation check before the release could be called done.
- `.claude/**` is **out of doc-audit scope**, so no automated pass would ever catch this drift.

Now names the allowlist as the source of truth, states a count in the dozens is expected, and notes the server arrives via the release-pinned `dnx` launch rather than the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)