### PR TITLE
fix: disambiguate qualified scaffold targets

### DIFF
--- a/changelog.d/scaffold-fqn-target-type-disambiguation.md
+++ b/changelog.d/scaffold-fqn-target-type-disambiguation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Preserve fully qualified scaffold targets through semantic resolution so duplicate simple type names remain selectable. Closes `scaffold-fqn-target-type-disambiguation`.

--- a/src/RoslynMcp.Roslyn/Services/BatchTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/BatchTestScaffolder.cs
@@ -150,17 +150,24 @@ internal sealed class BatchTestScaffolder
             return;
         }
 
-        // See PreviewScaffoldTestAsync — accept dotted FQN input, resolve via simple name,
-        // and let the matched symbol supply the authoritative class identifier.
-        var lookupName = TestScaffoldRenderer.StripToSimpleTypeName(target.TargetTypeName);
+        // Keep the requested FQN for candidate filtering. The shared resolver enumerates by its
+        // simple tail and lets the matched symbol supply the generated class identifier.
         var typeInfo = ResolveTargetTypeAndMethodFromCache(
             cachedCompilations,
-            lookupName,
+            target.TargetTypeName,
             target.TargetMethodName,
             context.NSubstituteAvailable);
         if (typeInfo.MatchedType is null)
         {
-            state.Warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
+            if (typeInfo.Warnings is { Count: > 0 })
+            {
+                state.Warnings.AddRange(typeInfo.Warnings);
+            }
+            else
+            {
+                state.Warnings.Add($"Target type '{target.TargetTypeName}' not found in referenced projects — skipped.");
+            }
+
             return;
         }
 

--- a/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
+++ b/src/RoslynMcp.Roslyn/Services/SingleTestScaffolder.cs
@@ -57,12 +57,10 @@ internal sealed class SingleTestScaffolder
             ?? throw new InvalidOperationException($"Project directory could not be resolved for '{project.FilePath}'.");
         var testNamespace = project.Name;
 
-        // Accept a dotted FQN as input (callers who hit the ambiguity error get pointed at
-        // "the fully qualified type name", then re-invoke with `Namespace.Type`). The resolver
-        // only ever looks up the simple name, so strip to that for lookup — and treat the
-        // matched symbol's Name as authoritative once we have it, so the downstream class
-        // identifier is always a single identifier (dotted identifiers are a CS syntax error).
-        var lookupName = TestScaffoldRenderer.StripToSimpleTypeName(request.TargetTypeName);
+        // Preserve a dotted FQN until candidate selection. The renderer enumerates Roslyn symbols
+        // by their simple tail, then filters qualified requests by the matched symbol's full display
+        // name. Only the resolved symbol's simple Name can flow into generated C# identifiers.
+        var requestedTypeName = request.TargetTypeName;
 
         // scaffold-sampling-mrtr-replay-cost: the sampling exchange runs FIRST, ahead of every
         // semantic step below. Its provider may terminate this leg with a protocol input-required
@@ -71,7 +69,7 @@ internal sealed class SingleTestScaffolder
         // the syntactic prompt context and the retry leg consumes the answer without rebuilding it,
         // leaving project resolution, compilation and sibling inference paid exactly once.
         var (sampledTestName, solution) = await SuggestSampledTestNameAsync(
-            request, lookupName, workspaceId, project, projectDirectory, testNameSuggestionProvider, ct).ConfigureAwait(false);
+            request, requestedTypeName, workspaceId, project, projectDirectory, testNameSuggestionProvider, ct).ConfigureAwait(false);
 
         // The initial MRTR leg obtains a snapshot for the syntax-only ambiguity preflight, then
         // terminates while requesting input. The replay skips that preflight and obtains exactly
@@ -79,9 +77,9 @@ internal sealed class SingleTestScaffolder
         solution ??= _workspace.GetCurrentSolution(workspaceId);
 
         var typeInfo = await ResolveTargetTypeAndMethodAsync(
-            solution, request.TestProjectName, lookupName, request.TargetMethodName, ct).ConfigureAwait(false);
+            solution, request.TestProjectName, requestedTypeName, request.TargetMethodName, ct).ConfigureAwait(false);
 
-        var simpleTypeName = typeInfo.MatchedType?.Name ?? lookupName;
+        var simpleTypeName = typeInfo.MatchedType?.Name ?? TestScaffoldRenderer.StripToSimpleTypeName(requestedTypeName);
         var testFilePath = Path.Combine(projectDirectory, GeneratedTestFileName(simpleTypeName));
 
         // Sibling-pattern inference (scaffold-test-sibling-pattern-inference). When an explicit
@@ -119,7 +117,7 @@ internal sealed class SingleTestScaffolder
     /// </summary>
     private async Task<(TestNameSuggestionResult Suggestion, Solution? Solution)> SuggestSampledTestNameAsync(
         ScaffoldTestDto request,
-        string lookupTypeName,
+        string requestedTypeName,
         string workspaceId,
         ProjectStatusDto project,
         string projectDirectory,
@@ -143,18 +141,19 @@ internal sealed class SingleTestScaffolder
             return (NormalizeSuggestion(pending), null);
         }
 
+        var simpleTypeName = TestScaffoldRenderer.StripToSimpleTypeName(requestedTypeName);
         var solution = _workspace.GetCurrentSolution(workspaceId);
         await ThrowIfTargetTypeIsSyntacticallyAmbiguousAsync(
-            solution, project.Name, project.FilePath, lookupTypeName, ct).ConfigureAwait(false);
+            solution, project.Name, project.FilePath, requestedTypeName, ct).ConfigureAwait(false);
 
         // Syntactic inputs only: this runs ahead of symbol resolution, so anything the compilation
         // would supply is out of reach here by design — see ScaffoldTestNameSuggestionContext.
         var siblingNames = CollectSiblingTestMethodNames(
             projectDirectory,
-            Path.Combine(projectDirectory, GeneratedTestFileName(lookupTypeName)),
+            Path.Combine(projectDirectory, GeneratedTestFileName(simpleTypeName)),
             maxNames: 6);
         var context = new ScaffoldTestNameSuggestionContext(
-            lookupTypeName,
+            simpleTypeName,
             request.TargetMethodName,
             siblingNames.Names,
             siblingNames.Warning);
@@ -209,6 +208,9 @@ internal sealed class SingleTestScaffolder
             return [];
         }
 
+        var simpleTypeName = TestScaffoldRenderer.StripToSimpleTypeName(targetTypeName);
+        var isQualifiedTypeName = TestScaffoldRenderer.IsQualifiedTypeName(targetTypeName);
+
         // Match FindTargetTypeAsync exactly: inspect the test project, then each direct
         // reference in project-reference order, and stop at the first project with any matches.
         // Documents and their cached syntax trees come from this same loaded Solution snapshot,
@@ -231,12 +233,17 @@ internal sealed class SingleTestScaffolder
                 {
                     if (declaration.Kind() is not (SyntaxKind.ClassDeclaration or SyntaxKind.StructDeclaration or
                             SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration) ||
-                        !string.Equals(declaration.Identifier.ValueText, targetTypeName, StringComparison.Ordinal))
+                        !string.Equals(declaration.Identifier.ValueText, simpleTypeName, StringComparison.Ordinal))
                     {
                         continue;
                     }
 
                     var (identity, display) = GetQualifiedTypeNames(declaration);
+                    if (isQualifiedTypeName && !string.Equals(display, targetTypeName, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
                     candidates[identity] = display;
                 }
             }
@@ -616,10 +623,13 @@ internal static class TestScaffoldRenderer
         string targetTypeName,
         CancellationToken ct)
     {
-        return compilation.GetSymbolsWithName(targetTypeName, SymbolFilter.Type, ct)
+        var simpleTypeName = StripToSimpleTypeName(targetTypeName);
+        var isQualifiedTypeName = IsQualifiedTypeName(targetTypeName);
+        return compilation.GetSymbolsWithName(simpleTypeName, SymbolFilter.Type, ct)
             .OfType<INamedTypeSymbol>()
             .Where(t => t.TypeKind is TypeKind.Class or TypeKind.Struct &&
-                        string.Equals(t.Name, targetTypeName, StringComparison.Ordinal));
+                        string.Equals(t.Name, simpleTypeName, StringComparison.Ordinal))
+            .Where(t => !isQualifiedTypeName || string.Equals(t.ToDisplayString(), targetTypeName, StringComparison.Ordinal));
     }
 
     internal static ResolvedTargetTypeInfo CreateResolvedTargetTypeInfo(
@@ -1039,11 +1049,9 @@ internal static class TestScaffoldRenderer
 
     /// <summary>
     /// Strip a dotted input (e.g. <c>"SampleLib.Hierarchy.Circle"</c>) to its last identifier
-    /// segment so it can be used both as a lookup key against <see cref="Compilation.GetSymbolsWithName"/>
-    /// (which indexes on the simple name) and as a C# identifier in scaffolded output. Callers
-    /// sometimes arrive here with a fully-qualified name because the ambiguity-resolution
-    /// error message suggests "use the fully qualified type name" — without this strip, the
-    /// dotted input would flow into the class-name template and produce a CS syntax error.
+    /// segment for <see cref="Compilation.GetSymbolsWithName"/> enumeration and generated C# identifiers.
+    /// Candidate resolution must retain the original input so a qualified request can be filtered by
+    /// the matched symbol's full display name.
     /// </summary>
     internal static string StripToSimpleTypeName(string input)
     {
@@ -1052,6 +1060,9 @@ internal static class TestScaffoldRenderer
         var lastDot = input.LastIndexOf('.');
         return lastDot < 0 ? input : input[(lastDot + 1)..];
     }
+
+    internal static bool IsQualifiedTypeName(string input) =>
+        !string.Equals(StripToSimpleTypeName(input), input, StringComparison.Ordinal);
 
     /// <summary>
     /// Roslyn-parses the sibling source file, picks the first top-level class declaration

--- a/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
+++ b/tests/RoslynMcp.Tests/ScaffoldingIntegrationTests.cs
@@ -1441,6 +1441,88 @@ public class NestedHost
     }
 
     [TestMethod]
+    public async Task Scaffold_Test_QualifiedDuplicateTarget_RejectsSimpleNameAndSelectsExactSingleSymbol()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        await AddDuplicateWidgetFixtureAsync(workspace);
+
+        var ambiguous = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            ScaffoldingService.PreviewScaffoldTestAsync(
+                workspace.WorkspaceId,
+                new ScaffoldTestDto(
+                    "SampleLib.Tests",
+                    "Widget",
+                    "Describe",
+                    ReferenceTestFile: string.Empty),
+                CancellationToken.None));
+
+        StringAssert.Contains(ambiguous.Message, "Ambiguous type name 'Widget'");
+        StringAssert.Contains(ambiguous.Message, "Alpha.Widget");
+        StringAssert.Contains(ambiguous.Message, "Beta.Widget");
+
+        var provider = new RecordingTestNameSuggestionProvider("Describe_WhenAlphaWidgetIsReady_ReturnsAlpha");
+        var preview = await ScaffoldingService.PreviewScaffoldTestAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestDto(
+                "SampleLib.Tests",
+                "Alpha.Widget",
+                "Describe",
+                ReferenceTestFile: string.Empty,
+                UseSampling: true),
+            CancellationToken.None,
+            provider);
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        Assert.AreEqual(1, provider.CallCount,
+            "A qualified target must pass the sampling ambiguity preflight and invoke the provider.");
+        Assert.IsNotNull(provider.LastContext);
+        Assert.AreEqual("Widget", provider.LastContext.TargetTypeName,
+            "Sampling context must use the simple type name, not an invalid dotted identifier.");
+
+        var generatedPath = workspace.GetPath("SampleLib.Tests", "WidgetGeneratedTests.cs");
+        var contents = await File.ReadAllTextAsync(generatedPath, CancellationToken.None);
+        StringAssert.Contains(contents, "using Alpha;");
+        Assert.IsFalse(contents.Contains("using Beta;", StringComparison.Ordinal));
+        StringAssert.Contains(contents, "public class WidgetGeneratedTests");
+        StringAssert.Contains(contents, "new Widget(");
+    }
+
+    [TestMethod]
+    public async Task Scaffold_Test_Batch_QualifiedDuplicateTarget_RejectsSimpleNameAndSelectsExactSymbol()
+    {
+        await using var workspace = await CreateIsolatedWorkspaceAsync(CancellationToken.None);
+        await AddDuplicateWidgetFixtureAsync(workspace);
+
+        var preview = await ScaffoldingService.PreviewScaffoldTestBatchAsync(
+            workspace.WorkspaceId,
+            new ScaffoldTestBatchDto(
+                "SampleLib.Tests",
+                [
+                    new ScaffoldTestBatchTargetDto("Widget", "Describe"),
+                    new ScaffoldTestBatchTargetDto("Beta.Widget", "Describe"),
+                ],
+                "auto"),
+            CancellationToken.None);
+
+        Assert.AreEqual(1, preview.Changes.Count,
+            "The ambiguous simple target must be skipped while the qualified target creates one file.");
+        Assert.IsNotNull(preview.Warnings);
+        StringAssert.Contains(string.Join(Environment.NewLine, preview.Warnings), "Ambiguous type 'Widget'");
+
+        var applyResult = await RefactoringService.ApplyRefactoringAsync(preview.PreviewToken, "test_apply", CancellationToken.None);
+
+        Assert.IsTrue(applyResult.Success, applyResult.Error);
+        var generatedPath = workspace.GetPath("SampleLib.Tests", "WidgetGeneratedTests.cs");
+        var contents = await File.ReadAllTextAsync(generatedPath, CancellationToken.None);
+        StringAssert.Contains(contents, "using Beta;");
+        Assert.IsFalse(contents.Contains("using Alpha;", StringComparison.Ordinal));
+        StringAssert.Contains(contents, "public class WidgetGeneratedTests");
+        StringAssert.Contains(contents, "new Widget(");
+    }
+
+    [TestMethod]
     public async Task Scaffold_Test_Preview_StaticClass_Omits_NewT_InArrange()
     {
         // scaffold-test-preview-static-target-body: a `static class` target should scaffold
@@ -1478,6 +1560,30 @@ public static class StaticUtil
             "Static-class scaffold must NOT emit `new StaticUtil(...)` in Arrange.");
         Assert.IsFalse(contents.Contains("var subject ="),
             "Static-class scaffold must NOT emit a `subject` instance.");
+    }
+
+    private static async Task AddDuplicateWidgetFixtureAsync(IsolatedWorkspaceScope workspace)
+    {
+        var fixturePath = workspace.GetPath("SampleLib", "DuplicateWidgetFixture.cs");
+        await File.WriteAllTextAsync(fixturePath, """
+namespace Alpha
+{
+    public sealed class Widget
+    {
+        public string Describe() => "alpha";
+    }
+}
+
+namespace Beta
+{
+    public sealed class Widget
+    {
+        public string Describe() => "beta";
+    }
+}
+""", CancellationToken.None);
+
+        await workspace.ReloadAsync(CancellationToken.None);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Preserve fully qualified scaffold target names through semantic resolution.
- Reject ambiguous simple names while allowing a qualified type to select the intended symbol.
- Keep generated identifiers based on the resolved simple name.

## Validation
- `ScaffoldingIntegrationTests`: 41 passed.
- Roslyn compile check: 0 errors, 0 warnings.
- Aggregate `just ci`: 2,931 passed, 7 skipped, 0 failed; NuGet audit clean.