### PR TITLE
fix(scaffolding): warn on incomplete sibling discovery

### DIFF
--- a/changelog.d/sibling-test-name-discovery-warning-signal.md
+++ b/changelog.d/sibling-test-name-discovery-warning-signal.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Surface a redacted warning when sampled sibling-name discovery is incomplete. Closes `sibling-test-name-discovery-warning-signal`.

--- a/src/RoslynMcp.Roslyn/Services/ScaffoldingReadFailurePolicy.cs
+++ b/src/RoslynMcp.Roslyn/Services/ScaffoldingReadFailurePolicy.cs
@@ -19,6 +19,22 @@ internal static class ScaffoldingReadFailurePolicy
     }
 
     /// <summary>
+    /// Secret-safe diagnostic for partial sibling test-name discovery. The warning deliberately
+    /// omits the failed file identity and count because readable siblings remain usable.
+    /// </summary>
+    public static string CreateSiblingNameDiscoveryWarning(
+        IUnexpectedExceptionReporter? exceptionReporter,
+        Exception exception)
+    {
+        var detail = UnexpectedExceptionReporting.Report(
+            exceptionReporter,
+            exception,
+            UnexpectedExceptionCategory.Scaffolding).Public;
+        return "Sibling test-name discovery was incomplete; sampled naming used the readable siblings. " +
+            PublicExceptionDetailPolicy.FormatCorrelationIdSuffix(detail.CorrelationId);
+    }
+
+    /// <summary>
     /// Secret-safe diagnostic for a recovered project-file parse failure. Carries only the
     /// redacted project identity (file name, never the full path), the deterministic outcome
     /// text, and the correlation ID from the shared unexpected-exception projection.

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -31,15 +31,18 @@ internal sealed class SingleTestScaffolder
     private readonly IWorkspaceManager _workspace;
     private readonly IFileOperationService _fileOperationService;
     private readonly IUnexpectedExceptionReporter? _exceptionReporter;
+    private readonly Func<string, string> _readAllText;
 
     public SingleTestScaffolder(
         IWorkspaceManager workspace,
         IFileOperationService fileOperationService,
-        IUnexpectedExceptionReporter? exceptionReporter = null)
+        IUnexpectedExceptionReporter? exceptionReporter = null,
+        Func<string, string>? readAllText = null)
     {
         _workspace = workspace;
         _fileOperationService = fileOperationService;
         _exceptionReporter = exceptionReporter;
+        _readAllText = readAllText ?? File.ReadAllText;
     }
 
     public async Task<RefactoringPreviewDto> PreviewAsync(
@@ -146,15 +149,26 @@ internal sealed class SingleTestScaffolder
 
         // Syntactic inputs only: this runs ahead of symbol resolution, so anything the compilation
         // would supply is out of reach here by design — see ScaffoldTestNameSuggestionContext.
+        var siblingNames = CollectSiblingTestMethodNames(
+            projectDirectory,
+            Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),
+            maxNames: 6);
         var context = new ScaffoldTestNameSuggestionContext(
             lookupTypeName,
             request.TargetMethodName,
-            CollectSiblingTestMethodNames(
-                projectDirectory,
-                Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),
-                maxNames: 6));
+            siblingNames.Names);
+        var suggestion = NormalizeSuggestion(
+            await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false));
+        if (!string.IsNullOrWhiteSpace(siblingNames.Warning))
+        {
+            suggestion = suggestion with
+            {
+                Warning = AppendWarning(suggestion.Warning, siblingNames.Warning),
+            };
+        }
+
         return (
-            NormalizeSuggestion(await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false)),
+            suggestion,
             solution);
     }
 
@@ -429,7 +443,7 @@ internal sealed class SingleTestScaffolder
 
         try
         {
-            var sourceText = File.ReadAllText(resolved);
+            var sourceText = _readAllText(resolved);
             var pattern = TestScaffoldRenderer.ExtractPatternFromSource(sourceText, Path.GetFileName(resolved), compilation, resolved);
             return new SiblingInferenceResult(pattern, warnings);
         }
@@ -469,18 +483,19 @@ internal sealed class SingleTestScaffolder
             .FirstOrDefault();
     }
 
-    private static IReadOnlyList<string> CollectSiblingTestMethodNames(
+    private SiblingTestMethodNameCollection CollectSiblingTestMethodNames(
         string projectDirectory,
         string destinationFilePath,
         int maxNames)
     {
         if (!Directory.Exists(projectDirectory))
         {
-            return Array.Empty<string>();
+            return SiblingTestMethodNameCollection.Empty;
         }
 
         var destinationNormalized = Path.GetFullPath(destinationFilePath);
         var names = new List<string>();
+        string? warning = null;
         foreach (var file in Directory.EnumerateFiles(projectDirectory, "*Tests.cs", SearchOption.AllDirectories)
                      .Where(p =>
                      {
@@ -500,7 +515,7 @@ internal sealed class SingleTestScaffolder
         {
             try
             {
-                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file.FullName));
+                var tree = CSharpSyntaxTree.ParseText(_readAllText(file.FullName));
                 var root = tree.GetRoot();
                 foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
                 {
@@ -512,17 +527,19 @@ internal sealed class SingleTestScaffolder
                     names.Add(method.Identifier.Text);
                     if (names.Count >= maxNames)
                     {
-                        return names;
+                        return new SiblingTestMethodNameCollection(names, warning);
                     }
                 }
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                continue;
+                warning ??= ScaffoldingReadFailurePolicy.CreateSiblingNameDiscoveryWarning(
+                    _exceptionReporter,
+                    ex);
             }
         }
 
-        return names;
+        return new SiblingTestMethodNameCollection(names, warning);
     }
 
     private static bool LooksLikeTestMethod(MethodDeclarationSyntax method)
@@ -1760,6 +1777,17 @@ internal sealed record SiblingInferenceResult(
     IReadOnlyList<string> Warnings)
 {
     public static SiblingInferenceResult None { get; } = new(null, Array.Empty<string>());
+}
+
+/// <summary>
+/// Bounded sibling method-name discovery result. Expected per-file read failures retain names
+/// collected from readable siblings and contribute one secret-safe warning for the terminal result.
+/// </summary>
+internal sealed record SiblingTestMethodNameCollection(
+    IReadOnlyList<string> Names,
+    string? Warning)
+{
+    public static SiblingTestMethodNameCollection Empty { get; } = new(Array.Empty<string>(), null);
 }
 
 /// <summary>

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -571,6 +571,130 @@ public sealed class DogExistingTests
     }
 
     [TestMethod]
+    public async Task Scaffold_Test_Preview_SiblingNameReadFailure_PreservesNamesAndAddsOneSecretSafeWarning()
+    {
+        const string sentinel = "SECRET-SENTINEL-sibling-name-read";
+        const string secretSource = "SECRET-SOURCE-sibling-name-read";
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var readablePath = workspace.GetPath("SampleLib.Tests", "DogReadableTests.cs");
+        var unreadablePath = workspace.GetPath("SampleLib.Tests", "DogUnreadableTests.cs");
+        var secondUnreadablePath = workspace.GetPath("SampleLib.Tests", "DogAlsoUnreadableTests.cs");
+        await File.WriteAllTextAsync(readablePath, """
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SampleLib.Tests;
+
+[TestClass]
+public sealed class DogReadableTests
+{
+    [TestMethod]
+    public void Speak_WhenReadable_ReturnsBark()
+    {
+    }
+}
+""", CancellationToken.None);
+        await File.WriteAllTextAsync(unreadablePath, "// injected read failure", CancellationToken.None);
+        await File.WriteAllTextAsync(secondUnreadablePath, "// second injected read failure", CancellationToken.None);
+
+        var sink = new CapturingServerObservabilitySink();
+        var reporter = new ServerObservabilityReporter(sink);
+        var failure = new IOException(sentinel) { Source = secretSource };
+        var project = WorkspaceManager.GetStatus(workspace.WorkspaceId).Projects
+            .Single(project => string.Equals(project.Name, "SampleLib.Tests", StringComparison.Ordinal));
+        var provider = new RecordingTestNameSuggestionProvider("Speak_WhenDogIsReady_ReturnsBark");
+        var scaffolder = new SingleTestScaffolder(
+            WorkspaceManager,
+            FileOperationService,
+            reporter,
+            readAllText: path =>
+                (string.Equals(path, unreadablePath, StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(path, secondUnreadablePath, StringComparison.OrdinalIgnoreCase))
+                ? throw failure
+                : File.ReadAllText(path));
+
+        RefactoringPreviewDto preview;
+        using (RequestCorrelationContext.Begin())
+        {
+            preview = await scaffolder.PreviewAsync(
+                project,
+                "mstest",
+                workspace.WorkspaceId,
+                new ScaffoldTestDto(
+                    "SampleLib.Tests",
+                    "Dog",
+                    "Speak",
+                    ReferenceTestFile: string.Empty,
+                    UseSampling: true),
+                CancellationToken.None,
+                provider);
+        }
+
+        Assert.AreEqual(1, provider.CallCount);
+        Assert.IsNotNull(provider.LastContext);
+        CollectionAssert.Contains(
+            provider.LastContext.SiblingTestMethodNames.ToList(),
+            "Speak_WhenReadable_ReturnsBark",
+            "A failed sibling read must not discard method names collected from readable siblings.");
+        Assert.IsNotNull(preview.Warnings);
+        Assert.HasCount(1, preview.Warnings);
+        var warning = preview.Warnings.Single();
+        StringAssert.Contains(warning, "Sibling test-name discovery was incomplete");
+        StringAssert.Contains(warning, "correlationId=");
+        Assert.IsFalse(warning.Contains(sentinel, StringComparison.Ordinal));
+        Assert.IsFalse(warning.Contains(secretSource, StringComparison.Ordinal));
+        Assert.IsFalse(warning.Contains(unreadablePath, StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(warning.Contains(Path.GetFileName(unreadablePath), StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(warning.Contains(Path.GetFileName(secondUnreadablePath), StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(warning.Contains(nameof(IOException), StringComparison.Ordinal));
+
+        Assert.HasCount(1, sink.Events);
+        Assert.IsFalse(JsonSerializer.Serialize(sink.Events.Single())
+            .Contains(sentinel, StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    [DataRow("cancellation")]
+    [DataRow("unexpected")]
+    public async Task Scaffold_Test_Preview_SiblingNameReadCancellationAndUnexpectedFailures_Propagate(
+        string failureKind)
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        var siblingPath = workspace.GetPath("SampleLib.Tests", "DogFailureTests.cs");
+        await File.WriteAllTextAsync(siblingPath, "// injected read failure", CancellationToken.None);
+
+        Exception expected = failureKind == "cancellation"
+            ? new OperationCanceledException("injected sibling read cancellation")
+            : new InvalidOperationException("injected unexpected sibling read failure");
+        var project = WorkspaceManager.GetStatus(workspace.WorkspaceId).Projects
+            .Single(project => string.Equals(project.Name, "SampleLib.Tests", StringComparison.Ordinal));
+        var provider = new RecordingTestNameSuggestionProvider("Speak_WhenDogIsReady_ReturnsBark");
+        var scaffolder = new SingleTestScaffolder(
+            WorkspaceManager,
+            FileOperationService,
+            readAllText: _ => throw expected);
+
+        Task Act() => scaffolder.PreviewAsync(
+            project,
+            "mstest",
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "Dog",
+                "Speak",
+                ReferenceTestFile: string.Empty,
+                UseSampling: true),
+            CancellationToken.None,
+            provider);
+
+        Exception thrown = expected is OperationCanceledException
+            ? await Assert.ThrowsExactlyAsync<OperationCanceledException>(Act)
+            : await Assert.ThrowsExactlyAsync<InvalidOperationException>(Act);
+        Assert.AreSame(expected, thrown);
+        Assert.AreEqual(0, provider.CallCount,
+            "Sibling discovery failures must propagate before the sampling provider is invoked.");
+    }
+
+    [TestMethod]
     public async Task Scaffold_Test_Preview_SamplingReplay_PaysSemanticPreparationOnce()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary
- preserve readable sibling test names when an expected sibling-file read fails
- append one redacted, correlation-backed warning for incomplete sampled-name discovery
- propagate cancellation and unexpected failures, with deterministic injected-reader regressions

## Validation
- Roslyn compile check: 0 errors, 0 warnings
- new focused regressions: 3 passed
- ScaffoldingIntegrationTests: 39 passed
- Release gate: build and policy gates passed; test shard had 1 unrelated nondeterministic ElicitationChoicePromptTests failure among 2,905 tests
- isolated rerun of that unrelated failure: 3/3 passed

Closes: sibling-test-name-discovery-warning-signal