### PR TITLE
fix: propagate workspace warm cancellation

### DIFF
--- a/changelog.d/workspace-warm-cancellation-propagation.md
+++ b/changelog.d/workspace-warm-cancellation-propagation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Fail workspace warming on caller cancellation instead of reporting a partial successful result. Closes `workspace-warm-cancellation-propagation`.

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
@@ -53,6 +53,8 @@ public sealed class WorkspaceWarmService : IWorkspaceWarmService
 
     public async Task<WorkspaceWarmResult> WarmAsync(string workspaceId, string[]? projects, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+
         var stopwatch = Stopwatch.StartNew();
         var solution = _workspace.GetCurrentSolution(workspaceId);
 
@@ -62,7 +64,7 @@ public sealed class WorkspaceWarmService : IWorkspaceWarmService
 
         foreach (var project in solution.Projects)
         {
-            if (ct.IsCancellationRequested) break;
+            ct.ThrowIfCancellationRequested();
 
             if (projectFilter is not null && !projectFilter.Contains(project.Name))
                 continue;
@@ -72,6 +74,7 @@ public sealed class WorkspaceWarmService : IWorkspaceWarmService
             if (outcome.WasCold) coldCount++;
         }
 
+        ct.ThrowIfCancellationRequested();
         stopwatch.Stop();
         return new WorkspaceWarmResult(
             WorkspaceId: workspaceId,

--- a/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
+++ b/src/RoslynMcp.Roslyn/Services/WorkspaceWarmService.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using RoslynMcp.Core.Models;
 using RoslynMcp.Core.Services;
 using RoslynMcp.Roslyn.Contracts;
-using Microsoft.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 
 namespace RoslynMcp.Roslyn.Services;
 

--- a/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
+++ b/tests/RoslynMcp.Tests/WorkspaceWarmServiceTests.cs
@@ -39,6 +39,22 @@ public sealed class WorkspaceWarmServiceTests : IsolatedWorkspaceTestBase
     }
 
     [TestMethod]
+    public async Task WarmAsync_PreCancelledLoadedMultiProjectWorkspace_PropagatesCancellation()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+
+        Assert.IsTrue(
+            WorkspaceManager.GetCurrentSolution(workspace.WorkspaceId).Projects.Count() > 1,
+            "The cancellation regression requires a loaded multi-project workspace.");
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            WorkspaceWarmService.WarmAsync(workspace.WorkspaceId, projects: null, cancellation.Token));
+    }
+
+    [TestMethod]
     public async Task WarmAsync_SecondCall_NoCold_FasterThanFirst()
     {
         await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary
- Propagate caller cancellation before lookup, between projects, and before warm-result projection.
- Replace partial-success behavior with an `OperationCanceledException` contract.

## Validation
- `WorkspaceWarmServiceTests`: 3 passed.
- Roslyn compile check: 0 errors, 0 warnings.
- Aggregate `just ci`: 2,931 passed, 7 skipped, 0 failed; NuGet audit clean.