### PR TITLE
chore(backlog): file two CI-policy-doc staleness findings

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-03T15:03:48Z
+**updated_at:** 2026-09-03T17:22:39Z
 
 ## Agent contract
 
@@ -107,6 +107,7 @@
 | `scaffold-target-type-ambiguity-before-sampling` | Medium | — | **Ambiguous target type pays a sampling round trip** — validate `targetTypeName` ambiguity before issuing the scaffold sampling request, so a guaranteed-failing call never reaches the client. [type: bug] [source: 2026-09-02 PR #1428 cold review] | S | items/scaffold-target-type-ambiguity-before-sampling.md |
 | `test-service-container-duplicate-service-instances` | Medium | — | **Container hands out services it did not use** — `RefactoringSuggestionService` is built with fresh CodeMetrics/Cohesion/UnusedCode instances while the container exposes its own; tests observe different objects than production DI. [type: bug] [source: 2026-09-03 PR #1431] | S | items/test-service-container-duplicate-service-instances.md |
 | `test-assembly-donotparallelize-audit` | Medium | — | **Re-audit the 122 `[DoNotParallelize]` opt-outs** — their stated cause (TestBase mutable statics) was retired by PR #1431; split by opt-out cause before selecting. [type: test-infrastructure] [source: 2026-09-03 PR #1431] | L | items/test-assembly-donotparallelize-audit.md |
+| `coverage-baseline-stale` | Medium | — | **Re-measure and refresh docs/coverage-baseline.md.** Baseline stamped 2026-04-11 at v1.9.0 (329 tests); repo now v4.1.2 — 5-month, 2-version gap. Run verify-release.ps1, update the table + Updated stamp. [type: doc-staleness] [source: audit] | S | items/coverage-baseline-stale.md |
 
 ## Low
 
@@ -230,6 +231,7 @@
 | `test-assembly-fixture-disposal-observable-postcondition` | Low | — | **Fixture disposal regression proves entry, not release** — assert a deterministic observable post-condition that the release block ran; needs a small read accessor on `WorkspaceIdCache`. [type: test] [source: 2026-09-03 PR #1431 cold review] | S | items/test-assembly-fixture-disposal-observable-postcondition.md |
 | `test-service-container-two-phase-construction-cycle` | Low | — | **Order-dependent gate/manager construction cycle** — a mutable local captured by a `Lazy<>` is assigned after the ctor call; correct only by statement ordering. [type: refactor] [source: 2026-09-03 PR #1431] | S | items/test-service-container-two-phase-construction-cycle.md |
 | `test-fixture-filesystem-shells-out-for-junctions` | Low | — | **Fixture helper launches cmd.exe for junctions** — `mklink /J` shell-out inside test setup is a proven flake surface under load. [type: test-infrastructure] [source: 2026-09-03 PR #1431] | S | items/test-fixture-filesystem-shells-out-for-junctions.md |
+| `self-hosted-runner-doc-shard-decision-stale-crossref` | Low | — | **Refresh docs/self-hosted-runner.md's timing-evidence cross-reference.** It still frames shard rebalancing as open/future work; CI_POLICY.md's Hosted Shard Weighting Decision closed that calibration. Point the section there. [type: doc-staleness] [source: audit] | S | items/self-hosted-runner-doc-shard-decision-stale-crossref.md |
 
 ## Defer
 

--- a/ai_docs/items/coverage-baseline-stale.md
+++ b/ai_docs/items/coverage-baseline-stale.md
@@ -1,0 +1,24 @@
+# coverage-baseline-stale — re-measure and refresh the coverage baseline doc
+
+**row:** `coverage-baseline-stale` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `docs/coverage-baseline.md` — the only production file; a pure-doc update once fresh numbers exist.
+- `eng/verify-release.ps1` — run (not edited) to produce the fresh Cobertura measurement.
+- `artifacts/coverage/**/coverage.cobertura.xml` — build output (not edited) read for the fresh line/branch rates.
+
+## Acceptance
+
+- [ ] Run `./eng/verify-release.ps1 -Configuration Release` (full, uncapped) and open the produced `artifacts/coverage/**/coverage.cobertura.xml`.
+- [ ] Update the "Current baseline (root aggregate)" table's line/branch coverage percentages, test count, and `Updated:` stamp (date + version) to the fresh measurement.
+- [ ] Re-check the "Priority areas for new tests" list against current Cobertura output — drop entries that are no longer 0%/low-coverage, add any newly-identified gaps.
+- [ ] Update `.github/copilot-instructions.md` too if the aggregate moved materially (the doc's own closing instruction).
+
+## Evidence
+
+- `docs/coverage-baseline.md`'s baseline is stamped `2026-04-11 — measured after v1.9.0 (329 tests)`. The repo is now at v4.1.2 (2026-09-02 per `CHANGELOG.md`) — a ~5-month, 2-major-version gap. Found during a 2026-09-03 staleness check of the CI-policy doc cluster requested by the maintainer.
+
+## Context
+
+Not urgent/broken — this is stale reference data, not a functional defect. The doc's own instructions call for re-measurement "if the aggregate moves materially," which a gap this size (329 tests → current suite, several major versions) makes near-certain. No local SDK matches `global.json`'s pinned `10.0.400` on this machine (`dotnet` resolves 10.0.201), so this needs either a CI-side run (e.g. trigger the dispatch/schedule workflow, which already uploads the `code-coverage` artifact with Cobertura + HTML) or a machine with the matching SDK — not a plain local `dotnet` invocation.

--- a/ai_docs/items/self-hosted-runner-doc-shard-decision-stale-crossref.md
+++ b/ai_docs/items/self-hosted-runner-doc-shard-decision-stale-crossref.md
@@ -1,0 +1,21 @@
+# self-hosted-runner-doc-shard-decision-stale-crossref — refresh timing-evidence cross-reference
+
+**row:** `self-hosted-runner-doc-shard-decision-stale-crossref` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `docs/self-hosted-runner.md` — "Timing evidence" section, line ~59.
+- `CI_POLICY.md` — "Hosted Shard Weighting Decision" section (added in #1427), the now-authoritative status this cross-reference should point at.
+
+## Acceptance
+
+- [ ] `docs/self-hosted-runner.md`'s "Timing evidence" section no longer implies shard rebalancing is an open/future task by default; it states the calibration is closed per `CI_POLICY.md`'s "Hosted Shard Weighting Decision" and points there for the current decision + re-check trigger.
+- [ ] The line "Uploaded per-leg TRX files remain the source for future balancing; do not treat a static case-count estimate as measured performance." is either removed (redundant with the closed decision) or reworded to describe re-balancing as conditional on the documented re-check trigger, not an assumed ongoing task.
+
+## Evidence
+
+- Found during a 2026-09-03 staleness check of the CI-policy doc cluster requested by the maintainer. Not factually wrong — a future re-check per the documented trigger would still use TRX evidence — just an unrefreshed cross-reference left over from before `CI_POLICY.md`'s "Hosted Shard Weighting Decision" section existed.
+
+## Context
+
+Cosmetic/low-severity doc-drift, not a functional or safety issue. `CI_POLICY.md` is the canonical validation/merge-gating contract (per its own header) and already carries the authoritative, up-to-date decision with an explicit re-check trigger (shard count changes, non-test work moves between legs, or achievable gain exceeds the noise band across 5+ green runs). `docs/self-hosted-runner.md` is explicitly scoped to "human self-hosted operations" (per `CI_POLICY.md`'s Ownership section) and duplicates some of the same historical timing evidence to explain why self-hosted was retired — that duplication is fine; only this one line reads as stale now that the calibration it describes as ongoing has been formally closed elsewhere.


### PR DESCRIPTION
## Summary
- Files two backlog rows found during a maintainer-requested staleness sweep of the CI-policy doc cluster.
- `coverage-baseline-stale` (Medium): `docs/coverage-baseline.md`'s numbers are stamped 2026-04-11 at v1.9.0 (329 tests); repo is now v4.1.2 — a ~5-month, 2-major-version gap.
- `self-hosted-runner-doc-shard-decision-stale-crossref` (Low): `docs/self-hosted-runner.md`'s timing-evidence section still frames shard rebalancing as open/future work; `CI_POLICY.md`'s newer "Hosted Shard Weighting Decision" section already closed that calibration.
- `CI_POLICY.md` itself was checked clean — cross-verified against live `.github/workflows/ci.yml` and GitHub's current published runner specs, zero drift found.

Backlog-only change; no source/test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LYcD57C97Xz7QRdWrvEGy