### PR TITLE
fix(ci): surface actionlint chmod failures

### DIFF
--- a/changelog.d/actionlint-chmod-failure-diagnostic.md
+++ b/changelog.d/actionlint-chmod-failure-diagnostic.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Report actionlint executable permission failures precisely.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -21,7 +21,9 @@ Resolution order:
      any network failure -- never falls back to an unpinned download.
 #>
 param(
-    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [Parameter(DontShow)]
+    [switch]$FailChmodForTest
 )
 
 Set-StrictMode -Version Latest
@@ -69,6 +71,29 @@ function Get-CurrentRid {
 function Get-FileSha256 {
     param([Parameter(Mandatory)][string]$Path)
     (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Set-ActionlintExecutablePermission {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(DontShow)][switch]$FailForTest
+    )
+    if ($FailForTest) {
+        & (Get-Process -Id $PID).Path -NoProfile -NonInteractive -Command 'exit 1'
+    }
+    else {
+        & chmod +x $Path 2>$null
+    }
+    $chmodExitCode = $LASTEXITCODE
+    if ($chmodExitCode -ne 0) {
+        [Console]::Error.WriteLine(
+            "verify-actionlint: failed to mark actionlint executable (chmod exit code $chmodExitCode).")
+        exit $chmodExitCode
+    }
+}
+
+if ($FailChmodForTest) {
+    Set-ActionlintExecutablePermission -Path 'test-only' -FailForTest
 }
 
 $rid = Get-CurrentRid
@@ -130,7 +155,7 @@ else {
 }
 
 if ($rid -notlike 'win-*') {
-    & chmod +x $binaryPath 2>$null
+    Set-ActionlintExecutablePermission -Path $binaryPath
 }
 
 $workflowDir = Join-Path $RepoRoot '.github/workflows'

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -110,6 +110,30 @@ public sealed class ActionlintGateContractTests
         }
     }
 
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_ChmodFailure_ReportsBoundedDiagnosticWithoutNetworkAccess()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunGateAsync(fixtureRoot, failChmodForTest: true);
+
+            Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
+            const string diagnostic =
+                "verify-actionlint: failed to mark actionlint executable (chmod exit code 1).";
+            Assert.AreEqual(diagnostic, result.StdErr.Trim());
+            Assert.AreEqual(string.Empty, result.StdOut);
+            Assert.IsFalse(
+                result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
+                $"The failure-only test seam must run before network access. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
     // Live-network smoke test: downloads the real pinned release once (verifying the archive
     // hash), then re-runs against the now-populated cache and asserts the second run completes
     // in well under the time a fresh download+extract would take -- the offline cache-hit path,
@@ -173,16 +197,24 @@ public sealed class ActionlintGateContractTests
     private static Task<PwshScriptResult> RunGateAsync(
         string fixtureRoot,
         IReadOnlyDictionary<string, string?>? environment = null,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        bool failChmodForTest = false)
     {
+        var arguments = new List<string>
+        {
+            "-NoProfile",
+            "-File",
+            ResolveScriptPath(),
+            "-RepoRoot",
+            fixtureRoot,
+        };
+        if (failChmodForTest)
+        {
+            arguments.Add("-FailChmodForTest");
+        }
+
         return PwshScriptRunner.RunAsync(
-            [
-                "-NoProfile",
-                "-File",
-                ResolveScriptPath(),
-                "-RepoRoot",
-                fixtureRoot,
-            ],
+            arguments,
             environment: environment,
             timeout: timeout ?? TimeSpan.FromSeconds(30),
             description: "actionlint gate");


### PR DESCRIPTION
Closes: actionlint-chmod-failure-diagnostic

Capture `chmod`'s native exit code immediately and fail with one bounded executable-marking diagnostic. Add a hidden failure-only process seam so Windows executes the same exit-code handling without reaching RID, hash, filesystem, or network work.

Validation:
- `dotnet test RoslynMcp.slnx -c Release --filter "ClassName=RoslynMcp.Tests.ActionlintGateContractTests" --nologo` — 6 passed
- `pwsh -NoProfile -File ./eng/verify-actionlint.ps1` — passed
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1` — passed
- `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release` — 2,880 passed, 7 skipped, 0 failed; publish/hash completed

Files: 3 changed, 73 insertions, 10 deletions.