### PR TITLE
docs: condense fix-all and bulk tool discovery

### DIFF
--- a/changelog.d/method-diet-fixall-bulk-operations.md
+++ b/changelog.d/method-diet-fixall-bulk-operations.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Condense fix-all, bulk-refactoring, operation, and scripting tool descriptions into discovery-focused capability statements while retaining operational guidance in XML remarks. Closes `method-diet-fixall-bulk-operations`.

--- a/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/BulkRefactoringTools.cs
@@ -16,10 +16,15 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class BulkRefactoringTools
 {
+    /// <remarks>
+    /// Scope may be <c>parameters</c>, <c>fields</c>, or <c>all</c>. Parameter scope also walks
+    /// generic arguments in implemented-interface and base-class declarations so the type's
+    /// contract remains aligned with rewritten parameter types.
+    /// </remarks>
     [McpServerTool(Name = "bulk_replace_type_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "stable", true, false,
         "Preview replacing all references to one type with another across the solution. Scope can be 'parameters', 'fields', or 'all'. 'parameters' also covers generic arguments in implemented-interface / base-class declarations so the class's interface contract stays in sync. Useful after extracting an interface."),
-     Description("Preview replacing all references to one type with another across the solution. Useful after extracting an interface to update all consumers. Scope can be 'parameters', 'fields', or 'all'. Under 'parameters' the replacement also walks generic arguments on implemented-interface / base-class declarations so the class's interface contract stays in sync with the rewritten parameter types.")]
+     Description("Preview replacing one type across solution consumers after interface extraction. Choose parameters, fields, or all; parameters also updates generic base/interface arguments.")]
     public static Task<string> PreviewBulkReplaceType(
         IWorkspaceExecutionGate gate,
         IBulkRefactoringService bulkRefactoringService,
@@ -37,10 +42,14 @@ public static class BulkRefactoringTools
             ct);
     }
 
+    /// <remarks>
+    /// Both supported preview routes store the same preview kind. Producer-family and workspace
+    /// provenance are validated before the shared apply path mutates the workspace.
+    /// </remarks>
     [McpServerTool(Name = "bulk_replace_type_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", false, true,
         "Apply a previewed bulk type replacement or invocation rewrite. Redeems tokens from bulk_replace_type_preview and replace_invocation_preview."),
-     Description("Apply a token returned by bulk_replace_type_preview or replace_invocation_preview")]
+     Description("Apply a token from bulk_replace_type_preview or replace_invocation_preview. This shared route rejects other preview families before mutating the workspace.")]
     public static Task<string> ApplyBulkReplaceType(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,
@@ -65,10 +74,15 @@ public static class BulkRefactoringTools
     // from parameter-name matching between the two signatures. Apply reuses the existing
     // bulk_replace_type_apply for symmetry — both tools store a previewed Solution snapshot,
     // which the shared apply path redeems via the preview token.
+    /// <remarks>
+    /// Supply fully-qualified signatures with parameter types to disambiguate overloads.
+    /// Parameter-name equality derives the reorder: positional arguments move, while named
+    /// arguments retain their names and are ordered to match the replacement signature.
+    /// </remarks>
     [McpServerTool(Name = "replace_invocation_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview rewriting every call-site of a method to call a different method with a declared argument-reorder mapping derived from parameter-name equality. Redeem the token with bulk_replace_type_apply."),
-     Description("Preview rewriting every call-site of oldMethod with a call to newMethod whose parameter list is a permutation of oldMethod's. Supply fully-qualified signatures like 'Namespace.Type.Old(P1, P2, P3)' and 'Namespace.Type.New(P2, P3, P1)' — the parameter-type list disambiguates overloads; parameter-name equality (old P1 ↔ new P1) derives the reorder. Positional call sites are reordered; named-argument call sites keep their names and shuffle lexically into the new parameter order. Redeem the preview token with bulk_replace_type_apply.")]
+     Description("Preview rewriting every oldMethod call to newMethod by matching parameter names and reordering arguments. Redeem the returned token with bulk_replace_type_apply.")]
     public static Task<string> PreviewReplaceInvocation(
         IWorkspaceExecutionGate gate,
         IBulkRefactoringService bulkRefactoringService,

--- a/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/FixAllTools.cs
@@ -16,10 +16,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class FixAllTools
 {
+    /// <remarks>
+    /// Scope is document, project, or solution. Discover diagnostic ids with
+    /// <c>list_analyzers</c> or <c>project_diagnostics</c>. When no provider or Fix All support
+    /// exists, <c>guidanceMessage</c> names the next route. Provider crashes return a structured
+    /// <c>FixAllProviderCrash</c> envelope and state whether per-occurrence fallback is available.
+    /// </remarks>
     [McpServerTool(Name = "fix_all_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview fixing ALL instances of a diagnostic across a scope."),
-     Description("Preview applying a code fix to ALL instances of a diagnostic across a scope (document, project, or solution). Dramatically faster than fixing diagnostics one at a time. Use list_analyzers or project_diagnostics to find diagnostic IDs. When no provider or no FixAll support exists, the response includes guidanceMessage with next steps (e.g. organize_usings_preview for IDE0005). When the registered FixAll provider itself throws (e.g. the 'Sequence contains no elements' crash on IDE0300 / IDE0305 and analogous failures on other fixers), the response is a structured envelope with error=true, category='FixAllProviderCrash', and perOccurrenceFallbackAvailable=true so callers can fall back to code_fix_preview on individual occurrences.")]
+     Description("Preview one Fix All provider across document, project, or solution scope. Use after list_analyzers or project_diagnostics; the result identifies per-occurrence code_fix_preview fallback when needed.")]
     public static Task<string> PreviewFixAll(
         IWorkspaceExecutionGate gate,
         IFixAllService fixAllService,
@@ -35,10 +41,14 @@ public static class FixAllTools
             c => fixAllService.PreviewFixAllAsync(workspaceId, diagnosticId, scope, filePath, projectName, c),
             ct);
 
+    /// <remarks>
+    /// The preview token records its producer family and workspace. Tokens minted by unrelated
+    /// preview routes are rejected before any mutation.
+    /// </remarks>
     [McpServerTool(Name = "fix_all_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", false, true,
         "Apply a previously previewed fix-all operation."),
-     Description("Apply a previously previewed fix-all operation using its preview token")]
+     Description("Apply a fix-all preview token across its recorded scope. Use only after fix_all_preview; tokens from unrelated preview families are rejected before workspace mutation.")]
     public static Task<string> ApplyFixAll(
         IWorkspaceExecutionGate gate,
         IRefactoringService refactoringService,

--- a/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/OperationTools.cs
@@ -10,10 +10,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class OperationTools
 {
+    /// <remarks>
+    /// The column must identify the token whose operation is wanted, not merely its enclosing
+    /// expression. For calls, target the method-name identifier; for binary expressions, target
+    /// the operator. When the cursor is approximate, query adjacent columns until the expected
+    /// operation kind appears.
+    /// </remarks>
     [McpServerTool(Name = "get_operations", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("advanced-analysis", "stable", true, false,
         "Get the IOperation tree for behavioral analysis at a source position."),
-     Description("Get the IOperation tree (language-agnostic behavioral representation) for a syntax node. Returns operation kinds like Invocation, Assignment, Loop, etc. Use for behavioral pattern matching at a higher abstraction than syntax trees. IMPORTANT (UX-003): the column must point at the syntax token whose operation you want — calling on a token returns that token's operation, NOT the enclosing expression. To inspect a method call, place the column on the method-name identifier, not on '(' or whitespace; to inspect a binary expression, place it on the operator. If you only have an approximate cursor, walk outward by re-querying with adjacent columns until the desired operation kind appears.")]
+     Description("Return the language-agnostic IOperation tree at an exact source token for behavioral analysis. Use a method identifier or operator token; approximate cursors may select a narrower operation.")]
     public static Task<string> GetOperations(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScriptingTools.cs
@@ -11,10 +11,16 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class ScriptingTools
 {
+    /// <remarks>
+    /// The server default budget is ten seconds. <c>timeoutSeconds</c> overrides it per call;
+    /// <c>ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS</c> sets the server default. After the configured budget
+    /// plus <c>ROSLYNMCP_SCRIPT_WATCHDOG_GRACE_SECONDS</c>, the route returns a timeout even when
+    /// Roslyn code ignores cancellation. Client session timeouts remain independent.
+    /// </remarks>
     [McpServerTool(Name = "evaluate_csharp", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("scripting", "stable", true, false,
         "Evaluate a C# expression or script interactively via the Roslyn Scripting API. Emits MCP progress and heartbeat logs during long compile/run so clients are not stuck on a static label."),
-     Description("Evaluate a C# expression or script interactively using the Roslyn Scripting API. Returns the result value and type. The server enforces a script budget (default 10 seconds, override per-call with timeoutSeconds or env ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS — UX-002). After budget + ROSLYNMCP_SCRIPT_WATCHDOG_GRACE_SECONDS (default 10), the tool returns a timeout response even if Roslyn is still running (e.g. tight infinite loops do not honor CancellationToken). A Critical watchdog log may still fire on a timer for observability. MCP progress and heartbeats apply as documented. The MCP client may enforce its own session timeout (e.g. error -32001) independently of the server.")]
+     Description("Evaluate a C# expression or multi-line script and return its value and type. Use timeoutSeconds for a per-call budget; progress reports cover long compile and execution work.")]
     public static async Task<string> EvaluateCSharp(
         IScriptingService scriptingService,
         [Description("The C# code to evaluate (expression, statement, or multi-line script)")] string code,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietFixallBulkOperationsTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietFixallBulkOperationsTests.cs
@@ -1,0 +1,50 @@
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class MethodDescriptionDietFixallBulkOperationsTests
+{
+    private const int _maxDescriptionCharacters = 200;
+
+    /// <summary>
+    /// Measured 3,176 characters across seven tools before the diet and 1,218 after. The
+    /// aggregate ratchet leaves 32 characters of maintenance headroom without treating the
+    /// per-tool ceiling as a target.
+    /// </summary>
+    private const int _maxAggregateDescriptionCharacters = 1_250;
+
+    private static readonly Type[] _sliceToolTypes =
+    [
+        typeof(FixAllTools),
+        typeof(BulkRefactoringTools),
+        typeof(OperationTools),
+        typeof(ScriptingTools),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayWithinPerToolBudget() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayWithinAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(_sliceToolTypes, _maxAggregateDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreNonEmpty() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
+
+    [TestMethod]
+    public void SliceToolDescriptions_KeepDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(
+            _sliceToolTypes,
+            [
+                new("fix_all_preview", "per-occurrence code_fix_preview fallback"),
+                new("fix_all_apply", "only after fix_all_preview"),
+                new("bulk_replace_type_preview", "generic base/interface arguments"),
+                new("bulk_replace_type_apply", "bulk_replace_type_preview or replace_invocation_preview"),
+                new("replace_invocation_preview", "matching parameter names"),
+                new("get_operations", "method identifier or operator token"),
+                new("evaluate_csharp", "timeoutSeconds"),
+            ]);
+}


### PR DESCRIPTION
Closes backlog row `method-diet-fixall-bulk-operations`.

Condenses seven fix-all, bulk-refactoring, operation, and scripting method descriptions to discovery-focused capability statements. Operational detail remains in method XML remarks, and the shared description-budget harness now ratchets this slice at 200 characters per tool and 1,250 total.

Validation:
- focused description-budget slice: 4/4 passed
- measured post-diet aggregate: 1,218 characters (from 3,176)
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1`
- `git diff --check`