### PR TITLE
fix(scaffolding): request sampling before semantic prep so MRTR replay pays it once

### DIFF
--- a/changelog.d/scaffold-sampling-mrtr-replay-cost.md
+++ b/changelog.d/scaffold-sampling-mrtr-replay-cost.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `scaffold_test_preview` no longer repeats project resolution, compilation and sibling-test discovery when an MRTR sampling exchange replays the tool call.

--- a/src/RoslynMcp.Core/Services/IScaffoldingService.cs
+++ b/src/RoslynMcp.Core/Services/IScaffoldingService.cs
@@ -55,10 +55,38 @@ public interface IScaffoldingService
 /// <summary>
 /// Transport-neutral bridge for opt-in test-method-name suggestions during scaffold preview.
 /// Implementations may use MCP sampling, fixtures, or a deterministic fake in tests.
+///
+/// <para>Two-phase contract (scaffold-sampling-mrtr-replay-cost): a transport whose exchange
+/// spans more than one round trip of the same logical call — MCP sampling over MRTR, where the
+/// first leg terminates with an input-required signal and the client retries the whole
+/// <c>tools/call</c> — answers <see cref="TryConsumePendingSuggestion"/> on the retry leg. Callers
+/// MUST probe that first and only build the (expensive) suggestion context when it returns false,
+/// so the semantic work behind <see cref="ScaffoldTestNameSuggestionContext"/> is paid on exactly
+/// one leg of the exchange instead of every replay.</para>
 /// </summary>
 public interface ITestNameSuggestionProvider
 {
     Task<TestNameSuggestionResult> SuggestTestNameAsync(ScaffoldTestNameSuggestionContext context, CancellationToken ct);
+
+    /// <summary>
+    /// Attempts to consume a suggestion the client already answered on an earlier round trip of
+    /// THIS logical request, without issuing a new suggestion request and without a context.
+    /// </summary>
+    /// <param name="result">
+    /// The already-answered suggestion (or its sanitized deterministic fallback) when this returns
+    /// true; an empty result otherwise.
+    /// </param>
+    /// <returns>
+    /// True when this request carried an answer that was consumed here. The default implementation
+    /// returns false: a single-round-trip provider (fixture, deterministic fake, in-process model)
+    /// has no prior leg to consume from, which is the correct answer rather than a compatibility
+    /// stub — it keeps <see cref="SuggestTestNameAsync"/> the only path such a provider needs.
+    /// </returns>
+    bool TryConsumePendingSuggestion(out TestNameSuggestionResult result)
+    {
+        result = new TestNameSuggestionResult(null);
+        return false;
+    }
 }
 
 public sealed record ScaffoldTestNameSuggestionContext(

--- a/src/RoslynMcp.Core/Services/IScaffoldingService.cs
+++ b/src/RoslynMcp.Core/Services/IScaffoldingService.cs
@@ -89,11 +89,16 @@ public interface ITestNameSuggestionProvider
     }
 }
 
+/// <summary>
+/// Everything the suggestion prompt is built from. Every member is obtainable WITHOUT a
+/// <c>Compilation</c>: the request is issued ahead of symbol resolution (see the two-phase
+/// contract on <see cref="ITestNameSuggestionProvider"/>), so symbol-derived detail such as a
+/// method signature or declaring namespace is deliberately not part of this contract — carrying
+/// it would either be permanently null or reintroduce the semantic work the hoist defers.
+/// </summary>
 public sealed record ScaffoldTestNameSuggestionContext(
     string TargetTypeName,
     string TargetMethodName,
-    string? TargetMethodSignature,
-    string? TargetNamespace,
     IReadOnlyList<string> SiblingTestMethodNames);
 
 public sealed record TestNameSuggestionResult(string? MethodName, string? Warning = null);

--- a/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
+++ b/src/RoslynMcp.Host.Stdio/Elicitation/RequestScopedInputAdapter.cs
@@ -171,11 +171,57 @@ internal static class RequestScopedInputAdapter
     }
 
     /// <summary>
+    /// Capability and protocol gate for the whole sampling exchange, retries included. A client
+    /// must not be able to bypass the sampling boundary by hand-crafting inputResponses on a
+    /// legacy request or on a modern request that did not advertise sampling. Both sampling entry
+    /// points below route through this single predicate.
+    /// </summary>
+#pragma warning disable MCP9005 // The SDK marks sampling itself obsolete; this adapter is the bounded MRTR compatibility boundary.
+    private static bool SupportsRequestScopedSampling(RequestContext<CallToolRequestParams> context)
+        => RequestProtocolFeatureGate.SupportsJuly2026Features(context) &&
+           RequestProtocolFeatureGate.ResolveClientCapabilities(context)?.Sampling is not null;
+
+    /// <summary>
+    /// MRTR retry leg only: consumes the sampling answer the client attached to THIS request, with
+    /// no prompt text and no client round trip. Returns false when the request carries no such
+    /// answer (the initial leg) or when <see cref="SupportsRequestScopedSampling"/> refuses it.
+    ///
+    /// <para>Split out of <see cref="RequestSampling"/> so a caller can find out whether the
+    /// exchange is already answered BEFORE paying to build the prompt — the initial leg terminates
+    /// with <see cref="InputRequiredException"/> and the client replays the entire
+    /// <c>tools/call</c>, so any preparation done ahead of the request is paid on every replay.</para>
+    /// </summary>
+    internal static bool TryConsumeSampling(
+        RequestContext<CallToolRequestParams> context,
+        ILogger? logger,
+        out RequestScopedInputOutcome outcome,
+        out string? text)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        outcome = RequestScopedInputOutcome.Unsupported;
+        text = null;
+
+        if (!SupportsRequestScopedSampling(context) ||
+            context.Params?.InputResponses is not { } inputResponses ||
+            !inputResponses.TryGetValue(SamplingInputRequestKey, out var inputResponse))
+        {
+            return false;
+        }
+
+        var (classified, result) = ClassifySamplingResponse(inputResponse, logger);
+        outcome = classified;
+        text = result?.Content?
+            .OfType<TextContentBlock>()
+            .Select(static block => block.Text)
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+        return true;
+    }
+
+    /// <summary>
     /// Requests a sampling completion through MRTR. Sampling has no legacy nested-request leg:
     /// pre-MRTR or sampling-incapable clients receive <see cref="RequestScopedInputOutcome.Unsupported"/>
     /// so callers retain deterministic behavior without relying on the deprecated SDK API.
     /// </summary>
-#pragma warning disable MCP9005 // The SDK marks sampling itself obsolete; this adapter is the bounded MRTR compatibility boundary.
     internal static (RequestScopedInputOutcome Outcome, string? Text) RequestSampling(
         RequestContext<CallToolRequestParams> context,
         string promptText,
@@ -184,24 +230,14 @@ internal static class RequestScopedInputAdapter
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(promptText);
 
-        // Capability and protocol support gate the entire exchange, including retries. A client
-        // must not be able to bypass the sampling boundary by hand-crafting inputResponses on a
-        // legacy request or on a modern request that did not advertise sampling.
-        if (!RequestProtocolFeatureGate.SupportsJuly2026Features(context) ||
-            RequestProtocolFeatureGate.ResolveClientCapabilities(context)?.Sampling is null)
+        if (TryConsumeSampling(context, logger, out var outcome, out var text))
         {
-            return (RequestScopedInputOutcome.Unsupported, null);
+            return (outcome, text);
         }
 
-        if (context.Params?.InputResponses is { } inputResponses &&
-            inputResponses.TryGetValue(SamplingInputRequestKey, out var inputResponse))
+        if (!SupportsRequestScopedSampling(context))
         {
-            var (outcome, result) = ClassifySamplingResponse(inputResponse, logger);
-            var text = result?.Content?
-                .OfType<TextContentBlock>()
-                .Select(static block => block.Text)
-                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
-            return (outcome, text);
+            return (RequestScopedInputOutcome.Unsupported, null);
         }
 
         throw new InputRequiredException(

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -142,6 +142,16 @@ public static class ScaffoldingTools
             ct);
     }
 
+    /// <summary>
+    /// Seam for the retry-leg half of the exchange, mirroring the <c>requestSampling</c> delegate:
+    /// it lets a test fault the consume path the way the sampling path can already be faulted.
+    /// </summary>
+    internal delegate bool TryConsumeSamplingDelegate(
+        RequestContext<CallToolRequestParams> context,
+        ILogger? logger,
+        out RequestScopedInputOutcome outcome,
+        out string? text);
+
     internal sealed class McpSamplingTestNameSuggestionProvider : ITestNameSuggestionProvider
     {
         private readonly RequestContext<CallToolRequestParams> _requestContext;
@@ -150,6 +160,7 @@ public static class ScaffoldingTools
             string,
             ILogger?,
             (RequestScopedInputOutcome Outcome, string? Text)> _requestSampling;
+        private readonly TryConsumeSamplingDelegate _tryConsumeSampling;
 
         internal McpSamplingTestNameSuggestionProvider(
             RequestContext<CallToolRequestParams> requestContext)
@@ -163,10 +174,12 @@ public static class ScaffoldingTools
                 RequestContext<CallToolRequestParams>,
                 string,
                 ILogger?,
-                (RequestScopedInputOutcome Outcome, string? Text)> requestSampling)
+                (RequestScopedInputOutcome Outcome, string? Text)> requestSampling,
+            TryConsumeSamplingDelegate? tryConsumeSampling = null)
         {
             _requestContext = requestContext ?? throw new ArgumentNullException(nameof(requestContext));
             _requestSampling = requestSampling ?? throw new ArgumentNullException(nameof(requestSampling));
+            _tryConsumeSampling = tryConsumeSampling ?? RequestScopedInputAdapter.TryConsumeSampling;
         }
 
         private ILogger? Logger =>
@@ -184,8 +197,7 @@ public static class ScaffoldingTools
         {
             try
             {
-                if (!RequestScopedInputAdapter.TryConsumeSampling(
-                        _requestContext, Logger, out var outcome, out var text))
+                if (!_tryConsumeSampling(_requestContext, Logger, out var outcome, out var text))
                 {
                     result = new TestNameSuggestionResult(null);
                     return false;
@@ -194,7 +206,7 @@ public static class ScaffoldingTools
                 result = ProjectOutcome(outcome, text);
                 return true;
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
             {
                 // The answer was present but unusable for an unforeseen reason. Report true with the
                 // sanitized fallback rather than false: falling through would re-issue the sampling
@@ -250,26 +262,16 @@ public static class ScaffoldingTools
         }
 
         /// <summary>
-        /// Omits the fields the caller could not supply rather than substituting a placeholder for
-        /// them. The initial MRTR leg deliberately runs ahead of symbol resolution, so signature
-        /// and namespace are frequently unknown there — printing "(global)" for an unknown
-        /// namespace would assert something false to the sampling model.
+        /// Prompts from the syntactic context alone. The request is issued ahead of symbol
+        /// resolution, so symbol-derived detail (declaring namespace, method signature) is not
+        /// available to describe here — and inventing a placeholder such as "(global)" would
+        /// assert something false to the sampling model.
         /// </summary>
         private static string BuildSamplingPrompt(ScaffoldTestNameSuggestionContext context)
         {
             var prompt = new StringBuilder("Suggest a Given/When/Then test method name.\n")
-                .Append("Target type: ").Append(context.TargetTypeName).Append('\n');
-            if (!string.IsNullOrWhiteSpace(context.TargetNamespace))
-            {
-                prompt.Append("Target namespace: ").Append(context.TargetNamespace).Append('\n');
-            }
-
-            prompt.Append("Target method: ").Append(context.TargetMethodName).Append('\n');
-            if (!string.IsNullOrWhiteSpace(context.TargetMethodSignature))
-            {
-                prompt.Append("Signature: ").Append(context.TargetMethodSignature).Append('\n');
-            }
-
+                .Append("Target type: ").Append(context.TargetTypeName).Append('\n')
+                .Append("Target method: ").Append(context.TargetMethodName).Append('\n');
             if (context.SiblingTestMethodNames.Count > 0)
             {
                 prompt.Append("Sibling examples: ")

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
@@ -168,6 +169,41 @@ public static class ScaffoldingTools
             _requestSampling = requestSampling ?? throw new ArgumentNullException(nameof(requestSampling));
         }
 
+        private ILogger? Logger =>
+            _requestContext.Services?
+                .GetService<ILoggerFactory>()?
+                .CreateLogger(typeof(McpSamplingTestNameSuggestionProvider).FullName ??
+                              nameof(McpSamplingTestNameSuggestionProvider));
+
+        /// <summary>
+        /// MRTR retry leg: the answer already rode in on this request, so it is consumed without a
+        /// prompt. Returning true here is what lets the caller skip rebuilding the (expensive)
+        /// suggestion context on every replay of the same logical <c>tools/call</c>.
+        /// </summary>
+        public bool TryConsumePendingSuggestion(out TestNameSuggestionResult result)
+        {
+            try
+            {
+                if (!RequestScopedInputAdapter.TryConsumeSampling(
+                        _requestContext, Logger, out var outcome, out var text))
+                {
+                    result = new TestNameSuggestionResult(null);
+                    return false;
+                }
+
+                result = ProjectOutcome(outcome, text);
+                return true;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // The answer was present but unusable for an unforeseen reason. Report true with the
+                // sanitized fallback rather than false: falling through would re-issue the sampling
+                // request the client has already answered.
+                result = ReportSanitizedFailure(ex);
+                return true;
+            }
+        }
+
         public Task<TestNameSuggestionResult> SuggestTestNameAsync(
             ScaffoldTestNameSuggestionContext context,
             CancellationToken ct)
@@ -179,52 +215,72 @@ public static class ScaffoldingTools
                 var (outcome, text) = _requestSampling(
                     _requestContext,
                     BuildSamplingPrompt(context),
-                    _requestContext.Services?
-                        .GetService<ILoggerFactory>()?
-                        .CreateLogger(typeof(McpSamplingTestNameSuggestionProvider).FullName ??
-                                      nameof(McpSamplingTestNameSuggestionProvider)));
+                    Logger);
                 ct.ThrowIfCancellationRequested();
-                if (outcome == RequestScopedInputOutcome.Unsupported)
-                {
-                    return Task.FromResult(new TestNameSuggestionResult(
-                        null,
-                        "useSampling was true but request-scoped sampling was unavailable; emitted the deterministic placeholder test name."));
-                }
-
-                if (outcome != RequestScopedInputOutcome.Accepted)
-                {
-                    return Task.FromResult(new TestNameSuggestionResult(
-                        null,
-                        "The request-scoped sampling response was malformed; emitted the deterministic placeholder test name."));
-                }
-
-                return Task.FromResult(new TestNameSuggestionResult(text));
+                return Task.FromResult(ProjectOutcome(outcome, text));
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
             {
-                var diagnostic = UnexpectedExceptionReporting.Report(
-                    _requestContext.Services?.GetService<IUnexpectedExceptionReporter>(),
-                    ex,
-                    UnexpectedExceptionCategory.Scaffolding);
-                return Task.FromResult(new TestNameSuggestionResult(
-                    null,
-                    $"Sampling test-name suggestion failed (correlationId={diagnostic.Public.CorrelationId}); emitted the deterministic placeholder test name."));
+                return Task.FromResult(ReportSanitizedFailure(ex));
             }
         }
 
-        private static string FormatSiblingExamples(IReadOnlyList<string> siblingTestMethodNames)
-            => siblingTestMethodNames.Count == 0
-                ? "(none)"
-                : string.Join(", ", siblingTestMethodNames.Take(6));
+        private static TestNameSuggestionResult ProjectOutcome(
+            RequestScopedInputOutcome outcome,
+            string? text) => outcome switch
+            {
+                RequestScopedInputOutcome.Accepted => new TestNameSuggestionResult(text),
+                RequestScopedInputOutcome.Unsupported => new TestNameSuggestionResult(
+                    null,
+                    "useSampling was true but request-scoped sampling was unavailable; emitted the deterministic placeholder test name."),
+                _ => new TestNameSuggestionResult(
+                    null,
+                    "The request-scoped sampling response was malformed; emitted the deterministic placeholder test name."),
+            };
 
-        private static string BuildSamplingPrompt(ScaffoldTestNameSuggestionContext context) =>
-            "Suggest a Given/When/Then test method name.\n" +
-            $"Target type: {context.TargetTypeName}\n" +
-            $"Target namespace: {context.TargetNamespace ?? "(global)"}\n" +
-            $"Target method: {context.TargetMethodName}\n" +
-            $"Signature: {context.TargetMethodSignature ?? context.TargetMethodName}\n" +
-            $"Sibling examples: {FormatSiblingExamples(context.SiblingTestMethodNames)}\n" +
-            "Format example: LoadIntoSessionAsync_WhenCacheMiss_FallsThroughToColdLoad";
+        private TestNameSuggestionResult ReportSanitizedFailure(Exception ex)
+        {
+            var diagnostic = UnexpectedExceptionReporting.Report(
+                _requestContext.Services?.GetService<IUnexpectedExceptionReporter>(),
+                ex,
+                UnexpectedExceptionCategory.Scaffolding);
+            return new TestNameSuggestionResult(
+                null,
+                $"Sampling test-name suggestion failed (correlationId={diagnostic.Public.CorrelationId}); emitted the deterministic placeholder test name.");
+        }
+
+        /// <summary>
+        /// Omits the fields the caller could not supply rather than substituting a placeholder for
+        /// them. The initial MRTR leg deliberately runs ahead of symbol resolution, so signature
+        /// and namespace are frequently unknown there — printing "(global)" for an unknown
+        /// namespace would assert something false to the sampling model.
+        /// </summary>
+        private static string BuildSamplingPrompt(ScaffoldTestNameSuggestionContext context)
+        {
+            var prompt = new StringBuilder("Suggest a Given/When/Then test method name.\n")
+                .Append("Target type: ").Append(context.TargetTypeName).Append('\n');
+            if (!string.IsNullOrWhiteSpace(context.TargetNamespace))
+            {
+                prompt.Append("Target namespace: ").Append(context.TargetNamespace).Append('\n');
+            }
+
+            prompt.Append("Target method: ").Append(context.TargetMethodName).Append('\n');
+            if (!string.IsNullOrWhiteSpace(context.TargetMethodSignature))
+            {
+                prompt.Append("Signature: ").Append(context.TargetMethodSignature).Append('\n');
+            }
+
+            if (context.SiblingTestMethodNames.Count > 0)
+            {
+                prompt.Append("Sibling examples: ")
+                    .Append(string.Join(", ", context.SiblingTestMethodNames.Take(6)))
+                    .Append('\n');
+            }
+
+            return prompt
+                .Append("Format example: LoadIntoSessionAsync_WhenCacheMiss_FallsThroughToColdLoad")
+                .ToString();
+        }
     }
 
     [McpServerTool(Name = "scaffold_test_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -208,9 +208,11 @@ public static class ScaffoldingTools
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
             {
-                // The answer was present but unusable for an unforeseen reason. Report true with the
-                // sanitized fallback rather than false: falling through would re-issue the sampling
-                // request the client has already answered.
+                // The consume probe faulted for an unforeseen reason. This covers both an answer
+                // that was present but unusable and a fault raised before any answer was inspected
+                // (the capability gate or logger resolution). Report true with the sanitized
+                // fallback rather than false: falling through would re-issue the sampling request
+                // the client has already answered.
                 result = ReportSanitizedFailure(ex);
                 return true;
             }

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -60,11 +60,21 @@ internal sealed class SingleTestScaffolder
         // matched symbol's Name as authoritative once we have it, so the downstream class
         // identifier is always a single identifier (dotted identifiers are a CS syntax error).
         var lookupName = TestScaffoldRenderer.StripToSimpleTypeName(request.TargetTypeName);
+
+        // scaffold-sampling-mrtr-replay-cost: the sampling exchange runs FIRST, ahead of every
+        // semantic step below. Its provider may terminate this leg with a protocol input-required
+        // signal, after which the client replays the whole tools/call — so anything resolved before
+        // the request is resolved again on every replay. Hoisted here, the initial leg builds only
+        // the syntactic prompt context and the retry leg consumes the answer without rebuilding it,
+        // leaving project resolution, compilation and sibling inference paid exactly once.
+        var sampledTestName = await SuggestSampledTestNameAsync(
+            request, lookupName, projectDirectory, testNameSuggestionProvider, ct).ConfigureAwait(false);
+
         var typeInfo = await ResolveTargetTypeAndMethodAsync(
             workspaceId, request.TestProjectName, lookupName, request.TargetMethodName, ct).ConfigureAwait(false);
 
         var simpleTypeName = typeInfo.MatchedType?.Name ?? lookupName;
-        var testFilePath = Path.Combine(projectDirectory, $"{simpleTypeName}GeneratedTests.cs");
+        var testFilePath = Path.Combine(projectDirectory, GeneratedTestFileName(simpleTypeName));
 
         // Sibling-pattern inference (scaffold-test-sibling-pattern-inference). When an explicit
         // referenceTestFile is supplied we use that as the pattern source; otherwise we
@@ -83,15 +93,6 @@ internal sealed class SingleTestScaffolder
             : await testRoslynProject.GetCompilationAsync(ct).ConfigureAwait(false);
         var siblingInference = InferSiblingTestPattern(request.ReferenceTestFile, projectDirectory, testFilePath, testProjectCompilation);
         var siblingWarnings = siblingInference.Warnings;
-        var sampledTestName = await SuggestSampledTestNameAsync(
-            request,
-            simpleTypeName,
-            typeInfo.TargetNamespace,
-            typeInfo.TargetMethod,
-            projectDirectory,
-            testFilePath,
-            testNameSuggestionProvider,
-            ct).ConfigureAwait(false);
 
         var content = TestScaffoldRenderer.BuildTestContent(new BuildTestContentRequest(
             testNamespace, request, simpleTypeName, typeInfo.TargetNamespace, typeInfo.ConstructorArgs, framework,
@@ -103,13 +104,16 @@ internal sealed class SingleTestScaffolder
         return combinedWarnings.Count == 0 ? preview : preview with { Warnings = combinedWarnings };
     }
 
+    /// <summary>
+    /// Runs the opt-in sampling exchange before any semantic resolution. On a transport whose
+    /// exchange spans several replays of one logical call, the provider answers
+    /// <see cref="ITestNameSuggestionProvider.TryConsumePendingSuggestion"/> on the retry leg, so
+    /// the sibling enumerate-and-parse below is paid only on the leg that actually sends a prompt.
+    /// </summary>
     private static async Task<TestNameSuggestionResult> SuggestSampledTestNameAsync(
         ScaffoldTestDto request,
-        string simpleTypeName,
-        string targetNamespace,
-        IMethodSymbol? targetMethod,
+        string lookupTypeName,
         string projectDirectory,
-        string testFilePath,
         ITestNameSuggestionProvider? provider,
         CancellationToken ct)
     {
@@ -125,13 +129,29 @@ internal sealed class SingleTestScaffolder
                 "useSampling was true but no sampling provider was available; emitted the deterministic placeholder test name.");
         }
 
+        if (provider.TryConsumePendingSuggestion(out var pending))
+        {
+            return NormalizeSuggestion(pending);
+        }
+
+        // The symbol-derived signature and namespace are deliberately absent: obtaining them costs
+        // the compilation this hoist exists to defer, and the prompt omits what it does not know.
         var context = new ScaffoldTestNameSuggestionContext(
-            simpleTypeName,
+            lookupTypeName,
             request.TargetMethodName,
-            FormatMethodSignature(targetMethod),
-            string.IsNullOrWhiteSpace(targetNamespace) ? null : targetNamespace,
-            CollectSiblingTestMethodNames(projectDirectory, testFilePath, maxNames: 6));
-        var result = await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false);
+            TargetMethodSignature: null,
+            TargetNamespace: null,
+            CollectSiblingTestMethodNames(
+                projectDirectory,
+                Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),
+                maxNames: 6));
+        return NormalizeSuggestion(await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false));
+    }
+
+    private static string GeneratedTestFileName(string simpleTypeName) => $"{simpleTypeName}GeneratedTests.cs";
+
+    private static TestNameSuggestionResult NormalizeSuggestion(TestNameSuggestionResult result)
+    {
         var normalized = NormalizeSuggestedTestMethodName(result.MethodName);
         if (normalized is not null)
         {
@@ -329,17 +349,6 @@ internal sealed class SingleTestScaffolder
             .OrderByDescending(fi => fi.LastWriteTimeUtc)
             .Select(fi => fi.FullName)
             .FirstOrDefault();
-    }
-
-    private static string? FormatMethodSignature(IMethodSymbol? method)
-    {
-        if (method is null)
-        {
-            return null;
-        }
-
-        var parameters = string.Join(", ", method.Parameters.Select(p => $"{p.Type.ToMinimalDisplay()} {p.Name}"));
-        return $"{method.ReturnType.ToMinimalDisplay()} {method.Name}({parameters})";
     }
 
     private static IReadOnlyList<string> CollectSiblingTestMethodNames(

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -134,13 +134,11 @@ internal sealed class SingleTestScaffolder
             return NormalizeSuggestion(pending);
         }
 
-        // The symbol-derived signature and namespace are deliberately absent: obtaining them costs
-        // the compilation this hoist exists to defer, and the prompt omits what it does not know.
+        // Syntactic inputs only: this runs ahead of symbol resolution, so anything the compilation
+        // would supply is out of reach here by design — see ScaffoldTestNameSuggestionContext.
         var context = new ScaffoldTestNameSuggestionContext(
             lookupTypeName,
             request.TargetMethodName,
-            TargetMethodSignature: null,
-            TargetNamespace: null,
             CollectSiblingTestMethodNames(
                 projectDirectory,
                 Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),

--- a/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
+++ b/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol;
 using ModelContextProtocol.Client;
@@ -406,6 +407,52 @@ public sealed class SamplingMrtrWireTests
 
     [TestMethod]
     [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task ConsumeFailure_ReportsSanitizedDiagnostic_AndDoesNotReissueSampling()
+    {
+        const string sentinel = "consume-secret-sentinel";
+        const string secretPath = "C:/private/tenant/answered-leg.json";
+        var reporter = new RecordingReporter();
+        await using var harness = await CreateHarnessAsync(
+            protocolVersion: "2025-11-25",
+            samplingHandler: null,
+            reporter);
+        var samplingRequests = 0;
+        var provider = new ScaffoldingTools.McpSamplingTestNameSuggestionProvider(
+            CreateRequestContext(harness.Server),
+            (_, _, _) =>
+            {
+                Interlocked.Increment(ref samplingRequests);
+                return (RequestScopedInputOutcome.Accepted, _suggestedName);
+            },
+            ThrowingConsume);
+
+        var consumed = provider.TryConsumePendingSuggestion(out var result);
+
+        // The retry leg carries an answer the client already paid for. A fault while reading it
+        // must still be claimed, or the caller falls through and re-asks a question already asked.
+        Assert.IsTrue(consumed);
+        Assert.AreEqual(0, samplingRequests,
+            "A faulted consume must not issue a second sampling request for the same exchange.");
+        Assert.IsNull(result.MethodName);
+        Assert.IsNotNull(result.Warning);
+        Assert.IsFalse(result.Warning.Contains(sentinel, StringComparison.Ordinal));
+        Assert.IsFalse(result.Warning.Contains(secretPath, StringComparison.Ordinal));
+        Assert.IsFalse(result.Warning.Contains(nameof(InvalidOperationException), StringComparison.Ordinal));
+        StringAssert.Contains(result.Warning, "correlationId=sampling-test");
+        var diagnostic = JsonSerializer.Serialize(reporter.LastReport);
+        Assert.IsFalse(diagnostic.Contains(sentinel, StringComparison.Ordinal));
+        Assert.IsFalse(diagnostic.Contains(secretPath, StringComparison.Ordinal));
+
+        static bool ThrowingConsume(
+            RequestContext<CallToolRequestParams> context,
+            ILogger? logger,
+            out RequestScopedInputOutcome outcome,
+            out string? text)
+            => throw new InvalidOperationException($"{sentinel} at {secretPath}");
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
     public async Task ProviderCancellation_PropagatesUnchanged()
     {
         await using var harness = await CreateHarnessAsync("2025-11-25", samplingHandler: null);
@@ -457,8 +504,6 @@ public sealed class SamplingMrtrWireTests
     private static ScaffoldTestNameSuggestionContext SuggestionContext() => new(
         "CacheService",
         "Load",
-        "Task<string> Load(string key)",
-        "Sample",
         ["Load_WhenFound_ReturnsValue"]);
 
     private static RequestContext<CallToolRequestParams> CreateRequestContext(McpServer server) =>

--- a/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
+++ b/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
@@ -125,6 +125,11 @@ public sealed class SamplingMrtrWireTests
             "Each replay enters the production provider boundary once: request, then response consumption.");
         Assert.AreEqual(1, scaffoldingService.CompletedCount,
             "Only the retry carrying inputResponses may complete and return a preview.");
+        Assert.AreEqual(1, scaffoldingService.PromptedSuggestionCount,
+            "scaffold-sampling-mrtr-replay-cost: only the leg with no answer yet may build the " +
+            "suggestion prompt; the replay must not repeat that preparation.");
+        Assert.IsTrue(scaffoldingService.LastLegConsumedPendingSuggestion,
+            "The retry leg must consume the already-answered suggestion instead of rebuilding the prompt context.");
         Assert.AreEqual(originalWorkspaceId, scaffoldingService.LastWorkspaceId,
             "The production sampling retry must retain the workspace selected before input_required.");
         Assert.AreEqual(concurrentWorkspaceId, workspaceManager.ListWorkspaces().Single().WorkspaceId,
@@ -616,17 +621,27 @@ public sealed class SamplingMrtrWireTests
         }
     }
 
+    /// <summary>
+    /// Stands in for <c>ScaffoldingService</c> at the wire boundary, reproducing the ordering the
+    /// real <c>SingleTestScaffolder</c> uses: probe the provider's already-answered leg first, and
+    /// only build a prompt context on the leg that has no answer yet.
+    /// <see cref="PromptedSuggestionCount"/> counts the legs that had to build one, and must stay
+    /// at 1 across the whole MRTR round trip (scaffold-sampling-mrtr-replay-cost).
+    /// </summary>
     private sealed class RecordingScaffoldingService : IScaffoldingService
     {
         private int _attemptCount;
         private int _providerAttemptCount;
         private int _completedCount;
+        private int _promptedSuggestionCount;
 
         public int AttemptCount => Volatile.Read(ref _attemptCount);
         public int ProviderAttemptCount => Volatile.Read(ref _providerAttemptCount);
         public int CompletedCount => Volatile.Read(ref _completedCount);
+        public int PromptedSuggestionCount => Volatile.Read(ref _promptedSuggestionCount);
         public string? LastWorkspaceId { get; private set; }
         public ScaffoldTestDto? LastRequest { get; private set; }
+        public bool LastLegConsumedPendingSuggestion { get; private set; }
 
         public Task<RefactoringPreviewDto> PreviewScaffoldTypeAsync(
             string workspaceId,
@@ -648,9 +663,20 @@ public sealed class SamplingMrtrWireTests
                     "The production tool did not supply its request-scoped sampling provider.");
 
             Interlocked.Increment(ref _providerAttemptCount);
-            var suggestion = await provider
-                .SuggestTestNameAsync(SuggestionContext(), ct)
-                .ConfigureAwait(false);
+
+            // Retry leg: the answer already rode in on this request, so no prompt context is built.
+            LastLegConsumedPendingSuggestion = provider.TryConsumePendingSuggestion(out var suggestion);
+            if (!LastLegConsumedPendingSuggestion)
+            {
+                // Initial leg: build the prompt context and request sampling. In the real
+                // scaffolder this is the only leg that pays for sibling discovery, and it
+                // terminates here with the input-required signal.
+                Interlocked.Increment(ref _promptedSuggestionCount);
+                suggestion = await provider
+                    .SuggestTestNameAsync(SuggestionContext(), ct)
+                    .ConfigureAwait(false);
+            }
+
             Interlocked.Increment(ref _completedCount);
 
             return new RefactoringPreviewDto(

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -563,13 +563,6 @@ public sealed class DogExistingTests
         Assert.AreEqual("Speak", provider.LastContext.TargetMethodName);
         CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenQuiet_ReturnsEmpty",
             "Sibling naming conventions are filesystem-derived and must still steer the suggestion.");
-        // scaffold-sampling-mrtr-replay-cost: the request is issued ahead of symbol resolution, so
-        // the symbol-derived fields are deliberately absent. Their presence would mean the
-        // compilation had already been paid for on a leg that a retry replays from scratch.
-        Assert.IsNull(provider.LastContext.TargetMethodSignature,
-            "The sampling request must precede the compilation that would supply the signature.");
-        Assert.IsNull(provider.LastContext.TargetNamespace,
-            "The sampling request must precede the compilation that would supply the namespace.");
 
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "Speak_WhenDogIsReady_ReturnsBark");

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using Microsoft.CodeAnalysis;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Diagnostics;
 using RoslynMcp.Host.Stdio.Tools;
+using RoslynMcp.Roslyn.Contracts;
 using RoslynMcp.Roslyn.Services;
 using RoslynMcp.Tests.TestInfrastructure;
 
@@ -559,13 +561,84 @@ public sealed class DogExistingTests
         Assert.IsNotNull(provider.LastContext);
         Assert.AreEqual("Dog", provider.LastContext.TargetTypeName);
         Assert.AreEqual("Speak", provider.LastContext.TargetMethodName);
-        StringAssert.Contains(provider.LastContext.TargetMethodSignature!, "Speak(");
-        CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenQuiet_ReturnsEmpty");
+        CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenQuiet_ReturnsEmpty",
+            "Sibling naming conventions are filesystem-derived and must still steer the suggestion.");
+        // scaffold-sampling-mrtr-replay-cost: the request is issued ahead of symbol resolution, so
+        // the symbol-derived fields are deliberately absent. Their presence would mean the
+        // compilation had already been paid for on a leg that a retry replays from scratch.
+        Assert.IsNull(provider.LastContext.TargetMethodSignature,
+            "The sampling request must precede the compilation that would supply the signature.");
+        Assert.IsNull(provider.LastContext.TargetNamespace,
+            "The sampling request must precede the compilation that would supply the namespace.");
 
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "Speak_WhenDogIsReady_ReturnsBark");
         Assert.IsFalse(contents.Contains("Speak_Needs_Test"),
             "Opted-in sampled scaffold should replace the deterministic placeholder with the suggested method name.");
+    }
+
+    [TestMethod]
+    public async Task Scaffold_Test_Preview_SamplingReplay_PaysSemanticPreparationOnce()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var siblingPath = workspace.GetPath("SampleLib.Tests", "DogReplayTests.cs");
+        await File.WriteAllTextAsync(siblingPath, """
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SampleLib.Tests;
+
+[TestClass]
+public sealed class DogReplayTests
+{
+    [TestMethod]
+    public void Speak_WhenReplayed_ReturnsEcho()
+    {
+    }
+}
+""", CancellationToken.None);
+        var targetFilePath = workspace.GetPath("SampleLib.Tests", "DogGeneratedTests.cs");
+
+        // The decorator counts every entry into the semantic layer. Project resolution and framework
+        // detection go through GetStatus on the facade, so this counter isolates exactly the work the
+        // hoist is meant to keep off the replayed leg.
+        var countingWorkspace = new CountingWorkspaceManager(WorkspaceManager);
+        var scaffoldingService = new ScaffoldingService(countingWorkspace, FileOperationService, PreviewStore);
+        var provider = new ReplayTestNameSuggestionProvider("Speak_WhenDogIsReady_ReturnsBark");
+        var request = new ScaffoldTestDto(
+            "SampleLib.Tests",
+            "Dog",
+            "Speak",
+            ReferenceTestFile: string.Empty,
+            UseSampling: true);
+
+        // Leg 1: the transport terminates the call with its input-required signal, exactly as the
+        // MRTR adapter does, and the client then replays the whole tools/call.
+        await Assert.ThrowsExactlyAsync<SimulatedInputRequiredException>(() =>
+            scaffoldingService.PreviewScaffoldTestAsync(
+                workspace.WorkspaceId, request, CancellationToken.None, provider));
+
+        Assert.AreEqual(1, provider.SuggestCallCount, "The initial leg issues exactly one sampling request.");
+        Assert.AreEqual(0, countingWorkspace.GetCurrentSolutionCount,
+            "The initial leg must terminate before any target resolution or compilation — every " +
+            "semantic step taken ahead of the sampling request is paid again on the replay.");
+        Assert.IsNotNull(provider.LastContext);
+        CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenReplayed_ReturnsEcho",
+            "Sibling naming conventions cost no compilation, so the prompt keeps them.");
+
+        // Leg 2: the replay carries the client's answer.
+        var preview = await scaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId, request, CancellationToken.None, provider);
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(
+            preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.AreEqual(1, provider.SuggestCallCount,
+            "The replay must consume the answered suggestion, not request a second one.");
+        Assert.AreEqual(2, provider.ConsumeCallCount, "Both legs probe for an already-answered suggestion first.");
+        Assert.AreEqual(2, countingWorkspace.GetCurrentSolutionCount,
+            "One target resolution plus one test-project compilation, across both legs combined.");
+        var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
+        StringAssert.Contains(contents, "Speak_WhenDogIsReady_ReturnsBark");
     }
 
     [TestMethod]
@@ -1433,5 +1506,115 @@ public class SnapshotContentHasher
             ScaffoldTestNameSuggestionContext context,
             CancellationToken ct) =>
             Task.FromException<TestNameSuggestionResult>(exception);
+    }
+
+    /// <summary>Stands in for the transport's input-required protocol signal.</summary>
+    private sealed class SimulatedInputRequiredException : Exception;
+
+    /// <summary>
+    /// Drives both legs of a replayed sampling exchange: the first request terminates the call the
+    /// way the MRTR adapter does, and the client's answer then rides in on the replay for
+    /// <see cref="ITestNameSuggestionProvider.TryConsumePendingSuggestion"/> to consume.
+    /// </summary>
+    private sealed class ReplayTestNameSuggestionProvider(string methodName) : ITestNameSuggestionProvider
+    {
+        private bool _answered;
+
+        public int SuggestCallCount { get; private set; }
+
+        public int ConsumeCallCount { get; private set; }
+
+        public ScaffoldTestNameSuggestionContext? LastContext { get; private set; }
+
+        public Task<TestNameSuggestionResult> SuggestTestNameAsync(
+            ScaffoldTestNameSuggestionContext context,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            SuggestCallCount++;
+            LastContext = context;
+            _answered = true;
+            throw new SimulatedInputRequiredException();
+        }
+
+        public bool TryConsumePendingSuggestion(out TestNameSuggestionResult result)
+        {
+            ConsumeCallCount++;
+            result = new TestNameSuggestionResult(_answered ? methodName : null);
+            return _answered;
+        }
+    }
+
+    /// <summary>
+    /// Pass-through <see cref="IWorkspaceManager"/> that counts entries into the semantic layer.
+    /// <see cref="GetCurrentSolution"/> is the only door to a <see cref="Compilation"/>, so its call
+    /// count measures the preparation the sampling hoist must keep off a replayed leg.
+    /// </summary>
+    private sealed class CountingWorkspaceManager(IWorkspaceManager inner) : IWorkspaceManager
+    {
+        private int _getCurrentSolutionCount;
+
+        public int GetCurrentSolutionCount => Volatile.Read(ref _getCurrentSolutionCount);
+
+        public event Action<string>? WorkspaceClosed
+        {
+            add => inner.WorkspaceClosed += value;
+            remove => inner.WorkspaceClosed -= value;
+        }
+
+        public event Action<string>? WorkspaceReloaded
+        {
+            add => inner.WorkspaceReloaded += value;
+            remove => inner.WorkspaceReloaded -= value;
+        }
+
+        public Solution GetCurrentSolution(string workspaceId)
+        {
+            Interlocked.Increment(ref _getCurrentSolutionCount);
+            return inner.GetCurrentSolution(workspaceId);
+        }
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) =>
+            inner.LoadAsync(path, evictPolicy, ct);
+
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) =>
+            inner.ReloadAsync(workspaceId, ct);
+
+        public bool ContainsWorkspace(string workspaceId) => inner.ContainsWorkspace(workspaceId);
+
+        public bool IsStale(string workspaceId) => inner.IsStale(workspaceId);
+
+        public bool Close(string workspaceId) => inner.Close(workspaceId);
+
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => inner.ListWorkspaces();
+
+        public IReadOnlyList<string> FindWorkspaceIdsContainingFile(string filePath) =>
+            inner.FindWorkspaceIdsContainingFile(filePath);
+
+        public WorkspaceStatusDto GetStatus(string workspaceId) => inner.GetStatus(workspaceId);
+
+        public Task<WorkspaceStatusDto> GetStatusAsync(
+            string workspaceId,
+            CancellationToken cancellationToken = default) => inner.GetStatusAsync(workspaceId, cancellationToken);
+
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => inner.GetProjectGraph(workspaceId);
+
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(
+            string workspaceId,
+            string? projectName,
+            CancellationToken ct) => inner.GetSourceGeneratedDocumentsAsync(workspaceId, projectName, ct);
+
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) =>
+            inner.GetSourceTextAsync(workspaceId, filePath, ct);
+
+        public int GetCurrentVersion(string workspaceId) => inner.GetCurrentVersion(workspaceId);
+
+        public Project? GetProject(string workspaceId, string projectNameOrPath) =>
+            inner.GetProject(workspaceId, projectNameOrPath);
+
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) =>
+            inner.TryApplyChanges(workspaceId, newSolution);
+
+        public void RestoreVersion(string workspaceId, int version) => inner.RestoreVersion(workspaceId, version);
     }
 }


### PR DESCRIPTION
## Problem

`scaffold_test_preview` ordered its work so that the opt-in sampling request came **last**. Target/method resolution, a second test-project `GetCompilationAsync`, and the recursive sibling `*Tests.cs` enumerate-and-parse all ran *before* `SuggestSampledTestNameAsync`. That request terminates the initial leg with an input-required protocol signal, and the client then replays the entire `tools/call` — so every one of those steps was paid twice per exchange.

The replay itself is correct protocol behaviour (`SamplingMrtrWireTests` already pins `AttemptCount == 2` / `CompletedCount == 1`) and is unchanged here. The defect was the ordering around it.

There was inverse waste too: the sibling enumerate-and-parse was built on **both** legs but consumed only on the first.

## Change

The sampling exchange now runs first, ahead of every semantic step.

- **`ITestNameSuggestionProvider.TryConsumePendingSuggestion`** — new member, default-implemented to return `false`. That is the correct answer for a single-round-trip provider (fixture, deterministic fake, in-process model), which has no prior leg to consume from — not a compatibility stub.
- **`RequestScopedInputAdapter.TryConsumeSampling`** — splits the retry-leg half out of `RequestSampling`, so a caller can learn the exchange is already answered *before* paying to build the prompt. The capability + protocol gate both entry points share moves into one `SupportsRequestScopedSampling` predicate, keeping the "a client must not bypass the sampling boundary with hand-crafted `inputResponses`" rule in a single place.
- **`SingleTestScaffolder.PreviewAsync`** — hoists the exchange above `ResolveTargetTypeAndMethodAsync`. The initial leg builds only the syntactic prompt context and lets the signal escape; the replay consumes the answer without rebuilding it. Resolution, compilation and sibling inference now run exactly once across the pair.
- **`BuildSamplingPrompt`** — omits fields it does not have instead of printing `(global)` for an unknown namespace or echoing the method name as its own signature. The initial leg legitimately runs ahead of symbol resolution, and a placeholder would assert something false to the model.

Sibling naming examples are filesystem-derived and cost no compilation, so they are still collected on the leg that actually sends a prompt — only the symbol-derived signature/namespace are given up, and both were already `string?`.

**No server-side state was added.** A `requestState`-keyed prepared-context cache was rejected: it would be a process-static cache of absolute paths needing eviction/TTL, contradicting the no-session-cache guarantee. The prepared context lives only on the stack of the single leg that consumes it, and `requestState` still carries nothing but `RequestStateCodec`'s fixed 54-char opaque token.

## Regressions

- `SamplingMrtrWireTests.ModernSession_ProductionScaffoldingTool_AdvertisesAndCompletesMrtrSampling` — pins one prompted suggestion, one client sampling request and one completed preview across the input-required/retry exchange, and asserts the retry leg consumed rather than re-prompted. `AttemptCount == 2` / `CompletedCount == 1` unchanged.
- `ScaffoldingIntegrationTests.Scaffold_Test_Preview_SamplingReplay_PaysSemanticPreparationOnce` — new. Runs the **real** `ScaffoldingService` against a decorating `IWorkspaceManager` that counts `GetCurrentSolution`, the only door to a `Compilation`. Initial leg: `0`. Both legs combined: `2` (one target resolution + one test-project compilation). Before this change it was `2` and `4`.

## Validation

- `./eng/verify-release.ps1 -Configuration Release` — 2813 passed, 0 failed, 7 skipped.
- `./eng/verify-ai-docs.ps1` — passed.

Both re-run on the final tree.

Closes: scaffold-sampling-mrtr-replay-cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PywUGhxtTbeVSDUwNPHFbC
