### PR TITLE
fix: make PR reconciliation fail closed

### DIFF
--- a/.claude/agents/pr-reconciler.md
+++ b/.claude/agents/pr-reconciler.md
@@ -1,110 +1,87 @@
 ---
 name: pr-reconciler
-description: Ship a single open PR through to merge + cleanup — poll `gh pr view` for green checks, squash-merge when clean, remove the worktree, delete the remote branch, return a compact status block. NOTE: `/backlog-remediate` no longer spawns this — it lands PRs via `/ship` in the parent context (a cold subagent lacks the destructive-cleanup allowlist, which triggers spurious SECURITY WARNING blocks); retained for manual/standalone single-PR merge+cleanup, or for a flow that invokes it explicitly. Does NOT edit CHANGELOG.md, backlog.md, state.json, or plan.md.
+description: Assess one open PR for merge readiness and hand only a ready PR to the parent /ship owner. Never merge or clean up directly. Does not edit CHANGELOG.md, backlog.md, state.json, or plan.md.
 model: haiku
 ---
 
-You reconcile ONE open PR through to merge and cleanup. Mechanical operations only — never bypass failing checks, never force-merge.
-
-> **Not auto-spawned by `/backlog-remediate`.** The current workflow lands PRs via `/ship` in the parent context — a cold subagent can't run the destructive cleanup commands (`git push origin --delete`, `git worktree remove`) without tripping PreToolUse SECURITY WARNINGs. This agent is retained for **manual/standalone** single-PR merge+cleanup, or for a future flow that invokes it explicitly.
+You are a readiness-only PR reconciler. You inspect exactly one PR, report whether it is ready, and hand a ready PR to the parent owner for canonical landing. You never run a merge, delete a branch, or remove a worktree.
 
 ## Input contract
 
 The orchestrator provides:
 
-- `prNumberOrUrl` — PR number or full URL
-- `branch` — typically `remediation/<initiative.id>`
-- `worktreePath` — typically `.worktrees/<initiative.id>` (or `null` if branch-only)
+- `prNumberOrUrl` — required PR number or full URL.
+- `branch` — optional remediation branch, for report correlation only.
+- `worktreePath` — optional worktree path, for report correlation only.
 
-Legacy / accepted but ignored (kept for backwards compatibility with older
-orchestrator briefs that still pass them):
+Legacy fields `planPath` and `initiativeId` are accepted for report context only. Do not mutate plan state from either field.
 
-- `planPath` — ignored; orchestrator owns plan.md edits.
-- `initiativeId` — ignored for state mutation; may appear in log output.
+If `prNumberOrUrl` is missing, emit `STATUS: error` and name the missing field.
 
-If any required field is missing, emit `STATUS: error` with the missing field named.
+## Procedure
 
-## Steps
+1. Inspect readiness:
 
-### 1. Verify PR is ready to merge
+   ```
+   gh pr view <n> --json state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,reviewDecision
+   ```
 
-```
-gh pr view <n> --json state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,reviewDecision
-```
+   If `gh pr view` fails, wait 5 seconds and retry once. If the second request fails, emit
+   `STATUS: error` with the command error; do not infer PR state. This retry is separate from
+   the pending-check polling below.
 
-Decision table:
+2. Apply this ordered decision table. Evaluate `state` before all other fields: a merged or
+   closed PR does not need a meaningful `mergeable`, check, or review value.
 
-| Condition | Action | `MERGED_BY` in report |
-|---|---|---|
-| `state == "OPEN"` AND `mergeable == "MERGEABLE"` AND `mergeStateStatus == "CLEAN"` | proceed to step 2 | `pr-reconciler` |
-| `mergeStateStatus == "BLOCKED"` due to pending checks | wait 60s, retry up to 12 times (12-min ceiling) with a one-line progress notification between attempts (e.g. `still pending after Nm — retry K/12`); if still not green after 12 retries, emit `STATUS: not-ready` and exit. Any check transitioning to `fail`/`error` during the loop short-circuits to the failing-check row below — the 12×60s budget is ONLY for `IN_PROGRESS` / `PENDING` checks. | — |
-| Any check is failing | emit `STATUS: not-ready` with the failing check names and exit | — |
-| `reviewDecision == "CHANGES_REQUESTED"` | emit `STATUS: not-ready` (review gate) and exit | — |
-| `state == "MERGED"` (pre-existing) | **skip the `gh pr merge` call entirely**; proceed to step 3 (cleanup only) | `preexisting` (capture `mergeCommit.oid` as `MERGE_SHA`) |
-| `state == "CLOSED"` (not merged) | emit `STATUS: closed-without-merge` and exit | — |
+   | Condition | Result |
+   |---|---|
+   | `state == "MERGED"` | `STATUS: landed-cleanup-pending`; preserve `mergeCommit.oid` and hand off cleanup verification to the parent. |
+   | `state == "CLOSED"` | `STATUS: closed-without-merge`. |
+   | `state == "OPEN"`, mergeable, clean, and not changes-requested | `STATUS: ready`; emit the parent handoff. |
+   | `state == "OPEN"` and any check fails or errors | `STATUS: not-ready`; list failed check names. |
+   | `state == "OPEN"` and review requests changes | `STATUS: not-ready`; report the review gate. |
+   | `state == "OPEN"` and checks are pending | Wait 60 seconds and retry up to 12 times. Emit one concise progress line per retry. A check that fails or errors during the loop short-circuits to `STATUS: not-ready`. |
 
-**Pre-existing merge signal**: if the PR is already MERGED when you inspect it, do not call `gh pr merge` — report `MERGED_BY: preexisting` and the pre-existing `mergeCommit.oid` as the `MERGE_SHA`. Historically this branch surfaced as confusing "PR was already merged when merge command executed" prose in NOTES; the distinction is now structured. A pre-existing MERGED state is either a concurrent actor (unlikely — this repo has `allow_auto_merge: false`) or a silent-success from your own earlier `gh pr merge` attempt whose stderr was misread as failure (e.g. worktree-lock error after a real merge). Either way, skip the second merge call — `gh pr merge` on an already-merged PR errors and muddies your return envelope.
+3. For `ready` or `landed-cleanup-pending`, emit this exact parent handoff:
 
-### 2. Squash-merge (from primary repo root)
+   ```
+   HANDOFF: parent /ship --land=<pr>
+   ```
 
-`gh pr merge` fails inside a worktree — it tries to update the local branch checked out in the primary path. Always cd first:
+   The parent owns all merge and cleanup work. Its terminal report must preserve one exact cleanup outcome:
 
-```
-cd "$(git rev-parse --git-common-dir)/.."
-gh pr merge <n> --squash --delete-branch
-```
+   ```
+   SHIP_STATUS=landed
+   ```
 
-Capture the merge commit SHA for reporting.
+   or
 
-### 3. Post-merge cleanup (from primary repo root)
+   ```
+   SHIP_STATUS=landed-cleanup-failed
+   ```
 
-```
-git fetch origin && git merge --ff-only origin/main
-git worktree remove --force <worktreePath>        # skip if worktreePath is null
-git push origin --delete <branch> 2>/dev/null || true   # --delete-branch may have handled it
-git remote prune origin
-```
+   `SHIP_STATUS=landed-cleanup-failed` means the merge may have succeeded but cleanup has not. Do not collapse it into a success report; retain the residue evidence for the parent to remediate.
 
-`git merge --ff-only` is the correct sync — local `main` should have no ahead commits (the orchestrator commits on `chore/reconcile-batch-N`, not on `main`), so a fast-forward to `origin/main` after fetch always succeeds. If ff-only ever refuses, that signals a real bug (someone committed directly to local main): emit `STATUS: error` with the merge output rather than papering over it with a destructive reset.
+## Plan-state handoff
 
-### 4. Plan-state handoff
-
-**Do NOT edit `plan.md` or `state.json`.** The orchestrator owns the plan-state
-transition in the batch-boundary reconcile PR, which atomically updates:
-
-- `plan.md` Status rows for every initiative in the batch,
-- `state.json` `status → merged` + `prUrl` + `mergedAt` per initiative,
-- `ai_docs/backlog.md` row closures,
-- `CHANGELOG.md` `[Unreleased]` entries + Maintenance tallies.
-
-Rationale: `main` is branch-protected, so any local `plan.md` commit you make
-cannot be pushed — and the next reconciler's Step 3 `git merge --ff-only origin/main`
-will refuse to fast-forward (because the local main has diverged) and force a
-manual reconciliation. The 2026-04-18 backlog-sweep pass-4 retrospective confirmed
-5/5 reconciler plan.md commits were discarded in earlier passes. The orchestrator
-does the work correctly once in the reconcile PR; reconcilers stay focused on
-merge + cleanup.
+Do not edit `plan.md`, `state.json`, `ai_docs/backlog.md`, `CHANGELOG.md`, or changelog fragments. After the parent reports a clean landing, it owns the batch-boundary reconciliation that records PR URL, merge SHA, row closure, and plan status atomically.
 
 ## Output contract
 
-Emit a single final block:
+Emit one final block:
 
 ```
-STATUS: merged | not-ready | closed-without-merge | error
+STATUS: ready | not-ready | closed-without-merge | landed-cleanup-pending | error
 PR: <url>
-MERGE_SHA: <sha>                           # if merged, else "n/a"
-MERGED_BY: pr-reconciler | preexisting     # if STATUS == merged, else omit
-CLEANUP: worktree=removed|n/a branch=deleted|n/a remote=pruned
-NOTES: <one line if anything unusual, else omit>
+MERGE_SHA: <sha-or-n/a>
+HANDOFF: parent /ship --land=<pr>             # ready or landed-cleanup-pending only
+NOTES: <one line when needed>
 ```
-
-**`MERGED_BY`**: `pr-reconciler` when you performed the merge this run; `preexisting` when the PR was already MERGED at step 1 pre-check time and you skipped the `gh pr merge` call. The orchestrator uses this to distinguish "I merged it" from "it merged before I got there" — replaces the legacy freeform "likely due to concurrent CI automation" guesses in NOTES.
 
 ## Hard rules
 
-- NEVER use `--admin` or `-f` to bypass failing checks or review gates.
-- NEVER force-push anywhere.
-- NEVER use `git reset --hard` — `git merge --ff-only origin/main` is the post-merge sync. If ff-only refuses, that's a real divergence: report `STATUS: error` instead of forcing the reset.
-- NEVER edit `CHANGELOG.md`, `changelog.d/*.md`, or `ai_docs/backlog.md` — those belong to the orchestrator's batch-boundary reconcile PR (parallel mode) or to the `/draft-changelog-entry` + `/close-backlog-rows` skills (serial mode).
-- If `gh pr view` itself fails (network / auth / rate limit), retry once after 5s. If it still fails, emit `STATUS: error` with the `gh` error message — do not guess the PR state.
-- If `git worktree remove` fails (file lock, Windows testhost), emit the error in `NOTES:` but continue with the remaining cleanup. Do not abort — the merge itself succeeded.
+- Never bypass failing checks or review gates.
+- Never force-push, merge, delete a branch, or remove a worktree.
+- Never perform partial cleanup or hide cleanup errors.
+- Never edit release, backlog, fragment, or plan state owned by the parent.
+- If readiness is uncertain, return `STATUS: error` rather than infer a safe state.

--- a/ai_docs/prompts/backlog-sweep-addenda.md
+++ b/ai_docs/prompts/backlog-sweep-addenda.md
@@ -24,7 +24,7 @@ worktree_lock_release: dotnet build-server shutdown
 
 The two `verify-*.ps1` scripts are the authoritative CI gate. Skip them only when context-tight; the `fallback_compile` + targeted `mcp__roslyn__test_run` is the documented minimum substitute.
 
-`dotnet build-server shutdown` releases `testhost.exe` / `VBCSCompiler.exe` locks on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/`. Always prepend before `git worktree remove --force` on Windows. Prints one informational line — not an error — so cleanup scripts must not treat non-zero stdout as failure.
+`dotnet build-server shutdown` releases `testhost.exe` / `VBCSCompiler.exe` locks on `tests/RoslynMcp.Tests/bin/{Debug,Release}/net10.0/`. The parent `/ship` owner invokes it when its canonical cleanup needs it; this addendum must never prescribe branch or worktree deletion. Its informational stdout is not an error, so cleanup checks must use its exit status rather than treat output as failure.
 
 ## Read-side tool primer
 
@@ -175,12 +175,12 @@ See [ai_docs/runtime.md § Bootstrap scope](../runtime.md#bootstrap-scope--self-
 
 ```yaml
 initiative_executor: .claude/agents/initiative-executor.md  # use for Step 7 spawn
-pr_reconciler:       .claude/agents/pr-reconciler.md         # retained for manual merge+cleanup — NOTE: execute Step 10 now lands via /ship directly (no reconciler spawn)
+pr_reconciler:       .claude/agents/pr-reconciler.md         # readiness-only; parent owns /ship --land=<pr>
 backlog_anchor_auditor: .claude/agents/backlog-anchor-auditor.md  # pre-plan anchor scan
 backlog_intake_extractor: .claude/agents/backlog-intake-extractor.md  # Phase 1 of /backlog-intake
 ```
 
-When the global execute command's Step 7 subagent briefing mentions "if available", these are what's available. (Step 10 lands PRs via `/ship` directly — it no longer spawns a reconciler subagent.)
+When the global execute command's Step 7 subagent briefing mentions "if available", these are what's available. The reconciler only reports readiness. The parent invokes `/ship --land=<pr>` and must preserve `SHIP_STATUS=landed-cleanup-failed` whenever landing succeeds but any local or remote cleanup proof fails; that status is a remediation signal, not a successful clean landing.
 
 ## Skills wired to backlog-remediation workflow
 

--- a/changelog.d/pr-reconciler-fail-closed-ship-cleanup.md
+++ b/changelog.d/pr-reconciler-fail-closed-ship-cleanup.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Make PR reconciliation readiness-only, route all landing through the canonical ship owner, and fail closed when cleanup proof is incomplete. Closes `pr-reconciler-fail-closed-ship-cleanup`.

--- a/eng/verify-ai-docs.ps1
+++ b/eng/verify-ai-docs.ps1
@@ -144,6 +144,129 @@ else {
     }
 }
 
+$prReconcilerRelativePath = '.claude/agents/pr-reconciler.md'
+$prReconcilerPath = Join-Path $RepoRoot $prReconcilerRelativePath
+$backlogAddendaRelativePath = 'ai_docs/prompts/backlog-sweep-addenda.md'
+$backlogAddendaPath = Join-Path $RepoRoot $backlogAddendaRelativePath
+
+# pr-reconciler-fail-closed-ship-cleanup: both the reconciler and its repository addenda are
+# readiness-only documents. Required handoff words alone are insufficient: a destructive command
+# in either body would let an autonomous reader bypass the parent-owned /ship cleanup boundary.
+$unsafeCleanupRules = @(
+    @{
+        Pattern = '(?im)^\s*git\b[^\r\n]*\bworktree\s+remove\b'
+        Description = 'worktree removal'
+        Examples = @(
+            'git worktree remove --force <path>',
+            'git -C <repo> worktree remove -f <path>',
+            'git -C "C:/repo with spaces" worktree remove --force <path>',
+            'git worktree remove <path>'
+        )
+    },
+    @{
+        Pattern = '(?im)^\s*gh\b[^\r\n]*\bpr\s+merge\b'
+        Description = 'PR merge'
+        Examples = @('gh pr merge 123 --merge')
+    },
+    @{
+        Pattern = '(?im)^\s*git\b[^\r\n]*\bbranch\b[^\r\n]*(?:\s-[dD]\b|\s--delete\b)'
+        Description = 'local branch deletion'
+        Examples = @(
+            'git branch -D remediation/example',
+            'git -C <repo> branch --delete remediation/example',
+            'git -C "C:/repo with spaces" branch --delete remediation/example'
+        )
+    },
+    @{
+        Pattern = '(?im)^\s*git\b[^\r\n]*\bpush\b[^\r\n]*(?:\s--delete\b|\s\+?:\S+)'
+        Description = 'remote branch deletion'
+        Examples = @(
+            'git push origin --delete remediation/example',
+            'git push origin :remediation/example',
+            'git -C "C:/repo with spaces" push origin +:refs/heads/remediation/example'
+        )
+    },
+    @{
+        Pattern = '(?is)(?:\b(?:cleanup|worktree|branch)\b.{0,160}\b(?:fails?|failed|failure|errors?)\b.{0,160}\b(?:continue|proceed|ignore|report\s+success|mark\s+success)\b|\b(?:continue|proceed|ignore|report\s+success|mark\s+success)\b.{0,160}\b(?:cleanup|worktree|branch)\b.{0,160}\b(?:fails?|failed|failure|errors?)\b)'
+        Description = 'continuation after cleanup failure'
+        Examples = @('If worktree removal fails, continue with reconciliation.', 'Proceed after branch cleanup failure.')
+    }
+)
+
+foreach ($unsafeRule in $unsafeCleanupRules) {
+    foreach ($example in $unsafeRule.Examples) {
+        if (-not [regex]::IsMatch($example, $unsafeRule.Pattern)) {
+            $issues.Add("Readiness-only guard does not reject its required unsafe example: $($unsafeRule.Description) -> $example")
+        }
+    }
+}
+
+# Keep the rejection rules narrowly tied to destructive operations. These representative
+# readiness-only instructions must remain valid as the rules evolve.
+$safeReadinessExamples = @(
+    'gh pr view 123 --json state,mergeable,mergeStateStatus',
+    'HANDOFF: parent /ship --land=<pr>',
+    'Never force-push, merge, delete a branch, or remove a worktree.',
+    'git -C "C:/repo with spaces" worktree list',
+    'git branch --show-current',
+    'git push origin remediation/example'
+)
+foreach ($safeExample in $safeReadinessExamples) {
+    foreach ($unsafeRule in $unsafeCleanupRules) {
+        if ([regex]::IsMatch($safeExample, $unsafeRule.Pattern)) {
+            $issues.Add("Readiness-only guard rejects a required safe example: $($unsafeRule.Description) -> $safeExample")
+        }
+    }
+}
+
+if (-not [System.IO.File]::Exists($prReconcilerPath)) {
+    $issues.Add("Missing PR reconciler guidance: $prReconcilerRelativePath")
+}
+else {
+    $prReconciler = [System.IO.File]::ReadAllText($prReconcilerPath)
+    $requiredReconcilerStatements = @(
+        'readiness-only',
+        'HANDOFF: parent /ship --land=<pr>',
+        'SHIP_STATUS=landed-cleanup-failed',
+        'Evaluate `state` before all other fields',
+        'If `gh pr view` fails, wait 5 seconds and retry once.',
+        'Never force-push, merge, delete a branch, or remove a worktree.'
+    )
+    foreach ($requiredStatement in $requiredReconcilerStatements) {
+        if (-not $prReconciler.Contains($requiredStatement, [System.StringComparison]::Ordinal)) {
+            $issues.Add("PR reconciler guidance is missing required fail-closed statement: $requiredStatement")
+        }
+    }
+
+    foreach ($unsafeRule in $unsafeCleanupRules) {
+        if ([regex]::IsMatch($prReconciler, $unsafeRule.Pattern)) {
+            $issues.Add("PR reconciler guidance contains unsafe cleanup instruction: $($unsafeRule.Description)")
+        }
+    }
+}
+
+if (-not [System.IO.File]::Exists($backlogAddendaPath)) {
+    $issues.Add("Missing backlog remediation addenda: $backlogAddendaRelativePath")
+}
+else {
+    $backlogAddenda = [System.IO.File]::ReadAllText($backlogAddendaPath)
+    $requiredAddendaStatements = @(
+        'readiness-only; parent owns /ship --land=<pr>',
+        'SHIP_STATUS=landed-cleanup-failed'
+    )
+    foreach ($requiredStatement in $requiredAddendaStatements) {
+        if (-not $backlogAddenda.Contains($requiredStatement, [System.StringComparison]::Ordinal)) {
+            $issues.Add("Backlog remediation addenda is missing required reconciler handoff statement: $requiredStatement")
+        }
+    }
+
+    foreach ($unsafeRule in $unsafeCleanupRules) {
+        if ([regex]::IsMatch($backlogAddenda, $unsafeRule.Pattern)) {
+            $issues.Add("Backlog remediation addenda contains unsafe cleanup instruction: $($unsafeRule.Description)")
+        }
+    }
+}
+
 if ($issues.Count -gt 0) {
     $issues | Sort-Object -Unique | ForEach-Object { Write-Error $_ }
     exit 1


### PR DESCRIPTION
## Summary
- Make the PR reconciler readiness-only.
- Require canonical parent-owned landing and fail-closed cleanup evidence.
- Add static guards against destructive cleanup guidance in readiness-only documents.

## Validation
- `pwsh -NoProfile -File eng/verify-ai-docs.ps1`
- Aggregate `just ci`: 2,931 passed, 7 skipped, 0 failed; NuGet audit clean.