### PR TITLE
Fail closed on unpinned actionlint runtime identifiers

### DIFF
--- a/changelog.d/actionlint-unpinned-rid-contract.md
+++ b/changelog.d/actionlint-unpinned-rid-contract.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Fail closed when the current actionlint OS/architecture pair has no pinned binary.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -26,7 +26,10 @@ param(
     [switch]$FailChmodForTest,
     [Parameter(DontShow)]
     [ValidateSet('windows', 'macos', 'linux', 'unsupported')]
-    [string]$PlatformForTest
+    [string]$PlatformForTest,
+    [Parameter(DontShow)]
+    [ValidateSet('x64', 'arm64')]
+    [string]$ArchitectureForTest
 )
 
 Set-StrictMode -Version Latest
@@ -62,37 +65,55 @@ $PinnedArchiveHashes = [ordered]@{
     }
 }
 
-function Get-CurrentRid {
-    param([string]$PlatformForTest)
+function Stop-WithDiagnostic {
+    param(
+        [Parameter(Mandatory)][string]$Diagnostic,
+        [int]$ExitCode = 1
+    )
 
-    if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
-        switch ($PlatformForTest) {
-            'windows' { return 'win-x64' }
-            'macos' { return 'osx-arm64' }
-            'linux' {
-                $arch = (uname -m)
-                if ($arch -eq 'aarch64') { return 'linux-arm64' }
-                return 'linux-x64'
-            }
-            'unsupported' {
-                Stop-UnsupportedPlatform
-            }
-        }
-    }
-
-    if ($IsWindows) { return 'win-x64' }
-    if ($IsMacOS) { return 'osx-arm64' }
-    if ($IsLinux) {
-        $arch = (uname -m)
-        if ($arch -eq 'aarch64') { return 'linux-arm64' }
-        return 'linux-x64'
-    }
-    Stop-UnsupportedPlatform
+    [Console]::Error.WriteLine($Diagnostic)
+    exit $ExitCode
 }
 
-function Stop-UnsupportedPlatform {
-    [Console]::Error.WriteLine($UnsupportedPlatformDiagnostic)
-    exit 1
+function Get-CurrentRid {
+    param(
+        [string]$PlatformForTest,
+        [string]$ArchitectureForTest
+    )
+
+    if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
+        $platform = $PlatformForTest
+    }
+    elseif ($IsWindows) {
+        $platform = 'windows'
+    }
+    elseif ($IsMacOS) {
+        $platform = 'macos'
+    }
+    elseif ($IsLinux) {
+        $platform = 'linux'
+    }
+    else {
+        $platform = 'unsupported'
+    }
+
+    if ($platform -eq 'unsupported') {
+        Stop-WithDiagnostic -Diagnostic $UnsupportedPlatformDiagnostic
+    }
+
+    $architecture = if ($PSBoundParameters.ContainsKey('ArchitectureForTest')) {
+        $ArchitectureForTest
+    }
+    else {
+        ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture).ToString().ToLowerInvariant()
+    }
+    $ridPlatform = switch ($platform) {
+        'windows' { 'win' }
+        'macos' { 'osx' }
+        'linux' { 'linux' }
+    }
+
+    return "$ridPlatform-$architecture"
 }
 
 function Get-FileSha256 {
@@ -113,9 +134,8 @@ function Set-ActionlintExecutablePermission {
     }
     $chmodExitCode = $LASTEXITCODE
     if ($chmodExitCode -ne 0) {
-        [Console]::Error.WriteLine(
+        Stop-WithDiagnostic -ExitCode $chmodExitCode -Diagnostic (
             "verify-actionlint: failed to mark actionlint executable (chmod exit code $chmodExitCode).")
-        exit $chmodExitCode
     }
 }
 
@@ -123,14 +143,17 @@ if ($FailChmodForTest) {
     Set-ActionlintExecutablePermission -Path 'test-only' -FailForTest
 }
 
-$rid = if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
-    Get-CurrentRid -PlatformForTest $PlatformForTest
+$ridArguments = @{}
+if ($PSBoundParameters.ContainsKey('PlatformForTest')) {
+    $ridArguments['PlatformForTest'] = $PlatformForTest
 }
-else {
-    Get-CurrentRid
+if ($PSBoundParameters.ContainsKey('ArchitectureForTest')) {
+    $ridArguments['ArchitectureForTest'] = $ArchitectureForTest
 }
+$rid = Get-CurrentRid @ridArguments
 if (-not $PinnedArchiveHashes.Contains($rid)) {
-    throw "verify-actionlint: no pinned actionlint archive/hash recorded for RID '$rid'."
+    Stop-WithDiagnostic -Diagnostic (
+        "verify-actionlint: no pinned actionlint archive/hash recorded for RID '$rid'.")
 }
 $pin = $PinnedArchiveHashes[$rid]
 

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -65,13 +65,16 @@ public sealed class ActionlintGateContractTests
         {
             var toolRoot = Path.Combine(fixtureRoot, "artifacts", "tools", "actionlint", "1.7.12");
             Directory.CreateDirectory(toolRoot);
-            var binaryName = OperatingSystem.IsWindows() ? "actionlint.exe" : "actionlint";
+            const string binaryName = "actionlint.exe";
             // A cached binary whose bytes do NOT match the pinned hash -- this must be detected
             // and refused BEFORE the script ever considers re-downloading, so a tampered or
             // corrupted cache entry never silently runs.
             File.WriteAllText(Path.Combine(toolRoot, binaryName), "not the real actionlint binary");
 
-            var result = await RunGateAsync(fixtureRoot);
+            var result = await RunGateAsync(
+                fixtureRoot,
+                platformForTest: "windows",
+                architectureForTest: "x64");
 
             Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
             StringAssert.Contains(result.AllOutput, "hash mismatch");
@@ -97,7 +100,9 @@ public sealed class ActionlintGateContractTests
                 environment: new Dictionary<string, string?>
                 {
                     ["ROSLYNMCP_ACTIONLINT_PATH"] = overridePath,
-                });
+                },
+                platformForTest: "windows",
+                architectureForTest: "x64");
 
             Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
             StringAssert.Contains(result.AllOutput, "ROSLYNMCP_ACTIONLINT_PATH");
@@ -154,6 +159,73 @@ public sealed class ActionlintGateContractTests
             Assert.IsFalse(
                 result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
                 $"The unsupported-platform test seam must fail before network access. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    [DataRow("windows", "x64", "actionlint.exe", "54ca21be3de4c7cfa26914aa8b61bd76bf573ef3caac5f80d110558cdf241718")]
+    [DataRow("macos", "arm64", "actionlint", "8db11704dc296f096216db4db65d86cd7f0ebfdf4c38453a1da276b137b88388")]
+    [DataRow("linux", "x64", "actionlint", "c872d6db8c6bf83a8eaa704fc93999f027d55dffbc63b8a6abdccb47df5f4cd4")]
+    [DataRow("linux", "arm64", "actionlint", "ac0323433c2853ec3fb978c611430c5b3dc5d43c58d1a1ec031b00ab572beb60")]
+    public async Task VerifyActionlint_SupportedPlatformArchitecture_UsesMatchingPin(
+        string platform,
+        string architecture,
+        string binaryName,
+        string expectedBinaryHash)
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var toolRoot = Path.Combine(fixtureRoot, "artifacts", "tools", "actionlint", "1.7.12");
+            Directory.CreateDirectory(toolRoot);
+            File.WriteAllText(Path.Combine(toolRoot, binaryName), "not the real actionlint binary");
+
+            var result = await RunGateAsync(
+                fixtureRoot,
+                platformForTest: platform,
+                architectureForTest: architecture);
+
+            Assert.AreNotEqual(0, result.ExitCode, result.AllOutput);
+            StringAssert.Contains(result.AllOutput, "cached binary");
+            StringAssert.Contains(result.AllOutput, expectedBinaryHash);
+            Assert.IsFalse(
+                result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
+                $"Supported RID selection must use its cached pin without network access. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_UnpinnedPlatformArchitecture_FailsClosedBeforeFilesystemOrNetworkMutation()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunGateAsync(
+                fixtureRoot,
+                platformForTest: "windows",
+                architectureForTest: "arm64");
+
+            Assert.AreEqual(1, result.ExitCode, result.AllOutput);
+            const string diagnostic =
+                "verify-actionlint: no pinned actionlint archive/hash recorded for RID 'win-arm64'.";
+            Assert.AreEqual(diagnostic, result.StdErr.Trim());
+            Assert.AreEqual(string.Empty, result.StdOut);
+            Assert.IsFalse(
+                Directory.Exists(Path.Combine(fixtureRoot, "artifacts")),
+                "Unpinned-RID detection must fail before creating the actionlint cache.");
+            Assert.IsFalse(
+                result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
+                $"The unpinned-RID test seam must fail before network access. Output:{Environment.NewLine}{result.AllOutput}");
         }
         finally
         {
@@ -226,7 +298,8 @@ public sealed class ActionlintGateContractTests
         IReadOnlyDictionary<string, string?>? environment = null,
         TimeSpan? timeout = null,
         bool failChmodForTest = false,
-        string? platformForTest = null)
+        string? platformForTest = null,
+        string? architectureForTest = null)
     {
         var arguments = new List<string>
         {
@@ -244,6 +317,11 @@ public sealed class ActionlintGateContractTests
         {
             arguments.Add("-PlatformForTest");
             arguments.Add(platformForTest);
+        }
+        if (architectureForTest is not null)
+        {
+            arguments.Add("-ArchitectureForTest");
+            arguments.Add(architectureForTest);
         }
 
         return PwshScriptRunner.RunAsync(


### PR DESCRIPTION
Summary:
- derive the actionlint RID from both OS and process architecture
- reject recognized but unpinned combinations before cache or network mutation
- lock every supported RID mapping and the win-arm64 refusal with hermetic tests

Validation:
- ActionlintGateContractTests: 12/12 passed
- eng/verify-actionlint.ps1: passed
- full release gate: 2913 passed, 7 skipped, 1 unrelated ResourceRead wire protocol failure; the exact failing test passed 3/3 in isolation and is tracked by prompt-wire-protocol-negotiation-parallel-isolation