### PR TITLE
test: finish method description harness adoption

### DIFF
--- a/changelog.d/desc-budget-harness-method-adopt-wave-3.md
+++ b/changelog.d/desc-budget-harness-method-adopt-wave-3.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Migrated the final method-description test slices to the shared harness.

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietServerSurfaceTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -35,77 +33,30 @@ public sealed class MethodDescriptionDietServerSurfaceTests
         typeof(PromptShimTools),
     ];
 
-    [TestMethod]
-    public void SliceToolDescriptions_AreCapabilityStatements()
-    {
-        var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
-            "(what it does plus the one discriminating trigger); move operational detail to XML " +
-            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
-    }
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] _triggerExpectations =
+    [
+        new("server_heartbeat", "Do not poll waiting for `idle` to self-advance"),
+        new("server_info", "workspace_list is authoritative"),
+        new("server_heartbeat", "cheaper than server_info"),
+        new("suggest_refactorings", "LCOM4"),
+        new("get_prompt_text", "prompts/get"),
+        new("recommend_workflow", "requiredWorkspaceState"),
+    ];
 
     [TestMethod]
-    public void SliceToolDescriptions_StayUnderAggregateBudget()
-    {
-        var entries = EnumerateSliceTools().ToArray();
-        var total = entries.Sum(entry => entry.Description.Length);
-
-        Assert.IsTrue(
-            entries.Length > 0,
-            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
-
-        Assert.IsTrue(
-            total <= _maxAggregateDescriptionCharacters,
-            $"Aggregate method-description budget for the slice is " +
-            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
-    }
+    public void SliceToolDescriptions_AreCapabilityStatements() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
 
     [TestMethod]
-    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
-    {
-        // The two clauses most at risk of being dropped rather than relocated.
-        AssertDescriptionContains(
-            "server_heartbeat",
-            "Do not poll waiting for `idle` to self-advance");
-        AssertDescriptionContains(
-            "server_info",
-            "workspace_list is authoritative");
+    public void SliceToolDescriptions_StayUnderAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            _sliceToolTypes, _maxAggregateDescriptionCharacters);
 
-        // Remaining per-tool discriminators.
-        AssertDescriptionContains("server_heartbeat", "cheaper than server_info");
-        AssertDescriptionContains("suggest_refactorings", "LCOM4");
-        AssertDescriptionContains("get_prompt_text", "prompts/get");
-        AssertDescriptionContains("recommend_workflow", "requiredWorkspaceState");
-    }
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
 
-    private static void AssertDescriptionContains(string toolName, string expected)
-    {
-        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
-
-        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
-        StringAssert.Contains(
-            entry.Description,
-            expected,
-            $"Trimming '{toolName}' dropped its discriminating trigger.");
-    }
-
-    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => _sliceToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null && entry.Description is not null)
-            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(_sliceToolTypes, _triggerExpectations);
 }

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietTestToolingTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietTestToolingTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -34,88 +32,35 @@ public sealed class MethodDescriptionDietTestToolingTests
         typeof(RecordImpactTools),
     ];
 
-    [TestMethod]
-    public void SliceToolDescriptions_AreCapabilityStatements()
-    {
-        var violations = EnumerateSliceTools()
-            .Where(entry => entry.Description.Length > _maxDescriptionCharacters)
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .Select(entry => $"{entry.Name}: {entry.Description.Length} chars")
-            .ToArray();
-
-        Assert.AreEqual(
-            0,
-            violations.Length,
-            $"Method [Description] for these tools must be <= {_maxDescriptionCharacters} characters " +
-            "(what it does plus the one discriminating trigger); move operational detail to XML " +
-            "<remarks>. Violations:\n  " + string.Join("\n  ", violations));
-    }
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] _triggerExpectations =
+    [
+        new("test_coverage", "Run tests with code coverage collection"),
+        new("test_coverage", "coverlet.collector"),
+        new("get_test_coverage_map", "Alias for `test_coverage`"),
+        new("get_test_coverage_map", "Prefer `test_coverage`"),
+        new("test_reference_map", "statically, without running tests"),
+        new("symbol_impact_sweep", "references"),
+        new("symbol_impact_sweep", "CS8509/CS8524/IDE0072"),
+        new("symbol_impact_sweep", "mapper/converter-suffix callsites"),
+        new("preview_record_field_addition", "adding a positional field to a record"),
+        new("preview_record_field_addition", "construction, deconstruction, property-pattern, and `with`-expression sites"),
+        new("preview_record_field_addition", "does NOT flag"),
+    ];
 
     [TestMethod]
-    public void SliceToolDescriptions_StayUnderAggregateBudget()
-    {
-        var entries = EnumerateSliceTools().ToArray();
-        var total = entries.Sum(entry => entry.Description.Length);
-
-        Assert.IsTrue(
-            entries.Length > 0,
-            "Expected the slice types to declare [McpServerTool] methods; reflection found none.");
-
-        Assert.IsTrue(
-            total <= _maxAggregateDescriptionCharacters,
-            $"Aggregate method-description budget for the slice is " +
-            $"{_maxAggregateDescriptionCharacters} chars across {entries.Length} tools; measured {total}.");
-    }
+    public void SliceToolDescriptions_AreCapabilityStatements() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(_sliceToolTypes, _maxDescriptionCharacters);
 
     [TestMethod]
-    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers()
-    {
-        // Runtime coverage collection — the discriminator against test_run and test_reference_map.
-        AssertDescriptionContains("test_coverage", "Run tests with code coverage collection");
-        AssertDescriptionContains("test_coverage", "coverlet.collector");
+    public void SliceToolDescriptions_StayUnderAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            _sliceToolTypes, _maxAggregateDescriptionCharacters);
 
-        // The alias exists only to state its identity and point at the canonical tool.
-        AssertDescriptionContains("get_test_coverage_map", "Alias for `test_coverage`");
-        AssertDescriptionContains("get_test_coverage_map", "Prefer `test_coverage`");
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(_sliceToolTypes);
 
-        // Static-vs-runtime is the only thing separating this from test_coverage in tool search.
-        AssertDescriptionContains("test_reference_map", "statically, without running tests");
-
-        // The three result buckets.
-        AssertDescriptionContains("symbol_impact_sweep", "references");
-        AssertDescriptionContains("symbol_impact_sweep", "CS8509/CS8524/IDE0072");
-        AssertDescriptionContains("symbol_impact_sweep", "mapper/converter-suffix callsites");
-
-        // Trigger plus the site categories the response buckets by.
-        AssertDescriptionContains(
-            "preview_record_field_addition",
-            "adding a positional field to a record");
-        AssertDescriptionContains(
-            "preview_record_field_addition",
-            "construction, deconstruction, property-pattern, and `with`-expression sites");
-        AssertDescriptionContains("preview_record_field_addition", "does NOT flag");
-    }
-
-    private static void AssertDescriptionContains(string toolName, string expected)
-    {
-        var entry = EnumerateSliceTools().SingleOrDefault(candidate => candidate.Name == toolName);
-
-        Assert.IsNotNull(entry.Name, $"Tool '{toolName}' was not found on the slice types.");
-        StringAssert.Contains(
-            entry.Description,
-            expected,
-            $"Trimming '{toolName}' dropped its discriminating trigger.");
-    }
-
-    private static IEnumerable<(string Name, string Description)> EnumerateSliceTools()
-        => _sliceToolTypes
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool is not null && entry.Description is not null)
-            .Select(entry => (entry.Tool!.Name ?? string.Empty, entry.Description!.Description));
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(_sliceToolTypes, _triggerExpectations);
 }

--- a/tests/RoslynMcp.Tests/RefactoringCoreDescriptionBudgetTests.cs
+++ b/tests/RoslynMcp.Tests/RefactoringCoreDescriptionBudgetTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ModelContextProtocol.Server;
 using RoslynMcp.Host.Stdio.Tools;
 
 namespace RoslynMcp.Tests;
@@ -15,57 +13,40 @@ namespace RoslynMcp.Tests;
 public sealed class RefactoringCoreDescriptionBudgetTests
 {
     private const int MaxDescriptionCharacters = 220;
+    private const int MaxAggregateDescriptionCharacters = 1_150;
 
-    private static readonly string[] RatchetedToolNames =
+    private static readonly Type[] SliceToolTypes =
     [
-        "change_signature_preview",
-        "extract_method_apply",
-        "extract_method_preview",
-        "extract_shared_expression_to_helper_preview",
-        "get_syntax_tree",
-        "parameter_object_preview",
+        typeof(ChangeSignatureTools),
+        typeof(ExtractMethodTools),
+        typeof(SyntaxTools),
+        typeof(ParameterObjectTools),
+    ];
+
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] TriggerExpectations =
+    [
+        new("change_signature_preview", "every callsite"),
+        new("extract_method_preview", "complete statements"),
+        new("extract_method_apply", "previously previewed"),
+        new("extract_shared_expression_to_helper_preview", "occurrences < 2"),
+        new("get_syntax_tree", "TruncationNotice"),
+        new("parameter_object_preview", "Refuses with a reason"),
     ];
 
     [TestMethod]
-    public void RefactoringCoreToolDescriptions_AreNonEmptyAndWithinSliceBudget()
-    {
-        var descriptions = typeof(ServerTools).Assembly.GetTypes()
-            .SelectMany(type => type.GetMethods(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
-            .Select(method => new
-            {
-                Tool = method.GetCustomAttribute<McpServerToolAttribute>(),
-                Description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(),
-            })
-            .Where(entry => entry.Tool?.Name is not null)
-            .GroupBy(entry => entry.Tool!.Name!, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.First().Description?.Description, StringComparer.Ordinal);
+    public void RefactoringCoreToolDescriptions_StayWithinPerToolBudget() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(SliceToolTypes, MaxDescriptionCharacters);
 
-        var violations = new List<string>();
-        foreach (var toolName in RatchetedToolNames)
-        {
-            if (!descriptions.TryGetValue(toolName, out var description))
-            {
-                violations.Add($"{toolName}: no [McpServerTool] method found");
-                continue;
-            }
+    [TestMethod]
+    public void RefactoringCoreToolDescriptions_StayWithinAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            SliceToolTypes, MaxAggregateDescriptionCharacters);
 
-            if (string.IsNullOrWhiteSpace(description))
-            {
-                violations.Add($"{toolName}: description is missing or empty");
-                continue;
-            }
+    [TestMethod]
+    public void RefactoringCoreToolDescriptions_AreNonEmpty() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(SliceToolTypes);
 
-            if (description.Length > MaxDescriptionCharacters)
-            {
-                violations.Add($"{toolName}: {description.Length} chars");
-            }
-        }
-
-        Assert.AreEqual(
-            0,
-            violations.Count,
-            $"Refactoring-core tool descriptions must be non-empty and <= {MaxDescriptionCharacters} characters. " +
-            "Violations:\n  " + string.Join("\n  ", violations));
-    }
+    [TestMethod]
+    public void RefactoringCoreToolDescriptions_KeepDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(SliceToolTypes, TriggerExpectations);
 }


### PR DESCRIPTION
## Summary
- migrate the remaining server-surface and test-tooling budget ratchets to ToolDescriptionBudgetHarness
- adapt the refactoring-core outlier with explicit type scope, aggregate ceiling, and discriminating triggers
- remove 196 lines of duplicated reflection/assertion code

Closes: desc-budget-harness-method-adopt-wave-3

## Validation
- Roslyn compile_check: 0 errors, 0 warnings
- focused slice and harness tests: 12 passed
- just verify-changed-format: passed