### PR TITLE
test: name validation tool arguments

### DIFF
--- a/changelog.d/workspace-id-named-args-validation.md
+++ b/changelog.d/workspace-id-named-args-validation.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Convert direct validation-tool tests with required post-`workspaceId` parameters to fully named arguments, preserving safe future parameter reordering. Closes `workspace-id-named-args-validation`.

--- a/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
+++ b/tests/RoslynMcp.Tests/TestRunFailureEnvelopeTests.cs
@@ -1085,8 +1085,8 @@ public sealed class TestRunFailureEnvelopeTests
     public async Task FindRelatedTestsForFiles_ServiceThrows_ReturnsStructuredEnvelopeWithSchemaHint()
     {
         var json = await ValidationTools.FindRelatedTestsForFiles(
-            new PassthroughGate(),
-            new ThrowingTestDiscoveryService(new InvalidOperationException("related-files blew up")),
+            gate: new PassthroughGate(),
+            testDiscoveryService: new ThrowingTestDiscoveryService(new InvalidOperationException("related-files blew up")),
             workspaceId: "ws-test-related-files-envelope",
             filePaths: ["C:/fake/Changed.cs"],
             maxResults: 100,

--- a/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ValidationToolsIntegrationTests.cs
@@ -255,12 +255,12 @@ public sealed class ValidationToolsIntegrationTests : SharedWorkspaceTestBase
 
         var animalServicePath = FindDocumentPath("AnimalService.cs");
         var filesJson = await ValidationTools.FindRelatedTestsForFiles(
-            WorkspaceExecutionGate,
-            TestDiscoveryService,
-            WorkspaceId,
-            new[] { animalServicePath },
+            gate: WorkspaceExecutionGate,
+            testDiscoveryService: TestDiscoveryService,
+            workspaceId: WorkspaceId,
+            filePaths: new[] { animalServicePath },
             maxResults: 100,
-            CancellationToken.None);
+            ct: CancellationToken.None);
 
         using var symbolDoc = JsonDocument.Parse(symbolJson);
         using var filesDoc = JsonDocument.Parse(filesJson);


### PR DESCRIPTION
Closes backlog row `workspace-id-named-args-validation`.

Fully names both direct read-only `test_related_files` invocations whose required `filePaths` argument follows `workspaceId`, preserving argument expressions, evaluation order, and assertions.

Validation:
- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --filter FullyQualifiedName~TestRunFailureEnvelopeTests|FullyQualifiedName~ValidationToolsIntegrationTests`
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1`
- `git diff --check`