### PR TITLE
docs(backlog): track adjacent workflow defects

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-08T17:29:41Z
+**updated_at:** 2026-09-08T18:00:09Z
 
 ## Agent contract
 
@@ -103,6 +103,7 @@
 | `retired-route-intake-workflow-guidance` | Medium | — | **Refresh intake and workflow remediation routes** — route both intake/workflow surfaces through `/backlog-remediate` while preserving compatibility semantics. [type: chore] [source: retired-route-executor-intake-guidance] | M | items/retired-route-intake-workflow-guidance.md |
 | `retired-route-reconciliation-guidance` | Medium | — | **Refresh reconciliation remediation routes** — route both reconciliation skills through `/backlog-remediate` without changing their durable semantics. [type: chore] [source: retired-route-recovery-guidance] | M | items/retired-route-reconciliation-guidance.md |
 | `retired-route-recovery-operations-guidance` | Medium | — | **Refresh recovery and flake remediation routes** — route recovery/flake guidance through `/backlog-remediate` without changing durable semantics. [type: chore] [source: retired-route-recovery-guidance] | M | items/retired-route-recovery-operations-guidance.md |
+| `pr-reconciler-fail-closed-ship-cleanup` | Medium | — | Route reconciler cleanup through canonical fail-closed shipping, preserve dirty-residue reporting, and statically reject force removal or swallowed deletion failures. | S | items/pr-reconciler-fail-closed-ship-cleanup.md |
 
 ## Low
 
@@ -236,6 +237,7 @@
 | `user-scoped-roslyn-mcp-runtime-guidance` | Low | — | **Refresh runtime MCP guidance** — distinguish configured intent from verified liveness and stop relying on the repo-local transition file. [type: chore] [source: user-scoped-roslyn-mcp-guidance] | M | items/user-scoped-roslyn-mcp-runtime-guidance.md |
 | `retire-root-roslyn-mcp-config` | Low | user-scoped-roslyn-mcp-editor-guidance,user-scoped-roslyn-mcp-runtime-guidance | **Remove the redundant root MCP configuration** — delete the root registration and keep local project registrations ignored. [type: chore] [source: retire-root-roslyn-mcp-registration] | M | items/retire-root-roslyn-mcp-config.md |
 | `retire-root-roslyn-mcp-bootstrap-docs` | Low | user-scoped-roslyn-mcp-editor-guidance,user-scoped-roslyn-mcp-runtime-guidance | **Remove obsolete root-registration documentation** — delete the file-triggered bootstrap and distinguish the shipped plugin descriptor. [type: chore] [source: retire-root-roslyn-mcp-registration] | M | items/retire-root-roslyn-mcp-bootstrap-docs.md |
+| `reserved-row-remediation-route-guidance` | Low | — | Replace the active Reserved-row `/backlog-sweep:plan` instruction with canonical `/backlog-remediate` guidance and add scoped retired-command validation. | S | items/reserved-row-remediation-route-guidance.md |
 
 ## Defer
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-08T18:00:09Z
+**updated_at:** 2026-09-08T18:04:16Z
 
 ## Agent contract
 
@@ -103,7 +103,7 @@
 | `retired-route-intake-workflow-guidance` | Medium | — | **Refresh intake and workflow remediation routes** — route both intake/workflow surfaces through `/backlog-remediate` while preserving compatibility semantics. [type: chore] [source: retired-route-executor-intake-guidance] | M | items/retired-route-intake-workflow-guidance.md |
 | `retired-route-reconciliation-guidance` | Medium | — | **Refresh reconciliation remediation routes** — route both reconciliation skills through `/backlog-remediate` without changing their durable semantics. [type: chore] [source: retired-route-recovery-guidance] | M | items/retired-route-reconciliation-guidance.md |
 | `retired-route-recovery-operations-guidance` | Medium | — | **Refresh recovery and flake remediation routes** — route recovery/flake guidance through `/backlog-remediate` without changing durable semantics. [type: chore] [source: retired-route-recovery-guidance] | M | items/retired-route-recovery-operations-guidance.md |
-| `pr-reconciler-fail-closed-ship-cleanup` | Medium | — | Route reconciler cleanup through canonical fail-closed shipping, preserve dirty-residue reporting, and statically reject force removal or swallowed deletion failures. | S | items/pr-reconciler-fail-closed-ship-cleanup.md |
+| `pr-reconciler-fail-closed-ship-cleanup` | Medium | — | **Make reconciler cleanup fail closed** — route cleanup through canonical shipping, preserve dirty-residue reporting, and reject force removal or swallowed deletion failures. [type: chore] [source: adjacent-cold-review] | M | items/pr-reconciler-fail-closed-ship-cleanup.md |
 
 ## Low
 
@@ -237,7 +237,7 @@
 | `user-scoped-roslyn-mcp-runtime-guidance` | Low | — | **Refresh runtime MCP guidance** — distinguish configured intent from verified liveness and stop relying on the repo-local transition file. [type: chore] [source: user-scoped-roslyn-mcp-guidance] | M | items/user-scoped-roslyn-mcp-runtime-guidance.md |
 | `retire-root-roslyn-mcp-config` | Low | user-scoped-roslyn-mcp-editor-guidance,user-scoped-roslyn-mcp-runtime-guidance | **Remove the redundant root MCP configuration** — delete the root registration and keep local project registrations ignored. [type: chore] [source: retire-root-roslyn-mcp-registration] | M | items/retire-root-roslyn-mcp-config.md |
 | `retire-root-roslyn-mcp-bootstrap-docs` | Low | user-scoped-roslyn-mcp-editor-guidance,user-scoped-roslyn-mcp-runtime-guidance | **Remove obsolete root-registration documentation** — delete the file-triggered bootstrap and distinguish the shipped plugin descriptor. [type: chore] [source: retire-root-roslyn-mcp-registration] | M | items/retire-root-roslyn-mcp-bootstrap-docs.md |
-| `reserved-row-remediation-route-guidance` | Low | — | Replace the active Reserved-row `/backlog-sweep:plan` instruction with canonical `/backlog-remediate` guidance and add scoped retired-command validation. | S | items/reserved-row-remediation-route-guidance.md |
+| `reserved-row-remediation-route-guidance` | Low | — | **Correct active Reserved-row remediation guidance** — replace the retired command with canonical `/backlog-remediate` guidance and add scoped validation. [type: chore] [source: adjacent-cold-review] | M | items/reserved-row-remediation-route-guidance.md |
 
 ## Defer
 

--- a/ai_docs/items/pr-reconciler-fail-closed-ship-cleanup.md
+++ b/ai_docs/items/pr-reconciler-fail-closed-ship-cleanup.md
@@ -1,0 +1,18 @@
+# pr-reconciler-fail-closed-ship-cleanup — Route reconciler cleanup through fail-closed shipping
+
+**row:** `pr-reconciler-fail-closed-ship-cleanup` · **pri:** `Medium` · **size:** `S`
+
+## Anchors
+
+- `.claude/agents/pr-reconciler.md`
+- `eng/verify-ai-docs.ps1`
+
+## Acceptance
+
+- [ ] Replace manual `git worktree remove --force` and swallowed remote-branch deletion failures with canonical `/ship --land=<pr>` cleanup or its fail-closed helper contract.
+- [ ] Preserve explicit reporting for dirty retained worktrees and failed local or remote cleanup.
+- [ ] Add a static AI-doc regression that rejects forced worktree removal and swallowed branch-deletion failures in active reconciler guidance.
+
+## Evidence
+
+- `.claude/agents/pr-reconciler.md:79-80` can discard dirty worktree residue and hides remote-delete failures, conflicting with the current operator-safe `/ship` cleanup contract.

--- a/ai_docs/items/pr-reconciler-fail-closed-ship-cleanup.md
+++ b/ai_docs/items/pr-reconciler-fail-closed-ship-cleanup.md
@@ -1,6 +1,6 @@
 # pr-reconciler-fail-closed-ship-cleanup — Route reconciler cleanup through fail-closed shipping
 
-**row:** `pr-reconciler-fail-closed-ship-cleanup` · **pri:** `Medium` · **size:** `S`
+**row:** `pr-reconciler-fail-closed-ship-cleanup` · **pri:** `Medium` · **size:** `M`
 
 ## Anchors
 

--- a/ai_docs/items/reserved-row-remediation-route-guidance.md
+++ b/ai_docs/items/reserved-row-remediation-route-guidance.md
@@ -1,0 +1,17 @@
+# reserved-row-remediation-route-guidance — Correct active Reserved-row remediation guidance
+
+**row:** `reserved-row-remediation-route-guidance` · **pri:** `Low` · **size:** `S`
+
+## Anchors
+
+- `ai_docs/backlog.md`
+- `eng/verify-ai-docs.ps1`
+
+## Acceptance
+
+- [ ] Replace the active `/backlog-sweep:plan` Reserved-row instruction with the canonical `/backlog-remediate` route and its `reserved` skip reason; preserve contributor-reservation and reclaim semantics.
+- [ ] Extend AI-doc validation to reject retired executable backlog command references in active workflow contracts without rejecting explicitly historical changelog or archive evidence.
+
+## Evidence
+
+- `ai_docs/backlog.md:32` still directs agents to a retired `/backlog-sweep:plan` Step 1 contract, while the canonical remediation rules now classify Reserved rows under skip reason `reserved`.

--- a/ai_docs/items/reserved-row-remediation-route-guidance.md
+++ b/ai_docs/items/reserved-row-remediation-route-guidance.md
@@ -1,6 +1,6 @@
 # reserved-row-remediation-route-guidance — Correct active Reserved-row remediation guidance
 
-**row:** `reserved-row-remediation-route-guidance` · **pri:** `Low` · **size:** `S`
+**row:** `reserved-row-remediation-route-guidance` · **pri:** `Low` · **size:** `M`
 
 ## Anchors
 


### PR DESCRIPTION
## Summary
- record the active Reserved-row reference to the retired backlog command
- record fail-open reconciler cleanup that can discard dirty residue or hide remote-delete failures
- keep the findings independently scoped with one regression shape each

## Validation
- backlog lint: 0 errors (17 pre-existing warnings)
- backlog audit: both rows declared/effective S, anchors resolve
- eng/verify-ai-docs.ps1
- eng/verify-changelog-fragments.ps1
- staged-only guard: exact 3/3 paths, post-commit verified

No runtime or public API behavior changes.