### PR TITLE
test: share parameter description harness

### DIFF
--- a/changelog.d/desc-budget-harness-param-family.md
+++ b/changelog.d/desc-budget-harness-param-family.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Share exact parameter-description budget assertions across tool slices.

--- a/tests/RoslynMcp.Tests/ParamDescriptionCanonicalFormCodeActionSuppressionTests.cs
+++ b/tests/RoslynMcp.Tests/ParamDescriptionCanonicalFormCodeActionSuppressionTests.cs
@@ -1,35 +1,15 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
-using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 namespace RoslynMcp.Tests;
 
 /// <summary>
-/// param-description-dedupe-code-action-suppression: locks the canonical one-liner forms for
-/// <c>workspaceId</c> and <c>filePath</c> parameters across the code-action, suppression,
-/// symbol-refactor, and bulk-refactoring tool surfaces so phrasing drift cannot re-accumulate.
-/// Scoped to exactly the four in-scope types — NOT assembly-wide.
+/// Locks exact canonical boilerplate forms across the code-action, suppression,
+/// symbol-refactor, and bulk-refactoring tool surfaces.
 /// </summary>
 [TestClass]
 public sealed class ParamDescriptionCanonicalFormCodeActionSuppressionTests
 {
-    private const string CanonicalWorkspaceIdDescription =
-        "The workspace session identifier returned by workspace_load";
-
-    private const string CanonicalFilePathDescription = "Absolute path to the source file";
-
-    /// <summary>
-    /// (tool, param) pairs whose description is deliberately non-canonical because it carries
-    /// call-accuracy information the canonical one-liner would lose.
-    /// </summary>
-    private static readonly HashSet<(string ToolName, string ParamName)> LoadBearingFilePathExceptions =
-    [
-        // Explains WHICH .editorconfig the server mutates — a real disambiguator.
-        ("set_diagnostic_severity", "filePath"),
-    ];
-
     private static readonly Type[] InScopeTypes =
     [
         typeof(CodeActionTools),
@@ -38,93 +18,22 @@ public sealed class ParamDescriptionCanonicalFormCodeActionSuppressionTests
         typeof(BulkRefactoringTools),
     ];
 
-    [TestMethod]
-    public void InScopeTools_WorkspaceIdAndFilePathDescriptions_UseCanonicalForms()
-    {
-        var failures = new List<string>();
-        var workspaceIdCount = 0;
-        var filePathCount = 0;
-        var paramCount = 0;
-
-        foreach (var (toolName, param) in EnumerateToolParameters())
-        {
-            paramCount++;
-            var description = param.GetCustomAttribute<DescriptionAttribute>()?.Description ?? string.Empty;
-
-            switch (param.Name)
-            {
-                case "workspaceId":
-                    workspaceIdCount++;
-                    if (!string.Equals(description, CanonicalWorkspaceIdDescription, StringComparison.Ordinal))
-                        failures.Add($"({toolName}, workspaceId): expected \"{CanonicalWorkspaceIdDescription}\" but got \"{description}\".");
-                    break;
-
-                // Exactly "filePath" — not filePaths, sourceFilePath, hostRegistrationFile, etc.
-                case "filePath":
-                    if (LoadBearingFilePathExceptions.Contains((toolName, "filePath"))) break;
-                    filePathCount++;
-                    if (!string.Equals(description, CanonicalFilePathDescription, StringComparison.Ordinal))
-                        failures.Add($"({toolName}, filePath): expected \"{CanonicalFilePathDescription}\" but got \"{description}\".");
-                    break;
-            }
-        }
-
-        Assert.IsTrue(paramCount > 0,
-            "No tool parameters discovered on the in-scope types — reflection walk or tool registration changed.");
-        Assert.IsTrue(workspaceIdCount > 0, "No 'workspaceId' parameters discovered on the in-scope types.");
-        Assert.IsTrue(filePathCount > 0, "No non-exempt 'filePath' parameters discovered on the in-scope types.");
-        Assert.AreEqual(0, failures.Count,
-            "Non-canonical parameter descriptions:\n  " + string.Join("\n  ", failures));
-    }
+    private static readonly ParameterDescriptionBudgetHarness.CanonicalFormExpectation[] CanonicalForms =
+    [
+        new(
+            "workspaceId",
+            _ => "The workspace session identifier returned by workspace_load"),
+        new(
+            "filePath",
+            _ => "Absolute path to the source file",
+            entry => entry.ToolName != "set_diagnostic_severity"),
+    ];
 
     [TestMethod]
-    public void InScopeTools_EveryParameter_CarriesNonEmptyDescription()
-    {
-        var failures = new List<string>();
-        var paramCount = 0;
+    public void InScopeTools_WorkspaceIdAndFilePathDescriptions_UseCanonicalForms() =>
+        ParameterDescriptionBudgetHarness.AssertCanonicalForms(InScopeTypes, CanonicalForms);
 
-        foreach (var (toolName, param) in EnumerateToolParameters())
-        {
-            paramCount++;
-            var description = param.GetCustomAttribute<DescriptionAttribute>()?.Description;
-            if (string.IsNullOrWhiteSpace(description))
-                failures.Add($"({toolName}, {param.Name}): [Description] is missing or empty.");
-        }
-
-        Assert.IsTrue(paramCount > 0,
-            "No tool parameters discovered on the in-scope types — reflection walk or tool registration changed.");
-        Assert.AreEqual(0, failures.Count,
-            "Tool parameters without a [Description]:\n  " + string.Join("\n  ", failures));
-    }
-
-    private static IEnumerable<(string ToolName, ParameterInfo Parameter)> EnumerateToolParameters()
-    {
-        foreach (var method in InScopeTypes
-            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)))
-        {
-            var serverTool = method.GetCustomAttribute<McpServerToolAttribute>();
-            if (serverTool is null) continue;
-
-            var toolName = serverTool.Name ?? method.Name;
-            foreach (var param in method.GetParameters())
-            {
-                if (!IsSchemaParameter(param)) continue;
-                yield return (toolName, param);
-            }
-        }
-    }
-
-    /// <summary>
-    /// True for parameters that surface in the tool's JSON input schema. Excludes the
-    /// DI-injected host services (<see cref="McpServer"/> and service interfaces) and the
-    /// trailing <see cref="CancellationToken"/>, none of which carry a [Description].
-    /// </summary>
-    private static bool IsSchemaParameter(ParameterInfo param)
-    {
-        var type = param.ParameterType;
-        if (type == typeof(CancellationToken)) return false;
-        if (type == typeof(McpServer)) return false;
-        if (type.IsInterface) return false;
-        return true;
-    }
+    [TestMethod]
+    public void InScopeTools_EveryParameter_CarriesNonEmptyDescription() =>
+        ParameterDescriptionBudgetHarness.AssertAllSchemaParametersHaveNonEmptyDescriptions(InScopeTypes);
 }

--- a/tests/RoslynMcp.Tests/ParameterDescriptionBudgetHarness.cs
+++ b/tests/RoslynMcp.Tests/ParameterDescriptionBudgetHarness.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Server;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Shared reflection and assertion harness for parameter-description canonicalization slices.
+/// Callers declare their swept tool types and exact boilerplate forms; descriptions carrying
+/// tool-specific call guidance stay outside those expectations.
+/// </summary>
+internal static class ParameterDescriptionBudgetHarness
+{
+    internal sealed record CanonicalFormExpectation(
+        string ParameterName,
+        Func<ToolParameterEntry, string> ExpectedDescription,
+        Func<ToolParameterEntry, bool>? IsBoilerplate = null);
+
+    internal readonly record struct ToolParameterEntry(
+        Type DeclaringType,
+        MethodInfo Method,
+        string ToolName,
+        ParameterInfo Parameter,
+        string? Description)
+    {
+        internal string Site => $"{DeclaringType.Name}.{Method.Name}({Parameter.Name})";
+    }
+
+    internal static void AssertCanonicalForms(
+        IReadOnlyList<Type> sliceTypes,
+        IReadOnlyList<CanonicalFormExpectation> expectations)
+    {
+        var parameters = EnumerateSchemaToolParameters(sliceTypes);
+        Assert.IsGreaterThan(0, parameters.Length, "No schema parameters were discovered on the swept tool types.");
+
+        var duplicateNames = expectations
+            .GroupBy(expectation => expectation.ParameterName, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToArray();
+        Assert.AreEqual(
+            0,
+            duplicateNames.Length,
+            "Each parameter family must have one canonical-form expectation. Duplicates:\n  "
+            + string.Join("\n  ", duplicateNames));
+
+        var failures = new List<string>();
+
+        foreach (var expectation in expectations)
+        {
+            var matches = parameters
+                .Where(entry => string.Equals(
+                    entry.Parameter.Name,
+                    expectation.ParameterName,
+                    StringComparison.Ordinal))
+                .Where(entry => expectation.IsBoilerplate?.Invoke(entry) is not false)
+                .ToArray();
+
+            if (matches.Length == 0)
+            {
+                failures.Add($"{expectation.ParameterName}: no matching boilerplate parameter found");
+                continue;
+            }
+
+            foreach (var match in matches)
+            {
+                var expectedDescription = expectation.ExpectedDescription(match);
+                if (!string.Equals(expectedDescription, match.Description, StringComparison.Ordinal))
+                {
+                    failures.Add(
+                        $"{match.Site}: expected \"{expectedDescription}\", "
+                        + $"got \"{match.Description ?? "<missing>"}\"");
+                }
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            failures.Count,
+            "Boilerplate parameter descriptions must use an exact canonical form:\n  "
+            + string.Join("\n  ", failures));
+    }
+
+    internal static void AssertAllSchemaParametersHaveNonEmptyDescriptions(IReadOnlyList<Type> sliceTypes)
+    {
+        var parameters = EnumerateSchemaToolParameters(sliceTypes);
+        Assert.IsGreaterThan(0, parameters.Length, "No schema parameters were discovered on the swept tool types.");
+
+        var missing = parameters
+            .Where(entry => string.IsNullOrWhiteSpace(entry.Description))
+            .Select(entry => entry.Site)
+            .ToArray();
+
+        Assert.AreEqual(
+            0,
+            missing.Length,
+            "Tool parameters without a [Description]:\n  " + string.Join("\n  ", missing));
+    }
+
+    private static ToolParameterEntry[] EnumerateSchemaToolParameters(IReadOnlyList<Type> sliceTypes) =>
+        sliceTypes
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+            .Select(method => new
+            {
+                Method = method,
+                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
+            })
+            .Where(entry => entry.Tool is not null)
+            .SelectMany(entry => entry.Method.GetParameters().Select(parameter => new
+            {
+                entry.Method,
+                entry.Tool,
+                Parameter = parameter,
+            }))
+            .Where(entry => IsSchemaParameter(entry.Parameter))
+            .Select(entry => new ToolParameterEntry(
+                entry.Method.DeclaringType!,
+                entry.Method,
+                entry.Tool!.Name ?? entry.Method.Name,
+                entry.Parameter,
+                entry.Parameter.GetCustomAttribute<DescriptionAttribute>()?.Description))
+            .OrderBy(entry => entry.ToolName, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Parameter.Position)
+            .ToArray();
+
+    private static bool IsSchemaParameter(ParameterInfo parameter)
+    {
+        var type = parameter.ParameterType;
+        return type != typeof(CancellationToken)
+            && type != typeof(McpServer)
+            && !type.IsInterface;
+    }
+}
+
+[TestClass]
+public sealed class ParameterDescriptionBudgetHarnessTests
+{
+    [TestMethod]
+    public void AssertCanonicalForms_RequiresExactText_AndSkipsLoadBearingSites()
+    {
+        var exactForms = new[]
+        {
+            new ParameterDescriptionBudgetHarness.CanonicalFormExpectation(
+                "workspaceId",
+                _ => "Canonical workspace description.",
+                entry => entry.ToolName != "load_bearing_fixture"),
+        };
+
+        ParameterDescriptionBudgetHarness.AssertCanonicalForms([typeof(CanonicalFixtureTools)], exactForms);
+
+        var failure = Assert.ThrowsExactly<AssertFailedException>(() =>
+            ParameterDescriptionBudgetHarness.AssertCanonicalForms(
+                [typeof(CanonicalFixtureTools)],
+                [new("workspaceId", _ => "Canonical workspace description")]));
+        StringAssert.Contains(failure.Message, "expected \"Canonical workspace description\"");
+    }
+
+    [TestMethod]
+    public void AssertAllSchemaParametersHaveNonEmptyDescriptions_ReportsMissingDescription()
+    {
+        var failure = Assert.ThrowsExactly<AssertFailedException>(() =>
+            ParameterDescriptionBudgetHarness.AssertAllSchemaParametersHaveNonEmptyDescriptions(
+                [typeof(MissingDescriptionFixtureTools)]));
+
+        StringAssert.Contains(failure.Message, "MissingDescriptionFixtureTools.MissingDescription(value)");
+    }
+
+    private static class CanonicalFixtureTools
+    {
+        [McpServerTool(Name = "canonical_fixture")]
+        public static void Canonical(
+            [Description("Canonical workspace description.")] string workspaceId,
+            [Description("Tool-specific guidance remains unconstrained.")] string command)
+        {
+        }
+
+        [McpServerTool(Name = "load_bearing_fixture")]
+        public static void LoadBearing(
+            [Description("Source workspace whose role must remain explicit.")] string workspaceId)
+        {
+        }
+    }
+
+    private static class MissingDescriptionFixtureTools
+    {
+        [McpServerTool(Name = "missing_description_fixture")]
+        public static void MissingDescription(string value)
+        {
+        }
+    }
+}

--- a/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
+++ b/tests/RoslynMcp.Tests/ParameterDescriptionCanonicalizationTests.cs
@@ -1,7 +1,4 @@
-using System.Reflection;
-using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -10,12 +7,9 @@ namespace RoslynMcp.Tests;
 /// Slice-scoped ratchet for the parameter-description canonicalization sweep.
 /// </summary>
 /// <remarks>
-/// Scope is deliberately limited to the tool types swept so far —
-/// <c>param-description-dedupe-edit-file-ops</c>, then
-/// <c>param-description-dedupe-validation-signature</c>, then
-/// <c>param-description-dedupe-refactoring-core</c> (the last four). The remaining
-/// <c>Tools/*.cs</c> files are still unswept, so a repo-wide assertion would red CI; later
-/// slices widen <see cref="SweptToolTypes"/>.
+/// Scope is deliberately limited to the tool types swept so far. The shared
+/// <see cref="ParameterDescriptionBudgetHarness"/> owns parameter discovery and assertions;
+/// this slice owns only its type set and exact boilerplate forms.
 /// </remarks>
 [TestClass]
 public sealed class ParameterDescriptionCanonicalizationTests
@@ -36,158 +30,65 @@ public sealed class ParameterDescriptionCanonicalizationTests
         typeof(OperationTools),
     ];
 
-    private const string CanonicalWorkspaceId = "Workspace session id from workspace_load.";
-
-    /// <summary>
-    /// (type name, method name, parameter name) triples whose <c>workspaceId</c> description is
-    /// deliberately non-canonical because it carries call-accuracy information the canonical
-    /// one-liner would lose. Mirrors <c>LoadBearingFilePathExceptions</c> in
-    /// <see cref="ParamDescriptionCanonicalFormCodeActionSuppressionTests"/>, but keyed by
-    /// type/method because this ratchet enumerates <see cref="Type"/> rather than tool name,
-    /// and each entry pins its exact allowed text so an exemption is a second canonical form
-    /// rather than an unguarded hole.
-    /// </summary>
-    private static readonly Dictionary<(string Type, string Method, string Parameter), string> _loadBearingWorkspaceIdExceptions =
-        new()
-        {
-            // workspace_fork_apply juggles TWO workspaces; "Source" is the disambiguator.
-            [(nameof(ValidationBundleTools), nameof(ValidationBundleTools.WorkspaceForkApply), "workspaceId")] =
-                "Source workspace session id from workspace_load.",
-        };
-
-    /// <summary>
-    /// The exact <c>workspaceId</c> description a site must carry: the canonical one-liner, or the
-    /// pinned text when the site is a declared load-bearing exception.
-    /// </summary>
-    private static string ExpectedWorkspaceId(string typeName, string methodName, string parameterName) =>
-        _loadBearingWorkspaceIdExceptions.TryGetValue((typeName, methodName, parameterName), out var exempted)
-            ? exempted
-            : CanonicalWorkspaceId;
-
-    private static readonly Regex CanonicalPreviewToken =
-        new(@"^Preview token from (?:[a-z0-9_]+_preview\.|any \*_preview tool\.)$", RegexOptions.Compiled);
-
-    private static readonly Regex CanonicalPath =
-        new(@"^Absolute path to the .+\.$", RegexOptions.Compiled);
-
-    /// <summary>(type name, parameter name) -> substring the description must still contain.</summary>
-    private static readonly (string Type, string Parameter, string Keyword)[] LoadBearingContracts =
+    private static readonly ParameterDescriptionBudgetHarness.CanonicalFormExpectation[] CanonicalForms =
     [
-        (nameof(EditTools), "edits", "1-based"),
-        (nameof(EditTools), "verify", "compile_check"),
-        (nameof(EditTools), "autoRevertOnError", "Ignored when verify is false"),
-        (nameof(MSBuildTools), "includedNames", "native JSON array"),
-        (nameof(ValidationBundleTools), "changedFilePaths", "native JSON array"),
-        (nameof(ValidationBundleTools), "retention", "drop-on-success"),
-        (nameof(ParameterObjectTools), "dtoFolders", "native JSON array"),
-        (nameof(ChangeSignatureTools), "metadataName", "NOT accepted"),
-        (nameof(ChangeSignatureTools), "newOrder", "exactly once"),
-        (nameof(RefactoringTools), "summary", ">150 refs"),
-        (nameof(RestructureTools), "pattern", "__"),
-        (nameof(RestructureTools), "goal", "same syntactic kind"),
-        (nameof(OperationTools), "column", "UX-003"),
-        (nameof(ScriptingTools), "timeoutSeconds", "ROSLYNMCP_SCRIPT_TIMEOUT_SECONDS"),
+        new(
+            "workspaceId",
+            _ => "Workspace session id from workspace_load.",
+            entry => entry.ToolName != "workspace_fork_apply"),
+        new(
+            "previewToken",
+            ExpectedPreviewTokenDescription),
+        new(
+            "filePath",
+            ExpectedRequiredPathDescription,
+            entry => !entry.Parameter.IsOptional),
+        new(
+            "sourceFilePath",
+            ExpectedRequiredPathDescription,
+            entry => !entry.Parameter.IsOptional),
+        new(
+            "targetFilePath",
+            ExpectedRequiredPathDescription,
+            entry => !entry.Parameter.IsOptional),
     ];
 
-    private static IEnumerable<(Type Type, MethodInfo Method, ParameterInfo Parameter, string Description)> SweptToolParameters()
-    {
-        foreach (var type in SweptToolTypes)
-        {
-            var methods = type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
-
-            foreach (var method in methods)
-            {
-                if (method.GetCustomAttribute<McpServerToolAttribute>() is null)
-                {
-                    continue;
-                }
-
-                foreach (var parameter in method.GetParameters())
-                {
-                    var description = parameter.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
-                    if (description is not null)
-                    {
-                        yield return (type, method, parameter, description);
-                    }
-                }
-            }
-        }
-    }
-
     [TestMethod]
-    public void SweptTools_BoilerplateParameterDescriptions_UseCanonicalForm()
+    public void SweptTools_BoilerplateParameterDescriptions_UseCanonicalForm() =>
+        ParameterDescriptionBudgetHarness.AssertCanonicalForms(SweptToolTypes, CanonicalForms);
+
+    private static string ExpectedPreviewTokenDescription(
+        ParameterDescriptionBudgetHarness.ToolParameterEntry entry)
     {
-        var violations = new List<string>();
-
-        foreach (var (type, method, parameter, description) in SweptToolParameters())
+        if (entry.ToolName == "workspace_fork_apply")
         {
-            var site = $"{type.Name}.{method.Name}({parameter.Name})";
-
-            switch (parameter.Name)
-            {
-                case "workspaceId" when !string.Equals(
-                    description,
-                    ExpectedWorkspaceId(type.Name, method.Name, parameter.Name),
-                    StringComparison.Ordinal):
-                    violations.Add(
-                        $"{site}: expected \"{ExpectedWorkspaceId(type.Name, method.Name, parameter.Name)}\", "
-                        + $"got \"{description}\"");
-                    break;
-                case "previewToken" when !CanonicalPreviewToken.IsMatch(description):
-                    violations.Add(
-                        $"{site}: expected \"Preview token from <tool>_preview.\" or "
-                        + $"\"Preview token from any *_preview tool.\", got \"{description}\"");
-                    break;
-                // Optional path parameters (e.g. TypeMoveTools.targetFilePath) keep their
-                // "Optional: ... defaults to ..." form — the defaulting rule is a discriminator,
-                // not boilerplate, so only required path parameters carry the canonical one-liner.
-                case "filePath" or "sourceFilePath" or "targetFilePath"
-                    when !parameter.IsOptional && !CanonicalPath.IsMatch(description):
-                    violations.Add($"{site}: expected \"Absolute path to the <role>.\", got \"{description}\"");
-                    break;
-            }
+            return "Preview token from any *_preview tool.";
         }
 
-        Assert.AreEqual(
-            0,
-            violations.Count,
-            "Boilerplate parameter descriptions on the swept tool types must use the canonical form:\n  "
-            + string.Join("\n  ", violations));
+        const string applySuffix = "_apply";
+        return entry.ToolName.EndsWith(applySuffix, StringComparison.Ordinal)
+            ? $"Preview token from {entry.ToolName[..^applySuffix.Length]}_preview."
+            : $"<no exact preview-token form declared for {entry.ToolName}>";
     }
 
-    [TestMethod]
-    public void SweptTools_LoadBearingParameterDescriptions_RetainTheirContractKeyword()
-    {
-        var parameters = SweptToolParameters().ToArray();
-        var violations = new List<string>();
-
-        foreach (var (typeName, parameterName, keyword) in LoadBearingContracts)
+    private static string ExpectedRequiredPathDescription(
+        ParameterDescriptionBudgetHarness.ToolParameterEntry entry) =>
+        (entry.ToolName, entry.Parameter.Name) switch
         {
-            var matches = parameters
-                .Where(entry => entry.Type.Name == typeName && entry.Parameter.Name == parameterName)
-                .ToArray();
-
-            if (matches.Length == 0)
-            {
-                violations.Add($"{typeName}.{parameterName}: no [Description]-carrying tool parameter found");
-                continue;
-            }
-
-            foreach (var match in matches)
-            {
-                if (!match.Description.Contains(keyword, StringComparison.Ordinal))
-                {
-                    violations.Add(
-                        $"{typeName}.{match.Method.Name}({parameterName}): must still document \"{keyword}\"");
-                }
-            }
-        }
-
-        Assert.AreEqual(
-            0,
-            violations.Count,
-            "Load-bearing parameter descriptions must not be trimmed past their contract:\n  "
-            + string.Join("\n  ", violations));
-    }
+            ("apply_text_edit", "filePath") => "Absolute path to the file to edit.",
+            ("create_file_preview", "filePath") => "Absolute path to the file to create.",
+            ("delete_file_preview", "filePath") => "Absolute path to the file to delete.",
+            ("move_file_preview", "sourceFilePath") => "Absolute path to the source file.",
+            ("move_file_preview", "targetFilePath") => "Absolute path to the destination file.",
+            ("move_type_to_file_preview", "sourceFilePath") =>
+                "Absolute path to the source file containing the type.",
+            ("move_type_to_project_preview", "sourceFilePath") =>
+                "Absolute path to the source file containing the type.",
+            ("extract_interface_cross_project_preview", "filePath") =>
+                "Absolute path to the source file containing the type.",
+            ("dependency_inversion_preview", "filePath") =>
+                "Absolute path to the source file containing the concrete type.",
+            (_, "filePath") => "Absolute path to the source file.",
+            _ => $"<no exact required-path form declared for {entry.ToolName}.{entry.Parameter.Name}>",
+        };
 }


### PR DESCRIPTION
## Summary

- centralize parameter-level MCP tool reflection and exact canonical-description assertions
- migrate both existing parameter-description slices to the shared harness while excluding load-bearing descriptions
- add helper regressions for near-match rejection and missing descriptions

## Validation

- `dotnet test tests/RoslynMcp.Tests/RoslynMcp.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~ParameterDescriptionCanonicalizationTests|FullyQualifiedName~ParamDescriptionCanonicalFormCodeActionSuppressionTests|FullyQualifiedName~ParameterDescriptionBudgetHarnessTests"` (5 passed)
- Roslyn `compile_check` on `RoslynMcp.Tests` (0 errors)
- `pwsh -NoProfile -File ./eng/verify-release.ps1 -Configuration Release` (2,880 passed, 7 skipped, 0 failed)




Closes: desc-budget-harness-param-family
