### PR TITLE
docs(prompts): pin retro quotes to a locator

### DIFF
--- a/ai_docs/prompts/roslyn-mcp-multisession-retro.md
+++ b/ai_docs/prompts/roslyn-mcp-multisession-retro.md
@@ -112,7 +112,7 @@ Body, in order:
 - `## 4. Suggested findings (up to 8)` — ranked, informational only. Each: **id** (kebab slug), **priority hint** (low / medium / high plus a one-line justification from cross-session and cross-harness recurrence), **title** (imperative, ≤80 chars), **summary** (2–4 sentences, quote-backed), **proposed action**, **surface** (`server` / `claude-harness` / `codex-harness` / `docs`, derived from the 2a attribution — a client-side fix is not a server defect), **evidence** (`2a#<tool>`, `2b#<task>`, `3#<pattern>` plus agent-tagged session ids). Skip anything not pinned to a quote; mark single-session or single-harness findings as such.
 - `## 5. Meta-note`
 
-Evidence rule for every section: quote verbatim from the JSONL, tag each quote with agent and session id, no hypotheticals.
+Evidence rule for every section: quote verbatim from the JSONL; tag each quote with agent, session id, and a locator (the `call_id` for a tool call, the record line number or message id for prose) so a reader can find it without a text search; no hypotheticals.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #1497 from an ultracode review of the thinned retro prompt (three-agent workflow: toolset-convention survey, Workflow-API decomposition proposal, adversarial refutation).

**Review outcome:** no orchestration section. Under ultracode the orchestrating model reads the prompt and authors the workflow itself; the prompt already names its aggregate seams lexically ("collapse across sessions and harnesses", "seen in ≥2 sessions", "compute the aggregate mix"), and the toolset's own rule keeps prose prompts harness-agnostic with topology in the runtime script (`workflows/README.md`). A proposed 15-line "§0b Orchestration" block was refuted as duplicating §0a and §1–§3 in a second shape.

**One change kept, over the refuter's objection:** the §4 evidence rule now requires a locator on every quote (`call_id` for a tool call, record line number or message id for prose). It is mode-independent: it lets the maintainer, the intake extractor, or a skeptic agent find a quote in a multi-MB JSONL without a text search, and it matches the transcript-anchor convention already used by `audit-findings-schema.md`. The refuter's grounds were that an orchestrator could add the locator at schema time; that covers a workflow's internal contract but not the report, which is the deliverable.

**Data point from the review's scout, not a prompt change:** the current 14-day window has zero Codex Roslyn MCP calls (newest is 2026-07-30 in `archived_sessions`); the next retro will report Codex as sample imbalance unless Codex usage resumes.

## Verification

- `eng/verify-ai-docs.ps1` passes.
- One-line change, LF-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
