### PR TITLE
refactor: reuse structured workspace dispatch

### DIFF
--- a/changelog.d/structured-tool-dispatch-adapter.md
+++ b/changelog.d/structured-tool-dispatch-adapter.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Reused the standard read dispatch path for structured workspace results.

--- a/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ToolDispatch.cs
@@ -13,7 +13,7 @@ namespace RoslynMcp.Host.Stdio.Tools;
 /// Shared runtime dispatch helper for MCP tool shims under
 /// <c>src/RoslynMcp.Host.Stdio/Tools/*Tools.cs</c>. Every <c>*_apply</c>, <c>*_preview</c>,
 /// and read-only tool method whose body is pure "resolve workspace → gate → service →
-/// serialize" delegates inline to the workspace-ID guard or one of the dispatch
+/// project result" delegates inline to the workspace-ID guard or one of the dispatch
 /// methods below; 87+ of ~157 stable tool shims currently route through this helper.
 /// </summary>
 /// <remarks>
@@ -94,11 +94,11 @@ internal static class ToolDispatch
     /// <param name="previewStore">The preview store holding the token → workspaceId mapping.</param>
     /// <param name="previewToken">The opaque token returned by the paired <c>*_preview</c> tool.</param>
     /// <param name="serviceCall">
-    /// A closure the generator emits that invokes the service method with the
+    /// A closure the tool shim supplies that invokes the service method with the
     /// <paramref name="previewToken"/> and the gate-provided <see cref="CancellationToken"/>.
     /// Kept as <c>Func&lt;CancellationToken, Task&lt;TDto&gt;&gt;</c> rather than
-    /// <c>Func&lt;string, CancellationToken, Task&lt;TDto&gt;&gt;</c> so the generator
-    /// can emit a parameter-less lambda identical to the existing hand-written body.
+    /// <c>Func&lt;string, CancellationToken, Task&lt;TDto&gt;&gt;</c> so each tool shim
+    /// can use a parameter-less lambda identical to the existing hand-written body.
     /// </param>
     /// <param name="ct">The caller's cancellation token.</param>
     /// <param name="expectedKind">
@@ -408,7 +408,7 @@ internal static class ToolDispatch
     /// <param name="gate">The workspace execution gate.</param>
     /// <param name="workspaceId">The workspace session identifier.</param>
     /// <param name="serviceCall">
-    /// A closure the generator emits that invokes the service method with the
+    /// A closure the tool shim supplies that invokes the service method with the
     /// tool's parameters (captured via closure) and the gate-provided
     /// <see cref="CancellationToken"/>.
     /// </param>
@@ -433,7 +433,7 @@ internal static class ToolDispatch
     /// <param name="gate">The workspace execution gate.</param>
     /// <param name="workspaceId">The workspace session identifier.</param>
     /// <param name="serviceCall">
-    /// A closure the generator emits that invokes the service method with the
+    /// A closure the tool shim supplies that invokes the service method with the
     /// tool's parameters (captured via closure) and the gate-provided
     /// <see cref="CancellationToken"/>.
     /// </param>
@@ -444,10 +444,42 @@ internal static class ToolDispatch
         string workspaceId,
         Func<CancellationToken, Task<TDto>> serviceCall,
         CancellationToken ct)
+        => ReadByWorkspaceIdAsync(
+            gate,
+            workspaceId,
+            serviceCall,
+            result => JsonSerializer.Serialize(result, JsonDefaults.Indented),
+            ct);
+
+    /// <summary>
+    /// Dispatch body for read-only tools that take an explicit
+    /// <paramref name="workspaceId"/>, run under the per-workspace read gate, and own a
+    /// non-string result projection such as structured MCP content.
+    /// </summary>
+    /// <typeparam name="TDto">The DTO type returned by the underlying service call.</typeparam>
+    /// <typeparam name="TResult">The tool-owned projected result type.</typeparam>
+    /// <param name="gate">The workspace execution gate.</param>
+    /// <param name="workspaceId">The workspace session identifier.</param>
+    /// <param name="serviceCall">
+    /// A closure the tool shim supplies that invokes the service method with the
+    /// tool's parameters (captured via closure) and the gate-provided
+    /// <see cref="CancellationToken"/>.
+    /// </param>
+    /// <param name="resultProjection">
+    /// The tool-owned projection from the service DTO to its public result type.
+    /// </param>
+    /// <param name="ct">The caller's cancellation token.</param>
+    /// <returns>The projected result.</returns>
+    public static Task<TResult> ReadByWorkspaceIdAsync<TDto, TResult>(
+        IWorkspaceExecutionGate gate,
+        string workspaceId,
+        Func<CancellationToken, Task<TDto>> serviceCall,
+        Func<TDto, TResult> resultProjection,
+        CancellationToken ct)
         => gate.RunReadAsync(workspaceId, async c =>
         {
             var result = await serviceCall(c).ConfigureAwait(false);
-            return JsonSerializer.Serialize(result, JsonDefaults.Indented);
+            return resultProjection(result);
         }, ct);
 
     /// <summary>

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
@@ -32,9 +32,10 @@ public static class WorkspaceDriftTool
         IWorkspaceDriftService driftService,
         [Description("Workspace session id from workspace_load.")] string workspaceId,
         CancellationToken ct = default)
-        => gate.RunReadAsync(
+        => ToolDispatch.ReadByWorkspaceIdAsync(
+            gate,
             workspaceId,
-            async c => StructuredToolResult.Create(
-                await driftService.CheckDriftAsync(workspaceId, c).ConfigureAwait(false)),
+            c => driftService.CheckDriftAsync(workspaceId, c),
+            StructuredToolResult.Create,
             ct);
 }

--- a/tests/RoslynMcp.Tests/Services/WorkspaceDriftServiceTests.cs
+++ b/tests/RoslynMcp.Tests/Services/WorkspaceDriftServiceTests.cs
@@ -1,3 +1,8 @@
+using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Models;
+using RoslynMcp.Core.Services;
+using RoslynMcp.Host.Stdio.Tools;
+
 namespace RoslynMcp.Tests.Services;
 
 /// <summary>
@@ -14,6 +19,45 @@ public sealed class WorkspaceDriftServiceTests : IsolatedWorkspaceTestBase
 
     [ClassCleanup]
     public static void ClassCleanup() => DisposeServices();
+
+    [TestMethod]
+    public async Task WorkspaceDriftCheck_UsesStructuredReadDispatch_AndPreservesInputs()
+    {
+        const string workspaceId = "workspace-with-identity";
+        using var callerCancellation = new CancellationTokenSource();
+        using var gateCancellation = new CancellationTokenSource();
+        var expected = new WorkspaceDriftResult(
+            Stale: true,
+            FilesDrifted: ["/workspace/Changed.cs"],
+            Recommended: "reload");
+        var gate = new RecordingReadGate(gateCancellation.Token);
+        var service = new RecordingWorkspaceDriftService(expected);
+
+        var result = await WorkspaceDriftTool.WorkspaceDriftCheck(
+            gate,
+            service,
+            workspaceId,
+            callerCancellation.Token);
+
+        Assert.AreEqual(1, gate.ReadCallCount, "Structured dispatch must use exactly one read gate hop.");
+        Assert.AreEqual(workspaceId, gate.WorkspaceId, "The caller's workspace id must reach the gate unchanged.");
+        Assert.AreEqual(callerCancellation.Token, gate.CallerCancellationToken,
+            "The caller's cancellation token must reach the gate unchanged.");
+        Assert.AreEqual(workspaceId, service.WorkspaceId,
+            "The caller's workspace id must reach the service unchanged.");
+        Assert.AreEqual(gateCancellation.Token, service.CancellationToken,
+            "The gate-provided cancellation token must reach the service unchanged.");
+
+        Assert.IsNotNull(result.StructuredContent);
+        var structured = result.StructuredContent.Value;
+        Assert.IsTrue(structured.GetProperty("stale").GetBoolean());
+        Assert.AreEqual("/workspace/Changed.cs", structured.GetProperty("filesDrifted")[0].GetString());
+        Assert.AreEqual("reload", structured.GetProperty("recommended").GetString());
+        Assert.AreEqual(
+            structured.GetRawText(),
+            ((TextContentBlock)result.Content![0]).Text,
+            "Structured and legacy text channels must retain the same projected payload.");
+    }
 
     /// <summary>
     /// Clean workspace: no on-disk changes since load → drift check returns
@@ -142,5 +186,54 @@ public sealed class WorkspaceDriftServiceTests : IsolatedWorkspaceTestBase
             expected,
             result.FilesDrifted.ToArray(),
             "files_drifted must be sorted ordinally for deterministic output.");
+    }
+
+    private sealed class RecordingReadGate(CancellationToken gateCancellationToken) : IWorkspaceExecutionGate
+    {
+        public int ReadCallCount { get; private set; }
+
+        public string? WorkspaceId { get; private set; }
+
+        public CancellationToken CallerCancellationToken { get; private set; }
+
+        public async Task<T> RunReadAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct)
+        {
+            ReadCallCount++;
+            WorkspaceId = workspaceId;
+            CallerCancellationToken = ct;
+            return await action(gateCancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<T> RunWriteAsync<T>(
+            string workspaceId,
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct,
+            bool applyStalenessPolicy = true) => throw Unsupported(nameof(RunWriteAsync));
+
+        public Task<T> RunLoadGateAsync<T>(
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken ct) => throw Unsupported(nameof(RunLoadGateAsync));
+
+        public void RemoveGate(string workspaceId) => throw Unsupported(nameof(RemoveGate));
+
+        private static NotSupportedException Unsupported(string member) =>
+            new($"Structured read dispatch must not call {member}.");
+    }
+
+    private sealed class RecordingWorkspaceDriftService(WorkspaceDriftResult result) : IWorkspaceDriftService
+    {
+        public string? WorkspaceId { get; private set; }
+
+        public CancellationToken CancellationToken { get; private set; }
+
+        public Task<WorkspaceDriftResult> CheckDriftAsync(string workspaceId, CancellationToken ct)
+        {
+            WorkspaceId = workspaceId;
+            CancellationToken = ct;
+            return Task.FromResult(result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a result-projecting overload to the standard workspace read dispatcher while preserving the existing JSON string route
- route `workspace_drift_check` through the shared adapter with its typed structured-result projection
- cover the single gate hop, workspace identity, cancellation boundaries, and dual-channel payload contract

## Validation
- Roslyn `compile_check` with emit validation: 0 errors, 0 warnings
- Roslyn focused `test_run`: 5 passed, 0 failed
- `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release`: 2,880 passed, 7 skipped, 0 failed

Closes: structured-tool-dispatch-adapter