### PR TITLE
fix(eng): stop an owned tool-store process before just tool-update

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -54,22 +54,32 @@ Resolves `Darylmcd.RoslynMcp` from NuGet.org (`dotnet tool update -g`, falling b
 
 If `dotnet tool update` reports the previous version right after a release, NuGet indexing has not caught up — wait and retry rather than accepting the old version.
 
-**Windows file lock.** A running Layer 1 process holds its store directory, and the update fails:
+**Windows file lock.** A running Layer 1 process holds its store directory, and the update can fail:
 
 ```
 Failed to uninstall tool package 'darylmcd.roslynmcp':
 Access to the path 'C:\Users\<user>\.dotnet\tools\.store\darylmcd.roslynmcp\<old>' is denied.
 ```
 
-This is the common case, not an edge case — anyone who actually uses Layer 1 has one running, and it is very often **this session's own MCP server**: when Claude Code launched the server from the Layer 1 shim rather than the `dnx` pin, the holder's PID equals `server_info`'s `stdioPid` (verified on the v4.1.2 cut). Restarting Claude Code first therefore clears the lock on its own, which is why the practical order is stop-or-restart *then* update.
+This is the common case, not an edge case — anyone who actually uses Layer 1 has one running, and it is very often **this session's own MCP server**: when Claude Code launched the server from the Layer 1 shim rather than the `dnx` pin, the holder's PID equals `server_info`'s `stdioPid` (verified on the v4.1.2 cut).
 
-Identify the holder by image path before retrying — the `ExecutablePath` is what distinguishes the layers, not the process name:
+`just tool-update` now stops one owned process automatically before mutating anything. It runs `eng/stop-owned-tool-store-process.ps1` as a leading step, which reads `ROSLYNMCP_REINSTALL_PROCESS_ID` and `ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC` (the same two variables `just tool-install-local` uses), stops that one process only after confirming its image name is `roslynmcp` AND its image path resolves under the tool store root, and then asserts the store is unlocked — failing closed and naming every PID + image path still holding it (never terminating anything it cannot attribute) if one remains. Identify the holder by image path, never by process name alone (the plugin's `dnx`-launched Layer 2 server is also called `roslynmcp.exe`, runs from the NuGet package cache rather than the tool store, does not hold the lock, and killing it drops the MCP connection of whoever is attached):
 
 ```bash
 pwsh -NoProfile -Command "Get-CimInstance Win32_Process -Filter \"Name='roslynmcp.exe'\" | Select-Object ProcessId, ExecutablePath, CreationDate"
 ```
 
-Stop only a process you have confirmed is an owned Layer 1 instance — one whose image path is under `~/.dotnet/tools/` — then re-run `just tool-update`. Never stop a `roslynmcp` process by image name alone: the plugin's `dnx`-launched Layer 2 server is also called `roslynmcp.exe`, runs from the NuGet package cache rather than the tool store, does not hold the lock, and killing it drops the MCP connection of whoever is attached. `just tool-update` has no owned-process shutdown of its own; only the local-pack path (`eng/reinstall-local-tool.ps1`, via `ROSLYNMCP_REINSTALL_PROCESS_ID` + `ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC`) does. Backlog row `tool-update-owned-process-shutdown` tracks closing that gap.
+Set the identity, then run the update:
+
+```bash
+$ownedPid = <owned-roslynmcp-pid>
+$owned = Get-Process -Id $ownedPid
+$env:ROSLYNMCP_REINSTALL_PROCESS_ID = $ownedPid
+$env:ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC = $owned.StartTime.ToUniversalTime().ToString('O')
+just tool-update
+```
+
+With no identity supplied, the leading step stops nothing and only asserts the store is unlocked — if a process still holds it, `just tool-update` fails closed with a clear "still locked by PID … " error instead of the opaque `dotnet` I/O failure above. Restarting Claude Code first also clears the lock on its own when the holder was this session's own server. The same shutdown/assert pair backs the local-pack path (`eng/reinstall-local-tool.ps1`, via the same two env vars or `-OwnedProcessId`/`-OwnedProcessStartedAtUtc`).
 
 ### Step 4: Verify both layers
 

--- a/changelog.d/tool-update-owned-process-shutdown.md
+++ b/changelog.d/tool-update-owned-process-shutdown.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** `just tool-update` failing with an access-denied error when an owned Layer 1 `roslynmcp` process holds the tool-store lock; the update now stops only an owned process (by PID + start time, matched by image path under the tool store) and fails closed naming the holder when it cannot attribute the lock.

--- a/eng/reinstall-local-tool.ps1
+++ b/eng/reinstall-local-tool.ps1
@@ -10,14 +10,16 @@ param(
     [ValidateRange(0, [int]::MaxValue)]
     [int]$OwnedProcessId = 0,
 
-    [string]$OwnedProcessStartedAtUtc = ''
+    [string]$OwnedProcessStartedAtUtc = '',
+
+    [string]$ToolStoreRoot = (Join-Path $env:USERPROFILE '.dotnet' 'tools')
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$shutdownTimeout = [TimeSpan]::FromSeconds(10)
-$ownershipTimestampTolerance = [TimeSpan]::FromSeconds(1)
+. (Join-Path $PSScriptRoot 'stop-owned-tool-store-process.ps1')
+
 $currentPackageId = 'Darylmcd.RoslynMcp'
 $legacyPackageId = 'RoslynMcp'
 
@@ -28,74 +30,6 @@ if (-not $PSBoundParameters.ContainsKey('OwnedProcessId') -and
 if (-not $PSBoundParameters.ContainsKey('OwnedProcessStartedAtUtc') -and
     -not [string]::IsNullOrWhiteSpace($env:ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC)) {
     $OwnedProcessStartedAtUtc = $env:ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC
-}
-
-function Stop-OwnedRoslynMcpProcess {
-    if ($OwnedProcessId -eq 0) {
-        if (-not [string]::IsNullOrWhiteSpace($OwnedProcessStartedAtUtc)) {
-            throw 'OwnedProcessStartedAtUtc requires a nonzero OwnedProcessId.'
-        }
-
-        Write-Host 'No owned roslynmcp process identity was supplied; no process was stopped.'
-        return
-    }
-
-    if ([string]::IsNullOrWhiteSpace($OwnedProcessStartedAtUtc)) {
-        throw 'OwnedProcessId requires OwnedProcessStartedAtUtc as a PID-reuse guard.'
-    }
-
-    $expectedStart = [DateTimeOffset]::MinValue
-    if (-not [DateTimeOffset]::TryParseExact(
-            $OwnedProcessStartedAtUtc,
-            'O',
-            [Globalization.CultureInfo]::InvariantCulture,
-            [Globalization.DateTimeStyles]::RoundtripKind,
-            [ref]$expectedStart)) {
-        throw 'OwnedProcessStartedAtUtc must use the round-trip UTC timestamp format.'
-    }
-
-    if ($OwnedProcessId -eq $PID) {
-        throw 'The reinstall helper refuses to terminate its own PowerShell process.'
-    }
-
-    try {
-        $process = Get-Process -Id $OwnedProcessId -ErrorAction Stop
-    }
-    catch [Microsoft.PowerShell.Commands.ProcessCommandException] {
-        Write-Host "Owned roslynmcp process $OwnedProcessId already exited; continuing."
-        return
-    }
-
-    if (-not [string]::Equals($process.ProcessName, 'roslynmcp', [StringComparison]::OrdinalIgnoreCase)) {
-        throw "Process $OwnedProcessId is '$($process.ProcessName)', not roslynmcp; refusing termination."
-    }
-
-    try {
-        $actualStart = [DateTimeOffset]$process.StartTime.ToUniversalTime()
-    }
-    catch {
-        throw "Could not verify the start time for owned roslynmcp process $OwnedProcessId; refusing termination."
-    }
-
-    if (($actualStart - $expectedStart.ToUniversalTime()).Duration() -gt $ownershipTimestampTolerance) {
-        throw "Process $OwnedProcessId start time does not match the supplied ownership identity; refusing termination."
-    }
-
-    try {
-        Stop-Process -Id $OwnedProcessId -Force -ErrorAction Stop
-    }
-    catch {
-        $process.Refresh()
-        if (-not $process.HasExited) {
-            throw "Failed to stop owned roslynmcp process $OwnedProcessId."
-        }
-    }
-
-    if (-not $process.WaitForExit([int]$shutdownTimeout.TotalMilliseconds)) {
-        throw "Owned roslynmcp process $OwnedProcessId did not exit within $($shutdownTimeout.TotalSeconds) seconds."
-    }
-
-    Write-Host "Stopped owned roslynmcp process $OwnedProcessId."
 }
 
 function Invoke-DotnetStep {
@@ -148,7 +82,10 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
     }
 }
 
-Stop-OwnedRoslynMcpProcess
+Stop-OwnedToolStoreProcess `
+    -OwnedProcessId $OwnedProcessId `
+    -OwnedProcessStartedAtUtc $OwnedProcessStartedAtUtc `
+    -ToolStoreRoot $ToolStoreRoot
 
 $inventoryJson = Invoke-DotnetStep `
     -Description 'Global tool inventory' `

--- a/eng/stop-owned-tool-store-process.ps1
+++ b/eng/stop-owned-tool-store-process.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+Ownership-scoped shutdown and lock detection for the `roslynmcp` global-tool store.
+
+.DESCRIPTION
+Defines two functions used to keep a Windows `dotnet tool update`/`uninstall`/`install`
+from failing on a locked tool-store directory:
+
+  - Stop-OwnedToolStoreProcess: stops exactly one process, identified by PID + UTC start
+    time (a PID-reuse guard), after confirming its image name is `roslynmcp` AND its image
+    path resolves under the given tool-store root. Refuses (throws) rather than terminating
+    anything it cannot fully attribute. Never discovers processes by name alone.
+  - Assert-ToolStoreUnlocked: fails closed, naming every PID + image path still holding a
+    file under the tool-store root, without terminating anything. Used as a final pre-flight
+    so a caller gets a clear, attributable error instead of an opaque `dotnet` I/O failure.
+
+This file is meant to be BOTH dot-sourced (by eng/reinstall-local-tool.ps1, to reuse the
+functions with its own already-resolved parameters) and invoked directly (by `just
+tool-update`, which has no per-invocation parameters of its own). To keep dot-sourcing
+side-effect-free, the file declares no top-level `param()` block — only functions — so
+dot-sourcing it can never clobber a caller's already-resolved variables of the same name.
+Standalone execution (env-var-sourced identity, default tool-store root) is gated behind an
+InvocationName check so it never runs when dot-sourced.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Stop-OwnedToolStoreProcess {
+    [CmdletBinding()]
+    param(
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$OwnedProcessId = 0,
+
+        [string]$OwnedProcessStartedAtUtc = '',
+
+        [Parameter(Mandatory)]
+        [string]$ToolStoreRoot
+    )
+
+    $shutdownTimeout = [TimeSpan]::FromSeconds(10)
+    $ownershipTimestampTolerance = [TimeSpan]::FromSeconds(1)
+
+    if ($OwnedProcessId -eq 0) {
+        if (-not [string]::IsNullOrWhiteSpace($OwnedProcessStartedAtUtc)) {
+            throw 'OwnedProcessStartedAtUtc requires a nonzero OwnedProcessId.'
+        }
+
+        Write-Host 'No owned roslynmcp process identity was supplied; no process was stopped.'
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($OwnedProcessStartedAtUtc)) {
+        throw 'OwnedProcessId requires OwnedProcessStartedAtUtc as a PID-reuse guard.'
+    }
+
+    $expectedStart = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParseExact(
+            $OwnedProcessStartedAtUtc,
+            'O',
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::RoundtripKind,
+            [ref]$expectedStart)) {
+        throw 'OwnedProcessStartedAtUtc must use the round-trip UTC timestamp format.'
+    }
+
+    if ($OwnedProcessId -eq $PID) {
+        throw 'The reinstall helper refuses to terminate its own PowerShell process.'
+    }
+
+    try {
+        $process = Get-Process -Id $OwnedProcessId -ErrorAction Stop
+    }
+    catch [Microsoft.PowerShell.Commands.ProcessCommandException] {
+        Write-Host "Owned roslynmcp process $OwnedProcessId already exited; continuing."
+        return
+    }
+
+    if (-not [string]::Equals($process.ProcessName, 'roslynmcp', [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Process $OwnedProcessId is '$($process.ProcessName)', not roslynmcp; refusing termination."
+    }
+
+    $resolvedToolStoreRoot = $null
+    try {
+        $resolvedToolStoreRoot = (Resolve-Path -LiteralPath $ToolStoreRoot -ErrorAction Stop).Path.TrimEnd('\', '/')
+    }
+    catch {
+        throw "Could not resolve tool store root '$ToolStoreRoot'; refusing termination."
+    }
+
+    $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $OwnedProcessId" -ErrorAction Stop
+    $imagePath = [string]$processInfo.ExecutablePath
+    if ([string]::IsNullOrWhiteSpace($imagePath) -or
+        -not $imagePath.StartsWith($resolvedToolStoreRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Process $OwnedProcessId image path '$imagePath' is not under the tool store root '$resolvedToolStoreRoot'; refusing termination."
+    }
+
+    try {
+        $actualStart = [DateTimeOffset]$process.StartTime.ToUniversalTime()
+    }
+    catch {
+        throw "Could not verify the start time for owned roslynmcp process $OwnedProcessId; refusing termination."
+    }
+
+    if (($actualStart - $expectedStart.ToUniversalTime()).Duration() -gt $ownershipTimestampTolerance) {
+        throw "Process $OwnedProcessId start time does not match the supplied ownership identity; refusing termination."
+    }
+
+    try {
+        Stop-Process -Id $OwnedProcessId -Force -ErrorAction Stop
+    }
+    catch {
+        $process.Refresh()
+        if (-not $process.HasExited) {
+            throw "Failed to stop owned roslynmcp process $OwnedProcessId."
+        }
+    }
+
+    if (-not $process.WaitForExit([int]$shutdownTimeout.TotalMilliseconds)) {
+        throw "Owned roslynmcp process $OwnedProcessId did not exit within $($shutdownTimeout.TotalSeconds) seconds."
+    }
+
+    Write-Host "Stopped owned roslynmcp process $OwnedProcessId."
+}
+
+function Assert-ToolStoreUnlocked {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ToolStoreRoot
+    )
+
+    if (-not (Test-Path -LiteralPath $ToolStoreRoot)) {
+        return
+    }
+
+    $resolvedToolStoreRoot = (Resolve-Path -LiteralPath $ToolStoreRoot -ErrorAction Stop).Path.TrimEnd('\', '/')
+    $holders = @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_.ExecutablePath) -and
+        ([string]$_.ExecutablePath).StartsWith($resolvedToolStoreRoot, [StringComparison]::OrdinalIgnoreCase)
+    })
+
+    if ($holders.Count -gt 0) {
+        $holderDescriptions = $holders | ForEach-Object { "PID $($_.ProcessId): $($_.ExecutablePath)" }
+        throw "The tool store root '$resolvedToolStoreRoot' is still locked by $($holders.Count) process(es): $($holderDescriptions -join '; ')"
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    $standaloneOwnedProcessId = 0
+    if (-not [string]::IsNullOrWhiteSpace($env:ROSLYNMCP_REINSTALL_PROCESS_ID)) {
+        $standaloneOwnedProcessId = [int]$env:ROSLYNMCP_REINSTALL_PROCESS_ID
+    }
+    $standaloneOwnedProcessStartedAtUtc = ''
+    if (-not [string]::IsNullOrWhiteSpace($env:ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC)) {
+        $standaloneOwnedProcessStartedAtUtc = $env:ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC
+    }
+    $standaloneToolStoreRoot = Join-Path $env:USERPROFILE '.dotnet' 'tools'
+
+    Stop-OwnedToolStoreProcess `
+        -OwnedProcessId $standaloneOwnedProcessId `
+        -OwnedProcessStartedAtUtc $standaloneOwnedProcessStartedAtUtc `
+        -ToolStoreRoot $standaloneToolStoreRoot
+    Assert-ToolStoreUnlocked -ToolStoreRoot $standaloneToolStoreRoot
+}

--- a/justfile
+++ b/justfile
@@ -103,7 +103,11 @@ pack:
     dotnet pack {{ host-project }} -c Release -o {{ nupkg-dir }}
 
 # Update or install global `roslynmcp` from nuget.org (package id Darylmcd.RoslynMcp)
+# Stops one owned Layer 1 process (identified via ROSLYNMCP_REINSTALL_PROCESS_ID +
+# ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC, matched by image path under the tool
+# store) before mutating, then fails closed naming any holder it cannot attribute.
 tool-update:
+    pwsh -NoProfile -File ./eng/stop-owned-tool-store-process.ps1
     dotnet tool update -g Darylmcd.RoslynMcp || dotnet tool install -g Darylmcd.RoslynMcp
     dotnet tool list -g
 

--- a/tests/RoslynMcp.Tests/LocalToolReinstallProcessOwnershipTests.cs
+++ b/tests/RoslynMcp.Tests/LocalToolReinstallProcessOwnershipTests.cs
@@ -52,6 +52,8 @@ public sealed class LocalToolReinstallProcessOwnershipTests
                     ownedProcess.Id.ToString(CultureInfo.InvariantCulture),
                     "-OwnedProcessStartedAtUtc",
                     ownedStartUtc,
+                    "-ToolStoreRoot",
+                    fixtureRoot,
                     "-InvocationLogPath",
                     invocationLogPath,
                 ],
@@ -98,6 +100,7 @@ public sealed class LocalToolReinstallProcessOwnershipTests
             "RoslynMcp.Host.Stdio.csproj"));
         var justfile = File.ReadAllText(Path.Combine(repositoryRoot, "justfile"));
         var script = File.ReadAllText(Path.Combine(repositoryRoot, "eng", "reinstall-local-tool.ps1"));
+        var sharedScript = File.ReadAllText(Path.Combine(repositoryRoot, "eng", "stop-owned-tool-store-process.ps1"));
 
         StringAssert.Contains(project, "reinstall-local-tool.ps1");
         StringAssert.Contains(project, "ReinstallToolProcessId");
@@ -105,11 +108,16 @@ public sealed class LocalToolReinstallProcessOwnershipTests
         StringAssert.Contains(justfile, "reinstall-local-tool.ps1");
         StringAssert.Contains(script, "ROSLYNMCP_REINSTALL_PROCESS_ID");
         StringAssert.Contains(script, "ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC");
-        StringAssert.Contains(script, "Stop-Process -Id $OwnedProcessId");
+        // The termination call itself now lives in the shared, dot-sourced script
+        // (eng/stop-owned-tool-store-process.ps1) so eng/reinstall-local-tool.ps1 and
+        // `just tool-update` cannot drift out of sync on how a PID gets stopped.
+        StringAssert.Contains(sharedScript, "Stop-Process -Id $OwnedProcessId");
         Assert.IsFalse(project.Contains("taskkill", StringComparison.OrdinalIgnoreCase));
         Assert.IsFalse(justfile.Contains("taskkill", StringComparison.OrdinalIgnoreCase));
         Assert.IsFalse(script.Contains("Get-Process -Name", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(sharedScript.Contains("Get-Process -Name", StringComparison.OrdinalIgnoreCase));
         Assert.IsFalse(script.Contains("killall", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(sharedScript.Contains("killall", StringComparison.OrdinalIgnoreCase));
     }
 
     private static Process StartNamedRoslynMcpProcess(string fixtureRoot, string instanceName)
@@ -151,6 +159,7 @@ public sealed class LocalToolReinstallProcessOwnershipTests
                 [string]$ProjectPath,
                 [int]$OwnedProcessId,
                 [string]$OwnedProcessStartedAtUtc,
+                [string]$ToolStoreRoot,
                 [string]$InvocationLogPath
             )
 
@@ -177,7 +186,8 @@ public sealed class LocalToolReinstallProcessOwnershipTests
                 -PackageSource $PackageSource `
                 -ProjectPath $ProjectPath `
                 -OwnedProcessId $OwnedProcessId `
-                -OwnedProcessStartedAtUtc $OwnedProcessStartedAtUtc
+                -OwnedProcessStartedAtUtc $OwnedProcessStartedAtUtc `
+                -ToolStoreRoot $ToolStoreRoot
             """);
         return wrapperPath;
     }

--- a/tests/RoslynMcp.Tests/ToolUpdateOwnedProcessShutdownTests.cs
+++ b/tests/RoslynMcp.Tests/ToolUpdateOwnedProcessShutdownTests.cs
@@ -1,0 +1,321 @@
+using System.Diagnostics;
+using System.Globalization;
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Covers <c>eng/stop-owned-tool-store-process.ps1</c>, the script that makes the owned-process
+/// shutdown guard reachable from <c>just tool-update</c> (previously only the local-pack path via
+/// <c>eng/reinstall-local-tool.ps1</c> could stop an owned process). The critical new behavior
+/// this row adds over the prior inlined guard: an image-path-under-tool-store check that can tell
+/// the Layer 1 shim (running from the tool store) apart from the plugin's <c>dnx</c>-launched
+/// Layer 2 server (same process name, different origin) — the old guard, keyed on process name
+/// alone, could not make that distinction.
+/// </summary>
+[TestClass]
+public sealed class ToolUpdateOwnedProcessShutdownTests
+{
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
+
+    [TestMethod]
+    public void SharedScript_DiscoversProcessesViaCimInsteadOfProcessNameLookup()
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repositoryRoot, "eng", "stop-owned-tool-store-process.ps1"));
+
+        Assert.IsFalse(
+            script.Contains("Get-Process -Name", StringComparison.OrdinalIgnoreCase),
+            "Tool-store lock discovery must use Get-CimInstance Win32_Process, not name-based Get-Process, so it can see every holder including ones this process cannot enumerate by name alone.");
+        Assert.IsFalse(script.Contains("taskkill", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(script.Contains("killall", StringComparison.OrdinalIgnoreCase));
+        StringAssert.Contains(script, "Get-CimInstance Win32_Process");
+        StringAssert.Contains(script, "function Stop-OwnedToolStoreProcess");
+        StringAssert.Contains(script, "function Assert-ToolStoreUnlocked");
+    }
+
+    [TestMethod]
+    public void ReinstallScript_DotSourcesSharedScriptAndNoLongerInlinesTheGuard()
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repositoryRoot, "eng", "reinstall-local-tool.ps1"));
+
+        StringAssert.Contains(script, "stop-owned-tool-store-process.ps1");
+        StringAssert.Contains(script, "Stop-OwnedToolStoreProcess");
+        Assert.IsFalse(
+            script.Contains("function Stop-OwnedRoslynMcpProcess", StringComparison.Ordinal),
+            "The ownership guard must be extracted, not duplicated, so eng/reinstall-local-tool.ps1 and " +
+            "eng/stop-owned-tool-store-process.ps1 cannot drift out of sync.");
+    }
+
+    [TestMethod]
+    public void Justfile_ToolUpdateRecipe_RunsSharedScriptBeforeMutatingTheToolStore()
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var justfile = File.ReadAllText(Path.Combine(repositoryRoot, "justfile"));
+
+        var recipeStart = justfile.IndexOf("tool-update:", StringComparison.Ordinal);
+        Assert.AreNotEqual(-1, recipeStart, "justfile must declare a tool-update recipe.");
+        var recipeEnd = justfile.IndexOf("\n\n", recipeStart, StringComparison.Ordinal);
+        var recipeBody = recipeEnd == -1
+            ? justfile[recipeStart..]
+            : justfile[recipeStart..recipeEnd];
+
+        var shutdownIndex = recipeBody.IndexOf("stop-owned-tool-store-process.ps1", StringComparison.Ordinal);
+        var updateIndex = recipeBody.IndexOf("dotnet tool update", StringComparison.Ordinal);
+        Assert.AreNotEqual(-1, shutdownIndex, "tool-update must invoke the shared shutdown/assert script.");
+        Assert.AreNotEqual(-1, updateIndex, "tool-update must still run dotnet tool update.");
+        Assert.IsTrue(
+            shutdownIndex < updateIndex,
+            "The shutdown/assert script must run before dotnet tool update mutates the tool store.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task StopOwnedToolStoreProcess_RefusesTerminationWhenImagePathIsOutsideToolStoreRoot()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("The tool-store image-path attribution contract is Windows-specific.");
+        }
+
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var fixtureRoot = Path.Combine(
+            TestTempRoot.Current,
+            nameof(ToolUpdateOwnedProcessShutdownTests),
+            "outside",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(fixtureRoot);
+        var unrelatedStoreRoot = Path.Combine(fixtureRoot, "unrelated-store");
+        Directory.CreateDirectory(unrelatedStoreRoot);
+
+        Process? fixtureProcess = null;
+        try
+        {
+            // The fixture process's image lives OUTSIDE the tool store root — this simulates the
+            // plugin's dnx-launched Layer 2 server, which shares the roslynmcp.exe process name
+            // but never runs from the tool store.
+            fixtureProcess = StartRoslynMcpFixtureProcess(Path.Combine(fixtureRoot, "layer2-like"));
+            var startedAtUtc = fixtureProcess.StartTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+            var wrapperPath = await WriteWrapperAsync(fixtureRoot);
+
+            var result = await PwshScriptRunner.RunAsync(
+                [
+                    "-NoProfile",
+                    "-File",
+                    wrapperPath,
+                    "-SharedScript",
+                    Path.Combine(repositoryRoot, "eng", "stop-owned-tool-store-process.ps1"),
+                    "-Mode",
+                    "Stop",
+                    "-OwnedProcessId",
+                    fixtureProcess.Id.ToString(CultureInfo.InvariantCulture),
+                    "-OwnedProcessStartedAtUtc",
+                    startedAtUtc,
+                    "-ToolStoreRoot",
+                    unrelatedStoreRoot,
+                ],
+                workingDirectory: fixtureRoot,
+                timeout: ProcessTimeout,
+                description: "tool-store shutdown outside-store fixture");
+
+            Assert.AreNotEqual(0, result.ExitCode, "Termination must be refused when the image path is outside the tool store root." + Environment.NewLine + result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "not under the tool store root");
+            fixtureProcess.Refresh();
+            Assert.IsFalse(fixtureProcess.HasExited, "A process outside the tool store root must never be terminated, even with a matching PID and start time.");
+        }
+        finally
+        {
+            await TerminateIfRunningAsync(fixtureProcess);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task AssertToolStoreUnlocked_FailsClosedNamingHolderWithoutTerminatingIt()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("The tool-store lock assertion contract is Windows-specific.");
+        }
+
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var fixtureRoot = Path.Combine(
+            TestTempRoot.Current,
+            nameof(ToolUpdateOwnedProcessShutdownTests),
+            "locked",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(fixtureRoot);
+        var toolStoreRoot = Path.Combine(fixtureRoot, "store");
+        Directory.CreateDirectory(toolStoreRoot);
+
+        Process? holderProcess = null;
+        try
+        {
+            holderProcess = StartRoslynMcpFixtureProcess(Path.Combine(toolStoreRoot, "holder"));
+            var wrapperPath = await WriteWrapperAsync(fixtureRoot);
+
+            var result = await PwshScriptRunner.RunAsync(
+                [
+                    "-NoProfile",
+                    "-File",
+                    wrapperPath,
+                    "-SharedScript",
+                    Path.Combine(repositoryRoot, "eng", "stop-owned-tool-store-process.ps1"),
+                    "-Mode",
+                    "Assert",
+                    "-ToolStoreRoot",
+                    toolStoreRoot,
+                ],
+                workingDirectory: fixtureRoot,
+                timeout: ProcessTimeout,
+                description: "tool-store assert-unlocked fixture");
+
+            Assert.AreNotEqual(0, result.ExitCode, "A held tool store must fail closed." + Environment.NewLine + result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "still locked");
+            StringAssert.Contains(result.AllOutput, holderProcess.Id.ToString(CultureInfo.InvariantCulture));
+            holderProcess.Refresh();
+            Assert.IsFalse(holderProcess.HasExited, "Assert-ToolStoreUnlocked must never terminate a holder — it only detects and names it.");
+        }
+        finally
+        {
+            await TerminateIfRunningAsync(holderProcess);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task AssertToolStoreUnlocked_ReturnsWithoutThrowingWhenToolStoreRootDoesNotExistYet()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("The tool-store lock assertion contract is Windows-specific.");
+        }
+
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var fixtureRoot = Path.Combine(
+            TestTempRoot.Current,
+            nameof(ToolUpdateOwnedProcessShutdownTests),
+            "missing",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(fixtureRoot);
+        var neverCreatedToolStoreRoot = Path.Combine(fixtureRoot, "never-created-store");
+
+        try
+        {
+            var wrapperPath = await WriteWrapperAsync(fixtureRoot);
+
+            var result = await PwshScriptRunner.RunAsync(
+                [
+                    "-NoProfile",
+                    "-File",
+                    wrapperPath,
+                    "-SharedScript",
+                    Path.Combine(repositoryRoot, "eng", "stop-owned-tool-store-process.ps1"),
+                    "-Mode",
+                    "Assert",
+                    "-ToolStoreRoot",
+                    neverCreatedToolStoreRoot,
+                ],
+                workingDirectory: fixtureRoot,
+                timeout: ProcessTimeout,
+                description: "tool-store assert-unlocked missing-root fixture");
+
+            Assert.AreEqual(0, result.ExitCode, "A fresh machine with no tool store yet must not fail closed." + Environment.NewLine + result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "NO_THROW");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    private static Process StartRoslynMcpFixtureProcess(string executableDirectory)
+    {
+        Directory.CreateDirectory(executableDirectory);
+        var executablePath = Path.Combine(executableDirectory, "roslynmcp.exe");
+        File.Copy(Path.Combine(Environment.SystemDirectory, "PING.EXE"), executablePath);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("127.0.0.1");
+        startInfo.ArgumentList.Add("-t");
+        var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start the controlled roslynmcp process fixture.");
+        if (process.WaitForExit(250))
+        {
+            throw new InvalidOperationException("The controlled roslynmcp process fixture exited before the test began.");
+        }
+
+        Assert.AreEqual("roslynmcp", process.ProcessName, ignoreCase: true);
+        return process;
+    }
+
+    private static async Task<string> WriteWrapperAsync(string fixtureRoot)
+    {
+        var wrapperPath = Path.Combine(fixtureRoot, "invoke-shared-script.ps1");
+        await File.WriteAllTextAsync(
+            wrapperPath,
+            """
+            param(
+                [string]$SharedScript,
+                [string]$Mode,
+                [int]$OwnedProcessId = 0,
+                [string]$OwnedProcessStartedAtUtc = '',
+                [string]$ToolStoreRoot = ''
+            )
+
+            . $SharedScript
+
+            try {
+                switch ($Mode) {
+                    'Stop' {
+                        Stop-OwnedToolStoreProcess `
+                            -OwnedProcessId $OwnedProcessId `
+                            -OwnedProcessStartedAtUtc $OwnedProcessStartedAtUtc `
+                            -ToolStoreRoot $ToolStoreRoot
+                        Write-Output 'NO_THROW'
+                    }
+                    'Assert' {
+                        Assert-ToolStoreUnlocked -ToolStoreRoot $ToolStoreRoot
+                        Write-Output 'NO_THROW'
+                    }
+                    default {
+                        throw "Unknown mode: $Mode"
+                    }
+                }
+                exit 0
+            }
+            catch {
+                Write-Output "THREW:$($_.Exception.Message)"
+                exit 1
+            }
+            """);
+        return wrapperPath;
+    }
+
+    private static async Task TerminateIfRunningAsync(Process? process)
+    {
+        if (process is null)
+        {
+            return;
+        }
+
+        using (process)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `just tool-update` failed with an access-denied error when an owned Layer 1 `roslynmcp` process held the tool-store lock; the existing shutdown guard was reachable only from the local-pack reinstall path and attributed ownership by process name alone, which cannot tell the Layer 1 shim (running from the tool store) apart from the plugin's `dnx`-launched Layer 2 server (same process name, different origin).
- Extracted the guard into new `eng/stop-owned-tool-store-process.ps1`: `Stop-OwnedToolStoreProcess` (PID + start-time attribution, now also requiring the image path resolve under the tool store root) and `Assert-ToolStoreUnlocked` (fails closed naming every holder, never terminates). `eng/reinstall-local-tool.ps1` dot-sources it instead of inlining its own copy.
- `justfile`'s `tool-update` recipe runs the script as a leading step (env-var-sourced identity, same `ROSLYNMCP_REINSTALL_PROCESS_ID` / `ROSLYNMCP_REINSTALL_PROCESS_STARTED_AT_UTC` pair `tool-install-local` already uses) before `dotnet tool update`.
- Updated `.claude/skills/update/SKILL.md` Step 3 to document the automated contract instead of the interim manual one.

## Test plan

- [x] `mcp__roslyn__compile_check` on the new/edited test files — 0 errors, 0 warnings.
- [x] `mcp__roslyn__test_run --filter "LocalToolReinstallProcessOwnershipTests|ToolUpdateOwnedProcessShutdownTests"` — 8/8 passed.
- [x] `mcp__roslyn__test_run --filter "InstallLayerRefreshContractTests|JustfilePortabilityTests"` — 8/8 passed (unaffected siblings).
- [x] Full `./eng/verify-release.ps1 -Configuration Release` — 2851 passed, 0 failed, 7 skipped (unrelated), exit 0.
- [x] `./eng/verify-ai-docs.ps1` — passed.
- [x] Manual functional smoke of the new script's four scenarios against real fixture processes (outside-store refusal, in-store stop, Assert-ToolStoreUnlocked fail-closed without terminating, Assert-ToolStoreUnlocked no-op on a not-yet-created store root) — all matched expected behavior before the .NET test suite ran.

Closes: `tool-update-owned-process-shutdown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)