### PR TITLE
docs(workflow): refresh remediation intake guidance

### DIFF
--- a/ai_docs/procedures/deep-review-backlog-intake.md
+++ b/ai_docs/procedures/deep-review-backlog-intake.md
@@ -18,9 +18,9 @@ The skill does end-to-end intake:
 1. **Stages** deep-review artifacts by invoking `eng/stage-review-inbox.ps1`, which discovers the recognized deep-review artifact shapes (canonical list: see `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes"; do not re-list the globs here) across sibling repos + this repo's own `ai_docs/audit-reports/` + `ai_docs/reports/`, and copies them into `review-inbox/` (default — preserves the canonical source location; pass `-Move` to clear the source instead).
 2. **Extracts** actionable items via a subagent (context-protecting).
 3. **Deduplicates** semantically across files (not literal-text matching).
-4. **Verifies** each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest backlog-sweep plan, dropping items that have already shipped.
+4. **Verifies** each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest remediation plan, dropping items that have already shipped.
 5. **Fixes anchors** — rewrites each row to cite real service-class filenames (under `src/RoslynMcp.Roslyn/Services/`) plus the tool registration (under `src/RoslynMcp.Host.Stdio/Tools/`).
-6. **Splits heroic rows** per `~/.claude/prompts/backlog-sweep-plan.md` Rule 1 (one code path, ≤4 prod files, ≤3 test files, one regression shape).
+6. **Splits heroic rows** per `~/.claude/prompts/backlog-remediate-rules.md` (one code path, ≤4 prod files, ≤3 test files, one regression shape).
 7. **Ranks** P2 / P3 / P4 using correctness-risk bands.
 8. **Commits** to a fresh branch off `main` (never pushed automatically).
 
@@ -54,4 +54,4 @@ If you just want files copied into `review-inbox/` without triage:
 - [`deep-review-program.md`](deep-review-program.md) — program context (coverage matrix, client lanes, cadence).
 - [`deep-review-command-reference.md`](deep-review-command-reference.md) — concrete commands.
 - [`../../skills/mcp-server-surface-test/prompts/full.md`](../../skills/mcp-server-surface-test/prompts/full.md) — canonical audit prompt run by both `/mcp-server-surface-test` (consumer) and `/mcp-server-stress` (maintainer alias for `--output-mode=fragments`); produces the artifacts this skill consumes.
-- `~/.claude/prompts/backlog-sweep-plan.md` (global) — planner prompt that consumes the backlog this skill produces.
+- `~/.claude/prompts/backlog-remediate.md` and `backlog-remediate-rules.md` (global) — workflow contract that consumes the backlog this skill produces.

--- a/ai_docs/procedures/deep-review-command-reference.md
+++ b/ai_docs/procedures/deep-review-command-reference.md
@@ -31,9 +31,9 @@ This runs the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) s
 1. Stages the recognized deep-review artifact shapes from sibling repos + this repo into `review-inbox/`. The canonical list of recognized shapes lives in `eng/stage-review-inbox.ps1` `.DESCRIPTION` -> "Recognized shapes" — read it there; do not re-list the globs here. (`backlog.d/` fragments are the exception: they are consumed in place, not staged.)
 2. Extracts actionable items via a subagent (context-protecting).
 3. Deduplicates semantically across files.
-4. Verifies each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest backlog-sweep plan.
+4. Verifies each candidate against `CHANGELOG.md` [Unreleased] + last 3 versions + the newest remediation plan.
 5. Fixes service / tool anchors so each row lands on real files.
-6. Splits heroic rows per `~/.claude/prompts/backlog-sweep-plan.md` Rule 1 / 3 / 4.
+6. Splits heroic rows per `~/.claude/prompts/backlog-remediate-rules.md` initiative-sizing rules.
 7. Ranks P2 / P3 / P4.
 8. Commits to a fresh branch off `main`.
 

--- a/ai_docs/procedures/deep-review-program.md
+++ b/ai_docs/procedures/deep-review-program.md
@@ -120,7 +120,7 @@ Each batch rollup in `ai_docs/reports/` should include:
 
 ## Backlog intake rules
 
-Default intake is **driven by the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) skill** (`/backlog-intake`). It stages review artifacts, extracts actionable items via a context-protecting subagent, dedupes semantically, verifies each candidate against `CHANGELOG.md` + the newest backlog-sweep plan, fixes service / tool anchors, splits heroic rows per `~/.claude/prompts/backlog-sweep-plan.md` Rule 1 / 3 / 4, ranks P2 / P3 / P4, and commits to a fresh branch off `main`.
+Default intake is **driven by the [`backlog-intake`](../../.claude/skills/backlog-intake/SKILL.md) skill** (`/backlog-intake`). It stages review artifacts, extracts actionable items via a context-protecting subagent, dedupes semantically, verifies each candidate against `CHANGELOG.md` + the newest remediation plan, fixes service / tool anchors, splits heroic rows per `~/.claude/prompts/backlog-remediate-rules.md`, ranks P2 / P3 / P4, and commits to a fresh branch off `main`.
 
 - Dedupe key (human triage): `tool + symptom + catalog-version + client-family`.
 - Narrative-only sources (test-suite audits, manual retros without a matching filename pattern) still need a by-hand row in `ai_docs/backlog.md`.

--- a/ai_docs/prompts/backlog-sweep-addenda.md
+++ b/ai_docs/prompts/backlog-sweep-addenda.md
@@ -1,10 +1,10 @@
-# Backlog-sweep addenda — Roslyn-Backed-MCP
+# Backlog-remediation addenda — Roslyn-Backed-MCP
 
-<!-- purpose: Repo-specific facts consumed by the global /backlog-sweep:{plan,review,execute} commands. -->
+<!-- purpose: Repo-specific facts consumed by the global /backlog-remediate workflow. -->
 <!-- scope: in-repo -->
-<!-- contract: read by ~/.claude/commands/backlog-sweep/*.md when present in this repo. -->
+<!-- contract: historical filename retained for compatibility; read by /backlog-remediate when present. -->
 
-This file is the single source of repo-specific extensions to the generic `/backlog-sweep` workflow. The global commands handle Rules 1–5, state.json schema, plan-dir convention, ship discipline, and mode dispatch. Everything below is **facts about this repo** the global commands need to do their job here.
+This file is the single source of repo-specific extensions to `/backlog-remediate`. The global workflow handles routing, state schema, plan-directory convention, ship discipline, and mode dispatch. Everything below is **facts about this repo** the workflow needs to do its job here.
 
 If you change a fact (e.g. add a new hotspot file, swap build commands, ship a new analyzer that gates a structural unit), update this file in the same PR.
 
@@ -61,7 +61,7 @@ parallel_safety:
   scope_caveat: |
     The evidence covers the fixture-copy path, which is where the contention was.
     It is NOT a proof that every test in the suite is parallel-safe. Flip
-    parallelSafe back to false (which forces `/backlog-sweep:execute` serial mode
+    parallelSafe back to false (which forces `/backlog-remediate` serial mode
     and engages `bsweep-state.mjs ci-lock-acquire`) if a NEW machine-global
     dependency appears — a fixed port, a shared database, an HKCU/%AppData% write,
     or any test writing outside `TestTempRoot.Current`.
@@ -182,7 +182,7 @@ backlog_intake_extractor: .claude/agents/backlog-intake-extractor.md  # Phase 1 
 
 When the global execute command's Step 7 subagent briefing mentions "if available", these are what's available. (Step 10 lands PRs via `/ship` directly — it no longer spawns a reconciler subagent.)
 
-## Skills wired to backlog-sweep workflow
+## Skills wired to backlog-remediation workflow
 
 ```yaml
 draft_changelog_entry: /draft-changelog-entry

--- a/changelog.d/retired-remediation-guidance-intake.md
+++ b/changelog.d/retired-remediation-guidance-intake.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Align deep-review intake addenda and procedures with `/backlog-remediate`.


### PR DESCRIPTION
## Summary
- designate the historical backlog-sweep addenda filename as a compatibility label
- route active intake guidance through /backlog-remediate and its rules contract
- update deep-review procedure references without touching immutable reports or plans

## Validation
- pwsh -NoProfile -File ./eng/verify-ai-docs.ps1
- pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1

Open-only: do not merge.