### PR TITLE
Preserve sibling discovery warnings across scaffold replay

### DIFF
--- a/changelog.d/sibling-test-name-discovery-warning.md
+++ b/changelog.d/sibling-test-name-discovery-warning.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Preserve incomplete sibling-name discovery warnings across sampled scaffold replay. Closes `sibling-test-name-discovery-warning`.

--- a/src/RoslynMcp.Core/Services/IScaffoldingService.cs
+++ b/src/RoslynMcp.Core/Services/IScaffoldingService.cs
@@ -90,15 +90,18 @@ public interface ITestNameSuggestionProvider
 }
 
 /// <summary>
-/// Everything the suggestion prompt is built from. Every member is obtainable WITHOUT a
+/// Syntactic inputs for the suggestion prompt plus optional redacted warning state that must
+/// survive a two-phase transport replay. Every member is obtainable WITHOUT a
 /// <c>Compilation</c>: the request is issued ahead of symbol resolution (see the two-phase
 /// contract on <see cref="ITestNameSuggestionProvider"/>), so symbol-derived detail such as a
 /// method signature or declaring namespace is deliberately not part of this contract — carrying
-/// it would either be permanently null or reintroduce the semantic work the hoist defers.
+/// it would either be permanently null or reintroduce the semantic work the hoist defers. The
+/// warning is continuation metadata and is not included in the sampling prompt.
 /// </summary>
 public sealed record ScaffoldTestNameSuggestionContext(
     string TargetTypeName,
     string TargetMethodName,
-    IReadOnlyList<string> SiblingTestMethodNames);
+    IReadOnlyList<string> SiblingTestMethodNames,
+    string? SiblingNameDiscoveryWarning = null);
 
 public sealed record TestNameSuggestionResult(string? MethodName, string? Warning = null);

--- a/src/RoslynMcp.Host.Stdio/ProtocolCompatibility/RequestStateCodec.cs
+++ b/src/RoslynMcp.Host.Stdio/ProtocolCompatibility/RequestStateCodec.cs
@@ -1,17 +1,25 @@
 using System.Text.Json;
 using ModelContextProtocol.Protocol;
+using RoslynMcp.Core.Services;
 
 namespace RoslynMcp.Host.Stdio.ProtocolCompatibility;
 
 /// <summary>
-/// Encodes the workspace identity that the filter resolved before a modern MRTR hand-off and
-/// restores it on the client's retry. MCP request state is client-visible and echoed by the
-/// client, so this carries only the same opaque workspace id callers may already submit; it is
+/// Encodes producer-owned state that must survive a modern MRTR hand-off and restores it on the
+/// client's retry. MCP request state is client-visible and echoed by the client, so the compound
+/// shape carries only opaque workspace/correlation identifiers and stable non-secret codes; it is
 /// not an authorization or secrecy boundary.
 /// </summary>
 internal static class RequestStateCodec
 {
     private const string _workspacePrefix = "roslynmcp.workspace.v1:";
+    private const string _requestPrefix = "roslynmcp.request.v1:";
+    private const string _emptyComponent = "-";
+    private const string _siblingNameDiscoveryWarningCode = "sibling-name-discovery-incomplete";
+    private const string _siblingNameDiscoveryWarningText =
+        "Sibling test-name discovery was incomplete; sampled naming used the readable siblings. ";
+    private const string _correlationIdPrefix = "correlationId=";
+    private const int _maxRequestStateLength = 192;
 
     internal static string? CaptureWorkspaceId(
         IDictionary<string, JsonElement>? arguments,
@@ -32,6 +40,121 @@ internal static class RequestStateCodec
     internal static bool TryRestoreWorkspaceId(string? requestState, out string workspaceId)
     {
         workspaceId = string.Empty;
+        if (TryParseLegacyWorkspaceId(requestState, out workspaceId))
+        {
+            return true;
+        }
+
+        if (!TryParseCompoundState(requestState, out var state) || state.WorkspaceId is null)
+        {
+            return false;
+        }
+
+        workspaceId = state.WorkspaceId;
+        return true;
+    }
+
+    internal static bool TryRestoreSiblingNameDiscoveryWarning(
+        string? requestState,
+        out string warning)
+    {
+        warning = string.Empty;
+        if (!TryParseCompoundState(requestState, out var state) ||
+            !string.Equals(
+                state.WarningCode,
+                _siblingNameDiscoveryWarningCode,
+                StringComparison.Ordinal) ||
+            state.CorrelationId is null)
+        {
+            return false;
+        }
+
+        warning = _siblingNameDiscoveryWarningText +
+            PublicExceptionDetailPolicy.FormatCorrelationIdSuffix(state.CorrelationId);
+        return true;
+    }
+
+    /// <summary>
+    /// Attaches the workspace identity visible in <paramref name="arguments"/> to an MRTR signal
+    /// before a temporary-dispatch scope restores the caller's original arguments. Recognized
+    /// producer-owned compound state is augmented; unknown state is never overwritten.
+    /// </summary>
+    internal static void PreserveWorkspaceId(
+        InputRequiredException inputRequired,
+        IDictionary<string, JsonElement>? arguments,
+        string workspaceIdParameterName)
+    {
+        ArgumentNullException.ThrowIfNull(inputRequired);
+        var capturedState = CaptureWorkspaceId(arguments, workspaceIdParameterName);
+        if (!TryParseLegacyWorkspaceId(capturedState, out var workspaceId))
+        {
+            return;
+        }
+
+        var currentState = inputRequired.Result.RequestState;
+        if (currentState is null)
+        {
+            inputRequired.Result.RequestState = capturedState;
+            return;
+        }
+
+        if (TryParseCompoundState(currentState, out var state) && state.WorkspaceId is null)
+        {
+            inputRequired.Result.RequestState = EncodeCompoundState(state with
+            {
+                WorkspaceId = workspaceId,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Carries a sibling-discovery warning across MRTR without copying client prose into request
+    /// state. Only the recognized warning code and its normalized public correlation identifier
+    /// are retained; unknown or malformed producer state remains untouched.
+    /// </summary>
+    internal static void PreserveSiblingNameDiscoveryWarning(
+        InputRequiredException inputRequired,
+        string? warning)
+    {
+        ArgumentNullException.ThrowIfNull(inputRequired);
+        if (!TryExtractSiblingNameDiscoveryCorrelationId(warning, out var correlationId))
+        {
+            return;
+        }
+
+        var warningState = new RequestStateParts(
+            WorkspaceId: null,
+            WarningCode: _siblingNameDiscoveryWarningCode,
+            CorrelationId: correlationId);
+        var currentState = inputRequired.Result.RequestState;
+        if (currentState is null)
+        {
+            inputRequired.Result.RequestState = EncodeCompoundState(warningState);
+            return;
+        }
+
+        if (TryParseLegacyWorkspaceId(currentState, out var workspaceId))
+        {
+            inputRequired.Result.RequestState = EncodeCompoundState(warningState with
+            {
+                WorkspaceId = workspaceId,
+            });
+            return;
+        }
+
+        if (TryParseCompoundState(currentState, out var state) && state.WarningCode is null)
+        {
+            inputRequired.Result.RequestState = EncodeCompoundState(state with
+            {
+                WarningCode = _siblingNameDiscoveryWarningCode,
+                CorrelationId = correlationId,
+            });
+        }
+    }
+
+    private static bool TryParseLegacyWorkspaceId(string? requestState, out string workspaceId)
+    {
+        workspaceId = string.Empty;
         if (requestState is null ||
             !requestState.StartsWith(_workspacePrefix, StringComparison.Ordinal) ||
             requestState.Length != _workspacePrefix.Length + 32 ||
@@ -44,18 +167,107 @@ internal static class RequestStateCodec
         return true;
     }
 
-    /// <summary>
-    /// Attaches the workspace identity visible in <paramref name="arguments"/> to an MRTR signal
-    /// before a temporary-dispatch scope restores the caller's original arguments. Existing
-    /// producer-owned request state wins; this helper never overwrites it.
-    /// </summary>
-    internal static void PreserveWorkspaceId(
-        InputRequiredException inputRequired,
-        IDictionary<string, JsonElement>? arguments,
-        string workspaceIdParameterName)
+    private static bool TryExtractSiblingNameDiscoveryCorrelationId(
+        string? warning,
+        out string correlationId)
     {
-        ArgumentNullException.ThrowIfNull(inputRequired);
-        inputRequired.Result.RequestState ??=
-            CaptureWorkspaceId(arguments, workspaceIdParameterName);
+        correlationId = string.Empty;
+        if (warning is null ||
+            !warning.StartsWith(_siblingNameDiscoveryWarningText, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var suffix = warning.AsSpan(_siblingNameDiscoveryWarningText.Length);
+        if (!suffix.StartsWith(_correlationIdPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        correlationId = suffix[_correlationIdPrefix.Length..].ToString();
+        return string.Equals(
+            warning,
+            _siblingNameDiscoveryWarningText +
+                PublicExceptionDetailPolicy.FormatCorrelationIdSuffix(correlationId),
+            StringComparison.Ordinal);
     }
+
+    private static bool TryParseCompoundState(
+        string? requestState,
+        out RequestStateParts state)
+    {
+        state = new RequestStateParts(null, null, null);
+        if (requestState is null ||
+            requestState.Length > _maxRequestStateLength ||
+            !requestState.StartsWith(_requestPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var components = requestState[_requestPrefix.Length..].Split(':');
+        if (components.Length != 3)
+        {
+            return false;
+        }
+
+        string? workspaceId = null;
+        if (!string.Equals(components[0], _emptyComponent, StringComparison.Ordinal))
+        {
+            if (!Guid.TryParseExact(components[0], "N", out var parsedWorkspaceId))
+            {
+                return false;
+            }
+
+            workspaceId = parsedWorkspaceId.ToString("N");
+        }
+
+        string? warningCode = null;
+        string? correlationId = null;
+        var hasWarningCode = !string.Equals(components[1], _emptyComponent, StringComparison.Ordinal);
+        var hasCorrelationId = !string.Equals(components[2], _emptyComponent, StringComparison.Ordinal);
+        if (hasWarningCode != hasCorrelationId)
+        {
+            return false;
+        }
+
+        if (hasWarningCode)
+        {
+            if (!string.Equals(
+                    components[1],
+                    _siblingNameDiscoveryWarningCode,
+                    StringComparison.Ordinal) ||
+                !IsNormalizedCorrelationId(components[2]))
+            {
+                return false;
+            }
+
+            warningCode = components[1];
+            correlationId = components[2];
+        }
+
+        if (workspaceId is null && warningCode is null)
+        {
+            return false;
+        }
+
+        state = new RequestStateParts(workspaceId, warningCode, correlationId);
+        return true;
+    }
+
+    private static bool IsNormalizedCorrelationId(string correlationId) =>
+        string.Equals(
+            PublicExceptionDetailPolicy.FormatCorrelationIdSuffix(correlationId),
+            _correlationIdPrefix + correlationId,
+            StringComparison.Ordinal);
+
+    private static string EncodeCompoundState(RequestStateParts state) =>
+        _requestPrefix +
+        (state.WorkspaceId ?? _emptyComponent) + ":" +
+        (state.WarningCode ?? _emptyComponent) + ":" +
+        (state.CorrelationId ?? _emptyComponent);
+
+    private sealed record RequestStateParts(
+        string? WorkspaceId,
+        string? WarningCode,
+        string? CorrelationId);
 }

--- a/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/ScaffoldingTools.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Host.Stdio.Catalog;
 using RoslynMcp.Host.Stdio.Elicitation;
+using RoslynMcp.Host.Stdio.ProtocolCompatibility;
 
 namespace RoslynMcp.Host.Stdio.Tools;
 
@@ -203,7 +204,7 @@ public static class ScaffoldingTools
                     return false;
                 }
 
-                result = ProjectOutcome(outcome, text);
+                result = RestoreSiblingNameDiscoveryWarning(ProjectOutcome(outcome, text));
                 return true;
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
@@ -213,7 +214,7 @@ public static class ScaffoldingTools
                 // (the capability gate or logger resolution). Report true with the sanitized
                 // fallback rather than false: falling through would re-issue the sampling request
                 // the client has already answered.
-                result = ReportSanitizedFailure(ex);
+                result = RestoreSiblingNameDiscoveryWarning(ReportSanitizedFailure(ex));
                 return true;
             }
         }
@@ -233,10 +234,35 @@ public static class ScaffoldingTools
                 ct.ThrowIfCancellationRequested();
                 return Task.FromResult(ProjectOutcome(outcome, text));
             }
-            catch (Exception ex) when (ex is not OperationCanceledException and not InputRequiredException)
+            catch (InputRequiredException inputRequired)
+            {
+                RequestStateCodec.PreserveSiblingNameDiscoveryWarning(
+                    inputRequired,
+                    context.SiblingNameDiscoveryWarning);
+                throw;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 return Task.FromResult(ReportSanitizedFailure(ex));
             }
+        }
+
+        private TestNameSuggestionResult RestoreSiblingNameDiscoveryWarning(
+            TestNameSuggestionResult result)
+        {
+            if (!RequestStateCodec.TryRestoreSiblingNameDiscoveryWarning(
+                    _requestContext.Params?.RequestState,
+                    out var warning))
+            {
+                return result;
+            }
+
+            return result with
+            {
+                Warning = string.IsNullOrWhiteSpace(result.Warning)
+                    ? warning
+                    : $"{result.Warning} {warning}",
+            };
         }
 
         private static TestNameSuggestionResult ProjectOutcome(

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -156,7 +156,8 @@ internal sealed class SingleTestScaffolder
         var context = new ScaffoldTestNameSuggestionContext(
             lookupTypeName,
             request.TargetMethodName,
-            siblingNames.Names);
+            siblingNames.Names,
+            siblingNames.Warning);
         var suggestion = NormalizeSuggestion(
             await provider.SuggestTestNameAsync(context, ct).ConfigureAwait(false));
         if (!string.IsNullOrWhiteSpace(siblingNames.Warning))

--- a/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
+++ b/tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs
@@ -17,6 +17,7 @@ using RoslynMcp.Host.Stdio.Middleware;
 using RoslynMcp.Host.Stdio.ProtocolCompatibility;
 using RoslynMcp.Host.Stdio.Tools;
 using RoslynMcp.Roslyn.Contracts;
+using RoslynMcp.Roslyn.Services;
 using RoslynMcp.Tests.Helpers;
 
 namespace RoslynMcp.Tests;
@@ -174,6 +175,143 @@ public sealed class SamplingMrtrWireTests : IsolatedWorkspaceTestBase
             prior,
             _samplingMethod),
             "MRTR sampling must not also issue a deprecated nested sampling request.");
+    }
+
+    [TestMethod]
+    [Timeout(30_000, CooperativeCancellation = true)]
+    public async Task ModernSession_IncompleteSiblingDiscoveryWarning_RoundTripsOnceWithoutRescan()
+    {
+        const string sentinel = "SECRET-SENTINEL-mrtr-sibling-read";
+        const string secretSource = "SECRET-SOURCE-mrtr-sibling-read";
+        const string countSentinel = "SECRET-COUNT-mrtr-sibling-read";
+        const string readableMethodName = "Speak_WhenReadable_ReturnsBark";
+        const string warningPrefix = "Sibling test-name discovery was incomplete";
+        await using var workspace = CreateIsolatedWorkspaceCopy();
+        var readablePath = workspace.GetPath("SampleLib.Tests", "DogReadableTests.cs");
+        var unreadablePath = workspace.GetPath("SampleLib.Tests", "DogUnreadableTests.cs");
+        var secondUnreadablePath = workspace.GetPath("SampleLib.Tests", "DogAlsoUnreadableTests.cs");
+        await File.WriteAllTextAsync(readablePath, $$"""
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SampleLib.Tests;
+
+[TestClass]
+public sealed class DogReadableTests
+{
+    [TestMethod]
+    public void {{readableMethodName}}()
+    {
+    }
+}
+""", CancellationToken.None);
+        await File.WriteAllTextAsync(unreadablePath, "// injected read failure", CancellationToken.None);
+        await File.WriteAllTextAsync(secondUnreadablePath, "// second injected read failure", CancellationToken.None);
+        await workspace.LoadAsync(CancellationToken.None);
+
+        var failingReadCount = 0;
+        var failure = new IOException(sentinel) { Source = secretSource };
+        failure.Data["count"] = countSentinel;
+        string ReadAllText(string path)
+        {
+            if (string.Equals(path, unreadablePath, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(path, secondUnreadablePath, StringComparison.OrdinalIgnoreCase))
+            {
+                Interlocked.Increment(ref failingReadCount);
+                throw failure;
+            }
+
+            return File.ReadAllText(path);
+        }
+
+        var reporter = new RecordingReporter();
+        var scaffoldingService = new SingleTestScaffoldingService(
+            WorkspaceManager,
+            FileOperationService,
+            reporter,
+            ReadAllText);
+        var samplingCount = 0;
+        string? samplingRequest = null;
+#pragma warning disable MCP9005 // The handler proves the real scaffold flow carries one warning across MRTR.
+        await using var harness = await CreateProductionHarnessAsync(
+            scaffoldingService,
+            (request, _, _) =>
+            {
+                Interlocked.Increment(ref samplingCount);
+                samplingRequest = JsonSerializer.Serialize(request);
+                return ValueTask.FromResult(SamplingResult(_suggestedName));
+            },
+            WorkspaceManager);
+#pragma warning restore MCP9005
+
+        var prior = harness.RawServerMessages.Count;
+        var result = await harness.Client.CallToolAsync(
+            "scaffold_test_preview",
+            new Dictionary<string, object?>
+            {
+                ["workspaceId"] = workspace.WorkspaceId,
+                ["testProjectName"] = "SampleLib.Tests",
+                ["targetTypeName"] = "Dog",
+                ["targetMethodName"] = "Speak",
+                ["referenceTestFile"] = string.Empty,
+                ["useSampling"] = true,
+            },
+            cancellationToken: CancellationToken.None);
+
+        Assert.IsFalse(result.IsError is true);
+        Assert.AreEqual(1, samplingCount);
+        Assert.AreEqual(2, scaffoldingService.AttemptCount,
+            "MRTR must execute one input-required leg and one terminal replay.");
+        Assert.AreEqual(2, failingReadCount,
+            "Each injected failure must be observed on the initial scan only; replay must not rescan siblings.");
+        Assert.IsNotNull(samplingRequest);
+        StringAssert.Contains(samplingRequest, readableMethodName,
+            "Readable sibling names must remain available to the sampling prompt.");
+
+        var results = FindNewResults(harness.RawServerMessages, prior);
+        Assert.HasCount(2, results);
+        var requestState = results[0].GetProperty("requestState").GetString();
+        Assert.IsNotNull(requestState);
+        Assert.IsTrue(RequestStateCodec.TryRestoreWorkspaceId(requestState, out var restoredWorkspaceId));
+        Assert.AreEqual(workspace.WorkspaceId, restoredWorkspaceId);
+        Assert.IsTrue(RequestStateCodec.TryRestoreSiblingNameDiscoveryWarning(requestState, out var restoredWarning));
+        StringAssert.Contains(restoredWarning, warningPrefix);
+        StringAssert.Contains(restoredWarning, "correlationId=sampling-test");
+        Assert.IsFalse(requestState.Contains(warningPrefix, StringComparison.Ordinal),
+            "Request state must carry only the warning code and correlation state, not client prose.");
+        AssertSecretSafe(requestState);
+
+        var terminalText = ((TextContentBlock)result.Content![0]).Text;
+        StringAssert.Contains(terminalText, _suggestedName);
+        Assert.AreEqual(1, CountOccurrences(terminalText, warningPrefix),
+            "The terminal preview must contain exactly one incomplete-discovery warning.");
+        Assert.AreEqual(1, CountOccurrences(terminalText, "correlationId=sampling-test"));
+        AssertSecretSafe(terminalText);
+
+        void AssertSecretSafe(string value)
+        {
+            Assert.IsFalse(value.Contains(sentinel, StringComparison.Ordinal));
+            Assert.IsFalse(value.Contains(secretSource, StringComparison.Ordinal));
+            Assert.IsFalse(value.Contains(countSentinel, StringComparison.Ordinal));
+            Assert.IsFalse(value.Contains(unreadablePath, StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(value.Contains(Path.GetFileName(unreadablePath), StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(value.Contains(Path.GetFileName(secondUnreadablePath), StringComparison.OrdinalIgnoreCase));
+            Assert.IsFalse(value.Contains(nameof(IOException), StringComparison.Ordinal));
+        }
+    }
+
+    [TestMethod]
+    [DataRow("roslynmcp.request.v1:-:-:-")]
+    [DataRow("roslynmcp.request.v1:not-a-guid:sibling-name-discovery-incomplete:sampling-test")]
+    [DataRow("roslynmcp.request.v1:0123456789abcdef0123456789abcdef:-:sampling-test")]
+    [DataRow("roslynmcp.request.v1:0123456789abcdef0123456789abcdef:unknown:sampling-test")]
+    [DataRow("roslynmcp.request.v1:0123456789abcdef0123456789abcdef:sibling-name-discovery-incomplete:bad!")]
+    [DataRow("roslynmcp.request.v1:0123456789abcdef0123456789abcdef:sibling-name-discovery-incomplete:sampling-test:extra")]
+    public void CompoundRequestState_MalformedOrUnknownComponent_FailsClosed(string state)
+    {
+        Assert.IsFalse(RequestStateCodec.TryRestoreWorkspaceId(state, out var workspaceId));
+        Assert.AreEqual(string.Empty, workspaceId);
+        Assert.IsFalse(RequestStateCodec.TryRestoreSiblingNameDiscoveryWarning(state, out var warning));
+        Assert.AreEqual(string.Empty, warning);
     }
 
     [TestMethod]
@@ -797,6 +935,19 @@ public sealed class Dog { public void Speak() { } }
             .OfType<JsonObject>()
             .Any(message => (string?)message["method"] == method);
 
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var startIndex = 0;
+        while ((startIndex = value.IndexOf(search, startIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            startIndex += search.Length;
+        }
+
+        return count;
+    }
+
     [McpServerToolType]
     private sealed class SyntheticSamplingTools
     {
@@ -912,6 +1063,59 @@ public sealed class Dog { public void Speak() { } }
                 $"Scaffolded {suggestion.MethodName}",
                 [],
                 suggestion.Warning is null ? null : [suggestion.Warning]);
+        }
+
+        public Task<RefactoringPreviewDto> PreviewScaffoldTestBatchAsync(
+            string workspaceId,
+            ScaffoldTestBatchDto request,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewScaffoldFirstTestFileAsync(
+            string workspaceId,
+            ScaffoldFirstTestFileDto request,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class SingleTestScaffoldingService(
+        IWorkspaceManager workspace,
+        IFileOperationService fileOperationService,
+        IUnexpectedExceptionReporter exceptionReporter,
+        Func<string, string> readAllText) : IScaffoldingService
+    {
+        private int _attemptCount;
+
+        public int AttemptCount => Volatile.Read(ref _attemptCount);
+
+        public Task<RefactoringPreviewDto> PreviewScaffoldTypeAsync(
+            string workspaceId,
+            ScaffoldTypeDto request,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<RefactoringPreviewDto> PreviewScaffoldTestAsync(
+            string workspaceId,
+            ScaffoldTestDto request,
+            CancellationToken ct,
+            ITestNameSuggestionProvider? testNameSuggestionProvider = null)
+        {
+            Interlocked.Increment(ref _attemptCount);
+            var project = workspace.GetStatus(workspaceId).Projects.Single(project =>
+                string.Equals(project.Name, request.TestProjectName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(project.FilePath, request.TestProjectName, StringComparison.OrdinalIgnoreCase));
+            var scaffolder = new SingleTestScaffolder(
+                workspace,
+                fileOperationService,
+                exceptionReporter,
+                readAllText);
+            return scaffolder.PreviewAsync(
+                project,
+                "mstest",
+                workspaceId,
+                request,
+                ct,
+                testNameSuggestionProvider);
         }
 
         public Task<RefactoringPreviewDto> PreviewScaffoldTestBatchAsync(


### PR DESCRIPTION
Summary:
- carry redacted incomplete sibling-discovery state across modern input-required replay
- preserve the originally selected workspace without rescanning sibling files
- emit the terminal warning exactly once and reject malformed compound request state

Validation:
- SamplingMrtrWireTests: 24/24 passed
- Roslyn compile and format checks: zero findings
- release gate: 2911 passed, 7 skipped, 0 failed; publish and manifest completed

Follow-up:
- cold review found rendered-warning parsing in the request-state codec; reconciliation will add a bounded typed warning-payload refactor row rather than widen this public-contract slice