### PR TITLE
feat(ci): checksum-pinned repository-owned actionlint gate

### DIFF
--- a/CI_POLICY.md
+++ b/CI_POLICY.md
@@ -127,10 +127,11 @@ Combine filters with `&` (AND) or `|` (OR) per `dotnet test` syntax.
 | AI-doc changes | `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` |
 | Required PR-equivalent gate | `just ci` |
 | Formatter debt on touched C# files | `pwsh -NoProfile -File ./eng/verify-changed-format.ps1` |
+| GitHub Actions workflow YAML/expression lint | `pwsh -NoProfile -File ./eng/verify-actionlint.ps1` |
 | Informational coverage/live-network gate | `just full` |
 | One release shard | `pwsh -NoProfile -File ./eng/verify-release.ps1 -NoCoverage -ExcludeNetworkTests -TestShardIndex <zero-based> -TestShardCount <count>` |
 
-`just ci` composes docs, shipped skills, the changed-file formatter gate, unsharded PR-equivalent release validation, and the vulnerability audit. Local validation remains unsharded so one command proves the complete suite.
+`just ci` composes docs, shipped skills, the changed-file formatter gate, the checksum-pinned actionlint gate, unsharded PR-equivalent release validation, and the vulnerability audit. Local validation remains unsharded so one command proves the complete suite.
 
 ## Merge Gating Expectations
 

--- a/changelog.d/ci-actionlint-pinned-gate.md
+++ b/changelog.d/ci-actionlint-pinned-gate.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Added:** Added a checksum-pinned, repository-owned `actionlint` gate wired into `just ci`, so a malformed GitHub Actions `if:`/`${{ }}` expression is caught locally before push instead of only after.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -1,0 +1,148 @@
+<#
+.SYNOPSIS
+Runs a checksum-pinned, repository-owned actionlint against .github/workflows/*.yml.
+
+.DESCRIPTION
+No developer-global actionlint install is required. The pinned version and every RID's
+archive/binary SHA-256 are declared below; bump all of them together when upgrading, the
+same discipline eng/verify-release.ps1 applies to its publish-output hash manifest.
+
+Archive hashes come from actionlint's published `<version>_checksums.txt`; binary hashes are
+computed once at pin time by extracting each archive and hashing the resulting executable, so
+a pre-staged binary (ROSLYNMCP_ACTIONLINT_PATH) can be verified without re-deriving the
+archive it came from.
+
+Resolution order:
+  1. ROSLYNMCP_ACTIONLINT_PATH, if set -- verified against the pinned BINARY hash.
+  2. A cached binary under artifacts/tools/actionlint/<version>/ -- re-verified against the
+     pinned BINARY hash on every run (a corrupted or tampered cache entry fails closed
+     instead of running silently). Pure local hashing: never touches the network.
+  3. Download the pinned archive, hash it BEFORE extracting, fail closed on mismatch or on
+     any network failure -- never falls back to an unpinned download.
+#>
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$PinnedVersion = '1.7.12'
+$PinnedArchiveHashes = [ordered]@{
+    'win-x64'     = [ordered]@{
+        Asset         = "actionlint_${PinnedVersion}_windows_amd64.zip"
+        ArchiveSha256 = '6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9'
+        BinarySha256  = '54ca21be3de4c7cfa26914aa8b61bd76bf573ef3caac5f80d110558cdf241718'
+        BinaryName    = 'actionlint.exe'
+    }
+    'linux-x64'   = [ordered]@{
+        Asset         = "actionlint_${PinnedVersion}_linux_amd64.tar.gz"
+        ArchiveSha256 = '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
+        BinarySha256  = 'c872d6db8c6bf83a8eaa704fc93999f027d55dffbc63b8a6abdccb47df5f4cd4'
+        BinaryName    = 'actionlint'
+    }
+    'linux-arm64' = [ordered]@{
+        Asset         = "actionlint_${PinnedVersion}_linux_arm64.tar.gz"
+        ArchiveSha256 = '325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6'
+        BinarySha256  = 'ac0323433c2853ec3fb978c611430c5b3dc5d43c58d1a1ec031b00ab572beb60'
+        BinaryName    = 'actionlint'
+    }
+    'osx-arm64'   = [ordered]@{
+        Asset         = "actionlint_${PinnedVersion}_darwin_arm64.tar.gz"
+        ArchiveSha256 = 'aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f'
+        BinarySha256  = '8db11704dc296f096216db4db65d86cd7f0ebfdf4c38453a1da276b137b88388'
+        BinaryName    = 'actionlint'
+    }
+}
+
+function Get-CurrentRid {
+    if ($IsWindows) { return 'win-x64' }
+    if ($IsMacOS) { return 'osx-arm64' }
+    if ($IsLinux) {
+        $arch = (uname -m)
+        if ($arch -eq 'aarch64') { return 'linux-arm64' }
+        return 'linux-x64'
+    }
+    throw 'verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).'
+}
+
+function Get-FileSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+$rid = Get-CurrentRid
+if (-not $PinnedArchiveHashes.Contains($rid)) {
+    throw "verify-actionlint: no pinned actionlint archive/hash recorded for RID '$rid'."
+}
+$pin = $PinnedArchiveHashes[$rid]
+
+$toolRoot = Join-Path $RepoRoot "artifacts/tools/actionlint/$PinnedVersion"
+$binaryPath = Join-Path $toolRoot $pin.BinaryName
+
+if ($env:ROSLYNMCP_ACTIONLINT_PATH) {
+    $overridePath = $env:ROSLYNMCP_ACTIONLINT_PATH
+    if (-not (Test-Path -LiteralPath $overridePath -PathType Leaf)) {
+        throw "verify-actionlint: ROSLYNMCP_ACTIONLINT_PATH='$overridePath' does not exist."
+    }
+    $overrideHash = Get-FileSha256 -Path $overridePath
+    if ($overrideHash -ne $pin.BinarySha256) {
+        throw "verify-actionlint: ROSLYNMCP_ACTIONLINT_PATH='$overridePath' hash mismatch (expected $($pin.BinarySha256), got $overrideHash) -- refusing to run an unverified binary."
+    }
+    $binaryPath = $overridePath
+}
+elseif (Test-Path -LiteralPath $binaryPath -PathType Leaf) {
+    $cachedHash = Get-FileSha256 -Path $binaryPath
+    if ($cachedHash -ne $pin.BinarySha256) {
+        throw "verify-actionlint: cached binary at '$binaryPath' hash mismatch (expected $($pin.BinarySha256), got $cachedHash) -- delete $toolRoot and re-run to re-download."
+    }
+}
+else {
+    $downloadUrl = "https://github.com/rhysd/actionlint/releases/download/v$PinnedVersion/$($pin.Asset)"
+    New-Item -ItemType Directory -Path $toolRoot -Force | Out-Null
+    $archivePath = Join-Path $toolRoot $pin.Asset
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
+    }
+    catch {
+        throw "verify-actionlint: no cached actionlint binary at '$binaryPath' and the pinned archive could not be downloaded from '$downloadUrl' (expected SHA-256 $($pin.ArchiveSha256)): $($_.Exception.Message)"
+    }
+    $archiveHash = Get-FileSha256 -Path $archivePath
+    if ($archiveHash -ne $pin.ArchiveSha256) {
+        Remove-Item -LiteralPath $archivePath -Force
+        throw "verify-actionlint: downloaded archive '$downloadUrl' hash mismatch (expected $($pin.ArchiveSha256), got $archiveHash) -- refusing to extract an unverified archive."
+    }
+    if ($rid -like 'win-*') {
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $toolRoot -Force
+    }
+    else {
+        & tar -xzf $archivePath -C $toolRoot
+        if ($LASTEXITCODE -ne 0) { throw "verify-actionlint: 'tar' extraction of '$archivePath' failed with exit code $LASTEXITCODE." }
+    }
+    Remove-Item -LiteralPath $archivePath -Force
+    if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+        throw "verify-actionlint: extraction of '$($pin.Asset)' did not produce the expected binary at '$binaryPath'."
+    }
+    $extractedHash = Get-FileSha256 -Path $binaryPath
+    if ($extractedHash -ne $pin.BinarySha256) {
+        throw "verify-actionlint: extracted binary at '$binaryPath' hash mismatch (expected $($pin.BinarySha256), got $extractedHash) -- the pinned archive hash matched but its extracted contents did not."
+    }
+}
+
+if ($rid -notlike 'win-*') {
+    & chmod +x $binaryPath 2>$null
+}
+
+$workflowDir = Join-Path $RepoRoot '.github/workflows'
+$workflowFiles = @(Get-ChildItem -LiteralPath $workflowDir -Filter '*.yml' -File)
+if ($workflowFiles.Count -eq 0) {
+    throw "verify-actionlint: no workflow files found under $workflowDir."
+}
+
+Write-Host "verify-actionlint: running pinned actionlint $PinnedVersion ($rid) against $($workflowFiles.Count) workflow file(s)."
+& $binaryPath @($workflowFiles.FullName)
+$actionlintExitCode = $LASTEXITCODE
+if ($actionlintExitCode -ne 0) {
+    throw "verify-actionlint: actionlint reported issue(s) (exit code $actionlintExitCode) -- see output above."
+}
+Write-Host 'verify-actionlint: no issues found.'

--- a/justfile
+++ b/justfile
@@ -64,6 +64,10 @@ verify-changed-format:
 verify-registry-readiness:
     pwsh -NoProfile -File ./eng/verify-registry-readiness.ps1
 
+# Lint GitHub Actions workflow YAML with a checksum-pinned repository-owned actionlint
+verify-actionlint:
+    pwsh -NoProfile -File ./eng/verify-actionlint.ps1
+
 # --- Run ---
 
 # Run the stdio host process locally
@@ -76,10 +80,10 @@ run:
 validate: build test
 
 # Local equivalent of the required pull-request pipeline (no coverage/live-network canary)
-ci: verify-docs verify-skills verify-changed-format verify-release-pr vuln-audit
+ci: verify-docs verify-skills verify-changed-format verify-actionlint verify-release-pr vuln-audit
 
 # Everything including coverage and the live-network canary
-full: verify-docs verify-skills verify-changed-format verify-release vuln-audit
+full: verify-docs verify-skills verify-changed-format verify-actionlint verify-release vuln-audit
 
 # --- Clean ---
 

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -1,0 +1,190 @@
+using RoslynMcp.Tests.Helpers;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class ActionlintGateContractTests
+{
+    [TestMethod]
+    public void VerifyActionlintScript_DeclaresPinnedVersionAndPerRidArchiveAndBinaryHashes()
+    {
+        var script = File.ReadAllText(ResolveScriptPath());
+
+        StringAssert.Contains(script, "$PinnedVersion = '1.7.12'");
+
+        foreach (var rid in new[] { "win-x64", "linux-x64", "linux-arm64", "osx-arm64" })
+        {
+            Assert.IsTrue(
+                script.Contains($"'{rid}'", StringComparison.Ordinal),
+                $"Pin table must declare an entry for RID '{rid}'.");
+        }
+
+        // Every declared hash must be a lowercase 64-character hex string (SHA-256), pinned
+        // literally in the script text -- not derived at runtime from an unpinned source.
+        var hexHashPattern = new System.Text.RegularExpressions.Regex(
+            @"(?:ArchiveSha256|BinarySha256)\s*=\s*'([0-9a-f]{64})'");
+        var matches = hexHashPattern.Matches(script);
+        Assert.AreEqual(
+            8,
+            matches.Count,
+            $"Expected one ArchiveSha256 + one BinarySha256 per RID (4 RIDs x 2 = 8); found {matches.Count}. Script:{Environment.NewLine}{script}");
+    }
+
+    [TestMethod]
+    public void JustfileAndCiPolicy_WireTheActionlintGateIntoRequiredValidation()
+    {
+        var repositoryRoot = TestFixtureFileSystem.FindRepositoryRoot();
+        var justfile = File.ReadAllText(Path.Combine(repositoryRoot, "justfile"));
+        var ciPolicy = File.ReadAllText(Path.Combine(repositoryRoot, "CI_POLICY.md"));
+
+        StringAssert.Contains(justfile, "verify-actionlint:");
+        StringAssert.Contains(justfile, "pwsh -NoProfile -File ./eng/verify-actionlint.ps1");
+
+        var ciRecipeIndex = justfile.IndexOf("\nci:", StringComparison.Ordinal);
+        Assert.IsTrue(ciRecipeIndex >= 0, "justfile must declare a 'ci:' aggregate recipe.");
+        var ciRecipeLineEnd = justfile.IndexOf('\n', ciRecipeIndex + 1);
+        var ciRecipeLine = justfile[ciRecipeIndex..(ciRecipeLineEnd < 0 ? justfile.Length : ciRecipeLineEnd)];
+        StringAssert.Contains(
+            ciRecipeLine,
+            "verify-actionlint",
+            "The 'just ci' aggregate must depend on verify-actionlint so a malformed workflow expression fails locally before push.");
+
+        StringAssert.Contains(ciPolicy, "./eng/verify-actionlint.ps1");
+        StringAssert.Contains(
+            ciPolicy,
+            "actionlint",
+            "CI_POLICY.md's just ci composition sentence must name the actionlint gate as one of the composed children.");
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_CachedBinaryHashMismatch_FailsClosedWithoutAttemptingDownload()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var toolRoot = Path.Combine(fixtureRoot, "artifacts", "tools", "actionlint", "1.7.12");
+            Directory.CreateDirectory(toolRoot);
+            var binaryName = OperatingSystem.IsWindows() ? "actionlint.exe" : "actionlint";
+            // A cached binary whose bytes do NOT match the pinned hash -- this must be detected
+            // and refused BEFORE the script ever considers re-downloading, so a tampered or
+            // corrupted cache entry never silently runs.
+            File.WriteAllText(Path.Combine(toolRoot, binaryName), "not the real actionlint binary");
+
+            var result = await RunGateAsync(fixtureRoot);
+
+            Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "hash mismatch");
+            StringAssert.Contains(result.AllOutput, "cached binary");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_RoslynMcpActionlintPathOverride_HashMismatchFailsClosedAndNeverRuns()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        var overridePath = Path.Combine(fixtureRoot, "not-actionlint.exe");
+        File.WriteAllText(overridePath, "definitely not the pinned binary");
+        try
+        {
+            var result = await RunGateAsync(
+                fixtureRoot,
+                environment: new Dictionary<string, string?>
+                {
+                    ["ROSLYNMCP_ACTIONLINT_PATH"] = overridePath,
+                });
+
+            Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "ROSLYNMCP_ACTIONLINT_PATH");
+            StringAssert.Contains(result.AllOutput, "hash mismatch");
+            StringAssert.Contains(result.AllOutput, "refusing to run an unverified binary");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    // Live-network smoke test: downloads the real pinned release once (verifying the archive
+    // hash), then re-runs against the now-populated cache and asserts the second run completes
+    // in well under the time a fresh download+extract would take -- the offline cache-hit path,
+    // not a live re-download. Marked Network per CI_POLICY.md (excluded on PR; included
+    // weekly/manual), mirroring NuGetVulnerabilityScanIntegrationTests' precedent for a gate
+    // that legitimately needs one real external call.
+    [TestMethod]
+    [TestCategory("Network")]
+    public async Task VerifyActionlint_ColdDownloadThenCacheHit_LintsRealWorkflowsAndStaysOfflineOnRerun()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var coldResult = await RunGateAsync(fixtureRoot, timeout: TimeSpan.FromMinutes(2));
+            Assert.AreEqual(0, coldResult.ExitCode, coldResult.AllOutput);
+            StringAssert.Contains(coldResult.AllOutput, "no issues found");
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var cachedResult = await RunGateAsync(fixtureRoot, timeout: TimeSpan.FromSeconds(30));
+            stopwatch.Stop();
+
+            Assert.AreEqual(0, cachedResult.ExitCode, cachedResult.AllOutput);
+            Assert.IsTrue(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"A cache hit must not re-download the archive; took {stopwatch.Elapsed.TotalSeconds:F1}s.");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    private static string ResolveScriptPath() => Path.Combine(
+        TestFixtureFileSystem.FindRepositoryRoot(),
+        "eng",
+        "verify-actionlint.ps1");
+
+    private static string CreateFixtureRoot()
+    {
+        var root = Path.Combine(
+            TestTempRoot.Current,
+            nameof(ActionlintGateContractTests),
+            Guid.NewGuid().ToString("N"));
+        var workflowsDir = Path.Combine(root, ".github", "workflows");
+        Directory.CreateDirectory(workflowsDir);
+        File.WriteAllText(
+            Path.Combine(workflowsDir, "fixture.yml"),
+            """
+            name: fixture
+            on:
+              push:
+            jobs:
+              noop:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: echo ok
+            """);
+        return root;
+    }
+
+    private static Task<PwshScriptResult> RunGateAsync(
+        string fixtureRoot,
+        IReadOnlyDictionary<string, string?>? environment = null,
+        TimeSpan? timeout = null)
+    {
+        return PwshScriptRunner.RunAsync(
+            [
+                "-NoProfile",
+                "-File",
+                ResolveScriptPath(),
+                "-RepoRoot",
+                fixtureRoot,
+            ],
+            environment: environment,
+            timeout: timeout ?? TimeSpan.FromSeconds(30),
+            description: "actionlint gate");
+    }
+}

--- a/tests/RoslynMcp.Tests/CiRunnerParityContractTests.cs
+++ b/tests/RoslynMcp.Tests/CiRunnerParityContractTests.cs
@@ -157,12 +157,12 @@ public sealed class CiRunnerParityContractTests
         StringAssert.Contains(releaseStep, "./eng/verify-release.ps1 @parameters");
         Assert.IsFalse(releaseStep.Contains("--filter", StringComparison.Ordinal));
 
-        StringAssert.Contains(justfile, "ci: verify-docs verify-skills verify-changed-format verify-release-pr vuln-audit");
+        StringAssert.Contains(justfile, "ci: verify-docs verify-skills verify-changed-format verify-actionlint verify-release-pr vuln-audit");
         StringAssert.Contains(
             justfile,
             "verify-release-pr:\n" +
             "    pwsh -NoProfile -File ./eng/verify-release.ps1 -NoCoverage -ExcludeNetworkTests");
-        StringAssert.Contains(justfile, "full: verify-docs verify-skills verify-changed-format verify-release vuln-audit");
+        StringAssert.Contains(justfile, "full: verify-docs verify-skills verify-changed-format verify-actionlint verify-release vuln-audit");
 
         // The changed-file formatter gate is a standalone validate-leg step, deliberately NOT a
         // verify-release child (that script's child set is a separate hard-listed contract). Local


### PR DESCRIPTION
Closes ci-actionlint-pinned-gate.

Adds `eng/verify-actionlint.ps1`: pins actionlint 1.7.12 with both archive and extracted-binary SHA-256 per RID, wired into `just ci`/`just full` as `verify-actionlint`. No developer-global actionlint install required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NwiR6w83LRt81t5b7ZRJg