### PR TITLE
test(desc-budget): consolidate method-family description-budget harness

### DIFF
--- a/changelog.d/desc-budget-harness-method-family.md
+++ b/changelog.d/desc-budget-harness-method-family.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Consolidated the duplicated method-description-budget test harness shared by `ToolDescriptionDietAnalysisMetricsTests` and `ToolDescriptionDietWorkspaceValidationTests` into a single `ToolDescriptionBudgetHarness`.

--- a/tests/RoslynMcp.Tests/ToolDescriptionBudgetHarness.cs
+++ b/tests/RoslynMcp.Tests/ToolDescriptionBudgetHarness.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Shared reflection harness for the method-level tool-description-budget ratchets. Each
+/// consuming slice test class (e.g. <c>ToolDescriptionDietAnalysisMetricsTests</c>,
+/// <c>ToolDescriptionDietWorkspaceValidationTests</c>) declares its own swept-type set and
+/// per-slice ceilings, then calls into these helpers instead of re-declaring the reflection
+/// enumeration and assertion bodies.
+/// </summary>
+/// <remarks>
+/// <para>Mirrors the reflection harness of
+/// <c>SurfaceCatalogTests.AllMcpToolMethodDescriptions_AreWithinClientLimit</c>, but enumerates an
+/// explicit declaring-type set instead of the whole assembly so sibling diet slices stay
+/// independent.</para>
+/// <para>Only METHOD-level <c>[Description]</c> attributes are in scope. Parameter-level
+/// descriptions and the <c>[McpToolMetadata]</c> summaries the surface catalog mirrors are
+/// deliberately excluded.</para>
+/// <para>This harness covers the METHOD-family diet only. The PARAMETER-family (reflecting over
+/// method parameters) needs its own helper — out of scope here.</para>
+/// </remarks>
+internal static class ToolDescriptionBudgetHarness
+{
+    /// <summary>One tool's discriminating-trigger expectation: the substring its trimmed
+    /// method-level description must still contain.</summary>
+    internal readonly record struct TriggerExpectation(string ToolName, string ExpectedSubstring);
+
+    private readonly record struct DescriptionEntry(string Name, string Description);
+
+    internal static void AssertPerToolBudget(IReadOnlyList<Type> sliceTypes, int maxPerToolDescriptionCharacters)
+    {
+        var violations = EnumerateSweptToolDescriptions(sliceTypes)
+            .Where(entry => entry.Description.Length > maxPerToolDescriptionCharacters)
+            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            violations.Length,
+            $"Swept tool descriptions must be <= {maxPerToolDescriptionCharacters} characters. " +
+            "Move operational guidance into XML <remarks> on the same method instead of the wire " +
+            "description. Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    internal static void AssertSliceTotalBudget(IReadOnlyList<Type> sliceTypes, int maxSweptSetTotalCharacters)
+    {
+        var swept = EnumerateSweptToolDescriptions(sliceTypes);
+        var total = swept.Sum(entry => entry.Description.Length);
+
+        Assert.IsTrue(
+            total <= maxSweptSetTotalCharacters,
+            $"Swept-set method description total is {total} chars across {swept.Length} tools, " +
+            $"over the {maxSweptSetTotalCharacters}-char slice budget.");
+    }
+
+    internal static void AssertAllHaveNonEmptyDescription(IReadOnlyList<Type> sliceTypes)
+    {
+        var missing = EnumerateSweptToolDescriptions(sliceTypes)
+            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
+            .Select(entry => entry.Name)
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            missing.Length,
+            "Every swept tool must keep a non-empty method-level description so clients can " +
+            "discriminate it from sibling tools. Missing:\n  " + string.Join("\n  ", missing));
+    }
+
+    /// <summary>
+    /// Asserts each <paramref name="expectations"/> entry's trigger substring is still present in
+    /// the named tool's trimmed method-level description. Slices that don't declare a trigger
+    /// ratchet simply pass an empty list — this method must never silently no-op a non-empty list.
+    /// </summary>
+    internal static void AssertDiscriminatingTriggers(
+        IReadOnlyList<Type> sliceTypes, IReadOnlyList<TriggerExpectation> expectations)
+    {
+        if (expectations.Count == 0)
+        {
+            return;
+        }
+
+        var entries = EnumerateSweptToolDescriptions(sliceTypes);
+
+        foreach (var expectation in expectations)
+        {
+            var entry = entries.SingleOrDefault(candidate => candidate.Name == expectation.ToolName);
+
+            Assert.IsNotNull(entry.Name, $"Tool '{expectation.ToolName}' was not found on the slice types.");
+            StringAssert.Contains(
+                entry.Description,
+                expectation.ExpectedSubstring,
+                $"Trimming '{expectation.ToolName}' dropped its discriminating trigger.");
+        }
+    }
+
+    private static DescriptionEntry[] EnumerateSweptToolDescriptions(IReadOnlyList<Type> sliceTypes) =>
+        sliceTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null)
+            .OrderBy(entry => entry.Tool!.Name, StringComparer.Ordinal)
+            .Select(entry => new DescriptionEntry(
+                entry.Tool!.Name ?? "(unnamed)",
+                entry.Description?.Description ?? string.Empty))
+            .ToArray();
+}

--- a/tests/RoslynMcp.Tests/ToolDescriptionDietAnalysisMetricsTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDescriptionDietAnalysisMetricsTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -12,10 +10,9 @@ namespace RoslynMcp.Tests;
 /// tighter per-slice budget so a future edit cannot silently regrow the <c>tools/list</c> payload.
 /// </summary>
 /// <remarks>
-/// <para>Mirrors the reflection harness of
-/// <c>SurfaceCatalogTests.AllMcpToolMethodDescriptions_AreWithinClientLimit</c>, but enumerates an
-/// explicit declaring-type set instead of the whole assembly so sibling diet slices stay
-/// independent and do not collide in this file.</para>
+/// <para>Reflection enumeration and shared assertions live in
+/// <see cref="ToolDescriptionBudgetHarness"/>; this class owns only the swept-type set and the
+/// per-slice ceilings.</para>
 /// <para>Only METHOD-level <c>[Description]</c> attributes are in scope. Parameter-level
 /// descriptions and the <c>[McpToolMetadata]</c> summaries the surface catalog mirrors are
 /// deliberately excluded.</para>
@@ -37,62 +34,15 @@ public sealed class ToolDescriptionDietAnalysisMetricsTests
         typeof(FlowAnalysisTools),
     ];
 
-    private static (string Name, string Description)[] SweptToolDescriptions() =>
-        _sweptToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null)
-            .OrderBy(entry => entry.Tool!.Name, StringComparer.Ordinal)
-            .Select(entry => (
-                Name: entry.Tool!.Name ?? "(unnamed)",
-                Description: entry.Description?.Description ?? string.Empty))
-            .ToArray();
-
     [TestMethod]
     public void SweptToolDescriptions_AreWithinPerToolBudget()
-    {
-        var violations = SweptToolDescriptions()
-            .Where(entry => entry.Description.Length > _maxPerToolDescriptionCharacters)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Swept tool descriptions must be <= {_maxPerToolDescriptionCharacters} characters. " +
-            "Move operational guidance into XML <remarks> on the same method instead of the wire " +
-            "description. Violations:\n  " + string.Join("\n  ", violations));
-    }
+        => ToolDescriptionBudgetHarness.AssertPerToolBudget(_sweptToolTypes, _maxPerToolDescriptionCharacters);
 
     [TestMethod]
     public void SweptToolDescriptions_TotalIsWithinSliceBudget()
-    {
-        var swept = SweptToolDescriptions();
-        var total = swept.Sum(entry => entry.Description.Length);
-
-        Assert.IsTrue(
-            total <= _maxSweptSetTotalCharacters,
-            $"Swept-set method description total is {total} chars across {swept.Length} tools, " +
-            $"over the {_maxSweptSetTotalCharacters}-char slice budget.");
-    }
+        => ToolDescriptionBudgetHarness.AssertSliceTotalBudget(_sweptToolTypes, _maxSweptSetTotalCharacters);
 
     [TestMethod]
     public void SweptTools_AllHaveNonEmptyDescription()
-    {
-        var missing = SweptToolDescriptions()
-            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
-            .Select(entry => entry.Name)
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            missing.Length,
-            "Every swept tool must keep a non-empty method-level description so clients can " +
-            "discriminate it from sibling tools. Missing:\n  " + string.Join("\n  ", missing));
-    }
+        => ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sweptToolTypes);
 }

--- a/tests/RoslynMcp.Tests/ToolDescriptionDietWorkspaceValidationTests.cs
+++ b/tests/RoslynMcp.Tests/ToolDescriptionDietWorkspaceValidationTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -12,10 +10,9 @@ namespace RoslynMcp.Tests;
 /// tighter per-slice budget so a future edit cannot silently regrow the <c>tools/list</c> payload.
 /// </summary>
 /// <remarks>
-/// <para>Mirrors the reflection harness of
-/// <c>SurfaceCatalogTests.AllMcpToolMethodDescriptions_AreWithinClientLimit</c>, but enumerates an
-/// explicit declaring-type set instead of the whole assembly so sibling diet slices stay
-/// independent and do not collide in this file.</para>
+/// <para>Reflection enumeration and shared assertions live in
+/// <see cref="ToolDescriptionBudgetHarness"/>; this class owns only the swept-type set and the
+/// per-slice ceilings.</para>
 /// <para>Only METHOD-level <c>[Description]</c> attributes are in scope. Parameter-level
 /// descriptions and the <c>[McpToolMetadata]</c> summaries the surface catalog mirrors are
 /// deliberately excluded.</para>
@@ -34,62 +31,15 @@ public sealed class ToolDescriptionDietWorkspaceValidationTests
         typeof(CompileCheckTools),
     ];
 
-    private static (string Name, string Description)[] SweptToolDescriptions() =>
-        s_sweptToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null)
-            .OrderBy(entry => entry.Tool!.Name, StringComparer.Ordinal)
-            .Select(entry => (
-                Name: entry.Tool!.Name ?? "(unnamed)",
-                Description: entry.Description?.Description ?? string.Empty))
-            .ToArray();
-
     [TestMethod]
     public void SweptToolDescriptions_AreWithinPerToolBudget()
-    {
-        var violations = SweptToolDescriptions()
-            .Where(entry => entry.Description.Length > MaxPerToolDescriptionCharacters)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Swept tool descriptions must be <= {MaxPerToolDescriptionCharacters} characters. " +
-            "Move operational guidance into XML <remarks> on the same method instead of the wire " +
-            "description. Violations:\n  " + string.Join("\n  ", violations));
-    }
+        => ToolDescriptionBudgetHarness.AssertPerToolBudget(s_sweptToolTypes, MaxPerToolDescriptionCharacters);
 
     [TestMethod]
     public void SweptToolDescriptions_TotalIsWithinSliceBudget()
-    {
-        var swept = SweptToolDescriptions();
-        var total = swept.Sum(entry => entry.Description.Length);
-
-        Assert.IsTrue(
-            total <= MaxSweptSetTotalCharacters,
-            $"Swept-set method description total is {total} chars across {swept.Length} tools, " +
-            $"over the {MaxSweptSetTotalCharacters}-char slice budget.");
-    }
+        => ToolDescriptionBudgetHarness.AssertSliceTotalBudget(s_sweptToolTypes, MaxSweptSetTotalCharacters);
 
     [TestMethod]
     public void SweptTools_AllHaveNonEmptyDescription()
-    {
-        var missing = SweptToolDescriptions()
-            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
-            .Select(entry => entry.Name)
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            missing.Length,
-            "Every swept tool must keep a non-empty method-level description so clients can " +
-            "discriminate it from sibling tools. Missing:\n  " + string.Join("\n  ", missing));
-    }
+        => ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(s_sweptToolTypes);
 }


### PR DESCRIPTION
## Summary

- Extracts the near-duplicate `[McpServerTool]`/`[Description]` reflection harness shared by `ToolDescriptionDietAnalysisMetricsTests` and `ToolDescriptionDietWorkspaceValidationTests` into a new `ToolDescriptionBudgetHarness`.
- The harness owns reflection enumeration plus the per-tool-ceiling, slice-total, non-empty, and (for future adopters) discriminating-trigger assertions, invoked as `(sliceTypes, perToolMax, sliceTotalMax[, triggerExpectations])`.
- Both adopting classes shrink to their own constants + swept-type set + a call into the shared helper, with byte-identical pass/fail behaviour (same ceilings, same totals, same tool sets) as before.
- This is the method-family harness only; the parameter-family (reflecting over method parameters) is out of scope, tracked separately. The remaining 8 method-family slice classes (`MethodDescriptionDiet*Tests`) adopt this helper in separately-tracked `desc-budget-harness-method-adopt-wave-2/3` rows.

## Validation

- `mcp__roslyn__test_run --filter "ToolDescriptionDietAnalysisMetricsTests|ToolDescriptionDietWorkspaceValidationTests"` — 6/6 passed.
- Full `./eng/verify-release.ps1 -Configuration Release` — 2845 passed, 0 failed, 7 skipped (2852 total), build succeeded.
- `./eng/verify-ai-docs.ps1` — passed.

## Test plan

- [x] Targeted test_run for both adopting classes passes with identical assertions.
- [x] Full release verification (build + full test suite) passes.
- [x] AI-docs verification passes.

Closes: `desc-budget-harness-method-family`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NwiR6w83LRt81t5b7ZRJg