### PR TITLE
test(ci): lock unsupported actionlint platform refusal

### DIFF
--- a/changelog.d/actionlint-unsupported-platform-contract.md
+++ b/changelog.d/actionlint-unsupported-platform-contract.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Lock the unsupported-platform actionlint gate contract.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -33,6 +33,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $PinnedVersion = '1.7.12'
+$UnsupportedPlatformDiagnostic =
+    'verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).'
 $PinnedArchiveHashes = [ordered]@{
     'win-x64'     = [ordered]@{
         Asset         = "actionlint_${PinnedVersion}_windows_amd64.zip"
@@ -73,7 +75,7 @@ function Get-CurrentRid {
                 return 'linux-x64'
             }
             'unsupported' {
-                throw 'verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).'
+                Stop-UnsupportedPlatform
             }
         }
     }
@@ -85,7 +87,12 @@ function Get-CurrentRid {
         if ($arch -eq 'aarch64') { return 'linux-arm64' }
         return 'linux-x64'
     }
-    throw 'verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).'
+    Stop-UnsupportedPlatform
+}
+
+function Stop-UnsupportedPlatform {
+    [Console]::Error.WriteLine($UnsupportedPlatformDiagnostic)
+    exit 1
 }
 
 function Get-FileSha256 {

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -23,7 +23,10 @@ Resolution order:
 param(
     [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
     [Parameter(DontShow)]
-    [switch]$FailChmodForTest
+    [switch]$FailChmodForTest,
+    [Parameter(DontShow)]
+    [ValidateSet('windows', 'macos', 'linux', 'unsupported')]
+    [string]$PlatformForTest
 )
 
 Set-StrictMode -Version Latest
@@ -58,6 +61,23 @@ $PinnedArchiveHashes = [ordered]@{
 }
 
 function Get-CurrentRid {
+    param([string]$PlatformForTest)
+
+    if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
+        switch ($PlatformForTest) {
+            'windows' { return 'win-x64' }
+            'macos' { return 'osx-arm64' }
+            'linux' {
+                $arch = (uname -m)
+                if ($arch -eq 'aarch64') { return 'linux-arm64' }
+                return 'linux-x64'
+            }
+            'unsupported' {
+                throw 'verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).'
+            }
+        }
+    }
+
     if ($IsWindows) { return 'win-x64' }
     if ($IsMacOS) { return 'osx-arm64' }
     if ($IsLinux) {
@@ -96,7 +116,12 @@ if ($FailChmodForTest) {
     Set-ActionlintExecutablePermission -Path 'test-only' -FailForTest
 }
 
-$rid = Get-CurrentRid
+$rid = if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
+    Get-CurrentRid -PlatformForTest $PlatformForTest
+}
+else {
+    Get-CurrentRid
+}
 if (-not $PinnedArchiveHashes.Contains($rid)) {
     throw "verify-actionlint: no pinned actionlint archive/hash recorded for RID '$rid'."
 }

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -146,7 +146,8 @@ public sealed class ActionlintGateContractTests
             Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
             const string diagnostic =
                 "verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).";
-            StringAssert.Contains(result.AllOutput, diagnostic);
+            Assert.AreEqual(diagnostic, result.StdErr.Trim());
+            Assert.AreEqual(string.Empty, result.StdOut);
             Assert.IsFalse(
                 Directory.Exists(Path.Combine(fixtureRoot, "artifacts")),
                 "Unsupported-platform detection must fail before creating the actionlint cache.");

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -134,6 +134,32 @@ public sealed class ActionlintGateContractTests
         }
     }
 
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_UnsupportedPlatform_FailsClosedBeforeFilesystemOrNetworkMutation()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunGateAsync(fixtureRoot, platformForTest: "unsupported");
+
+            Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
+            const string diagnostic =
+                "verify-actionlint: unsupported platform (neither Windows, macOS, nor Linux detected).";
+            StringAssert.Contains(result.AllOutput, diagnostic);
+            Assert.IsFalse(
+                Directory.Exists(Path.Combine(fixtureRoot, "artifacts")),
+                "Unsupported-platform detection must fail before creating the actionlint cache.");
+            Assert.IsFalse(
+                result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
+                $"The unsupported-platform test seam must fail before network access. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
     // Live-network smoke test: downloads the real pinned release once (verifying the archive
     // hash), then re-runs against the now-populated cache and asserts the second run completes
     // in well under the time a fresh download+extract would take -- the offline cache-hit path,
@@ -198,7 +224,8 @@ public sealed class ActionlintGateContractTests
         string fixtureRoot,
         IReadOnlyDictionary<string, string?>? environment = null,
         TimeSpan? timeout = null,
-        bool failChmodForTest = false)
+        bool failChmodForTest = false,
+        string? platformForTest = null)
     {
         var arguments = new List<string>
         {
@@ -211,6 +238,11 @@ public sealed class ActionlintGateContractTests
         if (failChmodForTest)
         {
             arguments.Add("-FailChmodForTest");
+        }
+        if (platformForTest is not null)
+        {
+            arguments.Add("-PlatformForTest");
+            arguments.Add(platformForTest);
         }
 
         return PwshScriptRunner.RunAsync(


### PR DESCRIPTION
## Summary
- add a hidden, closed-set platform seam that preserves ordinary runtime OS detection
- lock the unsupported-platform refusal before actionlint cache or network mutation
- add the initiative-owned maintenance changelog fragment

## Validation
- `ActionlintGateContractTests`: 7/7 passed
- `pwsh -NoProfile -File ./eng/verify-actionlint.ps1`: passed
- Roslyn `compile_check` for `RoslynMcp.Tests`: 0 errors, 0 warnings
- full Release gate: 2,893 passed, 7 skipped, 3 unrelated failures; all three failed FQNs then passed in each of three isolated reruns (9/9)

Closes: actionlint-unsupported-platform-contract