### PR TITLE
docs: align backlog intake with v15 writer

### DIFF
--- a/.claude/agents/backlog-intake-extractor.md
+++ b/.claude/agents/backlog-intake-extractor.md
@@ -64,13 +64,16 @@ Target ratio: 3-5 raw candidates → 1 deduped row. If you're at < 2:1 dedupe, l
 
 ### 5. Classify priority
 
-- **P2**: tool broken for its core purpose, blocks ship, correctness bug with silent bad output, host-crash-class.
-- **P3**: meaningful friction / gap that consistently hurts workflow quality; real fix needed.
-- **P4**: polish, nice-to-have, edge case, speculative.
+- **Critical**: tool broken for its core purpose, blocks ship, correctness bug with silent bad output, host-crash-class.
+- **High**: a material user-facing regression or broad workflow blocker with a bounded fix.
+- **Medium**: meaningful friction / gap that consistently hurts workflow quality; real fix needed.
+- **Low**: polish, nice-to-have, edge case, or speculative improvement.
+
+Raw external-source severity is not a local priority label. When a source explicitly carries a raw severity, map it only as `P0 -> Critical`, `P1 -> High`, `P2 -> Medium`, and `P3 -> Low`; otherwise classify directly with the v15 bands above. Emit only `Critical`, `High`, `Medium`, or `Low` in `pri`. Preserve an upstream raw value as evidence rather than emitting it as a backlog band.
 
 ### 6. Cross-check against existing backlog
 
-Read `existingBacklogPath`. For each new candidate, check if any existing row in P2/P3/P4 describes the same issue. If so, mark the candidate as `"refine existing row <id>"` rather than a new row.
+Read `existingBacklogPath`. For each new candidate, check every existing `Critical`, `High`, `Medium`, and `Low` row for the same issue. If one overlaps, mark the candidate as `"refine existing row <id>"` rather than a new row.
 
 ### 7. Emit the report
 
@@ -91,7 +94,7 @@ overlapsWithExisting: <int>
 
 | id | pri | deps | do |
 |----|-----|------|-----|
-| `<kebab-id>` | P2|P3|P4 | — or <dep-id> | <one-paragraph summary citing tool/service/file anchors> |
+| `<kebab-id>` | Critical|High|Medium|Low | — or <dep-id> | <one-paragraph summary citing tool/service/file anchors> |
 ...
 
 ### Notes
@@ -105,9 +108,10 @@ overlapsWithExisting: <int>
 ## Hard rules
 
 - **Do NOT write to disk.** Read-only agent. If you find yourself calling a writer, stop and emit `ERROR: writer called`.
+- **Do NOT prescribe a direct table edit.** This result is a proposal only. The caller persists accepted rows, refinements, detail notes, preamble changes, and timestamps through the global `node ~/.claude/scripts/backlog.mjs` writer.
 - **Do NOT invent anchors.** If a review file names a service class like `FooService`, verify (via Glob or Grep in `src/RoslynMcp.Roslyn/Services/`) that the file exists before citing it in a row's `do` text. If the file doesn't exist but the described behavior is real, cite the actual file you found that handles the behavior.
 - **Do NOT exceed 50 rows** after dedupe. If you produce 50+, dedupe harder or return with `status: error, message: "dedupe ratio too low — review file set may need manual triage"`.
-- **Do NOT rank every row P3** to avoid decisions. Force P2 / P3 / P4 distribution to match the severity you observed.
+- **Do NOT rank every row Medium** to avoid decisions. Use the v15 bands that match the evidence.
 - **Do NOT split heroic rows yourself.** If a raw candidate describes 2-3 distinct code paths (e.g., "scaffold-test-preview emits invalid C# because (1) X (2) Y (3) Z"), emit it as ONE row and let the `/backlog-intake` skill's Phase 4 split it. Your job is to extract + dedupe, not to plan.
 
 ## Why this agent exists

--- a/.claude/skills/backlog-intake/SKILL.md
+++ b/.claude/skills/backlog-intake/SKILL.md
@@ -12,9 +12,28 @@ You are triaging a batch of deep-review artifacts into `ai_docs/backlog.md`. You
 
 This skill replaces the `eng/new-deep-review-batch.ps1 → sync-deep-review-backlog.ps1` pipeline. The PowerShell pipeline handled only `*_mcp-server-audit.md`, did literal-text dedupe, and couldn't verify anchors or size rows to Rule 1/3/4. The judgment work belongs in an LLM; the mechanical file-staging is delegated to `eng/stage-review-inbox.ps1`.
 
+## v15 backlog boundary
+
+Raw external-source severity is metadata, not a local backlog priority. Map it only as follows before materializing a local row:
+
+| Raw source severity | Local v15 `pri` |
+|---|---|
+| `P0` | `Critical` |
+| `P1` | `High` |
+| `P2` | `Medium` |
+| `P3` | `Low` |
+
+Raw external-source severity maps only as `P0 -> Critical`, `P1 -> High`, `P2 -> Medium`, and `P3 -> Low`.
+
+No raw source severity maps to `Defer`. Emit only `Critical`, `High`, `Medium`, or `Low` in an actionable local row; preserve the raw value in source evidence or public-issue metadata when it matters.
+
+Every mutation of `ai_docs/backlog.md`, its paired `ai_docs/items/<id>.md` files, its preamble, or its `updated_at` stamp uses the global writer: `node ~/.claude/scripts/backlog.mjs <subcommand> <repo-root> …`. Use `add` for a new row/detail pair, `update` for an existing slim row, `note` for an existing detail file, `preamble-replace` for one verified preamble replacement, and `touch` only when no row changed. The writer transactionally lint-checks, synchronizes the row/detail pair, and bumps `updated_at`; if it exits nonzero, stop that mutation and retain the source artifact. Do not hand-edit, append, re-sort, or count the backlog table. Derive the final count only with `node ~/.claude/scripts/backlog.mjs count <repo-root>`.
+
+Moving staged reports and deleting a consumed source fragment are artifact operations, not local backlog writes. Do them only after the corresponding writer transaction succeeded, or after an exact duplicate match was recorded with no local mutation; never delete evidence to compensate for a failed or rolled-back writer call.
+
 ## Server discovery
 
-This skill edits repository files, shells out to `pwsh` / `gh` / `git`, and uses Roslyn MCP **read-only** tools (`symbol_search`, `find_references`, `get_source_text`) to verify anchors. No `*_apply` / `*_preview` writers. If you find yourself calling a writer, you are in the wrong skill — stop and hand back.
+This skill edits repository files, shells out to `pwsh` / `gh` / `git`, and uses Roslyn MCP **read-only** tools (`symbol_search`, `find_references`, `get_source_text`) to verify anchors. No Roslyn MCP `*_apply` / `*_preview` writers are allowed. The global `backlog.mjs` writer is the required local-backlog exception described above; any other direct backlog writer is a stop-and-hand-back error.
 
 ## Input
 
@@ -35,9 +54,10 @@ Default (no flags): stage if `review-inbox/` is empty, verify against CHANGELOG,
 
 1. **`git` CLI on PATH.** If not, refuse.
 2. **`pwsh` CLI on PATH** (used by the staging script). If not, refuse.
-3. **Working tree clean** OR the only dirty paths are `review-inbox/` + `ai_docs/backlog.md`. If other paths are dirty, refuse: `"Working tree has unrelated changes — commit or stash before intake."`
+3. **Working tree clean** OR the only dirty paths are `review-inbox/`, `ai_docs/backlog.md`, and the paired `ai_docs/items/<id>.md` files intake owns. If other paths are dirty, refuse: `"Working tree has unrelated changes — commit or stash before intake."`
 4. **`main` up to date with `origin/main`** (`git fetch origin main` first). Refuse if `main` diverged in a way that requires manual resolution.
-5. **`ai_docs/backlog.md` exists** with the `## P2 / P3 / P4 — open work` + `## Refs` structure. If the file is missing or shape-wrong, refuse: `"backlog.md shape is unexpected — hand edit before re-running this skill."`
+5. **`ai_docs/backlog.md` exists** with `## Critical`, `## High`, `## Medium`, `## Low`, `## Defer`, and `## Refs`. If the file is missing or shape-wrong, refuse: `"backlog.md shape is unexpected — run /doc-audit initial before re-running this skill."`
+6. Unless `--no-commit` is set, create `chore/backlog-audit-intake-{YYYYMMDD}` from the verified clean, current `main` before the first writer transaction. Do not switch branches or pull after intake-owned writes begin.
 
 ## Workflow
 
@@ -66,17 +86,17 @@ Record the count: `N reports + F fragments staged from M repos` for the final su
 
 ### Phase 0.5 — Consume fragments (`backlog.d/` pattern)
 
-Fragments take a different path from prose reports. They are **not** moved into `review-inbox/`; instead intake reads them in place from each source repo's `backlog.d/`, dedupes, appends new rows, and **deletes the consumed fragments at the source**. The deletion IS the consumption record — there is no manifest file.
+Fragments take a different path from prose reports. They are **not** moved into `review-inbox/`; instead intake reads them in place from each source repo's `backlog.d/`, dedupes, materializes local rows through `backlog.mjs`, and **deletes the consumed fragments at the source**. The deletion IS the consumption record — there is no manifest file.
 
 For each configured sibling repo (and this repo) with a `backlog.d/` directory:
 
 1. **Walk** `<repo>/backlog.d/*.md`. For each file, parse YAML frontmatter; require `id`, `source_audit`, `source_repo`, `severity`, `area`, `server_version`, `anchors` (per `ai_docs/items/backlog-d-fragment-schema.md`). If any required key is missing OR `severity` / `area` is outside the documented enum OR `anchors` is empty OR the filename does not match `id`, **skip** that fragment with a warning — leave it on disk for the audit operator to fix. Do NOT delete malformed fragments.
 2. **Dedupe** each remaining fragment against existing `ai_docs/backlog.md` rows in this order:
-   - **Exact `(source_repo, id)` match** — if a backlog row already cites the same `source_repo` and the same row id, the fragment is a duplicate. Drop it from the candidate list AND delete the source fragment (the row already represents this finding).
-   - **Anchor-set similarity** — compare each fragment's `anchors` against existing rows. When ≥50 % of anchor paths overlap on the same shared code (typical for cross-repo audits hitting the same Roslyn-MCP server bug from two reporters), fold the fragment into the existing row's `do` cell — append the new `source_repo` and any unique anchors. Delete the source fragment after folding.
+   - **Exact `(source_repo, id)` match** — if a backlog row already cites the same `source_repo` and the same row id, the fragment is a duplicate. Record the exact match, drop it from the candidate list, then delete the source fragment (the row already represents this finding).
+   - **Anchor-set similarity** — compare each fragment's `anchors` against existing rows. When ≥50 % of anchor paths overlap on the same shared code (typical for cross-repo audits hitting the same Roslyn-MCP server bug from two reporters), prepare the merged v15 `do` cell and any detail note, then call `backlog.mjs update` and `backlog.mjs note` as needed. Delete the source fragment only after those writer calls succeed.
    - **Already-shipped check** — same Phase 2 logic that runs on prose-report candidates (CHANGELOG / recent plans / git log).
-3. **Append** any non-duplicate, non-shipped fragments as new rows in `ai_docs/backlog.md`, classified by their `severity` field into the matching priority band. Use the body paragraph (finding + repro + proposed fix sketch) as the seed for the row's `do` cell; rewrite into the standard cell shape during Phase 4.
-4. **Delete** each consumed source fragment with `git rm` (when the sibling repo is git-tracked) or `Remove-Item` (when it is not). Track deletions for the final commit message.
+3. **Materialize** any non-duplicate, non-shipped fragment with `backlog.mjs add`, passing the mapped v15 `--pri`, a slim `--do-file`, and one `--items-file`. Use the body paragraph (finding + repro + proposed fix sketch) as the seed; do not write a table row directly.
+4. **Delete** each source fragment with `git rm` (when the sibling repo is git-tracked) or `Remove-Item` (when it is not) only after its duplicate match is confirmed or its writer call succeeds. Re-resolve the exact file beneath that sibling's `backlog.d/` immediately before deletion; do not use a glob. Track deletions for the final commit message.
 
 **Idempotency contract:** re-running intake on a clean `backlog.d/` (no fragments, or only fragments already represented in `ai_docs/backlog.md`) is a no-op. The deletion is what makes this true — once consumed, the fragment is gone, so the next pass sees nothing to consume.
 
@@ -99,11 +119,11 @@ continue through `/promote-tier`.
 
 For each proposal:
 
-1. If `action == "add-new"`, append the row to the matching priority band using
-   the emitted `id`, `pri`, `deps`, and `do` fields.
-2. If `action == "update-existing"`, update the existing row's `do` cell only
-   when the proposal contains new blockers, source repos, or rationale that the
-   row does not already mention.
+1. If `action == "add-new"`, materialize the emitted `id`, v15 `pri`, `deps`, and
+   slim `do` text with `backlog.mjs add` and an `--items-file` when the row touches code.
+2. If `action == "update-existing"`, call `backlog.mjs update --do-file` only when
+   the proposal contains new blockers, source repos, or rationale that the row does
+   not already mention; use `backlog.mjs note` for evidence that belongs in its detail file.
 3. Preserve idempotency: rerunning the script after a row is represented must
    produce `update-existing`, not a duplicate row.
 4. If you intentionally skip a proposal, add a maintainer-readable note to the
@@ -151,7 +171,7 @@ If this phase finds a row already shipped, **drop it** from the candidate list a
 
 For each remaining row, verify every service class, tool file, and file:line anchor resolves:
 
-1. For service-class names (e.g. `DeadCodeService`, `CodeActionService`): confirm the `.cs` file exists at the cited path. If the row says `src/RoslynMcp.Roslyn/Services/FooService.cs` but only `src/RoslynMcp.Roslyn/Services/BarService.cs` exists, rewrite the row to cite the real file. **Common mistakes the extraction subagent makes**:
+1. For service-class names (e.g. `DeadCodeService`, `CodeActionService`): confirm the `.cs` file exists at the cited path. If the row says `src/RoslynMcp.Roslyn/Services/FooService.cs` but only `src/RoslynMcp.Roslyn/Services/BarService.cs` exists, prepare revised `do` text that cites the real file. **Common mistakes the extraction subagent makes**:
    - `CodeActionsService` (plural) → actual is `CodeActionService.cs`
    - `MoveTypeService` → actual is `TypeMoveService.cs`
    - `SemanticSearchService` → logic lives in `CodePatternAnalyzer.cs`
@@ -159,9 +179,9 @@ For each remaining row, verify every service class, tool file, and file:line anc
 2. For tool registrations (e.g. `find_references_bulk`): grep `src/RoslynMcp.Host.Stdio/Tools/` for `Name = "<tool_name>"` and cite the real file + line. The PS1 pipeline NEVER did this; it's a distinctive value-add of this skill.
 3. For file:line references (e.g. `CompileCheckService.cs:155`): run `get_source_text` on that span to confirm the referenced code is still there.
 
-Rewrite each row's `do` text to cite **both** the core service (under `src/RoslynMcp.Roslyn/Services/`) **and** the tool registration (under `src/RoslynMcp.Host.Stdio/Tools/`). Executors can then land on the right file immediately.
+Prepare each row's revised `do` text to cite **both** the core service (under `src/RoslynMcp.Roslyn/Services/`) **and** the tool registration (under `src/RoslynMcp.Host.Stdio/Tools/`). Materialize a new row with `backlog.mjs add --do-file` or refine an existing row with `backlog.mjs update --do-file`; do not edit the table directly. Executors can then land on the right file immediately.
 
-If an anchor genuinely cannot be resolved, tag the row with `[stale — cited anchor not found; executor may use synthetic examples]` per the `/backlog-remediate` anchor-verification contract, rather than dropping the row.
+If an anchor genuinely cannot be resolved, prepare `do` text tagged with `[stale — cited anchor not found; executor may use synthetic examples]` per the `/backlog-remediate` anchor-verification contract, then persist it through the applicable writer command rather than dropping the row.
 
 ### Phase 4 — Split heroic rows
 
@@ -176,7 +196,7 @@ Common heroic shapes to watch for:
 
 | Shape | Split strategy |
 |---|---|
-| "Fix tool X has 3 issues: schema drift + perf + empty data field" | Three rows, one per concern. Often different priorities (schema=P3, perf=P3, empty=P4). |
+| "Fix tool X has 3 issues: schema drift + perf + empty data field" | Three rows, one per concern. Often different priorities (for example, Medium, Medium, Low). |
 | "Scaffolder emits invalid C# because (a) identifier bug, (b) static target, (c) ctor args" | Three rows — each touches a different code path in the service. |
 | "Tool A and Tool B both need summary-mode paging" | Two rows — different tool files, different handlers, even if the shape is similar. |
 | "Guard X in WorkspaceManager AND in every tool wrapper" | Tighten to the single choke point; usually WorkspaceManager alone covers all callers. |
@@ -185,7 +205,7 @@ For each split, give each child a distinct kebab-case id (prefix with the origin
 
 ### Phase 5 — Ensure planner-prompt refs
 
-Before writing, verify the Refs table in `ai_docs/backlog.md` includes these entries (add any missing). Note: the remediation contract is NOT a repo Refs entry — it lives globally in `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/backlog-remediate-rules.md`, so do NOT add repo-local rows for it:
+Before a transactional mutation, verify the Refs table in `ai_docs/backlog.md` includes these entries. Add a missing one only through one exact `backlog.mjs preamble-replace` call. Note: the remediation contract is NOT a repo Refs entry — it lives globally in `~/.claude/prompts/backlog-remediate.md` and `~/.claude/prompts/backlog-remediate-rules.md`, so do NOT add repo-local rows for it:
 
 | Path | Role (template text) |
 |---|---|
@@ -193,25 +213,22 @@ Before writing, verify the Refs table in `ai_docs/backlog.md` includes these ent
 | `ai_docs/runtime.md` | Bootstrap scope policy — main-checkout self-edit (no `*_apply`) vs worktree/parallel-subagent sessions. |
 | `review-inbox/` | Source evidence for the open rows. Keep until each row is closed or superseded. |
 
-### Phase 6 — Archive processed files, write backlog.md, commit
+### Phase 6 — Persist through the writer, archive processed files, commit
 
-1. Update `updated_at:` to current UTC. Record this timestamp as the batch id in the form `YYYYMMDDTHHMMSSZ` (e.g. `20260424T031936Z`).
-2. Re-sort each priority band alphabetically by id.
-3. Ensure the "Standing rules" section includes the initiative-sizing rule: `"Size every row to a single /backlog-remediate initiative: one code path, ≤4 production files, ≤3 test files, one regression-test shape."` (add if missing).
-4. **Archive the processed review files.** Only the files that produced rows this batch — do NOT touch any existing `review-inbox/archive/<prior-batch>/` subdirectories.
+1. Generate `BATCH_ID` in the form `YYYYMMDDTHHMMSSZ` from current UTC before the first writer transaction. It names the archive directory only; do not write `updated_at` manually.
+2. Build each accepted row's slim `do` text and, when needed, its detail file before its writer call. Use the target `review-inbox/archive/{BATCH_ID}/<file>` citation in the generated text, then use `backlog.mjs add`, `update`, or `note` for every local row/detail change. Do not edit or re-sort the table. The successful transaction owns the `updated_at` bump.
+3. Ensure the "Standing rules" section includes the initiative-sizing rule through one verified `backlog.mjs preamble-replace` call when it is missing: `"Size every row to a single /backlog-remediate initiative: one code path, ≤4 production files, ≤3 test files, one regression-test shape."` If any writer call fails or rolls back, stop and retain its source report or fragment for a later retry.
+4. **Archive the processed review files only after all associated writer calls succeed.** Only move files that produced accepted rows this batch — do NOT touch any existing `review-inbox/archive/<prior-batch>/` subdirectories.
    ```bash
-   mkdir -p review-inbox/archive/{BATCH_ID}
-   for f in review-inbox/*.md; do git mv "$f" "review-inbox/archive/{BATCH_ID}/$(basename "$f")"; done
+   mkdir -p "review-inbox/archive/${BATCH_ID}"
+   for f in review-inbox/*.md; do git mv "$f" "review-inbox/archive/${BATCH_ID}/$(basename "$f")"; done
    ```
    The flat `review-inbox/` directory is now empty (save for the `archive/` subdirectory) and ready for the next batch to stage into.
-5. **Rewrite any `review-inbox/<file>` citations in the new backlog rows** to point at the archive path: `review-inbox/archive/{BATCH_ID}/<file>`. This keeps anchors resolvable after the move. Use `Edit` with exact-string replace on each affected row.
-6. **Verify the Refs table** in `ai_docs/backlog.md` describes both the flat `review-inbox/` (staging) and `review-inbox/archive/<batch-ts>/` (processed evidence) roles. The contract: row citations point into the archive; the flat directory is always the next batch's inbox.
-7. Skip the commit if `--no-commit`; otherwise:
+5. **For a pre-existing row whose citation must change**, use `backlog.mjs update --do-file` before the move. This keeps anchors resolvable after the archive without a direct table edit.
+6. **Verify the Refs table** in `ai_docs/backlog.md` describes both the flat `review-inbox/` (staging) and `review-inbox/archive/<batch-ts>/` (processed evidence) roles. Use `backlog.mjs preamble-replace` for any correction; the flat directory is always the next batch's inbox.
+7. Read the final count with `node ~/.claude/scripts/backlog.mjs count <repo-root>`. Skip the commit if `--no-commit`; otherwise:
    ```bash
-   git switch main
-   git pull --ff-only
-   git switch -c chore/backlog-audit-intake-{YYYYMMDD}
-   git add ai_docs/backlog.md review-inbox/
+   git add -- ai_docs/backlog.md review-inbox/ ai_docs/items/<id>.md [additional-exact-item-paths]
    git commit -m "..."
    ```
    Commit message template:
@@ -223,8 +240,8 @@ Before writing, verify the Refs table in `ai_docs/backlog.md` includes these ent
    review-inbox/archive/{BATCH_ID}/ so the flat review-inbox/ stays empty for
    the next batch.
 
-   Backlog now: {P2-count} P2 + {P3-count} P3 + {P4-count} P4 = {total} open
-   rows (up from {prior}). Rows anchored to both core services (src/RoslynMcp.Roslyn/Services/)
+   Backlog now: {output from `node ~/.claude/scripts/backlog.mjs count <repo-root>`}.
+   Rows anchored to both core services (src/RoslynMcp.Roslyn/Services/)
    and tool registrations (src/RoslynMcp.Host.Stdio/Tools/) so first executor lands
    on the right file without a scavenger hunt.
 
@@ -246,7 +263,7 @@ Before writing, verify the Refs table in `ai_docs/backlog.md` includes these ent
 
 Skip this phase if `--publish` is not set.
 
-For every row appended to `ai_docs/backlog.md` in this batch (Phase 4's deduped + split set, after Phase 6 wrote the file), file a public GitHub Issue against `darylmcd/Roslyn-Backed-MCP` using the shared renderer. This validates the schema + issue template by exercising it on every accepted finding — the user's load-bearing reason for hooking publish into intake rather than a separate skill.
+For every row successfully materialized through `backlog.mjs` in this batch (Phase 4's deduped + split set, after Phase 6 completes), file a public GitHub Issue against `darylmcd/Roslyn-Backed-MCP` using the shared renderer. This validates the schema + issue template by exercising it on every accepted finding — the user's load-bearing reason for hooking publish into intake rather than a separate skill.
 
 1. **Preconditions.** `gh` is on `PATH` AND `gh auth status` reports authenticated. If either fails, emit one warning line per row (`gh unavailable — printed body to stdout instead`) and fall back to print-only for the whole phase. Do not raise.
 2. **Dot-source the renderer.**
@@ -275,7 +292,7 @@ For every row appended to `ai_docs/backlog.md` in this batch (Phase 4's deduped 
        --label "area:<area>" --label "severity:<severity>" \
        --body-file <tempfile>
      ```
-   - Capture the returned Issue URL (or the deduped existing URL from the pre-check) and append it to the row's body inside `ai_docs/backlog.md` so the planner can cite the public Issue (`Closes #N`) when the row is sized into an initiative. Use `Edit` with exact-string replace; do NOT regenerate the whole file.
+   - Capture the returned Issue URL (or the deduped existing URL from the pre-check) and use `backlog.mjs update --do-file` to replace the complete slim `do` cell so the planner can cite the public Issue (`Closes #N`) when the row is sized into an initiative. Do not edit the table directly.
 4. **Recommit when rows changed.** If any row gained an Issue URL, the working tree now diverges from Phase 6's commit. Amend the Phase 6 commit OR add a follow-up commit on the same branch — your call which is cleaner. Do NOT push without explicit user confirmation.
 5. **Report counts in Phase 7.** Add a `Published` line: `Published: {filed} GitHub Issues + {refused} P0/security refused (printed only)`.
 
@@ -293,14 +310,14 @@ Backlog intake complete.
   Dropped (already shipped): {shipped-count}
   Anchor fixes applied: {anchor-fix-count}
   Heroic splits: {split-count} rows → {split-total}
-  Final: {P2} P2 + {P3} P3 + {P4} P4 = {total} open rows
+  Final: {output from `node ~/.claude/scripts/backlog.mjs count <repo-root>`}
   Commit: {SHA} on branch {branch-name} (local-only; push when ready)
 ```
 
 ## Refusal cases (explicit)
 
 - **`review-inbox/` empty AND staging found nothing** → refuse per Phase 0.
-- **Working tree dirty beyond backlog.md + review-inbox/** → refuse per Precondition 3.
+- **Working tree dirty beyond the intake-owned backlog pair + review-inbox/** → refuse per Precondition 3.
 - **`backlog.md` shape unexpected** → refuse per Precondition 5.
 - **Subagent returns 0 rows** → do NOT write an empty commit. Report "no actionable items extracted from {N} files" and exit.
 - **Subagent returns > 60 rows after dedupe** → stop and ask the user whether to proceed with a clearly-under-deduped result, rather than silently writing a heroic backlog.

--- a/ai_docs/items/backlog-d-fragment-schema.md
+++ b/ai_docs/items/backlog-d-fragment-schema.md
@@ -16,7 +16,7 @@ The original cross-repo flow had `/mcp-server-stress` (running in audited repo X
 The `changelog.d/` pattern at `.claude/skills/draft-changelog-entry/` + `.claude/skills/bump/` already proves the fragment-then-consolidate flow for in-repo release notes. This schema applies the same idea to cross-repo audit findings:
 
 - **Audit run emits one fragment per actionable finding** into the audited repo's local `backlog.d/`.
-- **`/backlog-intake` walks configured sibling repos**, dedupes fragments against existing rows in `<Roslyn-MCP-root>/ai_docs/backlog.md`, appends new rows, and **deletes consumed fragments at the source**. The deletion *is* the consumption record — no manifest is kept.
+- **`/backlog-intake` walks configured sibling repos**, dedupes fragments against existing rows in `<Roslyn-MCP-root>/ai_docs/backlog.md`, materializes accepted rows through the global transactional writer, and **deletes consumed fragments at the source only after that transaction succeeds**. The deletion *is* the consumption record — no manifest is kept.
 - **Re-running intake on a clean `backlog.d/` is a no-op.**
 
 The prose `*_mcp-server-audit.md` and the scorecard JSON stay where the audit run wrote them (under `<X>/ai_docs/audit-reports/`); fragments are the only artifact intake consumes for new-row creation. The prose report remains available for cross-reference via the fragment's `source_audit` field.
@@ -53,10 +53,18 @@ Each fragment is a markdown file with YAML frontmatter, then a single-paragraph 
 | `id` | string (kebab-case) | Stable hash/slug of the finding. MUST match the filename (sans `.md`). Used for dedup. Should encode the audited repo's id where finding could collide with similar findings in other repos (e.g. `roslyn-mcp-find-references-stale-cache`, `tradewise-find-references-stale-cache`). |
 | `source_audit` | string (relative path) | Filename of the source `*_mcp-server-audit.md` report **within the audited repo's `ai_docs/audit-reports/`**, e.g. `20260507T203015Z_tradewise_mcp-server-audit.md`. Intake uses this to back-reference evidence when the fragment alone is ambiguous. |
 | `source_repo` | string (kebab-case) | Repo id, e.g. `roslyn-backed-mcp`, `tradewise`, `it-chat-bot`. Disambiguates `id` collisions when two repos independently produce the same slug. The `(source_repo, id)` pair is the dedup key. |
-| `severity` | enum | One of `P0` (critical, ship-blocker), `P1` (high), `P2` (medium), `P3` (low). Maps to the priority bands in `ai_docs/backlog.md` so intake can place the row without re-classifying. |
+| `severity` | raw external-source enum | One of `P0` (critical, ship-blocker), `P1` (high), `P2` (medium), `P3` (low). Map only as `P0 -> Critical`, `P1 -> High`, `P2 -> Medium`, `P3 -> Low` when emitting the local v15 row; retain this raw field as source metadata, never as its local `pri`. |
 | `area` | enum | One of `tools`, `resources`, `prompts`, `skills`, `concurrency`, `perf`, `docs`, `security`. Coarse classification used by intake for grouping and by the planner prompt for context-budget sizing. **Note:** `area: security` is a load-bearing pre-disclosure refusal token — both `/mcp-server-surface-test --auto-file` and `/backlog-intake --publish` refuse to file such fragments to public GitHub Issues, regardless of severity. |
 | `server_version` | string (semver) | Roslyn MCP server version captured during the audit run (`server_info.version` at Phase -1). Required as of Row 2 of the move-to-git-issues design. Lets the planner correlate findings to a specific server version when triaging a regression. |
 | `anchors` | list of `file:line` strings | One or more `path/to/file.cs:NNN` entries pointing at the live code or doc the finding cites. Relative to the audited repo's root. May be a single-element list. |
+
+## v15 materialization boundary
+
+`severity` is an upstream observation. The local backlog has only `Critical`, `High`, `Medium`, `Low`, and `Defer` bands; actionable fragment rows use the four mapped bands above, and no raw value maps to `Defer`.
+
+Every mutation of the local backlog row/detail pair, preamble, or `updated_at` stamp uses the global `node ~/.claude/scripts/backlog.mjs` writer. Use `add` for a new pair, `update` for a slim-row change, `note` for additional detail evidence, `preamble-replace` for a verified preamble correction, and `touch` only when no row changed. Do not hand-edit or append the `ai_docs/backlog.md` table. A nonzero writer exit leaves the source fragment in place and stops that mutation.
+
+Deleting a source `backlog.d/` fragment or archiving a staged report is separate artifact bookkeeping. It is safe only after the related writer transaction succeeds (or after an exact duplicate is confirmed without a local mutation). Re-resolve the exact source path beneath the configured repo's `backlog.d/` immediately before deletion; do not make the evidence disappear before the local row is durable.
 
 ## Body
 
@@ -76,21 +84,21 @@ audit run in repo X            /backlog-intake (this repo)
 emit <X>/backlog.d/<id>.md ──> walk siblings + this repo
                                collect fragments
                                dedupe by (source_repo, id)
-                               append new rows to ai_docs/backlog.md
+                               backlog.mjs add/update local v15 rows
                                delete consumed fragments at <X>/backlog.d/<id>.md
 ```
 
-After intake runs, the audited repo's `backlog.d/` contains only fragments that *could not* be consolidated (e.g. dedup match against an existing row, or intake detected they had been superseded). Those are left in place for the next intake pass; intake is idempotent on already-consolidated input.
+After intake runs, the audited repo's `backlog.d/` contains only fragments that could not be consolidated because the writer failed or because evidence still requires operator attention. Exact duplicates and successfully materialized rows are consumed. This preserves idempotency without deleting evidence ahead of a durable local row.
 
 ## Dedup rule
 
-Intake dedupes fragments before appending rows in this order:
+Intake dedupes fragments before materializing local rows through the writer in this order:
 
-1. **Exact `(source_repo, id)` match against existing rows.** If `ai_docs/backlog.md` already has a row whose id equals the fragment's `id` AND its evidence cites the same `source_repo`, the fragment is a duplicate. Drop it; delete the source fragment.
-2. **Anchor-set similarity.** If two fragments from different repos cite a substantial overlap of anchors (≥50 % of paths overlap, intersection on the same shared code), intake folds them into a single row whose `do` cell mentions both source repos. Common case: a Roslyn-MCP server bug observed independently from two different audited repos — same code, two reporters.
+1. **Exact `(source_repo, id)` match against existing rows.** If `ai_docs/backlog.md` already has a row whose id equals the fragment's `id` AND its evidence cites the same `source_repo`, the fragment is a duplicate. Drop it; delete the source fragment after recording the exact match.
+2. **Anchor-set similarity.** If two fragments from different repos cite a substantial overlap of anchors (≥50 % of paths overlap, intersection on the same shared code), intake prepares the merged `do` text and detail note, then uses `backlog.mjs update` / `note` before deleting the source fragment. Common case: a Roslyn-MCP server bug observed independently from two different audited repos — same code, two reporters.
 3. **Anchors map to already-shipped CHANGELOG entries.** Same Phase 2 verify-not-already-shipped logic the intake skill already runs.
 
-Anything not deduped becomes a new row; the source fragment is deleted only after the row is written.
+Anything not deduped becomes a new row through `backlog.mjs add`; the source fragment is deleted only after that transaction succeeds.
 
 ## Disambiguating fragment `.md` from audit-report `.md`
 
@@ -121,14 +129,14 @@ anchors:
 `find_references` returns stale results after a `rename_apply` against the same symbol within ~200ms; the bulk-cache window is not invalidated on rename. Repro: load `TradeWise.slnx`, call `rename_apply` on `OrderService.PlaceOrder`, immediately call `find_references` against the renamed symbol — the response cites the old name's locations. Proposed fix: invalidate `FindReferencesService`'s LRU bucket from `RenameService.Apply` before returning, mirroring the pattern in `MoveTypeService.Apply`.
 ```
 
-After `/backlog-intake` consumes this fragment, a new row appears in `ai_docs/backlog.md` and the file at `tradewise/backlog.d/tradewise-find-references-stale-cache.md` is deleted.
+The raw `P2` in this example maps to local `Medium`. After `/backlog-intake` successfully creates the row through `backlog.mjs add`, the file at `tradewise/backlog.d/tradewise-find-references-stale-cache.md` is deleted.
 
 ## Validation rules (intake side)
 
 Intake refuses a fragment (does not delete it; logs a warning) when any of:
 
 - Missing required frontmatter key (including `server_version` as of Row 2).
-- `severity` not in the documented enum.
+- `severity` not in the documented raw external-source enum.
 - `area` not in the documented enum (note: `security` is now a member of the enum and triggers the public-filing refusal, not validation rejection).
 - `anchors` empty.
 - Filename does not match `id`.

--- a/changelog.d/backlog-intake-v15-writer-contract.md
+++ b/changelog.d/backlog-intake-v15-writer-contract.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+---
+
+- **Maintenance:** Align backlog intake artifacts with the v15 transactional writer contract. Closes `backlog-intake-v15-writer-contract`.

--- a/eng/verify-ai-docs.ps1
+++ b/eng/verify-ai-docs.ps1
@@ -267,6 +267,254 @@ else {
     }
 }
 
+# backlog-intake-v15-writer-contract: raw audit severities are source metadata, while
+# `ai_docs/backlog.md` has v15 named bands. The intake prompt used to mix both vocabularies
+# and prescribe direct table writes, which bypasses the transactional row/detail writer.
+$backlogIntakeContractPaths = @(
+    '.claude/skills/backlog-intake/SKILL.md',
+    '.claude/agents/backlog-intake-extractor.md',
+    'ai_docs/items/backlog-d-fragment-schema.md'
+)
+$backlogIntakeContents = @{}
+foreach ($relativePath in $backlogIntakeContractPaths) {
+    $path = Join-Path $RepoRoot $relativePath
+    if (-not [System.IO.File]::Exists($path)) {
+        $issues.Add("Missing backlog-intake v15 contract: $relativePath")
+        continue
+    }
+
+    $backlogIntakeContents[$relativePath] = [System.IO.File]::ReadAllText($path)
+}
+
+$rawSeverityMapPattern = '(?s)P0\s*-\>\s*Critical.*P1\s*-\>\s*High.*P2\s*-\>\s*Medium.*P3\s*-\>\s*Low'
+foreach ($relativePath in $backlogIntakeContractPaths) {
+    if ($backlogIntakeContents.ContainsKey($relativePath) -and -not [regex]::IsMatch($backlogIntakeContents[$relativePath], $rawSeverityMapPattern)) {
+        $issues.Add("Backlog-intake contract is missing the raw P0/P1/P2/P3 to v15-band mapping: $relativePath")
+    }
+}
+
+$requiredBacklogIntakeStatements = @{
+    '.claude/skills/backlog-intake/SKILL.md' = @(
+        'Every mutation of `ai_docs/backlog.md`, its paired `ai_docs/items/<id>.md` files, its preamble, or its `updated_at` stamp uses the global writer',
+        'Do not hand-edit, append, re-sort, or count the backlog table.',
+        'backlog.mjs count <repo-root>'
+    )
+    '.claude/agents/backlog-intake-extractor.md' = @(
+        'The caller persists accepted rows, refinements, detail notes, preamble changes, and timestamps through the global `node ~/.claude/scripts/backlog.mjs` writer.',
+        'Do NOT prescribe a direct table edit.'
+    )
+    'ai_docs/items/backlog-d-fragment-schema.md' = @(
+        'Every mutation of the local backlog row/detail pair, preamble, or `updated_at` stamp uses the global `node ~/.claude/scripts/backlog.mjs` writer.',
+        'Do not hand-edit or append the `ai_docs/backlog.md` table.'
+    )
+}
+foreach ($relativePath in $requiredBacklogIntakeStatements.Keys) {
+    if (-not $backlogIntakeContents.ContainsKey($relativePath)) {
+        continue
+    }
+
+    foreach ($requiredStatement in $requiredBacklogIntakeStatements[$relativePath]) {
+        if (-not $backlogIntakeContents[$relativePath].Contains($requiredStatement, [System.StringComparison]::Ordinal)) {
+            $issues.Add("Backlog-intake contract is missing required writer guidance: $relativePath -> $requiredStatement")
+        }
+    }
+}
+
+$activeIntakeGuidancePaths = @(
+    '.claude/skills/backlog-intake/SKILL.md',
+    '.claude/agents/backlog-intake-extractor.md'
+)
+$retiredIntakePriorityRules = @(
+    @{
+        Pattern = '(?im)^\s*##\s*P2\s*/\s*P3\s*/\s*P4\b'
+        Description = 'retired P2/P3/P4 priority heading'
+        Examples = @('## P2 / P3 / P4 — open work')
+    },
+    @{
+        Pattern = '(?im)^\s*-\s+\*\*P[0-4]\*\*:'
+        Description = 'retired raw-P local-priority classifier'
+        Examples = @('- **P3**: meaningful friction / gap.')
+    },
+    @{
+        Pattern = '(?i)\bP2\s*\|\s*P3\s*\|\s*P4\b'
+        Description = 'retired P2|P3|P4 output enum'
+        Examples = @('| `<kebab-id>` | P2|P3|P4 | — | summary |')
+    },
+    @{
+        Pattern = '(?i)\bP0\s*\|\s*P1\s*\|\s*P2\s*\|\s*P3\b'
+        Description = 'raw P0|P1|P2|P3 local-priority output enum'
+        Examples = @('| `<kebab-id>` | P0|P1|P2|P3 | — | summary |')
+    },
+    @{
+        Pattern = '(?im)\bbacklog\.mjs\b[^\r\n]*\s--pri\s+P[0-4]\b'
+        Description = 'retired P severity passed as a local writer priority'
+        Examples = @(
+            'node ~/.claude/scripts/backlog.mjs add . --id raw-priority --pri P0 --do-file row-do.md --items-file row-detail.md',
+            'node ~/.claude/scripts/backlog.mjs add . --id retired-priority --pri P4 --do-file row-do.md --items-file row-detail.md'
+        )
+    },
+    @{
+        Pattern = '(?im)^\s*\|[^|\r\n]*\|\s*P[0-4]\s*\|'
+        Description = 'retired P severity in a local priority-table cell'
+        Examples = @('| `retired-priority` | P4 | — | summary |')
+    },
+    @{
+        Pattern = '(?im)\b(?:local\s+)?(?:pri|priority)\s*(?:may\s+be|is|=|:)\s*P[0-4]\b'
+        Description = 'retired P severity described as a local priority'
+        Examples = @('The local priority is P4 for a speculative improvement.')
+    },
+    @{
+        Pattern = '(?im)\b(?:Backlog now|Final)\s*:\s*\{P2(?:-count)?\}\s*P2\s*\+\s*\{P3(?:-count)?\}\s*P3\s*\+\s*\{P4(?:-count)?\}\s*P4\b'
+        Description = 'stale manually maintained P2/P3/P4 count'
+        Examples = @('Final: {P2} P2 + {P3} P3 + {P4} P4 = {total} open rows')
+    }
+)
+$directIntakeMutationRules = @(
+    @{
+        Pattern = '(?im)\b(?:append|add)(?:s|ed|ing)?\s+(?:(?:a|the)\s+)?(?:new\s+)?rows?\s+(?:to|in)\s+(?:the\s+)?(?:matching\s+)?priority\s+band\b'
+        Description = 'direct priority-band append'
+        Examples = @(
+            'Append the row to the matching priority band.',
+            'Add a new row to the matching priority band.',
+            'Do not hesitate to append a new row to the matching priority band.'
+        )
+    },
+    @{
+        Pattern = '(?im)\bUse\s+(?:Edit|MultiEdit|Write)\b.{0,200}\b(?:backlog\.md|row(?:s)?|do\s+cell)\b'
+        Description = 'direct editor backlog mutation'
+        Examples = @(
+            'Use Edit with exact-string replace on the affected backlog row.',
+            'Use MultiEdit to rewrite the backlog.md table.',
+            'Use Write to replace the do cell.',
+            'Never wait for the writer; use Edit to change ai_docs/backlog.md.'
+        )
+    },
+    @{
+        Pattern = '(?im)\bdirectly\s+(?:append|add|edit|rewrite|update|sort)\b.{0,160}\b(?:backlog(?:\.md)?|table|row(?:s)?|do\s+cell)\b'
+        Description = 'direct table mutation'
+        Examples = @('Directly edit the backlog table after filtering.')
+    },
+    @{
+        Pattern = '(?im)^\s*(?:Set-Content|Add-Content|Out-File|sed\s+-i|perl\s+-pi)\b[^\r\n]*\bai_docs/backlog\.md\b'
+        Description = 'direct file-write command for backlog.md'
+        Examples = @(
+            'Set-Content ai_docs/backlog.md $rewritten',
+            'Add-Content ai_docs/backlog.md $row',
+            'Out-File -FilePath ai_docs/backlog.md -InputObject $row',
+            'sed -i "s/old/new/" ai_docs/backlog.md',
+            'perl -pi -e "s/old/new/" ai_docs/backlog.md'
+        )
+    },
+    @{
+        Pattern = '(?im)^\s*(?:echo|printf)\b[^\r\n]*(?:>>|>)\s*["'']?ai_docs/backlog\.md\b'
+        Description = 'shell redirection write for backlog.md'
+        Examples = @('echo "row" >> ai_docs/backlog.md')
+    },
+    @{
+        Pattern = '(?im)^\s*(?:git\b[^\r\n]*\b(?:mv|rm)\b|(?:Remove|Move)-Item)\b[^\r\n]*\bai_docs/backlog\.md\b'
+        Description = 'direct backlog-table move or deletion'
+        Examples = @(
+            'git rm ai_docs/backlog.md',
+            'git mv ai_docs/backlog.md ai_docs/archive/backlog.md',
+            'git -C C:/repo rm ai_docs/backlog.md',
+            'Remove-Item ai_docs/backlog.md',
+            'Move-Item ai_docs/backlog.md ai_docs/archive/backlog.md'
+        )
+    }
+)
+$backlogIntakeGuardRules = @($retiredIntakePriorityRules) + @($directIntakeMutationRules)
+
+function Test-UnsafeBacklogIntakeGuidance {
+    param(
+        [Parameter(Mandatory)] [string] $Text,
+        [Parameter(Mandatory)] [string] $Pattern
+    )
+
+    foreach ($match in [regex]::Matches($Text, $Pattern)) {
+        $lineStart = $Text.LastIndexOf("`n", [Math]::Max(0, $match.Index - 1))
+        if ($lineStart -lt 0) {
+            $lineStart = 0
+        }
+        else {
+            $lineStart++
+        }
+
+        $lineEnd = $Text.IndexOf("`n", $match.Index)
+        if ($lineEnd -lt 0) {
+            $lineEnd = $Text.Length
+        }
+
+        $line = $Text.Substring($lineStart, $lineEnd - $lineStart).TrimEnd("`r")
+        $beforeMatch = $line.Substring(0, $match.Index - $lineStart)
+        if ($beforeMatch -match '(?i)\b(?:Do\s+not|Don''t|Never)\s+(?:(?:run|use|directly)\s+)?$') {
+            continue
+        }
+
+        return $true
+    }
+
+    return $false
+}
+
+foreach ($retiredRule in $backlogIntakeGuardRules) {
+    foreach ($example in $retiredRule.Examples) {
+        if (-not (Test-UnsafeBacklogIntakeGuidance -Text $example -Pattern $retiredRule.Pattern)) {
+            $issues.Add("Backlog-intake guard does not reject its required unsafe example: $($retiredRule.Description) -> $example")
+        }
+    }
+}
+
+# Raw external severity and artifact archival remain valid concepts. These examples ensure the
+# retired-guidance rules stay narrow rather than rejecting the v15 mapping or safe bookkeeping.
+$safeBacklogIntakeExamples = @(
+    'Raw external-source severity maps only as P0 -> Critical, P1 -> High, P2 -> Medium, P3 -> Low.',
+    'node ~/.claude/scripts/backlog.mjs add . --id example-row --pri Medium --do-file row-do.md --items-file row-detail.md',
+    'node ~/.claude/scripts/backlog.mjs count .',
+    'git mv review-inbox/example.md review-inbox/archive/20260910T000000Z/example.md',
+    'git rm C:/Code-Repo/Sibling/backlog.d/example-row.md',
+    'Do not append a new row to the matching priority band; use backlog.mjs add instead.',
+    'Do not use Edit to change ai_docs/backlog.md; use backlog.mjs update instead.',
+    'Never directly rewrite the backlog table; use backlog.mjs update instead.',
+    'echo "fragment" >> C:/Code-Repo/Sibling/backlog.d/example-row.md',
+    'Move-Item review-inbox/example.md review-inbox/archive/example.md',
+    'severity: P2 is raw source metadata, not a local priority.',
+    'Do not edit the table directly; use backlog.mjs update --do-file instead.'
+)
+foreach ($safeExample in $safeBacklogIntakeExamples) {
+    foreach ($retiredRule in $backlogIntakeGuardRules) {
+        if (Test-UnsafeBacklogIntakeGuidance -Text $safeExample -Pattern $retiredRule.Pattern) {
+            $issues.Add("Backlog-intake guard rejects a required safe example: $($retiredRule.Description) -> $safeExample")
+        }
+    }
+}
+
+foreach ($relativePath in $activeIntakeGuidancePaths) {
+    if (-not $backlogIntakeContents.ContainsKey($relativePath)) {
+        continue
+    }
+
+    foreach ($retiredRule in $retiredIntakePriorityRules) {
+        if (Test-UnsafeBacklogIntakeGuidance -Text $backlogIntakeContents[$relativePath] -Pattern $retiredRule.Pattern) {
+            $issues.Add("Backlog-intake guidance contains $($retiredRule.Description): $relativePath")
+        }
+    }
+}
+
+# The schema legitimately documents raw P0-P3 source fields, so apply the retired-priority
+# checks only to documents that emit local priorities. Direct-mutation checks, however, protect
+# every intake contract document, including the schema that tells operators when deletion is safe.
+foreach ($relativePath in $backlogIntakeContractPaths) {
+    if (-not $backlogIntakeContents.ContainsKey($relativePath)) {
+        continue
+    }
+
+    foreach ($directRule in $directIntakeMutationRules) {
+        if (Test-UnsafeBacklogIntakeGuidance -Text $backlogIntakeContents[$relativePath] -Pattern $directRule.Pattern) {
+            $issues.Add("Backlog-intake contract contains $($directRule.Description): $relativePath")
+        }
+    }
+}
+
 if ($issues.Count -gt 0) {
     $issues | Sort-Object -Unique | ForEach-Object { Write-Error $_ }
     exit 1


### PR DESCRIPTION
## Summary
- Align backlog intake guidance and static validation with the v15 transactional writer contract.
- Replace retired priority terminology and direct-edit instructions.

## Validation
- `pwsh -NoProfile -File eng/verify-ai-docs.ps1`
- Aggregate `just ci`: 2,931 passed, 7 skipped, 0 failed; NuGet audit clean.