### PR TITLE
docs(workflow): refresh remediation recovery guidance

### DIFF
--- a/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
+++ b/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
@@ -3,7 +3,7 @@ name: reconcile-backlog-sweep-plan
 installed_as: reconcile-backlog-sweep-plan
 description: "Reconcile a remediation plan's state.json + plan.md against merged/closed PR reality. Use when: multiple remediation PRs have landed and the plan still shows them as in-review/in-progress, or before picking the next pending initiative to avoid re-shipping already-merged work. Queries `gh pr view` per initiative, applies merged/deferred transitions, mirrors status into plan.md's table, and commits on a short-lived branch + PR (main is branch-protected). Automates the in-review reconcile from `/backlog-remediate`."
 user-invocable: true
-argument-hint: "[plan-dir path] — defaults to oldest non-terminal ai_docs/plans/*_backlog-sweep/ (FIFO drain; mirrors :execute Step 0b)"
+argument-hint: "[plan-dir path] — defaults to the oldest non-terminal ai_docs/plans/*_backlog-sweep/ per `/backlog-remediate` FIFO selection"
 ---
 
 # Reconcile Remediation Plan

--- a/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
+++ b/.claude/skills/reconcile-backlog-sweep-plan/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: reconcile-backlog-sweep-plan
 installed_as: reconcile-backlog-sweep-plan
-description: "Reconcile a backlog-sweep plan's state.json + plan.md against merged/closed PR reality. Use when: multiple backlog-sweep PRs have landed and the plan still shows them as in-review/in-progress, or before picking the next pending initiative to avoid re-shipping already-merged work. Queries `gh pr view` per initiative, applies merged/deferred transitions, mirrors status into plan.md's table, and commits on a short-lived branch + PR (main is branch-protected). Automates the in-review reconcile (Step 2) of `~/.claude/prompts/backlog-sweep-execute.md`."
+description: "Reconcile a remediation plan's state.json + plan.md against merged/closed PR reality. Use when: multiple remediation PRs have landed and the plan still shows them as in-review/in-progress, or before picking the next pending initiative to avoid re-shipping already-merged work. Queries `gh pr view` per initiative, applies merged/deferred transitions, mirrors status into plan.md's table, and commits on a short-lived branch + PR (main is branch-protected). Automates the in-review reconcile from `/backlog-remediate`."
 user-invocable: true
 argument-hint: "[plan-dir path] — defaults to oldest non-terminal ai_docs/plans/*_backlog-sweep/ (FIFO drain; mirrors :execute Step 0b)"
 ---
 
-# Reconcile Backlog-Sweep Plan
+# Reconcile Remediation Plan
 
 You are a plan-state reconciler. Your job is to walk a backlog-sweep plan's `state.json` and `plan.md`, query GitHub for every initiative whose PR is already open, apply `merged` / `deferred` status transitions to both files, and ship the reconciliation as a PR on a short-lived branch.
 
@@ -18,13 +18,13 @@ This skill edits repository files and shells out to `gh` + `git`. Roslyn MCP **`
 
 ## Input
 
-`$ARGUMENTS` optionally names the plan directory (relative to repo root, e.g. `ai_docs/plans/20260417T120000Z_backlog-sweep`). If omitted, enumerate `ai_docs/plans/*_backlog-sweep/`, classify each as terminal vs non-terminal (terminal = `completed: true` AND every initiative status in `{merged, obsolete, deferred}` — the canonical terminal set per `~/.claude/prompts/backlog-sweep-plan.md` § *State machine*), and select the **oldest non-terminal** plan (FIFO drain). This mirrors `:execute` Step 0b / `:status` — do NOT default to newest-by-name, which strands older non-terminal plans whose in-review PRs never get reconciled.
+`$ARGUMENTS` optionally names the plan directory (relative to repo root, e.g. `ai_docs/plans/20260417T120000Z_backlog-sweep`). The `_backlog-sweep` directory suffix is a historical compatibility label. If omitted, enumerate `ai_docs/plans/*_backlog-sweep/`, classify each as terminal vs non-terminal (terminal = `completed: true` AND every initiative status in `{merged, obsolete, deferred}` — the canonical terminal set in `~/.claude/prompts/backlog-remediate-rules.md`), and select the **oldest non-terminal** plan (FIFO drain). This mirrors `/backlog-remediate` plan selection — do NOT default to newest-by-name, which strands older non-terminal plans whose in-review PRs never get reconciled.
 
 ## Preconditions (HARD GATES — refuse if any fail)
 
 1. **`state.json` exists** at `{plan-dir}/state.json`. If missing, refuse: `"No state.json at {path}. Is this a backlog-sweep plan directory?"`.
 2. **`plan.md` exists** at `{plan-dir}/plan.md`. If missing, refuse.
-3. **`schemaVersion ∈ {2, 3, 4}`** in `state.json` (2 = legacy `/backlog-sweep:plan`; 3 = legacy `/backlog-sweep:prepare`-extended; 4 = `/backlog-sweep:prepare` status-SSOT, the **current default** — all three valid per the canonical field contract, which states every consumer including this skill MUST accept all three). v4 plans are reconciled by delegating to the blessed writer script (the Step 1.2 v4 fast path); 2/3 plans use the manual path below. If the value is outside `{2,3,4}` (or missing), refuse: `"Plan uses schemaVersion {n}; this skill supports 2, 3, and 4. Re-run /backlog-sweep:plan or :prepare to regenerate."`.
+3. **`schemaVersion ∈ {2, 3, 4}`** in `state.json` (2 and 3 are legacy schemas produced by the retired `/backlog-sweep:plan` and `/backlog-sweep:prepare` routes; 4 is the **current default** — all three remain valid per the canonical field contract). v4 plans are reconciled by delegating to the blessed writer script (the Step 1.2 v4 fast path); 2/3 plans use the manual path below. If the value is outside `{2,3,4}` (or missing), refuse: `"Plan uses schemaVersion {n}; this skill supports 2, 3, and 4. Re-run /backlog-remediate to regenerate."`.
 4. **`gh` CLI is on PATH** (`gh --version` exits 0). If not, refuse: `"gh CLI not available — cannot query PR state. Install gh or run Step 1b manually."`.
 5. **`git` CLI is on PATH** (`git --version` exits 0). If not, refuse.
 6. **Working tree is clean** (`git status --porcelain` is empty) OR the only dirty paths are the two files this skill will edit (`state.json` + `plan.md`). If dirtier, refuse: `"Working tree has unrelated changes — commit or stash before reconciling."`.
@@ -38,7 +38,7 @@ This skill edits repository files and shells out to `gh` + `git`. Roslyn MCP **`
 2. Read `{plan-dir}/state.json` into memory. Validate `schemaVersion ∈ {2, 3, 4}`.
    - **v4 fast path:** if `schemaVersion == 4` AND `~/.claude/scripts/bsweep-state.mjs` exists, delegate the whole reconcile to `node ~/.claude/scripts/bsweep-state.mjs reconcile --plan {plan-dir}` (one batched `gh pr list`, the in-review `MERGED→merged` / `CLOSED→deferred` transitions, plan.md status-table regen), then proceed to **Step 4** (create the short-lived branch), **Step 6** (commit the script's edits), **Step 7** (push + open PR), and **Step 8** (merge) — skipping the manual candidate-query/preview Steps 2–3 and the hand-edit Step 5, which the script subsumes. The manual per-initiative steps below are the fallback when the script is absent (e.g. an external plugin consumer) or the plan is pre-v4.
 3. Read `{plan-dir}/plan.md` into memory.
-4. Build the **reconciliation candidate list**: every initiative whose `status` is `in-review` or `in-progress` AND whose `prUrl` is non-null. Skip `pending`, `merged`, `obsolete`, `deferred`, and `paused-usage-limit` (the last is a mid-flight recovery state with no mergeable PR — resume it via `/backlog-sweep:execute initiative=<id>`, don't reconcile it here).
+4. Build the **reconciliation candidate list**: every initiative whose `status` is `in-review` or `in-progress` AND whose `prUrl` is non-null. Skip `pending`, `merged`, `obsolete`, `deferred`, and `paused-usage-limit` (the last is a mid-flight recovery state with no mergeable PR — resume it via `/backlog-remediate initiative=<id>`, don't reconcile it here).
 5. If the candidate list is empty, report `"Nothing to reconcile — no in-review/in-progress initiatives with a PR URL."` and exit **without** creating a branch or PR.
 
 ### Step 2 — Query GitHub for each candidate
@@ -51,7 +51,7 @@ gh pr view <prUrl> --json number,state,mergedAt,mergeCommit,closedAt
 
 Parse the JSON. Tolerate a single-retry on transient `gh` failure (network / rate limit). If `gh pr view` fails twice, record the initiative id + error in a failure list; do NOT flip its status; continue with the rest.
 
-Compute the intended transition per the rules from `~/.claude/prompts/backlog-sweep-execute.md` § Step 2 (in-review reconcile) and the canonical field contract in `~/.claude/prompts/backlog-sweep-plan.md` § *Canonical state.json field contract*:
+Compute the intended transition per the in-review reconciliation and canonical state contract in `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/backlog-remediate-rules.md`:
 
 | Observed `state` | `mergedAt` | New `status` | Notes field update |
 |---|---|---|---|
@@ -102,7 +102,7 @@ For each in-flight transition:
    - For `deferred`: append the "PR #<n> closed without merge — manual triage required" note to `notes` (separator `" | "` if notes already non-empty).
    - Leave other fields (branch, worktreePath, rowsClosedCount, …) untouched — but NEVER null out `prUrl` on a `merged` record.
 
-2. **Update plan.md's Status row** for this initiative (legacy 2/3 plans only — v4 plans have NO per-stanza Status row; the Step 1.2 v4 fast path already regenerated the generated status table via the script). The initiative's stanza in `plan.md` is a markdown table under its `### {order}. \`{initiative-id}\` — {title}` heading (canonical shape: `~/.claude/prompts/backlog-sweep-plan.md` Step 8), with a `| Status | {value} |` row. Rewrite ONLY that row's value cell:
+2. **Update plan.md's Status row** for this initiative (legacy 2/3 plans only — v4 plans have NO per-stanza Status row; the Step 1.2 v4 fast path already regenerated the generated status table via the script). The initiative's stanza in `plan.md` is a markdown table under its `### {order}. \`{initiative-id}\` — {title}` heading (legacy shape retained by `~/.claude/prompts/backlog-remediate-rules.md`), with a `| Status | {value} |` row. Rewrite ONLY that row's value cell:
    - `merged` → `| Status | merged (PR #{n}, {YYYY-MM-DD from mergedAt}) |`
    - `deferred` → `| Status | deferred (PR #{n} closed; see notes) |`
    - Do not touch any other table row (Order / Correctness class / Schedule hint / Estimated context / CHANGELOG category).
@@ -190,7 +190,7 @@ Reconciliation complete.
   Post-reconciliation status buckets: {pending-count} pending, {in-review-count} in-review, {merged-count} merged, {obsolete-count} obsolete, {deferred-count} deferred.
 ```
 
-If all initiatives are now terminal (`merged` / `obsolete` / `deferred`), additionally note: `"Plan fully shipped — run /backlog-sweep:execute Step 2 completion (marks completed: true + adds Refs entry) or prompt the user."` — do NOT do that completion step yourself; that is the executor's job.
+If all initiatives are now terminal (`merged` / `obsolete` / `deferred`), additionally note: `"Plan fully shipped — run /backlog-remediate completion (marks completed: true + adds Refs entry) or prompt the user."` — do NOT do that completion step yourself; that is the executor's job.
 
 **Worktree teardown discipline (Windows).** After this skill completes, the orchestrator typically removes worktrees for merged initiatives via `git worktree remove --force .worktrees/<id>`. On Windows, `VBCSCompiler.exe` and `MSBuild.exe` build-server processes hold file-system locks on the worktree's bin/obj directories — `git worktree remove` will fail with `Permission denied` until those locks are released. The fix: call `workspace_close(workspaceId: <id>, drainProcesses: true)` for each loaded workspace BEFORE calling `git worktree remove`. The `drainProcesses: true` flag runs `dotnet build-server shutdown` after session disposal, which releases all out-of-process build-server locks. This step is a no-op when no build-server is running, so it is always safe to prepend.
 
@@ -231,5 +231,5 @@ The executor prompt historically said "commit both edits on main". This repo has
 ## Distinct from related skills
 
 - **`/ship`**: ships the working branch's PR-scope changes. This skill runs on main after `/ship`-style PRs have merged, to mirror GitHub-observed state back into the plan files. Do not confuse: `/ship` runs per initiative; `/reconcile-backlog-sweep-plan` runs between initiative waves.
-- **`~/.claude/prompts/backlog-sweep-execute.md` Step 2 (in-review reconcile)**: the prompt logic this skill automates. If the user says "run the in-review reconcile" (legacy name: "Step 1b") they want this skill.
-- **`:execute` Step 2 completion (mark `completed: true`, add Refs row)**: deliberately NOT automated here — that edit also touches `ai_docs/backlog.md`'s Refs table, which is an executor concern, not a reconciliation concern.
+- **`/backlog-remediate` in-review reconcile**: the prompt logic this skill automates. If the user says "run the in-review reconcile" (legacy name: "Step 1b") they want this skill.
+- **`/backlog-remediate` completion (mark `completed: true`, add Refs row)**: deliberately NOT automated here — that edit also touches `ai_docs/backlog.md`'s Refs table, which is an executor concern, not a reconciliation concern.

--- a/.claude/skills/reconcile-backlog-vs-issues/SKILL.md
+++ b/.claude/skills/reconcile-backlog-vs-issues/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reconcile-backlog-vs-issues
 installed_as: reconcile-backlog-vs-issues
-description: "Audit every `gh #NNN` reference in `ai_docs/backlog.md` against live GitHub Issue state and emit a 5-state triage report. Use when: chasing drift between backlog rows and Issues after merges, manual issue closures, label changes, or contributor inactivity; before a `/backlog-sweep:plan` run to surface zombie rows or stale reservations the planner shouldn't pick. Read-only — does not edit `backlog.md` or close Issues; produces a structured recommendation list the maintainer applies via `/close-backlog-rows` or manual edits."
+description: "Audit every `gh #NNN` reference in `ai_docs/backlog.md` against live GitHub Issue state and emit a 5-state triage report. Use when: chasing drift between backlog rows and Issues after merges, manual issue closures, label changes, or contributor inactivity; before `/backlog-remediate` to surface zombie rows or stale reservations the workflow shouldn't pick. Read-only — does not edit `backlog.md` or close Issues; produces a structured recommendation list the maintainer applies via `/close-backlog-rows` or manual edits."
 user-invocable: true
 argument-hint: "[--stale-days N] (default 60) — threshold for the reserved-stale classification"
 ---

--- a/.claude/skills/recover-stalled-subagent/SKILL.md
+++ b/.claude/skills/recover-stalled-subagent/SKILL.md
@@ -14,7 +14,7 @@ This skill does **not** query GitHub, reconcile plan state, edit `state.json` / 
 
 ## Why this exists
 
-Cold-subagent stalls (~1 in 10 spawn rate observed across 2026-04-17+18 passes) can emit a thought-fragment final message without the `<<<RESULT>>>` sentinel — see `~/.claude/prompts/_subagent-result-protocol.md` Appendix B's malformed-result detection (the subagent result protocol extracted from `backlog-sweep-execute.md`). The orchestrator then cannot parse a PR URL, but the subagent may have already produced real edits in its worktree. 2026-04-18 pass-3 init-5 stranded 729 insertions across 4 prod files + 1 test file before a 3-turn manual recovery dance.
+Cold-subagent stalls (~1 in 10 spawn rate observed across 2026-04-17+18 passes) can emit a thought-fragment final message without the `<<<RESULT>>>` sentinel — see `~/.claude/prompts/_subagent-result-protocol.md` Appendix B's malformed-result detection. The orchestrator then cannot parse a PR URL, but the subagent may have already produced real edits in its worktree. 2026-04-18 pass-3 init-5 stranded 729 insertions across 4 prod files + 1 test file before a 3-turn manual recovery dance.
 
 Manual recovery steps (each with its own foot-gun):
 
@@ -23,7 +23,7 @@ Manual recovery steps (each with its own foot-gun):
 3. Commit with a well-formed WIP message citing the original branch.
 4. Push to origin (so the WIP is durable before worktree removal).
 5. `cd` back to primary repo root — NOT from inside the worktree, or the next step fails.
-6. `dotnet build-server shutdown` **before** `git worktree remove --force`, or the Windows testhost/VBCSCompiler file lock on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/` leaves a stale `.worktrees/<id>` directory that the orchestrator must `rm -rf` manually (`Device or resource busy` on `git worktree remove`). This is the fix shipped by initiative 5 in PR #288; see `~/.claude/prompts/backlog-sweep-execute.md` § Worktree cleanup for the canonical discipline.
+6. `dotnet build-server shutdown` **before** `git worktree remove --force`, or the Windows testhost/VBCSCompiler file lock on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/` leaves a stale `.worktrees/<id>` directory that the orchestrator must `rm -rf` manually (`Device or resource busy` on `git worktree remove`). This is the fix shipped by initiative 5 in PR #288; see `~/.claude/prompts/backlog-remediate.md` for the canonical cleanup discipline.
 7. `git worktree remove --force .worktrees/<id>`.
 8. Emit a STATE_HANDOFF block the orchestrator can paste into `state.json.initiatives[n].notes`.
 
@@ -131,7 +131,7 @@ dotnet build-server shutdown
 
 The command prints one informational line even in the no-op case (e.g. `"Build server didn't shut down due to an error or it wasn't running."`) — ignore this; it is not an error.
 
-See `~/.claude/prompts/backlog-sweep-execute.md` § Worktree cleanup for the canonical shipped discipline (initiative 5 / PR #288).
+See `~/.claude/prompts/backlog-remediate.md` for the canonical shipped cleanup discipline (initiative 5 / PR #288).
 
 ### Step 6 — Remove the worktree
 
@@ -190,7 +190,7 @@ After the STATE_HANDOFF block, emit a one-line human summary for the console (e.
 Classification: full-recovery (4 modified files, 0 unpushed commits).
 Staging explicit paths:
   A  .claude/agents/workspace-health-triage.md
-  M  ai_docs/prompts/backlog-sweep-execute.md
+  M  ai_docs/prompts/backlog-remediate.md
   M  ai_docs/workflow.md
   M  README.md
 Committing as wip(workspace): remediation/workspace-health-triage-subagent-partial (subagent stalled)... 1f3a9c2

--- a/ai_docs/known-flakes.md
+++ b/ai_docs/known-flakes.md
@@ -1,10 +1,10 @@
 # Known flakes
 
-<!-- purpose: Authoritative list of pre-existing flaky tests that subagents and the orchestrator should ignore when judging "is the build green?". Consulted by /backlog-sweep:execute Step 7 and Appendix B's failure-result parser. -->
+<!-- purpose: Authoritative list of pre-existing flaky tests that remediation executors and the orchestrator consult when judging "is the build green?". -->
 
 Pre-existing flaky tests that subagents and the orchestrator should ignore when judging "is the build green?". When all failing tests match a registered pattern, the validation step treats the result as success and surfaces the count via `known flakes encountered: N` in the report.
 
-**Discipline** (per `/backlog-sweep:execute` skill § *Known-flakes registry*):
+**Discipline** (per `/backlog-remediate`):
 
 - Subagents MUST NOT add new entries themselves — flakes go in via a dedicated PR after triage so the registry reflects real, investigated flakes, not noise.
 - The orchestrator may consult this registry to override a subagent's failure verdict, but MUST NOT add entries during a sweep.

--- a/changelog.d/retired-remediation-guidance-recovery.md
+++ b/changelog.d/retired-remediation-guidance-recovery.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Refresh remediation-plan reconciliation, recovery, and known-flake guidance.


### PR DESCRIPTION
## Summary
- point plan reconciliation and issue drift checks at /backlog-remediate
- retain retired command names only as explicit legacy schema provenance
- refresh stalled-subagent cleanup and known-flake references

## Validation
- pwsh -NoProfile -File ./eng/verify-ai-docs.ps1
- pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1

Open-only: do not merge.