### PR TITLE
docs(workflow): refresh remediation executor guidance

### DIFF
--- a/.claude/agents/initiative-executor.md
+++ b/.claude/agents/initiative-executor.md
@@ -1,13 +1,13 @@
 ---
 name: initiative-executor
-description: Execute ONE initiative from a backlog-sweep plan end-to-end — create the worktree, implement per plan.md, validate, open the PR, return a <<<RESULT>>> envelope. Use proactively when the `backlog-sweep-execute` flow enters parallel mode (Step 7 — subagent briefing/spawn). Orchestrator supplies initiative id, plan path, and tool policy; this agent handles the rest and does NOT merge or touch shared files.
+description: Execute ONE initiative from a remediation plan end-to-end — create the worktree, implement per plan.md, validate, open the PR, return a <<<RESULT>>> envelope. Use when `/backlog-remediate` delegates a prepared initiative. Orchestrator supplies initiative id, plan path, and tool policy; this agent handles the rest and does NOT merge or touch shared files.
 ---
 
-You are a one-shot executor for ONE initiative from a backlog-sweep plan. You work in an isolated git worktree, open a PR, and exit. You do NOT merge and do NOT touch shared files.
+You are a one-shot executor for ONE initiative from a remediation plan. You work in an isolated git worktree, open a PR, and exit. You do NOT merge and do NOT touch shared files.
 
 ## Canonical flow
 
-Read `~/.claude/prompts/backlog-sweep-execute.md` Appendix A "Subagent briefing template (fallback)" first — that is the authoritative, evolving specification of what an executor subagent does. This agent file holds the stable contract; the global prompt file holds the current flow details.
+Read `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/_subagent-result-protocol.md` first. They are the authoritative, evolving remediation and executor-result contracts. This agent file holds the stable repo-specific contract.
 
 ## Input contract (orchestrator-supplied)
 
@@ -62,7 +62,7 @@ If any field is missing, emit a failure `<<<RESULT>>>` immediately — do not gu
    ```
    PR body MUST include both:
    - `Closes: <backlog row ids>` — orchestrator correlation (machine-greppable).
-   - `Fixes #NNN` — one line per non-Reserved `[gh #NNN]` reference found in the row's `do` cell in `ai_docs/backlog.md`. GitHub then auto-closes the linked Issue when the PR merges. Reserved rows (text starts `**Reserved — [gh #NNN] (good first issue); skip in sweeps...**`) are pre-skipped by `/backlog-sweep:plan`, so this typically yields 0 or 1 reference; defensive parsing handles the rare follow-on row that references a parent tracked-only Issue (e.g. row text `[gh #760] follow-on (split from ..., shipped in PR #780)` — shipping this PR closes #760).
+   - `Fixes #NNN` — one line per non-Reserved `[gh #NNN]` reference found in the row's `do` cell in `ai_docs/backlog.md`. GitHub then auto-closes the linked Issue when the PR merges. Reserved rows (text starts `**Reserved — [gh #NNN] (good first issue); skip in sweeps...**`) are skipped by `/backlog-remediate`, so this typically yields 0 or 1 reference; defensive parsing handles the rare follow-on row that references a parent tracked-only Issue (e.g. row text `[gh #760] follow-on (split from ..., shipped in PR #780)` — shipping this PR closes #760).
 
    **Resolution algorithm** (run before `gh pr create`):
    1. For each `rowId` in `Closes:`, `Grep` `^\| \`<rowId>\`` in `ai_docs/backlog.md` to locate the row.

--- a/.claude/agents/pr-reconciler.md
+++ b/.claude/agents/pr-reconciler.md
@@ -1,12 +1,12 @@
 ---
 name: pr-reconciler
-description: Ship a single open PR through to merge + cleanup — poll `gh pr view` for green checks, squash-merge when clean, remove the worktree, delete the remote branch, return a compact status block. NOTE: `/backlog-sweep:execute` Step 10 no longer spawns this — it lands PRs via `/ship` in the parent context (a cold subagent lacks the destructive-cleanup allowlist, which triggers spurious SECURITY WARNING blocks); retained for manual/standalone single-PR merge+cleanup, or for a flow that invokes it explicitly. Does NOT edit CHANGELOG.md, backlog.md, state.json, or plan.md.
+description: Ship a single open PR through to merge + cleanup — poll `gh pr view` for green checks, squash-merge when clean, remove the worktree, delete the remote branch, return a compact status block. NOTE: `/backlog-remediate` no longer spawns this — it lands PRs via `/ship` in the parent context (a cold subagent lacks the destructive-cleanup allowlist, which triggers spurious SECURITY WARNING blocks); retained for manual/standalone single-PR merge+cleanup, or for a flow that invokes it explicitly. Does NOT edit CHANGELOG.md, backlog.md, state.json, or plan.md.
 model: haiku
 ---
 
 You reconcile ONE open PR through to merge and cleanup. Mechanical operations only — never bypass failing checks, never force-merge.
 
-> **Not auto-spawned by `/backlog-sweep:execute`.** Since the worktree-pre-prune update, execute Step 10 lands PRs via `/ship` in the parent context — a cold subagent can't run the destructive cleanup commands (`git push origin --delete`, `git worktree remove`) without tripping PreToolUse SECURITY WARNINGs. This agent is retained for **manual/standalone** single-PR merge+cleanup, or for a future flow that invokes it explicitly.
+> **Not auto-spawned by `/backlog-remediate`.** The remediation workflow lands PRs via `/ship` in the parent context — a cold subagent can't run the destructive cleanup commands (`git push origin --delete`, `git worktree remove`) without tripping PreToolUse SECURITY WARNINGs. This agent is retained for **manual/standalone** single-PR merge+cleanup, or for a future flow that invokes it explicitly.
 
 ## Input contract
 

--- a/.claude/skills/backlog-intake/SKILL.md
+++ b/.claude/skills/backlog-intake/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: backlog-intake
 installed_as: backlog-intake
-description: "Consolidate deep-review artifacts (mcp-server-audit, experimental-promotion, roslyn-mcp-retro) into ai_docs/backlog.md with anchor verification, dedupe, priority classification, and Rule 1/3/4/5 sizing for the backlog-sweep-plan.md planner prompt. Use when: a deep-review / audit wave has produced `*_mcp-server-audit.md` / `*_roslyn-mcp-retro.md` / `*_experimental-promotion.md` files across sibling repos (or this one) and you want them reviewed, deduped, and merged into the backlog as properly-sized initiative rows."
+description: "Consolidate deep-review artifacts (mcp-server-audit, experimental-promotion, roslyn-mcp-retro) into ai_docs/backlog.md with anchor verification, dedupe, priority classification, and sizing for the `/backlog-remediate` workflow. Use when: a deep-review / audit wave has produced `*_mcp-server-audit.md` / `*_roslyn-mcp-retro.md` / `*_experimental-promotion.md` files across sibling repos (or this one) and you want them reviewed, deduped, and merged into the backlog as properly-sized initiative rows."
 user-invocable: true
 argument-hint: "[--stage | --skip-verify | --no-commit | --publish] — defaults: stage files first, verify against CHANGELOG, commit on a fresh branch; pass --publish to file each accepted row as a public GitHub Issue via gh issue create"
 ---
 
 # Backlog intake
 
-You are triaging a batch of deep-review artifacts into `ai_docs/backlog.md`. Your job is to turn raw audit / retro / experimental-promotion markdown files into **properly-sized, anchor-verified, de-duplicated, priority-ranked** rows that the `backlog-sweep-plan.md` planner prompt can plan against without re-processing.
+You are triaging a batch of deep-review artifacts into `ai_docs/backlog.md`. Your job is to turn raw audit / retro / experimental-promotion markdown files into **properly-sized, anchor-verified, de-duplicated, priority-ranked** rows that `/backlog-remediate` can route without re-processing.
 
 This skill replaces the `eng/new-deep-review-batch.ps1 → sync-deep-review-backlog.ps1` pipeline. The PowerShell pipeline handled only `*_mcp-server-audit.md`, did literal-text dedupe, and couldn't verify anchors or size rows to Rule 1/3/4. The judgment work belongs in an LLM; the mechanical file-staging is delegated to `eng/stage-review-inbox.ps1`.
 
@@ -139,7 +139,7 @@ Skip this phase if `--skip-verify` is set.
 For each candidate row, cross-check:
 
 1. **`CHANGELOG.md` [Unreleased] + last 3 versions** — grep for the tool name, service, or symbol the row cites.
-2. **Newest backlog-sweep plan** under `ai_docs/plans/*_backlog-sweep/` — read its `state.json` and `plan.md`. Does any shipped initiative describe the same fix?
+2. **Newest remediation plan** under `ai_docs/plans/*_backlog-sweep/` — read its `state.json` and `plan.md`. The directory suffix is retained for historical compatibility. Does any shipped initiative describe the same fix?
 3. **Git log, last 100 commits** — `git log --oneline -n 100 | grep -i <keyword>` on tool / service / symbol names.
 4. **Code spot-check for rows flagged by 1-3** — open the named service / tool file and confirm the specific behavior still reproduces. For example, if the row says `symbol_search("")` overflows, grep `SymbolSearchService.cs` for an empty-query guard.
 
@@ -161,11 +161,11 @@ For each remaining row, verify every service class, tool file, and file:line anc
 
 Rewrite each row's `do` text to cite **both** the core service (under `src/RoslynMcp.Roslyn/Services/`) **and** the tool registration (under `src/RoslynMcp.Host.Stdio/Tools/`). Executors can then land on the right file immediately.
 
-If an anchor genuinely cannot be resolved, tag the row with `[stale — cited anchor not found; executor may use synthetic examples]` per `backlog-sweep-plan.md` Step 3's anchor-verification guidance, rather than dropping the row.
+If an anchor genuinely cannot be resolved, tag the row with `[stale — cited anchor not found; executor may use synthetic examples]` per the `/backlog-remediate` anchor-verification contract, rather than dropping the row.
 
 ### Phase 4 — Split heroic rows
 
-Apply `backlog-sweep-plan.md` Rule 1 to each row. A row is **heroic** (and must be split) if any of:
+Apply the `/backlog-remediate` initiative-sizing contract to each row. A row is **heroic** (and must be split) if any of:
 
 - It describes two or more distinct bugs that live in **different code paths** (different functions, different files).
 - It asks for ≥4 production-file edits to fulfill.
@@ -185,7 +185,7 @@ For each split, give each child a distinct kebab-case id (prefix with the origin
 
 ### Phase 5 — Ensure planner-prompt refs
 
-Before writing, verify the Refs table in `ai_docs/backlog.md` includes these entries (add any missing). Note: the backlog-sweep **planner/executor prompts are NOT repo Refs entries** — they live globally in `~/.claude/prompts/` (`backlog-sweep-plan.md`, `backlog-sweep-execute.md`) and are loaded by the `/backlog-sweep:*` commands, so do NOT add repo-local rows for them:
+Before writing, verify the Refs table in `ai_docs/backlog.md` includes these entries (add any missing). Note: the remediation contract is NOT a repo Refs entry — it lives globally in `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/backlog-remediate-rules.md`, so do NOT add repo-local rows for it:
 
 | Path | Role (template text) |
 |---|---|
@@ -197,7 +197,7 @@ Before writing, verify the Refs table in `ai_docs/backlog.md` includes these ent
 
 1. Update `updated_at:` to current UTC. Record this timestamp as the batch id in the form `YYYYMMDDTHHMMSSZ` (e.g. `20260424T031936Z`).
 2. Re-sort each priority band alphabetically by id.
-3. Ensure the "Standing rules" section includes the initiative-sizing rule: `"Size every row to a single backlog-sweep-plan.md initiative: one code path, ≤4 production files, ≤3 test files, one regression-test shape."` (add if missing).
+3. Ensure the "Standing rules" section includes the initiative-sizing rule: `"Size every row to a single /backlog-remediate initiative: one code path, ≤4 production files, ≤3 test files, one regression-test shape."` (add if missing).
 4. **Archive the processed review files.** Only the files that produced rows this batch — do NOT touch any existing `review-inbox/archive/<prior-batch>/` subdirectories.
    ```bash
    mkdir -p review-inbox/archive/{BATCH_ID}
@@ -230,7 +230,7 @@ Before writing, verify the Refs table in `ai_docs/backlog.md` includes these ent
 
    - Splits applied: {list of heroic rows that were split}
    - Dropped (already shipped): {list, if any}
-   - Verified against CHANGELOG [Unreleased] + last 3 versions + newest backlog-sweep plan.
+   - Verified against CHANGELOG [Unreleased] + last 3 versions + newest remediation plan.
 
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    ```
@@ -314,9 +314,9 @@ If the batch is small (≤3 files, ≤1000 total lines), skip the subagent and r
 ## Distinct from related skills
 
 - **`close-backlog-rows`**: removes specific row ids from the open table after their PRs ship. This skill (`backlog-intake`) ADDS rows from raw audit evidence. Use `close-backlog-rows` after a ship, this one after an audit wave.
-- **`reconcile-backlog-sweep-plan`**: updates a backlog-sweep plan's `state.json` when its PRs have merged. Different file, different concern.
+- **`reconcile-backlog-sweep-plan`**: legacy-named compatibility skill that updates a remediation plan's `state.json` when its PRs have merged. Different file, different concern.
 - **`draft-changelog-entry`**: drafts one changelog fragment per PR from commit metadata. Different artifact.
-- **`backlog-sweep-plan.md` (prompt, not skill)**: consumes the backlog this skill produces. Run `backlog-intake` first, then the sweep planner.
+- **`/backlog-remediate`**: consumes the backlog this skill produces. Run `backlog-intake` first, then remediation.
 
 ## Historical note
 

--- a/.claude/skills/backlog-intake/SKILL.md
+++ b/.claude/skills/backlog-intake/SKILL.md
@@ -168,7 +168,7 @@ If an anchor genuinely cannot be resolved, tag the row with `[stale — cited an
 Apply the `/backlog-remediate` initiative-sizing contract to each row. A row is **heroic** (and must be split) if any of:
 
 - It describes two or more distinct bugs that live in **different code paths** (different functions, different files).
-- It asks for ≥4 production-file edits to fulfill.
+- It asks for more than 4 production-file edits to fulfill.
 - Its regression tests are not trivially-additive variants of one shape.
 - Its "do" field contains a numbered "(1) fix A, (2) fix B, (3) fix C" list where each item is a different code change.
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-04T21:13:44Z
+**updated_at:** 2026-09-08T15:06:41Z
 
 ## Agent contract
 
@@ -29,7 +29,7 @@
 - **Detail lives in `items/<id>.md`, evidence in referenced reports** — not in this file. The `do` cell carries the title + next step only; the detail file carries anchors + acceptance + a one-line evidence summary plus the report path.
 - **Weak-evidence flag.** When a row's signal is thin (single retro session, self-audit only, etc.) say so explicitly in the `do` cell ("Weaker evidence — N until external session reproduces").
 - **GitHub-issue cross-link.** When a row has a corresponding open GitHub Issue, surface the link at the start of the `do` cell so the backlog and issue stay paired. Two flavors:
-  - **Reserved for contributor pickup** (`good first issue` / `help wanted` labels): prefix the `do` cell with `**Reserved — [gh #NNN](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/NNN) (good first issue|help wanted); skip in sweeps until contributor pickup.**` — `/backlog-sweep:plan` skips these per its Step 1 hard-skip rule. Remove the marker (or close the row) when a contributor PR lands or when the maintainer reclaims the work.
+  - **Reserved for contributor pickup** (`good first issue` / `help wanted` labels): prefix the `do` cell with `**Reserved — [gh #NNN](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/NNN) (good first issue|help wanted); skip in sweeps until contributor pickup.**` — `/backlog-remediate` skips these per its Step 1 hard-skip rule. Remove the marker (or close the row) when a contributor PR lands or when the maintainer reclaims the work.
   - **Tracked-only** (auto-filed audit issues that aren't promoted to a contributor label): prefix the `do` cell with `[gh #NNN](https://github.com/darylmcd/Roslyn-Backed-MCP/issues/NNN) — `. Sweep treats these as normal claimable rows; the implementing PR closes both the issue (via `Fixes #NNN`) and the backlog row.
 - **Priority tiers:** Critical > High > Medium > Low > Defer.
 - See `workflow.md` → **Backlog closure** for close-in-PR expectations.

--- a/ai_docs/workflow.md
+++ b/ai_docs/workflow.md
@@ -52,7 +52,7 @@ repo root:
 
     cd "$(git rev-parse --git-common-dir)/.." && gh pr merge <n> --squash --delete-branch
 
-See `~/.claude/prompts/backlog-sweep-execute.md` § Step 8 for the subagent-flow wording (global skill prompt; not in this repo).
+See `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/_subagent-result-protocol.md` for the current subagent-flow wording (global prompts; not in this repo).
 
 ## Release-managed file guard
 

--- a/changelog.d/retired-remediation-guidance-executors.md
+++ b/changelog.d/retired-remediation-guidance-executors.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Point executor and backlog-intake guidance at the current `/backlog-remediate` contract.


### PR DESCRIPTION
## Summary
- point executor and reconciler guidance at the current /backlog-remediate workflow
- update backlog intake sizing and verification references without renaming historical plan directories
- preserve the stable subagent result protocol link

## Validation
- pwsh -NoProfile -File ./eng/verify-ai-docs.ps1
- pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1

Open-only: do not merge.