### PR TITLE
test(descriptions): adopt shared budget harness

### DIFF
--- a/changelog.d/desc-budget-harness-method-adopt-wave-2.md
+++ b/changelog.d/desc-budget-harness-method-adopt-wave-2.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Migrate the second method-description test wave to the shared harness.

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietDiagnosticsSecurityTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietDiagnosticsSecurityTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -37,79 +35,51 @@ public sealed class MethodDescriptionDietDiagnosticsSecurityTests
         typeof(AnalyzerInfoTools),
     ];
 
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] _triggerExpectations =
+    [
+        // trace_exception_flow: both handling AND origination sites, and the find_references contrast.
+        new("trace_exception_flow", "`throw new` origination sites"),
+        new("trace_exception_flow", "usage sites, not handling sites"),
+
+        // nuget_vulnerability_scan: direct-vs-transitive default and the SDK floor.
+        new("nuget_vulnerability_scan", "includeTransitive=false returns direct references only"),
+        new("nuget_vulnerability_scan", ".NET 8+ SDK"),
+
+        // analyze_snippet: ephemeral workspace with no solution load, and the kind-selects-wrapper pointer.
+        new("analyze_snippet", "ephemeral workspace"),
+        new("analyze_snippet", "`kind` selects the wrapper"),
+
+        // list_analyzers: the code-fix discovery use case and flattened-rule pagination unit.
+        new("list_analyzers", "code_fix_preview or fix_all_preview"),
+        new("list_analyzers", "flattened rule list, not whole analyzers"),
+    ];
+
     [TestMethod]
     public void SliceToolDescriptions_AreCapabilityStatements()
-    {
-        var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
-            "(what it does plus the one discriminating trigger); move operational detail to XML " +
-            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
-    }
+        => ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
 
     [TestMethod]
     public void SliceToolDescriptions_StayUnderAggregateBudget()
-    {
-        var entries = EnumerateSliceTools().ToArray();
-        var total = entries.Sum(entry => entry.Description.Length);
+        => ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            _sliceToolTypes, _maxAggregateDescriptionCharacters);
 
-        Assert.IsTrue(
-            entries.Length > 0,
-            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
-
-        Assert.IsTrue(
-            total <= _maxAggregateDescriptionCharacters,
-            $"Aggregate method-description budget for the slice is " +
-            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
-    }
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions()
+        => ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
 
     [TestMethod]
     public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
+        => ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(_sliceToolTypes, _triggerExpectations);
+
+    [TestMethod]
+    public void DiscriminatingTriggerHarness_RejectsMissingSubstring()
     {
-        // trace_exception_flow: both handling AND origination sites, and the find_references contrast.
-        AssertDescriptionContains("trace_exception_flow", "`throw new` origination sites");
-        AssertDescriptionContains("trace_exception_flow", "usage sites, not handling sites");
+        ToolDescriptionBudgetHarness.TriggerExpectation[] missingTrigger =
+        [
+            new("trace_exception_flow", "__missing_discriminating_trigger__"),
+        ];
 
-        // nuget_vulnerability_scan: direct-vs-transitive default and the SDK floor.
-        AssertDescriptionContains("nuget_vulnerability_scan", "includeTransitive=false returns direct references only");
-        AssertDescriptionContains("nuget_vulnerability_scan", ".NET 8+ SDK");
-
-        // analyze_snippet: ephemeral workspace with no solution load, and the kind-selects-wrapper pointer.
-        AssertDescriptionContains("analyze_snippet", "ephemeral workspace");
-        AssertDescriptionContains("analyze_snippet", "`kind` selects the wrapper");
-
-        // list_analyzers: the code-fix discovery use case and the flattened-rule pagination unit.
-        AssertDescriptionContains("list_analyzers", "code_fix_preview or fix_all_preview");
-        AssertDescriptionContains("list_analyzers", "flattened rule list, not whole analyzers");
+        Assert.ThrowsExactly<AssertFailedException>(() =>
+            ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(_sliceToolTypes, missingTrigger));
     }
-
-    private static void AssertDescriptionContains(string toolName, string expected)
-    {
-        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
-
-        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
-        StringAssert.Contains(
-            entry.Description,
-            expected,
-            $"Trimming '{toolName}' dropped its discriminating trigger.");
-    }
-
-    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => _sliceToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null && entry.Description is not null)
-            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
 }

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietEditingMsBuildTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietEditingMsBuildTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -34,97 +32,35 @@ public sealed class MethodDescriptionDietEditingMsBuildTests
         typeof(SymbolRefactorTools),
     ];
 
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] _triggerExpectations =
+    [
+        new("apply_text_edit", "Prefer a semantic preview/apply Roslyn tool whenever one exists"),
+        new("apply_text_edit", "Revertible via revert_last_apply"),
+        new("pragma_scope_widen", "Refuses when the move would cross a #region/#endregion boundary"),
+        new("verify_pragma_suppresses", "'cosmetic pragma' bugs"),
+        new("verify_pragma_suppresses", "Read-only"),
+        new("record_field_add_with_satellites_preview", "patternDetectionReason"),
+        new("symbol_refactor_preview", "a failure in any step aborts the whole preview"),
+        new("split_service_with_di_preview", "forwarding facade"),
+        new("split_service_with_di_preview", "DI-registration deltas"),
+        new("evaluate_msbuild_items", "(e.g. Compile, PackageReference)"),
+        new("get_msbuild_properties", "always pass a propertyNameFilter substring or an includedNames allowlist"),
+    ];
+
     [TestMethod]
     public void SliceToolDescriptions_AreCapabilityStatements()
-    {
-        var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
-            "(what it does plus the one discriminating trigger); move operational detail to XML " +
-            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
-    }
+        => ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
 
     [TestMethod]
     public void SliceToolDescriptions_StayUnderAggregateBudget()
-    {
-        var entries = EnumerateSliceTools().ToArray();
-        var total = entries.Sum(entry => entry.Description.Length);
+        => ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            _sliceToolTypes, _maxAggregateDescriptionCharacters);
 
-        Assert.IsTrue(
-            entries.Length > 0,
-            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
-
-        Assert.IsTrue(
-            total <= _maxAggregateDescriptionCharacters,
-            $"Aggregate method-description budget for the slice is " +
-            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
-    }
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions()
+        => ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
 
     [TestMethod]
     public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
-    {
-        AssertDescriptionContains(
-            "apply_text_edit",
-            "Prefer a semantic preview/apply Roslyn tool whenever one exists");
-        AssertDescriptionContains(
-            "apply_text_edit",
-            "Revertible via revert_last_apply");
-        AssertDescriptionContains(
-            "pragma_scope_widen",
-            "Refuses when the move would cross a #region/#endregion boundary");
-        AssertDescriptionContains(
-            "verify_pragma_suppresses",
-            "'cosmetic pragma' bugs");
-        AssertDescriptionContains(
-            "verify_pragma_suppresses",
-            "Read-only");
-        AssertDescriptionContains(
-            "record_field_add_with_satellites_preview",
-            "patternDetectionReason");
-        AssertDescriptionContains(
-            "symbol_refactor_preview",
-            "a failure in any step aborts the whole preview");
-        AssertDescriptionContains(
-            "split_service_with_di_preview",
-            "forwarding facade");
-        AssertDescriptionContains(
-            "split_service_with_di_preview",
-            "DI-registration deltas");
-        AssertDescriptionContains(
-            "evaluate_msbuild_items",
-            "(e.g. Compile, PackageReference)");
-        AssertDescriptionContains(
-            "get_msbuild_properties",
-            "always pass a propertyNameFilter substring or an includedNames allowlist");
-    }
-
-    private static void AssertDescriptionContains(string toolName, string expected)
-    {
-        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
-
-        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
-        StringAssert.Contains(
-            entry.Description,
-            expected,
-            $"Trimming '{toolName}' dropped its discriminating trigger.");
-    }
-
-    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => _sliceToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null && entry.Description is not null)
-            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+        => ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(_sliceToolTypes, _triggerExpectations);
 }

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietScaffoldingMutationTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietScaffoldingMutationTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -34,70 +32,26 @@ public sealed class MethodDescriptionDietScaffoldingMutationTests
         typeof(CrossProjectRefactoringTools),
     ];
 
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] TriggerExpectations =
+    [
+        new("scaffold_first_test_file_preview", "Errors when the destination file already exists"),
+        new("apply_multi_file_edit", "preview_multi_file_edit + preview_multi_file_edit_apply"),
+    ];
+
     [TestMethod]
     public void SliceToolDescriptions_AreCapabilityStatements()
-    {
-        var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > MaxDescriptionCharacters)
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Method [Description] for these tools must be <= {MaxDescriptionCharacters} characters " +
-            "(what it does plus the one discriminating trigger); move operational detail to XML " +
-            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
-    }
+        => ToolDescriptionBudgetHarness.AssertPerToolBudget(SliceToolTypes, MaxDescriptionCharacters);
 
     [TestMethod]
     public void SliceToolDescriptions_StayUnderAggregateBudget()
-    {
-        var entries = EnumerateSliceTools().ToArray();
-        var total = entries.Sum(entry => entry.Description.Length);
+        => ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            SliceToolTypes, MaxAggregateDescriptionCharacters);
 
-        Assert.IsTrue(
-            entries.Length > 0,
-            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
-
-        Assert.IsTrue(
-            total <= MaxAggregateDescriptionCharacters,
-            $"Aggregate method-description budget for the slice is " +
-            $"{MaxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
-    }
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions()
+        => ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(SliceToolTypes);
 
     [TestMethod]
     public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
-    {
-        AssertDescriptionContains(
-            "scaffold_first_test_file_preview",
-            "Errors when the destination file already exists");
-        AssertDescriptionContains(
-            "apply_multi_file_edit",
-            "preview_multi_file_edit + preview_multi_file_edit_apply");
-    }
-
-    private static void AssertDescriptionContains(string toolName, string expected)
-    {
-        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
-
-        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
-        StringAssert.Contains(
-            entry.Description,
-            expected,
-            $"Trimming '{toolName}' dropped its discriminating trigger.");
-    }
-
-    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => SliceToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null && entry.Description is not null)
-            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+        => ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(SliceToolTypes, TriggerExpectations);
 }


### PR DESCRIPTION
## Summary
- migrate the diagnostics/security, editing/MSBuild, and scaffolding/mutation method-description diet tests to the shared ToolDescriptionBudgetHarness
- preserve the reviewed per-tool, slice-total, and discriminating-trigger contracts
- add explicit harness pass/fail coverage for discriminating trigger enforcement

## Validation
- Roslyn compile check: 6/6 projects, 0 diagnostics
- Focused test filter: 13 passed, 0 failed, 0 skipped
- ./eng/verify-release.ps1 -Configuration Release: 2883 passed, 7 skipped, 0 failed

Closes: desc-budget-harness-method-adopt-wave-2
