### PR TITLE
docs: condense lifecycle tool descriptions

### DIFF
--- a/changelog.d/method-diet-undo-workspace-lifecycle.md
+++ b/changelog.d/method-diet-undo-workspace-lifecycle.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Condensed undo and workspace-lifecycle tool descriptions for discovery.

--- a/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ApplyWithVerifyTool.cs
@@ -34,7 +34,7 @@ public static class ApplyWithVerifyTool
     [McpServerTool(Name = "apply_with_verify", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "experimental", false, true,
         "Apply a preview AND immediately verify via compile_check; auto-revert on new errors."),
-     Description("Apply a previously previewed refactoring AND immediately verify the workspace still compiles. Supported producers: any token from a solution-snapshot *_preview tool (rename/organize_usings/format_document/format_range/code_fix_preview, plus untagged ones such as parameter_object_preview) — unlike the named *_apply routes this one is producer-agnostic and never rejects a token for its producer family. Composite and project-mutation tokens are not redeemable here; use apply_composite_preview / apply_project_mutation. When new compile errors appear (relative to the pre-apply baseline), automatically revert via revert_last_apply and return status=\"rolled_back\" with the introduced errors. Otherwise return status=\"applied\". Pass rollbackOnError=false to keep broken state for inspection (returns status=\"applied_with_errors\").")]
+     Description("Apply a solution-snapshot preview token, run compile_check, and auto-revert compile errors. Producer-specific apply routes enforce token-family checks; excludes composite and project-mutation tokens.")]
     public static Task<string> ApplyWithVerify(
         IWorkspaceExecutionGate gate,
         IApplyUndoWorkflowService workflowService,

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -13,7 +13,7 @@ public static class UndoTools
     [McpServerTool(Name = "revert_last_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "stable", false, true,
         "Revert the most recent Roslyn solution-level apply operation for a workspace."),
-     Description("SINGLE-SLOT LIFO: reverts ONLY the most recent apply — after one revert it reports 'No operation to revert' even if 20+ earlier applies are still listed in workspace_changes. To revert an EARLIER apply, use revert_apply_by_sequence with the target's workspace_changes sequence number (that is the multi-step path; this tool cannot reach back past the last apply). Restores the previous solution state. Coverage: renames, code fixes, format, organize usings, apply_text_edit / apply_multi_file_edit, create_file / delete_file / move_file / extract_interface_apply / extract_type_apply / move_type_to_file_apply (Item #2 — 2026-04-16). Project-file (csproj) mutations route through Item #5's SDK-style-safe apply path, which restores the pre-apply csproj bytes as part of the apply itself; on revert the csproj is already in its pre-apply state. Limitation: reverts text edits only — it does NOT remove files created as side effects (e.g. extracted files from extract_type_apply / extract_method_apply / extract_interface_apply). Pair with delete_file_apply on the extracted file to fully undo a file-creating refactor. workspaceId is required.")]
+     Description("SINGLE-SLOT LIFO: reverts only the latest apply; a second call reports 'No operation to revert'. For earlier workspace_changes entries, use revert_apply_by_sequence. Does not remove created files.")]
     public static Task<string> RevertLastApply(
         IWorkspaceExecutionGate gate,
         IUndoService undoService,
@@ -63,7 +63,7 @@ public static class UndoTools
     [McpServerTool(Name = "revert_apply_by_sequence", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "stable", false, true,
         "Revert a specific earlier apply identified by its workspace_changes sequence number."),
-     Description("Revert a specific earlier apply by its sequence number — the value reported by workspace_changes. Complements revert_last_apply: instead of LIFO, this revert targets any historical apply still in this session's revert history. Conservative dependency check: if a later apply touched any file that the target apply also touched, the revert is blocked and the offending later sequence numbers are returned in `blockingSequences` so the caller can revert them first. workspaceId is required. sequenceNumber must match a value returned by workspace_changes for this workspace. Returns `{reverted, revertedOperation, affectedFiles, reason?, blockingSequences?}` — `reason` is `unknown-sequence` when the sequence has no recorded snapshot, `dependency-blocked` when a later apply overlaps in files, and `revert-failed` when the snapshot exists but disk/workspace mechanics rejected the revert.")]
+     Description("Revert a specific earlier solution-snapshot apply by its workspace_changes sequence number. Refuses when a later apply touched the same file; revert blocking sequences first.")]
     public static Task<string> RevertApplyBySequence(
         IWorkspaceExecutionGate gate,
         IApplyUndoWorkflowService workflowService,

--- a/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/UndoTools.cs
@@ -10,6 +10,11 @@ namespace RoslynMcp.Host.Stdio.Tools;
 [McpServerToolType]
 public static class UndoTools
 {
+    /// <summary>Reverts the latest solution-snapshot apply for a workspace.</summary>
+    /// <remarks>
+    /// Reversion restores text snapshots but does not delete files created as refactoring side
+    /// effects. Use <c>delete_file_apply</c> on each created file to complete that recovery.
+    /// </remarks>
     [McpServerTool(Name = "revert_last_apply", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false),
      McpToolMetadata("undo", "stable", false, true,
         "Revert the most recent Roslyn solution-level apply operation for a workspace."),

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
@@ -26,7 +26,7 @@ public static class WorkspaceDriftTool
         UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceDriftResult)),
      McpToolMetadata("workspace", "experimental", true, false,
         "Compare the in-memory workspace snapshot against filesystem mtimes; return drift status, drifted file paths, and a reload/noop recommendation."),
-     Description("Fast probe that compares the in-memory MSBuildWorkspace snapshot for `workspaceId` against the current on-disk last-write times of every tracked document. Returns `{ stale: bool, filesDrifted: string[], recommended: 'reload' | 'noop' }`. A document drifts when its mtime is past the workspace's loadedAtUtc, or when the file no longer exists on disk (deletion is also drift). Agents call this BEFORE a read tool to decide whether `workspace_reload` is needed — eliminates the dilemma between always-reloading (slow) and never-reloading (silent stale reads after out-of-band Edit/Write mutations). Source-generated documents have no file path and are skipped. Output is deterministic: the `filesDrifted` list is sorted ordinally and deduped across linked documents.")]
+     Description("Compare a loaded workspace snapshot with files on disk and return drifted paths plus reload/noop guidance. Use before reads after out-of-band edits; source-generated documents are skipped.")]
     public static Task<CallToolResult> WorkspaceDriftCheck(
         IWorkspaceExecutionGate gate,
         IWorkspaceDriftService driftService,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceDriftTool.cs
@@ -26,7 +26,7 @@ public static class WorkspaceDriftTool
         UseStructuredContent = true, OutputSchemaType = typeof(WorkspaceDriftResult)),
      McpToolMetadata("workspace", "experimental", true, false,
         "Compare the in-memory workspace snapshot against filesystem mtimes; return drift status, drifted file paths, and a reload/noop recommendation."),
-     Description("Compare a loaded workspace snapshot with files on disk and return drifted paths plus reload/noop guidance. Use before reads after out-of-band edits; source-generated documents are skipped.")]
+     Description("Compare a loaded workspace snapshot with files on disk and return filesDrifted plus reload/noop guidance. Use before reads after out-of-band edits; source-generated documents are skipped.")]
     public static Task<CallToolResult> WorkspaceDriftCheck(
         IWorkspaceExecutionGate gate,
         IWorkspaceDriftService driftService,

--- a/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/WorkspaceWarmTools.cs
@@ -26,7 +26,7 @@ public static class WorkspaceWarmTools
     [McpServerTool(Name = "workspace_warm", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("workspace", "experimental", false, false,
         "Opt-in compilation prewarm: force GetCompilationAsync + first-semantic-model resolution across the workspace to cut the cold-start penalty of the first read-side tool call."),
-     Description("Opt-in compilation prewarm for a loaded workspace. Forces Roslyn's internal compilation cache and semantic-model cache to populate by calling GetCompilationAsync on every project (or the subset named by the `projects` filter) and resolving one semantic model per project. On a mid-sized solution this shifts the ~4600ms cold-start penalty of the first symbol_search / find_references call into this explicit warm invocation, so follow-up reads run at ~40ms. workspace_load may run the same warm path automatically for solutions with more than 50 projects unless the caller passes prewarm=false. Returns ElapsedMs so callers can budget subsequent invocations; a repeat call on an unchanged workspace returns ColdCompilationCount=0 and typically ElapsedMs < 10% of the first call. No internal timeout — the caller's CancellationToken is the only cap.")]
+     Description("Prewarm Roslyn compilations and first semantic models for all or selected projects. Use before the first read-side call; workspace_load may prewarm large solutions automatically.")]
     public static Task<string> WorkspaceWarm(
         IWorkspaceExecutionGate gate,
         IWorkspaceWarmService warmService,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietUndoWorkspaceLifecycleTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietUndoWorkspaceLifecycleTests.cs
@@ -39,6 +39,7 @@ public sealed class MethodDescriptionDietUndoWorkspaceLifecycleTests
                 new("workspace_warm", "first read-side call"),
                 new("apply_with_verify", "auto-revert"),
                 new("apply_with_verify", "composite and project-mutation tokens"),
+                new("workspace_drift_check", "filesDrifted"),
                 new("workspace_drift_check", "out-of-band edits"),
                 new("workspace_drift_check", "source-generated documents are skipped"),
             ]);

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietUndoWorkspaceLifecycleTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietUndoWorkspaceLifecycleTests.cs
@@ -1,0 +1,45 @@
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+[TestClass]
+public sealed class MethodDescriptionDietUndoWorkspaceLifecycleTests
+{
+    private const int _maxDescriptionCharacters = 200;
+    private const int _maxAggregateDescriptionCharacters = 950;
+
+    private static readonly Type[] _sliceToolTypes =
+    [
+        typeof(UndoTools),
+        typeof(WorkspaceWarmTools),
+        typeof(ApplyWithVerifyTool),
+        typeof(WorkspaceDriftTool),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayWithinPerToolBudget() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayWithinAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(_sliceToolTypes, _maxAggregateDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreNonEmpty() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
+
+    [TestMethod]
+    public void SliceToolDescriptions_KeepDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(
+            _sliceToolTypes,
+            [
+                new("revert_last_apply", "SINGLE-SLOT LIFO"),
+                new("revert_last_apply", "revert_apply_by_sequence"),
+                new("revert_apply_by_sequence", "blocking sequences"),
+                new("workspace_warm", "first read-side call"),
+                new("apply_with_verify", "auto-revert"),
+                new("apply_with_verify", "composite and project-mutation tokens"),
+                new("workspace_drift_check", "out-of-band edits"),
+                new("workspace_drift_check", "source-generated documents are skipped"),
+            ]);
+}


### PR DESCRIPTION
## Summary
- condense five undo and workspace lifecycle tool descriptions to capability-focused discovery text
- retain LIFO, dependency refusal, token-family, prewarm, and drift triggers
- add a shared-harness budget and trigger ratchet

Closes: method-diet-undo-workspace-lifecycle

## Validation
- Roslyn compile_check: 0 errors, 0 warnings
- focused description and destructive-warning tests: 7 passed
- just verify-changed-format: passed (0 new findings)