### PR TITLE
docs(backlog): track CRLF-intolerant release-header regex

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-02T14:05:15Z
+**updated_at:** 2026-09-02T14:56:00Z
 
 ## Agent contract
 
@@ -64,6 +64,7 @@
 | `ci-hosted-shard-duration-balancing` | Medium | — | Balance hosted Windows and Linux shards only after repeated per-image TRX evidence proves material skew. [type: performance] [source: 2026-08-24 CI timing audit] | M | items/ci-hosted-shard-duration-balancing.md |
 | `tool-description-slice-test-harness-consolidation` | Medium | — | **Share the per-slice description-budget test harness** — each diet/dedupe slice copies a ~98-line reflection harness (33 differing lines of 98 measured); five cold reviews flagged it independently. Split per slice-family before planning. [type: refactor] [source: 2026-08-26 backlog-sweep code review] | L | items/tool-description-slice-test-harness-consolidation.md |
 | `formatter-baseline-generator-concurrent-load-timeout` | Medium | — | Diagnose formatter baseline generator contention without masking five-minute timeouts. [type: test infrastructure] [source: 2026-09-01 just-ci] | M | items/formatter-baseline-generator-concurrent-load-timeout.md |
+| `release-header-regex-crlf-intolerant` | Medium | — | **CRLF-safe release-header matching** — `verify-breaking-version-bump.ps1` release-header regex ends `[ \t]*$`, which matches 0 of 80 headers on a CRLF checkout and aborts the release gate with a misleading "no released section" message. [type: bug] [source: 2026-09-02 v4.1.2 release cut] | S | items/release-header-regex-crlf-intolerant.md |
 
 ## Low
 

--- a/ai_docs/items/release-header-regex-crlf-intolerant.md
+++ b/ai_docs/items/release-header-regex-crlf-intolerant.md
@@ -1,0 +1,24 @@
+# release-header-regex-crlf-intolerant — CRLF-safe release-header matching
+
+**row:** `release-header-regex-crlf-intolerant` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `eng/verify-breaking-version-bump.ps1:151`
+
+## Acceptance
+
+- [ ] The release-header pattern matches `## [X.Y.Z] - YYYY-MM-DD` in a CRLF working-tree copy as well as an LF one (`[ \t]*\r?$`, or match against normalized text).
+- [ ] A regression test asserts the gate passes on a CRLF-line-ending CHANGELOG fixture and still rejects a genuinely missing release section.
+- [ ] The zero-match failure message distinguishes "no release section" from "release section present but unparseable", so the operator is not sent looking for a missing heading that is plainly there.
+- [ ] Sweep sibling release gates for the same `[ \t]*$` shape and fix any that share it.
+
+## Evidence
+
+- Hit during the 2026-09-02 v4.1.2 release cut. `verify-release.ps1` aborted at `verify-breaking-version-bump.ps1:154` with `CHANGELOG.md has no released ## [X.Y.Z] section.` while `## [4.1.2]` and eleven prior headers were present.
+- Measured on the same file: LF copy -> 79 strict matches; CRLF copy -> 0. Confirmed identically in .NET (`[regex]::Matches`) and Python, so it is the pattern, not the host.
+- `git diff` hides the trigger: git normalizes CRLF for diff and on commit, so the working tree can be CRLF while the diff looks clean and the commit would be correct. Only the worktree-reading gate fails.
+
+## Context
+
+`$releaseHeaderPattern` ends `[ \t]*$`. In both engines `$` under `(?m)` anchors before `\n`, not before the `\r` of a `\r\n`, so every header fails on a CRLF checkout. This repo stores LF and checks out LF, so the gate passes today; any clone with `core.autocrlf=true` would hit a fail-closed release gate with a misleading message. Fail-closed is right; the message and the CRLF blindness are not. One-character fix plus a fixture.


### PR DESCRIPTION
Backlog row only — no product change.

Filed while cutting v4.1.2, where this cost a full release-verify cycle to diagnose.

`eng/verify-breaking-version-bump.ps1:151` ends its release-header pattern with `[ \t]*$`. Under `(?m)`, `$` anchors before `\n` and not before the `\r` of a `\r\n`, so every header fails on a CRLF working copy. Measured on the same CHANGELOG:

| Copy | Line endings | Strict matches |
|---|---|---|
| HEAD blob | LF | 79 |
| working tree | CRLF | 0 |

Reproduced identically in .NET (`[regex]::Matches`) and Python, so it is the pattern rather than the host.

This repo stores and checks out LF, so the gate passes today. Any clone with `core.autocrlf=true` would hit a fail-closed release gate reporting `CHANGELOG.md has no released ## [X.Y.Z] section.` while the section is plainly there. Fail-closed is correct; the CRLF blindness and the misleading message are not.

Row: `release-header-regex-crlf-intolerant` (Medium, S). Acceptance criteria and evidence in `ai_docs/items/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjRjLJKaaBzTFBwU53YpXt