### PR TITLE
docs(mcp): use user-scoped Roslyn registration

### DIFF
--- a/.cursor/rules/operational-essentials.md
+++ b/.cursor/rules/operational-essentials.md
@@ -26,14 +26,14 @@ All commands are available as `just` recipes (`just --list` for the full menu).
 
 ## Roslyn MCP (C#)
 
-- Connect the **`roslyn`** MCP server (repo `.mcp.json`: `roslynmcp` stdio).
+- Connect the **`roslyn`** MCP server from user/session-scoped client configuration (`roslynmcp` stdio). Do not add or depend on a repo-local registration; confirm it is live with `server_heartbeat` or `server_info`.
 - **Read-side first (every session, including bootstrap):** `compile_check` over
   `dotnet build`; `test_related_files` + `test_run --filter` over `dotnet test`;
   `find_references` / `symbol_search` over `Grep`. Primer: `ai_docs/bootstrap-read-tool-primer.md`.
 - For C# edits on peer repos, use Roslyn MCP **refactoring** tools
   (`rename_*`, `extract_*`, `code_fix_*`, etc.) with preview → apply.
 - On THIS repo, write-side rules depend on session shape:
-  - **Worktree session** (default for backlog-sweep subagents; running against the
+  - **Worktree session** (default for `/backlog-remediate` delegated executors; running against the
     installed global tool): `*_apply` is safe — use it when a refactor tool covers the
     operation. Load the worktree's own `RoslynMcp.slnx`; `workspace_reload` after
     apply if a downstream call needs fresh state.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ For session bootstrap and workflow, follow `AGENTS.md` first.
 
 ## Roslyn MCP (AI sessions in this repo)
 
-- Enable the **`roslyn`** MCP server (`roslynmcp` via stdio; see repo `.mcp.json`).
+- Expect the **`roslyn`** MCP server from user/session-scoped client configuration (`roslynmcp` via stdio). Do not add or depend on a repo-local registration; verify liveness with `server_heartbeat` or `server_info` before relying on it.
 - **Read-side tools are the default** for every session — including bootstrap
   self-edit on this repo — and are 5–30× faster than `Grep` / `Bash: dotnet build` /
   `Bash: dotnet test`. Specifically: prefer `compile_check` over `dotnet build`,
@@ -35,7 +35,7 @@ For session bootstrap and workflow, follow `AGENTS.md` first.
   multi-file text edits when a tool covers the operation (rename, extract/move type,
   code fixes, bulk type replace, etc.) — preview first, then apply.
 - **Write-side on THIS repo:** depends on session shape.
-  - *Worktree session* (default for backlog-sweep subagents; running against the
+  - *Worktree session* (default for `/backlog-remediate` delegated executors; running against the
     installed global `roslynmcp` tool): `*_apply` is safe — use it when a Roslyn MCP
     refactor tool covers the operation. Load the worktree's own `RoslynMcp.slnx`;
     `workspace_reload` after apply if a downstream call needs fresh state.

--- a/ai_docs/README.md
+++ b/ai_docs/README.md
@@ -48,7 +48,7 @@ This directory is the canonical AI-facing documentation tree. Use this file to f
 | `ai_docs/prompts/standardize-backlog-hygiene.md` | Reference prompt for backlog/workflow hygiene alignment |
 | `ai_docs/prompts/stress-test-external-repo.md` | Performance and correctness stress-test protocol for large external solutions |
 | `ai_docs/prompts/roslyn-mcp-multisession-retro.md` | Cross-repo retrospective prompt that scans Claude Code session transcripts for Roslyn MCP issues, missing-tool gaps, and recommendations |
-| `ai_docs/prompts/backlog-sweep-addenda.md` | Repo-specific addenda for backlog-sweep planner/review prompts |
+| `ai_docs/prompts/backlog-sweep-addenda.md` | Repo-specific `/backlog-remediate` addenda; historical filename retained for compatibility |
 
 ## Reports And Archive
 

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -93,7 +93,7 @@ Plugin-relevant files in this repo:
 - `.claude-plugin/` — plugin manifest and marketplace descriptor
 - `skills/` — bundled skill prompts
 - `hooks/` — PreToolUse and PostToolUse safety hooks
-- User/session-scoped MCP client configuration — supplies the `roslynmcp` stdio registration; this repository intentionally carries no repo-local registration
+- User/session-scoped MCP client configuration — the preferred source of the `roslynmcp` stdio registration; do not depend on the redundant repo-local transition file while its removal is pending
 
 Install via:
 

--- a/ai_docs/runtime.md
+++ b/ai_docs/runtime.md
@@ -93,7 +93,7 @@ Plugin-relevant files in this repo:
 - `.claude-plugin/` — plugin manifest and marketplace descriptor
 - `skills/` — bundled skill prompts
 - `hooks/` — PreToolUse and PostToolUse safety hooks
-- `.mcp.json` — repo-local MCP declaration; may include literal `env` overrides for project-specific tuning
+- User/session-scoped MCP client configuration — supplies the `roslynmcp` stdio registration; this repository intentionally carries no repo-local registration
 
 Install via:
 
@@ -112,7 +112,7 @@ Copy-ready `.mcp.json` examples live under `docs/mcp-json-examples/`.
 
 ## Roslyn MCP Client Policy (AI sessions)
 
-The Roslyn MCP server is the default tool surface for C# work in this repository: navigation, search, diagnostics, verification, and covered refactoring flows.
+The Roslyn MCP server is the expected tool surface for C# work in this repository: navigation, search, diagnostics, verification, and covered refactoring flows. Its user/session-scoped configuration is intent, not proof of liveness; confirm `server_heartbeat` or `server_info` succeeds before relying on it.
 
 ### Read-side default
 

--- a/changelog.d/user-scoped-roslyn-mcp-guidance.md
+++ b/changelog.d/user-scoped-roslyn-mcp-guidance.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Document user-scoped Roslyn MCP configuration and explicit live verification.


### PR DESCRIPTION
## Summary
- remove active guidance that depended on a repository-local Roslyn MCP registration
- document user/session-scoped configuration as intent and require live probes
- refresh the remediation addenda index description

## Validation
- `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1`
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1`

## Live MCP evidence
- Configured intent: user/session-scoped MCP client configuration remains the preferred runtime source while the redundant root `.mcp.json` transition file is removed separately.
- Documented contract: this PR routes setup to live `server_heartbeat` and `server_info` probes.
- Verified live in the remediation session: `server_heartbeat` succeeded on version `4.1.2+a936448` with connection state `idle` and zero loaded workspaces.
- Verified live in the remediation session: `server_info` succeeded with path-boundary enforcement enabled (`configuredRootCount: 1`) and catalog parity reported as `parityOk: true`.

Open-only: do not merge.