### PR TITLE
fix(format-baseline): name the stall instead of blaming the five-minute bound

### DIFF
--- a/changelog.d/formatter-baseline-generator-concurrent-load-timeout.md
+++ b/changelog.d/formatter-baseline-generator-concurrent-load-timeout.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** The formatter baseline generator now reports per-phase timings and a `generator-hang` vs `host-contention` classification with the competing processes named, instead of a bare five-minute timeout that discarded the generator's own output.

--- a/eng/format-diagnostic-contract.ps1
+++ b/eng/format-diagnostic-contract.ps1
@@ -2,3 +2,7 @@
 # gate. Keep these values here so inventory generation and enforcement cannot drift.
 $formatDiagnosticPattern = '^(?<path>.+?)\((?<line>\d+),(?<column>\d+)\): (?<severity>error|warning) (?<id>[A-Za-z0-9_]+): (?<message>.*?)(?: \[(?<project>[^\]]+)\])?$'
 $formatTruncationMarker = 'Required references did not load'
+# Phase markers are written to STDERR only. STDOUT is the byte-compared determinism payload,
+# so anything emitted there would break the generator's determinism contract.
+# Line shape: "<prefix> <phase> <start|end> elapsedMs=<n>", e.g. "##format-phase## restore end elapsedMs=41230".
+$formatPhaseMarkerPrefix = '##format-phase##'

--- a/eng/generate-format-baseline.ps1
+++ b/eng/generate-format-baseline.ps1
@@ -31,6 +31,14 @@ Fail-closed contract:
 Exit codes of `dotnet format --verify-no-changes`: 0 = clean, 2 = findings reported.
 Both are success here; any other exit code is fatal.
 
+Phase-marker contract:
+  The restore and format phases are bracketed by `$formatPhaseMarkerPrefix` lines written
+  to STDERR with the elapsed milliseconds since script start. They exist so a caller that
+  has to kill this script on a timeout can tell a genuine generator hang from host-wide
+  MSBuild/dotnet-format contention, and so successful runs accumulate the phase timings
+  that would justify any future change to that timeout. STDOUT is the byte-compared
+  determinism payload and never carries a marker.
+
 .PARAMETER Check
 Regenerate the inventory in memory and compare it against the tracked artifact
 without writing. Exits 1 when they differ. CI and the contract test share this path.
@@ -52,6 +60,30 @@ $ErrorActionPreference = 'Stop'
 $schemaVersion = 1
 $solutionFileName = 'RoslynMcp.slnx'
 $formatArguments = @('format', $solutionFileName, '--verify-no-changes', '--no-restore')
+$phaseStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+function Write-FormatPhaseMarker {
+    <#
+    .SYNOPSIS
+    Emit one phase marker on STDERR.
+
+    .DESCRIPTION
+    Uses the raw console error writer on purpose. `Write-Error` would abort the script under
+    `$ErrorActionPreference = 'Stop'`, and `Write-Output` would corrupt the determinism payload.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('restore', 'format')]
+        [string]$Phase,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('start', 'end')]
+        [string]$Transition
+    )
+
+    $elapsedMs = [int]$phaseStopwatch.Elapsed.TotalMilliseconds
+    [System.Console]::Error.WriteLine("$formatPhaseMarkerPrefix $Phase $Transition elapsedMs=$elapsedMs")
+}
 
 $repositoryRoot = [System.IO.Path]::GetFullPath((Join-Path -Path $PSScriptRoot -ChildPath '..'))
 $solutionPath = Join-Path -Path $repositoryRoot -ChildPath $solutionFileName
@@ -81,16 +113,22 @@ function ConvertTo-RepositoryRelativePath {
 Push-Location -LiteralPath $repositoryRoot
 try {
     if (-not $NoRestore) {
+        Write-FormatPhaseMarker -Phase 'restore' -Transition 'start'
         $global:LASTEXITCODE = 0
         $restoreOutput = @(& dotnet restore $solutionFileName)
-        if ($global:LASTEXITCODE -ne 0) {
-            throw "dotnet restore failed with exit code $($global:LASTEXITCODE):`n$($restoreOutput -join [System.Environment]::NewLine)"
+        $restoreExitCode = $global:LASTEXITCODE
+        # Emitted before the exit-code check so a failing restore still reports its duration.
+        Write-FormatPhaseMarker -Phase 'restore' -Transition 'end'
+        if ($restoreExitCode -ne 0) {
+            throw "dotnet restore failed with exit code ${restoreExitCode}:`n$($restoreOutput -join [System.Environment]::NewLine)"
         }
     }
 
+    Write-FormatPhaseMarker -Phase 'format' -Transition 'start'
     $global:LASTEXITCODE = 0
     $formatOutput = @(& dotnet @formatArguments 2>&1 | ForEach-Object { $_.ToString() })
     $formatExitCode = $global:LASTEXITCODE
+    Write-FormatPhaseMarker -Phase 'format' -Transition 'end'
 }
 finally {
     Pop-Location

--- a/tests/RoslynMcp.Tests/FormatterBaselineContractTests.cs
+++ b/tests/RoslynMcp.Tests/FormatterBaselineContractTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -16,7 +17,42 @@ public sealed class FormatterBaselineContractTests
 {
     private const int _expectedSchemaVersion = 1;
 
+    /// <summary>
+    /// Mirrors <c>$formatPhaseMarkerPrefix</c> in <c>eng/format-diagnostic-contract.ps1</c>.
+    /// <see cref="GeneratorAndGate_ImportOneSharedDiagnosticGrammar"/> asserts the two stay identical.
+    /// </summary>
+    private const string _formatPhaseMarkerPrefix = "##format-phase##";
+
+    /// <summary>
+    /// Deliberately unchanged. A longer bound would hide host contention instead of naming it;
+    /// the diagnostics around it exist so a future measured replacement can be justified by
+    /// the phase timings every successful run now records.
+    /// </summary>
     private static readonly TimeSpan _processTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Bound on draining the already-started stdout/stderr readers after the generator tree is
+    /// killed. <see cref="Process.Kill(bool)"/> returns before the tree has actually torn down, and
+    /// the reads only complete once every inherited pipe-write handle is closed - which is slowest
+    /// under exactly the contention this diagnostic exists to name. Negligible next to
+    /// <see cref="_processTimeout"/>.
+    /// </summary>
+    private static readonly TimeSpan _drainTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Process names that contend for the same MSBuild/NuGet/compiler-server resources the
+    /// generator needs. Matched by name because that is all <see cref="Process"/> exposes without
+    /// elevated access.
+    /// </summary>
+    private static readonly string[] _competingProcessNames =
+    [
+        "dotnet",
+        "MSBuild",
+        "testhost",
+        "VBCSCompiler",
+    ];
+
+    private const int _maxCompetingProcessesReported = 10;
 
     private static readonly string[] _trackedDiagnosticIds =
     [
@@ -189,16 +225,73 @@ public sealed class FormatterBaselineContractTests
 
         StringAssert.Contains(contract, "$formatDiagnosticPattern =");
         StringAssert.Contains(contract, "$formatTruncationMarker =");
+        StringAssert.Contains(
+            contract,
+            $"$formatPhaseMarkerPrefix = '{_formatPhaseMarkerPrefix}'",
+            "The phase-marker prefix this test class parses must be the one the contract declares.");
         foreach (var consumer in consumers)
         {
             StringAssert.Contains(consumer, "format-diagnostic-contract.ps1");
             Assert.IsFalse(
                 Regex.IsMatch(
                     consumer,
-                    @"^\s*\$(?:formatDiagnosticPattern|diagnosticPattern|formatTruncationMarker|truncationMarker)\s*=",
+                    @"^\s*\$(?:formatDiagnosticPattern|diagnosticPattern|formatTruncationMarker|truncationMarker|formatPhaseMarkerPrefix|phaseMarkerPrefix)\s*=",
                     RegexOptions.Multiline),
-                "Formatter grammar consumers must not redeclare the shared regex or truncation marker.");
+                "Formatter grammar consumers must not redeclare the shared regex, truncation marker, or phase-marker prefix.");
         }
+    }
+
+    [TestMethod]
+    public void ClassifyGeneratorTimeout_NamesTheEvidenceInsteadOfBlamingTheBound()
+    {
+        var markers =
+            new[]
+            {
+                "##format-phase## restore start elapsedMs=8",
+                "##format-phase## restore end elapsedMs=41230",
+                "##format-phase## format start elapsedMs=41233",
+            };
+
+        Assert.AreEqual(
+            "generator-never-started",
+            ClassifyGeneratorTimeout(
+                [],
+                competingProcessesAtStart: 4,
+                competingProcessesStillRunning: 4,
+                stderrDrained: true),
+            "A drained but empty stderr means the generator never reached its first dotnet invocation.");
+        Assert.AreEqual(
+            "host-contention",
+            ClassifyGeneratorTimeout(
+                [],
+                competingProcessesAtStart: 4,
+                competingProcessesStillRunning: 4,
+                stderrDrained: false),
+            "An undrained stderr is missing evidence, so it must never be reported as 'never started'.");
+        Assert.AreEqual(
+            "host-contention",
+            ClassifyGeneratorTimeout(
+                markers,
+                competingProcessesAtStart: 4,
+                competingProcessesStillRunning: 3,
+                stderrDrained: true),
+            "A competitor that pre-dated the run and outlived the bound is the contention signature.");
+        Assert.AreEqual(
+            "generator-hang",
+            ClassifyGeneratorTimeout(
+                markers,
+                competingProcessesAtStart: 0,
+                competingProcessesStillRunning: 0,
+                stderrDrained: true),
+            "Phases started on an otherwise idle host and never finished: a real hang.");
+        Assert.AreEqual(
+            "generator-hang",
+            ClassifyGeneratorTimeout(
+                markers,
+                competingProcessesAtStart: 4,
+                competingProcessesStillRunning: 0,
+                stderrDrained: true),
+            "Competitors that all exited cannot explain a stall that outlasted them.");
     }
 
     [TestMethod]
@@ -212,6 +305,18 @@ public sealed class FormatterBaselineContractTests
             firstRun.StdOut,
             secondRun.StdOut,
             $"The generator must be byte-deterministic. stderr={firstRun.StdErr}{secondRun.StdErr}");
+
+        // Phase markers are diagnostics, not payload. stdout is the byte-compared inventory the
+        // assertion above locks, so a marker leaking there would break determinism outright.
+        Assert.IsFalse(
+            firstRun.StdOut.Contains(_formatPhaseMarkerPrefix, StringComparison.Ordinal),
+            "Phase markers must never reach stdout; stdout is the byte-compared determinism payload.");
+        CollectionAssert.AreEqual(
+            new[] { "restore start", "restore end", "format start", "format end" },
+            ExtractPhaseMarkers(firstRun.StdErr)
+                .Select(marker => string.Join(' ', marker.Split(' ').Skip(1).Take(2)))
+                .ToArray(),
+            $"The generator must bracket both phases on stderr. stderr={firstRun.StdErr}");
 
         var live = ParseInventory(
             firstRun.StdOut,
@@ -246,6 +351,152 @@ public sealed class FormatterBaselineContractTests
             $"Formatter debt grew: live={live.Totals.FindingCount} tracked={tracked.Totals.FindingCount}. Repair the new violations or regenerate the baseline deliberately.");
     }
 
+    /// <summary>
+    /// Classifies a generator timeout from evidence the caller already collected, so the verdict
+    /// itself is unit-testable without having to stall a real process.
+    /// </summary>
+    /// <param name="phaseMarkers">
+    /// Phase markers drained from the killed generator's stderr, in emission order.
+    /// </param>
+    /// <param name="competingProcessesAtStart">
+    /// How many contending processes were already running when the generator was launched.
+    /// </param>
+    /// <param name="competingProcessesStillRunning">
+    /// How many of those same processes were still alive when the timeout fired.
+    /// </param>
+    /// <param name="stderrDrained">
+    /// Whether the generator's stderr was fully read back. When it was not, an empty
+    /// <paramref name="phaseMarkers"/> means "evidence unavailable", not "no phase ran" - reporting
+    /// the latter would invent a verdict out of a failed read.
+    /// </param>
+    internal static string ClassifyGeneratorTimeout(
+        IReadOnlyList<string> phaseMarkers,
+        int competingProcessesAtStart,
+        int competingProcessesStillRunning,
+        bool stderrDrained)
+    {
+        // The first marker precedes the first `dotnet` invocation, so its absence means the
+        // generator produced no work at all - a launch problem, not a stall inside a phase.
+        if (stderrDrained && phaseMarkers.Count == 0)
+        {
+            return "generator-never-started";
+        }
+
+        // Contention is only credible when the competitor pre-dated the generator AND outlived the
+        // bound; one that exited early cannot explain a five-minute stall.
+        if (competingProcessesAtStart > 0 && competingProcessesStillRunning > 0)
+        {
+            return "host-contention";
+        }
+
+        return "generator-hang";
+    }
+
+    private static string[] ExtractPhaseMarkers(string stderr)
+        => stderr
+            .ReplaceLineEndings("\n")
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith(_formatPhaseMarkerPrefix, StringComparison.Ordinal))
+            .ToArray();
+
+    /// <summary>
+    /// Names the contending processes visible right now. Anything that cannot be inspected is
+    /// skipped rather than reported, because an un-openable process is evidence of neither
+    /// contention nor its absence.
+    /// </summary>
+    private static IReadOnlyList<CompetingProcess> SnapshotCompetingProcesses()
+    {
+        var selfProcessId = Environment.ProcessId;
+        var snapshot = new List<CompetingProcess>();
+        foreach (var processName in _competingProcessNames)
+        {
+            Process[] candidates;
+            try
+            {
+                candidates = Process.GetProcessesByName(processName);
+            }
+            catch (InvalidOperationException)
+            {
+                continue;
+            }
+            catch (Win32Exception)
+            {
+                continue;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    if (candidate.Id != selfProcessId)
+                    {
+                        snapshot.Add(new CompetingProcess(candidate.Id, processName));
+                    }
+                }
+                catch (Win32Exception)
+                {
+                    // Access denied on a process this test does not own.
+                }
+                catch (InvalidOperationException)
+                {
+                    // Exited between enumeration and inspection.
+                }
+                finally
+                {
+                    candidate.Dispose();
+                }
+            }
+        }
+
+        return snapshot;
+    }
+
+    private static string DescribeCompetingProcesses(IReadOnlyList<CompetingProcess> processes)
+    {
+        if (processes.Count == 0)
+        {
+            return "none";
+        }
+
+        var reported = processes
+            .Take(_maxCompetingProcessesReported)
+            .Select(process => $"{process.Name}#{process.Id}");
+        var suffix = processes.Count > _maxCompetingProcessesReported
+            ? $", +{processes.Count - _maxCompetingProcessesReported} more"
+            : string.Empty;
+        return $"{processes.Count} [{string.Join(", ", reported)}{suffix}]";
+    }
+
+    /// <summary>
+    /// Awaits an already-running reader under <see cref="_drainTimeout"/>. The reader was started
+    /// before the timeout fired; abandoning it would discard the killed generator's own account of
+    /// where it stalled, which is the only evidence that matters at that moment.
+    /// </summary>
+    private static async Task<DrainResult> DrainAsync(Task<string> readTask, string streamName)
+    {
+        try
+        {
+            var completed = await Task.WhenAny(readTask, Task.Delay(_drainTimeout));
+            if (completed != readTask)
+            {
+                return new DrainResult(
+                    false,
+                    $"<{streamName} not drained within {_drainTimeout.TotalSeconds:0} seconds>");
+            }
+
+            return new DrainResult(true, await readTask);
+        }
+        catch (IOException exception)
+        {
+            return new DrainResult(false, $"<{streamName} drain failed: {exception.Message}>");
+        }
+        catch (ObjectDisposedException exception)
+        {
+            return new DrainResult(false, $"<{streamName} drain failed: {exception.Message}>");
+        }
+    }
+
     private static async Task<ProcessResult> RunGeneratorCheckAsync()
     {
         var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
@@ -270,6 +521,10 @@ public sealed class FormatterBaselineContractTests
         // evaluated by the subset assertions rather than by the exit code.
         startInfo.ArgumentList.Add("-Check");
 
+        // Taken before launch, so nothing the generator itself spawns can appear in it.
+        var competingAtStart = SnapshotCompetingProcesses();
+        var elapsed = Stopwatch.StartNew();
+
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Could not start PowerShell.");
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
@@ -281,12 +536,47 @@ public sealed class FormatterBaselineContractTests
         }
         catch (OperationCanceledException) when (timeout.IsCancellationRequested)
         {
+            // Intersecting on pid with the pre-launch snapshot excludes the generator's own tree
+            // without a parent-pid lookup: every descendant it spawned started later.
+            var startingIds = competingAtStart.Select(entry => entry.Id).ToHashSet();
+            var stillCompeting = SnapshotCompetingProcesses()
+                .Where(entry => entry.Id != process.Id && startingIds.Contains(entry.Id))
+                .ToArray();
+
             process.Kill(entireProcessTree: true);
+
+            var partialStdOut = await DrainAsync(stdoutTask, "stdout");
+            var partialStdErr = await DrainAsync(stderrTask, "stderr");
+            var phaseMarkers = ExtractPhaseMarkers(partialStdErr.Text);
+            var classification = ClassifyGeneratorTimeout(
+                phaseMarkers,
+                competingAtStart.Count,
+                stillCompeting.Length,
+                partialStdErr.Drained);
+
             throw new TimeoutException(
-                $"Formatter baseline generator did not exit within {_processTimeout.TotalMinutes} minutes.");
+                $"Formatter baseline generator did not exit within {_processTimeout.TotalMinutes} minutes. "
+                + $"classification={classification}; "
+                + $"stderrDrained={partialStdErr.Drained}; "
+                + $"phases=[{string.Join(" | ", phaseMarkers)}]; "
+                + $"competingAtStart={DescribeCompetingProcesses(competingAtStart)}; "
+                + $"stillCompetingAtTimeout={DescribeCompetingProcesses(stillCompeting)}; "
+                + $"partialStdOutChars={partialStdOut.Text.Length}; "
+                + $"partialStdErr={partialStdErr.Text}");
         }
 
-        return new ProcessResult(process.ExitCode, await stdoutTask, await stderrTask);
+        elapsed.Stop();
+        var stdOut = await stdoutTask;
+        var stdErr = await stderrTask;
+
+        // Recorded on every successful run so TRX history accumulates the repeated phase evidence
+        // any future change to _processTimeout would have to be argued from.
+        Console.WriteLine(
+            $"[formatter-baseline] totalMs={elapsed.ElapsedMilliseconds}; "
+            + $"phases=[{string.Join(" | ", ExtractPhaseMarkers(stdErr))}]; "
+            + $"competingAtStart={DescribeCompetingProcesses(competingAtStart)}");
+
+        return new ProcessResult(process.ExitCode, stdOut, stdErr);
     }
 
     private static void AssertStrictlyAscendingOrdinal(string[] values, string description)
@@ -324,6 +614,10 @@ public sealed class FormatterBaselineContractTests
     }
 
     private sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);
+
+    private sealed record CompetingProcess(int Id, string Name);
+
+    private sealed record DrainResult(bool Drained, string Text);
 
     private sealed record FormatBaseline(
         int SchemaVersion,

--- a/tests/RoslynMcp.Tests/FormatterBaselineContractTests.cs
+++ b/tests/RoslynMcp.Tests/FormatterBaselineContractTests.cs
@@ -295,6 +295,65 @@ public sealed class FormatterBaselineContractTests
     }
 
     [TestMethod]
+    public void DescribeCompetingProcesses_NamesTheCappedHeadAndAccountsForTheRemainder()
+    {
+        Assert.AreEqual(
+            "none",
+            DescribeCompetingProcesses([]),
+            "An empty snapshot must read as an absence of contention, not as an empty list.");
+
+        Assert.AreEqual(
+            "2 [dotnet#1000, MSBuild#1001]",
+            DescribeCompetingProcesses(
+                [new CompetingProcess(1000, "dotnet"), new CompetingProcess(1001, "MSBuild")]),
+            "Below the cap every competitor is named and no remainder suffix appears.");
+
+        var overCap = Enumerable
+            .Range(0, _maxCompetingProcessesReported + 2)
+            .Select(index => new CompetingProcess(1000 + index, "dotnet"))
+            .ToArray();
+
+        Assert.AreEqual(
+            "12 [dotnet#1000, dotnet#1001, dotnet#1002, dotnet#1003, dotnet#1004, dotnet#1005, "
+            + "dotnet#1006, dotnet#1007, dotnet#1008, dotnet#1009, +2 more]",
+            DescribeCompetingProcesses(overCap),
+            "Truncation must keep the true total up front and account for the unnamed tail; a "
+            + "silently clipped list would understate the contention this diagnostic measures.");
+    }
+
+    [TestMethod]
+    public async Task DrainAsync_SeparatesWhatWasReadFromWhetherTheReadSucceededAsync()
+    {
+        var drained = await DrainAsync(Task.FromResult("payload"), "stdout");
+
+        Assert.IsTrue(drained.Drained, "An already-completed reader must be reported as drained.");
+        Assert.AreEqual("payload", drained.Text, "A drained reader must surface its own text verbatim.");
+        Assert.AreEqual(
+            "7 chars",
+            DescribeDrainedLength(drained),
+            "A successful drain reports the captured size.");
+
+        var stalled = await DrainAsync(
+            new TaskCompletionSource<string>().Task,
+            "stdout",
+            TimeSpan.FromMilliseconds(50));
+
+        Assert.IsFalse(
+            stalled.Drained,
+            "A reader that outlives the bound must never be reported as drained.");
+        StringAssert.Contains(
+            stalled.Text,
+            "stdout not drained within",
+            "The placeholder must name the stream and the failure.");
+        Assert.AreEqual(
+            "unavailable (drain failed)",
+            DescribeDrainedLength(stalled),
+            "A failed drain must never be reported as a character count: the placeholder's own "
+            + "length reads as a plausible payload size, which is exactly the ambiguity between a "
+            + "truncated payload and a failed read that this diagnostic exists to remove.");
+    }
+
+    [TestMethod]
     [TestCategory("Process")]
     public async Task Generator_IsDeterministicAndTheTrackedInventoryCoversTheLiveRunAsync()
     {
@@ -401,9 +460,11 @@ public sealed class FormatterBaselineContractTests
             .ToArray();
 
     /// <summary>
-    /// Names the contending processes visible right now. Anything that cannot be inspected is
-    /// skipped rather than reported, because an un-openable process is evidence of neither
-    /// contention nor its absence.
+    /// Names the contending processes visible right now. A process class whose enumeration fails is
+    /// skipped rather than reported, because an un-enumerable class is evidence of neither
+    /// contention nor its absence. Enumeration is the only step that can fail: every entry
+    /// <see cref="Process.GetProcessesByName(string)"/> returns already carries its
+    /// <see cref="Process.Id"/>, so reading it back needs no guard of its own.
     /// </summary>
     private static IReadOnlyList<CompetingProcess> SnapshotCompetingProcesses()
     {
@@ -427,24 +488,12 @@ public sealed class FormatterBaselineContractTests
 
             foreach (var candidate in candidates)
             {
-                try
+                using (candidate)
                 {
                     if (candidate.Id != selfProcessId)
                     {
                         snapshot.Add(new CompetingProcess(candidate.Id, processName));
                     }
-                }
-                catch (Win32Exception)
-                {
-                    // Access denied on a process this test does not own.
-                }
-                catch (InvalidOperationException)
-                {
-                    // Exited between enumeration and inspection.
-                }
-                finally
-                {
-                    candidate.Dispose();
                 }
             }
         }
@@ -469,20 +518,38 @@ public sealed class FormatterBaselineContractTests
     }
 
     /// <summary>
+    /// Reports how much of a stream the timeout actually captured. A failed drain has no size to
+    /// report: <see cref="DrainAsync(Task{string}, string)"/> substitutes a placeholder whose own
+    /// length would read as a plausible byte count, so the failure is named instead of numbered.
+    /// </summary>
+    private static string DescribeDrainedLength(DrainResult drain)
+        => drain.Drained ? $"{drain.Text.Length} chars" : "unavailable (drain failed)";
+
+    /// <summary>
     /// Awaits an already-running reader under <see cref="_drainTimeout"/>. The reader was started
     /// before the timeout fired; abandoning it would discard the killed generator's own account of
     /// where it stalled, which is the only evidence that matters at that moment.
     /// </summary>
-    private static async Task<DrainResult> DrainAsync(Task<string> readTask, string streamName)
+    private static Task<DrainResult> DrainAsync(Task<string> readTask, string streamName)
+        => DrainAsync(readTask, streamName, _drainTimeout);
+
+    /// <summary>
+    /// Explicit-bound overload. Exists so the not-drained branch is exercisable in milliseconds
+    /// rather than only after a real thirty-second stall.
+    /// </summary>
+    private static async Task<DrainResult> DrainAsync(
+        Task<string> readTask,
+        string streamName,
+        TimeSpan drainTimeout)
     {
         try
         {
-            var completed = await Task.WhenAny(readTask, Task.Delay(_drainTimeout));
+            var completed = await Task.WhenAny(readTask, Task.Delay(drainTimeout));
             if (completed != readTask)
             {
                 return new DrainResult(
                     false,
-                    $"<{streamName} not drained within {_drainTimeout.TotalSeconds:0} seconds>");
+                    $"<{streamName} not drained within {drainTimeout.TotalSeconds:0} seconds>");
             }
 
             return new DrainResult(true, await readTask);
@@ -557,11 +624,12 @@ public sealed class FormatterBaselineContractTests
             throw new TimeoutException(
                 $"Formatter baseline generator did not exit within {_processTimeout.TotalMinutes} minutes. "
                 + $"classification={classification}; "
+                + $"stdoutDrained={partialStdOut.Drained}; "
                 + $"stderrDrained={partialStdErr.Drained}; "
                 + $"phases=[{string.Join(" | ", phaseMarkers)}]; "
                 + $"competingAtStart={DescribeCompetingProcesses(competingAtStart)}; "
                 + $"stillCompetingAtTimeout={DescribeCompetingProcesses(stillCompeting)}; "
-                + $"partialStdOutChars={partialStdOut.Text.Length}; "
+                + $"partialStdOut={DescribeDrainedLength(partialStdOut)}; "
                 + $"partialStdErr={partialStdErr.Text}");
         }
 


### PR DESCRIPTION
Closes backlog row `formatter-baseline-generator-concurrent-load-timeout`.

## Problem

`FormatterBaselineContractTests` bounds the generator subprocess at five minutes. On expiry it killed the process tree and threw a `TimeoutException` carrying **only the bound** — while the `stdoutTask`/`stderrTask` it had already started were **abandoned**. The killed generator's partial output, the only evidence of where it stalled, was discarded at exactly the moment it was needed.

`eng/generate-format-baseline.ps1` compounded it: `dotnet restore` and `dotnet format` ran back-to-back with no phase marker or elapsed time, so even captured output could not separate restore contention from format contention.

That is the 2026-09-01 evidence exactly — a required `just ci` retry timed out at five minutes while another repository testhost was active, and the same test passed in **49 seconds** once the competing testhosts exited. The five-minute bound is not the defect. The blindness around it is.

## What changed — signal, not slack

`_processTimeout` **stays at five minutes verbatim.** Raising it would hide contention instead of naming it.

| File | Change |
|---|---|
| `eng/format-diagnostic-contract.ps1` | One additive `$formatPhaseMarkerPrefix = '##format-phase##'` alongside the existing two values, so emitter and parser share a single grammar. |
| `eng/generate-format-baseline.ps1` | New `Write-FormatPhaseMarker` brackets the restore and format phases: `##format-phase## <phase> <start\|end> elapsedMs=<n>`. `restore end` is emitted *before* the exit-code check so a failing restore still reports its duration. |
| `tests/RoslynMcp.Tests/FormatterBaselineContractTests.cs` | Competing-process snapshot before `Process.Start` and again on timeout; bounded drain of the already-started readers; pure static `ClassifyGeneratorTimeout`; enriched `TimeoutException`; success-path phase-timing line. |

The timeout path now:

1. Snapshots `dotnet` / `MSBuild` / `testhost` / `VBCSCompiler` processes **before** launch, and again on expiry — intersecting on pid excludes the generator's own tree without a parent-pid lookup, since every descendant it spawned started later. Per-process `Win32Exception` / `InvalidOperationException` swallowed; report capped at 10.
2. **Drains** `stdoutTask` and `stderrTask` under a bounded 30s wait after `Kill(entireProcessTree: true)` instead of abandoning them. `Kill` returns before the tree tears down and the reads only complete once every inherited pipe-write handle closes — slowest under exactly the contention this exists to name, hence the bound.
3. Classifies via a **testable pure static** `ClassifyGeneratorTimeout(phaseMarkers, competingProcessesAtStart, competingProcessesStillRunning, stderrDrained)` returning `generator-never-started` / `generator-hang` / `host-contention`. An *undrained* stderr never yields `generator-never-started` — that would invent a verdict out of a failed read.
4. Puts the verdict, the per-phase markers, and the named competing processes (`name#pid`) into the exception message.

The **same phase-timing line is written on the SUCCESS path** (`[formatter-baseline] totalMs=...; phases=[...]; competingAtStart=...`), so TRX history accumulates the repeated evidence acceptance bullet 3 requires before any measured replacement of the bound.

`ClassifyGeneratorTimeout` is covered by a new pure unit test over all five evidence shapes — no process needs to be stalled to test the verdict.

## How the two hard constraints are proven

**Constraint 1 — generator stdout is the byte-compared determinism payload; every diagnostic must go to stderr.**

Proven empirically, not asserted. The base commit's generator was run in the main checkout (verified at `3fcd132b`; `git diff 3fcd132b HEAD -- eng/` empty) and the patched generator in this worktree, each with stdout and stderr captured to **separate** files:

```
base.stdout    25301 bytes
patched.stdout 25301 bytes
RAW BYTE-IDENTICAL base.stdout vs patched.stdout: True

grep -c "format-phase" patched.stdout -> 0
grep -c "format-phase" patched.stderr -> 4
```

`patched.stderr` phase lines:

```
##format-phase## restore start elapsedMs=11
##format-phase## restore end elapsedMs=1128
##format-phase## format start elapsedMs=1129
##format-phase## format end elapsedMs=32535
```

Locked as a regression: the determinism test now asserts `firstRun.StdOut` contains no marker prefix, and that `firstRun.StdErr` carries exactly `restore start`, `restore end`, `format start`, `format end`.

**Constraint 2 — raw `[System.Console]::Error.WriteLine`, never `Write-Error`.**

`Write-FormatPhaseMarker` writes through `[System.Console]::Error.WriteLine`; `Write-Error` under the script's `$ErrorActionPreference = 'Stop'` would abort the run. The four markers appearing on stderr in a run that then proceeds through both phases to the normal `-Check` completion is the proof it does not abort. Its doc comment records why.

**Corollary — markers must not enter `$formatOutput`.** They are emitted outside the `& dotnet @formatArguments 2>&1 | ...` pipeline, which merges only the `dotnet format` child's stream, and `[System.Console]::Error` bypasses the PowerShell stream machinery entirely. The truncation check and the JSON payload are untouched — confirmed by the byte-identical stdout above.

## Validation

| Command | Exit code | Result |
|---|---|---|
| `pwsh -NoProfile -File ./eng/generate-format-baseline.ps1 -Check` (base, main checkout) | 1 | stdout 25301 bytes |
| `pwsh -NoProfile -File ./eng/generate-format-baseline.ps1 -Check` (patched, this branch) | 1 | stdout byte-identical to base; 4 markers on stderr, 0 on stdout |
| `dotnet build tests/RoslynMcp.Tests -c Release -p:TreatWarningsAsErrors=true` | 0 | 0 warnings, 0 errors |
| `dotnet test --filter "FormatterBaselineContractTests | ChangedFormatGateScriptTests"` | 0 | **20 passed, 0 failed, 0 skipped** |
| `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release` | **0** | **2813 passed, 0 failed, 7 skipped, 2820 total** (15m33s) |

Note on the `-Check` exit code 1: it is **pre-existing and identical on base and patched**. `eng/format-baseline.json` has drifted in the *shrinking* direction — `WHITESPACE` in `src/RoslynMcp.Roslyn/Services/ScriptExecutionSupervisor.cs` was repaired without regenerating the artifact (121 tracked vs 117 live findings). The contract test tolerates shrink drift by design via its subset assertions, which is why the suite is green. Not introduced here, not fixed here.

`eng/verify-changed-format.ps1` dot-sources the shared contract and ignores the additive variable; `Skills/ChangedFormatGateScriptTests` asserts on the gate's own streams. Both still pass — the grammar test was extended to forbid consumers redeclaring the new prefix, same as the existing two.

## Deliberately deferred

`RunGeneratorCheckAsync` omits `-NoRestore`, so the process test pays **two full `dotnet restore` passes**. Not fixed here: dropping restore weakens the fail-closed truncation contract, and it is precisely the "measured replacement" the new success-path timings exist to justify. Tracked by row `formatter-baseline-generator-double-restore-cost`. Verified untouched — no `-NoRestore` line appears in this diff.

`_processTimeout` verified unchanged at `TimeSpan.FromMinutes(5)`; the diff adds only a doc comment explaining why it stays.

## Bad code observed (Directive #3)

- **Fixed here:** the abandoned `stdoutTask`/`stderrTask` on the timeout throw path.
- **Observed, not fixed, no row filed yet:** `eng/format-baseline.json` is stale in the shrinking direction (see above). The generator's `-Check` path therefore exits 1 on a clean tree, which makes its exit code useless as a signal for callers other than this test. Worth a row to regenerate the artifact and decide whether shrink drift should stay a non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PywUGhxtTbeVSDUwNPHFbC
