### PR TITLE
test(actionlint): lock missing binary refusal

### DIFF
--- a/changelog.d/actionlint-missing-binary-contract.md
+++ b/changelog.d/actionlint-missing-binary-contract.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Locked the actionlint missing-binary refusal with a hermetic successful-extraction regression and a bounded diagnostic.

--- a/eng/verify-actionlint.ps1
+++ b/eng/verify-actionlint.ps1
@@ -31,7 +31,9 @@ param(
     [ValidateSet('x64', 'arm64')]
     [string]$ArchitectureForTest,
     [Parameter(DontShow)]
-    [switch]$FailTarExtractionForTest
+    [switch]$FailTarExtractionForTest,
+    [Parameter(DontShow)]
+    [switch]$UseArchiveFixtureForTest
 )
 
 Set-StrictMode -Version Latest
@@ -167,11 +169,37 @@ function Expand-ActionlintArchive {
     }
 }
 
+function Assert-ActionlintBinaryPresent {
+    param(
+        [Parameter(Mandatory)][string]$AssetName,
+        [Parameter(Mandatory)][string]$BinaryName,
+        [Parameter(Mandatory)][string]$BinaryPath
+    )
+
+    if (-not (Test-Path -LiteralPath $BinaryPath -PathType Leaf)) {
+        Stop-WithDiagnostic -Diagnostic (
+            "verify-actionlint: extraction of '$AssetName' did not produce expected binary '$BinaryName'.")
+    }
+}
+
 if ($FailChmodForTest) {
     Set-ActionlintExecutablePermission -Path 'test-only' -FailForTest
 }
 if ($FailTarExtractionForTest) {
     Expand-ActionlintArchive -Rid 'linux-x64' -ArchivePath 'test-only.tar.gz' -DestinationPath 'test-only' -FailForTest
+}
+if ($UseArchiveFixtureForTest) {
+    $archiveFixturePath = Join-Path $RepoRoot 'missing-actionlint.tar.gz'
+    $fixtureToolRoot = Join-Path $RepoRoot "artifacts/tools/actionlint/$PinnedVersion"
+    New-Item -ItemType Directory -Path $fixtureToolRoot -Force | Out-Null
+    Expand-ActionlintArchive -Rid 'linux-x64' -ArchivePath $archiveFixturePath -DestinationPath $fixtureToolRoot
+    $binaryAssertionArguments = @{
+        AssetName  = [IO.Path]::GetFileName($archiveFixturePath)
+        BinaryName = $PinnedArchiveHashes['linux-x64'].BinaryName
+        BinaryPath = Join-Path $fixtureToolRoot $PinnedArchiveHashes['linux-x64'].BinaryName
+    }
+    Assert-ActionlintBinaryPresent @binaryAssertionArguments
+    exit 0
 }
 
 $ridArguments = @{}
@@ -225,9 +253,7 @@ else {
     }
     Expand-ActionlintArchive -Rid $rid -ArchivePath $archivePath -DestinationPath $toolRoot
     Remove-Item -LiteralPath $archivePath -Force
-    if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
-        throw "verify-actionlint: extraction of '$($pin.Asset)' did not produce the expected binary at '$binaryPath'."
-    }
+    Assert-ActionlintBinaryPresent -AssetName $pin.Asset -BinaryName $pin.BinaryName -BinaryPath $binaryPath
     $extractedHash = Get-FileSha256 -Path $binaryPath
     if ($extractedHash -ne $pin.BinarySha256) {
         throw "verify-actionlint: extracted binary at '$binaryPath' hash mismatch (expected $($pin.BinarySha256), got $extractedHash) -- the pinned archive hash matched but its extracted contents did not."

--- a/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
+++ b/tests/RoslynMcp.Tests/ActionlintGateContractTests.cs
@@ -260,6 +260,42 @@ public sealed class ActionlintGateContractTests
         }
     }
 
+    [TestMethod]
+    [TestCategory("Process")]
+    public async Task VerifyActionlint_ArchiveWithoutExpectedBinary_FailsClosedAfterSuccessfulExtraction()
+    {
+        var fixtureRoot = CreateFixtureRoot();
+        try
+        {
+            var archivePath = Path.Combine(fixtureRoot, "missing-actionlint.tar.gz");
+            CreateTarGzipArchive(archivePath, "extraction-marker.txt", "archive extracted");
+
+            var result = await RunGateAsync(fixtureRoot, useArchiveFixtureForTest: true);
+
+            Assert.AreEqual(1, result.ExitCode, result.AllOutput);
+            const string diagnostic =
+                "verify-actionlint: extraction of 'missing-actionlint.tar.gz' did not produce expected binary 'actionlint'.";
+            Assert.AreEqual(diagnostic, result.StdErr.Trim());
+            Assert.AreEqual(string.Empty, result.StdOut);
+            var toolRoot = Path.Combine(fixtureRoot, "artifacts", "tools", "actionlint", "1.7.12");
+            Assert.AreEqual(
+                "archive extracted",
+                File.ReadAllText(Path.Combine(toolRoot, "extraction-marker.txt")),
+                "The fixture must prove extraction succeeded before the missing-binary refusal.");
+            Assert.IsFalse(File.Exists(Path.Combine(toolRoot, "actionlint")));
+            Assert.IsFalse(
+                result.AllOutput.Contains("could not be downloaded", StringComparison.Ordinal),
+                $"The archive fixture must stay offline. Output:{Environment.NewLine}{result.AllOutput}");
+            Assert.IsFalse(
+                result.AllOutput.Contains("running pinned actionlint", StringComparison.Ordinal),
+                $"A missing extracted binary must not reach actionlint execution. Output:{Environment.NewLine}{result.AllOutput}");
+        }
+        finally
+        {
+            TestFixtureFileSystem.DeleteDirectoryIfExists(fixtureRoot);
+        }
+    }
+
     // Live-network smoke test: downloads the real pinned release once (verifying the archive
     // hash), then re-runs against the now-populated cache and asserts the second run completes
     // in well under the time a fresh download+extract would take -- the offline cache-hit path,
@@ -320,12 +356,33 @@ public sealed class ActionlintGateContractTests
         return root;
     }
 
+    private static void CreateTarGzipArchive(
+        string archivePath,
+        string entryName,
+        string contents)
+    {
+        using var archiveStream = File.Create(archivePath);
+        using var gzipStream = new System.IO.Compression.GZipStream(
+            archiveStream,
+            System.IO.Compression.CompressionLevel.SmallestSize);
+        using var writer = new System.Formats.Tar.TarWriter(gzipStream);
+        using var contentsStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(contents));
+        var entry = new System.Formats.Tar.PaxTarEntry(
+            System.Formats.Tar.TarEntryType.RegularFile,
+            entryName)
+        {
+            DataStream = contentsStream,
+        };
+        writer.WriteEntry(entry);
+    }
+
     private static Task<PwshScriptResult> RunGateAsync(
         string fixtureRoot,
         IReadOnlyDictionary<string, string?>? environment = null,
         TimeSpan? timeout = null,
         bool failChmodForTest = false,
         bool failTarExtractionForTest = false,
+        bool useArchiveFixtureForTest = false,
         string? platformForTest = null,
         string? architectureForTest = null)
     {
@@ -344,6 +401,10 @@ public sealed class ActionlintGateContractTests
         if (failTarExtractionForTest)
         {
             arguments.Add("-FailTarExtractionForTest");
+        }
+        if (useArchiveFixtureForTest)
+        {
+            arguments.Add("-UseArchiveFixtureForTest");
         }
         if (platformForTest is not null)
         {


### PR DESCRIPTION
## Summary
- route post-extraction binary presence checks through one bounded fail-closed diagnostic
- add a hermetic tar.gz fixture that extracts successfully without the expected actionlint binary
- prove the refusal stays offline and never executes an unverified binary

## Validation
- ActionlintGateContractTests: 14 passed
- Roslyn compile_check: 0 errors, 0 warnings
- pwsh -NoProfile -File ./eng/verify-actionlint.ps1: passed
- verify-release.ps1: build passed with 0 warnings/errors; 2922 tests passed, 7 skipped, 1 unrelated ElicitationChoicePromptTests protocol-state isolation failure; exact failing test passed in isolation