### PR TITLE
docs(backlog): add remediation parent children

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-04T21:13:44Z
+**updated_at:** 2026-09-08T16:03:08Z
 
 ## Agent contract
 
@@ -100,6 +100,8 @@
 | `test-service-container-production-di-lifetime` | Medium | test-shared-gate-rate-limit-isolation, test-service-container-two-phase-construction-cycle | Replace the handwritten test composition-root lifetime with a test-owned production registration provider plus explicit overrides, and dispose the provider exactly once. [type: test-architecture] [source: 2026-09-04 execution re-vet] | S | items/test-service-container-production-di-lifetime.md |
 | `scripting-supervisor-outer-cancellation-contended-timeout` | Medium | — | Replace the timing-sensitive scripting outer-cancellation regression with a causal supervisor lifecycle seam and repeated contention proof. | S | items/scripting-supervisor-outer-cancellation-contended-timeout.md |
 | `formatter-baseline-contended-nested-process-timeout-investigation` | Medium | — | **Identify the formatter baseline contended child-process stall** — reproduce the unexplained nested-process timeout before changing behavior, then lock the proven cause. [type: chore] [source: PR #1473 validation cold review] | S | items/formatter-baseline-contended-nested-process-timeout-investigation.md |
+| `retired-route-executor-intake-guidance` | Medium | — | **Route executor and intake guidance through `/backlog-remediate`.** Update the bounded executor/intake surfaces while preserving historical evidence. [type: chore] [source: bl-0318] | M | items/retired-route-executor-intake-guidance.md |
+| `retired-route-recovery-guidance` | Medium | — | **Route reconciliation and recovery guidance through `/backlog-remediate`.** Update the bounded recovery surfaces without changing durable semantics. [type: chore] [source: bl-0318] | M | items/retired-route-recovery-guidance.md |
 
 ## Low
 
@@ -229,6 +231,8 @@
 | `unused-code-analyzer-dead-local-complexity` | Low | — | Separate dead-local discovery, owner resolution, and exclusion policy; reduce the three hotspots below CC10. [type: quality] [source: 2026-09-04 touched-code review] | S | items/unused-code-analyzer-dead-local-complexity.md |
 | `unused-code-analyzer-duplicate-helper-complexity` | Low | — | Separate duplicate-helper enumeration, semantic classification, and projection; reduce both hotspots below CC10. [type: quality] [source: 2026-09-04 touched-code review] | S | items/unused-code-analyzer-duplicate-helper-complexity.md |
 | `mcp002-synthetic-test-tool-noise` | Low | — | **Remove MCP002 noise from the synthetic error-wire tool fixture** — decide whether the analyzer should exclude nested test tools or the fixture should use the supported description shape without altering its wire contract. [type: diagnostics] [source: 2026-09-04 compile_check] | S | items/mcp002-synthetic-test-tool-noise.md |
+| `user-scoped-roslyn-mcp-guidance` | Low | — | **Document user-scoped Roslyn MCP configuration.** Remove active reliance on the redundant root registration and require live probes. [type: chore] [source: bl-0207] | M | items/user-scoped-roslyn-mcp-guidance.md |
+| `retire-root-roslyn-mcp-registration` | Low | user-scoped-roslyn-mcp-guidance | **Remove the redundant root Roslyn MCP registration.** Delete its bootstrap while retaining the shipped plugin descriptor. [type: chore] [source: bl-0207] | M | items/retire-root-roslyn-mcp-registration.md |
 
 ## Defer
 

--- a/ai_docs/items/retire-root-roslyn-mcp-registration.md
+++ b/ai_docs/items/retire-root-roslyn-mcp-registration.md
@@ -1,0 +1,22 @@
+# retire-root-roslyn-mcp-registration — Remove the redundant root MCP registration
+
+**row:** `retire-root-roslyn-mcp-registration` · **pri:** `Low` · **size:** `M` · **deps:** `user-scoped-roslyn-mcp-guidance`
+
+## Anchors
+
+- `.gitignore`
+- `.mcp.json`
+- `AGENTS.md`
+- `ai_docs/architecture.md`
+
+## Acceptance
+
+- [ ] Delete the root Roslyn-only registration and its file-triggered bootstrap while retaining and documenting the distinct shipped plugin descriptor.
+
+## Regression shape
+
+Assert the root `.mcp.json` is absent, the AGENTS bootstrap trigger is absent, and fresh heartbeat, server-info, and catalog-parity probes succeed independently.
+
+## Evidence
+
+- The root registration duplicates the shipped plugin descriptor; implementation is prepared in PR #1483 and must follow the guidance child.

--- a/ai_docs/items/retired-route-executor-intake-guidance.md
+++ b/ai_docs/items/retired-route-executor-intake-guidance.md
@@ -1,0 +1,22 @@
+# retired-route-executor-intake-guidance — Refresh executor and intake remediation routes
+
+**row:** `retired-route-executor-intake-guidance` · **pri:** `Medium` · **size:** `M`
+
+## Anchors
+
+- `.claude/agents/initiative-executor.md`
+- `.claude/agents/pr-reconciler.md`
+- `.claude/skills/backlog-intake/SKILL.md`
+- `ai_docs/workflow.md`
+
+## Acceptance
+
+- [ ] Active executor and intake instructions route through `/backlog-remediate`; compatibility filenames and immutable historical evidence remain explicitly historical.
+
+## Regression shape
+
+Run the retired-name inventory over the four active surfaces and require every remaining match to be an explicit historical label.
+
+## Evidence
+
+- The `bl-0318` inventory identified these four bounded active guidance surfaces; implementation is prepared in PR #1479.

--- a/ai_docs/items/retired-route-recovery-guidance.md
+++ b/ai_docs/items/retired-route-recovery-guidance.md
@@ -1,0 +1,22 @@
+# retired-route-recovery-guidance — Refresh reconciliation and recovery routes
+
+**row:** `retired-route-recovery-guidance` · **pri:** `Medium` · **size:** `M`
+
+## Anchors
+
+- `.claude/skills/reconcile-backlog-sweep-plan/SKILL.md`
+- `.claude/skills/reconcile-backlog-vs-issues/SKILL.md`
+- `.claude/skills/recover-stalled-subagent/SKILL.md`
+- `ai_docs/known-flakes.md`
+
+## Acceptance
+
+- [ ] Active reconciliation, recovery, and known-flake guidance routes through `/backlog-remediate` without changing durable recovery semantics or historical labels.
+
+## Regression shape
+
+Run the retired-name inventory over the four active surfaces and require every remaining match to be an explicit compatibility or historical label.
+
+## Evidence
+
+- The `bl-0318` inventory identified these four bounded active guidance surfaces; implementation is prepared in PR #1480.

--- a/ai_docs/items/user-scoped-roslyn-mcp-guidance.md
+++ b/ai_docs/items/user-scoped-roslyn-mcp-guidance.md
@@ -1,0 +1,22 @@
+# user-scoped-roslyn-mcp-guidance — Refresh user-scoped MCP guidance
+
+**row:** `user-scoped-roslyn-mcp-guidance` · **pri:** `Low` · **size:** `M`
+
+## Anchors
+
+- `.cursor/rules/operational-essentials.md`
+- `.github/copilot-instructions.md`
+- `ai_docs/README.md`
+- `ai_docs/runtime.md`
+
+## Acceptance
+
+- [ ] All four active guidance surfaces identify user/session-scoped configuration as runtime intent and require live probes without claiming a repository-local declaration proves availability.
+
+## Regression shape
+
+Inventory the four guidance surfaces, then verify `server_heartbeat` and `server_info` are reported separately as documented, configured, and verified-live evidence.
+
+## Evidence
+
+- The `bl-0207` removal requires consumer guidance to stop depending on the redundant root registration first; implementation is prepared in PR #1482.


### PR DESCRIPTION
## Summary
- add real v15 Roslyn child rows for the remaining `bl-0318` executor and recovery slices
- add real v15 Roslyn child rows for the remaining `bl-0207` guidance and registration slices
- keep each child at the existing reviewed PR scope of four production anchors and order registration after guidance

## Validation
- `node C:/Users/daryl/.claude/scripts/backlog-lint.mjs .` — 0 errors; 18 pre-existing warnings
- `pwsh -NoProfile -File ./eng/verify-ai-docs.ps1` — passed
- `pwsh -NoProfile -File ./eng/verify-changelog-fragments.ps1` — passed; internal `ai_docs/**` planning/provenance is fragment-exempt
- staged-only pre-commit and post-commit guards — passed for the exact five-file set

## Review
- independent cold review: PASS
- row/detail lockstep, exact scopes, source tags, single acceptance/regression shape, and dependency direction verified

Open-only: do not merge.