### PR TITLE
Lock actionlint tar extraction failure contract

### DIFF
--- a/changelog.d/actionlint-extraction-failure-contract.md
+++ b/changelog.d/actionlint-extraction-failure-contract.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Locked the actionlint archive-extraction failure contract with an offline regression.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -29,7 +29,9 @@ param(
     [string]$PlatformForTest,
     [Parameter(DontShow)]
     [ValidateSet('x64', 'arm64')]
-    [string]$ArchitectureForTest
+    [string]$ArchitectureForTest,
+    [Parameter(DontShow)]
+    [switch]$FailTarExtractionForTest
 )
 
 Set-StrictMode -Version Latest
@@ -139,8 +141,37 @@ function Set-ActionlintExecutablePermission {
     }
 }
 
+function Expand-ActionlintArchive {
+    param(
+        [Parameter(Mandatory)][string]$Rid,
+        [Parameter(Mandatory)][string]$ArchivePath,
+        [Parameter(Mandatory)][string]$DestinationPath,
+        [Parameter(DontShow)][switch]$FailForTest
+    )
+
+    if ($Rid -like 'win-*') {
+        Expand-Archive -LiteralPath $ArchivePath -DestinationPath $DestinationPath -Force
+        return
+    }
+
+    if ($FailForTest) {
+        & (Get-Process -Id $PID).Path -NoProfile -NonInteractive -Command 'exit 23'
+    }
+    else {
+        & tar -xzf $ArchivePath -C $DestinationPath
+    }
+    $tarExitCode = $LASTEXITCODE
+    if ($tarExitCode -ne 0) {
+        Stop-WithDiagnostic -ExitCode $tarExitCode -Diagnostic (
+            "verify-actionlint: 'tar' extraction of '$ArchivePath' failed with exit code $tarExitCode.")
+    }
+}
+
 if ($FailChmodForTest) {
     Set-ActionlintExecutablePermission -Path 'test-only' -FailForTest
+}
+if ($FailTarExtractionForTest) {
+    Expand-ActionlintArchive -Rid 'linux-x64' -ArchivePath 'test-only.tar.gz' -DestinationPath 'test-only' -FailForTest
 }
 
 $ridArguments = @{}
@@ -192,13 +223,7 @@ else {
         Remove-Item -LiteralPath $archivePath -Force
         throw "verify-actionlint: downloaded archive '$downloadUrl' hash mismatch (expected $($pin.ArchiveSha256), got $archiveHash) -- refusing to extract an unverified archive."
     }
-    if ($rid -like 'win-*') {
-        Expand-Archive -LiteralPath $archivePath -DestinationPath $toolRoot -Force
-    }
-    else {
-        & tar -xzf $archivePath -C $toolRoot
-        if ($LASTEXITCODE -ne 0) { throw "verify-actionlint: 'tar' extraction of '$archivePath' failed with exit code $LASTEXITCODE." }
-    }
+    Expand-ActionlintArchive -Rid $rid -ArchivePath $archivePath -DestinationPath $toolRoot
     Remove-Item -LiteralPath $archivePath -Force
     if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
         throw "verify-actionlint: extraction of '$($pin.Asset)' did not produce the expected binary at '$binaryPath'."

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -233,6 +233,33 @@ public sealed class ActionlintGateContractTests
         }
     }
 
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_TarExtractionFailure_ReportsBoundedDiagnosticBeforeExecution()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var result = await RunGateAsync(fixtureRoot, failTarExtractionForTest: true);
+
+            Assert.AreEqual(23, result.ExitCode, result.AllOutput);
+            const string diagnostic =
+                "verify-actionlint: 'tar' extraction of 'test-only.tar.gz' failed with exit code 23.";
+            Assert.AreEqual(diagnostic, result.StdErr.Trim());
+            Assert.AreEqual(string.Empty, result.StdOut);
+            Assert.IsFalse(
+                Directory.Exists(Path.Combine(fixtureRoot, "artifacts")),
+                "The failure-only extraction seam must run before cache creation or download.");
+            Assert.IsFalse(
+                result.AllOutput.Contains("running pinned actionlint", StringComparison.Ordinal),
+                $"A failed extraction must not reach actionlint execution. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
     // Live-network smoke test: downloads the real pinned release once (verifying the archive
     // hash), then re-runs against the now-populated cache and asserts the second run completes
     // in well under the time a fresh download+extract would take -- the offline cache-hit path,
@@ -298,6 +325,7 @@ public sealed class ActionlintGateContractTests
         IReadOnlyDictionary<string, string?>? environment = null,
         TimeSpan? timeout = null,
         bool failChmodForTest = false,
+        bool failTarExtractionForTest = false,
         string? platformForTest = null,
         string? architectureForTest = null)
     {
@@ -312,6 +340,10 @@ public sealed class ActionlintGateContractTests
         if (failChmodForTest)
         {
             arguments.Add("-FailChmodForTest");
+        }
+        if (failTarExtractionForTest)
+        {
+            arguments.Add("-FailTarExtractionForTest");
         }
         if (platformForTest is not null)
         {


### PR DESCRIPTION
Summary:
- isolate archive expansion behind one production helper
- inject a hermetic non-zero tar result through the hidden test seam
- preserve exact exit code and bounded stderr while proving no cache, download, or actionlint execution occurs

Validation:
- ActionlintGateContractTests: 13/13 passed
- eng/verify-actionlint.ps1: passed
- release gate: 2915 passed, 7 skipped, 0 failed; publish and manifest completed