### PR TITLE
test: prove fixture resource cleanup

### DIFF
--- a/changelog.d/test-assembly-fixture-disposal-observable-postcondition.md
+++ b/changelog.d/test-assembly-fixture-disposal-observable-postcondition.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Prove test-assembly fixture cleanup completed by asserting its populated workspace-id cache is empty after repeated disposal. Closes `test-assembly-fixture-disposal-observable-postcondition`.

--- a/tests/RoslynMcp.Tests/TestAssemblyFixtureTests.cs
+++ b/tests/RoslynMcp.Tests/TestAssemblyFixtureTests.cs
@@ -1,4 +1,5 @@
 using RoslynMcp.Roslyn.Services;
+using RoslynMcp.Tests.Helpers;
 
 namespace RoslynMcp.Tests;
 
@@ -92,37 +93,59 @@ public sealed class TestAssemblyFixtureSharingBetaTests : TestBase
     [TestMethod]
     public async Task DisposeAsync_ReleasesOwnedResourcesExactlyOnce()
     {
+        var copiedSolutionPath = CreateSampleSolutionCopy();
+        var solutionDirectory = Path.GetDirectoryName(copiedSolutionPath)!;
+
         // A standalone fixture, so the assembly-owned one stays live for the rest of the run. It
         // never requests a path-authorized server, so no MCP server is stood up.
         var fixture = new TestAssemblyFixture(
             TestServiceContainer.Create(new ValidationServiceOptions()),
             Fixture.RepositoryFixtures);
+        Exception? primaryFailure = null;
 
-        Assert.AreEqual(0, fixture.DisposalEntryCount, "A fresh fixture has released nothing.");
+        try
+        {
+            Assert.AreEqual(0, fixture.DisposalEntryCount, "A fresh fixture has released nothing.");
+            Assert.AreEqual(0, fixture.WorkspaceIdCache.Count, "A fresh fixture cache must be empty.");
 
-        await fixture.DisposeAsync();
-        await fixture.DisposeAsync();
-        await fixture.DisposeAsync();
+            await fixture.GetOrLoadWorkspaceIdAsync(copiedSolutionPath);
+            Assert.AreEqual(
+                1,
+                fixture.WorkspaceIdCache.Count,
+                "The standalone fixture must own one deterministic cache entry before disposal.");
 
-        Assert.AreEqual(
-            1,
-            fixture.DisposalEntryCount,
-            "Owned resources must be released exactly once however many callers dispose the fixture.");
+            await fixture.DisposeAsync();
+            await fixture.DisposeAsync();
+            await fixture.DisposeAsync();
 
-        // NOTE: this assertion proves the release block was ENTERED exactly once, not that it ran
-        // to completion — deleting the block's body would leave it green. An observable
-        // post-condition was attempted (asserting the disposed WorkspaceManager refuses a
-        // LoadAsync) and REVERTED: it throws only when the call reaches the disposed semaphore,
-        // and with the sample solutions pre-prepared by a full suite run it short-circuits before
-        // that, so it passed in isolation and failed under the full gate. A deterministic check
-        // needs a read accessor on WorkspaceIdCache to assert Clear() ran, which is a fourth test
-        // file and over this initiative's Rule 4 budget. Tracked by row
-        // test-assembly-fixture-disposal-observable-postcondition.
+            Assert.AreEqual(
+                1,
+                fixture.DisposalEntryCount,
+                "Owned resources must be released exactly once however many callers dispose the fixture.");
+            Assert.AreEqual(
+                0,
+                fixture.WorkspaceIdCache.Count,
+                "Disposal must clear the fixture-owned workspace-id cache; entering the release block is insufficient.");
 
-        // Disposing the fixture must not reach through to the assembly-owned one.
-        Assert.AreEqual(
-            0,
-            Fixture.DisposalEntryCount,
-            "The assembly-owned fixture must still be live; only AssemblyLifecycle.Cleanup disposes it.");
+            // Disposing the fixture must not reach through to the assembly-owned one.
+            Assert.AreEqual(
+                0,
+                Fixture.DisposalEntryCount,
+                "The assembly-owned fixture must still be live; only AssemblyLifecycle.Cleanup disposes it.");
+        }
+        catch (Exception ex)
+        {
+            primaryFailure = ex;
+            throw;
+        }
+        finally
+        {
+            await CleanupFailureCollector.RunAfterFailureAsync(
+                "Fixture-disposal regression and copied-solution cleanup both failed.",
+                primaryFailure,
+                () => fixture.DisposeAsync(),
+                CleanupFailureCollector.FromAction(
+                    () => TestFixtureFileSystem.DeleteDirectoryIfExists(solutionDirectory)));
+        }
     }
 }

--- a/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
+++ b/tests/RoslynMcp.Tests/TestInfrastructure/WorkspaceIdCache.cs
@@ -8,6 +8,8 @@ internal sealed class WorkspaceIdCache
     private readonly ConcurrentDictionary<string, string> _workspaceIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly SemaphoreSlim _loadGate = new(1, 1);
 
+    internal int Count => _workspaceIds.Count;
+
     public async Task<string> GetOrLoadAsync(IWorkspaceManager workspaceManager, string solutionPath, CancellationToken ct = default)
     {
         if (_workspaceIds.TryGetValue(solutionPath, out var cachedId)


### PR DESCRIPTION
Closes backlog row `test-assembly-fixture-disposal-observable-postcondition`.

Populates an isolated fixture-owned workspace-id cache before disposal and asserts the cache is empty afterward, proving the release body ran rather than merely that its entry guard was crossed.

Validation:
- focused disposal regression: 1/1 passed
- fixture-sharing classes together: 4/4 passed
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1`
- `git diff --check`