### PR TITLE
Record workspace ID optional-adoption NO-GO

### DIFF
--- a/changelog.d/workspace-id-optional-adoption-evidence.md
+++ b/changelog.d/workspace-id-optional-adoption-evidence.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Measured real-world `workspaceId` omission adoption and recorded the decision gate for the remaining read-only tool surface.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Human-facing documentation for the Roslyn-Backed MCP Server.
 | `decisions/0005-stable-profile-preview-apply-closure.md` | ADR: stable-profile preview/apply closure, registration invariants, and token redemption |
 | `decisions/0006-modelcontextprotocol-2-2-servicing.md` | ADR: ModelContextProtocol 2.1.0→2.2.0 servicing, stdio-only scope, and non-breaking compatibility disposition |
 | `decisions/0007-tasks-extension-compatibility.md` | ADR: exact Tasks/core 2.2.0 adoption posture, per-request opt-in, synchronous fallback, finite retention, and process-lifetime handles |
+| `decisions/0008-workspace-id-optional-adoption.md` | ADR: measured optional `workspaceId` adoption, NO-GO expansion decision, retired flip batches, and concrete recheck trigger |
 
 ## Claude Code Plugin
 

--- a/docs/decisions/0008-workspace-id-optional-adoption.md
+++ b/docs/decisions/0008-workspace-id-optional-adoption.md
@@ -1,0 +1,96 @@
+# ADR 0008 — Optional workspaceId adoption gate
+
+- **Status:** Accepted (2026-09-04)
+- **Deciders:** repository maintainers
+- **Scope:** expansion of optional `workspaceId` beyond the read-only pilot
+- **Supersedes:** nothing
+- **Superseded by:** nothing
+
+## Context
+
+PR #959 made `workspaceId` optional on `go_to_definition`, `find_references`, and
+`document_symbols`. The request middleware reports whether a call was explicit, resolved from the
+only loaded workspace, or rejected because omission was ambiguous. Surface-schema tests prove the
+capability exists; they do not prove clients use it safely.
+
+A read-only census examined real Claude Code plus live and archived Codex transcripts after PR #959
+merged. It correlated actual Roslyn MCP calls with their results, excluded this repository's own
+sessions, and counted the three pilot tools separately from the later `compile_check` addition.
+Aggregate evidence only is retained here; raw transcripts can contain source and local paths and are
+not repository artifacts.
+
+| Census boundary | Value |
+|---|---:|
+| Start, inclusive | 2026-06-09 15:50:23 UTC |
+| End, inclusive | 2026-09-04 13:30:00 UTC |
+| Transcript files scanned | 1,238 |
+| Parsed JSONL records | 667,658 |
+| Parse failures | 0 |
+| Discovered candidate calls | 3,193 |
+| Correlated call/result pairs | 1,937 |
+| Excluded host/self-test calls | 412 |
+| Eligible pilot calls | 1,137 |
+| Eligible pilot sessions | 77 |
+| Repository buckets | 6, including one unattributed Codex bucket |
+
+| Pilot tool | Claude | Codex archive | Codex live | Total | Organic omissions |
+|---|---:|---:|---:|---:|---:|
+| `document_symbols` | 17 | 27 | 14 | 58 | 2 |
+| `find_references` | 966 | 73 | 40 | 1,079 | 35 |
+| `go_to_definition` | 0 | 0 | 0 | 0 | 0 |
+| **Total** | **983** | **100** | **54** | **1,137** | **37** |
+
+| Omitted-call outcome | Count | Interpretation |
+|---|---:|---|
+| `single-workspace` | 35 | Middleware resolved the only loaded workspace. |
+| `fast-fail` | 2 | Two loaded workspaces made omission ambiguous; the client retried explicitly. |
+
+The two fast-fails were organic `find_references` calls in a consumer repository, not manual probes
+or this repository's tests. A bounded source check confirmed an omitted successful call carried
+`_meta.autoResolution=single-workspace`; a bounded failure check confirmed the ambiguous calls
+carried `_meta.autoResolution=fast-fail` and were followed by successful explicit retries.
+
+The pilot repository distribution reconciles to the eligible total: BioRemote 276,
+DotNet-Firewall-Analyzer 345, DotNet-Network-Documentation 2, SnipCue 182, TradeWise 178, and 154
+Codex calls without reliable repository attribution. The later `compile_check` cohort contained 388
+eligible calls and is not used to decide the original three-tool pilot.
+
+## Decision
+
+1. Record **NO-GO** for expanding optional `workspaceId` across the remaining read-only surface.
+2. Keep the existing pilot and `compile_check` behavior. Their fail-closed ambiguity handling is
+   correct and the census does not justify a breaking rollback.
+3. Retire `workspace-id-flip-batch-01` through `workspace-id-flip-batch-11`; closing this evidence
+   gate must not make those implementation batches appear actionable.
+4. Reconsider expansion only after a new trailing-30-day census observes at least 100 organic
+   omitted pilot calls across at least three known consumer repositories and both Claude and Codex
+   harness families, with zero multi-workspace fast-fails. A separately approved unambiguous
+   multi-workspace selection contract may also trigger reconsideration.
+5. Continue describing optionality as a schema capability. Do not claim that it causes clients to
+   omit `workspaceId`; current bootstrap guidance often tells clients to retain the identifier.
+
+## Consequences
+
+- The current pilot remains a bounded convenience for single-workspace sessions.
+- Clients retain deterministic behavior by supplying `workspaceId`, especially when multiple
+  workspaces may coexist.
+- The eleven broad flip batches are removed rather than left deceptively dependency-ready.
+- A future decision starts from this denominator, extraction method, failure signal, and explicit
+  recheck threshold instead of re-litigating the gate from anecdotes.
+- Codex repository attribution remains incomplete, so repository-level conclusions use only known
+  Claude Code paths. Transcript steering also makes the observed omission rate descriptive rather
+  than a causal estimate of schema behavior.
+
+## Validation
+
+- Run the census extractor twice against the fixed time boundary and require identical aggregate
+  output and SHA-256 digest.
+- Manually inspect at least one real call/result pair for each nonzero resolution bucket.
+- Reconcile totals across tool, harness, repository, session, and exclusion dimensions.
+- Run `WorkspaceIdOptionalSurfaceTests`.
+- Run `eng/verify-ai-docs.ps1` and the complete release gate.
+
+## References
+
+- [Product contract](../product-contract.md)
+- [MCP SDK wire compatibility](0003-sdk-2x-wire-compatibility.md)

--- a/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceIdOptionalSurfaceTests.cs
@@ -6,9 +6,9 @@ namespace RoslynMcp.Tests;
 /// <summary>
 /// Coverage for the <c>workspace-id-optional-readonly-surface-flip</c> initiative (pilot subset).
 /// Asserts, via the reflection-derived <see cref="ToolParameterIndex"/>, that the pilot read-only
-/// tools now advertise <c>workspaceId</c> as OPTIONAL (so agents proactively omit it and order-1's
-/// read-path middleware resolves it), while write/destructive tools — and the deferred
-/// <c>symbol_search</c> — keep it REQUIRED.
+/// tools now advertise <c>workspaceId</c> as OPTIONAL (so clients may omit it and order-1's
+/// read-path middleware can resolve an unambiguous omission), while write/destructive tools — and
+/// the deferred <c>symbol_search</c> — keep it REQUIRED.
 ///
 /// <para>
 /// The pilot flipped 3 tools (<c>go_to_definition</c>, <c>find_references</c>, <c>document_symbols</c>);
@@ -40,7 +40,7 @@ public sealed class WorkspaceIdOptionalSurfaceTests
             Assert.IsNotNull(schema, $"{tool} should declare a workspaceId parameter.");
             Assert.AreEqual("string", schema!.Type, $"{tool}.workspaceId should remain a string.");
             Assert.IsFalse(schema.Required,
-                $"{tool}.workspaceId must be Required=false after the flip so agents proactively omit it.");
+                $"{tool}.workspaceId must be Required=false after the flip so clients may omit it.");
         }
     }
 


### PR DESCRIPTION
Summary:
- census 1137 eligible pilot calls across 77 sessions and six repository buckets
- record 37 organic omissions: 35 single-workspace successes and two real multi-workspace fast-fails
- keep the bounded pilot, reject broad expansion, and define a concrete recheck threshold
- correct schema tests that claimed optionality caused proactive client omission

Validation:
- two census runs produced identical SHA-256 72cc9e68c721a39adcb98fe51e4866854703e3c4cad31cd28a1a0ad41456f1fe
- bounded source verification covered successful omission, fast-fail, and explicit retry buckets
- WorkspaceIdOptionalSurfaceTests: 4/4 passed
- AI docs validation: passed
- formatter contract: passed in isolation; the broad run had one classified host-contention timeout, with 2903 other tests passing and 7 skipped

Decision:
- NO-GO; reconciliation will retire workspace-id-flip-batch-01 through batch-11 so closing the evidence gate cannot unlock them