### PR TITLE
docs: record remediation quality follow-ups

### DIFF
--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-10T19:46:08Z
+**updated_at:** 2026-09-10T21:30:47Z
 
 ## Agent contract
 
@@ -110,6 +110,7 @@
 | `test-run-full-suite-timeout-envelope` | Medium | — | Return a structured test_run timeout envelope instead of an unclassified tool error. [type: bug] [source: live-surface-audit] | M | items/test-run-full-suite-timeout-envelope.md |
 | `reconcile-plan-force-worktree-removal-safety` | Medium | — | Make normal reconciliation refuse dirty worktrees instead of force-removing them. [type: safety] [source: adjacent-cold-review] | S | items/reconcile-plan-force-worktree-removal-safety.md |
 | `workspace-manager-file-watcher-disposal-ownership` | Medium | — | Establish one explicit file-watcher disposal owner between production DI and WorkspaceManager. | M | items/workspace-manager-file-watcher-disposal-ownership.md |
+| `scripting-startup-cancellation-causal-barrier` | Medium | scripting-supervisor-outer-cancellation-contended-timeout | Replace the remaining startup-cancellation timing inference with a causal barrier and deterministic recovery proof. [type: test-reliability] [source: 2026-09-10 scripting supervisor remediation] | S | items/scripting-startup-cancellation-causal-barrier.md |
 
 ## Low
 
@@ -246,6 +247,9 @@
 | `retired-root-mcp-doc-index-audit-sync` | Low | — | **Synchronize current documentation after root registration retirement** — repair the document index and generated audit state while preserving dated history. [type: docs] [source: adjacent-cold-review] | M | items/retired-root-mcp-doc-index-audit-sync.md |
 | `cohesion-overload-cluster-symbol-identity` | Low | — | Preserve overload identities during cohesion clustering. [type: correctness] [source: live-surface-audit] | S | items/cohesion-overload-cluster-symbol-identity.md |
 | `tool-consolidation-merge-child-dependency-repair` | Low | — | Repair stale tool-consolidation merge-child dependency metadata. [type: planning] [source: live-backlog-review] | S | items/tool-consolidation-merge-child-dependency-repair.md |
+| `scaffold-syntactic-preflight-candidate-enumeration-decomposition` | Low | scaffold-fqn-target-type-disambiguation | Decompose syntactic scaffold preflight candidate enumeration so qualification-aware lookup and ambiguity policy have focused ownership. [type: maintainability] [source: 2026-09-10 scaffold FQN remediation] | S | items/scaffold-syntactic-preflight-candidate-enumeration-decomposition.md |
+| `structured-call-filter-owner-documentation-drift` | Low | structured-call-tool-filter-pipeline-decomposition | Correct stale structured-call ownership comments after pipeline decomposition. [type: documentation] [source: 2026-09-10 cold review] | M | items/structured-call-filter-owner-documentation-drift.md |
+| `structured-call-pipeline-collaborator-cohesion` | Low | structured-call-tool-filter-pipeline-decomposition | Further decompose structured workspace resolution and dispatch collaborators after the initial filter split. [type: refactor] [source: 2026-09-10 cold review] | M | items/structured-call-pipeline-collaborator-cohesion.md |
 
 ## Defer
 

--- a/ai_docs/backlog.md
+++ b/ai_docs/backlog.md
@@ -3,7 +3,7 @@
 <!-- purpose: Open work only. Slim-index format — triage in the table, implementation detail in items/<id>.md. Sync rows on ship. -->
 <!-- scope: in-repo -->
 
-**updated_at:** 2026-09-10T21:30:47Z
+**updated_at:** 2026-09-11T16:13:10Z
 
 ## Agent contract
 

--- a/ai_docs/items/prompt-wire-protocol-negotiation-parallel-isolation.md
+++ b/ai_docs/items/prompt-wire-protocol-negotiation-parallel-isolation.md
@@ -66,3 +66,4 @@ the modern harness unexpectedly retained a non-null `ClientCapabilities` snapsho
 immediately in isolation (1/1 in 184 ms). The same run built with zero warnings/errors and passed 2,922
 other tests, so this is further evidence of cross-session protocol negotiation state under a loaded suite,
 not an actionlint regression.
+Anchor correction (2026-09-11): Include tests/RoslynMcp.Tests/ElicitationChoicePromptTests.cs in this item's affected-harness anchor set. After the loaded-suite failure, the exact test passed three Release and one Debug isolated reruns; preserve its coverage in the repeated concurrent regression.

--- a/ai_docs/items/scaffold-syntactic-preflight-candidate-enumeration-decomposition.md
+++ b/ai_docs/items/scaffold-syntactic-preflight-candidate-enumeration-decomposition.md
@@ -1,0 +1,19 @@
+# scaffold-syntactic-preflight-candidate-enumeration-decomposition — Separate syntactic preflight candidate enumeration
+
+**row:** `scaffold-syntactic-preflight-candidate-enumeration-decomposition` · **pri:** `Low` · **size:** `S` · **deps:** `scaffold-fqn-target-type-disambiguation`
+
+## Anchors
+
+- `src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs`
+- `tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs`
+- `tests/RoslynMcp.Tests/SamplingMrtrWireTests.cs`
+
+## Acceptance
+
+- [ ] Project traversal, syntax enumeration, qualified-name projection, and ambiguity policy have focused ownership rather than one mixed preflight method.
+- [ ] Simple and fully qualified duplicate-type requests keep the same syntactic candidate behavior as semantic resolution.
+- [ ] Replay/sampling paths preserve their current qualification-aware result.
+
+## Regression
+
+Exercise a duplicate simple-name fixture through simple-name rejection, fully qualified selection, and sampling replay, proving the syntactic preflight candidates remain equivalent to semantic resolution.

--- a/ai_docs/items/scripting-startup-cancellation-causal-barrier.md
+++ b/ai_docs/items/scripting-startup-cancellation-causal-barrier.md
@@ -1,0 +1,17 @@
+# scripting-startup-cancellation-causal-barrier — Make startup cancellation coverage causal
+
+**row:** `scripting-startup-cancellation-causal-barrier` · **pri:** `Medium` · **size:** `S` · **deps:** `scripting-supervisor-outer-cancellation-contended-timeout`
+
+## Anchors
+
+- `tests/RoslynMcp.Tests/ScriptingServiceTests.cs`
+
+## Acceptance
+
+- [ ] The startup-cancellation regression observes worker startup through an explicit causal barrier instead of a per-await wall-clock timeout.
+- [ ] The test retains a method-level deadlock guard and proves cancellation releases capacity before a succeeding recovery evaluation.
+- [ ] The controlled shape remains repeatable enough to expose a startup/cancellation ordering regression.
+
+## Regression
+
+Run five controlled startup-cancel-recovery repetitions with task-completion barriers and no per-await timing budget.

--- a/ai_docs/items/structured-call-filter-owner-documentation-drift.md
+++ b/ai_docs/items/structured-call-filter-owner-documentation-drift.md
@@ -1,0 +1,20 @@
+# structured-call-filter-owner-documentation-drift — Correct structured-call ownership comments
+
+**row:** `structured-call-filter-owner-documentation-drift` · **pri:** `Low` · **size:** `M` · **deps:** `structured-call-tool-filter-pipeline-decomposition`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Middleware/StructuredCallElicitationCoordinator.cs` — stale statements that the filter retains auto-resolution, auto-load, error-envelope construction, and workspace-load result extraction.
+- `src/RoslynMcp.Host.Stdio/Middleware/SolutionDiscoveryHelper.cs` — stale caller/owner reference for omitted-workspace auto-load.
+- `tests/RoslynMcp.Tests/StructuredCallToolFilterAutoLoadTests.cs` — stale test comment naming the filter rather than the responsible collaborator.
+
+## Acceptance
+
+- [ ] Update ownership comments to name `StructuredWorkspaceResolver` for workspace auto-resolution/auto-load and `StructuredResultProjector` for terminal error construction after the pipeline decomposition lands.
+- [ ] Update the workspace-load result extraction reference to its live owner, without changing behavior or broadening the refactor.
+- [ ] Update the test comment to identify the live owner of ambiguous auto-load fast-fail behavior.
+- [ ] A targeted source/reference check or existing focused structured-call regression confirms no stale owner claims remain in these anchors.
+
+## Evidence
+
+- 2026-09-10 cold review of `structured-call-tool-filter-pipeline-decomposition` found these comments still describe the pre-decomposition ownership graph. The code refactor intentionally excluded them to preserve its approved file set; this row keeps the stale architecture documentation visible and bounded.

--- a/ai_docs/items/structured-call-pipeline-collaborator-cohesion.md
+++ b/ai_docs/items/structured-call-pipeline-collaborator-cohesion.md
@@ -1,0 +1,21 @@
+# structured-call-pipeline-collaborator-cohesion — Further decompose structured pipeline collaborators
+
+**row:** `structured-call-pipeline-collaborator-cohesion` · **pri:** `Low` · **size:** `M` · **deps:** `structured-call-tool-filter-pipeline-decomposition`
+
+## Anchors
+
+- `src/RoslynMcp.Host.Stdio/Middleware/StructuredWorkspaceResolver.cs` — `ResolveAsync` request-state, loaded-workspace, auto-load, and terminal-outcome decisions.
+- `src/RoslynMcp.Host.Stdio/Middleware/StructuredDispatchPipeline.cs` — `DispatchAsync` normalization, pre-bind path recovery, workspace resolution, and bound-dispatch orchestration.
+- `tests/RoslynMcp.Tests/StructuredCallToolFilterResolutionTests.cs` — resolver decision matrix.
+- `tests/RoslynMcp.Tests/StructuredCallToolFilterTests.cs` — legacy/modern recovery and retry wire matrix.
+
+## Acceptance
+
+- [ ] Split the resolver's request-state, loaded-workspace, and zero-workspace auto-load decisions into focused, named operations with one explicit outcome type.
+- [ ] Split the dispatcher's pre-bind recovery/terminal-result decisions from ordinary bound dispatch without duplicating error classification or terminal projection.
+- [ ] Preserve arguments, cancellation, auto-resolution metrics, elicitation protocol behavior, and public result envelopes.
+- [ ] Add a compact table-driven resolver/recovery regression matrix that covers request-state, explicit, single/file-path, fast-fail, auto-load, and elicitation-retry outcomes.
+
+## Evidence
+
+- 2026-09-10 cold review of the initial pipeline decomposition measured `StructuredWorkspaceResolver.ResolveAsync` at 108 LOC / cyclomatic complexity 15 / maintainability index 35.17 and `StructuredDispatchPipeline.DispatchAsync` at 116 LOC / cyclomatic complexity 12 / maintainability index 34.92. The parent row appropriately reduced the 299-LOC filter first; this follow-up bounds the remaining coordinator complexity without expanding that PR.


### PR DESCRIPTION
## Summary
- Record four bounded follow-ups found during the remediation review.
- Preserve fresh evidence and the missing affected-test anchor for the known parallel protocol-negotiation issue.

## Validation
- `pwsh -NoProfile -File eng/verify-ai-docs.ps1`
- Aggregate `just ci`: 2,931 passed, 7 skipped, 0 failed; NuGet audit clean.