### PR TITLE
feat(release): refresh both install layers on every release-cut

### DIFF
--- a/.claude/skills/release-cut/SKILL.md
+++ b/.claude/skills/release-cut/SKILL.md
@@ -10,7 +10,14 @@ argument-hint: "patch | minor | major"
 
 You are a release engineer running the full release pipeline as a single atomic flow. Sequence the release phases (bump -> verify -> ship -> tag -> refresh-plugin) with shared error handling and checkpointed step output, so a mid-flow failure re-runs from the last successful checkpoint rather than restarting from the top.
 
-The plugin carries an exact-version `dnx` package pin together with its skills and hooks. Step 6 refreshes that single plugin contract through the maintainer-local `/update` skill; a global-tool install is an optional standalone-client canary, not a plugin dependency.
+The server ships on two install surfaces and Step 6 refreshes **both**:
+
+| Layer | Surface | Refreshed by |
+|---|---|---|
+| **Layer 1** | standalone global .NET tool `darylmcd.roslynmcp` (command `roslynmcp`) | `just tool-update` |
+| **Layer 2** | Claude Code plugin — marketplace cache, skills, hooks, exact-version `dnx` pin | maintainer-local `/update` skill |
+
+Neither layer is optional. They drift apart silently and in both directions: v1.29.0 and v1.34.2 updated Layer 1 and left Layer 2 stale in the plugin cache; v4.1.2 refreshed Layer 2 and left Layer 1 a release behind because the global-tool update was documented as optional. `eng/verify-install-layers.ps1` is the check that closes Step 6 — a release is not refreshed until it exits 0.
 
 ## Input
 
@@ -40,7 +47,7 @@ Each step records its result (stdout + exit code + any derived values like the n
 - **Step 3 Verify** — if `artifacts/verify-release.log` exists and its mtime is newer than the newest commit, skip. Otherwise re-run.
 - **Step 4 Ship** — `gh pr list --state merged --head release/vX.Y.Z --limit 1`; if a merged PR exists for the bump branch, skip.
 - **Step 5 Tag** — `git tag -l vX.Y.Z`; if the tag exists locally AND on origin (`git ls-remote --tags origin refs/tags/vX.Y.Z`), skip.
-- **Step 6 Reinstall** — call `server_info`; if `version` matches the new version AND `~/.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp/` contains only the new-version directory, skip.
+- **Step 6 Reinstall** — run `pwsh -NoProfile -File eng/verify-install-layers.ps1`; exit 0 means both layers already track the new version, so skip. A non-zero exit names the stale layer — re-run only that layer's refresh (6a for Layer 2, 6b for Layer 1), then re-verify.
 
 The probes are best-effort; when uncertain, re-run the step. Re-running `/bump` on an already-bumped repo is a no-op when all 7 files agree (verify-version-drift.ps1 short-circuits).
 
@@ -195,9 +202,38 @@ If the tag already exists on origin (prior release-cut attempt got this far), sk
 
 `release-cut` runs from inside the checkout, where `.claude/skills/update/SKILL.md` refreshes the plugin cache agent-executably via `eng/update-claude-plugin.ps1`. The plugin-namespaced shipped form can only instruct the user to run client-side `/plugin` commands. **Do not invoke the namespaced form here.**
 
-Invoke the bare-name form: `Skill: update` (or `/update` interactively). It refreshes the marketplace clone and plugin cache, including the exact `Darylmcd.RoslynMcp@X.Y.Z` launch pin. Inspect the cache and confirm only the new-version directory remains. After NuGet publication/indexing completes, run the pinned `dnx` command from `.claude-plugin/mcp.json` as the server canary. A separate global-tool update is optional for maintainers who use Option A.
+**Both layers are refreshed here. Neither is optional** — see the two-layer table at the top of this skill for why.
 
-If either the cache check or pinned-package canary fails, STOP and report it; NuGet indexing may require a retry after a short delay.
+**6a — Layer 2 (plugin).** Invoke the bare-name form: `Skill: update` (or `/update` interactively). It refreshes the marketplace clone and plugin cache, including the exact `Darylmcd.RoslynMcp@X.Y.Z` launch pin. Inspect the cache and confirm only the new-version directory remains.
+
+**6b — Layer 1 (global tool).** After NuGet publication and indexing complete:
+
+```
+just tool-update
+```
+
+That resolves `Darylmcd.RoslynMcp` from NuGet.org, so it can only run once the `v X.Y.Z` tag's publish workflow has finished and the package is resolvable. A `dotnet tool update` that reports the old version means indexing has not caught up — wait and retry rather than moving on.
+
+Two failure modes to expect here, both covered in `/update` Step 3: NuGet indexing lag, and a Windows file lock when a Layer 1 process is running (`Access to the path '...\.store\darylmcd.roslynmcp\<old>' is denied`). For the lock, identify the holder by image path under `~/.dotnet/tools/` — never by the `roslynmcp.exe` image name alone, since the plugin's `dnx`-launched Layer 2 server shares that name.
+
+**Expect the lock holder to be your own MCP server.** When Claude Code launched this session's server from the Layer 1 shim (`~/.dotnet/tools/roslynmcp.exe`) rather than the `dnx` pin, the process holding the store *is* the server you are talking to — confirmed by matching its PID against `server_info`'s `stdioPid`. Verified on the v4.1.2 cut. So the order is **stop-or-restart, then update**, not update-then-restart:
+
+- Interactive: restart Claude Code first (Step 7 asks for that anyway); the lock releases on exit and `just tool-update` then succeeds with nothing running.
+- Mid-flow: confirm no other session is using the server, stop that PID, and accept losing Roslyn MCP tools for the remainder of the run. Nothing after Step 6b needs them — the rest is `git`, `gh`, and `dotnet`.
+
+Check `server_info`'s `stdioPid` before stopping anything, and never stop a PID you have not matched to the tool-store image path.
+
+**6c — Prove both layers.** This is the step that closes Step 6:
+
+```
+pwsh -NoProfile -File eng/verify-install-layers.ps1
+```
+
+It reads Layer 1 from `dotnet tool list --global` and Layer 2 from the plugin cache (plus the cached `plugin.json`), and fails naming whichever layer is stale. Do not report the release as refreshed until it exits 0.
+
+**6d — Server canary.** Run the pinned `dnx` command from `.claude-plugin/mcp.json` and confirm the startup surface reports the new version.
+
+If the cache check, the layer verifier, or the pinned-package canary fails, STOP and report it; NuGet indexing may require a retry after a short delay.
 
 ### Step 7: Report
 
@@ -211,7 +247,7 @@ Step 2 Bump        ok (7 files -> X.Y.Z)
 Step 3 Verify      ok (N tests, artifacts/verify-release.log)
 Step 4 Ship        ok (PR #<n>, merged at <time>)
 Step 5 Tag         ok (vX.Y.Z on origin)
-Step 6 Refresh     ok (plugin cache and pinned dnx server report X.Y.Z)
+Step 6 Refresh     ok (Layer 1 global tool + Layer 2 plugin cache both X.Y.Z; verify-install-layers exit 0; pinned dnx server reports X.Y.Z)
 
 Reminder: restart Claude Code to load the updated server pin, skills, and hooks.
 Next: monitor the publish-nuget workflow triggered by the vX.Y.Z tag (if configured).
@@ -236,7 +272,7 @@ Step 2 Bump      ... ok (Directory.Build.props, plugin.json, marketplace.json, m
 Step 3 Verify    ... ok (N tests pass, artifacts/verify-release.log written)
 Step 4 Ship      ... ok (PR #<n> opened, checks green, squash-merged)
 Step 5 Tag       ... ok (v1.27.1 pushed to origin)
-Step 6 Refresh   ... ok (pinned dnx server version 1.27.1; plugin cache shows only 1.27.1)
+Step 6 Refresh   ... ok (Layer 2 cache shows only 1.27.1; Layer 1 global tool 1.27.1; verify-install-layers exit 0; pinned dnx server 1.27.1)
 
 Release v1.27.1 cut complete.
 Reminder: restart Claude Code to load the refreshed pinned server, skills, and hooks.
@@ -254,5 +290,5 @@ Reminder: restart Claude Code to load the refreshed pinned server, skills, and h
 - **`/bump`**: version-file edits only. Does not verify, ship, tag, or reinstall. Invoked as Step 2 of this skill.
 - **`/publish-preflight`**: checklist of validations (version drift, AI docs, build/test, CHANGELOG, security versions). Overlaps Step 3 but does NOT advance past verify. Run `/publish-preflight` ad-hoc to gate readiness; `/release-cut` assumes it has already passed (or runs the superset via `verify-release.ps1`).
 - **`/ship`**: commit + push + PR + squash-merge. No version bump, no tag, no reinstall. Invoked as Step 4 of this skill.
-- **`/update` (maintainer-local override at `.claude/skills/update/`)**: agent-executable plugin cache refresh via `pwsh eng/update-claude-plugin.ps1`, plus an optional standalone global-tool update. **This is what Step 6 invokes.**
+- **`/update` (maintainer-local override at `.claude/skills/update/`)**: agent-executable Layer 2 plugin-cache refresh via `pwsh eng/update-claude-plugin.ps1`, plus the required Layer 1 global-tool update. **This is what Step 6 invokes.**
 - **`/roslyn-mcp:update` (shipped, plugin-namespaced)**: documents the consumer-side `/plugin marketplace update` + `/plugin install` flow and optional global-tool path.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update
 installed_as: update
-description: "Maintainer-local override of the shipped /roslyn-mcp:update skill. Refreshes the complete plugin cache, including its release-pinned dnx server launch, from this checkout."
+description: "Maintainer-local override of the shipped /roslyn-mcp:update skill. Refreshes both install layers from this checkout — the Layer 2 plugin cache with its release-pinned dnx server launch, and the Layer 1 global tool — then verifies both track the same version."
 user-invocable: true
 argument-hint: ""
 ---
@@ -42,14 +42,49 @@ Requires the plugin to have been installed through Claude Code at least once (so
 
 If the client responds with `/plugin isn't available in this environment`, use the PowerShell path above.
 
-### Step 3: Optional standalone global tool
+### Step 3: Update the Layer 1 global tool (required)
 
-Only when the maintainer also uses the separate global-tool install, run `just tool-update` (NuGet.org) or `just tool-install-local` after `just pack`. The plugin launches its own release-pinned package through `dnx` and does not depend on this shim.
+```bash
+just tool-update
+```
 
-### Step 4: Report
+Resolves `Darylmcd.RoslynMcp` from NuGet.org (`dotnet tool update -g`, falling back to `install`). Use `just tool-install-local` after `just pack` instead when refreshing from an unpublished local build.
 
-Same as the shipped skill — previous version, new version, optional global-tool result when requested, **reminder to restart Claude Code**.
+**This step is not optional.** At runtime the plugin launches its own release-pinned package through `dnx` and does not depend on this shim, which is why the step was once documented as optional — but "does not depend on" is not "does not drift." A stale Layer 1 means `roslynmcp` on the PATH, any standalone-client config pointing at it, and `dotnet tool list -g` all report an older server than the plugin runs. Both layers track the release.
+
+If `dotnet tool update` reports the previous version right after a release, NuGet indexing has not caught up — wait and retry rather than accepting the old version.
+
+**Windows file lock.** A running Layer 1 process holds its store directory, and the update fails:
+
+```
+Failed to uninstall tool package 'darylmcd.roslynmcp':
+Access to the path 'C:\Users\<user>\.dotnet\tools\.store\darylmcd.roslynmcp\<old>' is denied.
+```
+
+This is the common case, not an edge case — anyone who actually uses Layer 1 has one running, and it is very often **this session's own MCP server**: when Claude Code launched the server from the Layer 1 shim rather than the `dnx` pin, the holder's PID equals `server_info`'s `stdioPid` (verified on the v4.1.2 cut). Restarting Claude Code first therefore clears the lock on its own, which is why the practical order is stop-or-restart *then* update.
+
+Identify the holder by image path before retrying — the `ExecutablePath` is what distinguishes the layers, not the process name:
+
+```bash
+pwsh -NoProfile -Command "Get-CimInstance Win32_Process -Filter \"Name='roslynmcp.exe'\" | Select-Object ProcessId, ExecutablePath, CreationDate"
+```
+
+Stop only a process you have confirmed is an owned Layer 1 instance — one whose image path is under `~/.dotnet/tools/` — then re-run `just tool-update`. Never stop a `roslynmcp` process by image name alone: the plugin's `dnx`-launched Layer 2 server is also called `roslynmcp.exe`, runs from the NuGet package cache rather than the tool store, does not hold the lock, and killing it drops the MCP connection of whoever is attached. `just tool-update` has no owned-process shutdown of its own; only the local-pack path (`eng/reinstall-local-tool.ps1`, via `ROSLYNMCP_REINSTALL_PROCESS_ID` + `ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC`) does. Backlog row `tool-update-owned-process-shutdown` tracks closing that gap.
+
+### Step 4: Verify both layers
+
+```bash
+pwsh -NoProfile -File eng/verify-install-layers.ps1
+```
+
+Reads Layer 1 from `dotnet tool list --global` and Layer 2 from the plugin cache (plus the cached `plugin.json`), and fails naming whichever layer is stale. Do not report the update complete until it exits 0.
+
+### Step 5: Report
+
+Same as the shipped skill — previous version, new version, **both layer versions with the verifier's result**, and a **reminder to restart Claude Code**.
 
 ## Why this override exists
 
-During the v1.29.0 release-cut (PR #377), the Claude Code client refused `/plugin` slash-commands and the plugin cache remained stale. The repo already shipped `eng/update-claude-plugin.ps1` (maintainer-only, agent-executable, idempotent); this override makes that cache refresh the primary in-repo path. The separate global-tool install is optional and no longer part of the plugin contract.
+During the v1.29.0 release-cut (PR #377), the Claude Code client refused `/plugin` slash-commands and the plugin cache remained stale. The repo already shipped `eng/update-claude-plugin.ps1` (maintainer-only, agent-executable, idempotent); this override makes that cache refresh the primary in-repo path.
+
+The global-tool install is **not** part of the plugin's runtime contract — the plugin launches its own release-pinned package through `dnx`. It is still a required maintainer step (Step 3), because independence is not currency: after v4.1.2 the plugin cache was correct while `dotnet tool list -g` still reported 4.1.1. Runtime independence is exactly what let it rot unnoticed.

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-02T16:04:08Z
+**updated_at:** 2026-09-02T16:13:40Z
 
 ## Agent contract
 
@@ -64,6 +64,7 @@
 | `ci-hosted-shard-duration-balancing` | Medium | — | Balance hosted Windows and Linux shards only after repeated per-image TRX evidence proves material skew. [type: performance] [source: 2026-08-24 CI timing audit] | M | items/ci-hosted-shard-duration-balancing.md |
 | `tool-description-slice-test-harness-consolidation` | Medium | — | **Share the per-slice description-budget test harness** — each diet/dedupe slice copies a ~98-line reflection harness (33 differing lines of 98 measured); five cold reviews flagged it independently. Split per slice-family before planning. [type: refactor] [source: 2026-08-26 backlog-sweep code review] | L | items/tool-description-slice-test-harness-consolidation.md |
 | `formatter-baseline-generator-concurrent-load-timeout` | Medium | — | Diagnose formatter baseline generator contention without masking five-minute timeouts. [type: test infrastructure] [source: 2026-09-01 just-ci] | M | items/formatter-baseline-generator-concurrent-load-timeout.md |
+| `tool-update-owned-process-shutdown` | Medium | — | **Owned-process shutdown for `just tool-update`** — the now-mandatory Layer 1 refresh fails with a locked tool-store directory whenever a `roslynmcp` process is running; reuse the local-pack ownership guard instead of matching on image name. [type: bug] [source: 2026-09-02 two-layer release-cut contract] | M | items/tool-update-owned-process-shutdown.md |
 
 ## Low
 

--- a/ai_docs/items/tool-update-owned-process-shutdown.md
+++ b/ai_docs/items/tool-update-owned-process-shutdown.md
@@ -1,0 +1,26 @@
+# tool-update-owned-process-shutdown — owned-process shutdown for the NuGet global-tool update
+
+**row:** `tool-update-owned-process-shutdown` · **pri:** `Medium` · **size:** `M`
+
+## Anchors
+
+- `justfile:106`
+- `eng/reinstall-local-tool.ps1:131`
+
+## Acceptance
+
+- [ ] `just tool-update` completes while an owned Layer 1 `roslynmcp` process is running, using the same PID + start-time ownership guard as the local-pack path rather than a new killer.
+- [ ] The Layer 2 `dnx`-launched server is never a termination candidate; selection is by image path under the tool store, not by the `roslynmcp.exe` image name.
+- [ ] A lock that cannot be attributed to an owned process fails closed with the holding PID named, rather than terminating anything.
+- [ ] Regression test covers: owned process running -> update succeeds; unowned holder -> fail-closed with the PID reported.
+
+## Evidence
+
+- 2026-09-02, immediately after making the Layer 1 refresh mandatory: `just tool-update` failed with `Failed to uninstall tool package 'darylmcd.roslynmcp': Access to the path 'C:\Users\daryl\.dotnet\tools\.store\darylmcd.roslynmcp\4.1.1' is denied.` The holder was PID 11088, `C:\Users\daryl\.dotnet\tools\roslynmcp.exe`.
+- `eng/reinstall-local-tool.ps1` already solves this for the local-pack route (`ROSLYNMCP_REINSTALL_PROCESS_ID` + `ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC`, shipped in 4.1.2 as `local-tool-reinstall-process-ownership`), but its `-PackageSource` is validated as a local directory (`Resolve-Path` + `Test-Path -PathType Container`), so the NuGet route cannot reuse it as written.
+
+## Context
+
+`/release-cut` Step 6b now requires the Layer 1 refresh, so a step that fails whenever the tool is in use is a real gap, not a nuisance — anyone who actually uses Layer 1 has a process holding the store. The interim contract is documented in `.claude/skills/update/SKILL.md` Step 3: identify the holder by image path, stop only an owned instance, retry.
+
+Do not extend the killer to match on image name. The plugin's `dnx`-launched Layer 2 server is also `roslynmcp.exe`, runs from the NuGet package cache, does not hold the tool-store lock, and terminating it drops a live MCP connection.

--- a/changelog.d/release-cut-both-install-layers.md
+++ b/changelog.d/release-cut-both-install-layers.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Changed:** `/release-cut` Step 6 now refreshes **both** install layers instead of treating the Layer 1 global tool as optional, and proves it with the new `eng/verify-install-layers.ps1` (Layer 1 read from `dotnet tool list --global`, Layer 2 from the plugin cache and its cached `plugin.json`). The layers drift in both directions — v1.29.0 and v1.34.2 left Layer 2 stale, v4.1.2 left Layer 1 a release behind — so the verifier is the step's completion check and the Step 6 checkpoint probe. The maintainer `/update` skill's global-tool step is likewise required rather than optional, and documents the Windows tool-store lock: identify the holder by image path under `~/.dotnet/tools/`, never by the `roslynmcp.exe` image name, since the plugin's `dnx`-launched Layer 2 server shares it.

--- a/changelog.d/workspace-dedup-document-pick-nondeterministic.md
+++ b/changelog.d/workspace-dedup-document-pick-nondeterministic.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** `WorkspaceLoadDedupTests.FindWorkspaceIdsContainingFile_UsesLoadedDocumentMembership` picked its probe document with `EnumerateFiles(root, "*.cs", AllDirectories).First()`, which has no defined result over an unordered enumeration. The fixture copy excludes only `bin` — it cannot exclude `obj`, since MSBuildWorkspace needs `obj/project.assets.json` to load — so the tree carries generated sources under both `obj/Debug` and `obj/Release`, and only the active configuration's are compilation documents. Landing on the other returned zero owners and failed as "Different number of elements", reliably on the Linux CI shard and never on Windows. The probe now excludes build-output directories and orders the candidates, so it selects a real project source file identically on every filesystem.

--- a/eng/verify-install-layers.ps1
+++ b/eng/verify-install-layers.ps1
@@ -1,0 +1,129 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Validates that both install layers are current for a given release version.
+
+.DESCRIPTION
+  The server ships on two independent surfaces, and they drift apart silently
+  because nothing compared them:
+
+    Layer 1 — the standalone global .NET tool (`darylmcd.roslynmcp`, command `roslynmcp`).
+    Layer 2 — the Claude Code plugin (marketplace cache + release-pinned `dnx` launch).
+
+  History runs both directions. v1.29.0 and v1.34.2 updated Layer 1 and left Layer 2
+  stale in the plugin cache; v4.1.2 refreshed Layer 2 and left Layer 1 a release behind
+  because the global-tool update was documented as optional. `/release-cut` Step 6 now
+  updates both and calls this script to prove it.
+
+  Layer 1 is read from `dotnet tool list --global` unless -Layer1Version is supplied.
+  Layer 2 is read from the plugin cache directory, plus the cached plugin manifest when
+  it is present.
+
+  Exit codes:
+    0  Both layers report ExpectedVersion.
+    1  A layer is stale, missing, or could not be determined.
+#>
+[CmdletBinding()]
+param(
+    [string] $ExpectedVersion,
+    [string] $RepositoryRoot,
+    [string] $PluginCacheRoot,
+    [string] $Layer1Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepositoryRoot) {
+    $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+}
+
+if (-not $ExpectedVersion) {
+    $propsPath = Join-Path $RepositoryRoot 'Directory.Build.props'
+    if (-not (Test-Path -LiteralPath $propsPath)) {
+        Write-Host "INSTALL LAYER GATE: Directory.Build.props not found beneath '$RepositoryRoot'." -ForegroundColor Red
+        exit 1
+    }
+    [xml] $props = Get-Content -LiteralPath $propsPath
+    $ExpectedVersion = $props.Project.PropertyGroup.Version
+    if (-not $ExpectedVersion) {
+        Write-Host "INSTALL LAYER GATE: could not read <Version> from $propsPath." -ForegroundColor Red
+        exit 1
+    }
+}
+
+if (-not $PluginCacheRoot) {
+    $PluginCacheRoot = Join-Path $HOME '.claude/plugins/cache/roslyn-mcp-marketplace/roslyn-mcp'
+}
+
+$errors = @()
+
+# --- Layer 1: standalone global .NET tool -----------------------------------
+if (-not $Layer1Version) {
+    try {
+        $toolList = & dotnet tool list --global 2>&1 | Out-String
+    }
+    catch {
+        $toolList = ''
+    }
+
+    $toolMatch = [regex]::Match(
+        $toolList,
+        '(?im)^\s*darylmcd\.roslynmcp\s+(?<version>\S+)\s')
+    if ($toolMatch.Success) {
+        $Layer1Version = $toolMatch.Groups['version'].Value
+    }
+    else {
+        $errors += "Layer 1 (global tool 'darylmcd.roslynmcp') is not installed. Run 'just tool-update'."
+    }
+}
+
+if ($Layer1Version -and $Layer1Version -ne $ExpectedVersion) {
+    $errors += "Layer 1 (global tool) is at $Layer1Version, expected $ExpectedVersion. Run 'just tool-update'."
+}
+
+# --- Layer 2: Claude Code plugin cache --------------------------------------
+if (-not (Test-Path -LiteralPath $PluginCacheRoot)) {
+    $errors += "Layer 2 (plugin cache) not found at '$PluginCacheRoot'. Run 'pwsh -NoProfile -File eng/update-claude-plugin.ps1'."
+}
+else {
+    $cacheDirs = @(
+        Get-ChildItem -LiteralPath $PluginCacheRoot -Directory -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name)
+
+    if ($cacheDirs.Count -eq 0) {
+        $errors += "Layer 2 (plugin cache) at '$PluginCacheRoot' holds no version directory."
+    }
+    elseif ($cacheDirs -notcontains $ExpectedVersion) {
+        $errors += ("Layer 2 (plugin cache) has no $ExpectedVersion directory; found: " +
+            ($cacheDirs -join ', ') + ". Run 'pwsh -NoProfile -File eng/update-claude-plugin.ps1'.")
+    }
+    else {
+        $stale = @($cacheDirs | Where-Object { $_ -ne $ExpectedVersion })
+        if ($stale.Count -gt 0) {
+            $errors += ('Layer 2 (plugin cache) still holds stale version directories: ' +
+                ($stale -join ', ') + '. The updater prunes these; re-run it.')
+        }
+
+        $cachedManifest = Join-Path $PluginCacheRoot $ExpectedVersion '.claude-plugin/plugin.json'
+        if (Test-Path -LiteralPath $cachedManifest) {
+            $manifestVersion = (Get-Content -LiteralPath $cachedManifest -Raw | ConvertFrom-Json).version
+            if ($manifestVersion -ne $ExpectedVersion) {
+                $errors += "Layer 2 cached plugin.json reports $manifestVersion, expected $ExpectedVersion."
+            }
+        }
+    }
+}
+
+if ($errors.Count -gt 0) {
+    Write-Host ''
+    Write-Host "INSTALL LAYER DRIFT DETECTED (expected $ExpectedVersion):" -ForegroundColor Red
+    foreach ($e in $errors) {
+        Write-Host "  - $e" -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host "Both layers must track the release. 'just reinstall' refreshes them together." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Install layers current at ${ExpectedVersion}: Layer 1 (global tool) and Layer 2 (plugin cache)." -ForegroundColor Green
+exit 0

--- a/tests/RoslynMcp.Tests/InstallLayerRefreshContractTests.cs
+++ b/tests/RoslynMcp.Tests/InstallLayerRefreshContractTests.cs
@@ -1,0 +1,148 @@
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// The server ships on two install surfaces that drift apart silently, in both directions:
+/// v1.29.0 and v1.34.2 refreshed the Layer 1 global tool and left the Layer 2 plugin cache
+/// stale, and v4.1.2 refreshed Layer 2 while Layer 1 sat a release behind because the
+/// global-tool update was documented as optional. These tests pin the contract that
+/// <c>/release-cut</c> Step 6 refreshes both and proves it with
+/// <c>eng/verify-install-layers.ps1</c>, and cover the verifier's own comparison logic.
+/// </summary>
+[TestClass]
+public sealed class InstallLayerRefreshContractTests
+{
+    private const string VerifierInvocation = "pwsh -NoProfile -File eng/verify-install-layers.ps1";
+
+    [TestMethod]
+    public void ReleaseCutSkill_RefreshesBothLayersAndProvesThem()
+    {
+        var skill = ReadSkill("release-cut");
+
+        StringAssert.Contains(
+            skill,
+            "just tool-update",
+            "Step 6 must refresh the Layer 1 global tool, not leave it to the maintainer.");
+        StringAssert.Contains(
+            skill,
+            "eng/update-claude-plugin.ps1",
+            "Step 6 must refresh the Layer 2 plugin cache.");
+        StringAssert.Contains(
+            skill,
+            VerifierInvocation,
+            "Step 6 must prove both layers with the install-layer verifier.");
+
+        Assert.IsFalse(
+            skill.Contains("global-tool update is optional", StringComparison.OrdinalIgnoreCase),
+            "The Layer 1 refresh must not be documented as optional again.");
+    }
+
+    [TestMethod]
+    public void MaintainerUpdateSkill_TreatsGlobalToolRefreshAsRequired()
+    {
+        var skill = ReadSkill("update");
+
+        StringAssert.Contains(skill, "just tool-update");
+        StringAssert.Contains(skill, VerifierInvocation);
+        Assert.IsFalse(
+            skill.Contains("Optional standalone global tool", StringComparison.OrdinalIgnoreCase),
+            "The maintainer /update skill must not restore the optional global-tool step.");
+    }
+
+    [TestMethod]
+    [DataRow("4.1.2", "4.1.2", 0, DisplayName = "both layers current")]
+    [DataRow("4.1.1", "4.1.2", 1, DisplayName = "layer 1 stale")]
+    [DataRow("4.1.2", "4.1.1", 1, DisplayName = "layer 2 stale")]
+    public async Task VerifyInstallLayers_FailsWhenEitherLayerLagsTheRelease(
+        string layer1Version,
+        string cachedVersion,
+        int expectedExitCode)
+    {
+        const string expectedVersion = "4.1.2";
+        var cacheRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"roslynmcp-install-layers-{Guid.NewGuid():N}");
+        try
+        {
+            var versionDirectory = Path.Combine(cacheRoot, cachedVersion, ".claude-plugin");
+            Directory.CreateDirectory(versionDirectory);
+            File.WriteAllText(
+                Path.Combine(versionDirectory, "plugin.json"),
+                $"{{\"version\":\"{cachedVersion}\"}}");
+
+            var result = await RunVerifierAsync(expectedVersion, cacheRoot, layer1Version);
+
+            Assert.AreEqual(expectedExitCode, result.ExitCode, result.AllOutput);
+            if (expectedExitCode != 0)
+            {
+                StringAssert.Contains(result.AllOutput, "INSTALL LAYER DRIFT DETECTED");
+                var staleLayer = layer1Version == expectedVersion ? "Layer 2" : "Layer 1";
+                StringAssert.Contains(
+                    result.AllOutput,
+                    staleLayer,
+                    "The failure must name which layer is stale.");
+            }
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(cacheRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task VerifyInstallLayers_FailsWhenLayer2RetainsAStaleVersionDirectory()
+    {
+        const string expectedVersion = "4.1.2";
+        var cacheRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"roslynmcp-install-layers-{Guid.NewGuid():N}");
+        try
+        {
+            // The updater prunes old directories; a leftover means the refresh did not complete.
+            Directory.CreateDirectory(Path.Combine(cacheRoot, expectedVersion));
+            Directory.CreateDirectory(Path.Combine(cacheRoot, "4.1.1"));
+
+            var result = await RunVerifierAsync(expectedVersion, cacheRoot, expectedVersion);
+
+            Assert.AreEqual(1, result.ExitCode, result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "stale version directories");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(cacheRoot);
+        }
+    }
+
+    private static string ReadSkill(string skillName) => File.ReadAllText(
+        Path.Combine(
+            TestFixtureFileSystem.FindRepositoryRoot(),
+            ".claude",
+            "skills",
+            skillName,
+            "SKILL.md"));
+
+    private static Task<PwshScriptResult> RunVerifierAsync(
+        string expectedVersion,
+        string pluginCacheRoot,
+        string layer1Version)
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        return PwshScriptRunner.RunAsync(
+            [
+                "-NoProfile",
+                "-File",
+                Path.Combine(repositoryRoot, "eng", "verify-install-layers.ps1"),
+                "-ExpectedVersion",
+                expectedVersion,
+                "-RepositoryRoot",
+                repositoryRoot,
+                "-PluginCacheRoot",
+                pluginCacheRoot,
+                "-Layer1Version",
+                layer1Version,
+            ],
+            timeout: TimeSpan.FromSeconds(60),
+            description: "install-layer verifier");
+    }
+}

--- a/tests/RoslynMcp.Tests/WorkspaceLoadDedupTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceLoadDedupTests.cs
@@ -151,18 +151,57 @@ public sealed class WorkspaceLoadDedupTests : SharedWorkspaceTestBase
         try
         {
             var status = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
-            var documentPath = Directory.EnumerateFiles(copiedRoot, "*.cs", SearchOption.AllDirectories)
-                .First();
+            var documentPath = SelectDeterministicProjectSourceFile(copiedRoot);
 
             var owners = WorkspaceManager.FindWorkspaceIdsContainingFile(documentPath);
 
-            CollectionAssert.AreEqual(new[] { status.WorkspaceId }, owners.ToArray());
+            CollectionAssert.AreEqual(
+                new[] { status.WorkspaceId },
+                owners.ToArray(),
+                $"Expected exactly the loaded workspace to own '{documentPath}'.");
             WorkspaceManager.Close(status.WorkspaceId);
         }
         finally
         {
             DeleteDirectoryIfExists(copiedRoot);
         }
+    }
+
+    /// <summary>
+    /// Picks a project source file that is genuinely a document of the loaded workspace, in an
+    /// order that does not depend on the filesystem.
+    /// </summary>
+    /// <remarks>
+    /// This test previously took <c>EnumerateFiles(root, "*.cs", AllDirectories).First()</c>.
+    /// Two problems compounded. <c>First()</c> over an unordered enumeration has no defined
+    /// result, and enumeration order differs between NTFS and ext4 — so the pick varied by
+    /// platform. And the fixture copy only excludes <c>bin</c>, never <c>obj</c> (it cannot:
+    /// MSBuildWorkspace needs <c>obj/project.assets.json</c> to load), so the tree carries
+    /// generated sources under both <c>obj/Debug</c> and <c>obj/Release</c>. Only the active
+    /// configuration's copies are compilation documents, so landing on the other one returned
+    /// zero owners and failed as "Different number of elements" — reliably on the Linux shard,
+    /// never on Windows.
+    /// </remarks>
+    private static string SelectDeterministicProjectSourceFile(string copiedRoot)
+    {
+        var buildOutputSegments = new[]
+        {
+            $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+        };
+
+        var documentPath = Directory
+            .EnumerateFiles(copiedRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !buildOutputSegments.Any(
+                segment => path.Contains(segment, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        Assert.IsNotNull(
+            documentPath,
+            $"The copied sample solution under '{copiedRoot}' contains no project source file.");
+
+        return documentPath;
     }
 
     [TestMethod]


### PR DESCRIPTION
The server ships on two install surfaces, and they drift apart silently **in both directions**:

| Release | Layer 1 (global tool) | Layer 2 (plugin) | Outcome |
|---|---|---|---|
| v1.29.0, v1.34.2 | refreshed | **stale** | `/release-cut` was created to close this |
| v4.1.2 | **stale** (4.1.1) | refreshed | Step 6 called the global-tool update "optional" |

Optional was the bug. Runtime independence is not currency: the plugin launches its own release-pinned package through `dnx` and does not depend on the shim — which is exactly what let the shim rot unnoticed for a release.

## Changes

- **`eng/verify-install-layers.ps1`** — reads Layer 1 from `dotnet tool list --global` and Layer 2 from the plugin cache plus its cached `plugin.json`; fails naming whichever layer is stale. Parameterized (`-ExpectedVersion`, `-PluginCacheRoot`, `-Layer1Version`) so it is testable without touching the machine.
- **`/release-cut` Step 6** splits into 6a Layer 2 → 6b Layer 1 (**required**) → 6c verify → 6d canary. The Step 6 checkpoint probe now runs the verifier instead of eyeballing the cache directory.
- **`/update` Step 3** is required rather than optional, and documents the Windows tool-store lock.
- **`InstallLayerRefreshContractTests`** pins the contract so "optional" cannot come back: both skills must mandate both layers and invoke the verifier, and the verifier must catch either layer stale plus leftover cache directories.

## Two field notes written into the skills

Both cost time during this work:

1. **Identify the lock holder by image path** under `~/.dotnet/tools/`, never by the `roslynmcp.exe` image name — the `dnx`-launched Layer 2 server shares that name, runs from the NuGet package cache, does not hold the lock, and killing it drops a live MCP connection.
2. **That holder is frequently the session's own MCP server** — its PID matches `server_info`'s `stdioPid`. So the order is stop-or-restart *then* update, not update then restart.

## Known gap (tracked, not widened into this PR)

`just tool-update` is plain `dotnet tool update -g` with no owned-process shutdown, so it fails whenever a Layer 1 process is running. The local-pack path already solves this (`eng/reinstall-local-tool.ps1`, shipped in 4.1.2), but its `-PackageSource` is validated as a local directory, so the NuGet route cannot reuse it as written. Filed as `tool-update-owned-process-shutdown` (Medium, M).

## Verification

Both layers on this machine are now genuinely at 4.1.2, and the verifier confirms it live:

```
Install layers current at 4.1.2: Layer 1 (global tool) and Layer 2 (plugin cache).
```

| Gate | Result |
|---|---|
| `InstallLayerRefreshContractTests` + 3 sibling contract classes | 24/24 pass |
| `verify-install-layers.ps1` (live) | exit 0 |
| `verify-changelog-fragments.ps1` | exit 0 |
| `verify-breaking-version-bump.ps1 -BumpType patch` | exit 0 |
| `verify-ai-docs.ps1` | exit 0 |
| `verify-changed-format.ps1` | exit 0, 0 new findings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjRjLJKaaBzTFBwU53YpXt