### PR TITLE
fix(scaffolding): reject ambiguity before sampling

### DIFF
--- a/changelog.d/scaffold-target-type-ambiguity-before-sampling.md
+++ b/changelog.d/scaffold-target-type-ambiguity-before-sampling.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Refuse ambiguous scaffold targets before requesting sampled test names.

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -67,11 +67,16 @@ internal sealed class SingleTestScaffolder
         // the request is resolved again on every replay. Hoisted here, the initial leg builds only
         // the syntactic prompt context and the retry leg consumes the answer without rebuilding it,
         // leaving project resolution, compilation and sibling inference paid exactly once.
-        var sampledTestName = await SuggestSampledTestNameAsync(
-            request, lookupName, projectDirectory, testNameSuggestionProvider, ct).ConfigureAwait(false);
+        var (sampledTestName, solution) = await SuggestSampledTestNameAsync(
+            request, lookupName, workspaceId, project, projectDirectory, testNameSuggestionProvider, ct).ConfigureAwait(false);
+
+        // The initial MRTR leg obtains a snapshot for the syntax-only ambiguity preflight, then
+        // terminates while requesting input. The replay skips that preflight and obtains exactly
+        // one snapshot here, which is reused by target resolution and sibling compilation.
+        solution ??= _workspace.GetCurrentSolution(workspaceId);
 
         var typeInfo = await ResolveTargetTypeAndMethodAsync(
-            workspaceId, request.TestProjectName, lookupName, request.TargetMethodName, ct).ConfigureAwait(false);
+            solution, request.TestProjectName, lookupName, request.TargetMethodName, ct).ConfigureAwait(false);
 
         var simpleTypeName = typeInfo.MatchedType?.Name ?? lookupName;
         var testFilePath = Path.Combine(projectDirectory, GeneratedTestFileName(simpleTypeName));
@@ -84,7 +89,6 @@ internal sealed class SingleTestScaffolder
         // compilation so usings can be trimmed to those actually referenced by the captured
         // surface (base list + ctor params). Without semantic resolution the scaffold pulls in
         // every using from the sibling fixture (typically 10+ unused imports).
-        var solution = _workspace.GetCurrentSolution(workspaceId);
         var testRoslynProject = solution.Projects.FirstOrDefault(p =>
             string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(p.FilePath, project.FilePath, StringComparison.OrdinalIgnoreCase));
@@ -110,29 +114,35 @@ internal sealed class SingleTestScaffolder
     /// <see cref="ITestNameSuggestionProvider.TryConsumePendingSuggestion"/> on the retry leg, so
     /// the sibling enumerate-and-parse below is paid only on the leg that actually sends a prompt.
     /// </summary>
-    private static async Task<TestNameSuggestionResult> SuggestSampledTestNameAsync(
+    private async Task<(TestNameSuggestionResult Suggestion, Solution? Solution)> SuggestSampledTestNameAsync(
         ScaffoldTestDto request,
         string lookupTypeName,
+        string workspaceId,
+        ProjectStatusDto project,
         string projectDirectory,
         ITestNameSuggestionProvider? provider,
         CancellationToken ct)
     {
         if (!request.UseSampling || string.IsNullOrWhiteSpace(request.TargetMethodName))
         {
-            return new TestNameSuggestionResult(null);
+            return (new TestNameSuggestionResult(null), null);
         }
 
         if (provider is null)
         {
-            return new TestNameSuggestionResult(
+            return (new TestNameSuggestionResult(
                 null,
-                "useSampling was true but no sampling provider was available; emitted the deterministic placeholder test name.");
+                "useSampling was true but no sampling provider was available; emitted the deterministic placeholder test name."), null);
         }
 
         if (provider.TryConsumePendingSuggestion(out var pending))
         {
-            return NormalizeSuggestion(pending);
+            return (NormalizeSuggestion(pending), null);
         }
+
+        var solution = _workspace.GetCurrentSolution(workspaceId);
+        await ThrowIfTargetTypeIsSyntacticallyAmbiguousAsync(
+            solution, project.Name, project.FilePath, lookupTypeName, ct).ConfigureAwait(false);
 
         // Syntactic inputs only: this runs ahead of symbol resolution, so anything the compilation
         // would supply is out of reach here by design — see ScaffoldTestNameSuggestionContext.
@@ -143,8 +153,112 @@ internal sealed class SingleTestScaffolder
                 projectDirectory,
                 Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),
                 maxNames: 6));
-        return NormalizeSuggestion(await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false));
+        return (
+            NormalizeSuggestion(await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false)),
+            solution);
     }
+
+    /// <summary>
+    /// Refuses a guaranteed-ambiguous target before the first sampling request. The probe inspects
+    /// the loaded solution's cached syntax trees without requesting a compilation. A replay
+    /// carrying an answered suggestion skips this method through
+    /// <see cref="ITestNameSuggestionProvider.TryConsumePendingSuggestion"/>.
+    /// </summary>
+    private static async Task ThrowIfTargetTypeIsSyntacticallyAmbiguousAsync(
+        Solution solution,
+        string testProjectName,
+        string testProjectFilePath,
+        string targetTypeName,
+        CancellationToken ct)
+    {
+        var candidates = await FindSyntacticTargetTypeCandidatesAsync(
+            solution, testProjectName, testProjectFilePath, targetTypeName, ct).ConfigureAwait(false);
+        if (candidates is { Count: > 1 })
+        {
+            throw CreateAmbiguousTargetTypeException(targetTypeName, candidates);
+        }
+    }
+
+    private static async Task<IReadOnlyList<string>> FindSyntacticTargetTypeCandidatesAsync(
+        Solution solution,
+        string testProjectName,
+        string testProjectFilePath,
+        string targetTypeName,
+        CancellationToken ct)
+    {
+        var testProject = solution.Projects.FirstOrDefault(project =>
+            string.Equals(project.Name, testProjectName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(project.FilePath, testProjectFilePath, StringComparison.OrdinalIgnoreCase));
+        if (testProject is null)
+        {
+            return [];
+        }
+
+        // Match FindTargetTypeAsync exactly: inspect the test project, then each direct
+        // reference in project-reference order, and stop at the first project with any matches.
+        // Documents and their cached syntax trees come from this same loaded Solution snapshot,
+        // so stale-policy and evaluated-property differences cannot make the preflight disagree
+        // with the authoritative resolver that follows on the same logical call.
+        foreach (var project in GetProjectsToSearch(solution, testProject))
+        {
+            ct.ThrowIfCancellationRequested();
+            var candidates = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var document in project.Documents)
+            {
+                ct.ThrowIfCancellationRequested();
+                var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+                if (root is null)
+                {
+                    continue;
+                }
+
+                foreach (var declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (declaration.Kind() is not (SyntaxKind.ClassDeclaration or SyntaxKind.StructDeclaration or
+                            SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration) ||
+                        !string.Equals(declaration.Identifier.ValueText, targetTypeName, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var (identity, display) = GetQualifiedTypeNames(declaration);
+                    candidates[identity] = display;
+                }
+            }
+
+            if (candidates.Count > 0)
+            {
+                return candidates.Values.Order(StringComparer.Ordinal).ToArray();
+            }
+        }
+
+        return [];
+    }
+
+    private static (string Identity, string Display) GetQualifiedTypeNames(TypeDeclarationSyntax declaration)
+    {
+        var namespaceSegments = declaration.Ancestors()
+            .OfType<BaseNamespaceDeclarationSyntax>()
+            .Reverse()
+            .Select(static namespaceDeclaration => namespaceDeclaration.Name.ToString())
+            .ToArray();
+        var containingTypes = declaration.Ancestors()
+            .OfType<TypeDeclarationSyntax>()
+            .Reverse()
+            .ToArray();
+        var display = string.Join('.', namespaceSegments
+            .Concat(containingTypes.Select(static containingType => containingType.Identifier.ValueText))
+            .Append(declaration.Identifier.ValueText));
+        var identity = string.Join('.', namespaceSegments
+            .Concat(containingTypes.Select(GetMetadataTypeName))
+            .Append(GetMetadataTypeName(declaration)));
+        return (identity, display);
+    }
+
+    private static string GetMetadataTypeName(TypeDeclarationSyntax declaration) =>
+        declaration.TypeParameterList is { Parameters.Count: > 0 } typeParameters
+            ? $"{declaration.Identifier.ValueText}`{typeParameters.Parameters.Count}"
+            : declaration.Identifier.ValueText;
 
     private static string GeneratedTestFileName(string simpleTypeName) => $"{simpleTypeName}GeneratedTests.cs";
 
@@ -184,9 +298,8 @@ internal sealed class SingleTestScaffolder
 
     private async Task<ResolvedTargetTypeInfo>
         ResolveTargetTypeAndMethodAsync(
-            string workspaceId, string testProjectName, string targetTypeName, string? targetMethodName, CancellationToken ct)
+            Solution solution, string testProjectName, string targetTypeName, string? targetMethodName, CancellationToken ct)
     {
-        var solution = _workspace.GetCurrentSolution(workspaceId);
         var testProject = solution.Projects.FirstOrDefault(p =>
             string.Equals(p.Name, testProjectName, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(p.FilePath, testProjectName, StringComparison.OrdinalIgnoreCase));
@@ -251,15 +364,22 @@ internal sealed class SingleTestScaffolder
 
             if (candidates.Count > 1)
             {
-                throw new InvalidOperationException(
-                    $"Ambiguous type name '{targetTypeName}' — found in multiple namespaces: " +
-                    string.Join(", ", candidates.Select(c => c.ToDisplayString())) +
-                    ". Use the fully qualified type name.");
+                throw CreateAmbiguousTargetTypeException(
+                    targetTypeName,
+                    candidates.Select(static candidate => candidate.ToDisplayString()));
             }
         }
 
         return null;
     }
+
+    private static InvalidOperationException CreateAmbiguousTargetTypeException(
+        string targetTypeName,
+        IEnumerable<string> candidates) =>
+        new(
+            $"Ambiguous type name '{targetTypeName}' — found in multiple namespaces: " +
+            string.Join(", ", candidates) +
+            ". Use the fully qualified type name.");
 
     /// <summary>
     /// Per scaffold-test-sibling-pattern-inference: infers the boilerplate shape from a

--- a/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
+++ b/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,10 +24,16 @@ namespace RoslynMcp.Tests;
 /// <summary>Raw-wire and redaction coverage for request-scoped sampling.</summary>
 [DoNotParallelize]
 [TestClass]
-public sealed class SamplingMrtrWireTests
+public sealed class SamplingMrtrWireTests : IsolatedWorkspaceTestBase
 {
     private const string _suggestedName = "Load_WhenCacheMiss_ReturnsValue";
     private const string _samplingMethod = "sampling/createMessage";
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _) => InitializeServices();
+
+    [ClassCleanup]
+    public static void ClassCleanup() => DisposeServices();
 
     [TestMethod]
     [Timeout(30_000, CooperativeCancellation = true)]
@@ -167,6 +174,169 @@ public sealed class SamplingMrtrWireTests
             prior,
             _samplingMethod),
             "MRTR sampling must not also issue a deprecated nested sampling request.");
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task ModernSession_AmbiguousTarget_FailsBeforeSamplingRequest()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await File.WriteAllTextAsync(
+            workspace.GetPath("SampleLib", "AmbiguousDog.cs"),
+            "namespace Alternate; public sealed class Dog { public void Speak() { } }",
+            CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+        var directProvider = new CountingTestNameSuggestionProvider();
+        var ambiguity = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            ScaffoldingService.PreviewScaffoldTestAsync(
+                workspace.WorkspaceId,
+                new ScaffoldTestDto("SampleLib.Tests", "Dog", "Speak", UseSampling: true),
+                CancellationToken.None,
+                directProvider));
+        StringAssert.Contains(ambiguity.Message, "Ambiguous type name 'Dog'");
+        Assert.AreEqual(0, directProvider.CallCount,
+            "The service must detect target ambiguity before entering its sampling provider boundary.");
+
+        var samplingCount = 0;
+#pragma warning disable MCP9005 // The handler proves no client sampling request is issued for deterministic ambiguity.
+        await using var harness = await CreateProductionHarnessAsync(
+            ScaffoldingService,
+            (_, _, _) =>
+            {
+                Interlocked.Increment(ref samplingCount);
+                return ValueTask.FromResult(SamplingResult(_suggestedName));
+            },
+            WorkspaceManager);
+#pragma warning restore MCP9005
+
+        var prior = harness.RawServerMessages.Count;
+        var result = await harness.Client.CallToolAsync(
+            "scaffold_test_preview",
+            new Dictionary<string, object?>
+            {
+                ["workspaceId"] = workspace.WorkspaceId,
+                ["testProjectName"] = "SampleLib.Tests",
+                ["targetTypeName"] = "Dog",
+                ["targetMethodName"] = "Speak",
+                ["useSampling"] = true,
+            },
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsTrue(result.IsError is true);
+        var envelope = JsonDocument.Parse(((TextContentBlock)result.Content![0]).Text).RootElement;
+        Assert.AreEqual("InvalidOperation", envelope.GetProperty("category").GetString());
+        Assert.AreEqual("InvalidOperationException", envelope.GetProperty("exceptionType").GetString());
+        Assert.AreEqual(0, samplingCount,
+            "A deterministic target-type ambiguity must fail before the client receives a sampling request.");
+        Assert.IsFalse(AnyServerRequest(
+            harness.RawServerMessages,
+            prior,
+            _samplingMethod));
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task ModernSession_ConditionalDuplicate_UsesLoadedProjectParseOptionsBeforeSampling()
+    {
+        const string conditionalSource = """
+#if CONDITIONAL_DOG
+namespace Alternate;
+public sealed class Dog { public void Speak() { } }
+#endif
+""";
+        var request = new ScaffoldTestDto("SampleLib.Tests", "Dog", "Speak", UseSampling: true);
+
+        await using (var inactiveWorkspace = CreateIsolatedWorkspaceCopy())
+        {
+            await File.WriteAllTextAsync(
+                inactiveWorkspace.GetPath("SampleLib", "ConditionalDog.cs"),
+                conditionalSource,
+                CancellationToken.None);
+            await inactiveWorkspace.LoadAsync(CancellationToken.None);
+
+            var inactiveProvider = new CountingTestNameSuggestionProvider();
+            _ = await ScaffoldingService.PreviewScaffoldTestAsync(
+                inactiveWorkspace.WorkspaceId,
+                request,
+                CancellationToken.None,
+                inactiveProvider);
+
+            Assert.AreEqual(1, inactiveProvider.CallCount,
+                "A declaration disabled by the loaded project's parse options must not be treated as a candidate.");
+        }
+
+        await using (var activeWorkspace = CreateIsolatedWorkspaceCopy())
+        {
+            await File.WriteAllTextAsync(
+                activeWorkspace.GetPath("SampleLib", "ConditionalDog.cs"),
+                conditionalSource,
+                CancellationToken.None);
+            var projectPath = activeWorkspace.GetPath("SampleLib", "SampleLib.csproj");
+            var projectDocument = XDocument.Load(projectPath, LoadOptions.PreserveWhitespace);
+            var propertyGroup = projectDocument.Root?.Element("PropertyGroup")
+                ?? throw new AssertFailedException("SampleLib.csproj must retain its primary PropertyGroup fixture.");
+            propertyGroup.Add(new XElement("DefineConstants", "$(DefineConstants);CONDITIONAL_DOG"));
+            projectDocument.Save(projectPath);
+            await activeWorkspace.LoadAsync(CancellationToken.None);
+
+            var activeProvider = new CountingTestNameSuggestionProvider();
+            var ambiguity = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                ScaffoldingService.PreviewScaffoldTestAsync(
+                    activeWorkspace.WorkspaceId,
+                    request,
+                    CancellationToken.None,
+                    activeProvider));
+
+            StringAssert.Contains(ambiguity.Message, "Ambiguous type name 'Dog'");
+            Assert.AreEqual(0, activeProvider.CallCount,
+                "The same declaration enabled by loaded parse options must block before sampling.");
+        }
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task ModernSession_DiskDriftWithoutReload_PreflightUsesLoadedSolutionSnapshot()
+    {
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        await workspace.LoadAsync(CancellationToken.None);
+
+        // PassThroughWorkspaceExecutionGate below models the no-reload behavior of the off policy
+        // (and the execution behavior of warn after reporting staleness). The loaded Solution has
+        // one Dog; disk is then made ambiguous. Sampling must follow the loaded snapshot that the
+        // authoritative resolver will use, rather than independently re-evaluating MSBuild/disk.
+        await File.WriteAllTextAsync(
+            workspace.GetPath("SampleLib", "AmbiguousDog.cs"),
+            "namespace Alternate; public sealed class Dog { public void Speak() { } }",
+            CancellationToken.None);
+
+        var samplingCount = 0;
+#pragma warning disable MCP9005 // The handler proves stale disk does not override the loaded snapshot.
+        await using var harness = await CreateProductionHarnessAsync(
+            ScaffoldingService,
+            (_, _, _) =>
+            {
+                Interlocked.Increment(ref samplingCount);
+                return ValueTask.FromResult(SamplingResult(_suggestedName));
+            },
+            WorkspaceManager);
+#pragma warning restore MCP9005
+
+        var result = await harness.Client.CallToolAsync(
+            "scaffold_test_preview",
+            new Dictionary<string, object?>
+            {
+                ["workspaceId"] = workspace.WorkspaceId,
+                ["testProjectName"] = "SampleLib.Tests",
+                ["targetTypeName"] = "Dog",
+                ["targetMethodName"] = "Speak",
+                ["useSampling"] = true,
+            },
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsFalse(result.IsError is true,
+            "With reload disabled, both preflight and resolution must use the same loaded snapshot.");
+        Assert.AreEqual(1, samplingCount);
+        StringAssert.Contains(((TextContentBlock)result.Content![0]).Text, _suggestedName);
     }
 
     [TestMethod]
@@ -559,7 +729,7 @@ public sealed class SamplingMrtrWireTests
 
 #pragma warning disable MCP9005 // The SDK client handler advertises sampling for this production-tool MRTR fixture.
     private static async Task<InMemoryMcpClientServerHarness> CreateProductionHarnessAsync(
-        RecordingScaffoldingService scaffoldingService,
+        IScaffoldingService scaffoldingService,
         Func<CreateMessageRequestParams?, IProgress<ProgressNotificationValue>?, CancellationToken,
             ValueTask<CreateMessageResult>> samplingHandler,
         IWorkspaceManager workspaceManager)
@@ -663,6 +833,19 @@ public sealed class SamplingMrtrWireTests
         {
             LastReport = PublicExceptionDetailPolicy.ProjectUnexpected(exception, "sampling-test");
             return LastReport;
+        }
+    }
+
+    private sealed class CountingTestNameSuggestionProvider : ITestNameSuggestionProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<TestNameSuggestionResult> SuggestTestNameAsync(
+            ScaffoldTestNameSuggestionContext context,
+            CancellationToken ct)
+        {
+            CallCount++;
+            return Task.FromResult(new TestNameSuggestionResult(_suggestedName));
         }
     }
 

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -611,9 +611,9 @@ public sealed class DogReplayTests
                 workspace.WorkspaceId, request, CancellationToken.None, provider));
 
         Assert.AreEqual(1, provider.SuggestCallCount, "The initial leg issues exactly one sampling request.");
-        Assert.AreEqual(0, countingWorkspace.GetCurrentSolutionCount,
-            "The initial leg must terminate before any target resolution or compilation — every " +
-            "semantic step taken ahead of the sampling request is paid again on the replay.");
+        Assert.AreEqual(1, countingWorkspace.GetCurrentSolutionCount,
+            "The initial leg may read one loaded Solution for the syntax-only ambiguity preflight, " +
+            "but must terminate before target resolution requests any compilation.");
         Assert.IsNotNull(provider.LastContext);
         CollectionAssert.Contains(provider.LastContext.SiblingTestMethodNames.ToList(), "Speak_WhenReplayed_ReturnsEcho",
             "Sibling naming conventions cost no compilation, so the prompt keeps them.");
@@ -629,7 +629,8 @@ public sealed class DogReplayTests
             "The replay must consume the answered suggestion, not request a second one.");
         Assert.AreEqual(2, provider.ConsumeCallCount, "Both legs probe for an already-answered suggestion first.");
         Assert.AreEqual(2, countingWorkspace.GetCurrentSolutionCount,
-            "One target resolution plus one test-project compilation, across both legs combined.");
+            "One syntax-only initial snapshot plus one replay snapshot reused for target resolution " +
+            "and test-project compilation, across both legs combined.");
         var contents = await File.ReadAllTextAsync(targetFilePath, CancellationToken.None);
         StringAssert.Contains(contents, "Speak_WhenDogIsReady_ReturnsBark");
     }


### PR DESCRIPTION
## Summary
- refuse a syntactically ambiguous scaffold target before issuing the first sampled-name request
- derive preflight candidates from the loaded Solution's test-project and direct-reference Documents in resolver order, without compilation
- reuse one loaded snapshot on replay for target resolution and test-project compilation
- cover direct/wire ambiguity, no-reload disk drift, configured conditional declarations, and bounded MRTR replay cost

## Validation
- Roslyn compile_check emit validation: 6/6 projects, 0 compiler errors/warnings
- focused ambiguity/configuration/drift/replay tests: 18 passed, 0 failed
- full Release at production commit 778f4f2b: 2,881 passed, 7 skipped, 0 failed
- post-test-amend full Release: 2,881 passed, 7 skipped; one unrelated formatter-baseline timeout self-classified as host contention (35 competing dotnet processes); isolated rerun remained host-contention-blocked with 5 unrelated processes preserved

Backlog: scaffold-target-type-ambiguity-before-sampling

Closes: scaffold-target-type-ambiguity-before-sampling
