### PR TITLE
refactor(tools): trim method descriptions

### DIFF
--- a/changelog.d/method-diet-restructure-interface.md
+++ b/changelog.d/method-diet-restructure-interface.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Fixed:** Trim restructure and interface tool descriptions into focused capability statements.

--- a/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/InterfaceExtractionTools.cs
@@ -20,7 +20,7 @@ public static class InterfaceExtractionTools
     [McpServerTool(Name = "extract_interface_preview", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview extracting an interface from a concrete type within the same project. Optionally replaces concrete type references with the interface."),
-     Description("Preview extracting an interface from a concrete type. Creates a new interface file with selected member signatures, adds it to the type's base list, and optionally replaces concrete type references with the interface.")]
+     Description("Preview extracting an interface from a concrete type in the same project, with selected members. Optionally replace concrete-type references with the interface.")]
     public static Task<string> PreviewExtractInterface(
         IWorkspaceExecutionGate gate,
         IInterfaceExtractionService interfaceExtractionService,

--- a/src/RoslynMcp.Host.Stdio/Tools/RemoveInterfaceMemberTool.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RemoveInterfaceMemberTool.cs
@@ -21,7 +21,7 @@ public static class RemoveInterfaceMemberTool
     [McpServerTool(Name = "remove_interface_member_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("dead-code", "experimental", true, false,
         "Composite preview removing a dead interface member and every implementation in one shot. Refuses if any external caller exists."),
-     Description("Preview removing a dead interface member (method/property/event) AND every concrete implementation in one shot. Refuses to remove if the member has any non-implementation callers — returns the caller list instead. Apply via remove_dead_code_apply with the returned preview token.")]
+     Description("Preview removal of a dead interface method, property, or event and every implementation. Refuses if a non-implementation caller exists; redeem via remove_dead_code_apply.")]
     public static Task<string> PreviewRemoveInterfaceMember(
         IWorkspaceExecutionGate gate,
         IInterfaceMemberRemovalOrchestrator orchestrator,

--- a/src/RoslynMcp.Host.Stdio/Tools/RestructureTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/RestructureTools.cs
@@ -19,7 +19,7 @@ public static class RestructureTools
     [McpServerTool(Name = "restructure_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview a syntax-tree pattern-based find-and-replace using __placeholder__ captures."),
-     Description("Preview a syntax-tree pattern-based find-and-replace. Pattern and goal are C# expression or statement fragments; placeholders of the form __name__ capture and splice arbitrary sub-expressions. Returns a preview token redeemable via preview_multi_file_edit_apply.")]
+     Description("Preview a syntax-tree pattern-based C# find-and-replace. __name__ placeholders capture and splice subexpressions; redeem the result through preview_multi_file_edit_apply.")]
     public static Task<string> PreviewRestructure(
         IWorkspaceExecutionGate gate,
         IRestructureService restructureService,
@@ -40,7 +40,7 @@ public static class RestructureTools
     [McpServerTool(Name = "replace_string_literals_preview", ReadOnly = true, Destructive = false, Idempotent = false, OpenWorld = false),
      McpToolMetadata("refactoring", "experimental", true, false,
         "Preview replacing string literals in argument/initializer position with a constant expression."),
-     Description("Preview replacing string literals in argument or initializer position with a constant/identifier expression. Useful for magic-string centralization. Returns a preview token redeemable via preview_multi_file_edit_apply.")]
+     Description("Preview replacing argument or initializer string literals with constant or identifier expressions for magic-string centralization; redeem via preview_multi_file_edit_apply.")]
     public static Task<string> PreviewReplaceStringLiterals(
         IWorkspaceExecutionGate gate,
         IStringLiteralReplaceService stringLiteralReplaceService,

--- a/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
+++ b/src/RoslynMcp.Host.Stdio/Tools/SyntaxTools.cs
@@ -14,7 +14,7 @@ public static class SyntaxTools
     [McpServerTool(Name = "get_syntax_tree", ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false),
      McpToolMetadata("syntax", "stable", true, false,
         "Return a structured syntax tree for a document or range."),
-     Description("Get the hierarchical syntax tree (AST) for a file or line range, with node kinds and positions. Three budgets cap it (maxOutputChars, maxNodes, maxTotalBytes); output stops at the first cap and emits a TruncationNotice.")]
+     Description("Get a hierarchical syntax tree for a file or range, including node kinds and positions. Response budgets stop at the first cap and emit a TruncationNotice.")]
     public static Task<string> GetSyntaxTree(
         McpServer server,
         IWorkspaceExecutionGate gate,

--- a/tests/RoslynMcp.Tests/MethodDescriptionDietRestructureInterfaceTests.cs
+++ b/tests/RoslynMcp.Tests/MethodDescriptionDietRestructureInterfaceTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynMcp.Host.Stdio.Tools;
+
+namespace RoslynMcp.Tests;
+
+/// <summary>
+/// Slice-scoped ratchet for method descriptions on restructure, syntax, and interface tools.
+/// </summary>
+[TestClass]
+public sealed class MethodDescriptionDietRestructureInterfaceTests
+{
+    private const int MaxDescriptionCharacters = 200;
+    private const int MaxAggregateDescriptionCharacters = 900;
+
+    private static readonly Type[] s_sliceToolTypes =
+    [
+        typeof(RestructureTools),
+        typeof(RemoveInterfaceMemberTool),
+        typeof(SyntaxTools),
+        typeof(InterfaceExtractionTools),
+    ];
+
+    private static readonly ToolDescriptionBudgetHarness.TriggerExpectation[] s_triggerExpectations =
+    [
+        new("restructure_preview", "__name__ placeholders"),
+        new("replace_string_literals_preview", "magic-string centralization"),
+        new("remove_interface_member_preview", "Refuses if a non-implementation caller exists"),
+        new("get_syntax_tree", "TruncationNotice"),
+        new("extract_interface_preview", "concrete type in the same project"),
+        new("extract_interface_preview", "replace concrete-type references"),
+    ];
+
+    [TestMethod]
+    public void SliceToolDescriptions_AreCapabilityStatements() =>
+        ToolDescriptionBudgetHarness.AssertPerToolBudget(s_sliceToolTypes, MaxDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceToolDescriptions_StayUnderAggregateBudget() =>
+        ToolDescriptionBudgetHarness.AssertSliceTotalBudget(
+            s_sliceToolTypes, MaxAggregateDescriptionCharacters);
+
+    [TestMethod]
+    public void SliceTools_AllHaveNonEmptyDescriptions() =>
+        ToolDescriptionBudgetHarness.AssertAllHaveNonEmptyDescription(s_sliceToolTypes);
+
+    [TestMethod]
+    public void TrimmedDescriptions_KeepTheirDiscriminatingTriggers() =>
+        ToolDescriptionBudgetHarness.AssertDiscriminatingTriggers(s_sliceToolTypes, s_triggerExpectations);
+}


### PR DESCRIPTION
## Summary
- Trim six restructure and interface capability statements below the 200-character slice ceiling.
- Add the shared-harness ratchet for ceiling, aggregate, non-empty, and trigger coverage.

## Validation
- mcp__roslyn__compile_check (0 errors)
- mcp__roslyn__test_run MethodDescriptionDietRestructureInterfaceTests (4 passed)
- ./eng/verify-ai-docs.ps1
- ./eng/verify-release.ps1 -Configuration Release (2940 passed, 7 skipped)

Closes: method-diet-restructure-interface