### PR TITLE
fix(catalog): declare one output-schema generation authority

### DIFF
--- a/changelog.d/output-schema-generation-authority.md
+++ b/changelog.d/output-schema-generation-authority.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Declared one output-schema generation authority so an advertised fixed DTO schema can no longer drift from the SDK-generated shape unnoticed.

--- a/src/RoslynMcp.Host.Stdio/Catalog/SurfaceRegistrationPolicy.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/SurfaceRegistrationPolicy.cs
@@ -51,10 +51,7 @@ internal static class SurfaceRegistrationPolicy
             var toolName = tool.ProtocolTool.Name;
             var entry = GetCatalogEntry(ServerSurfaceCatalog.Tools, toolName, "tool");
 
-            if (ToolOutputSchemaIndex.GetSchema(toolName) is { } schema)
-            {
-                tool.ProtocolTool.OutputSchema = JsonSerializer.SerializeToElement(schema);
-            }
+            ProjectDeclaredOutputSchema(tool);
 
             if (!selectedToolNames.Contains(entry.Name))
             {
@@ -90,6 +87,50 @@ internal static class SurfaceRegistrationPolicy
 
             ProjectSelectedProfileDescription(resource, selection);
         }
+    }
+
+    /// <summary>
+    /// Replaces the SDK-generated <c>outputSchema</c> with the catalog-declared one, which is the
+    /// single generation authority for advertised structured output
+    /// (see <see cref="ToolOutputSchemaIndex"/>). The overwrite is load-bearing rather than
+    /// redundant: the SDK generator runs on its own serializer defaults, while the index clones
+    /// <see cref="JsonDefaults.Indented"/> — the exact options the runtime
+    /// <c>structuredContent</c> channel serializes with.
+    /// <para>
+    /// Both asymmetries fail closed, so neither authority can quietly become the only one:
+    /// an SDK-generated schema the index does not declare would ship an unreviewed shape, and an
+    /// index declaration the SDK never generated means the tool no longer opts into structured
+    /// content while still advertising a schema.
+    /// </para>
+    /// </summary>
+    private static void ProjectDeclaredOutputSchema(McpServerTool tool)
+    {
+        var toolName = tool.ProtocolTool.Name;
+        var declared = ToolOutputSchemaIndex.GetSchema(toolName);
+        var sdkGenerated = tool.ProtocolTool.OutputSchema;
+
+        if (declared is null)
+        {
+            if (sdkGenerated is not null)
+            {
+                throw new InvalidOperationException(
+                    $"MCP tool '{toolName}' advertises an SDK-generated outputSchema that " +
+                    $"{nameof(ToolOutputSchemaIndex)} does not declare. Declare the tool's generation route " +
+                    "there so one authority owns the advertised schema, or drop its OutputSchemaType.");
+            }
+
+            return;
+        }
+
+        if (sdkGenerated is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ToolOutputSchemaIndex)} declares an outputSchema for MCP tool '{toolName}' but the " +
+                "registered tool advertises none. The tool must keep [McpServerTool(UseStructuredContent = true, " +
+                "OutputSchemaType = ...)] or the declaration must be removed.");
+        }
+
+        tool.ProtocolTool.OutputSchema = JsonSerializer.SerializeToElement(declared);
     }
 
     internal static void ValidateCatalogSupportTiers(

--- a/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
@@ -9,31 +9,113 @@ using RoslynMcp.Core.Models;
 namespace RoslynMcp.Host.Stdio.Catalog;
 
 /// <summary>
-/// tool-output-schema-infrastructure: cached reflection over every
-/// <see cref="McpServerToolAttribute"/>-attributed method that declares an
-/// <see cref="McpServerToolAttribute.OutputSchemaType"/>, projecting each tool's declared DTO
-/// type into a JSON-Schema document via
-/// <see cref="System.Text.Json.Schema.JsonSchemaExporter"/>.
+/// How a tool's advertised output schema is produced from the DTO type its
+/// <see cref="McpServerToolAttribute.OutputSchemaType"/> names.
+/// </summary>
+internal enum OutputSchemaKind
+{
+    /// <summary>
+    /// One response shape: the advertised schema is the declared DTO's generated schema verbatim.
+    /// </summary>
+    Fixed,
+
+    /// <summary>
+    /// A mode-dependent response: the advertised schema is a variant union whose first branch is
+    /// the declared DTO and whose remaining branches are the other modes the tool can serialize.
+    /// </summary>
+    Union,
+}
+
+/// <summary>
+/// Explicit, per-tool statement of how <see cref="ToolOutputSchemaIndex"/> builds one advertised
+/// output schema. Declaring the route (rather than inferring it from a fall-through
+/// <see langword="switch"/>) is what makes the index the single generation authority: a tool with
+/// no declaration, or a declaration with no tool, aborts index construction instead of silently
+/// falling back to a generated shape nobody reviewed.
+/// </summary>
+/// <param name="Kind">Fixed DTO shape or mode-dependent union.</param>
+/// <param name="UnionKeyword">
+/// JSON-Schema combinator for <see cref="OutputSchemaKind.Union"/> declarations
+/// (<c>anyOf</c> or <c>oneOf</c>); <see langword="null"/> for a fixed shape.
+/// </param>
+/// <param name="AdditionalVariants">
+/// Response DTOs beyond the SDK-declared one. Empty for a fixed shape.
+/// </param>
+internal sealed record OutputSchemaDeclaration(
+    OutputSchemaKind Kind,
+    string? UnionKeyword,
+    IReadOnlyList<Type> AdditionalVariants)
+{
+    /// <summary>
+    /// Declares that the tool advertises its SDK-declared DTO shape unchanged.
+    /// </summary>
+    internal static OutputSchemaDeclaration FixedShape() =>
+        new(OutputSchemaKind.Fixed, UnionKeyword: null, AdditionalVariants: []);
+
+    /// <summary>
+    /// Declares that the tool serializes more than one DTO depending on its request mode, and
+    /// advertises all of them under <paramref name="unionKeyword"/>.
+    /// </summary>
+    internal static OutputSchemaDeclaration UnionOf(string unionKeyword, params Type[] additionalVariants)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(unionKeyword);
+        ArgumentNullException.ThrowIfNull(additionalVariants);
+        if (additionalVariants.Length == 0)
+        {
+            throw new ArgumentException(
+                "A union declaration must name at least one response variant beyond the SDK-declared DTO.",
+                nameof(additionalVariants));
+        }
+
+        return new(OutputSchemaKind.Union, unionKeyword, additionalVariants);
+    }
+
+    /// <summary>
+    /// Ordered response DTOs for this declaration: the SDK-declared type first, then the extra
+    /// modes. A fixed declaration yields exactly <paramref name="declaredDtoType"/>.
+    /// </summary>
+    internal IReadOnlyList<Type> Variants(Type declaredDtoType)
+    {
+        ArgumentNullException.ThrowIfNull(declaredDtoType);
+        return Kind == OutputSchemaKind.Fixed
+            ? [declaredDtoType]
+            : [declaredDtoType, .. AdditionalVariants];
+    }
+}
+
+/// <summary>
+/// tool-output-schema-infrastructure: the single generation authority for every advertised
+/// <c>outputSchema</c>. Reflection over each <see cref="McpServerToolAttribute"/>-attributed method
+/// that declares an <see cref="McpServerToolAttribute.OutputSchemaType"/> supplies the DTO type;
+/// the <see cref="Declarations"/> table supplies the route (fixed shape or variant union); and
+/// <see cref="System.Text.Json.Schema.JsonSchemaExporter"/> projects the result into JSON Schema.
 /// <para>
-/// The catalog publishes the generated schema per tool on <see cref="SurfaceEntry.OutputSchema"/>
-/// so MCP clients can know in advance what shape to expect on the
-/// <c>structuredContent</c> channel. Reflection runs once at first
-/// access; the dictionary is immutable thereafter — schema generation per type is deterministic
-/// so the cache is safe across the server's lifetime.
+/// The two halves must agree exactly. An SDK adopter with no declaration, or a declaration with no
+/// SDK adopter, throws at index construction — the asymmetry that would otherwise let an advertised
+/// schema drift from the shape the server actually serializes.
+/// <see cref="SurfaceRegistrationPolicy"/> enforces the same symmetry against the SDK's own
+/// generated schemas at registration time.
 /// </para>
 /// <para>
-/// Tools without an <see cref="McpServerToolAttribute.OutputSchemaType"/> are absent from
-/// the dictionary and <see cref="GetSchema"/> returns <see langword="null"/>. Registered schemas
-/// are projected into the SDK's protocol-tool objects by <see cref="SurfaceRegistrationPolicy"/>.
+/// Schema generation clones <see cref="JsonDefaults.Indented"/> — the same options object the
+/// runtime <c>structuredContent</c> channel serializes with — so the advertised property names,
+/// enum spellings, and converter projections match the wire bytes. Letting the SDK's own generator
+/// win instead would drop camelCase and the string-enum converter. Any future polymorphic contract
+/// must be expressed in the DTO's serializer metadata so runtime output and the advertised schema
+/// continue to share one type source.
+/// </para>
+/// <para>
+/// Reflection and generation run once at first access; the dictionary is immutable thereafter —
+/// schema generation per type is deterministic so the cache is safe across the server's lifetime.
+/// Tools without an <see cref="McpServerToolAttribute.OutputSchemaType"/> are absent from the
+/// dictionary and <see cref="GetSchema"/> returns <see langword="null"/>.
 /// </para>
 /// </summary>
 internal static class ToolOutputSchemaIndex
 {
     /// <summary>
     /// Schema-export options matched to the server's runtime serializer. The exporter recursively
-    /// describes the nested records and collections used by current tool DTOs. Any future
-    /// polymorphic contract must be expressed in the DTO's serializer metadata so runtime output
-    /// and the advertised schema continue to share one type source.
+    /// describes the nested records and collections used by current tool DTOs.
     /// </summary>
     private static readonly JsonSchemaExporterOptions _exportOptions = new()
     {
@@ -45,8 +127,51 @@ internal static class ToolOutputSchemaIndex
         TypeInfoResolver = JsonDefaults.Indented.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver(),
     };
 
+    /// <summary>
+    /// The declared generation route per advertised tool. Every entry here MUST have a matching
+    /// <c>[McpServerTool(OutputSchemaType = ...)]</c> method, and every such method MUST appear
+    /// here; <see cref="BuildIndex"/> fails closed on either asymmetry.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, OutputSchemaDeclaration> _declarations =
+        new Dictionary<string, OutputSchemaDeclaration>(StringComparer.Ordinal)
+        {
+            ["server_info"] = OutputSchemaDeclaration.FixedShape(),
+            ["server_heartbeat"] = OutputSchemaDeclaration.FixedShape(),
+            ["workspace_health"] = OutputSchemaDeclaration.FixedShape(),
+            ["workspace_drift_check"] = OutputSchemaDeclaration.FixedShape(),
+            ["workspace_readiness_report"] = OutputSchemaDeclaration.FixedShape(),
+            ["workspace_support_bundle"] = OutputSchemaDeclaration.FixedShape(),
+
+            // Both workspace-list variants have the same outer object shape. In particular,
+            // { count: 0, workspaces: [] } satisfies both item schemas because an empty array
+            // has no element with which to distinguish summary from verbose. oneOf would
+            // therefore reject a valid fresh-host response; anyOf expresses the real contract.
+            ["workspace_list"] = OutputSchemaDeclaration.UnionOf("anyOf", typeof(WorkspaceListVerboseDto)),
+
+            // workspace_status serializes exactly one of its two shapes per request mode and the
+            // verbose shape carries fields the summary lacks, so oneOf is the precise contract.
+            ["workspace_status"] = OutputSchemaDeclaration.UnionOf("oneOf", typeof(WorkspaceStatusDto)),
+        };
+
+    private static readonly Lazy<IReadOnlyDictionary<string, Type>> _adopters =
+        new(DiscoverAdopters, LazyThreadSafetyMode.ExecutionAndPublication);
+
     private static readonly Lazy<IReadOnlyDictionary<string, JsonNode>> _index =
         new(BuildIndex, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// The declared generation route per advertised tool. Exposed <see langword="internal"/> so the
+    /// catalog contract tests can assert the fixed-versus-union matrix without re-deriving it.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, OutputSchemaDeclaration> Declarations => _declarations;
+
+    /// <summary>
+    /// The DTO type each tool declares through <see cref="McpServerToolAttribute.OutputSchemaType"/>,
+    /// discovered by reflection over the host assembly — i.e. exactly the set for which the MCP SDK
+    /// generates its own <c>outputSchema</c>. Exposed <see langword="internal"/> so tests can
+    /// compare the SDK-discovered surface against <see cref="Declarations"/>.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, Type> SdkDeclaredOutputSchemaTypes => _adopters.Value;
 
     /// <summary>
     /// Returns the cached JSON-Schema node for <paramref name="toolName"/>, or
@@ -76,11 +201,11 @@ internal static class ToolOutputSchemaIndex
     internal static JsonNode GenerateSchema(Type type) =>
         JsonSchemaExporter.GetJsonSchemaAsNode(_schemaSerializerOptions, type, _exportOptions);
 
-    private static IReadOnlyDictionary<string, JsonNode> BuildIndex()
+    private static IReadOnlyDictionary<string, Type> DiscoverAdopters()
     {
         // Anchor on a known tool-host type so we walk the same assembly that MCP discovery uses.
         var assembly = typeof(Tools.ServerTools).Assembly;
-        var dict = new Dictionary<string, JsonNode>(StringComparer.Ordinal);
+        var adopters = new Dictionary<string, Type>(StringComparer.Ordinal);
 
         foreach (var type in assembly.GetTypes())
         {
@@ -93,38 +218,67 @@ internal static class ToolOutputSchemaIndex
                 var schemaType = toolAttr.OutputSchemaType;
                 if (schemaType is null) continue;
 
-                // An opted-in schema is part of the advertised public contract. Let export
-                // failures abort startup instead of silently degrading that tool to text-only
-                // output while its metadata still claims structured-content support.
-                dict[toolAttr.Name] = GenerateAdvertisedSchema(toolAttr.Name, schemaType);
+                adopters[toolAttr.Name] = schemaType;
             }
+        }
+
+        return adopters;
+    }
+
+    private static IReadOnlyDictionary<string, JsonNode> BuildIndex()
+    {
+        var adopters = _adopters.Value;
+
+        // Fail closed on either asymmetry. An opted-in schema is part of the advertised public
+        // contract: an undeclared route would publish whatever the exporter happened to produce,
+        // and a stale declaration would advertise a shape no tool can return.
+        foreach (var (toolName, schemaType) in adopters)
+        {
+            if (!_declarations.ContainsKey(toolName))
+            {
+                throw new InvalidOperationException(
+                    $"Tool '{toolName}' declares [McpServerTool(OutputSchemaType = typeof({schemaType.Name}))] " +
+                    $"but {nameof(ToolOutputSchemaIndex)} has no output-schema declaration for it. Add an explicit " +
+                    $"{nameof(OutputSchemaDeclaration)}.{nameof(OutputSchemaDeclaration.FixedShape)}() or " +
+                    $".{nameof(OutputSchemaDeclaration.UnionOf)}(...) entry so exactly one authority produces the " +
+                    "advertised schema.");
+            }
+        }
+
+        foreach (var toolName in _declarations.Keys)
+        {
+            if (!adopters.ContainsKey(toolName))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(ToolOutputSchemaIndex)} declares an output schema for '{toolName}' but no " +
+                    "[McpServerTool(OutputSchemaType = ...)] method in the host assembly carries that name. " +
+                    "Remove the stale declaration or restore the tool's OutputSchemaType.");
+            }
+        }
+
+        var dict = new Dictionary<string, JsonNode>(StringComparer.Ordinal);
+        foreach (var (toolName, schemaType) in adopters)
+        {
+            // Let export failures abort startup instead of silently degrading that tool to
+            // text-only output while its metadata still claims structured-content support.
+            dict[toolName] = BuildAdvertisedSchema(_declarations[toolName], schemaType);
         }
 
         return dict;
     }
 
-    private static JsonNode GenerateAdvertisedSchema(string toolName, Type schemaType) =>
-        toolName switch
+    private static JsonNode BuildAdvertisedSchema(OutputSchemaDeclaration declaration, Type declaredDtoType)
+    {
+        var variants = declaration.Variants(declaredDtoType);
+        if (declaration.Kind == OutputSchemaKind.Fixed)
         {
-            // Both workspace-list variants have the same outer object shape. In particular,
-            // { count: 0, workspaces: [] } satisfies both item schemas because an empty array
-            // has no element with which to distinguish summary from verbose. `oneOf` would
-            // therefore reject a valid fresh-host response; `anyOf` expresses the real contract.
-            "workspace_list" => GenerateObjectVariantSchema(
-                "anyOf",
-                schemaType,
-                typeof(WorkspaceListVerboseDto)),
-            "workspace_status" => GenerateObjectVariantSchema(
-                "oneOf",
-                schemaType,
-                typeof(WorkspaceStatusDto)),
-            _ => GenerateSchema(schemaType),
-        };
+            return GenerateSchema(variants[0]);
+        }
 
-    private static JsonNode GenerateObjectVariantSchema(string keyword, params Type[] variants) =>
-        new JsonObject
+        return new JsonObject
         {
             ["type"] = "object",
-            [keyword] = new JsonArray(variants.Select(GenerateSchema).ToArray()),
+            [declaration.UnionKeyword!] = new JsonArray(variants.Select(GenerateSchema).ToArray()),
         };
+    }
 }

--- a/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
@@ -131,7 +131,23 @@ internal sealed record OutputSchemaDeclaration
                 nameof(additionalVariants));
         }
 
-        return new(OutputSchemaKind.Union, combinator, additionalVariants);
+        if (Array.IndexOf(additionalVariants, null) >= 0)
+        {
+            throw new ArgumentException(
+                "A union declaration cannot name a null response variant.",
+                nameof(additionalVariants));
+        }
+
+        if (additionalVariants.Distinct().Count() != additionalVariants.Length)
+        {
+            throw new ArgumentException(
+                "A union declaration cannot name the same response variant twice.",
+                nameof(additionalVariants));
+        }
+
+        // Copy defensively: params binds the caller's array when it is passed explicitly, so
+        // storing it by reference would let a caller mutate a validated declaration afterwards.
+        return new(OutputSchemaKind.Union, combinator, [.. additionalVariants]);
     }
 
     /// <summary>
@@ -186,9 +202,15 @@ internal static class ToolOutputSchemaIndex
         TreatNullObliviousAsNonNullable = true,
     };
 
+    // The options are already a COPY of JsonDefaults.Indented, so the exporter inherits the
+    // runtime naming policy and converters. The resolver is constructed unconditionally rather
+    // than read back from the shared static: JsonDefaults.Indented.TypeInfoResolver is null until
+    // something freezes that process-wide object, which would make the exporter's resolver depend
+    // on static-initialization order. Both branches produced an unmodified reflection resolver, so
+    // this is order-independence at no cost in behavior.
     private static readonly JsonSerializerOptions _schemaSerializerOptions = new(JsonDefaults.Indented)
     {
-        TypeInfoResolver = JsonDefaults.Indented.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver(),
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
     };
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
+++ b/src/RoslynMcp.Host.Stdio/Catalog/ToolOutputSchemaIndex.cs
@@ -27,38 +27,102 @@ internal enum OutputSchemaKind
 }
 
 /// <summary>
+/// The JSON-Schema combinators a <see cref="OutputSchemaKind.Union"/> declaration may advertise.
+/// A closed set rather than a free-form keyword string: an unrecognised combinator would emit an
+/// invalid schema that no round-trip assertion could see, because every reader would look the
+/// misspelled key straight back up.
+/// </summary>
+internal enum OutputSchemaUnionCombinator
+{
+    /// <summary>
+    /// JSON-Schema <c>anyOf</c>: a response may satisfy one or more branches. Correct when the
+    /// branches overlap, so demanding exactly one match would reject a valid response.
+    /// </summary>
+    AnyOf,
+
+    /// <summary>
+    /// JSON-Schema <c>oneOf</c>: a response satisfies exactly one branch. Correct when the modes
+    /// are mutually exclusive by shape.
+    /// </summary>
+    OneOf,
+}
+
+/// <summary>
 /// Explicit, per-tool statement of how <see cref="ToolOutputSchemaIndex"/> builds one advertised
 /// output schema. Declaring the route (rather than inferring it from a fall-through
 /// <see langword="switch"/>) is what makes the index the single generation authority: a tool with
 /// no declaration, or a declaration with no tool, aborts index construction instead of silently
 /// falling back to a generated shape nobody reviewed.
+/// <para>
+/// Construction is factory-only (<see cref="FixedShape"/> / <see cref="UnionOf"/>) so a
+/// declaration cannot be assembled in an invalid state — in particular, a union can only ever
+/// name a combinator from <see cref="OutputSchemaUnionCombinator"/>.
+/// </para>
 /// </summary>
-/// <param name="Kind">Fixed DTO shape or mode-dependent union.</param>
-/// <param name="UnionKeyword">
-/// JSON-Schema combinator for <see cref="OutputSchemaKind.Union"/> declarations
-/// (<c>anyOf</c> or <c>oneOf</c>); <see langword="null"/> for a fixed shape.
-/// </param>
-/// <param name="AdditionalVariants">
-/// Response DTOs beyond the SDK-declared one. Empty for a fixed shape.
-/// </param>
-internal sealed record OutputSchemaDeclaration(
-    OutputSchemaKind Kind,
-    string? UnionKeyword,
-    IReadOnlyList<Type> AdditionalVariants)
+internal sealed record OutputSchemaDeclaration
 {
+    private OutputSchemaDeclaration(
+        OutputSchemaKind kind,
+        OutputSchemaUnionCombinator? combinator,
+        IReadOnlyList<Type> additionalVariants)
+    {
+        Kind = kind;
+        Combinator = combinator;
+        AdditionalVariants = additionalVariants;
+    }
+
+    /// <summary>Fixed DTO shape or mode-dependent union.</summary>
+    internal OutputSchemaKind Kind { get; }
+
+    /// <summary>
+    /// JSON-Schema combinator for <see cref="OutputSchemaKind.Union"/> declarations;
+    /// <see langword="null"/> for a fixed shape.
+    /// </summary>
+    internal OutputSchemaUnionCombinator? Combinator { get; }
+
+    /// <summary>
+    /// Response DTOs beyond the SDK-declared one. Empty for a fixed shape.
+    /// </summary>
+    internal IReadOnlyList<Type> AdditionalVariants { get; }
+
+    /// <summary>
+    /// The literal JSON-Schema key this declaration writes (<c>anyOf</c> or <c>oneOf</c>), or
+    /// <see langword="null"/> for a fixed shape. Derived from <see cref="Combinator"/> so the
+    /// advertised keyword has exactly one spelling authority.
+    /// </summary>
+    internal string? UnionKeyword => Combinator switch
+    {
+        null => null,
+        OutputSchemaUnionCombinator.AnyOf => "anyOf",
+        OutputSchemaUnionCombinator.OneOf => "oneOf",
+        _ => throw new InvalidOperationException(
+            $"No JSON-Schema keyword is defined for combinator '{Combinator}'."),
+    };
+
     /// <summary>
     /// Declares that the tool advertises its SDK-declared DTO shape unchanged.
     /// </summary>
     internal static OutputSchemaDeclaration FixedShape() =>
-        new(OutputSchemaKind.Fixed, UnionKeyword: null, AdditionalVariants: []);
+        new(OutputSchemaKind.Fixed, combinator: null, additionalVariants: []);
 
     /// <summary>
     /// Declares that the tool serializes more than one DTO depending on its request mode, and
-    /// advertises all of them under <paramref name="unionKeyword"/>.
+    /// advertises all of them under <paramref name="combinator"/>.
     /// </summary>
-    internal static OutputSchemaDeclaration UnionOf(string unionKeyword, params Type[] additionalVariants)
+    internal static OutputSchemaDeclaration UnionOf(
+        OutputSchemaUnionCombinator combinator,
+        params Type[] additionalVariants)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(unionKeyword);
+        // An enum is not a closed set at runtime — any int can be cast into one — so reject an
+        // undefined value here rather than let it reach the advertised schema as a bad keyword.
+        if (!Enum.IsDefined(combinator))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(combinator),
+                combinator,
+                "A union declaration must name a defined JSON-Schema combinator (anyOf or oneOf).");
+        }
+
         ArgumentNullException.ThrowIfNull(additionalVariants);
         if (additionalVariants.Length == 0)
         {
@@ -67,7 +131,7 @@ internal sealed record OutputSchemaDeclaration(
                 nameof(additionalVariants));
         }
 
-        return new(OutputSchemaKind.Union, unionKeyword, additionalVariants);
+        return new(OutputSchemaKind.Union, combinator, additionalVariants);
     }
 
     /// <summary>
@@ -146,11 +210,13 @@ internal static class ToolOutputSchemaIndex
             // { count: 0, workspaces: [] } satisfies both item schemas because an empty array
             // has no element with which to distinguish summary from verbose. oneOf would
             // therefore reject a valid fresh-host response; anyOf expresses the real contract.
-            ["workspace_list"] = OutputSchemaDeclaration.UnionOf("anyOf", typeof(WorkspaceListVerboseDto)),
+            ["workspace_list"] = OutputSchemaDeclaration.UnionOf(
+                OutputSchemaUnionCombinator.AnyOf, typeof(WorkspaceListVerboseDto)),
 
             // workspace_status serializes exactly one of its two shapes per request mode and the
             // verbose shape carries fields the summary lacks, so oneOf is the precise contract.
-            ["workspace_status"] = OutputSchemaDeclaration.UnionOf("oneOf", typeof(WorkspaceStatusDto)),
+            ["workspace_status"] = OutputSchemaDeclaration.UnionOf(
+                OutputSchemaUnionCombinator.OneOf, typeof(WorkspaceStatusDto)),
         };
 
     private static readonly Lazy<IReadOnlyDictionary<string, Type>> _adopters =

--- a/tests/RoslynMcp.Tests/Batch1OutputSchemaTests.cs
+++ b/tests/RoslynMcp.Tests/Batch1OutputSchemaTests.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using RoslynMcp.Core.Models;
+using RoslynMcp.Host.Stdio;
 using RoslynMcp.Host.Stdio.Catalog;
 
 namespace RoslynMcp.Tests;
@@ -148,6 +149,119 @@ public sealed class Batch1OutputSchemaTests
                 Assert.IsTrue(JsonNode.DeepEquals(expected, variants[index]),
                     $"Tool '{toolName}' union branch {index} must describe " +
                     $"{expectedTypes[index].Name}, the DTO serialized by that mode.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void EverySdkAdopterPairsWithExactlyOneCatalogDeclaration()
+    {
+        // Authority symmetry, asserted statically. ToolOutputSchemaIndex fails closed on either
+        // asymmetry at index construction; this test names the offending side when it does, and
+        // fails on the CI machine rather than on a client's first tools/list.
+        var sdkDeclared = ToolOutputSchemaIndex.SdkDeclaredOutputSchemaTypes;
+
+        CollectionAssert.AreEquivalent(
+            ToolOutputSchemaIndex.Declarations.Keys.ToArray(),
+            sdkDeclared.Keys.ToArray(),
+            "Every [McpServerTool(OutputSchemaType = ...)] adopter must carry exactly one explicit " +
+            "OutputSchemaDeclaration, and every declaration must name a live adopter. One generation " +
+            "authority means neither side may drift alone.");
+
+        foreach (var (toolName, expectedDtoType) in _adopters)
+        {
+            Assert.AreEqual(expectedDtoType, sdkDeclared[toolName],
+                $"Tool '{toolName}' must keep OutputSchemaType = typeof({expectedDtoType.Name}); " +
+                "the catalog derives its advertised schema from that declared type.");
+        }
+    }
+
+    [TestMethod]
+    public void FixedVersusUnionMatrixMatchesEachToolsDeclaredGenerationRoute()
+    {
+        // The matrix: for every adopter, compare the SDK-discovered DTO type, its declared
+        // generation route, and the schema the catalog actually advertises.
+        var sdkDeclared = ToolOutputSchemaIndex.SdkDeclaredOutputSchemaTypes;
+
+        foreach (var (toolName, declaration) in ToolOutputSchemaIndex.Declarations)
+        {
+            var declaredDtoType = sdkDeclared[toolName];
+            var advertised = ToolOutputSchemaIndex.GetSchema(toolName);
+            Assert.IsNotNull(advertised, $"Tool '{toolName}' must publish an advertised schema.");
+            var advertisedObject = advertised!.AsObject();
+            var variants = declaration.Variants(declaredDtoType);
+
+            if (declaration.Kind == OutputSchemaKind.Fixed)
+            {
+                Assert.IsNull(declaration.UnionKeyword,
+                    $"Tool '{toolName}' is declared Fixed and must not name a union keyword.");
+                Assert.HasCount(1, variants);
+                Assert.IsFalse(
+                    advertisedObject.ContainsKey("anyOf") || advertisedObject.ContainsKey("oneOf"),
+                    $"Tool '{toolName}' is declared Fixed, so its advertised schema must be the DTO " +
+                    "shape verbatim — a union here means the declaration and the generator disagree.");
+                Assert.IsTrue(
+                    JsonNode.DeepEquals(ToolOutputSchemaIndex.GenerateSchema(declaredDtoType), advertised),
+                    $"Tool '{toolName}' advertises a schema that is not the generated shape of " +
+                    $"{declaredDtoType.Name}. A Fixed declaration must not reshape the DTO.");
+                continue;
+            }
+
+            Assert.IsNotNull(declaration.UnionKeyword,
+                $"Tool '{toolName}' is declared Union and must name anyOf or oneOf.");
+            Assert.AreEqual("object", advertisedObject["type"]!.GetValue<string>(),
+                $"Tool '{toolName}' union schema must still declare the outer structuredContent object type.");
+
+            var branches = advertisedObject[declaration.UnionKeyword!]!.AsArray();
+            Assert.HasCount(variants.Count, branches);
+            Assert.AreEqual(declaredDtoType, variants[0],
+                $"Tool '{toolName}' union branch 0 must be the SDK-declared DTO so the declaration " +
+                "cannot silently diverge from the attribute.");
+
+            for (var index = 0; index < variants.Count; index++)
+            {
+                Assert.IsTrue(
+                    JsonNode.DeepEquals(ToolOutputSchemaIndex.GenerateSchema(variants[index]), branches[index]),
+                    $"Tool '{toolName}' union branch {index} must describe {variants[index].Name}, " +
+                    "the DTO serialized by that mode.");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void AdvertisedSchemasUseTheRuntimeStructuredContentSerializerMetadata()
+    {
+        // Acceptance for "prove custom catalog schemas use the same serializer metadata as SDK
+        // runtime output": the catalog overwrites the SDK-generated schema precisely because the
+        // SDK generator runs on its own defaults. That overwrite is only defensible while the
+        // advertised property names are the names JsonDefaults.Indented — the options object the
+        // structuredContent channel serializes with — actually emits.
+        _ = JsonSerializer.Serialize(new { probe = 0 }, JsonDefaults.Indented);
+
+        foreach (var (toolName, declaration) in ToolOutputSchemaIndex.Declarations)
+        {
+            var declaredDtoType = ToolOutputSchemaIndex.SdkDeclaredOutputSchemaTypes[toolName];
+            var variants = declaration.Variants(declaredDtoType);
+            var advertised = ToolOutputSchemaIndex.GetSchema(toolName)!.AsObject();
+
+            JsonObject[] branches = declaration.Kind == OutputSchemaKind.Fixed
+                ? [advertised]
+                : advertised[declaration.UnionKeyword!]!.AsArray().Select(node => node!.AsObject()).ToArray();
+
+            for (var index = 0; index < variants.Count; index++)
+            {
+                var runtimeNames = JsonDefaults.Indented.GetTypeInfo(variants[index])
+                    .Properties
+                    .Select(static property => property.Name)
+                    .ToArray();
+                var advertisedNames = branches[index]["properties"]!.AsObject()
+                    .Select(static property => property.Key)
+                    .ToArray();
+
+                CollectionAssert.AreEquivalent(runtimeNames, advertisedNames,
+                    $"Tool '{toolName}' branch {index} ({variants[index].Name}) advertises property names " +
+                    "that JsonDefaults.Indented would not emit at runtime. The advertised schema and the " +
+                    "structuredContent bytes must come from one serializer-metadata source.");
             }
         }
     }

--- a/tests/RoslynMcp.Tests/Batch1OutputSchemaTests.cs
+++ b/tests/RoslynMcp.Tests/Batch1OutputSchemaTests.cs
@@ -236,7 +236,11 @@ public sealed class Batch1OutputSchemaTests
         // SDK generator runs on its own defaults. That overwrite is only defensible while the
         // advertised property names are the names JsonDefaults.Indented — the options object the
         // structuredContent channel serializes with — actually emits.
-        _ = JsonSerializer.Serialize(new { probe = 0 }, JsonDefaults.Indented);
+        //
+        // JsonDefaults.Indented names no TypeInfoResolver, so GetTypeInfo below throws
+        // NotSupportedException until the options are made read-only with the default reflection
+        // resolver populated — which is exactly what the first runtime serialization does.
+        JsonDefaults.Indented.MakeReadOnly(populateMissingResolver: true);
 
         foreach (var (toolName, declaration) in ToolOutputSchemaIndex.Declarations)
         {
@@ -263,6 +267,47 @@ public sealed class Batch1OutputSchemaTests
                     "that JsonDefaults.Indented would not emit at runtime. The advertised schema and the " +
                     "structuredContent bytes must come from one serializer-metadata source.");
             }
+        }
+    }
+
+    [TestMethod]
+    public void UnionDeclarationsCannotNameACombinatorOutsideAnyOfAndOneOf()
+    {
+        // Regression for the fail-open the declaration API shipped with: the combinator used to be
+        // a free-form string validated only for non-blankness, so a typo'd keyword would have
+        // advertised an invalid schema. The matrix test cannot catch that on its own — it reads the
+        // declared key back out of the schema, so a misspelling matches itself.
+        //
+        // Half 1: an undefined combinator is rejected at construction, not projected into a schema.
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => OutputSchemaDeclaration.UnionOf(
+                (OutputSchemaUnionCombinator)0xBAD, typeof(WorkspaceListVerboseDto)));
+
+        // Half 2: every live union declaration advertises a literal JSON-Schema combinator. The
+        // expected keywords are hard-coded here rather than read back from the declaration, so a
+        // future mapping change cannot agree with itself into an invalid schema.
+        string[] validCombinators = ["anyOf", "oneOf"];
+        foreach (var (toolName, declaration) in ToolOutputSchemaIndex.Declarations)
+        {
+            if (declaration.Kind == OutputSchemaKind.Fixed)
+            {
+                continue;
+            }
+
+            CollectionAssert.Contains(validCombinators, declaration.UnionKeyword,
+                $"Tool '{toolName}' declares union keyword '{declaration.UnionKeyword}', which is not a " +
+                "JSON-Schema combinator. Only anyOf and oneOf produce a valid advertised schema.");
+
+            var advertised = ToolOutputSchemaIndex.GetSchema(toolName)!.AsObject();
+            var advertisedCombinators = advertised
+                .Select(static property => property.Key)
+                .Where(validCombinators.Contains)
+                .ToArray();
+            Assert.HasCount(1, advertisedCombinators,
+                $"Tool '{toolName}' must advertise its variants under exactly one JSON-Schema combinator.");
+            Assert.AreEqual(declaration.UnionKeyword, advertisedCombinators[0],
+                $"Tool '{toolName}' advertises '{advertisedCombinators[0]}' but declares " +
+                $"'{declaration.UnionKeyword}'.");
         }
     }
 

--- a/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
+++ b/tests/RoslynMcp.Tests/StartupDiagnosticsTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -210,12 +211,76 @@ public sealed class StartupDiagnosticsTests
             .Value.ToolCollection!.ToArray();
         var advertised = tools
             .Where(static tool => tool.ProtocolTool.OutputSchema is not null)
-            .Select(static tool => tool.ProtocolTool.Name)
-            .ToArray();
+            .ToDictionary(
+                static tool => tool.ProtocolTool.Name,
+                static tool => tool.ProtocolTool.OutputSchema!.Value,
+                StringComparer.Ordinal);
 
         CollectionAssert.AreEquivalent(
             ToolOutputSchemaIndex.RegisteredToolNames.ToArray(),
-            advertised);
+            advertised.Keys.ToArray());
+
+        // Name parity alone would still pass if the SDK-generated schema survived registration,
+        // which would silently swap the generation authority (and with it camelCase + the string
+        // enum converter). Compare content: what reaches the wire must be the catalog's schema.
+        foreach (var toolName in ToolOutputSchemaIndex.RegisteredToolNames)
+        {
+            var declared = ToolOutputSchemaIndex.GetSchema(toolName);
+            var projected = JsonNode.Parse(advertised[toolName].GetRawText());
+
+            Assert.IsTrue(JsonNode.DeepEquals(declared, projected),
+                $"Tool '{toolName}' advertises an output schema that is not the one " +
+                "ToolOutputSchemaIndex declares. That index is the single generation authority; an " +
+                "SDK-generated schema surviving registration means the advertised contract no longer " +
+                "matches the bytes the structuredContent channel serializes.");
+        }
+    }
+
+    [TestMethod]
+    public void SurfaceRegistrationPolicy_RejectsAnUndeclaredSdkGeneratedOutputSchema()
+    {
+        // compile_check is a real catalog tool that deliberately has no advertised output schema.
+        // An SDK-generated schema appearing on it means a second generation authority came online.
+        var options = BuildToolOnlyOptions(
+            "compile_check",
+            JsonSerializer.SerializeToElement(new { type = "object" }));
+
+        var error = Assert.ThrowsExactly<InvalidOperationException>(
+            () => SurfaceRegistrationPolicy.Apply(options, ToolTierSelection.Parse("stable")));
+        StringAssert.Contains(error.Message, "compile_check");
+        StringAssert.Contains(error.Message, nameof(ToolOutputSchemaIndex));
+    }
+
+    [TestMethod]
+    public void SurfaceRegistrationPolicy_RejectsADeclaredSchemaTheToolNoLongerAdvertises()
+    {
+        // The mirror asymmetry: the index declares a schema for server_info, so a registered
+        // server_info that dropped UseStructuredContent/OutputSchemaType must not be projected
+        // over in silence.
+        var options = BuildToolOnlyOptions("server_info", outputSchema: null);
+
+        var error = Assert.ThrowsExactly<InvalidOperationException>(
+            () => SurfaceRegistrationPolicy.Apply(options, ToolTierSelection.Parse("stable")));
+        StringAssert.Contains(error.Message, "server_info");
+        StringAssert.Contains(error.Message, "OutputSchemaType");
+    }
+
+    private static McpServerOptions BuildToolOnlyOptions(string toolName, JsonElement? outputSchema)
+    {
+        var tool = McpServerTool.Create(
+            (Func<string>)(() => string.Empty),
+            new McpServerToolCreateOptions { Name = toolName });
+        tool.ProtocolTool.OutputSchema = outputSchema;
+
+        var toolCollection = new McpServerPrimitiveCollection<McpServerTool>();
+        toolCollection.Add(tool);
+
+        return new McpServerOptions
+        {
+            ToolCollection = toolCollection,
+            PromptCollection = new McpServerPrimitiveCollection<McpServerPrompt>(),
+            ResourceCollection = new McpServerResourceCollection(),
+        };
     }
 
     [TestMethod]


### PR DESCRIPTION
## Why

`SurfaceRegistrationPolicy` unconditionally replaced the SDK-generated `tool.ProtocolTool.OutputSchema` for every catalog-known tool, with no comparison against what it clobbered. Eight tools declare `[McpServerTool(OutputSchemaType = ...)]`; only two (`workspace_list`, `workspace_status`) actually need a custom union contract — the other six fell through an implicit `_ => GenerateSchema(schemaType)` arm.

The overwrite is load-bearing, not wrong. `McpServerOptions.SerializerOptions` is never assigned in this repo, so the SDK generator runs on its own defaults, while `ToolOutputSchemaIndex` clones `JsonDefaults.Indented` — the same options object the runtime `structuredContent` channel serializes with. The defect was that this authority was nowhere declared or asserted, so an advertised fixed schema could drift from the shape actually serialized with no gate.

## What changed

- `ToolOutputSchemaIndex` now carries an explicit per-tool `OutputSchemaDeclaration` (`Fixed` shape vs. a `Union` over the extra response modes) that replaces the fall-through `switch`. Index construction fails closed on either asymmetry: an SDK `OutputSchemaType` adopter with no declaration, or a declaration naming no live adopter.
- `SurfaceRegistrationPolicy.ProjectDeclaredOutputSchema` projects only from that declaration and enforces the same symmetry against the SDK's own generated schemas at registration time.
- Advertised schemas are unchanged. This PR **proves** the existing authority; it does not switch it. Letting the SDK win would drop camelCase and the `JsonStringEnumConverter`.

## Tests

- `Batch1OutputSchemaTests`: adopter↔declaration symmetry; the fixed-versus-union matrix over SDK-discovered DTO type, declared route, and advertised schema; and a parity check that advertised property names are the names `JsonDefaults.Indented` emits at runtime.
- `StartupDiagnosticsTests`: `DefaultSelection_ProjectsExactlyTheDeclaredOutputSchemas` upgraded from name-set parity to full content equivalence, plus one test per fail-closed guard direction.
- Mutation-verified: disabling the overwrite in `ProjectDeclaredOutputSchema` fails the content-equivalence assertion, so it is not vacuous.

## Validation

- `dotnet build RoslynMcp.slnx -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- `./eng/verify-release.ps1 -Configuration Release` — exit 0; 2817 passed, 0 failed, 7 skipped.
- `./eng/verify-ai-docs.ps1` — exit 0.

Closes: output-schema-generation-authority

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PywUGhxtTbeVSDUwNPHFbC
