### PR TITLE
fix: propagate interface cache failures

### DIFF
--- a/changelog.d/interface-extraction-catch-chain-dead-rethrow.md
+++ b/changelog.d/interface-extraction-catch-chain-dead-rethrow.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Remove a dead interface-extraction catch and lock unexpected compilation-cache failure propagation. Closes `interface-extraction-catch-chain-dead-rethrow`.

--- a/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
+++ b/src/RoslynMcp.Roslyn/Services/InterfaceExtractionService.cs
@@ -418,7 +418,6 @@ public sealed class InterfaceExtractionService : IInterfaceExtractionService
                         $"(namespace '{namespaceName}'). Choose a different interface name to avoid conflicts.");
                 }
             }
-            catch (InvalidOperationException) { throw; }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 // GetCompilationAsync ultimately re-reads source documents from disk; a file

--- a/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
+++ b/tests/RoslynMcp.Tests/ExtractInterfaceSemanticUsingsTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using RoslynMcp.Roslyn.Services;
 
 namespace RoslynMcp.Tests;
 
@@ -548,6 +551,62 @@ public sealed class ExtractInterfaceSemanticUsingsTests : TestBase
         {
             WorkspaceManager.Close(workspaceId);
             TestFixtureFileSystem.DeleteDirectoryIfExists(solutionDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractInterface_Propagates_Unexpected_CompilationCache_Failure()
+    {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDir = Path.GetDirectoryName(copiedSolutionPath)!;
+        var sourceFilePath = Path.Combine(solutionDir, "SampleLib", "AnimalService.cs");
+        var loadResult = await WorkspaceManager.LoadAsync(copiedSolutionPath, CancellationToken.None);
+        var workspaceId = loadResult.WorkspaceId;
+        var expected = new KeyNotFoundException("synthetic unexpected cache failure");
+        var service = new InterfaceExtractionService(
+            WorkspaceManager,
+            new PreviewStore(),
+            new ThrowingCompilationCache(expected),
+            NullLogger<InterfaceExtractionService>.Instance);
+
+        try
+        {
+            var actual = await Assert.ThrowsExactlyAsync<KeyNotFoundException>(() =>
+                service.PreviewExtractInterfaceAsync(
+                    workspaceId,
+                    sourceFilePath,
+                    typeName: "AnimalService",
+                    interfaceName: "IUnexpectedCacheFailureProbe",
+                    memberNames: null,
+                    replaceUsages: false,
+                    CancellationToken.None));
+
+            Assert.AreSame(
+                expected,
+                actual,
+                "Unexpected compilation-cache failures must propagate unchanged instead of skipping conflict validation.");
+        }
+        finally
+        {
+            WorkspaceManager.Close(workspaceId);
+            TestFixtureFileSystem.DeleteDirectoryIfExists(solutionDir);
+        }
+    }
+
+    private sealed class ThrowingCompilationCache(Exception failure) : ICompilationCache
+    {
+        public Task<Compilation?> GetCompilationAsync(string workspaceId, Project project, CancellationToken ct) =>
+            Task.FromException<Compilation?>(failure);
+
+        public Task<CompilationWithAnalyzers?> GetCompilationWithAnalyzersAsync(
+            string workspaceId,
+            Project project,
+            CancellationToken ct) => Task.FromException<CompilationWithAnalyzers?>(failure);
+
+        public bool IsLiveSolution(string workspaceId, Solution solution) => false;
+
+        public void Invalidate(string workspaceId)
+        {
         }
     }
 }


### PR DESCRIPTION
Closes backlog row `interface-extraction-catch-chain-dead-rethrow`.

Removes the dead explicit rethrow before the existing IO-only filter and adds a regression proving unexpected compilation-cache failures propagate unchanged. The pre-existing same-name conflict regression remains in the focused class run.

Validation:
- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --filter FullyQualifiedName~ExtractInterfaceSemanticUsingsTests`
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1`
- `git diff --check`