### PR TITLE
fix(unused-symbols): fail closed on reference-scan failure instead of confident zero

### DIFF
--- a/changelog.d/unused-symbol-scan-fail-unsafe-reference-count.md
+++ b/changelog.d/unused-symbol-scan-fail-unsafe-reference-count.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `find_unused_symbols` and `remove_dead_code_preview` treating a failed reference scan as a confident zero-reference result — a scan failure for a candidate now surfaces as an explicit error instead of a silent false "unused" claim, and the removal guard refuses removal when its own verification scan fails rather than proceeding on an unverifiable answer.

--- a/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/AdvancedAnalysisTools.cs
@@ -14,7 +14,7 @@ public static class AdvancedAnalysisTools
     [McpServerTool(Name = "find_unused_symbols", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Find likely unused symbols."),
-     Description("Find symbols with zero solution-wide references — likely dead code. Each hit carries Confidence: high (private/internal), medium (public API), low (enum/interface members). Convention-invoked shapes are skipped by default.")]
+     Description("Find symbols with zero solution-wide references — likely dead code. Confidence: high (private/internal), medium (public), low (enum/interface). Convention-invoked shapes skipped by default. A scan failure throws; success may still under-count.")]
     public static Task<string> FindUnusedSymbols(
         IWorkspaceExecutionGate gate,
         IUnusedCodeAnalyzer unusedCodeAnalyzer,

--- a/src/RoslynMcp.Roslyn/Services/DeadCodeService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DeadCodeService.cs
@@ -57,7 +57,7 @@ public sealed class DeadCodeService : IDeadCodeService
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                throw new InvalidOperationException(
+                throw new PublicInvalidOperationException(
                     $"Cannot verify '{symbol.Name}' has zero references — the verification scan failed; refusing removal.",
                     ex);
             }

--- a/src/RoslynMcp.Roslyn/Services/DeadCodeService.cs
+++ b/src/RoslynMcp.Roslyn/Services/DeadCodeService.cs
@@ -11,11 +11,21 @@ public sealed class DeadCodeService : IDeadCodeService
 {
     private readonly IWorkspaceManager _workspace;
     private readonly IPreviewStore _previewStore;
+    private readonly Func<ISymbol, Solution, CancellationToken, Task<IEnumerable<ReferencedSymbol>>> _referenceFinder;
 
     public DeadCodeService(IWorkspaceManager workspace, IPreviewStore previewStore)
+        : this(workspace, previewStore, static (symbol, solution, ct) => SymbolFinder.FindReferencesAsync(symbol, solution, ct))
+    {
+    }
+
+    internal DeadCodeService(
+        IWorkspaceManager workspace,
+        IPreviewStore previewStore,
+        Func<ISymbol, Solution, CancellationToken, Task<IEnumerable<ReferencedSymbol>>> referenceFinder)
     {
         _workspace = workspace;
         _previewStore = previewStore;
+        _referenceFinder = referenceFinder;
     }
 
     public async Task<RefactoringPreviewDto> PreviewRemoveDeadCodeAsync(string workspaceId, DeadCodeRemovalDto request, CancellationToken ct)
@@ -34,7 +44,24 @@ public sealed class DeadCodeService : IDeadCodeService
             var symbol = await SymbolResolver.ResolveAsync(updatedSolution, SymbolLocator.ByHandle(symbolHandle), ct).ConfigureAwait(false)
                 ?? throw new InvalidOperationException($"Symbol handle could not be resolved: {symbolHandle}");
 
-            var refs = await SymbolFinder.FindReferencesAsync(symbol, updatedSolution, ct).ConfigureAwait(false);
+            // Fail closed: a failure verifying this symbol's reference count must never be
+            // treated as a legitimate zero — that would let removal proceed on an
+            // unverifiable answer instead of refusing it. This makes the removal guard
+            // genuinely independent of the detector's failure path (though not of a
+            // detector scan that succeeds but under-counts — see UnusedCodeAnalyzer's
+            // matching guard for that documented, non-eliminated residual gap).
+            IEnumerable<ReferencedSymbol> refs;
+            try
+            {
+                refs = await _referenceFinder(symbol, updatedSolution, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot verify '{symbol.Name}' has zero references — the verification scan failed; refusing removal.",
+                    ex);
+            }
+
             if (refs.Sum(reference => reference.Locations.Count()) > 0)
             {
                 throw new InvalidOperationException($"Symbol '{symbol.Name}' still has references and cannot be removed safely.");

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -94,7 +94,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
 
         if (failedCandidateCount > 0)
         {
-            throw new InvalidOperationException(
+            throw new PublicInvalidOperationException(
                 $"Unused-symbol scan was incomplete: {failedCandidateCount} candidate(s) could not be verified and were excluded from the result rather than reported as unused.");
         }
 

--- a/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
+++ b/src/RoslynMcp.Roslyn/Services/UnusedCodeAnalyzer.cs
@@ -42,12 +42,23 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     private readonly IWorkspaceManager _workspace;
     private readonly ICompilationCache _compilationCache;
     private readonly ILogger<UnusedCodeAnalyzer> _logger;
+    private readonly Func<ISymbol, Solution, CancellationToken, Task<IEnumerable<ReferencedSymbol>>> _referenceFinder;
 
     public UnusedCodeAnalyzer(IWorkspaceManager workspace, ICompilationCache compilationCache, ILogger<UnusedCodeAnalyzer> logger)
+        : this(workspace, compilationCache, logger, static (symbol, solution, ct) => SymbolFinder.FindReferencesAsync(symbol, solution, ct))
+    {
+    }
+
+    internal UnusedCodeAnalyzer(
+        IWorkspaceManager workspace,
+        ICompilationCache compilationCache,
+        ILogger<UnusedCodeAnalyzer> logger,
+        Func<ISymbol, Solution, CancellationToken, Task<IEnumerable<ReferencedSymbol>>> referenceFinder)
     {
         _workspace = workspace;
         _compilationCache = compilationCache;
         _logger = logger;
+        _referenceFinder = referenceFinder;
     }
 
     public async Task<IReadOnlyList<UnusedSymbolDto>> FindUnusedSymbolsAsync(
@@ -59,6 +70,7 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         var solution = _workspace.GetCurrentSolution(workspaceId);
         var results = new List<UnusedSymbolDto>();
         var processedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var failedCandidateCount = 0;
 
         var projects = ProjectFilterHelper.FilterProjects(solution, options.ProjectFilter);
 
@@ -76,8 +88,14 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
                 compilation, options, processedSymbols, ct).ConfigureAwait(false);
             if (candidates.Count == 0) continue;
 
-            await ScanCandidatesAndAppendResultsAsync(
+            failedCandidateCount += await ScanCandidatesAndAppendResultsAsync(
                 workspaceId, project, solution, candidates, options.Limit, results, ct).ConfigureAwait(false);
+        }
+
+        if (failedCandidateCount > 0)
+        {
+            throw new InvalidOperationException(
+                $"Unused-symbol scan was incomplete: {failedCandidateCount} candidate(s) could not be verified and were excluded from the result rather than reported as unused.");
         }
 
         return results;
@@ -149,8 +167,11 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     /// order (project → tree → decl). Honors <paramref name="limit"/> once results
     /// are collected. Roslyn's <see cref="Solution"/> is immutable, so
     /// <see cref="SymbolFinder"/> is safe under concurrency.
+    /// Returns the number of candidates whose reference scan failed and were
+    /// therefore excluded from <paramref name="results"/> rather than confidently
+    /// reported as unused or not-unused.
     /// </summary>
-    private async Task ScanCandidatesAndAppendResultsAsync(
+    private async Task<int> ScanCandidatesAndAppendResultsAsync(
         string workspaceId,
         Project project,
         Solution solution,
@@ -161,9 +182,14 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     {
         var parallelism = Math.Clamp(Environment.ProcessorCount, 4, 16);
         using var semaphore = new SemaphoreSlim(parallelism, parallelism);
+        // A single-element array (not a plain int) so each concurrent
+        // TryBuildUnusedDtoAsync call can Interlocked.Increment the shared slot —
+        // async methods cannot declare `ref`/`out` parameters, so a boxed slot is
+        // the seam that lets this stay a per-call counter rather than an instance field.
+        var failedCandidateCount = new int[1];
 
         var tasks = candidates.Select(symbol =>
-            TryBuildUnusedDtoAsync(workspaceId, symbol, project, solution, semaphore, ct));
+            TryBuildUnusedDtoAsync(workspaceId, symbol, project, solution, semaphore, ct, failedCandidateCount));
 
         // Preserve original ordering (project → tree → declaration order) by awaiting
         // in input order, not completion order.
@@ -174,6 +200,8 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
             results.Add(dto);
             if (results.Count >= limit) break;
         }
+
+        return failedCandidateCount[0];
     }
 
     /// <summary>
@@ -185,6 +213,16 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
     /// extension methods and overloaded methods whose callers bind via implicit
     /// conversion — the project-local symbol from <c>GetDeclaredSymbol</c> may not
     /// match the reduced/converted form other compilations see.</para>
+    ///
+    /// <para>Fail-safe note: a failure verifying this candidate's reference count
+    /// (e.g. <see cref="SymbolFinder.FindReferencesAsync"/> throwing) must never be
+    /// treated as a zero-reference result — that would silently mislabel a symbol
+    /// as unused when its true reference count is simply unknown. The candidate is
+    /// excluded from the result and counted via the shared
+    /// <paramref name="failedCandidateCount"/> slot (incremented with
+    /// <see cref="Interlocked.Increment(ref int)"/> since this method runs
+    /// concurrently across candidates) so the caller can surface an
+    /// incomplete-scan error instead of returning a confidently partial list.</para>
     /// </summary>
     private async Task<UnusedSymbolDto?> TryBuildUnusedDtoAsync(
         string workspaceId,
@@ -192,21 +230,38 @@ public sealed class UnusedCodeAnalyzer : IUnusedCodeAnalyzer
         Project declaringProject,
         Solution solution,
         SemaphoreSlim semaphore,
-        CancellationToken ct)
+        CancellationToken ct,
+        int[] failedCandidateCount)
     {
         await semaphore.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct).ConfigureAwait(false);
-            var refCount = refs.Sum(r => r.Locations.Count());
-
-            if (refCount == 0 && NeedsCrossCompilationCheck(symbol))
+            try
             {
-                refCount = await CountCrossCompilationReferencesAsync(
-                    workspaceId, symbol, declaringProject, solution, ct).ConfigureAwait(false);
-            }
+                var refs = await _referenceFinder(symbol, solution, ct).ConfigureAwait(false);
+                var refCount = refs.Sum(r => r.Locations.Count());
 
-            return refCount == 0 ? BuildUnusedDto(symbol) : null;
+                if (refCount == 0 && NeedsCrossCompilationCheck(symbol))
+                {
+                    refCount = await CountCrossCompilationReferencesAsync(
+                        workspaceId, symbol, declaringProject, solution, ct).ConfigureAwait(false);
+                }
+
+                return refCount == 0 ? BuildUnusedDto(symbol) : null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Interlocked.Increment(ref failedCandidateCount[0]);
+                var detail = UnexpectedExceptionReporting.Report(
+                    reporter: null,
+                    ex,
+                    UnexpectedExceptionCategory.AnalysisScan).Public;
+                _logger.LogWarning(
+                    "Unused-symbol scan could not verify one candidate's reference count after an unexpected failure; symbol={SymbolName} correlationId={CorrelationId}",
+                    symbol.Name,
+                    detail.CorrelationId);
+                return null;
+            }
         }
         finally
         {

--- a/tests/RoslynMcp.Tests/UnusedSymbolScanFailSafeTests.cs
+++ b/tests/RoslynMcp.Tests/UnusedSymbolScanFailSafeTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Roslyn.Helpers;
+using RoslynMcp.Roslyn.Services;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers the unused-symbol-scan-fail-unsafe-reference-count fix:
+/// <see cref="UnusedCodeAnalyzer"/>'s per-candidate reference scan (used by both
+/// <c>find_unused_symbols</c> and <c>remove_dead_code_preview</c>'s independent
+/// removal guard) must never treat a failed reference-count verification as a
+/// confident zero. (a)/(b) pin the pre-existing correct-classification behavior
+/// as a baseline; (c)/(d) exercise the new fail-closed behavior via the internal
+/// injectable reference-finder seam.
+/// </summary>
+[TestClass]
+public sealed class UnusedSymbolScanFailSafeTests
+{
+    private const string WorkspaceId = "unused-scan-fail-safe-test-ws";
+
+    [TestMethod]
+    public async Task FindUnusedSymbols_PrivateStaticMethodInvokedEarlierInFile_IsNeverReportedUnused()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Runner
+            {
+                public void Run() => Helper();
+
+                private static void Helper()
+                {
+                }
+            }
+            """;
+
+        var (analyzer, _, _) = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindUnusedSymbolsAsync(
+            WorkspaceId,
+            new UnusedSymbolsAnalysisOptions { IncludePublic = true },
+            default);
+
+        Assert.IsFalse(
+            hits.Any(hit => hit.SymbolName == "Helper"),
+            "A private static method invoked earlier in the same file must not be reported unused.");
+    }
+
+    [TestMethod]
+    public async Task FindDeadFields_PrivateReadonlyFieldOfNestedStructReadInFile_IsNeverReportedUnused()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Container
+            {
+                private struct Info
+                {
+                    private readonly int _value;
+
+                    public Info(int value)
+                    {
+                        _value = value;
+                    }
+
+                    public int Get() => _value;
+                }
+            }
+            """;
+
+        var (analyzer, _, _) = BuildAnalyzerWithSource(source);
+
+        var hits = await analyzer.FindDeadFieldsAsync(
+            WorkspaceId,
+            new DeadFieldsAnalysisOptions(),
+            default);
+
+        Assert.IsFalse(
+            hits.Any(hit => hit.SymbolName == "_value"),
+            "A private readonly field of a nested struct that is read in the same file must not be reported unused.");
+    }
+
+    [TestMethod]
+    public async Task FindUnusedSymbols_ReferenceFinderThrowsForOneCandidate_ThrowsInsteadOfSilentlyOmitting()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Unreferenced
+            {
+                private static void Foo()
+                {
+                }
+
+                private static void Bar()
+                {
+                }
+            }
+            """;
+
+        var (analyzer, _, _) = BuildAnalyzerWithSource(
+            source,
+            referenceFinder: (symbol, solution, ct) => symbol.Name == "Bar"
+                ? throw new InvalidOperationException("simulated reference-scan failure")
+                : SymbolFinder.FindReferencesAsync(symbol, solution, ct));
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            analyzer.FindUnusedSymbolsAsync(
+                WorkspaceId,
+                new UnusedSymbolsAnalysisOptions(),
+                default));
+
+        StringAssert.Contains(ex.Message, "1 candidate");
+    }
+
+    [TestMethod]
+    public async Task PreviewRemoveDeadCode_ReferenceFinderThrows_RefusesRemovalInsteadOfProceeding()
+    {
+        const string source = """
+            namespace Sample;
+            internal sealed class Unreferenced
+            {
+                private static void Foo()
+                {
+                }
+            }
+            """;
+
+        var (analyzer, workspaceManager, previewStore) = BuildAnalyzerWithSource(
+            source,
+            referenceFinder: (_, _, _) => throw new InvalidOperationException("simulated reference-scan failure"));
+
+        var solution = workspaceManager.GetCurrentSolution(WorkspaceId);
+        var fooSymbol = await FindMethodSymbolAsync(solution, "Foo");
+        var handle = SymbolHandleSerializer.CreateHandle(fooSymbol);
+
+        var deadCodeService = new DeadCodeService(
+            workspaceManager,
+            previewStore,
+            (_, _, _) => throw new InvalidOperationException("simulated reference-scan failure"));
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            deadCodeService.PreviewRemoveDeadCodeAsync(
+                WorkspaceId,
+                new DeadCodeRemovalDto([handle]),
+                default));
+
+        StringAssert.Contains(ex.Message, "Cannot verify");
+        StringAssert.Contains(ex.Message, "refusing removal");
+
+        // The UnusedCodeAnalyzer built above is not exercised by this DeadCodeService-focused
+        // test; discard it so the shared BuildAnalyzerWithSource helper stays reusable across
+        // all four tests in this file without an unused-variable warning.
+        _ = analyzer;
+    }
+
+    private static async Task<ISymbol> FindMethodSymbolAsync(Solution solution, string methodName)
+    {
+        foreach (var project in solution.Projects)
+        {
+            var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var root = await tree.GetRootAsync().ConfigureAwait(false);
+                var semanticModel = compilation.GetSemanticModel(tree);
+                foreach (var methodDecl in root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>())
+                {
+                    var symbol = semanticModel.GetDeclaredSymbol(methodDecl);
+                    if (symbol is not null && symbol.Name == methodName)
+                    {
+                        return symbol;
+                    }
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Method '{methodName}' was not found in the test solution.");
+    }
+
+    private static (UnusedCodeAnalyzer Analyzer, TestWorkspaceManager WorkspaceManager, PreviewStore PreviewStore) BuildAnalyzerWithSource(
+        string source,
+        Func<ISymbol, Solution, CancellationToken, Task<IEnumerable<ReferencedSymbol>>>? referenceFinder = null)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            name: "TestAsm",
+            assemblyName: "TestAsm",
+            language: LanguageNames.CSharp,
+            filePath: Path.Combine(Path.GetTempPath(), "TestAsm.csproj"),
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        workspace.AddProject(projectInfo);
+
+        var docId = DocumentId.CreateNewId(projectId);
+        var fileName = "Sample.cs";
+        var fullPath = Path.Combine(Path.GetTempPath(), fileName);
+        workspace.AddDocument(DocumentInfo.Create(
+            docId,
+            fileName,
+            filePath: fullPath,
+            loader: TextLoader.From(
+                TextAndVersion.Create(
+                    SourceText.From(source),
+                    VersionStamp.Create(),
+                    fullPath))));
+
+        var wsManager = new TestWorkspaceManager(WorkspaceId, workspace);
+        var cache = new CompilationCache(wsManager);
+        var previewStore = new PreviewStore();
+
+        var analyzer = referenceFinder is null
+            ? new UnusedCodeAnalyzer(wsManager, cache, NullLogger<UnusedCodeAnalyzer>.Instance)
+            : new UnusedCodeAnalyzer(wsManager, cache, NullLogger<UnusedCodeAnalyzer>.Instance, referenceFinder);
+
+        return (analyzer, wsManager, previewStore);
+    }
+
+    private sealed class TestWorkspaceManager : IWorkspaceManager
+    {
+        private readonly string _workspaceId;
+        private readonly AdhocWorkspace _workspace;
+
+        public event Action<string>? WorkspaceClosed;
+        public event Action<string>? WorkspaceReloaded;
+
+        public TestWorkspaceManager(string workspaceId, AdhocWorkspace workspace)
+        {
+            _workspaceId = workspaceId;
+            _workspace = workspace;
+        }
+
+        public void RaiseWorkspaceClosed(string workspaceId) => WorkspaceClosed?.Invoke(workspaceId);
+        public void RaiseWorkspaceReloaded(string workspaceId) => WorkspaceReloaded?.Invoke(workspaceId);
+
+        public Solution GetCurrentSolution(string workspaceId)
+        {
+            return workspaceId == _workspaceId
+                ? _workspace.CurrentSolution
+                : throw new InvalidOperationException($"Unknown workspace {workspaceId}");
+        }
+
+        public int GetCurrentVersion(string workspaceId) => 1;
+        public void RestoreVersion(string workspaceId, int version) { }
+        public bool ContainsWorkspace(string workspaceId) => workspaceId == _workspaceId;
+        public bool IsStale(string workspaceId) => false;
+        public Project? GetProject(string workspaceId, string projectNameOrPath) => null;
+
+        public Task<WorkspaceStatusDto> LoadAsync(string path, EvictPolicy evictPolicy, CancellationToken ct) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> ReloadAsync(string workspaceId, CancellationToken ct) => throw new NotSupportedException();
+        public bool Close(string workspaceId) => throw new NotSupportedException();
+        public IReadOnlyList<WorkspaceStatusDto> ListWorkspaces() => throw new NotSupportedException();
+        public WorkspaceStatusDto GetStatus(string workspaceId) => throw new NotSupportedException();
+        public Task<WorkspaceStatusDto> GetStatusAsync(string workspaceId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ProjectGraphDto GetProjectGraph(string workspaceId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<GeneratedDocumentDto>> GetSourceGeneratedDocumentsAsync(string workspaceId, string? projectName, CancellationToken ct) => throw new NotSupportedException();
+        public Task<string?> GetSourceTextAsync(string workspaceId, string filePath, CancellationToken ct) => throw new NotSupportedException();
+        public bool TryApplyChanges(string workspaceId, Solution newSolution) => throw new NotSupportedException();
+    }
+}

--- a/tests/RoslynMcp.Tests/UnusedSymbolScanFailSafeTests.cs
+++ b/tests/RoslynMcp.Tests/UnusedSymbolScanFailSafeTests.cs
@@ -107,13 +107,18 @@ public sealed class UnusedSymbolScanFailSafeTests
                 ? throw new InvalidOperationException("simulated reference-scan failure")
                 : SymbolFinder.FindReferencesAsync(symbol, solution, ct));
 
-        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<PublicInvalidOperationException>(() =>
             analyzer.FindUnusedSymbolsAsync(
                 WorkspaceId,
                 new UnusedSymbolsAnalysisOptions(),
                 default));
 
         StringAssert.Contains(ex.Message, "1 candidate");
+        // The MCP tool boundary (ToolErrorHandler) surfaces PublicMessage verbatim for a
+        // PublicInvalidOperationException instead of its generic InvalidOperationException
+        // fallback — pin that the scan-failure text actually reaches the caller, not just the
+        // raw C# exception.
+        StringAssert.Contains(ex.PublicMessage, "1 candidate");
     }
 
     [TestMethod]
@@ -142,7 +147,7 @@ public sealed class UnusedSymbolScanFailSafeTests
             previewStore,
             (_, _, _) => throw new InvalidOperationException("simulated reference-scan failure"));
 
-        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<PublicInvalidOperationException>(() =>
             deadCodeService.PreviewRemoveDeadCodeAsync(
                 WorkspaceId,
                 new DeadCodeRemovalDto([handle]),
@@ -150,6 +155,9 @@ public sealed class UnusedSymbolScanFailSafeTests
 
         StringAssert.Contains(ex.Message, "Cannot verify");
         StringAssert.Contains(ex.Message, "refusing removal");
+        // Same MCP-boundary pin as the scan-failure test above: PublicMessage is what
+        // ToolErrorHandler actually surfaces to the remove_dead_code_preview caller.
+        StringAssert.Contains(ex.PublicMessage, "Cannot verify");
 
         // The UnusedCodeAnalyzer built above is not exercised by this DeadCodeService-focused
         // test; discard it so the shared BuildAnalyzerWithSource helper stays reusable across


### PR DESCRIPTION
## Summary

- `UnusedCodeAnalyzer.TryBuildUnusedDtoAsync` (and the shared `ScanCandidatesAndAppendResultsAsync`/`FindUnusedSymbolsAsync` chain) now catches per-candidate `FindReferencesAsync` failures instead of letting one candidate's exception abort the entire multi-hundred-symbol scan; a failed candidate is excluded from the result, and if any candidate failed, `FindUnusedSymbolsAsync` throws an explicit `InvalidOperationException` naming how many candidates could not be verified rather than silently returning a partial, confidently-labeled "unused" list.
- `DeadCodeService.PreviewRemoveDeadCodeAsync`'s removal guard fails closed the same way: a reference-scan failure now throws `InvalidOperationException` ("Cannot verify … refusing removal") instead of proceeding as if the reference count were a legitimate zero.
- Both services gain an `internal` injectable reference-finder constructor overload (mirroring `CodePatternAnalyzer`'s existing two-ctor seam pattern) so the fail-closed paths are covered by direct fault-injection tests; the existing public constructors are unchanged, so `TestServiceContainer.cs`, `DeadFieldDetectorTests.cs`, `DeadLocalDetectorTests.cs`, and `DuplicateHelperDetectionTests.cs` all continue to compile and pass unmodified.
- `find_unused_symbols`'s tool description now states the new fail-closed behavior and documents the residual gap (a successful-but-under-counting scan is still undetected — a documented non-independence, not eliminated by this fix).
- New `tests/RoslynMcp.Tests/UnusedSymbolScanFailSafeTests.cs`: (a)/(b) pin the pre-existing correct-classification baseline (a `private static` method invoked earlier in its own file, and a `private readonly` field of a nested `struct` read in the same file, are never reported unused); (c)/(d) exercise the new fail-closed behavior via the injectable seam on both services.

`find_dead_fields`'s identical unguarded shape (`UnusedCodeAnalyzer.cs:903`) is deliberately left untouched — already labeled `"experimental"`, out of scope for this initiative, flagged as a follow-up.

Closes: unused-symbol-scan-fail-unsafe-reference-count

## Test plan

- [x] `mcp__roslyn__compile_check` on all 4 touched files — 0 errors
- [x] `mcp__roslyn__test_run --filter "UnusedSymbolScanFailSafeTests"` — 4/4 passed
- [x] `mcp__roslyn__test_run` for `DeadCodeIntegrationTests`, `DeadFieldDetectorTests`, `UnusedSymbolsTestBridgeExclusionTests`, `DeadLocalDetectorTests`, `DuplicateHelperDetectionTests` — 63/63 passed
- [x] `SurfaceCatalogTests` (tool-description diet ceiling) — 22/22 passed
- [x] `./eng/verify-release.ps1 -Configuration Release` — Passed! Failed: 0, Passed: 2849, Skipped: 7, Total: 2856
- [x] `./eng/verify-ai-docs.ps1` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)