### PR TITLE
feat(ci): record the hosted shard weighting decision durably

### DIFF
--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -75,9 +75,22 @@ Measured from the five most recent successful PR legs before this refactor:
 
 Fresh Windows TRX baseline: 2,536 cases (2,530 passed, 6 skipped) in 16m30s. MSTest spent about 6m13s in the parallelizable phase and 10m17s in the serialized `[DoNotParallelize]` tail. The same run proved that scripting watchdog tests left eight CPU-bound background threads alive for the remainder of the testhost. Treat this baseline as pre-refactor evidence; use uploaded per-leg TRX from the merged workflow for the new steady state.
 
-The first hosted two-shard calibration completed Windows in 19m50s and 16m29s, with cumulative per-test TRX durations of 2,549s and 1,764s. Because that did not improve the prior 16m09s repository-level median, code pull requests use four hosted Windows shards. Use complete green four-shard hosted runs as the next calibration and rebalance only from repeated uploaded TRX evidence.
+The first hosted two-shard calibration completed Windows in 19m50s and 16m29s, with cumulative per-test TRX durations of 2,549s and 1,764s. Because that did not improve the prior 16m09s repository-level median, code pull requests use four hosted Windows shards.
 
 GitHub's public-repository `ubuntu-latest` and `windows-latest` standard runners currently provide 4 CPUs and 16 GB RAM. Do not retain the retired 2-vCPU assumption in repository documentation.
+
+## Hosted Shard Weighting Decision
+
+The four-shard calibration is closed. `eng/collect-hosted-shard-timings.ps1` measured five complete green `ci` runs (30 leg observations), modelling each hosted image independently and mixing in no local-machine timing:
+
+| Hosted image | Legs | Critical path | Balanced floor | Achievable gain | Single-leg noise band | Worst same-leg case-duration spread | Between-leg case-duration spread |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `windows-latest` | 4 | 720.4s | 647.1s | 73.4s (10.2%) | 82.9s | 1.87x | 1.50x |
+| `ubuntu-latest` | 2 | 743.2s | 662.6s | 80.6s (10.8%) | 140.3s | 2.21x | 1.18x |
+
+Decision: the deterministic discovered-case weights in `eng/get-test-shard-plan.ps1` remain the shard weighting on both hosted images. Do not add an OS-specific duration profile. A perfect duration partition recovers less than the single-leg wall-time noise band on either image, and summed TRX case duration is not a partition signal at all: its same-leg run-to-run swing exceeds the between-leg spread, so ranking legs by it reproduces runner noise rather than class cost. The residual `ubuntu-latest` gap is structural rather than class skew, because the artifact-owner leg also runs docs validation, the format gate, the NuGet audit, and the publish upload.
+
+Re-check trigger: re-run `eng/collect-hosted-shard-timings.ps1` when the shard count changes, when non-test work moves between legs, or when a hosted image's achievable gain exceeds its own single-leg noise band across at least five complete green runs. Uploaded per-leg TRX expires after 14 days, so always re-derive from fresh in-window runs. Never calibrate from a single sample, and never feed a local Windows profile into the hosted `windows-latest` profile.
 
 ## Test Execution Contract
 

--- a/ai_docs/references/testing.md
+++ b/ai_docs/references/testing.md
@@ -24,8 +24,12 @@
 | CI non-owner shard lane | Add `-TestShardOnly` to skip platform-neutral policy checks and publish/hash; do not use it as the standalone release gate |
 | Per-leg duration/failure evidence | `artifacts/test-results/*.trx`; hosted artifact `test-results-<leg>` |
 | Bounded job-summary renderer | `eng/summarize-test-results.ps1 -ResultsPath artifacts/test-results` |
+| Offline per-image shard-skew collector | `eng/collect-hosted-shard-timings.ps1 -ResultsRoot <dir> -LegManifest <json>` |
+| Standing shard-weighting decision | `CI_POLICY.md` section "Hosted Shard Weighting Decision" |
 
 - Keep local `just ci` unsharded; it proves the complete suite in one invocation.
+- Summed TRX case duration alone is not a partition signal on hosted runners. Its same-leg run-to-run swing can exceed the between-leg spread, so a shard ranked by it reproduces runner noise. Quote wall-time skew and summed case duration as separate metrics; `eng/collect-hosted-shard-timings.ps1` emits them in separate columns and refuses fewer than five samples per hosted image.
+- Model each hosted image on its own evidence. Never merge images into one profile and never feed a local-machine timing into a hosted profile.
 - For CI, require nonempty shards whose class sets are disjoint and whose union equals discovery.
 - Use exact `ClassName` filters. Do not revive per-source-regex or `FullyQualifiedName~` slicing.
 - Diagnose slow tests from repeated TRX durations. A timeout attribute or method count is not runtime evidence.

--- a/ai_docs/references/testing.md
+++ b/ai_docs/references/testing.md
@@ -28,7 +28,7 @@
 | Standing shard-weighting decision | `CI_POLICY.md` section "Hosted Shard Weighting Decision" |
 
 - Keep local `just ci` unsharded; it proves the complete suite in one invocation.
-- Summed TRX case duration alone is not a partition signal on hosted runners. Its same-leg run-to-run swing can exceed the between-leg spread, so a shard ranked by it reproduces runner noise. Quote wall-time skew and summed case duration as separate metrics; `eng/collect-hosted-shard-timings.ps1` emits them in separate columns and refuses fewer than five samples per hosted image.
+- Summed TRX case duration alone is not a partition signal on hosted runners. Its same-leg run-to-run swing can exceed the between-leg spread, so a shard ranked by it reproduces runner noise. Quote wall-time skew and summed case duration as separate metrics; `eng/collect-hosted-shard-timings.ps1` emits them in separate columns and refuses fewer than `-MinimumSamples` (default 5) runs per hosted image.
 - Model each hosted image on its own evidence. Never merge images into one profile and never feed a local-machine timing into a hosted profile.
 - For CI, require nonempty shards whose class sets are disjoint and whose union equals discovery.
 - Use exact `ClassName` filters. Do not revive per-source-regex or `FullyQualifiedName~` slicing.

--- a/changelog.d/ci-hosted-shard-duration-balancing.md
+++ b/changelog.d/ci-hosted-shard-duration-balancing.md
@@ -2,4 +2,4 @@
 category: Added
 ---
 
-- **Added:** `eng/collect-hosted-shard-timings.ps1`, an offline per-image hosted-shard timing collector that reports wall-time skew separately from summed TRX case duration and fails closed below five samples, and recorded the resulting shard-weighting decision durably in `CI_POLICY.md`.
+- **Added:** `eng/collect-hosted-shard-timings.ps1`, an offline per-image hosted-shard timing collector that reports wall-time skew separately from summed TRX case duration and fails closed below `-MinimumSamples` (default 5) runs per image, and recorded the resulting shard-weighting decision durably in `CI_POLICY.md`.

--- a/changelog.d/ci-hosted-shard-duration-balancing.md
+++ b/changelog.d/ci-hosted-shard-duration-balancing.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** `eng/collect-hosted-shard-timings.ps1`, an offline per-image hosted-shard timing collector that reports wall-time skew separately from summed TRX case duration and fails closed below five samples, and recorded the resulting shard-weighting decision durably in `CI_POLICY.md`.

--- a/eng/collect-hosted-shard-timings.ps1
+++ b/eng/collect-hosted-shard-timings.ps1
@@ -1,0 +1,547 @@
+<#
+.SYNOPSIS
+Quantify hosted CI shard timing skew per hosted image from downloaded per-leg TRX evidence.
+
+.DESCRIPTION
+Offline, deterministic, and hermetic: this script never contacts GitHub. Download the
+`test-results-<leg>` artifacts yourself, describe them in a JSON leg manifest, and point this
+script at both.
+
+The script answers one question: does repeated evidence justify replacing the deterministic
+discovered-case weights in `eng/get-test-shard-plan.ps1` with duration weights?
+
+Wall-time skew and summed TRX case duration are reported as SEPARATE metrics because they are
+not interchangeable. Summed case duration on a hosted runner is a shared-machine measurement
+whose same-leg run-to-run swing can exceed the between-leg spread; when it does, that metric
+cannot drive a partition and the report says so.
+
+Fail-closed rules (each throws rather than degrading):
+  - fewer than MinimumSamples distinct runs for any hosted image
+  - an entry missing leg, image, run id, wall time, or path (no untagged legs)
+  - one leg claimed by two hosted images (images are never merged)
+  - a run missing any leg of its own image's leg set
+  - a duplicate run id + leg pair
+  - a manifest path that escapes ResultsRoot, is absent, or holds no TRX
+
+.PARAMETER ResultsRoot
+Directory holding the downloaded `test-results-<leg>` folders. Every manifest path resolves
+beneath it.
+
+.PARAMETER LegManifest
+Path to a JSON array. Each element describes one leg observation:
+
+  [
+    {
+      "runId": "33657245113",
+      "leg": "windows-hosted-1-of-4",
+      "image": "windows-latest",
+      "wallTimeSeconds": 635,
+      "path": "33657245113/test-results-windows-hosted-1-of-4"
+    }
+  ]
+
+`wallTimeSeconds` is that leg job's own hosted wall clock. Never mix a local-machine timing
+into a hosted image profile.
+
+.PARAMETER MinimumSamples
+Minimum distinct runs required per hosted image. Defaults to 5.
+
+.PARAMETER OutputPath
+When omitted, Markdown goes to stdout. When provided, one complete report is appended in UTF-8
+so an existing summary is preserved.
+
+.EXAMPLE
+pwsh -NoProfile -File ./eng/collect-hosted-shard-timings.ps1 -ResultsRoot ./downloads -LegManifest ./downloads/legs.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ResultsRoot,
+
+    [Parameter(Mandatory)]
+    [string]$LegManifest,
+
+    [ValidateRange(1, 1000)]
+    [int]$MinimumSamples = 5,
+
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$invariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
+
+function Format-Seconds {
+    param([double]$Value)
+
+    return $Value.ToString('0.0', $invariantCulture)
+}
+
+function Format-Ratio {
+    param([double]$Value)
+
+    if ([double]::IsInfinity($Value) -or [double]::IsNaN($Value)) {
+        return 'n/a'
+    }
+
+    return $Value.ToString('0.00', $invariantCulture) + 'x'
+}
+
+function Get-RequiredText {
+    param(
+        [Parameter(Mandatory)][object]$Entry,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][int]$Index
+    )
+
+    if ($Entry.PSObject.Properties.Name -notcontains $Name) {
+        throw "Leg manifest entry $Index is untagged: '$Name' is missing."
+    }
+
+    $value = $Entry.$Name
+    if ($null -eq $value -or [string]::IsNullOrWhiteSpace([string]$value)) {
+        throw "Leg manifest entry $Index is untagged: '$Name' is empty."
+    }
+
+    return ([string]$value).Trim()
+}
+
+function Get-RequiredSeconds {
+    param(
+        [Parameter(Mandatory)][object]$Entry,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][int]$Index
+    )
+
+    if ($Entry.PSObject.Properties.Name -notcontains $Name) {
+        throw "Leg manifest entry $Index is untagged: '$Name' is missing."
+    }
+
+    # A JSON number arrives already typed. Never round-trip it through the current culture's
+    # string form, which would emit a decimal comma an invariant parse then rejects.
+    $value = $Entry.$Name
+    [double]$seconds = 0
+    if ($value -is [double] -or $value -is [single] -or $value -is [decimal] -or
+        $value -is [int] -or $value -is [long]) {
+        $seconds = [double]$value
+    }
+    elseif ($null -ne $value -and
+            -not [string]::IsNullOrWhiteSpace([string]$value) -and
+            [double]::TryParse(
+                ([string]$value).Trim(),
+                [System.Globalization.NumberStyles]::Float,
+                $invariantCulture,
+                [ref]$seconds)) {
+        # Parsed from an invariant-formatted string.
+    }
+    else {
+        throw "Leg manifest entry $Index has a missing or unparsable '$Name'."
+    }
+
+    if ([double]::IsNaN($seconds) -or [double]::IsInfinity($seconds) -or $seconds -le 0) {
+        throw "Leg manifest entry $Index has a non-positive '$Name'."
+    }
+
+    return $seconds
+}
+
+function Read-TrxCaseDuration {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $settings = [System.Xml.XmlReaderSettings]::new()
+    $settings.DtdProcessing = [System.Xml.DtdProcessing]::Prohibit
+    $settings.XmlResolver = $null
+    $settings.IgnoreComments = $true
+
+    $document = [System.Xml.XmlDocument]::new()
+    $document.XmlResolver = $null
+    $reader = $null
+    try {
+        $reader = [System.Xml.XmlReader]::Create($Path, $settings)
+        $document.Load($reader)
+    }
+    catch {
+        throw 'Malformed MSTest TRX input.'
+    }
+    finally {
+        if ($null -ne $reader) {
+            $reader.Dispose()
+        }
+    }
+
+    if ($null -eq $document.DocumentElement -or
+        $document.DocumentElement.LocalName -ne 'TestRun') {
+        throw 'Input XML is not an MSTest TRX document.'
+    }
+
+    $definitions = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($unitTest in $document.SelectNodes(
+        "/*[local-name()='TestRun']/*[local-name()='TestDefinitions']/*[local-name()='UnitTest']")) {
+        $testId = $unitTest.GetAttribute('id')
+        if ([string]::IsNullOrWhiteSpace($testId)) {
+            throw 'Malformed MSTest TRX test definition.'
+        }
+        if (-not $definitions.Add($testId)) {
+            throw 'Malformed MSTest TRX contains duplicate test definitions.'
+        }
+    }
+
+    [long]$sumTicks = 0
+    [int]$caseCount = 0
+    foreach ($result in $document.SelectNodes(
+        "/*[local-name()='TestRun']/*[local-name()='Results']/*[local-name()='UnitTestResult']")) {
+        $testId = $result.GetAttribute('testId')
+        if ([string]::IsNullOrWhiteSpace($testId) -or -not $definitions.Contains($testId)) {
+            throw 'Malformed MSTest TRX result cannot be joined to a test definition.'
+        }
+
+        [TimeSpan]$duration = [TimeSpan]::Zero
+        $durationText = $result.GetAttribute('duration')
+        if (-not [string]::IsNullOrWhiteSpace($durationText) -and
+            -not [TimeSpan]::TryParse($durationText, $invariantCulture, [ref]$duration)) {
+            throw 'Malformed MSTest TRX result contains an invalid duration.'
+        }
+        if ($duration.Ticks -lt 0) {
+            throw 'Malformed MSTest TRX result contains a negative duration.'
+        }
+
+        $sumTicks += $duration.Ticks
+        $caseCount++
+    }
+
+    if ($caseCount -eq 0) {
+        throw "TRX file reports zero cases: '$Path'."
+    }
+
+    return [pscustomobject]@{
+        SumSeconds = $sumTicks / [double][TimeSpan]::TicksPerSecond
+        CaseCount = $caseCount
+    }
+}
+
+function Publish-Report {
+    param([Parameter(Mandatory)][string]$Markdown)
+
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+        [Console]::Out.WriteLine($Markdown)
+        return
+    }
+
+    $canonicalOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+    $outputDirectory = [System.IO.Path]::GetDirectoryName($canonicalOutputPath)
+    if (-not [string]::IsNullOrEmpty($outputDirectory)) {
+        [System.IO.Directory]::CreateDirectory($outputDirectory) | Out-Null
+    }
+
+    $prefix = if ([System.IO.File]::Exists($canonicalOutputPath) -and
+                  [System.IO.FileInfo]::new($canonicalOutputPath).Length -gt 0) {
+        [Environment]::NewLine
+    }
+    else {
+        ''
+    }
+    [System.IO.File]::AppendAllText(
+        $canonicalOutputPath,
+        $prefix + $Markdown.TrimEnd() + [Environment]::NewLine,
+        [System.Text.UTF8Encoding]::new($false))
+}
+
+if (-not (Test-Path -LiteralPath $ResultsRoot -PathType Container)) {
+    throw "ResultsRoot is not an existing directory: '$ResultsRoot'."
+}
+$canonicalResultsRoot = [System.IO.Path]::GetFullPath($ResultsRoot)
+$resultsRootPrefix = $canonicalResultsRoot.TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar) +
+    [System.IO.Path]::DirectorySeparatorChar
+
+if (-not (Test-Path -LiteralPath $LegManifest -PathType Leaf)) {
+    throw "LegManifest is not an existing file: '$LegManifest'."
+}
+
+try {
+    $manifestText = Get-Content -LiteralPath $LegManifest -Raw -Encoding UTF8
+    $manifest = @($manifestText | ConvertFrom-Json -ErrorAction Stop)
+}
+catch {
+    throw 'Leg manifest is not valid JSON.'
+}
+
+if ($manifest.Count -eq 0) {
+    throw 'Leg manifest contains no leg observations.'
+}
+
+$observations = [System.Collections.Generic.List[object]]::new()
+$seenPairs = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$legImages = [System.Collections.Generic.Dictionary[string, string]]::new(
+    [System.StringComparer]::Ordinal)
+
+for ($index = 0; $index -lt $manifest.Count; $index++) {
+    $entry = $manifest[$index]
+    if ($null -eq $entry -or $entry -isnot [System.Management.Automation.PSCustomObject]) {
+        throw "Leg manifest entry $index is not an object."
+    }
+
+    $runId = Get-RequiredText -Entry $entry -Name 'runId' -Index $index
+    $leg = Get-RequiredText -Entry $entry -Name 'leg' -Index $index
+    $image = Get-RequiredText -Entry $entry -Name 'image' -Index $index
+    $relativePath = Get-RequiredText -Entry $entry -Name 'path' -Index $index
+    $wallTimeSeconds = Get-RequiredSeconds -Entry $entry -Name 'wallTimeSeconds' -Index $index
+
+    if ($legImages.ContainsKey($leg)) {
+        if ($legImages[$leg] -cne $image) {
+            throw ("Leg '$leg' is claimed by two hosted images " +
+                   "('$($legImages[$leg])' and '$image'). Hosted images are never merged.")
+        }
+    }
+    else {
+        $legImages.Add($leg, $image)
+    }
+
+    $pairKey = $runId + [char]0 + $leg
+    if (-not $seenPairs.Add($pairKey)) {
+        throw "Duplicate leg observation for run '$runId' leg '$leg'."
+    }
+
+    if ([System.IO.Path]::IsPathRooted($relativePath)) {
+        throw "Leg manifest entry $index 'path' must be relative to ResultsRoot."
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::Combine($canonicalResultsRoot, $relativePath))
+    if (-not $resolvedPath.StartsWith($resultsRootPrefix, [System.StringComparison]::Ordinal)) {
+        throw "Leg manifest entry $index 'path' escapes ResultsRoot."
+    }
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Container)) {
+        throw "Leg manifest entry $index 'path' is not an existing directory: '$relativePath'."
+    }
+
+    $trxFiles = [System.Collections.Generic.List[string]]::new()
+    foreach ($file in Get-ChildItem -LiteralPath $resolvedPath -File -Recurse) {
+        if ([System.IO.Path]::GetExtension($file.Name).Equals(
+                '.trx',
+                [System.StringComparison]::OrdinalIgnoreCase)) {
+            $trxFiles.Add([System.IO.Path]::GetFullPath($file.FullName))
+        }
+    }
+    if ($trxFiles.Count -eq 0) {
+        throw "Leg manifest entry $index 'path' holds no TRX files: '$relativePath'."
+    }
+    $trxFiles.Sort([System.StringComparer]::Ordinal)
+
+    [double]$sumSeconds = 0
+    [int]$caseCount = 0
+    foreach ($trxFile in $trxFiles) {
+        $parsed = Read-TrxCaseDuration -Path $trxFile
+        $sumSeconds += $parsed.SumSeconds
+        $caseCount += $parsed.CaseCount
+    }
+
+    $observations.Add([pscustomobject]@{
+        RunId = $runId
+        Leg = $leg
+        Image = $image
+        WallTimeSeconds = $wallTimeSeconds
+        CaseDurationSeconds = $sumSeconds
+        CaseCount = $caseCount
+    })
+}
+
+$imageNames = [System.Collections.Generic.List[string]]::new()
+foreach ($observation in $observations) {
+    if (-not $imageNames.Contains($observation.Image)) {
+        $imageNames.Add($observation.Image)
+    }
+}
+$imageNames.Sort([System.StringComparer]::Ordinal)
+
+$lines = [System.Collections.Generic.List[string]]::new()
+$lines.Add('## Hosted shard timing evidence')
+$lines.Add('')
+$lines.Add("Minimum samples per hosted image: $MinimumSamples. Wall time and summed TRX case " +
+           'duration are reported separately and are not interchangeable.')
+
+foreach ($imageName in $imageNames) {
+    $imageObservations = @($observations | Where-Object { $_.Image -ceq $imageName })
+
+    $runIds = [System.Collections.Generic.List[string]]::new()
+    foreach ($observation in $imageObservations) {
+        if (-not $runIds.Contains($observation.RunId)) {
+            $runIds.Add($observation.RunId)
+        }
+    }
+    $runIds.Sort([System.StringComparer]::Ordinal)
+
+    if ($runIds.Count -lt $MinimumSamples) {
+        throw ("Hosted image '$imageName' has $($runIds.Count) sampled runs, below the " +
+               "required minimum of $MinimumSamples.")
+    }
+
+    $legNames = [System.Collections.Generic.List[string]]::new()
+    foreach ($observation in $imageObservations) {
+        if (-not $legNames.Contains($observation.Leg)) {
+            $legNames.Add($observation.Leg)
+        }
+    }
+    $legNames.Sort([System.StringComparer]::Ordinal)
+
+    foreach ($runId in $runIds) {
+        foreach ($legName in $legNames) {
+            $present = @($imageObservations | Where-Object {
+                $_.RunId -ceq $runId -and $_.Leg -ceq $legName
+            })
+            if ($present.Count -ne 1) {
+                throw ("Run '$runId' is missing leg '$legName' of hosted image '$imageName'. " +
+                       'Every sampled run must carry the complete leg set for its image.')
+            }
+        }
+    }
+
+    $legStatistics = [System.Collections.Generic.List[object]]::new()
+    foreach ($legName in $legNames) {
+        $legObservations = @($imageObservations | Where-Object { $_.Leg -ceq $legName })
+        $wallValues = @($legObservations | ForEach-Object { $_.WallTimeSeconds })
+        $caseDurationValues = @($legObservations | ForEach-Object { $_.CaseDurationSeconds })
+        $caseCountValues = @($legObservations | ForEach-Object { $_.CaseCount })
+
+        $wallMinimum = ($wallValues | Measure-Object -Minimum).Minimum
+        $wallMaximum = ($wallValues | Measure-Object -Maximum).Maximum
+        $caseDurationMinimum = ($caseDurationValues | Measure-Object -Minimum).Minimum
+        $caseDurationMaximum = ($caseDurationValues | Measure-Object -Maximum).Maximum
+
+        $legStatistics.Add([pscustomobject]@{
+            Leg = $legName
+            Runs = $legObservations.Count
+            WallMean = ($wallValues | Measure-Object -Average).Average
+            WallMinimum = $wallMinimum
+            WallMaximum = $wallMaximum
+            WallSpread = if ($wallMinimum -gt 0) {
+                $wallMaximum / $wallMinimum
+            }
+            else {
+                [double]::PositiveInfinity
+            }
+            CaseDurationMean = ($caseDurationValues | Measure-Object -Average).Average
+            CaseDurationMinimum = $caseDurationMinimum
+            CaseDurationMaximum = $caseDurationMaximum
+            CaseDurationSpread = if ($caseDurationMinimum -gt 0) {
+                $caseDurationMaximum / $caseDurationMinimum
+            }
+            else {
+                [double]::PositiveInfinity
+            }
+            CaseCountMinimum = ($caseCountValues | Measure-Object -Minimum).Minimum
+            CaseCountMaximum = ($caseCountValues | Measure-Object -Maximum).Maximum
+        })
+    }
+
+    $perRunCriticalPath = [System.Collections.Generic.List[double]]::new()
+    $perRunBalancedFloor = [System.Collections.Generic.List[double]]::new()
+    foreach ($runId in $runIds) {
+        $runWallValues = @($imageObservations |
+            Where-Object { $_.RunId -ceq $runId } |
+            ForEach-Object { $_.WallTimeSeconds })
+        $perRunCriticalPath.Add(($runWallValues | Measure-Object -Maximum).Maximum)
+        $perRunBalancedFloor.Add(($runWallValues | Measure-Object -Average).Average)
+    }
+
+    $criticalPathMean = ($perRunCriticalPath | Measure-Object -Average).Average
+    $balancedFloorMean = ($perRunBalancedFloor | Measure-Object -Average).Average
+    $achievableGain = $criticalPathMean - $balancedFloorMean
+    $achievableGainShare = if ($criticalPathMean -gt 0) {
+        100.0 * $achievableGain / $criticalPathMean
+    }
+    else {
+        0.0
+    }
+
+    $noiseBand = (@($legStatistics | ForEach-Object {
+        ($_.WallMaximum - $_.WallMinimum) / 2.0
+    }) | Measure-Object -Average).Average
+
+    $caseDurationMeans = @($legStatistics | ForEach-Object { $_.CaseDurationMean })
+    $caseDurationMeanMinimum = ($caseDurationMeans | Measure-Object -Minimum).Minimum
+    $betweenLegCaseSpread = if ($caseDurationMeanMinimum -gt 0) {
+        ($caseDurationMeans | Measure-Object -Maximum).Maximum / $caseDurationMeanMinimum
+    }
+    else {
+        [double]::PositiveInfinity
+    }
+    $worstSameLegCaseSpread = (@($legStatistics |
+        ForEach-Object { $_.CaseDurationSpread }) | Measure-Object -Maximum).Maximum
+
+    $caseDurationIsUsable = $worstSameLegCaseSpread -lt $betweenLegCaseSpread
+    $gainExceedsNoise = $achievableGain -gt $noiseBand
+    $adoptDurationWeights = $caseDurationIsUsable -and $gainExceedsNoise
+
+    $lines.Add('')
+    $lines.Add("### $imageName")
+    $lines.Add('')
+    $lines.Add("Sampled runs: $($runIds.Count). Legs: $($legNames.Count).")
+    $lines.Add('')
+    $lines.Add('| Leg | Runs | Wall mean (s) | Wall min (s) | Wall max (s) | Wall spread | ' +
+               'Case duration mean (s) | Case duration min (s) | Case duration max (s) | ' +
+               'Case duration spread | Cases |')
+    $lines.Add('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |')
+    foreach ($statistic in $legStatistics) {
+        $caseCountText = if ($statistic.CaseCountMinimum -eq $statistic.CaseCountMaximum) {
+            [string]$statistic.CaseCountMinimum
+        }
+        else {
+            "$($statistic.CaseCountMinimum)-$($statistic.CaseCountMaximum)"
+        }
+        $lines.Add(
+            "| $($statistic.Leg) | $($statistic.Runs) | " +
+            "$(Format-Seconds $statistic.WallMean) | " +
+            "$(Format-Seconds $statistic.WallMinimum) | " +
+            "$(Format-Seconds $statistic.WallMaximum) | " +
+            "$(Format-Ratio $statistic.WallSpread) | " +
+            "$(Format-Seconds $statistic.CaseDurationMean) | " +
+            "$(Format-Seconds $statistic.CaseDurationMinimum) | " +
+            "$(Format-Seconds $statistic.CaseDurationMaximum) | " +
+            "$(Format-Ratio $statistic.CaseDurationSpread) | $caseCountText |")
+    }
+    $lines.Add('')
+    $lines.Add('| Image metric | Value |')
+    $lines.Add('| --- | ---: |')
+    $lines.Add("| Critical path, mean slowest leg | $(Format-Seconds $criticalPathMean) s |")
+    $lines.Add("| Balanced floor, mean leg average | $(Format-Seconds $balancedFloorMean) s |")
+    $lines.Add("| Achievable gain from a perfect partition | " +
+               "$(Format-Seconds $achievableGain) s " +
+               "($($achievableGainShare.ToString('0.0', $invariantCulture))%) |")
+    $lines.Add("| Single-leg wall-time noise band | $(Format-Seconds $noiseBand) s |")
+    $lines.Add("| Worst same-leg case-duration spread | $(Format-Ratio $worstSameLegCaseSpread) |")
+    $lines.Add("| Between-leg case-duration spread | $(Format-Ratio $betweenLegCaseSpread) |")
+    $lines.Add('')
+
+    if ($caseDurationIsUsable) {
+        $lines.Add('- Summed TRX case duration is reproducible enough on this image to rank legs.')
+    }
+    else {
+        $lines.Add('- Summed TRX case duration is NOT a partition signal for this image: the ' +
+                   'same-leg run-to-run swing meets or exceeds the between-leg spread.')
+    }
+
+    if ($gainExceedsNoise) {
+        $lines.Add('- The achievable gain from a perfect duration partition exceeds the ' +
+                   'single-leg wall-time noise band.')
+    }
+    else {
+        $lines.Add('- The achievable gain from a perfect duration partition does not exceed the ' +
+                   'single-leg wall-time noise band.')
+    }
+
+    $lines.Add('')
+    if ($adoptDurationWeights) {
+        $lines.Add("**Verdict for ${imageName}: material skew. An OS-specific duration profile is " +
+                   'warranted.**')
+    }
+    else {
+        $lines.Add("**Verdict for ${imageName}: no material skew. Keep the deterministic " +
+                   'discovered-case weights in `eng/get-test-shard-plan.ps1`.**')
+    }
+}
+
+Publish-Report -Markdown ($lines -join [Environment]::NewLine)

--- a/eng/collect-hosted-shard-timings.ps1
+++ b/eng/collect-hosted-shard-timings.ps1
@@ -23,6 +23,9 @@ Fail-closed rules (each throws rather than degrading):
   - a duplicate run id + leg pair
   - a manifest path that escapes ResultsRoot, is absent, or holds no TRX
 
+The Markdown report is written to stdout. Redirect it if you want it in a file; this script never
+writes to a path you give it, so it can never append into its own downloaded TRX input.
+
 .PARAMETER ResultsRoot
 Directory holding the downloaded `test-results-<leg>` folders. Every manifest path resolves
 beneath it.
@@ -46,10 +49,6 @@ into a hosted image profile.
 .PARAMETER MinimumSamples
 Minimum distinct runs required per hosted image. Defaults to 5.
 
-.PARAMETER OutputPath
-When omitted, Markdown goes to stdout. When provided, one complete report is appended in UTF-8
-so an existing summary is preserved.
-
 .EXAMPLE
 pwsh -NoProfile -File ./eng/collect-hosted-shard-timings.ps1 -ResultsRoot ./downloads -LegManifest ./downloads/legs.json
 #>
@@ -62,9 +61,7 @@ param(
     [string]$LegManifest,
 
     [ValidateRange(1, 1000)]
-    [int]$MinimumSamples = 5,
-
-    [string]$OutputPath
+    [int]$MinimumSamples = 5
 )
 
 Set-StrictMode -Version Latest
@@ -219,33 +216,6 @@ function Read-TrxCaseDuration {
         SumSeconds = $sumTicks / [double][TimeSpan]::TicksPerSecond
         CaseCount = $caseCount
     }
-}
-
-function Publish-Report {
-    param([Parameter(Mandatory)][string]$Markdown)
-
-    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
-        [Console]::Out.WriteLine($Markdown)
-        return
-    }
-
-    $canonicalOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
-    $outputDirectory = [System.IO.Path]::GetDirectoryName($canonicalOutputPath)
-    if (-not [string]::IsNullOrEmpty($outputDirectory)) {
-        [System.IO.Directory]::CreateDirectory($outputDirectory) | Out-Null
-    }
-
-    $prefix = if ([System.IO.File]::Exists($canonicalOutputPath) -and
-                  [System.IO.FileInfo]::new($canonicalOutputPath).Length -gt 0) {
-        [Environment]::NewLine
-    }
-    else {
-        ''
-    }
-    [System.IO.File]::AppendAllText(
-        $canonicalOutputPath,
-        $prefix + $Markdown.TrimEnd() + [Environment]::NewLine,
-        [System.Text.UTF8Encoding]::new($false))
 }
 
 if (-not (Test-Path -LiteralPath $ResultsRoot -PathType Container)) {
@@ -417,12 +387,9 @@ foreach ($imageName in $imageNames) {
             WallMean = ($wallValues | Measure-Object -Average).Average
             WallMinimum = $wallMinimum
             WallMaximum = $wallMaximum
-            WallSpread = if ($wallMinimum -gt 0) {
-                $wallMaximum / $wallMinimum
-            }
-            else {
-                [double]::PositiveInfinity
-            }
+            # Get-RequiredSeconds rejects a non-positive wall time, so the minimum is always
+            # positive and this division needs no zero guard.
+            WallSpread = $wallMaximum / $wallMinimum
             CaseDurationMean = ($caseDurationValues | Measure-Object -Average).Average
             CaseDurationMinimum = $caseDurationMinimum
             CaseDurationMaximum = $caseDurationMaximum
@@ -450,12 +417,8 @@ foreach ($imageName in $imageNames) {
     $criticalPathMean = ($perRunCriticalPath | Measure-Object -Average).Average
     $balancedFloorMean = ($perRunBalancedFloor | Measure-Object -Average).Average
     $achievableGain = $criticalPathMean - $balancedFloorMean
-    $achievableGainShare = if ($criticalPathMean -gt 0) {
-        100.0 * $achievableGain / $criticalPathMean
-    }
-    else {
-        0.0
-    }
+    # Every wall time is positive (Get-RequiredSeconds), so the mean slowest leg is too.
+    $achievableGainShare = 100.0 * $achievableGain / $criticalPathMean
 
     $noiseBand = (@($legStatistics | ForEach-Object {
         ($_.WallMaximum - $_.WallMinimum) / 2.0
@@ -544,4 +507,4 @@ foreach ($imageName in $imageNames) {
     }
 }
 
-Publish-Report -Markdown ($lines -join [Environment]::NewLine)
+[Console]::Out.WriteLine($lines -join [Environment]::NewLine)

--- a/eng/collect-hosted-shard-timings.ps1
+++ b/eng/collect-hosted-shard-timings.ps1
@@ -143,6 +143,24 @@ function Get-RequiredSeconds {
     return $seconds
 }
 
+function ConvertTo-ReportCell {
+    <#
+    .SYNOPSIS
+    Escape a manifest-supplied value for safe placement in Markdown.
+
+    .DESCRIPTION
+    Leg and image names come from the caller's manifest, so an unescaped pipe would silently add a
+    column and corrupt the report table. Mirrors ConvertTo-MarkdownCell in
+    eng/summarize-test-results.ps1 so both reports sanitize identically.
+    #>
+    param([AllowEmptyString()][string]$Value)
+
+    $sanitized = $Value.Replace('\', '\\').Replace('|', '\|')
+    $sanitized = [System.Text.RegularExpressions.Regex]::Replace($sanitized, '[\x00-\x1F\x7F]+', ' ')
+    $sanitized = [System.Text.RegularExpressions.Regex]::Replace($sanitized, '\s{2,}', ' ')
+    return $sanitized.Trim()
+}
+
 function Read-TrxCaseDuration {
     param([Parameter(Mandatory)][string]$Path)
 
@@ -159,7 +177,10 @@ function Read-TrxCaseDuration {
         $document.Load($reader)
     }
     catch {
-        throw 'Malformed MSTest TRX input.'
+        # Name the file and the underlying cause: one invocation reads every leg of every sampled
+        # run, so a bare "malformed" verdict cannot be acted on, and a locked or permission-denied
+        # file would otherwise be reported as malformed content.
+        throw "Malformed MSTest TRX input '$Path': $($_.Exception.Message)"
     }
     finally {
         if ($null -ne $reader) {
@@ -440,7 +461,7 @@ foreach ($imageName in $imageNames) {
     $adoptDurationWeights = $caseDurationIsUsable -and $gainExceedsNoise
 
     $lines.Add('')
-    $lines.Add("### $imageName")
+    $lines.Add("### $(ConvertTo-ReportCell $imageName)")
     $lines.Add('')
     $lines.Add("Sampled runs: $($runIds.Count). Legs: $($legNames.Count).")
     $lines.Add('')
@@ -456,7 +477,7 @@ foreach ($imageName in $imageNames) {
             "$($statistic.CaseCountMinimum)-$($statistic.CaseCountMaximum)"
         }
         $lines.Add(
-            "| $($statistic.Leg) | $($statistic.Runs) | " +
+            "| $(ConvertTo-ReportCell $statistic.Leg) | $($statistic.Runs) | " +
             "$(Format-Seconds $statistic.WallMean) | " +
             "$(Format-Seconds $statistic.WallMinimum) | " +
             "$(Format-Seconds $statistic.WallMaximum) | " +
@@ -498,11 +519,11 @@ foreach ($imageName in $imageNames) {
 
     $lines.Add('')
     if ($adoptDurationWeights) {
-        $lines.Add("**Verdict for ${imageName}: material skew. An OS-specific duration profile is " +
+        $lines.Add("**Verdict for $(ConvertTo-ReportCell $imageName): material skew. An OS-specific duration profile is " +
                    'warranted.**')
     }
     else {
-        $lines.Add("**Verdict for ${imageName}: no material skew. Keep the deterministic " +
+        $lines.Add("**Verdict for $(ConvertTo-ReportCell $imageName): no material skew. Keep the deterministic " +
                    'discovered-case weights in `eng/get-test-shard-plan.ps1`.**')
     }
 }

--- a/eng/collect-hosted-shard-timings.ps1
+++ b/eng/collect-hosted-shard-timings.ps1
@@ -150,15 +150,31 @@ function ConvertTo-ReportCell {
 
     .DESCRIPTION
     Leg and image names come from the caller's manifest, so an unescaped pipe would silently add a
-    column and corrupt the report table. Mirrors ConvertTo-MarkdownCell in
-    eng/summarize-test-results.ps1 so both reports sanitize identically.
+    column and corrupt the report table. Mirrors the escaping, empty-value fallback and length cap of
+    ConvertTo-MarkdownCell in eng/summarize-test-results.ps1.
+
+    Deliberate divergence: that function also HtmlEncodes, because its output is injected into a
+    GitHub job summary. This report is plain Markdown written to stdout, where HTML-encoding a legal
+    character would corrupt the value rather than protect it.
     #>
     param([AllowEmptyString()][string]$Value)
 
     $sanitized = $Value.Replace('\', '\\').Replace('|', '\|')
     $sanitized = [System.Text.RegularExpressions.Regex]::Replace($sanitized, '[\x00-\x1F\x7F]+', ' ')
     $sanitized = [System.Text.RegularExpressions.Regex]::Replace($sanitized, '\s{2,}', ' ')
-    return $sanitized.Trim()
+    $sanitized = $sanitized.Trim()
+    if ([string]::IsNullOrEmpty($sanitized)) {
+        # A control-character-only name survives Get-RequiredText but would render an empty heading
+        # or an empty cell, which reads as a collector bug rather than a bad manifest.
+        return '(unnamed)'
+    }
+
+    $maximumCellLength = 240
+    if ($sanitized.Length -gt $maximumCellLength) {
+        $sanitized = $sanitized.Substring(0, $maximumCellLength - 3) + '...'
+    }
+
+    return $sanitized
 }
 
 function Read-TrxCaseDuration {

--- a/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
+++ b/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
@@ -342,23 +342,36 @@ public sealed class TestResultsSummaryContractTests
     }
 
     [TestMethod]
-    public void NormalizeConsoleDiagnostic_ReassemblesAPowerShellWrappedError()
+    public void NormalizeConsoleDiagnostic_ReassemblesAPowerShellConciseViewError()
     {
-        // Captured verbatim from the hosted ubuntu-latest leg of run 33690371287, where PowerShell's
-        // error formatter wrapped the collector's minimum-samples diagnostic across two
-        // gutter-prefixed lines. The Windows console rendered the same message on one line, so every
-        // local gate passed while CI went red. Asserting on the raw text makes a fail-closed
-        // regression depend on the terminal that happened to run it.
-        const string wrapped =
+        // The full frame PowerShell's ConciseView emits for an uncaught throw, reproduced by running
+        // `pwsh -NoProfile -NonInteractive -File` against a throwing script and capturing the redirected
+        // stream: an "Exception:" header, a "Line |" header, the echoed source line, a squiggle, then
+        // the message behind a gutter. The message is shown wrapped as the hosted ubuntu-latest leg
+        // rendered it at width 80; a wider Windows console emits the same message on one line, which is
+        // why run 33690371287 was red in CI and green on every local gate.
+        const string conciseView =
             "\u001B[31;1mException: \u001B[0m/home/runner/work/eng/collect-hosted-shard-timings.ps1:369\u001B[0m\n"
-            + "\u001B[31;1m\u001B[0m\u001B[36;1m     | \u001B[31;1mHosted image 'windows-latest' has 4 sampled runs, below the required\u001B[0m\n"
-            + "\u001B[31;1m\u001B[0m\u001B[36;1m     | \u001B[31;1mminimum of 5.\u001B[0m\n";
+            + "\u001B[36;1mLine |\u001B[0m\n"
+            + "\u001B[36;1m 369 | \u001B[0m         \u001B[36;1mthrow (\"Hosted image '$imageName' has $($runIds.Count) sample\u001B[0m …\n"
+            + "\u001B[36;1m     | \u001B[31;1m         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\u001B[0m\n"
+            + "\u001B[36;1m     | \u001B[31;1mHosted image 'windows-latest' has 4 sampled runs, below the required\u001B[0m\n"
+            + "\u001B[36;1m     | \u001B[31;1mminimum of 5.\u001B[0m\n";
 
-        var normalized = NormalizeConsoleDiagnostic(wrapped);
+        var normalized = NormalizeConsoleDiagnostic(conciseView);
 
+        // The wrapped message is reassembled...
         StringAssert.Contains(normalized, "has 4 sampled runs, below the required minimum of 5");
+
+        // ...and the whole ConciseView frame is gone, including the echoed source line. That echo
+        // matters: it contains the throw statement's own text, so leaving it in would let an
+        // assertion pass on the source rather than on the rendered message.
         Assert.IsFalse(normalized.Contains('\u001B'), "ANSI escapes must not survive normalization.");
-        Assert.IsFalse(normalized.Contains(" | "), "The error-formatter gutter must not survive normalization.");
+        Assert.IsFalse(normalized.Contains('|'), $"No ConciseView gutter may survive: {normalized}");
+        Assert.IsFalse(
+            normalized.Contains("$imageName", StringComparison.Ordinal),
+            $"The echoed source line must not survive: {normalized}");
+        Assert.IsFalse(normalized.Contains('~'), $"The squiggle row must not survive: {normalized}");
     }
     [TestMethod]
     public async Task Collector_LegAndImageNamesWithMarkdownDelimiters_AreEscapedInReportAsync()
@@ -409,6 +422,50 @@ public sealed class TestResultsSummaryContractTests
                     CountMarkdownCells(row),
                     $"Row lost or gained a column: {row}");
             }
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+    [TestMethod]
+    public async Task Collector_DegenerateManifestNames_FallBackAndAreLengthCappedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            // A control-character-only name survives Get-RequiredText's non-empty check but sanitizes
+            // to nothing, and an unbounded name would stretch a table cell without limit. Both are
+            // manifest-supplied, so the report must degrade visibly rather than emit an empty heading.
+            var longLeg = new string('w', 400);
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (manifest, _) =>
+                {
+                    foreach (var entry in manifest)
+                    {
+                        entry["image"] = "\u0001\u0002";
+                        if ((string)entry["leg"] == "w-1")
+                        {
+                            entry["leg"] = longLeg;
+                        }
+                    }
+                });
+
+            AssertSucceeded(result);
+            StringAssert.Contains(result.StdOut, "### (unnamed)");
+            Assert.IsFalse(
+                result.StdOut.Contains("### \n", StringComparison.Ordinal),
+                "A sanitized-to-empty image name must not render an empty heading.");
+
+            var cappedRow = result.StdOut
+                .Split('\n')
+                .Select(static line => line.Trim())
+                .Single(static line => line.StartsWith("| www", StringComparison.Ordinal));
+            var legCell = cappedRow.Split('|')[1].Trim();
+            Assert.EndsWith("...", legCell);
+            Assert.AreEqual(240, legCell.Length, $"Leg cell was not capped: {legCell.Length} chars.");
         }
         finally
         {
@@ -698,9 +755,19 @@ public sealed class TestResultsSummaryContractTests
     /// </remarks>
     private static string NormalizeConsoleDiagnostic(string text)
     {
-        var withoutAnsi = Regex.Replace(text, @"\x1B\[[0-9;]*[A-Za-z]", string.Empty);
-        var withoutGutter = Regex.Replace(withoutAnsi, @"(?m)^\s*\|\s?", string.Empty);
-        return Regex.Replace(withoutGutter, @"\s+", " ").Trim();
+        var normalized = Regex.Replace(text, @"\x1B\[[0-9;]*[A-Za-z]", string.Empty);
+
+        // Drop ConciseView's frame in the order it renders: the "Line |" header, the "   N | <source>"
+        // echo, and the "     | ~~~~" squiggle. Removing the source echo also stops an assertion from
+        // being satisfied by the text of the `throw` statement itself rather than by the message it
+        // produced.
+        normalized = Regex.Replace(normalized, @"(?m)^\s*Line\s*\|\s*$", string.Empty);
+        normalized = Regex.Replace(normalized, @"(?m)^\s*\d+\s*\|.*$", string.Empty);
+        normalized = Regex.Replace(normalized, @"(?m)^\s*\|\s*~+\s*$", string.Empty);
+
+        // What remains of the message is gutter-prefixed and hard-wrapped at the console width.
+        normalized = Regex.Replace(normalized, @"(?m)^\s*\|\s?", string.Empty);
+        return Regex.Replace(normalized, @"\s+", " ").Trim();
     }
 
     private const string FirstTrx = """

--- a/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
+++ b/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using RoslynMcp.Tests.Helpers;
 
 namespace RoslynMcp.Tests;
@@ -332,7 +333,7 @@ public sealed class TestResultsSummaryContractTests
             // The collector reads every leg of every sampled run, so the diagnostic must name the
             // offending file rather than just declaring "malformed".
             AssertFailedWith(result, "Malformed MSTest TRX input '");
-            StringAssert.Contains(result.StdOut + result.StdErr, "results.trx");
+            StringAssert.Contains(NormalizeConsoleDiagnostic(result.StdOut + result.StdErr), "results.trx");
         }
         finally
         {
@@ -340,6 +341,25 @@ public sealed class TestResultsSummaryContractTests
         }
     }
 
+    [TestMethod]
+    public void NormalizeConsoleDiagnostic_ReassemblesAPowerShellWrappedError()
+    {
+        // Captured verbatim from the hosted ubuntu-latest leg of run 33690371287, where PowerShell's
+        // error formatter wrapped the collector's minimum-samples diagnostic across two
+        // gutter-prefixed lines. The Windows console rendered the same message on one line, so every
+        // local gate passed while CI went red. Asserting on the raw text makes a fail-closed
+        // regression depend on the terminal that happened to run it.
+        const string wrapped =
+            "\u001B[31;1mException: \u001B[0m/home/runner/work/eng/collect-hosted-shard-timings.ps1:369\u001B[0m\n"
+            + "\u001B[31;1m\u001B[0m\u001B[36;1m     | \u001B[31;1mHosted image 'windows-latest' has 4 sampled runs, below the required\u001B[0m\n"
+            + "\u001B[31;1m\u001B[0m\u001B[36;1m     | \u001B[31;1mminimum of 5.\u001B[0m\n";
+
+        var normalized = NormalizeConsoleDiagnostic(wrapped);
+
+        StringAssert.Contains(normalized, "has 4 sampled runs, below the required minimum of 5");
+        Assert.IsFalse(normalized.Contains('\u001B'), "ANSI escapes must not survive normalization.");
+        Assert.IsFalse(normalized.Contains(" | "), "The error-formatter gutter must not survive normalization.");
+    }
     [TestMethod]
     public async Task Collector_LegAndImageNamesWithMarkdownDelimiters_AreEscapedInReportAsync()
     {
@@ -660,7 +680,27 @@ public sealed class TestResultsSummaryContractTests
             0,
             result.ExitCode,
             $"Script unexpectedly succeeded. stdout={result.StdOut} stderr={result.StdErr}");
-        StringAssert.Contains(result.StdOut + result.StdErr, expectedDiagnostic);
+        StringAssert.Contains(
+            NormalizeConsoleDiagnostic(result.StdOut + result.StdErr),
+            NormalizeConsoleDiagnostic(expectedDiagnostic));
+    }
+
+    /// <summary>
+    /// Reduces PowerShell's rendered error output to the diagnostic's semantic content.
+    /// </summary>
+    /// <remarks>
+    /// An uncaught <c>throw</c> is printed through PowerShell's error formatter, which adds ANSI
+    /// colour codes and hard-wraps the message at the host's console width behind a <c>"     | "</c>
+    /// gutter. That width differs between a developer's Windows console and the hosted Linux leg, so
+    /// a diagnostic that matches as one contiguous substring locally can be split mid-sentence in CI
+    /// — which is exactly how this suite went green on Windows and red on ubuntu-latest. Assertions
+    /// must compare what the script said, not how a terminal happened to lay it out.
+    /// </remarks>
+    private static string NormalizeConsoleDiagnostic(string text)
+    {
+        var withoutAnsi = Regex.Replace(text, @"\x1B\[[0-9;]*[A-Za-z]", string.Empty);
+        var withoutGutter = Regex.Replace(withoutAnsi, @"(?m)^\s*\|\s?", string.Empty);
+        return Regex.Replace(withoutGutter, @"\s+", " ").Trim();
     }
 
     private const string FirstTrx = """

--- a/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
+++ b/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
@@ -329,7 +329,10 @@ public sealed class TestResultsSummaryContractTests
                     Path.Combine(resultsRoot, "r1", "test-results-w-1", "results.trx"),
                     "<TestRun><Results>"));
 
-            AssertFailedWith(result, "Malformed MSTest TRX input.");
+            // The collector reads every leg of every sampled run, so the diagnostic must name the
+            // offending file rather than just declaring "malformed".
+            AssertFailedWith(result, "Malformed MSTest TRX input '");
+            StringAssert.Contains(result.StdOut + result.StdErr, "results.trx");
         }
         finally
         {
@@ -337,6 +340,61 @@ public sealed class TestResultsSummaryContractTests
         }
     }
 
+    [TestMethod]
+    public async Task Collector_LegAndImageNamesWithMarkdownDelimiters_AreEscapedInReportAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            // Leg and image names are manifest-supplied. The leg is what lands in a table CELL, so
+            // an unescaped pipe there silently adds a column and corrupts the row; the image is what
+            // lands in the heading and verdict. Both must be escaped, as
+            // eng/summarize-test-results.ps1 already does for its own cells. The manifest's "leg" is
+            // independent of its "path", so the pipe can be injected without touching the on-disk
+            // directory name.
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (manifest, _) =>
+                {
+                    foreach (var entry in manifest)
+                    {
+                        entry["leg"] = ((string)entry["leg"]).Replace("w-", "w|");
+                        entry["image"] = "windows|latest";
+                    }
+                });
+
+            AssertSucceeded(result);
+            StringAssert.Contains(result.StdOut, @"### windows\|latest");
+            StringAssert.Contains(result.StdOut, @"**Verdict for windows\|latest:");
+            StringAssert.Contains(result.StdOut, @"| w\|1 |");
+
+            // Every data row must still carry the columns the header declares. The count is derived
+            // from the header rather than hard-coded so the assertion cannot rot when a column is
+            // added, and it is precisely the property an unescaped pipe would break.
+            var reportLines = result.StdOut
+                .Split('\n')
+                .Select(static line => line.Trim())
+                .ToArray();
+            var headerColumns = CountMarkdownCells(
+                reportLines.Single(static line => line.StartsWith("| Leg | Runs |", StringComparison.Ordinal)));
+            var dataRows = reportLines
+                .Where(static line => line.StartsWith(@"| w\|", StringComparison.Ordinal))
+                .ToArray();
+            Assert.HasCount(2, dataRows);
+            foreach (var row in dataRows)
+            {
+                Assert.AreEqual(
+                    headerColumns,
+                    CountMarkdownCells(row),
+                    $"Row lost or gained a column: {row}");
+            }
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
     [TestMethod]
     public async Task Collector_ValidProfile_ReportsBothMetricsSeparatelyAndNeverMergesImagesAsync()
     {
@@ -437,6 +495,24 @@ public sealed class TestResultsSummaryContractTests
         int WallTimeSeconds,
         int CaseDurationSeconds);
 
+    /// <summary>
+    /// Counts the cell delimiters in a Markdown table row. Only UNESCAPED pipes split a row: a
+    /// "\|" renders as a literal pipe inside one cell, so a naive Split('|') would report an
+    /// escaped value as an extra column and invert the property under test.
+    /// </summary>
+    private static int CountMarkdownCells(string row)
+    {
+        var delimiters = 0;
+        for (var i = 0; i < row.Length; i++)
+        {
+            if (row[i] == '|' && (i == 0 || row[i - 1] != '\\'))
+            {
+                delimiters++;
+            }
+        }
+
+        return delimiters;
+    }
     private static string ExtractImageSection(string report, string imageName)
     {
         var marker = "### " + imageName;

--- a/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
+++ b/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json;
 using RoslynMcp.Tests.Helpers;
 
 namespace RoslynMcp.Tests;
@@ -119,6 +121,254 @@ public sealed class TestResultsSummaryContractTests
 
         AssertSucceeded(result);
     }
+
+    [TestMethod]
+    public async Task Collector_UnderMinimumSamples_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var observations = new List<LegObservation>();
+            for (var run = 1; run <= 4; run++)
+            {
+                observations.Add(new LegObservation($"r{run}", "w-1", "windows-latest", 100, 10));
+                observations.Add(new LegObservation($"r{run}", "w-2", "windows-latest", 200, 40));
+            }
+
+            var result = await RunCollectorAsync(fixtureRoot, observations);
+
+            AssertFailedWith(
+                result,
+                "has 4 sampled runs, below the required minimum of 5");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_LegClaimedByTwoImages_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var observations = new List<LegObservation>();
+            for (var run = 1; run <= 5; run++)
+            {
+                var image = run == 3 ? "ubuntu-latest" : "windows-latest";
+                observations.Add(new LegObservation($"r{run}", "w-1", image, 100, 10));
+            }
+
+            var result = await RunCollectorAsync(fixtureRoot, observations);
+
+            AssertFailedWith(result, "is claimed by two hosted images");
+            StringAssert.Contains(
+                result.StdOut + result.StdErr,
+                "Hosted images are never merged.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_RunMissingOneLegOfItsImage_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var observations = new List<LegObservation>();
+            for (var run = 1; run <= 5; run++)
+            {
+                observations.Add(new LegObservation($"r{run}", "w-1", "windows-latest", 100, 10));
+                if (run != 3)
+                {
+                    observations.Add(
+                        new LegObservation($"r{run}", "w-2", "windows-latest", 200, 40));
+                }
+            }
+
+            var result = await RunCollectorAsync(fixtureRoot, observations);
+
+            AssertFailedWith(
+                result,
+                "Run 'r3' is missing leg 'w-2' of hosted image 'windows-latest'.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_ValidProfile_ReportsBothMetricsSeparatelyAndNeverMergesImagesAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var observations = new List<LegObservation>();
+            for (var run = 1; run <= 5; run++)
+            {
+                observations.Add(new LegObservation($"r{run}", "w-1", "windows-latest", 100, 10));
+                observations.Add(new LegObservation($"r{run}", "w-2", "windows-latest", 200, 40));
+                observations.Add(new LegObservation($"r{run}", "u-1", "ubuntu-latest", 300, 70));
+            }
+
+            var result = await RunCollectorAsync(fixtureRoot, observations);
+
+            AssertSucceeded(result);
+            Assert.AreEqual(string.Empty, result.StdErr);
+
+            // Wall time and summed case duration must land in distinct columns, never one blended
+            // number: 100s wall against 10.0s of cases, and 200s wall against 40.0s of cases.
+            StringAssert.Contains(
+                result.StdOut,
+                "| w-1 | 5 | 100.0 | 100.0 | 100.0 | 1.00x | 10.0 | 10.0 | 10.0 | 1.00x | 2 |");
+            StringAssert.Contains(
+                result.StdOut,
+                "| w-2 | 5 | 200.0 | 200.0 | 200.0 | 1.00x | 40.0 | 40.0 | 40.0 | 1.00x | 2 |");
+            StringAssert.Contains(
+                result.StdOut,
+                "| Achievable gain from a perfect partition | 50.0 s (25.0%) |");
+
+            var windowsSection = ExtractImageSection(result.StdOut, "windows-latest");
+            var ubuntuSection = ExtractImageSection(result.StdOut, "ubuntu-latest");
+            Assert.IsFalse(
+                windowsSection.Contains("| u-1 |", StringComparison.Ordinal),
+                "Hosted images must never be merged into one profile.");
+            Assert.IsFalse(
+                ubuntuSection.Contains("| w-1 |", StringComparison.Ordinal),
+                "Hosted images must never be merged into one profile.");
+            StringAssert.Contains(windowsSection, "Sampled runs: 5. Legs: 2.");
+            StringAssert.Contains(ubuntuSection, "Sampled runs: 5. Legs: 1.");
+
+            // Reproducible per-leg case duration plus a gain above the noise band adopts;
+            // a single-leg image has no skew to exploit and keeps the static weights.
+            StringAssert.Contains(
+                windowsSection,
+                "**Verdict for windows-latest: material skew.");
+            StringAssert.Contains(
+                ubuntuSection,
+                "**Verdict for ubuntu-latest: no material skew.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task CollectorScript_HasNoPowerShellAstParseErrorsAsync()
+    {
+        const string parseCommand =
+            "$tokens = $null; $errors = $null; " +
+            "[System.Management.Automation.Language.Parser]::ParseFile(" +
+            "$env:ROSLYN_MCP_SCRIPT_UNDER_TEST, [ref]$tokens, [ref]$errors) | Out-Null; " +
+            "if ($errors.Count -gt 0) { $errors | ForEach-Object { [Console]::Error.WriteLine($_) }; exit 1 }";
+
+        var result = await RunPowerShellAsync(
+            ["-NoProfile", "-NonInteractive", "-Command", parseCommand],
+            new Dictionary<string, string?>
+            {
+                ["ROSLYN_MCP_SCRIPT_UNDER_TEST"] = GetCollectorScriptPath(),
+            });
+
+        AssertSucceeded(result);
+    }
+
+    private sealed record LegObservation(
+        string RunId,
+        string Leg,
+        string Image,
+        int WallTimeSeconds,
+        int CaseDurationSeconds);
+
+    private static string ExtractImageSection(string report, string imageName)
+    {
+        var marker = "### " + imageName;
+        var start = report.IndexOf(marker, StringComparison.Ordinal);
+        Assert.AreNotEqual(-1, start, $"Report is missing the '{imageName}' section.");
+        var next = report.IndexOf("\n### ", start + marker.Length, StringComparison.Ordinal);
+        return next < 0 ? report[start..] : report[start..next];
+    }
+
+    private static async Task<PwshScriptResult> RunCollectorAsync(
+        string fixtureRoot,
+        IReadOnlyList<LegObservation> observations)
+    {
+        var resultsRoot = Path.Combine(fixtureRoot, "downloads");
+        var manifest = new List<Dictionary<string, object>>();
+        foreach (var observation in observations)
+        {
+            var relativePath = $"{observation.RunId}/test-results-{observation.Leg}";
+            var legDirectory = Path.Combine(
+                resultsRoot,
+                observation.RunId,
+                $"test-results-{observation.Leg}");
+            Directory.CreateDirectory(legDirectory);
+            await File.WriteAllTextAsync(
+                Path.Combine(legDirectory, "results.trx"),
+                BuildTwoCaseTrx(observation.CaseDurationSeconds));
+
+            manifest.Add(new Dictionary<string, object>
+            {
+                ["runId"] = observation.RunId,
+                ["leg"] = observation.Leg,
+                ["image"] = observation.Image,
+                ["wallTimeSeconds"] = observation.WallTimeSeconds,
+                ["path"] = relativePath,
+            });
+        }
+
+        var manifestPath = Path.Combine(fixtureRoot, "legs.json");
+        await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(manifest));
+
+        return await RunPowerShellAsync(
+            [
+                "-NoProfile",
+                "-NonInteractive",
+                "-File",
+                GetCollectorScriptPath(),
+                "-ResultsRoot",
+                resultsRoot,
+                "-LegManifest",
+                manifestPath,
+            ],
+            environment: null);
+    }
+
+    private static string BuildTwoCaseTrx(int totalSeconds)
+    {
+        // Split across two cases so the reported sum is an aggregate, not a single duration.
+        var first = TimeSpan.FromSeconds(totalSeconds - 1).ToString(
+            "c",
+            CultureInfo.InvariantCulture);
+        var second = TimeSpan.FromSeconds(1).ToString("c", CultureInfo.InvariantCulture);
+        return $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+              <Results>
+                <UnitTestResult testId="a" testName="one" outcome="Passed" duration="{first}" />
+                <UnitTestResult testId="b" testName="two" outcome="Passed" duration="{second}" />
+              </Results>
+              <TestDefinitions>
+                <UnitTest id="a">
+                  <TestMethod className="Example.Alpha" name="One" />
+                </UnitTest>
+                <UnitTest id="b">
+                  <TestMethod className="Example.Beta" name="Two" />
+                </UnitTest>
+              </TestDefinitions>
+            </TestRun>
+            """;
+    }
+
+    private static string GetCollectorScriptPath() => Path.Combine(
+        TestFixtureFileSystem.FindRepositoryRoot(),
+        "eng",
+        "collect-hosted-shard-timings.ps1");
 
     private static string CreateFixtureRoot()
     {

--- a/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
+++ b/tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs
@@ -8,6 +8,9 @@ namespace RoslynMcp.Tests;
 [TestCategory("Process")]
 public sealed class TestResultsSummaryContractTests
 {
+    private const string SummarizerDescription = "test-results summarizer";
+    private const string CollectorDescription = "hosted shard timing collector";
+
     private static readonly TimeSpan _processTimeout = TimeSpan.FromSeconds(30);
 
     [TestMethod]
@@ -117,7 +120,8 @@ public sealed class TestResultsSummaryContractTests
             new Dictionary<string, string?>
             {
                 ["ROSLYN_MCP_SCRIPT_UNDER_TEST"] = scriptPath,
-            });
+            },
+            SummarizerDescription);
 
         AssertSucceeded(result);
     }
@@ -203,6 +207,137 @@ public sealed class TestResultsSummaryContractTests
     }
 
     [TestMethod]
+    public async Task Collector_ManifestPathEscapesResultsRoot_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (manifest, _) =>
+                    manifest[0]["path"] = "../escaped/test-results-w-1");
+
+            AssertFailedWith(result, "Leg manifest entry 0 'path' escapes ResultsRoot.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_DuplicateRunAndLegPair_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (manifest, _) => manifest.Add(
+                    new Dictionary<string, object>(manifest[0])));
+
+            AssertFailedWith(result, "Duplicate leg observation for run 'r1' leg 'w-1'.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_LegDirectoryHoldsNoTrx_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (_, resultsRoot) => File.Delete(
+                    Path.Combine(resultsRoot, "r1", "test-results-w-1", "results.trx")));
+
+            AssertFailedWith(
+                result,
+                "Leg manifest entry 0 'path' holds no TRX files: 'r1/test-results-w-1'.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_NonPositiveWallTime_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (manifest, _) => manifest[0]["wallTimeSeconds"] = 0);
+
+            AssertFailedWith(
+                result,
+                "Leg manifest entry 0 has a non-positive 'wallTimeSeconds'.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_TrxWithZeroCases_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (_, resultsRoot) => File.WriteAllText(
+                    Path.Combine(resultsRoot, "r1", "test-results-w-1", "results.trx"),
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+                      <Results />
+                      <TestDefinitions />
+                    </TestRun>
+                    """));
+
+            AssertFailedWith(result, "TRX file reports zero cases:");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    public async Task Collector_MalformedTrx_FailsClosedAsync()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunCollectorAsync(
+                fixtureRoot,
+                BuildCompleteWindowsProfile(),
+                mutate: (_, resultsRoot) => File.WriteAllText(
+                    Path.Combine(resultsRoot, "r1", "test-results-w-1", "results.trx"),
+                    "<TestRun><Results>"));
+
+            AssertFailedWith(result, "Malformed MSTest TRX input.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
     public async Task Collector_ValidProfile_ReportsBothMetricsSeparatelyAndNeverMergesImagesAsync()
     {
         var fixtureRoot = CreateFixtureRoot();
@@ -273,9 +408,26 @@ public sealed class TestResultsSummaryContractTests
             new Dictionary<string, string?>
             {
                 ["ROSLYN_MCP_SCRIPT_UNDER_TEST"] = GetCollectorScriptPath(),
-            });
+            },
+            CollectorDescription);
 
         AssertSucceeded(result);
+    }
+
+    /// <summary>
+    /// Five complete runs of a two-leg <c>windows-latest</c> profile: the smallest observation set
+    /// that clears every sampling gate, so a corruption hook isolates the rule under test.
+    /// </summary>
+    private static List<LegObservation> BuildCompleteWindowsProfile()
+    {
+        var observations = new List<LegObservation>();
+        for (var run = 1; run <= 5; run++)
+        {
+            observations.Add(new LegObservation($"r{run}", "w-1", "windows-latest", 100, 10));
+            observations.Add(new LegObservation($"r{run}", "w-2", "windows-latest", 200, 40));
+        }
+
+        return observations;
     }
 
     private sealed record LegObservation(
@@ -294,9 +446,15 @@ public sealed class TestResultsSummaryContractTests
         return next < 0 ? report[start..] : report[start..next];
     }
 
+    /// <param name="mutate">
+    /// Optional corruption hook run after a well-formed fixture is laid down but before the
+    /// manifest is written, so a fail-closed regression can break exactly one invariant.
+    /// Receives the manifest entries and the resolved ResultsRoot.
+    /// </param>
     private static async Task<PwshScriptResult> RunCollectorAsync(
         string fixtureRoot,
-        IReadOnlyList<LegObservation> observations)
+        IReadOnlyList<LegObservation> observations,
+        Action<List<Dictionary<string, object>>, string>? mutate = null)
     {
         var resultsRoot = Path.Combine(fixtureRoot, "downloads");
         var manifest = new List<Dictionary<string, object>>();
@@ -322,6 +480,8 @@ public sealed class TestResultsSummaryContractTests
             });
         }
 
+        mutate?.Invoke(manifest, resultsRoot);
+
         var manifestPath = Path.Combine(fixtureRoot, "legs.json");
         await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(manifest));
 
@@ -336,7 +496,8 @@ public sealed class TestResultsSummaryContractTests
                 "-LegManifest",
                 manifestPath,
             ],
-            environment: null);
+            environment: null,
+            description: CollectorDescription);
     }
 
     private static string BuildTwoCaseTrx(int totalSeconds)
@@ -390,7 +551,10 @@ public sealed class TestResultsSummaryContractTests
             GetScriptPath(),
         };
         processArguments.AddRange(arguments);
-        return RunPowerShellAsync(processArguments, environment: null);
+        return RunPowerShellAsync(
+            processArguments,
+            environment: null,
+            description: SummarizerDescription);
     }
 
     private static string GetScriptPath() => Path.Combine(
@@ -400,13 +564,14 @@ public sealed class TestResultsSummaryContractTests
 
     private static Task<PwshScriptResult> RunPowerShellAsync(
         IEnumerable<string> arguments,
-        IReadOnlyDictionary<string, string?>? environment)
+        IReadOnlyDictionary<string, string?>? environment,
+        string description)
         => PwshScriptRunner.RunAsync(
             arguments,
             workingDirectory: TestFixtureFileSystem.FindRepositoryRoot(),
             environment: environment,
             timeout: _processTimeout,
-            description: "test-results summarizer");
+            description: description);
 
     private static void AssertSucceeded(PwshScriptResult result) => Assert.AreEqual(
         0,


### PR DESCRIPTION
## Why

`CI_POLICY.md` told the next reader to "use complete green four-shard hosted runs as the next calibration and rebalance only from repeated uploaded TRX evidence" — but that evidence lives in GitHub artifacts with a 14-day retention (`.github/workflows/ci.yml:247`). The calibration was therefore un-re-checkable, pushing the next reader toward exactly the single-sample and local-timing mistakes the row's acceptance criteria forbid. There was no offline tool that turns downloaded `test-results-<leg>` folders into a per-image skew report.

## What

- **New `eng/collect-hosted-shard-timings.ps1`** — offline, hermetic, deterministic. Takes a directory of downloaded `test-results-<leg>` folders plus a JSON leg manifest (leg, hosted image, wall-time seconds, run id) and writes a per-hosted-image Markdown report **to stdout** (redirect it if you want a file). Wall-time skew and summed TRX case duration are **separate columns**, alongside per-leg run-to-run spread, the achievable-gain figure, and the single-leg noise band, so a marginal skew cannot be misread as material. Makes no `gh` call and is wired into no workflow step.

  Fail-closed rules: fewer than `-MinimumSamples` (default 5) distinct runs per image; an entry missing leg/image/run-id/wall-time/path; a non-positive wall time; one leg claimed by two hosted images; a run missing any leg of its own image's leg set; a duplicate run+leg pair; a manifest path that escapes `-ResultsRoot`, is absent, or holds no TRX; and a malformed or zero-case TRX.

- **`CI_POLICY.md`** — replaces the open "next calibration" sentence with a new `## Hosted Shard Weighting Decision` section carrying the measurement table, the explicit decision, and the re-check trigger.

- **`ai_docs/references/testing.md`** — records the collector and the standing decision in the evidence table, plus bullets stating that summed TRX case duration alone is not a partition signal on hosted runners and that images are never merged.

- **`tests/RoslynMcp.Tests/TestResultsSummaryContractTests.cs`** — eleven collector regressions over TRX synthesized under `TestTempRoot.Current`.

`eng/get-test-shard-plan.ps1` is **deliberately unchanged**.

## Evidence (re-derived, not inherited)

Per Directive #5, no figure was copied from the backlog detail file's prior-session amendment. The eight cited runs were confirmed still in-window, five were downloaded (30 leg observations across both hosted images, no local timings), and the collector was run over them:

| Hosted image | Legs | Critical path | Balanced floor | Achievable gain | Single-leg noise band | Worst same-leg case-duration spread | Between-leg case-duration spread |
|---|---:|---:|---:|---:|---:|---:|---:|
| `windows-latest` | 4 | 720.4s | 647.1s | 73.4s (10.2%) | 82.9s | 1.87x | 1.50x |
| `ubuntu-latest` | 2 | 743.2s | 662.6s | 80.6s (10.8%) | 140.3s | 2.21x | 1.18x |

Independently, per-leg job wall time over all eight in-window runs means 11.18 / 9.56 / 11.43 / 11.11 min for the four Windows legs and 11.70 / 10.72 min for the two Linux legs.

**Conclusion: do not adopt duration weights.** A perfect duration partition recovers less than the single-leg wall-time noise band on either image, and summed TRX case duration cannot rank legs at all — its same-leg run-to-run swing exceeds the between-leg spread, so it reproduces runner noise rather than class cost. The deterministic discovered-case weights stay as the fail-closed weighting.

## Cold-review remediation

Six findings from the cold review of the first push are addressed here:

1. **Dropped the unrequested `-OutputPath` parameter and its `Publish-Report` file-append path.** The plan's Approach enumerated only the results directory, the leg manifest and `-MinimumSamples`; the flag had no caller and no test. Shell redirection covers the file case.
2. **That deletion also removes a real data-corruption hazard.** The appender was a near-copy of `eng/summarize-test-results.ps1:69-95` **without** that script's input-clobber guard (`:286-291`), so `-OutputPath` aimed at a file under `-ResultsRoot` would have appended Markdown into a downloaded TRX input. Confirmed eliminated — the script now contains no `OutputPath`, `Publish-Report`, or `AppendAllText`.
3. **Committed regressions for the previously untested fail-closed rules**: `Collector_ManifestPathEscapesResultsRoot_FailsClosedAsync`, `Collector_DuplicateRunAndLegPair_FailsClosedAsync`, `Collector_LegDirectoryHoldsNoTrx_FailsClosedAsync`, `Collector_MalformedTrx_FailsClosedAsync`, `Collector_TrxWithZeroCases_FailsClosedAsync`, and `Collector_NonPositiveWallTime_FailsClosedAsync`. Each asserts the specific diagnostic text, not merely that the script threw. A corruption hook on the fixture builder lays down a complete five-run two-leg profile and then breaks exactly one invariant, so each test isolates its own rule.
4. **Removed two unreachable defensive branches** (`$wallMinimum -gt 0`, `$criticalPathMean -gt 0`). `Get-RequiredSeconds` throws on any non-positive wall time, so neither `else` could ever execute; a comment now names that upstream invariant at each site. The two remaining zero guards on *case* duration are kept and are genuinely reachable — a TRX may legitimately report zero-duration cases.
5. **`ai_docs/references/testing.md`** no longer states five samples as an absolute: it now reads "refuses fewer than `-MinimumSamples` (default 5) runs per hosted image". The changelog fragment was corrected the same way.
6. **`RunPowerShellAsync` takes an explicit `description`**, so a collector process failure or timeout is no longer reported under the sibling summarizer's name.

### The measurement table is unchanged, and was not re-typed

Removing `-OutputPath` cannot move a number: the no-`OutputPath` branch was already `[Console]::Out.WriteLine($Markdown)` verbatim, so the deletion touched report *delivery* only, never the computation. The committed regression `Collector_ValidProfile_...` pins the exact rendered leg rows and the `| Achievable gain from a perfect partition | 50.0 s (25.0%) |` line and still passes, and a manual run over a synthesized five-run profile reproduced the identical layout. The five real downloaded CI runs were **not** re-downloaded in this remediation pass, so `CI_POLICY.md` was left byte-untouched rather than re-derived — the diff for this push does not include it.

### Coverage, stated honestly

The first push's body claimed each fail-closed rule had a deterministic regression; that was not true, and this is the corrected accounting. Nine rules now have committed regressions: under-minimum samples, leg claimed by two images, run missing a leg, duplicate run+leg pair, path escaping `-ResultsRoot`, leg directory holding no TRX, malformed TRX, zero-case TRX, and non-positive wall time. The remaining input-validation throws — an untagged or empty manifest field, a rooted or absent path, invalid manifest JSON, an empty manifest, a non-object entry, and the TRX definition-join checks — are **not** covered by committed tests.

## Validation

- `dotnet test --filter FullyQualifiedName~TestResultsSummaryContractTests` — exit 0, **15 passed / 0 failed / 0 skipped** (4 summarizer + 11 collector; was 9).
- `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` — exit **0**.
- `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release` — exit **0**, **2823 passed / 0 failed / 7 skipped** (2830 total, 13m10s).

Closes: ci-hosted-shard-duration-balancing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PywUGhxtTbeVSDUwNPHFbC
